### PR TITLE
Fix angle computation for vector math

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_planner/include/emd/common/math_functions.hpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/include/emd/common/math_functions.hpp
@@ -20,32 +20,25 @@
 #include <Eigen/Core>
 
 // For uuid
-#include "boost/uuid/uuid.hpp"
 #include "boost/uuid/random_generator.hpp"
+#include "boost/uuid/uuid.hpp"
 #include "boost/uuid/uuid_io.hpp"
 
 #include <pcl/point_types.h>
-namespace MathFunctions
-{
+namespace MathFunctions {
 
-struct Point
-{
+struct Point {
   Eigen::Vector3f reference_vector;
   Eigen::Vector3f reference_point;
   float projection_distance;
   float perpendicular_distance;
   int index;
   pcl::PointNormal pcl_npoint;
-  Point(
-    Eigen::Vector3f reference_vector_,
-    Eigen::Vector3f reference_point_,
-    float projection_distance_,
-    float perpendicular_distance_)
-  : reference_vector(reference_vector_),
-    reference_point(reference_point_),
-    projection_distance(projection_distance_),
-    perpendicular_distance(perpendicular_distance_)
-  {}
+  Point(Eigen::Vector3f reference_vector_, Eigen::Vector3f reference_point_,
+        float projection_distance_, float perpendicular_distance_)
+      : reference_vector(reference_vector_), reference_point(reference_point_),
+        projection_distance(projection_distance_),
+        perpendicular_distance(perpendicular_distance_) {}
 };
 
 /**
@@ -55,10 +48,7 @@ struct Point
  * \param[in] min Min value
  * \param[in] max Max value
  */
-float normalize(
-  const float & target,
-  const float & min,
-  const float & max);
+float normalize(const float &target, const float &min, const float &max);
 
 /**
  * Function to normalize int values
@@ -67,44 +57,40 @@ float normalize(
  * \param[in] min Min value
  * \param[in] max Max value
  */
-float normalize_int(
-  const int & target,
-  const int & min,
-  const int & max);
+float normalize_int(const int &target, const int &min, const int &max);
 
 /**
- * Function to find angle between two vectors
+ * Compute the angle between two vectors in radians.
  *
  * \param[in] vector_1 Vector 1
  * \param[in] vector_2 Vector 2
  */
-float get_angle_between_vectors(
-  const Eigen::Vector3f & vector_1,
-  const Eigen::Vector3f & vector_2);
+float get_angle_between_vectors(const Eigen::Vector3f &vector_1,
+                                const Eigen::Vector3f &vector_2);
 
 /**
- * Function to return a point in a certain direction and distance away from a base point
+ * Function to return a point in a certain direction and distance away from a
+ * base point
  *
  * \param[in] base_point Reference point from which calculations are made
- * \param[in] vector_direction Reference direction from which calcuations are made
+ * \param[in] vector_direction Reference direction from which calcuations are
+ * made
  * \param[in] distance distance from the resultant point to te base point
  */
-Eigen::Vector3f get_point_in_direction(
-  const Eigen::Vector3f & base_point,
-  const Eigen::Vector3f & vector_direction,
-  const float & distance);
+Eigen::Vector3f get_point_in_direction(const Eigen::Vector3f &base_point,
+                                       const Eigen::Vector3f &vector_direction,
+                                       const float &distance);
 
 /**
- * Function to return a target vector rotated by a certain angle about a cetain axis
+ * Function to return a target vector rotated by a certain angle about a cetain
+ * axis
  *
  * \param[in] target_vector Target vector to rotate
  * \param[in] angle Angle to rotate by in radians
  * \param[in] axis Axis about which to rotate
  */
-Eigen::Vector3f get_rotated_vector(
-  const Eigen::Vector3f & target_vector,
-  const float & angle,
-  const char & axis);
+Eigen::Vector3f get_rotated_vector(const Eigen::Vector3f &target_vector,
+                                   const float &angle, const char &axis);
 
 /**
  * Function to return a MathFunctions::Point object with given parameters
@@ -113,16 +99,15 @@ Eigen::Vector3f get_rotated_vector(
  * \param[in] vector_direction Vector direction
  * \param[in] point_on_vector Another point on the vector
  */
-MathFunctions::Point get_point_info(
-  const Eigen::Vector3f & target_point,
-  const Eigen::Vector3f & vector_direction,
-  const Eigen::Vector3f & point_on_vector);
+MathFunctions::Point get_point_info(const Eigen::Vector3f &target_point,
+                                    const Eigen::Vector3f &vector_direction,
+                                    const Eigen::Vector3f &point_on_vector);
 
 /**
  * Function to generate a random string id
  */
 std::string generate_task_id();
 
-}  // namespace MathFunctions
+} // namespace MathFunctions
 
-#endif  // EMD__GRASP_PLANNER__COMMON__MATH_FUNCTIONS_HPP_
+#endif // EMD__GRASP_PLANNER__COMMON__MATH_FUNCTIONS_HPP_

--- a/easy_manipulation_deployment/emd_grasp_planner/src/common/math_functions.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/common/math_functions.cpp
@@ -16,17 +16,16 @@
 
 #include "emd/common/math_functions.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include <algorithm>
 
-static const rclcpp::Logger & LOGGER = rclcpp::get_logger("EMD::MathFunctions");
+static const rclcpp::Logger &LOGGER = rclcpp::get_logger("EMD::MathFunctions");
 
-float MathFunctions::normalize(
-  const float & target,
-  const float & min,
-  const float & max)
-{
+float MathFunctions::normalize(const float &target, const float &min,
+                               const float &max) {
   if (min == max) {
     if (target == min) {
-      RCLCPP_WARN(LOGGER, "Possible Normalizing Error, Min, Max and target same value");
+      RCLCPP_WARN(LOGGER,
+                  "Possible Normalizing Error, Min, Max and target same value");
       return 1;
     } else {
       RCLCPP_WARN(LOGGER, "Error: Normalizing divides by zero.");
@@ -40,14 +39,12 @@ float MathFunctions::normalize(
   }
 }
 
-float MathFunctions::normalize_int(
-  const int & target,
-  const int & min,
-  const int & max)
-{
+float MathFunctions::normalize_int(const int &target, const int &min,
+                                   const int &max) {
   if (min == max) {
     if (target == min) {
-      RCLCPP_WARN(LOGGER, "Possible Normalizing Error, Min, Max and target same value");
+      RCLCPP_WARN(LOGGER,
+                  "Possible Normalizing Error, Min, Max and target same value");
       return 1;
     } else {
       RCLCPP_WARN(LOGGER, "Error: Normalizing divides by zero.");
@@ -62,50 +59,60 @@ float MathFunctions::normalize_int(
 }
 
 float MathFunctions::get_angle_between_vectors(
-  const Eigen::Vector3f & vector_1,
-  const Eigen::Vector3f & vector_2)
-{
-  return 1e-8 + std::abs((vector_1.dot(vector_2)) / (vector_1.norm() * vector_2.norm()));
+    const Eigen::Vector3f &vector_1, const Eigen::Vector3f &vector_2) {
+  float denom = vector_1.norm() * vector_2.norm();
+  if (denom == 0.0f) {
+    RCLCPP_ERROR(LOGGER, "Error: Zero-length vector supplied.");
+    throw std::invalid_argument("Zero-length vector supplied");
+  }
+  float ratio = vector_1.dot(vector_2) / denom;
+  // Clamp ratio to valid domain for acos to account for numeric inaccuracies
+  ratio = std::max(-1.0f, std::min(1.0f, ratio));
+  return std::acos(ratio);
 }
 
-Eigen::Vector3f MathFunctions::get_point_in_direction(
-  const Eigen::Vector3f & base_point,
-  const Eigen::Vector3f & vector_direction,
-  const float & distance)
-{
-  Eigen::Vector3f direction_normalized = vector_direction / vector_direction.norm();
+Eigen::Vector3f
+MathFunctions::get_point_in_direction(const Eigen::Vector3f &base_point,
+                                      const Eigen::Vector3f &vector_direction,
+                                      const float &distance) {
+  Eigen::Vector3f direction_normalized =
+      vector_direction / vector_direction.norm();
   return base_point + distance * direction_normalized;
 }
 
-MathFunctions::Point MathFunctions::get_point_info(
-  const Eigen::Vector3f & target_point,
-  const Eigen::Vector3f & vector_direction,
-  const Eigen::Vector3f & point_on_vector)
-{
+MathFunctions::Point
+MathFunctions::get_point_info(const Eigen::Vector3f &target_point,
+                              const Eigen::Vector3f &vector_direction,
+                              const Eigen::Vector3f &point_on_vector) {
   Eigen::Vector3f target_vector = target_point - point_on_vector;
   float projection_distance = vector_direction.dot(target_vector);
   Eigen::Vector3f projected_point = MathFunctions::get_point_in_direction(
-    point_on_vector, vector_direction, projection_distance);
+      point_on_vector, vector_direction, projection_distance);
   float perpendicular_distance = (projected_point - target_point).norm();
-  return Point(vector_direction, point_on_vector, projection_distance, perpendicular_distance);
+  return Point(vector_direction, point_on_vector, projection_distance,
+               perpendicular_distance);
 }
-Eigen::Vector3f MathFunctions::get_rotated_vector(
-  const Eigen::Vector3f & target_vector,
-  const float & angle,
-  const char & axis)
-{
+Eigen::Vector3f
+MathFunctions::get_rotated_vector(const Eigen::Vector3f &target_vector,
+                                  const float &angle, const char &axis) {
   Eigen::Vector3f result_vector;
   if (axis == 'x') {
     result_vector(0) = target_vector(0);
-    result_vector(1) = target_vector(1) * cos(angle) - target_vector(2) * sin(angle);
-    result_vector(2) = target_vector(1) * sin(angle) + target_vector(2) * cos(angle);
+    result_vector(1) =
+        target_vector(1) * cos(angle) - target_vector(2) * sin(angle);
+    result_vector(2) =
+        target_vector(1) * sin(angle) + target_vector(2) * cos(angle);
   } else if (axis == 'y') {
-    result_vector(0) = target_vector(0) * cos(angle) + target_vector(2) * sin(angle);
+    result_vector(0) =
+        target_vector(0) * cos(angle) + target_vector(2) * sin(angle);
     result_vector(1) = target_vector(1);
-    result_vector(2) = -target_vector(0) * sin(angle) + target_vector(2) * cos(angle);
+    result_vector(2) =
+        -target_vector(0) * sin(angle) + target_vector(2) * cos(angle);
   } else if (axis == 'z') {
-    result_vector(0) = target_vector(0) * cos(angle) - target_vector(1) * sin(angle);
-    result_vector(1) = target_vector(0) * sin(angle) + target_vector(1) * cos(angle);
+    result_vector(0) =
+        target_vector(0) * cos(angle) - target_vector(1) * sin(angle);
+    result_vector(1) =
+        target_vector(0) * sin(angle) + target_vector(1) * cos(angle);
     result_vector(2) = target_vector(2);
   } else {
     RCLCPP_ERROR(LOGGER, "Invalid axis of rotation.");
@@ -114,11 +121,10 @@ Eigen::Vector3f MathFunctions::get_rotated_vector(
   return result_vector;
 }
 
-/****************************************************************************************//**
- * Function that generates a unique ID for Grasp Tasks. Returns the unique ID
- *******************************************************************************************/
-std::string MathFunctions::generate_task_id()
-{
+/****************************************************************************************/ /**
+                                                                                            * Function that generates a unique ID for Grasp Tasks. Returns the unique ID
+                                                                                            *******************************************************************************************/
+std::string MathFunctions::generate_task_id() {
   boost::uuids::uuid uuid = boost::uuids::random_generator()();
   return boost::uuids::to_string(uuid);
 }

--- a/easy_manipulation_deployment/emd_grasp_planner/test/math_functions_test.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/test/math_functions_test.cpp
@@ -13,129 +13,113 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
 #include "emd/common/math_functions.hpp"
+#include <gtest/gtest.h>
 
-TEST(MathFunctionTest, NormalizeTest)
-{
+TEST(MathFunctionTest, NormalizeTest) {
   float result = MathFunctions::normalize(10.0, 0.0, 100.0);
   EXPECT_NEAR(result, 0.1, 0.00001);
 }
 
-TEST(MathFunctionTest, NormalizeTestMaxMinTargetEqual)
-{
+TEST(MathFunctionTest, NormalizeTestMaxMinTargetEqual) {
   float result = MathFunctions::normalize(5.5, 5.5, 5.5);
   EXPECT_NEAR(result, 1, 0.00001);
 }
 
-TEST(MathFunctionTest, NormalizeTestMinMoreThanMax)
-{
+TEST(MathFunctionTest, NormalizeTestMinMoreThanMax) {
   float result = MathFunctions::normalize(13.0, 5.6, 1.2);
   EXPECT_NEAR(result, -1, 0.00001);
 }
 
-TEST(MathFunctionTest, NormalizeTestMinEqualMax)
-{
+TEST(MathFunctionTest, NormalizeTestMinEqualMax) {
   float result = MathFunctions::normalize(2.4, 4.4, 4.4);
   EXPECT_NEAR(result, -1, 0.00001);
 }
 
-TEST(MathFunctionTest, NormalizeIntTest)
-{
+TEST(MathFunctionTest, NormalizeIntTest) {
   float result = MathFunctions::normalize_int(10, 1, 200);
   EXPECT_NEAR(result, 0.045226, 0.00001);
 }
 
-TEST(MathFunctionTest, NormalizeIntTestMaxMinTargetEqual)
-{
+TEST(MathFunctionTest, NormalizeIntTestMaxMinTargetEqual) {
   float result = MathFunctions::normalize_int(6, 6, 6);
   EXPECT_NEAR(result, 1, 0.00001);
 }
 
-TEST(MathFunctionTest, NormalizeIntTestMinMoreThanMax)
-{
+TEST(MathFunctionTest, NormalizeIntTestMinMoreThanMax) {
   float result = MathFunctions::normalize_int(22, 13, 7);
   EXPECT_NEAR(result, -1, 0.00001);
 }
 
-TEST(MathFunctionTest, NormalizeIntTestMinEqualMax)
-{
+TEST(MathFunctionTest, NormalizeIntTestMinEqualMax) {
   float result = MathFunctions::normalize_int(20, 60, 60);
   EXPECT_NEAR(result, -1, 0.00001);
 }
 
-
-TEST(MathFunctionTest, getAngleBetweenVectorsTest)
-{
+TEST(MathFunctionTest, getAngleBetweenVectorsTest) {
   Eigen::Vector3f vector_1{3, 4, 0};
   Eigen::Vector3f vector_2{4, 4, 2};
   float result = MathFunctions::get_angle_between_vectors(vector_1, vector_2);
-  EXPECT_NEAR(0.933333, result, 0.0001);
+  EXPECT_NEAR(0.367208, result, 0.0001);
 }
 
-TEST(MathFunctionTest, getPointInDirectionTestPosDir)
-{
+TEST(MathFunctionTest, getPointInDirectionTestPosDir) {
   Eigen::Vector3f direction{0, 1.0, 0};
   Eigen::Vector3f point_1{0, 3.1, 0};
-  Eigen::Vector3f point_2 = MathFunctions::get_point_in_direction(point_1, direction, 2.0);
+  Eigen::Vector3f point_2 =
+      MathFunctions::get_point_in_direction(point_1, direction, 2.0);
   EXPECT_NEAR(0, point_2(0), 0.0001);
   EXPECT_NEAR(5.1, point_2(1), 0.0001);
   EXPECT_NEAR(0, point_2(2), 0.0001);
 }
 
-TEST(MathFunctionTest, getPointInDirectionTestNegDir)
-{
+TEST(MathFunctionTest, getPointInDirectionTestNegDir) {
   Eigen::Vector3f direction{1, 0, 0};
   Eigen::Vector3f point_1{2.4, 0, 0};
-  Eigen::Vector3f point_2 = MathFunctions::get_point_in_direction(point_1, direction, -3.1);
+  Eigen::Vector3f point_2 =
+      MathFunctions::get_point_in_direction(point_1, direction, -3.1);
   EXPECT_NEAR(-0.7, point_2(0), 0.0001);
   EXPECT_NEAR(0, point_2(1), 0.0001);
   EXPECT_NEAR(0, point_2(2), 0.0001);
 }
 
-TEST(MathFunctionTest, getRotatedVectorTestXRot)
-{
+TEST(MathFunctionTest, getRotatedVectorTestXRot) {
   Eigen::Vector3f direction{0, 0, 1};
   Eigen::Vector3f direction2{1, 0, 0};
-  Eigen::Vector3f result = MathFunctions::get_rotated_vector(
-    direction, 1.57079632679, 'x');
+  Eigen::Vector3f result =
+      MathFunctions::get_rotated_vector(direction, 1.57079632679, 'x');
   EXPECT_NEAR(0, direction.dot(result), 0.0001);
   EXPECT_NEAR(0, direction2.dot(result), 0.0001);
 }
 
-TEST(MathFunctionTest, getRotatedVectorTestYRot)
-{
+TEST(MathFunctionTest, getRotatedVectorTestYRot) {
   Eigen::Vector3f direction{1, 0, 0};
   Eigen::Vector3f direction2{0, 1, 0};
-  Eigen::Vector3f result = MathFunctions::get_rotated_vector(
-    direction, 1.57079632679, 'y');
+  Eigen::Vector3f result =
+      MathFunctions::get_rotated_vector(direction, 1.57079632679, 'y');
   EXPECT_NEAR(0, direction.dot(result), 0.0001);
   EXPECT_NEAR(0, direction2.dot(result), 0.0001);
 }
 
-TEST(MathFunctionTest, getRotatedVectorTestZRot)
-{
+TEST(MathFunctionTest, getRotatedVectorTestZRot) {
   Eigen::Vector3f direction{0, 1, 0};
   Eigen::Vector3f direction2{0, 0, 1};
-  Eigen::Vector3f result = MathFunctions::get_rotated_vector(
-    direction, 1.57079632679, 'z');
+  Eigen::Vector3f result =
+      MathFunctions::get_rotated_vector(direction, 1.57079632679, 'z');
   EXPECT_NEAR(0, direction.dot(result), 0.0001);
   EXPECT_NEAR(0, direction2.dot(result), 0.0001);
 }
 
-TEST(MathFunctionTest, getRotatedVectorTestWrongRot)
-{
+TEST(MathFunctionTest, getRotatedVectorTestWrongRot) {
   Eigen::Vector3f direction{0, 1, 0};
   Eigen::Vector3f direction2{0, 0, 1};
-  EXPECT_THROW(
-    MathFunctions::get_rotated_vector(
-      direction, 1.57079632679, 'o'), std::invalid_argument);
+  EXPECT_THROW(MathFunctions::get_rotated_vector(direction, 1.57079632679, 'o'),
+               std::invalid_argument);
 }
 
-TEST(MathFunctionTest, generateTaskIdTest)
-{
+TEST(MathFunctionTest, generateTaskIdTest) {
   for (int i = 0; i < 10; i++) {
-    EXPECT_FALSE(MathFunctions::generate_task_id() == MathFunctions::generate_task_id());
+    EXPECT_FALSE(MathFunctions::generate_task_id() ==
+                 MathFunctions::generate_task_id());
   }
-
 }


### PR DESCRIPTION
## Summary
- compute true angle between vectors using acos and numeric clamping
- document new behavior and adjust unit test to expect radians

## Testing
- `colcon test` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689212457eb4833184c889b5bbdab980