### PR TITLE
Fix tf2_geometry_msgs usage and dependencies

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/fake_grasp_pose_publisher.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/fake_grasp_pose_publisher.cpp
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include "tf2/LinearMath/Quaternion.h"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "emd_msgs/msg/grasp_task.hpp"

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/fake_grasp_pose_publisher.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/fake_grasp_pose_publisher.cpp
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include "tf2/LinearMath/Quaternion.h"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "emd_msgs/msg/grasp_task.hpp"

--- a/easy_manipulation_deployment/emd_grasp_planner/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_planner/CMakeLists.txt
@@ -41,6 +41,7 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(cv_bridge REQUIRED) # Delete later
 find_package(visualization_msgs REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 
 include_directories(
   PUBLIC
@@ -91,6 +92,7 @@ if(epd_msgs_FOUND)
         geometry_msgs
         shape_msgs
         tf2_ros
+        tf2_geometry_msgs
         message_filters
         cv_bridge #temp
         visualization_msgs)
@@ -107,6 +109,7 @@ else()
         geometry_msgs
         shape_msgs
         tf2_ros
+        tf2_geometry_msgs
         message_filters
         cv_bridge #temp
         visualization_msgs)
@@ -209,6 +212,7 @@ if(epd_msgs_FOUND)
     cv_bridge
     message_filters
     tf2_ros
+    tf2_geometry_msgs
     PCL
     octomap
   )
@@ -220,6 +224,7 @@ else()
     cv_bridge
     message_filters
     tf2_ros
+    tf2_geometry_msgs
     PCL
     octomap
   )

--- a/easy_manipulation_deployment/emd_grasp_planner/include/emd/common/conversions.hpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/include/emd/common/conversions.hpp
@@ -50,7 +50,7 @@
 #include <stdexcept>
 
 #include <tf2/transform_datatypes.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace octomap
 {

--- a/easy_manipulation_deployment/emd_grasp_planner/include/emd/grasp_planner/end_effectors/finger_gripper.hpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/include/emd/grasp_planner/end_effectors/finger_gripper.hpp
@@ -33,7 +33,7 @@
 
 // ROS2 Libraries
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 // Custom msgs
 #include <emd_msgs/msg/grasp_method.hpp>

--- a/easy_manipulation_deployment/emd_grasp_planner/include/emd/grasp_planner/end_effectors/suction_gripper.hpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/include/emd/grasp_planner/end_effectors/suction_gripper.hpp
@@ -46,7 +46,7 @@
 
 // ROS2 Libraries
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <emd_msgs/msg/grasp_method.hpp>
 
 // Other Libraries

--- a/easy_manipulation_deployment/emd_grasp_planner/include/emd/grasp_planner/grasp_object.hpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/include/emd/grasp_planner/grasp_object.hpp
@@ -53,7 +53,7 @@
 #include <string>
 #include <algorithm>
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include "shape_msgs/msg/solid_primitive.hpp"
 
 // Custom Msg

--- a/easy_manipulation_deployment/emd_grasp_planner/package.xml
+++ b/easy_manipulation_deployment/emd_grasp_planner/package.xml
@@ -15,6 +15,9 @@
   <depend>geometry_msgs</depend>
   <depend>shape_msgs</depend>
   <depend>emd_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>message_filters</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/easy_manipulation_deployment/emd_waypoint_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_waypoint_execution/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(rclcpp REQUIRED)
 find_package(jsoncpp CONFIG REQUIRED)
 find_package(emd_grasp_execution REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 
 include_directories(
   PUBLIC
@@ -30,7 +31,8 @@ add_library(waypoint_execution_interface
 ament_target_dependencies(waypoint_execution_interface
   emd_grasp_execution
   rclcpp
-  geometry_msgs)
+  geometry_msgs
+  tf2_geometry_msgs)
 
 target_link_libraries(waypoint_execution_interface
   jsoncpp_lib
@@ -55,5 +57,5 @@ ament_export_include_directories(
 
 ament_export_libraries(waypoint_execution_interface)
 ament_export_targets(export_waypoint_execution_interface HAS_LIBRARY_TARGET)
-ament_export_dependencies(jsoncpp)
+ament_export_dependencies(jsoncpp tf2_geometry_msgs)
 ament_package()

--- a/easy_manipulation_deployment/emd_waypoint_execution/include/emd/waypoint_execution/waypoint_parser.hpp
+++ b/easy_manipulation_deployment/emd_waypoint_execution/include/emd/waypoint_execution/waypoint_parser.hpp
@@ -17,7 +17,7 @@
 #include <fstream>
 #include <vector>
 #include "geometry_msgs/msg/pose_stamped.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include "json/json.h"
 #include "rclcpp/rclcpp.hpp"

--- a/easy_manipulation_deployment/emd_waypoint_execution/package.xml
+++ b/easy_manipulation_deployment/emd_waypoint_execution/package.xml
@@ -11,6 +11,9 @@
 
   <depend>rclcpp</depend>
   <depend>emd_grasp_execution</depend>
+  <depend>geometry_msgs</depend>
+  <depend>jsoncpp</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Summary
- use tf2_geometry_msgs header with .hpp extension across planner and demos
- add tf2_geometry_msgs, tf2_ros and message_filters dependencies in grasp planner and waypoint execution

## Testing
- `source /opt/ros/humble/setup.bash && colcon build --packages-select emd_dynamic_safety emd_grasp_execution emd_grasp_planner` *(fails: /opt/ros/humble/setup.bash: No such file or directory)*
- `colcon build --packages-select emd_dynamic_safety emd_grasp_execution emd_grasp_planner` *(fails: command not found: colcon)*

------
https://chatgpt.com/codex/tasks/task_e_688e6f935b04833191f3ecd765be8a29