### PR TITLE
Remove redundant tf2_eigen dependency

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/package.xml
+++ b/easy_manipulation_deployment/emd_grasp_execution/package.xml
@@ -18,7 +18,6 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
-  <build_depend>tf2_eigen</build_depend>
   <depend>tf2_eigen</depend>
   <depend>yaml-cpp</depend>
 


### PR DESCRIPTION
## Summary
- fix `emd_grasp_execution` package manifest by keeping only generic `tf2_eigen` dependency

## Testing
- `colcon test --packages-select emd_grasp_execution` *(fails: command not found)*
- `xmllint --noout easy_manipulation_deployment/emd_grasp_execution/package.xml`


------
https://chatgpt.com/codex/tasks/task_e_6893a2d0c61c8331b5303b7d43742087