### PR TITLE
Fix formatting and adjust grasp object test

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/next_point_publisher.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/next_point_publisher.hpp
@@ -25,13 +25,16 @@
 #include "std_msgs/msg/float64_multi_array.hpp"
 #include "trajectory_msgs/msg/joint_trajectory.hpp"
 
-namespace dynamic_safety {
+namespace dynamic_safety
+{
 
 /// Next point publisher for dynamic safety.
-class NextPointPublisher {
+class NextPointPublisher
+{
 public:
   /// Next Point Publisher options.
-  struct Option {
+  struct Option
+  {
     /// Command out type, currently support
     /// `trajectory_msgs/JointTrajectory` and
     /// `std_msgs/Float64MultiArray`.
@@ -72,9 +75,10 @@ public:
    * \param[in] node ROS Node to use for the publisher.
    * \param[in] rate How fast the outer loop will run.
    */
-  void configure(const robot_trajectory::RobotTrajectoryPtr &traj,
-                 const Option &option, const rclcpp::Node::SharedPtr &node,
-                 double rate);
+  void configure(
+    const robot_trajectory::RobotTrajectoryPtr & traj,
+    const Option & option, const rclcpp::Node::SharedPtr & node,
+    double rate);
 
   /// Start the next point publisher.
   /**
@@ -112,7 +116,7 @@ public:
    *
    * \param[in] traj Trajectory to replace the current one.
    */
-  void update_traj(const robot_trajectory::RobotTrajectoryPtr &traj);
+  void update_traj(const robot_trajectory::RobotTrajectoryPtr & traj);
 
   /// Get execution status.
   /**
@@ -127,7 +131,7 @@ public:
    *
    * \return Current execution status.
    */
-  int8_t get_status() const { return static_cast<int8_t>(status_); }
+  int8_t get_status() const {return static_cast<int8_t>(status_);}
 
   /// Get scale.
   /**
@@ -137,7 +141,8 @@ public:
    *
    * \return Execution scale.
    */
-  double get_scale() const {
+  double get_scale() const
+  {
     // return target scale
     return scale_ - scale_step_ * remaining_steps_to_scale_;
   }
@@ -149,7 +154,7 @@ public:
    *
    * \return Time point reference.
    */
-  const double &get_time_point() const { return time_point_; }
+  const double & get_time_point() const {return time_point_;}
 
   /// Run the next point publisher once.
   /**
@@ -165,14 +170,14 @@ public:
    *
    * \return Time point.
    */
-  const double &current_point();
+  const double & current_point();
 
 protected:
   rclcpp::Node::SharedPtr node_;
   rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr
-      command_out_array_pub_;
+    command_out_array_pub_;
   rclcpp::Publisher<trajectory_msgs::msg::JointTrajectory>::SharedPtr
-      command_out_traj_pub_;
+    command_out_traj_pub_;
 
 private:
   // Get next point based on current time point.
@@ -185,7 +190,7 @@ private:
   void _scale_impl(double scale);
 
   // Utility function to convert command type from string to enum.
-  Command _from_string(const std::string &command_type);
+  Command _from_string(const std::string & command_type);
 
   // Deadline callback (not implemented)
   void _deadline_cb(rclcpp::QOSDeadlineOfferedInfo &);
@@ -228,6 +233,6 @@ private:
   bool publish_joint_effort_;
 };
 
-} // namespace dynamic_safety
+}  // namespace dynamic_safety
 
-#endif // EMD__DYNAMIC_SAFETY__NEXT_POINT_PUBLISHER_HPP_
+#endif  // EMD__DYNAMIC_SAFETY__NEXT_POINT_PUBLISHER_HPP_

--- a/easy_manipulation_deployment/emd_grasp_planner/include/emd/common/conversions.hpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/include/emd/common/conversions.hpp
@@ -52,7 +52,8 @@
 #include <tf2/transform_datatypes.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
-namespace octomap {
+namespace octomap
+{
 /**
  * @brief Conversion from octomap::point3d_list
  (e.g. all occupied nodes from getOccupied()) to
@@ -62,13 +63,15 @@ namespace octomap {
  * @param cloud
  */
 inline void
-points_octomap_to_pointcloud2(const point3d_list &points,
-                              sensor_msgs::msg::PointCloud2 &cloud) {
+points_octomap_to_pointcloud2(
+  const point3d_list & points,
+  sensor_msgs::msg::PointCloud2 & cloud)
+{
   bool has_x = false;
   bool has_y = false;
   bool has_z = false;
 
-  for (const auto &field : cloud.fields) {
+  for (const auto & field : cloud.fields) {
     if (field.name == "x" || field.name == "X") {
       has_x = true;
     } else if (field.name == "y" || field.name == "Y") {
@@ -90,7 +93,8 @@ points_octomap_to_pointcloud2(const point3d_list &points,
   sensor_msgs::PointCloud2Iterator<float> iter_z(cloud, "z");
 
   for (auto it = points.begin(); it != points.end();
-       ++it, ++iter_x, ++iter_y, ++iter_z) {
+    ++it, ++iter_x, ++iter_y, ++iter_z)
+  {
     *iter_x = it->x();
     *iter_y = it->y();
     *iter_z = it->z();
@@ -105,8 +109,10 @@ points_octomap_to_pointcloud2(const point3d_list &points,
  * @param octomapCloud
  */
 
-inline void pointcloud2_to_octomap(const sensor_msgs::msg::PointCloud2 &cloud,
-                                   Pointcloud &octomapCloud) {
+inline void pointcloud2_to_octomap(
+  const sensor_msgs::msg::PointCloud2 & cloud,
+  Pointcloud & octomapCloud)
+{
   octomapCloud.reserve(cloud.data.size() / cloud.point_step);
 
   sensor_msgs::PointCloud2ConstIterator<float> iter_x(cloud, "x");
@@ -115,7 +121,8 @@ inline void pointcloud2_to_octomap(const sensor_msgs::msg::PointCloud2 &cloud,
 
   for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z) {
     if (std::isfinite(*iter_x) && std::isfinite(*iter_y) &&
-        std::isfinite(*iter_z)) {
+      std::isfinite(*iter_z))
+    {
       octomapCloud.push_back(*iter_x, *iter_y, *iter_z);
     }
   }
@@ -123,7 +130,8 @@ inline void pointcloud2_to_octomap(const sensor_msgs::msg::PointCloud2 &cloud,
 
 /// Conversion from octomap::point3d to geometry_msgs::msg::Point
 static inline geometry_msgs::msg::Point
-pointOctomapToMsg(const point3d &octomapPt) {
+pointOctomapToMsg(const point3d & octomapPt)
+{
   geometry_msgs::msg::Point pt;
   pt.x = octomapPt.x();
   pt.y = octomapPt.y();
@@ -134,13 +142,15 @@ pointOctomapToMsg(const point3d &octomapPt) {
 
 /// Conversion from geometry_msgs::msg::Point to octomap::point3d
 static inline octomap::point3d
-pointmsg_to_octomap(const geometry_msgs::msg::Point &ptMsg) {
+pointmsg_to_octomap(const geometry_msgs::msg::Point & ptMsg)
+{
   return octomap::point3d(ptMsg.x, ptMsg.y, ptMsg.z);
 }
 
 /// Conversion from octomap::point3d to tf2::Point
 static inline geometry_msgs::msg::Point
-point_octomap_to_tf(const point3d &octomapPt) {
+point_octomap_to_tf(const point3d & octomapPt)
+{
   geometry_msgs::msg::Point pt;
   pt.x = octomapPt.x();
   pt.y = octomapPt.y();
@@ -150,36 +160,43 @@ point_octomap_to_tf(const point3d &octomapPt) {
 
 /// Conversion from tf2::Point to octomap::point3d
 static inline octomap::point3d
-point_tf_to_octomap(const geometry_msgs::msg::Point &ptTf) {
+point_tf_to_octomap(const geometry_msgs::msg::Point & ptTf)
+{
   return point3d(ptTf.x, ptTf.y, ptTf.z);
 }
 
 static inline octomap::point3d
-point_tf_to_octomap(const geometry_msgs::msg::Vector3 &ptTf) {
+point_tf_to_octomap(const geometry_msgs::msg::Vector3 & ptTf)
+{
   return point3d(ptTf.x, ptTf.y, ptTf.z);
 }
 
 /// Conversion from octomap Quaternion to tf2::Quaternion
 static inline tf2::Quaternion
-quaternion_octomap_to_tf(const octomath::Quaternion &octomapQ) {
-  return tf2::Quaternion(octomapQ.x(), octomapQ.y(), octomapQ.z(),
-                         octomapQ.u());
+quaternion_octomap_to_tf(const octomath::Quaternion & octomapQ)
+{
+  return tf2::Quaternion(
+    octomapQ.x(), octomapQ.y(), octomapQ.z(),
+    octomapQ.u());
 }
 
 /// Conversion from tf2::Quaternion to octomap Quaternion
 static inline octomath::Quaternion
-quaternion_tf_to_octomap(const tf2::Quaternion &qTf) {
+quaternion_tf_to_octomap(const tf2::Quaternion & qTf)
+{
   return octomath::Quaternion(qTf.w(), qTf.x(), qTf.y(), qTf.z());
 }
 
 static inline octomath::Quaternion
-quaternion_tf_to_octomap(const geometry_msgs::msg::Quaternion &qTf) {
+quaternion_tf_to_octomap(const geometry_msgs::msg::Quaternion & qTf)
+{
   return octomath::Quaternion(qTf.w, qTf.x, qTf.y, qTf.z);
 }
 
 /// Conversion from octomap::pose6f to tf2::Pose
 static inline geometry_msgs::msg::Pose
-pose_octomap_to_tf(const octomap::pose6d &octomapPose) {
+pose_octomap_to_tf(const octomap::pose6d & octomapPose)
+{
   auto r = quaternion_octomap_to_tf(octomapPose.rot());
   geometry_msgs::msg::Quaternion orientation;
   orientation.x = r.x();
@@ -195,10 +212,12 @@ pose_octomap_to_tf(const octomap::pose6d &octomapPose) {
 
 /// Conversion from tf2::Pose to octomap::pose6d
 static inline octomap::pose6d
-pose_tf_to_octomap(const geometry_msgs::msg::Pose &poseTf) {
-  return octomap::pose6d(point_tf_to_octomap(poseTf.position),
-                         quaternion_tf_to_octomap(poseTf.orientation));
+pose_tf_to_octomap(const geometry_msgs::msg::Pose & poseTf)
+{
+  return octomap::pose6d(
+    point_tf_to_octomap(poseTf.position),
+    quaternion_tf_to_octomap(poseTf.orientation));
 }
-} // namespace octomap
+}  // namespace octomap
 
-#endif // OCTOMAP_ROS_CONVERSIONS_HPP_ NOLINT
+#endif  // OCTOMAP_ROS_CONVERSIONS_HPP_ NOLINT

--- a/easy_manipulation_deployment/emd_grasp_planner/test/grasp_object_test.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/test/grasp_object_test.cpp
@@ -23,9 +23,9 @@ GraspObjectTest::GraspObjectTest()
 
 void GraspObjectTest::GenerateObjectCloud(float length, float breadth, float height)
 {
-  for (float length_ = 0.0; length_ < length; length_ += 0.0025) {
-    for (float breadth_ = 0.0; breadth_ < breadth; breadth_ += 0.0025) {
-      for (float height_ = 0.0; height_ < height; height_ += 0.0025) {
+  for (float length_ = 0.0; length_ <= length; length_ += 0.0025) {
+    for (float breadth_ = 0.0; breadth_ <= breadth; breadth_ += 0.0025) {
+      for (float height_ = 0.0; height_ <= height; height_ += 0.0025) {
         pcl::PointXYZRGB temp_point;
         temp_point.x = length_;
         temp_point.y = breadth_;


### PR DESCRIPTION
## Summary
- format dynamic safety's next point publisher implementation and headers
- apply consistent uncrustify style to octomap conversion helpers
- include boundary samples in grasp object test cloud generation

## Testing
- `cpplint easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/next_point_publisher.hpp easy_manipulation_deployment/emd_dynamic_safety/src/next_point_publisher.cpp easy_manipulation_deployment/emd_grasp_planner/include/emd/common/conversions.hpp easy_manipulation_deployment/emd_grasp_planner/test/grasp_object_test.cpp` *(fails: build/header_guard, whitespace/braces, build/include_order, etc.)*
- `uncrustify -c /tmp/uncrustify.cfg --check easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/next_point_publisher.hpp` *(fails: File size changed)*
- `colcon test --packages-select emd_dynamic_safety emd_grasp_planner` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e1eb813088331877ba446bcaf4155