### PR TITLE
Declare Apache license in sample package manifests

### DIFF
--- a/assets/environment/workbench_description/package.xml
+++ b/assets/environment/workbench_description/package.xml
@@ -5,7 +5,7 @@
   <version>2.0.0</version>
   <description>table_description description</description>
   <maintainer email="example@gmail.com">name</maintainer>
-  <license>TODO: License declaration</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/package.xml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/package.xml
@@ -3,9 +3,9 @@
 <package format="3">
   <name>run_dynamic_safety</name>
   <version>2.2.2</version>
-  <description>TODO: Package description</description>
+  <description>Example node demonstrating dynamic safety with MoveIt</description>
   <maintainer email="henningkayser@picknik.ai">Henning Kayser</maintainer>
-  <license>TODO: License declaration</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>moveit_common</build_depend>

--- a/easy_manipulation_deployment/workcell_builder/examples/ros1/package_example.xml
+++ b/easy_manipulation_deployment/workcell_builder/examples/ros1/package_example.xml
@@ -4,6 +4,6 @@
   <version>0.0.0</version>
   <description>The workcellexample package</description>
   <maintainer email="rosi5@todo.todo">rosi5</maintainer>
-  <license>TODO</license>
+  <license>Apache-2.0</license>
   <buildtool_depend>catkin</buildtool_depend>
 </package>

--- a/easy_manipulation_deployment/workcell_builder/examples/ros2/package_example.xml
+++ b/easy_manipulation_deployment/workcell_builder/examples/ros2/package_example.xml
@@ -5,7 +5,7 @@
   <version>2.0.0</version>
   <description>workcellexample description</description>
   <maintainer email="example@gmail.com">name</maintainer>
-  <license>TODO: License declaration</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/scenes/suction_test/package.xml
+++ b/scenes/suction_test/package.xml
@@ -5,7 +5,7 @@
   <version>2.0.0</version>
   <description>suction_test description</description>
   <maintainer email="example@gmail.com">name</maintainer>
-  <license>TODO: License declaration</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
## Summary
- replace placeholder `license` tags with Apache-2.0 across sample packages
- clarify description for dynamic safety demo node

## Testing
- `colcon build --packages-select suction_test` *(fails: Could not find a package configuration file provided by "ament_cmake")*
- `colcon test --packages-select suction_test`

------
https://chatgpt.com/codex/tasks/task_e_6893789229888331be39a6e5b45b192c