### PR TITLE
Fix Y-axis rotation bug in MathFunctions

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_planner/src/common/math_functions.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/common/math_functions.cpp
@@ -100,9 +100,9 @@ Eigen::Vector3f MathFunctions::get_rotated_vector(
     result_vector(1) = target_vector(1) * cos(angle) - target_vector(2) * sin(angle);
     result_vector(2) = target_vector(1) * sin(angle) + target_vector(2) * cos(angle);
   } else if (axis == 'y') {
-    result_vector(0) = target_vector(0) * cos(angle) - target_vector(1) * sin(angle);
+    result_vector(0) = target_vector(0) * cos(angle) + target_vector(2) * sin(angle);
     result_vector(1) = target_vector(1);
-    result_vector(2) = target_vector(2) * -sin(angle) + target_vector(1) * cos(angle);
+    result_vector(2) = -target_vector(0) * sin(angle) + target_vector(2) * cos(angle);
   } else if (axis == 'z') {
     result_vector(0) = target_vector(0) * cos(angle) - target_vector(1) * sin(angle);
     result_vector(1) = target_vector(0) * sin(angle) + target_vector(1) * cos(angle);


### PR DESCRIPTION
## Summary
- fix vector rotation around Y axis

## Testing
- `bash coverage.sh html` *(fails: cannot read build)*
- `colcon test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e1178c5948331b936a88b88c854d2