### PR TITLE
chore: improve humble compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 This package was tested with the [easy_perception_deployment](https://github.com/ros-industrial/easy_perception_deployment) ROS2 package, but any other perception system that provides the same ROS2 message in the right topic can work with this package as well. 
 
 It is recommended to run this package on **ROS 2 Humble** (Ubuntu 22.04).
+For installation guidance, see the [ROS 2 Humble documentation](https://docs.ros.org/en/humble/Installation.html).
 
 ---
 ## Full Documentation/Wiki

--- a/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/CMakeLists.txt
@@ -47,7 +47,6 @@ if(BUILD_TESTING)
 
   # These don't pass yet, disable them for now
   set(ament_cmake_copyright_FOUND TRUE)
-  set(ament_cmake_cpplint_FOUND TRUE)
   set(ament_cmake_flake8_FOUND TRUE)
   set(ament_cmake_uncrustify_FOUND TRUE)
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(run_grasp_execution)
 
-# Default to C++11
+# Use C++17
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(run_waypoint_execution)
 
-# Default to C++11
+# Use C++17
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()

--- a/easy_manipulation_deployment/emd_grasp_planner/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_planner/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(emd_grasp_planner)
 
-# Default to C++11
+# Use C++17
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
@@ -10,8 +10,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# add_definitions(-DEIGEN_MAX_ALIGN_BYTES=16)
-# add_definitions(-DEIGEN_UNALIGNED_VECTORIZE=0)
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
@@ -39,7 +37,7 @@ find_package(shape_msgs REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(tf2 REQUIRED)
-find_package(cv_bridge REQUIRED) # Delete later
+find_package(cv_bridge REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
@@ -94,7 +92,7 @@ if(epd_msgs_FOUND)
         tf2_ros
         tf2_geometry_msgs
         message_filters
-        cv_bridge #temp
+        cv_bridge
         visualization_msgs)
   target_compile_definitions(grasp_planning_interface
     PUBLIC
@@ -111,7 +109,7 @@ else()
         tf2_ros
         tf2_geometry_msgs
         message_filters
-        cv_bridge #temp
+        cv_bridge
         visualization_msgs)
   target_compile_definitions(grasp_planning_interface
     PUBLIC
@@ -155,7 +153,6 @@ if(BUILD_TESTING)
   # the following line skips the linter which checks for copyrights
   # uncomment the line when a copyright and license is not present in all source files
   set(ament_cmake_copyright_FOUND TRUE)
-  set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gtest(grasptest test/init_tests.cpp)

--- a/easy_manipulation_deployment/emd_grasp_planner/package.xml
+++ b/easy_manipulation_deployment/emd_grasp_planner/package.xml
@@ -31,6 +31,7 @@
   <build_depend>tf2</build_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>cv_bridge</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>


### PR DESCRIPTION
## Summary
- document ROS 2 Humble install guidance
- clean build scripts and enable cpplint
- clarify C++17 usage and cv_bridge dependency

## Testing
- `colcon build --packages-select emd_grasp_planner` *(fails: Failed to find the following files: /workspace/Easy_Manipulator_Improved/install/emd_msgs/share/emd_msgs/package.sh)*


------
https://chatgpt.com/codex/tasks/task_e_68937182fa2c833182579c4f2f44d7cf