### PR TITLE
Fix plain target_link_libraries for grasp_execution_interface

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
@@ -27,7 +27,6 @@ find_package(trajectory_msgs REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
 include_directories(
-  PUBLIC
   include
 )
 
@@ -50,13 +49,13 @@ ament_target_dependencies(grasp_execution_interface
   pluginlib
 )
 target_link_libraries(grasp_execution_interface
-  PUBLIC yaml-cpp::yaml-cpp
+  yaml-cpp::yaml-cpp
 )
 target_include_directories(grasp_execution_interface
-  PUBLIC ${YAML_CPP_INCLUDE_DIRS}
+  SYSTEM ${YAML_CPP_INCLUDE_DIRS}
 )
 target_compile_features(grasp_execution_interface
-  PUBLIC cxx_std_17
+  cxx_std_17
 )
 
 add_library(moveit_cpp_grasp_execution_interface
@@ -74,7 +73,7 @@ ament_target_dependencies(moveit_cpp_grasp_execution_interface
   tf2_eigen
 )
 target_compile_features(moveit_cpp_grasp_execution_interface
-  PUBLIC cxx_std_17
+  cxx_std_17
 )
 
 # Default Executor, Gripper plugin
@@ -88,7 +87,7 @@ ament_target_dependencies(grasp_execution_default_plugins
   rclcpp
 )
 target_compile_features(grasp_execution_default_plugins
-  PUBLIC cxx_std_17
+  cxx_std_17
 )
 
 install(

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
@@ -8,8 +8,8 @@ target_link_libraries(test_scheduler
   yaml-cpp::yaml-cpp
 )
 target_include_directories(test_scheduler
-  PUBLIC ${YAML_CPP_INCLUDE_DIRS}
+  ${YAML_CPP_INCLUDE_DIRS}
 )
 target_compile_features(test_scheduler
-  PUBLIC cxx_std_17
+  cxx_std_17
 )


### PR DESCRIPTION
## Summary
- keep grasp_execution_interface's CMake targets plain-signature
- drop visibility keywords from test_scheduler

## Testing
- `colcon build --packages-select emd_grasp_execution emd_grasp_planner emd_dynamic_safety -Wall -Wextra` *(fails: argument --packages-select: unrecognized argument: -Wall)*
- `colcon build --packages-select emd_grasp_execution emd_grasp_planner emd_dynamic_safety --cmake-args -Wall -Wextra` *(fails: emd_msgs package not built)*
- `colcon build --packages-select emd_msgs emd_grasp_execution emd_grasp_planner emd_dynamic_safety --cmake-args -Wall -Wextra` *(fails: Could not find a package configuration file provided by "ament_cmake")*

------
https://chatgpt.com/codex/tasks/task_e_689462b24a2883319b3b011deeeaa753