### PR TITLE
Refactor xacro tests

### DIFF
--- a/assets/environment/realsense2_description/tests/test_xacro.py
+++ b/assets/environment/realsense2_description/tests/test_xacro.py
@@ -1,21 +1,50 @@
 #!/usr/bin/env python
 
-import rospkg
-import subprocess
+"""Validate xacro files in the package.
+
+The original test relied on the ROS ``rospkg`` package to locate the
+``realsense2_description`` package and used nose-style ``yield`` tests.
+Both assumptions break in a minimal environment: ``rospkg`` is often not
+available and ``yield`` based tests are no longer supported by ``pytest``.
+
+To make the check robust we compute the package path relative to this
+file and generate individual parametrised tests for every ``.xacro``
+file.  The test is skipped automatically when the ``xacro``/``roslaunch``
+dependencies are missing.
+"""
+
+import glob
 import os
+import subprocess
 
-r = rospkg.RosPack()
-path = r.get_path('realsense2_description')
+import pytest
+
+# Skip the entire test module if required ROS tools are not available.
+pytest.importorskip("xacro")
+pytest.importorskip("roslaunch")
+
+# Determine the root of the realsense2_description package using the file
+# location instead of relying on ROS environment variables.
+PATH = os.path.dirname(os.path.dirname(__file__))
 
 
-def run_xacro_in_file(filename):
-    assert(filename != "")
-    assert(subprocess.check_output(["xacro", "--inorder", "tests/{}".format(filename)],
-                                   cwd=path))
+def run_xacro_in_file(filename: str) -> None:
+    """Run ``xacro`` on a single file to ensure it parses correctly."""
+    assert filename
+    subprocess.check_output([
+        "xacro",
+        "--inorder",
+        os.path.join("tests", filename),
+    ], cwd=PATH)
 
 
-def test_files():
-    for _, _, filenames in os.walk(os.path.join(path, "tests")):
-        for file in filenames:
-            if file.endswith(".xacro"):
-                yield run_xacro_in_file, file
+# Collect all xacro files once for parametrisation below
+XACRO_FILES = [
+    os.path.basename(f)
+    for f in glob.glob(os.path.join(PATH, "tests", "*.xacro"))
+]
+
+
+@pytest.mark.parametrize("file", XACRO_FILES)
+def test_files(file: str) -> None:
+    run_xacro_in_file(file)


### PR DESCRIPTION
## Summary
- refactor xacro validation test to use pytest parametrization
- skip tests when ROS xacro/roslaunch tools are unavailable and avoid rospkg

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e1178c5948331b936a88b88c854d2