### PR TITLE
Fix missing cmath include

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_planner/src/common/math_functions.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/common/math_functions.cpp
@@ -17,6 +17,7 @@
 #include "emd/common/math_functions.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include <algorithm>
+#include <cmath>
 
 static const rclcpp::Logger &LOGGER = rclcpp::get_logger("EMD::MathFunctions");
 
@@ -99,20 +100,20 @@ MathFunctions::get_rotated_vector(const Eigen::Vector3f &target_vector,
   if (axis == 'x') {
     result_vector(0) = target_vector(0);
     result_vector(1) =
-        target_vector(1) * cos(angle) - target_vector(2) * sin(angle);
+        target_vector(1) * std::cos(angle) - target_vector(2) * std::sin(angle);
     result_vector(2) =
-        target_vector(1) * sin(angle) + target_vector(2) * cos(angle);
+        target_vector(1) * std::sin(angle) + target_vector(2) * std::cos(angle);
   } else if (axis == 'y') {
     result_vector(0) =
-        target_vector(0) * cos(angle) + target_vector(2) * sin(angle);
+        target_vector(0) * std::cos(angle) + target_vector(2) * std::sin(angle);
     result_vector(1) = target_vector(1);
     result_vector(2) =
-        -target_vector(0) * sin(angle) + target_vector(2) * cos(angle);
+        -target_vector(0) * std::sin(angle) + target_vector(2) * std::cos(angle);
   } else if (axis == 'z') {
     result_vector(0) =
-        target_vector(0) * cos(angle) - target_vector(1) * sin(angle);
+        target_vector(0) * std::cos(angle) - target_vector(1) * std::sin(angle);
     result_vector(1) =
-        target_vector(0) * sin(angle) + target_vector(1) * cos(angle);
+        target_vector(0) * std::sin(angle) + target_vector(1) * std::cos(angle);
     result_vector(2) = target_vector(2);
   } else {
     RCLCPP_ERROR(LOGGER, "Invalid axis of rotation.");


### PR DESCRIPTION
## Summary
- include cmath for math helpers
- use std::sin and std::cos in MathFunctions

## Testing
- `pytest assets/environment/realsense2_description/tests/test_xacro.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68936270968c833190a8402826d4d256