### PR TITLE
Add executor preemption handling

### DIFF
--- a/easy_manipulation_deployment/CHANGELOG.rst
+++ b/easy_manipulation_deployment/CHANGELOG.rst
@@ -1,3 +1,7 @@
+Forthcoming
+-----------
+* Add preemption handling to executor.
+
 0.1.1 (2021-07-28)
 ------------------
 * Fixed bug that triggers Grasp Execution when no grasp plans found.

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/executor.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/executor.hpp
@@ -48,6 +48,14 @@ public:
   virtual bool run(
     const robot_trajectory::RobotTrajectory &) = 0;
 
+  /// Cancel any ongoing execution.
+  /**
+   * Default implementation does nothing. Executors that support
+   * preemption should override this method and stop any active
+   * trajectory execution.
+   */
+  virtual void cancel() {}
+
 private:
   // cppcheck-suppress unknownMacro
   RCLCPP_DISABLE_COPY(Executor)

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/executor/default_executor.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/executor/default_executor.hpp
@@ -41,6 +41,9 @@ public:
   bool run(
     const robot_trajectory::RobotTrajectory & robot_trajectory) override;
 
+  /// Cancel any ongoing trajectory execution.
+  void cancel() override;
+
 private:
   const rclcpp::Logger logger_;
   trajectory_execution_manager::TrajectoryExecutionManagerPtr trajectory_execution_manager_;

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
@@ -216,6 +216,11 @@ public:
     const robot_trajectory::RobotTrajectoryPtr & traj,
     const std::string & method = "default");
 
+  /// Cancel an active execution for a given group and method.
+  void cancel_execution(
+    const std::string & group,
+    const std::string & method = "default");
+
   bool squash_and_execute(
     const std::string & group,
     const std::string & method = "default",

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/executor/default_executor.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/executor/default_executor.cpp
@@ -63,6 +63,13 @@ bool DefaultExecutor::run(
          (status == moveit_controller_manager::ExecutionStatus::TIMED_OUT);
 }
 
+void DefaultExecutor::cancel()
+{
+  if (trajectory_execution_manager_) {
+    trajectory_execution_manager_->stopExecution();
+  }
+}
+
 }  // namespace moveit2
 
 }  // namespace grasp_execution

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -1148,6 +1148,36 @@ bool MoveitCppGraspExecution::execute(
   }
 }
 
+void MoveitCppGraspExecution::cancel_execution(
+  const std::string & group,
+  const std::string & method)
+{
+  if (method == "default" || method.empty()) {
+    if (default_executor_) {
+      default_executor_->cancel();
+    }
+  } else {
+    auto arm_it = arms_.find(group);
+    if (arm_it != arms_.end()) {
+      auto & arm = arm_it->second;
+      auto exe_it = arm.executors.find(method);
+      if (exe_it != arm.executors.end()) {
+        exe_it->second->cancel();
+      } else {
+        RCLCPP_WARN(
+          LOGGER,
+          "Method [%s] not found for group [%s], cannot cancel execution",
+          method.c_str(), group.c_str());
+      }
+    } else {
+      RCLCPP_WARN(
+        LOGGER,
+        "Group [%s] not initialized, cannot cancel execution",
+        group.c_str());
+    }
+  }
+}
+
 bool MoveitCppGraspExecution::squash_and_execute(
   const std::string & group,
   const std::string & method,


### PR DESCRIPTION
## Summary
- add generic cancel hook to execution interface
- stop trajectory execution on preempt request
- expose API for canceling executions and update changelog

## Testing
- `colcon test --packages-select emd_grasp_execution` *(fails: Has this package been built before?)*
- `colcon build --packages-select emd_grasp_execution` *(fails: missing dependency emd_msgs)*
- `colcon build --packages-select emd_msgs` *(fails: could not find ament_cmake)*
- `apt-get install -y ros-humble-ros-base` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68937182fa2c833182579c4f2f44d7cf