### PR TITLE
Fix logging format string to avoid std::string conversion issue

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/src/action/default_planning_action.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/action/default_planning_action.cpp
@@ -69,13 +69,19 @@ bool GraspExecutionInterface::plan_and_execute_job(
   prompt_job_end(node_->get_logger(), result);
 
   if (!result) {
-    RCLCPP_ERROR(node_->get_logger(), "Plan to " + action_description + " failed!");
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Plan to %s failed!",
+      action_description.c_str());
     return false;
   }
 
   // ------------------- Move to point above SKU --------------------------
   if (!execute_plan("Move to " + action_description, target_id, option.planning_group)) {
-    RCLCPP_ERROR(node_->get_logger(), "Move to " + action_description + " failed!");
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Move to %s failed!",
+      action_description.c_str());
     return false;
   }
   return true;
@@ -97,13 +103,19 @@ bool GraspExecutionInterface::plan_and_execute_collision_job(
   prompt_job_end(node_->get_logger(), result);
 
   if (!result) {
-    RCLCPP_ERROR(node_->get_logger(), "Plan to " + action_description + " failed!");
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Plan to %s failed!",
+      action_description.c_str());
     return false;
   }
 
   // ------------------- Move to point above SKU --------------------------
   if (!execute_plan("Move to " + action_description, target_id, option.planning_group)) {
-    RCLCPP_ERROR(node_->get_logger(), "Move to " + action_description + " failed!");
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "Move to %s failed!",
+      action_description.c_str());
     return false;
   }
   return true;


### PR DESCRIPTION
## Summary
- fix RCLCPP_ERROR calls by converting string concatenations to format strings

## Testing
- `colcon build --packages-select emd_msgs emd_grasp_execution --event-handlers console_direct+` *(fails: Could not find package `ament_cmake`)*

------
https://chatgpt.com/codex/tasks/task_e_688f4fc374388331a9f4d0a4990d04b1