### PR TITLE
chore: remove unused variable in test

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_planner/test/suction_gripper_test.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/test/suction_gripper_test.cpp
@@ -523,7 +523,6 @@ TEST_F(SuctionGripperTest, getGripperCenterTest)
     sliced_cloud_normal, 'z');
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr projected_cloud(new pcl::PointCloud<pcl::PointXYZRGB>);
   gripper->project_cloud_to_plane_public(sliced_cloud, plane, projected_cloud);
-  int centroid_index = gripper->get_centroid_index_public(projected_cloud);
 
   //Need to update test to reflect new implementation
   // pcl::PointXYZ sample_gripper_center_x = gripper->get_gripper_center_public(


### PR DESCRIPTION
## Summary
- remove unused variable in suction gripper test

## Testing
- `colcon build --packages-select emd_grasp_execution emd_grasp_planner emd_dynamic_safety` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895005100e083318ab40cf8ba8c6ae5