### PR TITLE
Default to humble and update python shebang

### DIFF
--- a/assets/environment/realsense2_description/tests/test_xacro.py
+++ b/assets/environment/realsense2_description/tests/test_xacro.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Validate xacro files in the package.
 

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -36,8 +36,8 @@ public:
   boost::filesystem::path workcell_path;
   Workcell workcell;
   bool success;
-  // Supported ROS distributions for ROS 1 and ROS 2 respectively. Add Humble for ROS 2.
-  std::vector < std::vector < std::string >> ros_dist {{"melodic"}, {"eloquent", "foxy", "humble"}};
+  // Supported ROS distributions for ROS 1 and ROS 2 respectively. Humble listed first for ROS 2.
+  std::vector<std::vector<std::string>> ros_dist{{"melodic"}, {"humble", "foxy", "eloquent"}};
   bool is_good_scene(boost::filesystem::path original_path, std::string scene_name);
 
   explicit MainWindow(QWidget * parent = nullptr);

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/scene_select.h
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/scene_select.h
@@ -41,8 +41,8 @@ public:
   boost::filesystem::path assets_path;
 
   Workcell workcell;
-  // Supported ROS distributions for ROS 1 and ROS 2 respectively. Add Humble for ROS 2.
-  std::vector < std::vector < std::string >> ros_dist {{"melodic"}, {"eloquent", "foxy", "humble"}};
+  // Supported ROS distributions for ROS 1 and ROS 2 respectively. Humble listed first for ROS 2.
+  std::vector<std::vector<std::string>> ros_dist{{"melodic"}, {"humble", "foxy", "eloquent"}};
   void generate_scene_package(
     boost::filesystem::path scene_filepath, std::string scene_name,
     int ros_ver);


### PR DESCRIPTION
## Summary
- prefer ROS 2 Humble as the default distribution in the workcell builder
- ensure realsense xacro test runs with Python3

## Testing
- `python3 -m pytest assets/environment/realsense2_description/tests/test_xacro.py`
- `colcon test --packages-select workcell_builder` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689212318c888331a02f1848ddabdf7e