### PR TITLE
fix: port dynamic safety controller to humble

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety.hpp
@@ -29,7 +29,7 @@
 #include "emd/dynamic_safety/replanner.hpp"
 #include "emd/dynamic_safety/visualizer.hpp"
 #include "emd/profiler.hpp"
-#include "realtime_tools/realtime_buffer.h"
+#include "realtime_tools/realtime_buffer.hpp"
 
 namespace dynamic_safety
 {

--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety_trajectory_controller.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety_trajectory_controller.hpp
@@ -42,7 +42,8 @@ public:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_activate(const rclcpp_lifecycle::State & state) override;
 
-  controller_interface::return_type update() override;
+  controller_interface::return_type update(
+    const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
 protected:
   struct TimeData
@@ -59,20 +60,6 @@ protected:
   /// Override existing ones used in on_configure
   void add_new_trajectory_msg(
     const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> & traj_msg);
-
-  // Reserve vtable for bind
-  rclcpp_action::GoalResponse goal_callback(
-    const rclcpp_action::GoalUUID & uuid, std::shared_ptr<const FollowJTrajAction::Goal> goal)
-  {
-    return JointTrajectoryController::goal_callback(uuid, goal);
-  }
-
-  // Reserve vtable for bind
-  rclcpp_action::CancelResponse cancel_callback(
-    const std::shared_ptr<rclcpp_action::ServerGoalHandle<FollowJTrajAction>> goal_handle)
-  {
-    return JointTrajectoryController::cancel_callback(goal_handle);
-  }
 
   /// Override existing ones used in on_configure
   void feedback_setup_callback(

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety_trajectory_controller.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety_trajectory_controller.cpp
@@ -19,6 +19,7 @@
 #include "emd/dynamic_safety/dynamic_safety_trajectory_controller.hpp"
 #include "rclcpp_action/create_server.hpp"
 #include "rclcpp_action/server_goal_handle.hpp"
+#include <lifecycle_msgs/msg/state.hpp>
 
 namespace dynamic_safety
 {
@@ -35,40 +36,41 @@ DynamicSafetyTrajectoryController::on_configure(const rclcpp_lifecycle::State & 
   if (result ==
     rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS)
   {
+    auto node = this->get_node();
     // Load safety officer configuration
-    safety_officer_ = std::make_unique<DynamicSafety>(node_);
+    safety_officer_ = std::make_unique<DynamicSafety>(node->shared_from_this());
 
     // Remove existing subscriber and action monitor setup
-    joint_command_subscriber_.reset();
-    action_server_.reset();
+    this->joint_command_subscriber_.reset();
+    this->action_server_.reset();
 
     // Create new subscriber callback
     auto sub_callback =
       [this](const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> msg) -> void {
-        if (!validate_trajectory_msg(*msg)) {
+        if (!this->validate_trajectory_msg(*msg)) {
           return;
         }
 
         // http://wiki.ros.org/joint_trajectory_controller/UnderstandingTrajectoryReplacement
         // always replace old msg with new one for now
-        if (subscriber_is_active_) {
+        if (this->subscriber_is_active_) {
           this->add_new_trajectory_msg(msg);
         }
       };
 
-    joint_command_subscriber_ = node_->create_subscription<trajectory_msgs::msg::JointTrajectory>(
+    this->joint_command_subscriber_ = node->create_subscription<trajectory_msgs::msg::JointTrajectory>(
       "~/joint_trajectory", rclcpp::SystemDefaultsQoS(), sub_callback);
 
     using namespace std::placeholders;
-    action_server_ = rclcpp_action::create_server<FollowJTrajAction>(
-      node_->get_node_base_interface(), node_->get_node_clock_interface(),
-      node_->get_node_logging_interface(), node_->get_node_waitables_interface(),
-      std::string(node_->get_name()) + "/follow_joint_trajectory",
-      std::bind(&DynamicSafetyTrajectoryController::goal_callback, this, _1, _2),
-      std::bind(&DynamicSafetyTrajectoryController::cancel_callback, this, _1),
+    this->action_server_ = rclcpp_action::create_server<FollowJTrajAction>(
+      node->get_node_base_interface(), node->get_node_clock_interface(),
+      node->get_node_logging_interface(), node->get_node_waitables_interface(),
+      std::string(node->get_name()) + "/follow_joint_trajectory",
+      std::bind(&DynamicSafetyTrajectoryController::goal_received_callback, this, _1, _2),
+      std::bind(&DynamicSafetyTrajectoryController::goal_cancelled_callback, this, _1),
       std::bind(&DynamicSafetyTrajectoryController::feedback_setup_callback, this, _1));
 
-    safety_officer_->configure(node_);
+    safety_officer_->configure(node->shared_from_this());
     safety_officer_->set_new_trajectory_callback(
       std::bind(
         &DynamicSafetyTrajectoryController::add_new_trajectory_msg, this,
@@ -80,28 +82,30 @@ DynamicSafetyTrajectoryController::on_configure(const rclcpp_lifecycle::State & 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 DynamicSafetyTrajectoryController::on_activate(const rclcpp_lifecycle::State & state)
 {
+  auto node = this->get_node();
   TimeData time_data;
-  time_data.time = node_->now();
+  time_data.time = node->now();
   time_data.period = rclcpp::Duration(0, 0);
-  time_data.uptime = node_->now();
-  time_data_.initRT(time_data);
+  time_data.uptime = node->now();
+  this->time_data_.initRT(time_data);
   scaling_factor_.initRT(1.0);
   return JointTrajectoryController::on_activate(state);
 }
 
-controller_interface::return_type DynamicSafetyTrajectoryController::update()
+controller_interface::return_type DynamicSafetyTrajectoryController::update(
+  const rclcpp::Time & time, const rclcpp::Duration & period)
 {
-  if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+  if (this->get_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
     return controller_interface::return_type::OK;
   }
 
   auto resize_joint_trajectory_point =
     [&](trajectory_msgs::msg::JointTrajectoryPoint & point, size_t size) {
       point.positions.resize(size);
-      if (has_velocity_state_interface_) {
+      if (this->has_velocity_state_interface_) {
         point.velocities.resize(size);
       }
-      if (has_acceleration_state_interface_) {
+      if (this->has_acceleration_state_interface_) {
         point.accelerations.resize(size);
       }
     };
@@ -114,39 +118,40 @@ controller_interface::return_type DynamicSafetyTrajectoryController::update()
       error.positions[uindex] = angles::shortest_angular_distance(
         current.positions[uindex],
         desired.positions[uindex]);
-      if (has_velocity_state_interface_ && has_velocity_command_interface_) {
+      if (this->has_velocity_state_interface_ && this->has_velocity_command_interface_) {
         error.velocities[uindex] = desired.velocities[uindex] - current.velocities[uindex];
       }
-      if (has_acceleration_state_interface_ && has_acceleration_command_interface_) {
-        error.accelerations[uindex] = desired.accelerations[uindex] - current.accelerations[uindex];
+      if (this->has_acceleration_state_interface_ && this->has_acceleration_command_interface_) {
+        error.accelerations[uindex] =
+          desired.accelerations[uindex] - current.accelerations[uindex];
       }
     };
 
   // Main Speed scaling difference...
   // Adjust time with scaling factor
   TimeData time_data;
-  time_data.time = node_->now();
+  time_data.time = time;
   double scale = safety_officer_->get_scale();
   scaling_factor_.writeFromNonRT(scale);
-  rcl_duration_value_t period = (time_data.time - time_data_.readFromRT()->time).nanoseconds();
-  time_data.period = rclcpp::Duration(period) * (*scaling_factor_.readFromRT());
-  time_data.uptime = time_data_.readFromRT()->uptime + time_data.period;
-  rclcpp::Time traj_time = time_data_.readFromRT()->uptime + time_data.period;
-  time_data_.writeFromNonRT(time_data);
+  time_data.period = rclcpp::Duration::from_nanoseconds(
+    period.nanoseconds() * (*scaling_factor_.readFromRT()));
+  time_data.uptime = this->time_data_.readFromRT()->uptime + time_data.period;
+  rclcpp::Time traj_time = this->time_data_.readFromRT()->uptime + time_data.period;
+  this->time_data_.writeFromNonRT(time_data);
 
   // Check if a new external message has been received from nonRT threads
-  auto current_external_msg = traj_external_point_ptr_->get_trajectory_msg();
-  auto new_external_msg = traj_msg_external_point_ptr_.readFromRT();
+  auto current_external_msg = this->traj_external_point_ptr_->get_trajectory_msg();
+  auto new_external_msg = this->traj_msg_external_point_ptr_.readFromRT();
   if (current_external_msg != *new_external_msg) {
-    fill_partial_goal(*new_external_msg);
-    sort_to_local_joint_order(*new_external_msg);
+    this->fill_partial_goal(*new_external_msg);
+    this->sort_to_local_joint_order(*new_external_msg);
     (*new_external_msg)->header.stamp = time_data.uptime;
-    traj_external_point_ptr_->update(*new_external_msg);
+    this->traj_external_point_ptr_->update(*new_external_msg);
   }
 
   // TODO(Briancbn): Trajectory replacement.
   JointTrajectoryPoint state_current, state_desired, state_error;
-  const auto joint_num = joint_names_.size();
+  const auto joint_num = this->joint_names_.size();
   resize_joint_trajectory_point(state_current, joint_num);
 
   // Current state update
@@ -171,13 +176,13 @@ controller_interface::return_type DynamicSafetyTrajectoryController::update()
 
   // Assign values from the hardware
   // Position states always exist
-  assign_point_from_interface(state_current.positions, joint_state_interface_[0]);
+  assign_point_from_interface(state_current.positions, this->joint_state_interface_[0]);
   // velocity and acceleration states are optional
-  if (has_velocity_state_interface_) {
-    assign_point_from_interface(state_current.velocities, joint_state_interface_[1]);
+  if (this->has_velocity_state_interface_) {
+    assign_point_from_interface(state_current.velocities, this->joint_state_interface_[1]);
     // Acceleration is used only in combination with velocity
-    if (has_acceleration_state_interface_) {
-      assign_point_from_interface(state_current.accelerations, joint_state_interface_[2]);
+    if (this->has_acceleration_state_interface_) {
+      assign_point_from_interface(state_current.accelerations, this->joint_state_interface_[2]);
     } else {
       // Make empty so the property is ignored during interpolation
       state_current.accelerations.clear();
@@ -189,39 +194,39 @@ controller_interface::return_type DynamicSafetyTrajectoryController::update()
   }
 
   // currently carrying out a trajectory
-  if (traj_point_active_ptr_ && (*traj_point_active_ptr_)->has_trajectory_msg()) {
+  if (this->traj_point_active_ptr_ && (*this->traj_point_active_ptr_)->has_trajectory_msg()) {
     // if sampling the first time, set the point before you sample
-    if (!(*traj_point_active_ptr_)->is_sampled_already()) {
-      (*traj_point_active_ptr_)->set_point_before_trajectory_msg(traj_time, state_current);
+    if (!(*this->traj_point_active_ptr_)->is_sampled_already()) {
+      (*this->traj_point_active_ptr_)->set_point_before_trajectory_msg(traj_time, state_current);
       safety_officer_->start();
     }
     double current_time =
-      (traj_time - (*traj_point_active_ptr_)->get_trajectory_start_time()).seconds();
+      (traj_time - (*this->traj_point_active_ptr_)->get_trajectory_start_time()).seconds();
     safety_officer_->update_time(current_time);
-    safety_officer_->update_state(joint_names_, state_current);
+    safety_officer_->update_state(this->joint_names_, state_current);
     resize_joint_trajectory_point(state_error, joint_num);
 
     // find segment for current timestamp
     joint_trajectory_controller::TrajectoryPointConstIter start_segment_itr, end_segment_itr;
     const bool valid_point =
-      (*traj_point_active_ptr_)->sample(
+      (*this->traj_point_active_ptr_)->sample(
       traj_time, state_desired, start_segment_itr,
       end_segment_itr);
 
     if (valid_point) {
       bool abort = false;
       bool outside_goal_tolerance = false;
-      const bool before_last_point = end_segment_itr != (*traj_point_active_ptr_)->end();
+      const bool before_last_point = end_segment_itr != (*this->traj_point_active_ptr_)->end();
 
       // set values for next hardware write()
-      if (has_position_command_interface_) {
-        assign_interface_from_point(joint_command_interface_[0], state_desired.positions);
+      if (this->has_position_command_interface_) {
+        assign_interface_from_point(this->joint_command_interface_[0], state_desired.positions);
       }
-      if (has_velocity_command_interface_) {
-        assign_interface_from_point(joint_command_interface_[1], state_desired.velocities);
+      if (this->has_velocity_command_interface_) {
+        assign_interface_from_point(this->joint_command_interface_[1], state_desired.velocities);
       }
-      if (has_acceleration_command_interface_) {
-        assign_interface_from_point(joint_command_interface_[2], state_desired.accelerations);
+      if (this->has_acceleration_command_interface_) {
+        assign_interface_from_point(this->joint_command_interface_[2], state_desired.accelerations);
       }
 
       for (size_t index = 0; index < joint_num; ++index) {
@@ -229,27 +234,28 @@ controller_interface::return_type DynamicSafetyTrajectoryController::update()
         compute_error_for_joint(state_error, static_cast<int>(index), state_current, state_desired);
 
         if (before_last_point &&
-          !check_state_tolerance_per_joint(
+          !this->check_state_tolerance_per_joint(
             state_error, static_cast<int>(index),
-            default_tolerances_.state_tolerance[index], true))
+            this->default_tolerances_.state_tolerance[index], true))
         {
           abort = true;
         }
         // past the final point, check that we end up inside goal tolerance
-        if (!before_last_point && !check_state_tolerance_per_joint(
-            state_error, static_cast<int>(index), default_tolerances_.goal_state_tolerance[index],
+        if (!before_last_point && !this->check_state_tolerance_per_joint(
+            state_error, static_cast<int>(index), this->default_tolerances_.goal_state_tolerance[index],
             true))
         {
           outside_goal_tolerance = true;
         }
       }
 
-      const auto active_goal = *rt_active_goal_.readFromRT();
+      const auto active_goal = *this->rt_active_goal_.readFromRT();
       if (active_goal) {
         // send feedback
         auto feedback = std::make_shared<FollowJTrajAction::Feedback>();
-        feedback->header.stamp = node_->now();
-        feedback->joint_names = joint_names_;
+        auto node = this->get_node();
+        feedback->header.stamp = node->now();
+        feedback->joint_names = this->joint_names_;
 
         feedback->actual = state_current;
         feedback->desired = state_desired;
@@ -261,16 +267,16 @@ controller_interface::return_type DynamicSafetyTrajectoryController::update()
           auto result = std::make_shared<FollowJTrajAction::Result>();
 
           if (abort) {
-            RCLCPP_WARN(node_->get_logger(), "Aborted due to state tolerance violation");
+            RCLCPP_WARN(node->get_logger(), "Aborted due to state tolerance violation");
             result->set__error_code(FollowJTrajAction::Result::PATH_TOLERANCE_VIOLATED);
           } else if (outside_goal_tolerance) {
-            RCLCPP_WARN(node_->get_logger(), "Aborted due to goal tolerance violation");
+            RCLCPP_WARN(node->get_logger(), "Aborted due to goal tolerance violation");
             result->set__error_code(FollowJTrajAction::Result::GOAL_TOLERANCE_VIOLATED);
           }
           safety_officer_->stop();
           active_goal->setAborted(result);
 
-          rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
+          this->rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
         }
 
         // check goal tolerance
@@ -280,25 +286,27 @@ controller_interface::return_type DynamicSafetyTrajectoryController::update()
             res->set__error_code(FollowJTrajAction::Result::SUCCESSFUL);
             safety_officer_->stop();
             active_goal->setSucceeded(res);
-            rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
+            this->rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
 
-            RCLCPP_INFO(node_->get_logger(), "Goal reached, success!");
-          } else if (default_tolerances_.goal_time_tolerance != 0.0) {
+            RCLCPP_INFO(node->get_logger(), "Goal reached, success!");
+          } else if (this->default_tolerances_.goal_time_tolerance != 0.0) {
             // if we exceed goal_time_toleralance set it to aborted
-            const rclcpp::Time traj_start = (*traj_point_active_ptr_)->get_trajectory_start_time();
+            const rclcpp::Time traj_start =
+              (*this->traj_point_active_ptr_)->get_trajectory_start_time();
             const rclcpp::Time traj_end = traj_start + start_segment_itr->time_from_start;
 
             // TODO(anyone): This will break in speed scaling we have to discuss
             // how to handle the goal time when the robot scales itself down.
-            const double difference = node_->now().seconds() - traj_end.seconds();
-            if (difference > default_tolerances_.goal_time_tolerance) {
+            auto node = this->get_node();
+            const double difference = node->now().seconds() - traj_end.seconds();
+            if (difference > this->default_tolerances_.goal_time_tolerance) {
               auto result = std::make_shared<FollowJTrajAction::Result>();
               result->set__error_code(FollowJTrajAction::Result::GOAL_TOLERANCE_VIOLATED);
               safety_officer_->stop();
               active_goal->setAborted(result);
-              rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
+              this->rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
               RCLCPP_WARN(
-                node_->get_logger(), "Aborted due goal_time_tolerance exceeding by %f seconds",
+                node->get_logger(), "Aborted due goal_time_tolerance exceeding by %f seconds",
                 difference);
             }
           }
@@ -308,12 +316,12 @@ controller_interface::return_type DynamicSafetyTrajectoryController::update()
   }
   // else {
   //   TimeData time_data;
-  //   time_data.time = node_->now();
-  //   time_data.uptime = node_->now();
-  //   time_data_.writeFromNonRT(time_data);
+  //   time_data.time = node->now();
+  //   time_data.uptime = node->now();
+  //   this->time_data_.writeFromNonRT(time_data);
   // }
 
-  publish_state(state_desired, state_current, state_error);
+  this->publish_state(state_desired, state_current, state_error);
   return controller_interface::return_type::OK;
 }
 
@@ -322,7 +330,7 @@ void DynamicSafetyTrajectoryController::feedback_setup_callback(
 {
   // Update new trajectory
   {
-    preempt_active_goal();
+    this->preempt_active_goal();
     auto traj_msg =
       std::make_shared<trajectory_msgs::msg::JointTrajectory>(goal_handle->get_goal()->trajectory);
 
@@ -331,13 +339,14 @@ void DynamicSafetyTrajectoryController::feedback_setup_callback(
 
   // Update the active goal
   RealtimeGoalHandlePtr rt_goal = std::make_shared<RealtimeGoalHandle>(goal_handle);
-  rt_goal->preallocated_feedback_->joint_names = joint_names_;
+  rt_goal->preallocated_feedback_->joint_names = this->joint_names_;
   rt_goal->execute();
-  rt_active_goal_.writeFromNonRT(rt_goal);
+  this->rt_active_goal_.writeFromNonRT(rt_goal);
 
+  auto node = this->get_node();
   // Setup goal status checking timer
-  goal_handle_timer_ = node_->create_wall_timer(
-    action_monitor_period_.to_chrono<std::chrono::seconds>(),
+  this->goal_handle_timer_ = node->create_wall_timer(
+    this->action_monitor_period_.to_chrono<std::chrono::seconds>(),
     std::bind(&RealtimeGoalHandle::runNonRealtime, rt_goal));
 }
 
@@ -345,7 +354,7 @@ void DynamicSafetyTrajectoryController::add_new_trajectory_msg(
   const std::shared_ptr<trajectory_msgs::msg::JointTrajectory> & traj_msg)
 {
   safety_officer_->add_trajectory(traj_msg);
-  traj_msg_external_point_ptr_.writeFromNonRT(traj_msg);
+  JointTrajectoryController::add_new_trajectory_msg(traj_msg);
 }
 
 

--- a/easy_manipulation_deployment/emd_dynamic_safety/test/test_collision_checking.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/test/test_collision_checking.cpp
@@ -57,7 +57,7 @@ protected:
 
     // First point
     point.positions = {0, -M_PI / 4, 0, -M_PI * 3 / 4, 0, M_PI / 2, M_PI / 4};
-    point.time_from_start = rclcpp::Duration(0);
+    point.time_from_start = rclcpp::Duration::from_seconds(0.0);
     trajectory_->points.push_back(point);
 
     // Second point


### PR DESCRIPTION
## Summary
- port dynamic safety controller to Humble API
- switch to realtime_buffer.hpp and fix zero-duration construction
- update collision checking test for Humble duration API

## Testing
- `source /opt/ros/humble/setup.bash` *(fails: No such file or directory)*
- `colcon build --packages-select emd_dynamic_safety emd_grasp_execution emd_grasp_planner` *(fails: Failed to find the following files: /workspace/Easy_Manipulator_Improved/install/emd_msgs/share/emd_msgs/package.sh)*

------
https://chatgpt.com/codex/tasks/task_e_688f5296aca483318fac0874b01fec22