### PR TITLE
Fix dynamic safety compilation errors

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety.hpp
@@ -73,7 +73,8 @@ struct Option
 
   Visualizer::Option visualizer_options;
 
-  const Option & load(const rclcpp::Node::SharedPtr & node);
+    template<typename NodeT>
+    const Option & load(const std::shared_ptr<NodeT> & node);
 };
 
 class DynamicSafety
@@ -128,6 +129,10 @@ public:
    */
   explicit DynamicSafety(
     rclcpp::Node::SharedPtr node);
+
+  /// Constructor for lifecycle nodes
+  explicit DynamicSafety(
+    rclcpp_lifecycle::LifecycleNode::SharedPtr lifecycle_node);
 
   /// Constructor
   /** loading options

--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/utils.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/utils.hpp
@@ -20,12 +20,12 @@
 #include <vector>
 
 #include "rclcpp/rclcpp.hpp"
-
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 namespace emd
 {
 
-template<typename T>
+template<typename T, typename NodeT>
 /// Get parameter (declare if doesn't allow overload)
 /**
  * Referenced from moveit servo.
@@ -33,7 +33,7 @@ template<typename T>
 inline void declare_or_get_param(
   T & output_value,
   const std::string & param_name,
-  const rclcpp::Node::SharedPtr & node,
+  const std::shared_ptr<NodeT> & node,
   const rclcpp::Logger & logger,
   const T & default_value = T{})
 {

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
@@ -33,7 +33,8 @@ namespace dynamic_safety
 static const rclcpp::Logger & LOGGER = rclcpp::get_logger("dynamic_safety");
 static const double LOG_RATE = 1;  // This is duration
 
-const Option & Option::load(const rclcpp::Node::SharedPtr & node)
+template<typename NodeT>
+const Option & Option::load(const std::shared_ptr<NodeT> & node)
 {
   // Load dyanmic safety parameters
   emd::declare_or_get_param<bool>(
@@ -1057,6 +1058,12 @@ double DynamicSafety::Impl::_back_track_last_collision()
 DynamicSafety::DynamicSafety(
   rclcpp::Node::SharedPtr node)
 : DynamicSafety(Option().load(node))
+{
+}
+
+DynamicSafety::DynamicSafety(
+  rclcpp_lifecycle::LifecycleNode::SharedPtr lifecycle_node)
+: DynamicSafety(Option().load(lifecycle_node))
 {
 }
 

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety_trajectory_controller.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety_trajectory_controller.cpp
@@ -86,7 +86,7 @@ DynamicSafetyTrajectoryController::on_configure(const rclcpp_lifecycle::State & 
   {
     auto node = this->get_node();
     // Load safety officer configuration
-    safety_officer_ = std::make_unique<DynamicSafety>(node->shared_from_this());
+    safety_officer_ = std::make_unique<DynamicSafety>(node);
 
     // Remove existing subscriber and action monitor setup
     this->joint_command_subscriber_.reset();
@@ -259,7 +259,7 @@ controller_interface::return_type DynamicSafetyTrajectoryController::update(
     joint_trajectory_controller::TrajectoryPointConstIter start_segment_itr, end_segment_itr;
     const bool valid_point =
       this->traj_external_point_ptr_->sample(
-      traj_time, state_desired, start_segment_itr,
+      traj_time, this->interpolation_method_, state_desired, start_segment_itr,
       end_segment_itr);
 
     if (valid_point) {


### PR DESCRIPTION
## Summary
- Generalize parameter utilities and option loading to accept both `rclcpp::Node` and lifecycle nodes
- Add lifecycle-node constructor for `DynamicSafety` and update controller to use it
- Pass interpolation method when sampling trajectories to match new API

## Testing
- `colcon build --packages-select emd_dynamic_safety` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6893b4535d448331bf5ccb775c6f2a27