### PR TITLE
Add tf2_eigen dependency for ROS 2 Humble compatibility

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(emd_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(tf2_eigen REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(trajectory_msgs REQUIRED)
 
@@ -44,6 +45,7 @@ ament_target_dependencies(grasp_execution_interface
   tf2
   tf2_ros
   tf2_geometry_msgs
+  tf2_eigen
   trajectory_msgs
   pluginlib
   yaml-cpp
@@ -61,6 +63,7 @@ target_link_libraries(moveit_cpp_grasp_execution_interface
 ament_target_dependencies(moveit_cpp_grasp_execution_interface
   moveit_ros_planning_interface
   trajectory_msgs
+  tf2_eigen
   #  yaml-cpp
 )
 
@@ -94,6 +97,7 @@ ament_export_dependencies(
   emd_msgs
   tf2
   tf2_ros
+  tf2_eigen
   trajectory_msgs
   yaml-cpp
   tinyxml2_vendor

--- a/easy_manipulation_deployment/emd_grasp_execution/package.xml
+++ b/easy_manipulation_deployment/emd_grasp_execution/package.xml
@@ -18,6 +18,8 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
+  <build_depend>tf2_eigen</build_depend>
+  <depend>tf2_eigen</depend>
   <depend>yaml-cpp</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -36,7 +36,7 @@
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2_ros/transform_listener.h"
 #include "tf2/impl/utils.h"
-#include "tf2_eigen/tf2_eigen.h"
+#include "tf2_eigen/tf2_eigen.hpp"
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "shape_msgs/msg/mesh.hpp"


### PR DESCRIPTION
## Summary
- replace deprecated tf2_eigen header include with modern `tf2_eigen.hpp`
- link against tf2_eigen and export it from emd_grasp_execution

## Testing
- `colcon test --packages-select emd_grasp_execution` *(fails: command not found: colcon)*

------
https://chatgpt.com/codex/tasks/task_e_68936db4778483318dd65e93dd7a0297