### PR TITLE
Integrate yaml-cpp with grasp execution

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
@@ -23,8 +23,8 @@ find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_eigen REQUIRED)
-find_package(yaml-cpp REQUIRED)
 find_package(trajectory_msgs REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 include_directories(
   PUBLIC
@@ -48,7 +48,15 @@ ament_target_dependencies(grasp_execution_interface
   tf2_eigen
   trajectory_msgs
   pluginlib
-  yaml-cpp
+)
+target_link_libraries(grasp_execution_interface
+  PUBLIC yaml-cpp::yaml-cpp
+)
+target_include_directories(grasp_execution_interface
+  PUBLIC ${YAML_CPP_INCLUDE_DIRS}
+)
+target_compile_features(grasp_execution_interface
+  PUBLIC cxx_std_17
 )
 
 add_library(moveit_cpp_grasp_execution_interface
@@ -64,7 +72,9 @@ ament_target_dependencies(moveit_cpp_grasp_execution_interface
   moveit_ros_planning_interface
   trajectory_msgs
   tf2_eigen
-  #  yaml-cpp
+)
+target_compile_features(moveit_cpp_grasp_execution_interface
+  PUBLIC cxx_std_17
 )
 
 # Default Executor, Gripper plugin
@@ -76,6 +86,9 @@ add_library(grasp_execution_default_plugins
 ament_target_dependencies(grasp_execution_default_plugins
   moveit_ros_planning_interface
   rclcpp
+)
+target_compile_features(grasp_execution_default_plugins
+  PUBLIC cxx_std_17
 )
 
 install(

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/context.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/context.hpp
@@ -19,7 +19,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "yaml-cpp/yaml.h"
+#include <yaml-cpp/yaml.h>
 
 namespace grasp_execution
 {

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
@@ -1,7 +1,15 @@
 # Scheduler Unit Test
+find_package(yaml-cpp REQUIRED)
 ament_add_gtest(test_scheduler
   test_scheduler.cpp
 )
 target_link_libraries(test_scheduler
   grasp_execution_interface
+  yaml-cpp::yaml-cpp
+)
+target_include_directories(test_scheduler
+  PUBLIC ${YAML_CPP_INCLUDE_DIRS}
+)
+target_compile_features(test_scheduler
+  PUBLIC cxx_std_17
 )


### PR DESCRIPTION
## Summary
- link yaml-cpp to grasp_execution_interface using modern imported target and expose include dirs
- compile grasp execution targets against C++17 and update unit tests to link yaml-cpp
- include yaml-cpp header via <yaml-cpp/yaml.h>

## Testing
- `python3 -m colcon build --packages-up-to emd_grasp_execution emd_grasp_planner run_dynamic_safety --symlink-install --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` *(fails: CMake error "Findament_cmake.cmake" not found)*


------
https://chatgpt.com/codex/tasks/task_e_6893c32f6e508331a874db4e4d9dbbb9