### PR TITLE
Add ROS 2 Humble support in workcell builder

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -36,7 +36,8 @@ public:
   boost::filesystem::path workcell_path;
   Workcell workcell;
   bool success;
-  std::vector < std::vector < std::string >> ros_dist {{"melodic"}, {"eloquent", "foxy"}};
+  // Supported ROS distributions for ROS 1 and ROS 2 respectively. Add Humble for ROS 2.
+  std::vector < std::vector < std::string >> ros_dist {{"melodic"}, {"eloquent", "foxy", "humble"}};
   bool is_good_scene(boost::filesystem::path original_path, std::string scene_name);
 
   explicit MainWindow(QWidget * parent = nullptr);

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/scene_select.h
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/scene_select.h
@@ -41,7 +41,8 @@ public:
   boost::filesystem::path assets_path;
 
   Workcell workcell;
-  std::vector < std::vector < std::string >> ros_dist {{"melodic"}, {"eloquent", "foxy"}};
+  // Supported ROS distributions for ROS 1 and ROS 2 respectively. Add Humble for ROS 2.
+  std::vector < std::vector < std::string >> ros_dist {{"melodic"}, {"eloquent", "foxy", "humble"}};
   void generate_scene_package(
     boost::filesystem::path scene_filepath, std::string scene_name,
     int ros_ver);


### PR DESCRIPTION
## Summary
- support ROS 2 Humble in workcell builder GUI by listing it among available ROS distributions

## Testing
- `colcon build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e0d2a92cc8331b014b98c79bf6097