### PR TITLE
Add waypoint execution tests

### DIFF
--- a/easy_manipulation_deployment/emd_waypoint_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_waypoint_execution/CMakeLists.txt
@@ -14,48 +14,53 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(jsoncpp CONFIG REQUIRED)
-find_package(emd_grasp_execution REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+
+option(BUILD_WAYPOINT_EXECUTION_INTERFACE "Build waypoint execution interface" ON)
+if(BUILD_WAYPOINT_EXECUTION_INTERFACE)
+  find_package(emd_grasp_execution REQUIRED)
+endif()
 
 include_directories(
   PUBLIC
   include
 )
 
-add_library(waypoint_execution_interface
-  SHARED
-  src/waypoint_parser.cpp
-)
+if(BUILD_WAYPOINT_EXECUTION_INTERFACE)
+  add_library(waypoint_execution_interface
+    SHARED
+    src/waypoint_parser.cpp)
 
-ament_target_dependencies(waypoint_execution_interface
-  emd_grasp_execution
-  rclcpp
-  geometry_msgs
-  tf2_geometry_msgs)
+  ament_target_dependencies(waypoint_execution_interface
+    emd_grasp_execution
+    rclcpp
+    geometry_msgs
+    tf2_geometry_msgs)
 
-target_link_libraries(waypoint_execution_interface
-  jsoncpp_lib
-)
+  target_link_libraries(waypoint_execution_interface
+    jsoncpp_lib)
 
-install(
-  DIRECTORY include/
-  DESTINATION include
-)
+  install(
+    DIRECTORY include/
+    DESTINATION include)
 
-install(
-  TARGETS waypoint_execution_interface
-  EXPORT export_waypoint_execution_interface
-  RUNTIME DESTINATION bin
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  INCLUDES DESTINATION include)
+  install(
+    TARGETS waypoint_execution_interface
+    EXPORT export_waypoint_execution_interface
+    RUNTIME DESTINATION bin
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    INCLUDES DESTINATION include)
 
-ament_export_include_directories(
-  include
-)
+  ament_export_include_directories(include)
+  ament_export_libraries(waypoint_execution_interface)
+  ament_export_targets(export_waypoint_execution_interface HAS_LIBRARY_TARGET)
+  ament_export_dependencies(jsoncpp tf2_geometry_msgs)
+endif()
 
-ament_export_libraries(waypoint_execution_interface)
-ament_export_targets(export_waypoint_execution_interface HAS_LIBRARY_TARGET)
-ament_export_dependencies(jsoncpp tf2_geometry_msgs)
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  add_subdirectory(test)
+endif()
 ament_package()

--- a/easy_manipulation_deployment/emd_waypoint_execution/include/emd/waypoint_execution/waypoint_parser.hpp
+++ b/easy_manipulation_deployment/emd_waypoint_execution/include/emd/waypoint_execution/waypoint_parser.hpp
@@ -23,8 +23,11 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include "emd/waypoint_execution/waypoint.hpp"
+
+#ifndef EMD_WAYPOINT_PARSER_DISABLE_EXECUTION
 #include "emd/grasp_execution/moveit2/moveit_cpp_if.hpp"
 #include "emd/end_effector/ee_execution_interface.hpp"
+#endif
 
 #ifndef WAYPOINT_PARSER__HPP_
 #define WAYPOINT_PARSER__HPP_
@@ -50,6 +53,7 @@ bool load_waypoints(
   std::vector<emd::WayPoint> & waypoints,
   const std::string waypoint_filepath);
 
+#ifndef EMD_WAYPOINT_PARSER_DISABLE_EXECUTION
 template<typename V, typename T, typename U>
 bool process_waypoint(
   V execution_interface,
@@ -200,6 +204,7 @@ bool process_waypoints(
   }
   return true;
 }
+#endif
 
 }
 }

--- a/easy_manipulation_deployment/emd_waypoint_execution/src/waypoint_parser.cpp
+++ b/easy_manipulation_deployment/emd_waypoint_execution/src/waypoint_parser.cpp
@@ -51,9 +51,9 @@ bool emd::WayPointParser::load_waypoints(
 {
   std::filesystem::path path{waypoint_filepath};
   if (!std::filesystem::exists(path)) {
-    RCLCPP_ERROR(
+    RCLCPP_ERROR_STREAM(
       LOGGER_WAYPOINT,
-      "Action Json filepath: \"" + waypoint_filepath + " \"not found!");
+      "Action Json filepath: \"" << waypoint_filepath << " \"not found!");
     return false;
   }
   std::ifstream ifs;
@@ -64,7 +64,7 @@ bool emd::WayPointParser::load_waypoints(
   builder["collectComments"] = true;
   JSONCPP_STRING errs;
   if (!parseFromStream(builder, ifs, &root, &errs)) {
-    RCLCPP_ERROR(LOGGER_WAYPOINT, errs);
+    RCLCPP_ERROR_STREAM(LOGGER_WAYPOINT, errs);
   }
   Json::Value action_name_obj = root.get("actions", "default");
   std::vector<std::string> action_names;

--- a/easy_manipulation_deployment/emd_waypoint_execution/test/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_waypoint_execution/test/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+add_definitions(-DTEST_DIRECTORY=\"${TEST_DIR}\")
+
+ament_add_gtest(test_waypoint_parser
+  test_waypoint_parser.cpp
+  ../src/waypoint_parser.cpp)
+
+ament_target_dependencies(test_waypoint_parser
+  rclcpp
+  geometry_msgs
+  tf2_geometry_msgs)
+
+target_link_libraries(test_waypoint_parser
+  jsoncpp_lib)
+
+target_compile_definitions(test_waypoint_parser PRIVATE EMD_WAYPOINT_PARSER_DISABLE_EXECUTION)

--- a/easy_manipulation_deployment/emd_waypoint_execution/test/test_waypoint_parser.cpp
+++ b/easy_manipulation_deployment/emd_waypoint_execution/test/test_waypoint_parser.cpp
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+#include "emd/waypoint_execution/waypoint_parser.hpp"
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <cmath>
+
+TEST(WaypointParserTest, AddRPYToPose)
+{
+  geometry_msgs::msg::PoseStamped pose;
+  pose.pose.orientation.w = 1.0;
+  ASSERT_TRUE(emd::WayPointParser::internal::add_rpy_to_pose(pose, 0.0, 0.0, M_PI / 2));
+  tf2::Quaternion q;
+  tf2::fromMsg(pose.pose.orientation, q);
+  EXPECT_NEAR(q.x(), 0.0, 1e-6);
+  EXPECT_NEAR(q.y(), 0.0, 1e-6);
+  EXPECT_NEAR(q.z(), std::sin(M_PI / 4), 1e-6);
+  EXPECT_NEAR(q.w(), std::cos(M_PI / 4), 1e-6);
+}
+
+TEST(WaypointParserTest, LoadWaypoints)
+{
+  std::vector<emd::WayPoint> waypoints;
+  std::string path = std::string(TEST_DIRECTORY) + "/waypoints.json";
+  ASSERT_TRUE(emd::WayPointParser::load_waypoints(waypoints, path));
+  ASSERT_EQ(waypoints.size(), 3u);
+  EXPECT_EQ(waypoints[0].action_type, "move");
+  EXPECT_EQ(waypoints[1].action_type, "move");
+  EXPECT_EQ(waypoints[2].action_type, "collision");
+}

--- a/easy_manipulation_deployment/emd_waypoint_execution/test/waypoints.json
+++ b/easy_manipulation_deployment/emd_waypoint_execution/test/waypoints.json
@@ -1,0 +1,62 @@
+{
+  "actions" : ["move_up", "rotate", "put_down"],
+
+  "move_up" : {
+    "relative_waypoint" : true,
+    "action_type" : "move",
+    "frame_id" : "world",
+    "position":{
+      "x": 0.4,
+      "y": 0.2,
+      "z": 0.15
+    },
+    "orientation":{
+      "r": 0.0,
+      "p": 0.0,
+      "y": 0.0
+    }
+  },
+
+  "rotate" : {
+    "relative_waypoint" : true,
+    "action_type" : "move",
+    "frame_id" : "world",
+    "position":{
+      "x": 0.0,
+      "y": 0.0,
+      "z": 0.0
+    },
+    "orientation":{
+      "r": 0.0,
+      "p": 1.57,
+      "y": 0.0
+    }
+  },
+
+  "put_down" : {
+    "relative_waypoint" : true,
+    "action_type" : "collision",
+    "collision_axis" : [1,0,0],
+    "frame_id" : "world",
+    "position":{
+      "x": 0.0,
+      "y": 0.0,
+      "z": -0.2
+    },
+    "orientation":{
+      "r": 0.0,
+      "p": 0.0,
+      "y": 0.0
+    }
+  },
+
+  "release_object" : {
+    "action_type" : "release",
+    "grasp_width" : 85
+  },
+
+  "grasp_object" : {
+    "action_type" : "grasp",
+    "grasp_width" : 30
+  }
+}


### PR DESCRIPTION
## Summary
- add gtest-based waypoint parser tests
- make waypoint parser optional to ease testing
- use stream-style logging to avoid formatting errors

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68937cf599d883319aa8ae8e3b1fc192