### PR TITLE
Use safe YAML loading in launch scripts

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/examples/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/examples/ros2/launch/demo.launch.py
@@ -58,7 +58,11 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
     try:
         with open(absolute_file_path, 'r') as file:
-            return yaml.load(file)
+            # ``yaml.load`` without an explicit loader is deprecated and may
+            # execute arbitrary code.  ``safe_load`` only parses a restricted
+            # subset of YAML ensuring untrusted input cannot perform code
+            # execution.
+            return yaml.safe_load(file)
     except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
         print(package_path)
         print(absolute_file_path)

--- a/scenes/suction_test/launch/demo.launch.py
+++ b/scenes/suction_test/launch/demo.launch.py
@@ -58,7 +58,8 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
     try:
         with open(absolute_file_path, 'r') as file:
-            return yaml.load(file)
+            # Use ``safe_load`` to avoid executing arbitrary YAML tags.
+            return yaml.safe_load(file)
     except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
         print(package_path)
         print(absolute_file_path)

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -58,7 +58,8 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
     try:
         with open(absolute_file_path, 'r') as file:
-            return yaml.load(file)
+            # Parse YAML safely to prevent arbitrary code execution.
+            return yaml.safe_load(file)
     except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
         print(package_path)
         print(absolute_file_path)

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -58,7 +58,8 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
     try:
         with open(absolute_file_path, 'r') as file:
-            return yaml.load(file)
+            # ``yaml.safe_load`` prevents execution of arbitrary YAML tags.
+            return yaml.safe_load(file)
     except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
         print(package_path)
         print(absolute_file_path)

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -58,7 +58,8 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
     try:
         with open(absolute_file_path, 'r') as file:
-            return yaml.load(file)
+            # ``safe_load`` avoids potential code execution from YAML content.
+            return yaml.safe_load(file)
     except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
         print(package_path)
         print(absolute_file_path)


### PR DESCRIPTION
## Summary
- replace deprecated `yaml.load` with `yaml.safe_load` in all demo `launch` scripts to avoid executing arbitrary YAML tags

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689223e2c90c83319c735b19c719327f