### PR TITLE
Add ROS 2 Humble message dependencies

### DIFF
--- a/emd_msgs/CMakeLists.txt
+++ b/emd_msgs/CMakeLists.txt
@@ -39,6 +39,8 @@ rosidl_generate_interfaces( ${PROJECT_NAME}
   visualization_msgs
 )
 
+ament_export_dependencies(rosidl_default_runtime)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/emd_msgs/package.xml
+++ b/emd_msgs/package.xml
@@ -14,6 +14,11 @@
 
   <build_depend>rosidl_default_generators</build_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>shape_msgs</depend>
+  <depend>visualization_msgs</depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>


### PR DESCRIPTION
## Summary
- Export `rosidl_default_runtime` from message CMake to support ROS 2 Humble
- Declare required message dependencies in `emd_msgs` package manifest

## Testing
- `colcon build --packages-select emd_msgs` *(fails: CMake can't find package "ament_cmake")*


------
https://chatgpt.com/codex/tasks/task_e_688e0d2a92cc8331b014b98c79bf6097