### PR TITLE
Fix logging macros in end effector interface

### DIFF
--- a/easy_manipulation_deployment/emd_waypoint_execution/include/emd/end_effector/ee_execution_interface.hpp
+++ b/easy_manipulation_deployment/emd_waypoint_execution/include/emd/end_effector/ee_execution_interface.hpp
@@ -41,7 +41,9 @@ public:
       std::is_base_of<grasp_execution::moveit2::MoveitCppGraspExecution, type>::value,
       "Execution_interface should inherit from grasp_execution::GraspExecutionInterface");
     // ------------------- Attach grasp object to robot --------------------------
-    RCLCPP_INFO(LOGGER_EE_INTERFACE, "Attaching to robot ee frame: [" + ee_link + "]");
+    RCLCPP_INFO_STREAM(
+      LOGGER_EE_INTERFACE,
+      "Attaching to robot ee frame: [" << ee_link << "]");
 
     execution_interface->attach_object_to_ee(target_id, ee_link);
     return true;
@@ -57,7 +59,9 @@ public:
       std::is_base_of<grasp_execution::moveit2::MoveitCppGraspExecution, type>::value,
       "Execution_interface should inherit from grasp_execution::GraspExecutionInterface");
 
-    RCLCPP_INFO(LOGGER_EE_INTERFACE, "Detaching from robot ee frame: [" + ee_link + "]");
+    RCLCPP_INFO_STREAM(
+      LOGGER_EE_INTERFACE,
+      "Detaching from robot ee frame: [" << ee_link << "]");
     execution_interface->detach_object_from_ee(target_id, ee_link);
 
     return true;


### PR DESCRIPTION
## Summary
- avoid invalid string conversion when logging

## Testing
- `colcon build --packages-up-to emd_waypoint_execution` *(fails: Could not find a package configuration file provided by "ament_cmake")*


------
https://chatgpt.com/codex/tasks/task_e_689502a34ba883319370d756dd901f00