### PR TITLE
Fix failing xacro tests

### DIFF
--- a/assets/environment/realsense2_description/urdf/_d415.urdf.xacro
+++ b/assets/environment/realsense2_description/urdf/_d415.urdf.xacro
@@ -9,7 +9,8 @@ aluminum peripherial evaluation case.
 
 <robot name="sensor_d415" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Includes -->
-  <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
+  <!-- Use a relative include so tests do not require ROS package lookups -->
+  <xacro:include filename="_materials.urdf.xacro" />
   
   <xacro:macro name="sensor_d415" params="parent *origin  name:=camera  use_nominal_extrinsics:=false">
     <xacro:property name="M_PI" value="3.1415926535897931" />

--- a/assets/environment/realsense2_description/urdf/_d435.urdf.xacro
+++ b/assets/environment/realsense2_description/urdf/_d435.urdf.xacro
@@ -10,7 +10,8 @@ aluminum peripherial evaluation case.
 
 <robot name="sensor_d435" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Includes -->
-  <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
+  <!-- Use a relative include so tests do not require ROS package lookups -->
+  <xacro:include filename="_materials.urdf.xacro" />
   
   <xacro:macro name="sensor_d435" params="parent *origin name:=camera use_nominal_extrinsics:=false">
     <xacro:property name="M_PI" value="3.1415926535897931" />

--- a/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro
+++ b/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro
@@ -8,8 +8,8 @@ aluminum peripherial evaluation case.
 -->
 
 <robot name="sensor_d435i" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro"/>
-  <xacro:include filename="$(find realsense2_description)/urdf/_d435i_imu_modules.urdf.xacro"/>
+  <xacro:include filename="_d435.urdf.xacro"/>
+  <xacro:include filename="_d435i_imu_modules.urdf.xacro"/>
 
   <xacro:macro name="sensor_d435i" params="parent *origin name:=camera use_nominal_extrinsics:=false">
     <xacro:sensor_d435 parent="${parent}" name="${name}" use_nominal_extrinsics="${use_nominal_extrinsics}">

--- a/assets/environment/realsense2_description/urdf/_r410.urdf.xacro
+++ b/assets/environment/realsense2_description/urdf/_r410.urdf.xacro
@@ -10,7 +10,8 @@ aluminum peripherial evaluation case.
 
 <robot name="sensor_r410" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Includes -->
-  <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
+  <!-- Use a relative include so tests do not require ROS package lookups -->
+  <xacro:include filename="_materials.urdf.xacro" />
   
   <xacro:macro name="sensor_r410" params="parent *origin  name:=camera  use_nominal_extrinsics:=false">
     <xacro:property name="M_PI" value="3.1415926535897931" />

--- a/assets/environment/realsense2_description/urdf/_r430.urdf.xacro
+++ b/assets/environment/realsense2_description/urdf/_r430.urdf.xacro
@@ -10,7 +10,8 @@ aluminum peripherial evaluation case.
 
 <robot name="sensor_r430" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Includes -->
-  <xacro:include filename="$(find realsense2_description)/urdf/_materials.urdf.xacro" />
+  <!-- Use a relative include so tests do not require ROS package lookups -->
+  <xacro:include filename="_materials.urdf.xacro" />
 
   <xacro:macro name="sensor_r430" params="parent *origin name:=camera use_nominal_extrinsics:=false">
   <xacro:property name="M_PI" value="3.1415926535897931" />

--- a/assets/environment/realsense2_description/urdf/test_d415_camera.urdf.xacro
+++ b/assets/environment/realsense2_description/urdf/test_d415_camera.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:arg name="use_nominal_extrinsics" default="false" />
-  <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro" />
+  <xacro:include filename="_d415.urdf.xacro" />
 
   <link name="base_link" />
   <xacro:sensor_d415 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">

--- a/assets/environment/realsense2_description/urdf/test_d435_camera.urdf.xacro
+++ b/assets/environment/realsense2_description/urdf/test_d435_camera.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:arg name="use_nominal_extrinsics" default="false"/>
-  <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
+  <xacro:include filename="_d435.urdf.xacro" />
   
   <link name="base_link" />
   <xacro:sensor_d435 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">

--- a/assets/environment/realsense2_description/urdf/test_d435_multiple_cameras.urdf.xacro
+++ b/assets/environment/realsense2_description/urdf/test_d435_multiple_cameras.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:arg name="use_nominal_extrinsics" default="false"/>
-  <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro" />
+  <xacro:include filename="_d435.urdf.xacro" />
 
   <link name="base_link" />
   <xacro:sensor_d435 parent="base_link" name="camera1" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">

--- a/assets/environment/realsense2_description/urdf/test_d435i_camera.urdf.xacro
+++ b/assets/environment/realsense2_description/urdf/test_d435i_camera.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <robot name="realsense2_camera" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:arg name="use_nominal_extrinsics" default="false" />
-  <xacro:include filename="$(find realsense2_description)/urdf/_d435i.urdf.xacro"/>
+  <xacro:include filename="_d435i.urdf.xacro"/>
 
   <link name="base_link" />
   <xacro:sensor_d435i parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">

--- a/assets/environment/realsense2_description/urdf/test_r410_camera.urdf.xacro
+++ b/assets/environment/realsense2_description/urdf/test_r410_camera.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:arg name="use_nominal_extrinsics" default="false"/>
-  <xacro:include filename="$(find realsense2_description)/urdf/_r410.urdf.xacro" />
+  <xacro:include filename="_r410.urdf.xacro" />
   
   <link name="base_link" />
   <xacro:sensor_r410 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">

--- a/assets/environment/realsense2_description/urdf/test_r430_camera.urdf.xacro
+++ b/assets/environment/realsense2_description/urdf/test_r430_camera.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot name="realsense2_camera" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:arg name="use_nominal_extrinsics" default="false"/>
-  <xacro:include filename="$(find realsense2_description)/urdf/_r430.urdf.xacro" />
+  <xacro:include filename="_r430.urdf.xacro" />
   
   <link name="base_link" />
   <xacro:sensor_r430 parent="base_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">


### PR DESCRIPTION
## Summary
- Make RealSense URDF xacro files use relative includes so they don't depend on ROS package lookups

## Testing
- `pytest -q`
- `PYTHONPATH=/tmp pytest assets/environment/realsense2_description/tests/test_xacro.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689212457eb4833184c889b5bbdab980