### PR TITLE
Add lifecycle node configure path

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety_trajectory_controller.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety_trajectory_controller.cpp
@@ -19,6 +19,7 @@
 #include "emd/dynamic_safety/dynamic_safety_trajectory_controller.hpp"
 #include "rclcpp_action/create_server.hpp"
 #include "rclcpp_action/server_goal_handle.hpp"
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
 #include <cmath>
 


### PR DESCRIPTION
## Summary
- support configuring DynamicSafety with rclcpp::Node or rclcpp_lifecycle::LifecycleNode
- factor common setup logic into templated configure_common helper
- include lifecycle node header in dynamic_safety_trajectory_controller.cpp

## Testing
- `source /opt/ros/humble/setup.bash` *(failed: No such file or directory)*
- `colcon build --packages-select emd_dynamic_safety emd_grasp_execution emd_grasp_planner` *(failed: command not found)*
- `sudo apt-get install -y ros-humble-ros-base python3-colcon-common-extensions` *(failed: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688f80b485188331b1d8ff825a61b64c