### PR TITLE
Fix missing dependencies for dynamic safety and grasp execution

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_dynamic_safety/CMakeLists.txt
@@ -151,6 +151,7 @@ target_link_libraries(${PROJECT_NAME}
 
 ament_target_dependencies(${PROJECT_NAME}
   rclcpp
+  realtime_tools
 )
 
 add_library(${PROJECT_NAME}_controller

--- a/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
+find_package(trajectory_msgs REQUIRED)
 
 include_directories(
   PUBLIC
@@ -43,6 +44,7 @@ ament_target_dependencies(grasp_execution_interface
   tf2
   tf2_ros
   tf2_geometry_msgs
+  trajectory_msgs
   pluginlib
   yaml_cpp_vendor
 )
@@ -58,6 +60,7 @@ target_link_libraries(moveit_cpp_grasp_execution_interface
 
 ament_target_dependencies(moveit_cpp_grasp_execution_interface
   moveit_ros_planning_interface
+  trajectory_msgs
   #  yaml_cpp_vendor
 )
 
@@ -91,6 +94,7 @@ ament_export_dependencies(
   emd_msgs
   tf2
   tf2_ros
+  trajectory_msgs
   yaml_cpp_vendor
   tinyxml2_vendor
 )

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/grasp_execution.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/grasp_execution.hpp
@@ -31,7 +31,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "pluginlib/class_loader.hpp"
 #include "sensor_msgs/msg/joint_state.hpp"

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/utils.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/utils.hpp
@@ -28,7 +28,7 @@
 
 #include "tf2_ros/buffer.h"
 #include "tf2/impl/utils.h"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 namespace grasp_execution
 {

--- a/easy_manipulation_deployment/emd_grasp_execution/package.xml
+++ b/easy_manipulation_deployment/emd_grasp_execution/package.xml
@@ -13,6 +13,7 @@
   <depend>moveit_ros_planning_interface</depend>
   <depend>emd_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>trajectory_msgs</depend>
 
   <build_depend>pluginlib</build_depend>
   <build_depend>tf2</build_depend>

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -33,7 +33,7 @@
 #include "moveit/trajectory_processing/iterative_time_parameterization.h"
 
 #include "tf2_ros/buffer.h"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2_ros/transform_listener.h"
 #include "tf2/impl/utils.h"
 #include "tf2_eigen/tf2_eigen.h"


### PR DESCRIPTION
## Summary
- Link `emd_dynamic_safety` against `realtime_tools`
- Declare and link `trajectory_msgs` in `emd_grasp_execution`
- Prefer `tf2_geometry_msgs.hpp` over deprecated header

## Testing
- `colcon build --packages-select emd_msgs emd_dynamic_safety emd_grasp_execution emd_grasp_planner` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_688e57901ff48331b1878eefeb50c971