### PR TITLE
chore: add angles dependency for ROS 2 Humble

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_dynamic_safety/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(realtime_tools REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(joint_trajectory_controller REQUIRED)
+find_package(angles REQUIRED)
 
 find_package(moveit_core QUIET)
 
@@ -175,6 +176,7 @@ ament_target_dependencies(${PROJECT_NAME}_controller
   joint_trajectory_controller
   realtime_tools
   pluginlib
+  angles
 )
 
 # prevent pluginlib from using boost
@@ -221,5 +223,7 @@ ament_export_libraries(
   ${PROJECT_NAME}
   ${PROJECT_NAME}_controller
 )
+
+ament_export_dependencies(angles)
 
 ament_package()

--- a/easy_manipulation_deployment/emd_dynamic_safety/package.xml
+++ b/easy_manipulation_deployment/emd_dynamic_safety/package.xml
@@ -17,6 +17,7 @@
   <depend>realtime_tools</depend>
   <depend>pluginlib</depend>
   <depend>joint_trajectory_controller</depend>
+  <depend>angles</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Summary
- locate angles in dynamic safety CMake
- depend on angles in package manifest

## Testing
- `colcon test --packages-select emd_dynamic_safety` *(fails: "Failed to find the following files: ... package.sh" because package has not been built)*

------
https://chatgpt.com/codex/tasks/task_e_68936db4778483318dd65e93dd7a0297