### PR TITLE
Fix rosdep dependency in workcell builder

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/package.xml
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/package.xml
@@ -13,7 +13,7 @@
   <build_depend>pkg-config</build_depend>
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>qt5-qmake</build_depend>
-  <exec_depend>libqt5-core</exec_depend>
+  <exec_depend>qtbase5-dev</exec_depend>
   <!--test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend-->
 


### PR DESCRIPTION
## Summary
- replace invalid libqt5-core rosdep key with qtbase5-dev

## Testing
- `colcon build --event-handlers console_cohesion+ --packages-select workcell_builder` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894ff79c41c8331881689af7127cac6