### PR TITLE
Fix mesh id generation

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/src/grasp_execution.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/grasp_execution.cpp
@@ -120,9 +120,8 @@ std::string GraspExecutionInterface::gen_target_mesh_id(
   const std::string & task_id,
   size_t index) const
 {
-  std::string shape_type;
   std::stringstream ss;
-  ss << "#" << "box" << "-" << task_id << "-" << index;
+  ss << "#" << "mesh" << "-" << task_id << "-" << index;
   return ss.str();
 }
 


### PR DESCRIPTION
## Summary
- ensure mesh IDs are generated correctly and remove unused variable

## Testing
- `colcon test` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68948c48ef3c83319c46dab68aeca3f0