### PR TITLE
Port dynamic safety to ROS 2 Humble

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety.hpp
@@ -30,6 +30,7 @@
 #include "emd/dynamic_safety/visualizer.hpp"
 #include "emd/profiler.hpp"
 #include "realtime_tools/realtime_buffer.hpp"
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
 
 namespace dynamic_safety
 {
@@ -147,6 +148,9 @@ public:
    */
   void configure(
     const rclcpp::Node::SharedPtr & node);
+
+  void configure(
+    const rclcpp_lifecycle::LifecycleNode::SharedPtr & lifecycle_node);
 
   /// Add a new trajectory to activate the dynamic safety node.
   /**

--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety_trajectory_controller.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety_trajectory_controller.hpp
@@ -49,7 +49,9 @@ protected:
   struct TimeData
   {
     TimeData()
-    : time(0.0), period(0.0), uptime(0.0)
+    : time(0.0),
+      period(rclcpp::Duration::from_seconds(0.0)),
+      uptime(0.0)
     {
     }
     rclcpp::Time time;

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "emd/dynamic_safety/dynamic_safety.hpp"
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
 
 namespace dynamic_safety
 {
@@ -1051,6 +1052,12 @@ void DynamicSafety::configure(
   const rclcpp::Node::SharedPtr & node)
 {
   impl_ptr_->configure(node);
+}
+
+void DynamicSafety::configure(
+  const rclcpp_lifecycle::LifecycleNode::SharedPtr & lifecycle_node)
+{
+  impl_ptr_->configure(lifecycle_node);
 }
 
 void DynamicSafety::add_trajectory(


### PR DESCRIPTION
## Summary
- add LifecycleNode overload for DynamicSafety configuration
- update TimeData duration construction for Humble
- refactor dynamic safety trajectory controller to use public JTC APIs

## Testing
- `source /opt/ros/humble/setup.bash` *(fails: No such file or directory)*
- `colcon build --packages-select emd_dynamic_safety emd_grasp_execution emd_grasp_planner` *(fails: command not found: colcon)*

------
https://chatgpt.com/codex/tasks/task_e_688f79d433f4833189e5be65265b4db3