### PR TITLE
Fix cmake target usage

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
@@ -52,10 +52,10 @@ target_link_libraries(grasp_execution_interface
   yaml-cpp::yaml-cpp
 )
 target_include_directories(grasp_execution_interface
-  SYSTEM ${YAML_CPP_INCLUDE_DIRS}
+  SYSTEM PRIVATE ${YAML_CPP_INCLUDE_DIRS}
 )
 target_compile_features(grasp_execution_interface
-  cxx_std_17
+  PUBLIC cxx_std_17
 )
 
 add_library(moveit_cpp_grasp_execution_interface
@@ -73,7 +73,7 @@ ament_target_dependencies(moveit_cpp_grasp_execution_interface
   tf2_eigen
 )
 target_compile_features(moveit_cpp_grasp_execution_interface
-  cxx_std_17
+  PUBLIC cxx_std_17
 )
 
 # Default Executor, Gripper plugin
@@ -87,7 +87,7 @@ ament_target_dependencies(grasp_execution_default_plugins
   rclcpp
 )
 target_compile_features(grasp_execution_default_plugins
-  cxx_std_17
+  PUBLIC cxx_std_17
 )
 
 install(

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
@@ -8,8 +8,8 @@ target_link_libraries(test_scheduler
   yaml-cpp::yaml-cpp
 )
 target_include_directories(test_scheduler
-  ${YAML_CPP_INCLUDE_DIRS}
+  SYSTEM PRIVATE ${YAML_CPP_INCLUDE_DIRS}
 )
 target_compile_features(test_scheduler
-  cxx_std_17
+  PRIVATE cxx_std_17
 )


### PR DESCRIPTION
## Summary
- fix incorrect `target_include_directories` and `target_compile_features` usage in emd_grasp_execution
- update test CMakeLists accordingly

## Testing
- `python3 -m colcon build --packages-select emd_msgs emd_grasp_execution emd_grasp_planner emd_dynamic_safety` *(fails: Could not find a package configuration file provided by `ament_cmake`)*

------
https://chatgpt.com/codex/tasks/task_e_6894fbb0b2048331bf7f727276cfb76a