### PR TITLE
feat: add jazzy support

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -36,8 +36,8 @@ public:
   boost::filesystem::path workcell_path;
   Workcell workcell;
   bool success;
-  // Supported ROS distributions for ROS 1 and ROS 2 respectively. Humble listed first for ROS 2.
-  std::vector<std::vector<std::string>> ros_dist{{"melodic"}, {"humble", "foxy", "eloquent"}};
+  // Supported ROS distributions for ROS 1 and ROS 2 respectively. Jazzy and Humble listed first for ROS 2.
+  std::vector<std::vector<std::string>> ros_dist{{"melodic"}, {"jazzy", "humble", "foxy", "eloquent"}};
   bool is_good_scene(boost::filesystem::path original_path, std::string scene_name);
 
   explicit MainWindow(QWidget * parent = nullptr);

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/scene_select.h
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/scene_select.h
@@ -41,8 +41,8 @@ public:
   boost::filesystem::path assets_path;
 
   Workcell workcell;
-  // Supported ROS distributions for ROS 1 and ROS 2 respectively. Humble listed first for ROS 2.
-  std::vector<std::vector<std::string>> ros_dist{{"melodic"}, {"humble", "foxy", "eloquent"}};
+  // Supported ROS distributions for ROS 1 and ROS 2 respectively. Jazzy and Humble listed first for ROS 2.
+  std::vector<std::vector<std::string>> ros_dist{{"melodic"}, {"jazzy", "humble", "foxy", "eloquent"}};
   void generate_scene_package(
     boost::filesystem::path scene_filepath, std::string scene_name,
     int ros_ver);


### PR DESCRIPTION
## Summary
- add ROS Jazzy to supported ROS 2 distributions for workcell builder

## Testing
- `colcon build --packages-select workcell_builder --symlink-install` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_689475adbb488331bfdc1009dcb5dcdc