### PR TITLE
Improve exception handling across dynamic safety modules

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/src/collision_checker.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/collision_checker.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <stdexcept>
 
 #include "emd/dynamic_safety/collision_checker.hpp"
 #include "emd/interpolate.hpp"
@@ -135,8 +136,7 @@ void CollisionChecker::Impl::configure(
         robot_urdf, robot_srdf, option.collision_checking_plugin);
 #else
       RCLCPP_ERROR(LOGGER, "Framework %s not defined", option.framework.c_str());
-      // TODO(anyone): exception handling
-      return;
+      throw std::runtime_error("MoveIt framework requested but not available");
 #endif
     } else if (option.framework == "tesseract") {
 #ifdef EMD_DYNAMIC_SAFETY_TESSERACT
@@ -144,8 +144,7 @@ void CollisionChecker::Impl::configure(
         robot_urdf, robot_srdf, option.collision_checking_plugin);
 #else
       RCLCPP_ERROR(LOGGER, "Framework %s not defined", option.framework.c_str());
-      // TODO(anyone): exception handling
-      return;
+      throw std::runtime_error("Tesseract framework requested but not available");
 #endif
     }
     context->configure(option);
@@ -171,8 +170,7 @@ void CollisionChecker::Impl::add_trajectory(
 {
   if (rt->points.empty()) {
     RCLCPP_ERROR(LOGGER, "Trajectory Empty");
-    // TODO(Briancbn): Proper exception handling.
-    return;
+    throw std::invalid_argument("Provided trajectory has no points");
   }
 
   trajectory_.joint_names = rt->joint_names;
@@ -295,9 +293,11 @@ void CollisionChecker::Impl::run_once(
   double look_ahead_time,
   double & collision_time)
 {
-  if (!started_ || trajectory_.points.empty()) {
-    // TODO(Briancbn): proper exception handling
-    return;
+  if (!started_) {
+    throw std::runtime_error("Collision checker has not been started");
+  }
+  if (trajectory_.points.empty()) {
+    throw std::runtime_error("Collision checker has no trajectory to evaluate");
   }
 
   int start_index = static_cast<int>((current_time - start_offset_) / step_);

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
@@ -20,6 +20,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <stdexcept>
 
 #include "emd/dynamic_safety/dynamic_safety.hpp"
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
@@ -62,10 +63,10 @@ const Option & Option::load(const rclcpp::Node::SharedPtr & node)
         RCLCPP_ERROR(
           LOGGER, "Interrupted while waiting for %s service. Exiting.",
           description_server.c_str());
-        // TODO(anyone): exception handling.
-        break;
+        throw std::runtime_error(
+                "Failed to connect to description service " + description_server);
       }
-      RCLCPP_ERROR(
+      RCLCPP_WARN(
         LOGGER, "%s service not available, waiting again...",
         description_server.c_str());
     }
@@ -260,10 +261,11 @@ const Option & Option::load(const rclcpp::Node::SharedPtr & node)
           RCLCPP_ERROR(
             LOGGER, "Interrupted while waiting for %s service. Exiting.",
             joint_limits_parameter_server.c_str());
-          // TODO(anyone): exception handling.
-          break;
+          throw std::runtime_error(
+                  "Failed to connect to joint limits service " +
+                  joint_limits_parameter_server);
         }
-        RCLCPP_ERROR(
+        RCLCPP_WARN(
           LOGGER, "%s service not available, waiting again...",
           joint_limits_parameter_server.c_str());
       }

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/moveit/collision_checker_moveit.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/moveit/collision_checker_moveit.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 #include "emd/dynamic_safety/collision_checker_moveit.hpp"
 #include "moveit/collision_detection_fcl/collision_detector_allocator_fcl.h"
@@ -41,11 +42,11 @@ MoveitCollisionCheckerContext::MoveitCollisionCheckerContext(
   if (umodel->initString(robot_urdf)) {
     if (!smodel->initString(*umodel, robot_srdf)) {
       RCLCPP_ERROR(LOGGER, "Unable to parse SRDF");
-      // TODO(anyone): exception handling
+      throw std::runtime_error("Unable to parse SRDF");
     }
   } else {
     RCLCPP_ERROR(LOGGER, "Unable to parse URDF");
-    // TODO(anyone): exception handling
+    throw std::runtime_error("Unable to parse URDF");
   }
   // Construct planning scene
   scene_ = std::make_shared<planning_scene::PlanningScene>(umodel, smodel);

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/moveit/replanner_moveit.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/moveit/replanner_moveit.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <stdexcept>
 
 #include "emd/dynamic_safety/replanner_moveit.hpp"
 #include "moveit/robot_state/conversions.h"
@@ -39,11 +40,11 @@ MoveitReplannerContext::MoveitReplannerContext(
   if (umodel->initString(robot_urdf)) {
     if (!smodel->initString(*umodel, robot_srdf)) {
       RCLCPP_ERROR(LOGGER, "Unable to parse SRDF");
-      // TODO(anyone): exception handling
+      throw std::runtime_error("Unable to parse SRDF");
     }
   } else {
     RCLCPP_ERROR(LOGGER, "Unable to parse URDF");
-    // TODO(anyone): exception handling
+    throw std::runtime_error("Unable to parse URDF");
   }
 
   // Construct robot model
@@ -63,10 +64,11 @@ MoveitReplannerContext::MoveitReplannerContext(
       RCLCPP_ERROR(
         LOGGER, "Interrupted while waiting for %s service. Exiting.",
         option.joint_limits_parameter_server.c_str());
-      // TODO(anyone): exception handling.
-      break;
+      throw std::runtime_error(
+              "Failed to connect to joint limits service " +
+              option.joint_limits_parameter_server);
     }
-    RCLCPP_ERROR(
+    RCLCPP_WARN(
       LOGGER, "%s service not available, waiting again...",
       option.joint_limits_parameter_server.c_str());
   }
@@ -153,10 +155,11 @@ MoveitReplannerContext::MoveitReplannerContext(
         RCLCPP_ERROR(
           LOGGER, "Interrupted while waiting for %s service. Exiting.",
           option.planner_parameter_server.c_str());
-        // TODO(anyone): exception handling.
-        break;
+        throw std::runtime_error(
+                "Failed to connect to planner parameter service " +
+                option.planner_parameter_server);
       }
-      RCLCPP_ERROR(
+      RCLCPP_WARN(
         LOGGER, "%s service not available, waiting again...",
         option.planner_parameter_server.c_str());
     }

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/tesseract/replanner_tesseract.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/tesseract/replanner_tesseract.cpp
@@ -18,6 +18,7 @@
 #include <utility>
 #include <unordered_map>
 #include <vector>
+#include <stdexcept>
 
 #include "emd/dynamic_safety/replanner_tesseract.hpp"
 #include "tesseract_kinematics/kdl/kdl_fwd_kin_chain.h"
@@ -232,10 +233,11 @@ TesseractReplannerContext::TesseractReplannerContext(
       RCLCPP_ERROR(
         LOGGER, "Interrupted while waiting for %s service. Exiting.",
         option.joint_limits_parameter_server.c_str());
-      // TODO(anyone): exception handling.
-      break;
+      throw std::runtime_error(
+              "Failed to connect to joint limits service " +
+              option.joint_limits_parameter_server);
     }
-    RCLCPP_ERROR(
+    RCLCPP_WARN(
       LOGGER, "%s service not available, waiting again...",
       option.joint_limits_parameter_server.c_str());
   }

--- a/easy_manipulation_deployment/emd_dynamic_safety/test/test_hardware.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/test/test_hardware.cpp
@@ -14,6 +14,7 @@
 
 #include <experimental/filesystem>
 #include <string>
+#include <stdexcept>
 
 #include "test_hardware.hpp"
 
@@ -24,37 +25,45 @@ static const rclcpp::Logger LOGGER = rclcpp::get_logger("test_dynamic_safety.tes
 void TestHardware::load_urdf(
   const std::string & path_to_urdf)
 {
-  // TODO(anyone): exception handling
-  get_file_content(path_to_urdf, urdf_);
+  if (!get_file_content(path_to_urdf, urdf_)) {
+    throw std::runtime_error("Failed to load URDF file: " + path_to_urdf);
+  }
 }
 
 void TestHardware::load_urdf(
   const std::string & package_name,
   const std::string & path_to_urdf)
 {
-  std::experimental::filesystem::path res_path(
-    ament_index_cpp::get_package_share_directory(package_name));
-
-  // TODO(anyone): exception handling
-  load_urdf((res_path / path_to_urdf).string());
+  try {
+    std::experimental::filesystem::path res_path(
+      ament_index_cpp::get_package_share_directory(package_name));
+    load_urdf((res_path / path_to_urdf).string());
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(LOGGER, "%s", e.what());
+    throw;
+  }
 }
 
 void TestHardware::load_srdf(
   const std::string & path_to_srdf)
 {
-  // TODO(anyone): exception handling
-  get_file_content(path_to_srdf, srdf_);
+  if (!get_file_content(path_to_srdf, srdf_)) {
+    throw std::runtime_error("Failed to load SRDF file: " + path_to_srdf);
+  }
 }
 
 void TestHardware::load_srdf(
   const std::string & package_name,
   const std::string & path_to_srdf)
 {
-  std::experimental::filesystem::path res_path(
-    ament_index_cpp::get_package_share_directory(package_name));
-
-  // TODO(anyone): exception handling
-  load_srdf((res_path / path_to_srdf).string());
+  try {
+    std::experimental::filesystem::path res_path(
+      ament_index_cpp::get_package_share_directory(package_name));
+    load_srdf((res_path / path_to_srdf).string());
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(LOGGER, "%s", e.what());
+    throw;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- throw runtime errors when dynamic safety waits for unavailable services
- add explicit exceptions in collision checker, MoveIt/Tesseract replanners, and hardware loading utilities

## Testing
- `colcon test --packages-select emd_dynamic_safety` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68937cc30c208331ae25e98ffc0487ab