### PR TITLE
Fix yaml-cpp linking

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
@@ -49,7 +49,7 @@ ament_target_dependencies(grasp_execution_interface
   pluginlib
 )
 target_link_libraries(grasp_execution_interface
-  yaml-cpp::yaml-cpp
+  yaml-cpp
 )
 target_include_directories(grasp_execution_interface
   SYSTEM PRIVATE ${YAML_CPP_INCLUDE_DIRS}

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
@@ -5,7 +5,7 @@ ament_add_gtest(test_scheduler
 )
 target_link_libraries(test_scheduler
   grasp_execution_interface
-  yaml-cpp::yaml-cpp
+  yaml-cpp
 )
 target_include_directories(test_scheduler
   SYSTEM PRIVATE ${YAML_CPP_INCLUDE_DIRS}


### PR DESCRIPTION
## Summary
- use the correct yaml-cpp target when linking grasp execution library
- update unit test to link against yaml-cpp target

## Testing
- `colcon build --packages-select emd_grasp_execution` *(fails: command not found: colcon)*

------
https://chatgpt.com/codex/tasks/task_e_6894fdb0cbdc8331a60c6e9d7ebfe311