### PR TITLE
Handle zero-length vector in get_point_in_direction

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_planner/src/common/math_functions.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/common/math_functions.cpp
@@ -18,6 +18,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include <algorithm>
 #include <cmath>
+#include <stdexcept>
 
 static const rclcpp::Logger &LOGGER = rclcpp::get_logger("EMD::MathFunctions");
 
@@ -76,8 +77,12 @@ Eigen::Vector3f
 MathFunctions::get_point_in_direction(const Eigen::Vector3f &base_point,
                                       const Eigen::Vector3f &vector_direction,
                                       const float &distance) {
-  Eigen::Vector3f direction_normalized =
-      vector_direction / vector_direction.norm();
+  float norm = vector_direction.norm();
+  if (norm == 0.0f) {
+    RCLCPP_ERROR(LOGGER, "Error: Zero-length direction vector supplied.");
+    throw std::invalid_argument("Zero-length direction vector supplied");
+  }
+  Eigen::Vector3f direction_normalized = vector_direction / norm;
   return base_point + distance * direction_normalized;
 }
 

--- a/easy_manipulation_deployment/emd_grasp_planner/test/math_functions_test.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/test/math_functions_test.cpp
@@ -15,6 +15,7 @@
 
 #include "emd/common/math_functions.hpp"
 #include <gtest/gtest.h>
+#include <stdexcept>
 
 TEST(MathFunctionTest, NormalizeTest) {
   float result = MathFunctions::normalize(10.0, 0.0, 100.0);
@@ -81,6 +82,14 @@ TEST(MathFunctionTest, getPointInDirectionTestNegDir) {
   EXPECT_NEAR(-0.7, point_2(0), 0.0001);
   EXPECT_NEAR(0, point_2(1), 0.0001);
   EXPECT_NEAR(0, point_2(2), 0.0001);
+}
+
+TEST(MathFunctionTest, getPointInDirectionZeroVector) {
+  Eigen::Vector3f direction{0, 0, 0};
+  Eigen::Vector3f point_1{0, 0, 0};
+  EXPECT_THROW(
+      MathFunctions::get_point_in_direction(point_1, direction, 1.0),
+      std::invalid_argument);
 }
 
 TEST(MathFunctionTest, getRotatedVectorTestXRot) {


### PR DESCRIPTION
## Summary
- guard against zero-length direction vectors in `get_point_in_direction`
- add test to ensure exception is thrown for zero-length direction vectors

## Testing
- `colcon test --event-handlers console_cohesion+ --packages-up-to easy_manipulation_deployment 2>&1 | head -n 200` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894864395bc833192ed5b53db4929c1