### PR TITLE
Fix YAML loading in launch scripts

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/examples/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/examples/ros2/launch/demo.launch.py
@@ -58,7 +58,7 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
     try:
         with open(absolute_file_path, 'r') as file:
-            return yaml.load(file)
+            return yaml.safe_load(file)
     except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
         print(package_path)
         print(absolute_file_path)

--- a/scenes/suction_test/launch/demo.launch.py
+++ b/scenes/suction_test/launch/demo.launch.py
@@ -58,7 +58,7 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
     try:
         with open(absolute_file_path, 'r') as file:
-            return yaml.load(file)
+            return yaml.safe_load(file)
     except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
         print(package_path)
         print(absolute_file_path)

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -58,7 +58,7 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
     try:
         with open(absolute_file_path, 'r') as file:
-            return yaml.load(file)
+            return yaml.safe_load(file)
     except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
         print(package_path)
         print(absolute_file_path)

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -58,7 +58,7 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
     try:
         with open(absolute_file_path, 'r') as file:
-            return yaml.load(file)
+            return yaml.safe_load(file)
     except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
         print(package_path)
         print(absolute_file_path)

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -58,7 +58,7 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
     try:
         with open(absolute_file_path, 'r') as file:
-            return yaml.load(file)
+            return yaml.safe_load(file)
     except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
         print(package_path)
         print(absolute_file_path)


### PR DESCRIPTION
## Summary
- use `yaml.safe_load` instead of deprecated `yaml.load` in launch scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689223e2c90c83319c735b19c719327f