### PR TITLE
Add Python unit test for to_urdf and enable CI coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,10 @@ jobs:
       # Run industrial_ci
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{matrix.env}}
+      - name: Run Python unit tests
+        run: |
+          pip install pytest xacro pyyaml
+          pytest easy_manipulation_deployment/workcell_builder/examples/ros2/test_to_urdf.py
       # Upload Coverage report if configured
       - name: Install dependency for Codecov
         run: sudo apt install curl git -y

--- a/easy_manipulation_deployment/workcell_builder/examples/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/examples/ros2/test_to_urdf.py
@@ -42,3 +42,14 @@ def test_to_urdf_creates_urdf_file(tmp_path):
         content = f.read()
     assert '<robot' in content
     os.remove(urdf_path)
+
+
+def test_to_urdf_respects_output_path(tmp_path):
+    xacro_file = tmp_path / 'robot.xacro'
+    xacro_file.write_text("<robot name='test'></robot>")
+    custom_path = tmp_path / 'custom.urdf'
+    result = demo.to_urdf(str(xacro_file), str(custom_path))
+    assert result == str(custom_path)
+    assert custom_path.exists()
+    with open(custom_path) as f:
+        assert '<robot' in f.read()


### PR DESCRIPTION
## Summary
- test `to_urdf` honors custom output path for generated URDFs
- run Python unit tests in GitHub Actions CI

## Testing
- `pytest -q easy_manipulation_deployment/workcell_builder/examples/ros2/test_to_urdf.py`


------
https://chatgpt.com/codex/tasks/task_e_68937cf599d883319aa8ae8e3b1fc192