### PR TITLE
Fix missing tf2_geometry_msgs dependency

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_planner/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_planner/CMakeLists.txt
@@ -39,6 +39,7 @@ find_package(shape_msgs REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(cv_bridge REQUIRED) # Delete later
 find_package(visualization_msgs REQUIRED)
 
@@ -91,6 +92,7 @@ if(epd_msgs_FOUND)
         geometry_msgs
         shape_msgs
         tf2_ros
+        tf2_geometry_msgs
         message_filters
         cv_bridge #temp
         visualization_msgs)
@@ -107,6 +109,7 @@ else()
         geometry_msgs
         shape_msgs
         tf2_ros
+        tf2_geometry_msgs
         message_filters
         cv_bridge #temp
         visualization_msgs)
@@ -209,6 +212,7 @@ if(epd_msgs_FOUND)
     cv_bridge
     message_filters
     tf2_ros
+    tf2_geometry_msgs
     PCL
     octomap
   )
@@ -220,6 +224,7 @@ else()
     cv_bridge
     message_filters
     tf2_ros
+    tf2_geometry_msgs
     PCL
     octomap
   )

--- a/easy_manipulation_deployment/emd_grasp_planner/package.xml
+++ b/easy_manipulation_deployment/emd_grasp_planner/package.xml
@@ -15,6 +15,7 @@
   <depend>geometry_msgs</depend>
   <depend>shape_msgs</depend>
   <depend>emd_msgs</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Summary
- add tf2_geometry_msgs to build, target, and export dependencies for emd_grasp_planner

## Testing
- `colcon build --packages-select emd_msgs emd_grasp_planner` *(fails: Could not find package configuration file provided by "ament_cmake")*


------
https://chatgpt.com/codex/tasks/task_e_688e6f935b04833191f3ecd765be8a29