### PR TITLE
Fix logging string formatting for EE interface and grasp planner

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
@@ -331,7 +331,10 @@ void grasp_planner::GraspScene<T>::extract_objects_epd(
     object.grasp_target.target_pose = object.get_object_pose(camera_frame);
     this->grasp_objects.push_back(object);
   }
-  RCLCPP_INFO(LOGGER, "EPD detected " + std::to_string(this->grasp_objects.size()) + " objects.");
+  RCLCPP_INFO(
+    LOGGER,
+    "EPD detected %zu objects.",
+    this->grasp_objects.size());
 }
 #endif
 
@@ -547,7 +550,10 @@ void grasp_planner::GraspScene<T>::setup(std::string topic_name)
     this->node->get_parameter("easy_perception_deployment.epd_service").as_string());
   //this->node->get_parameter("epd_service").as_string());
 
-  RCLCPP_INFO(LOGGER, "Listening to: " + topic_name + "...");
+  RCLCPP_INFO(
+    LOGGER,
+    "Listening to: %s...",
+    topic_name.c_str());
   this->perception_sub = std::make_shared<
     message_filters::Subscriber<T>>(
     node, topic_name);

--- a/easy_manipulation_deployment/emd_waypoint_execution/include/emd/end_effector/ee_execution_interface.hpp
+++ b/easy_manipulation_deployment/emd_waypoint_execution/include/emd/end_effector/ee_execution_interface.hpp
@@ -41,7 +41,10 @@ public:
       std::is_base_of<grasp_execution::moveit2::MoveitCppGraspExecution, type>::value,
       "Execution_interface should inherit from grasp_execution::GraspExecutionInterface");
     // ------------------- Attach grasp object to robot --------------------------
-    RCLCPP_INFO(LOGGER_EE_INTERFACE, "Attaching to robot ee frame: [" + ee_link + "]");
+    RCLCPP_INFO(
+      LOGGER_EE_INTERFACE,
+      "Attaching to robot ee frame: [%s]",
+      ee_link.c_str());
 
     execution_interface->attach_object_to_ee(target_id, ee_link);
     return true;
@@ -57,7 +60,10 @@ public:
       std::is_base_of<grasp_execution::moveit2::MoveitCppGraspExecution, type>::value,
       "Execution_interface should inherit from grasp_execution::GraspExecutionInterface");
 
-    RCLCPP_INFO(LOGGER_EE_INTERFACE, "Detaching from robot ee frame: [" + ee_link + "]");
+    RCLCPP_INFO(
+      LOGGER_EE_INTERFACE,
+      "Detaching from robot ee frame: [%s]",
+      ee_link.c_str());
     execution_interface->detach_object_from_ee(target_id, ee_link);
 
     return true;


### PR DESCRIPTION
## Summary
- replace string concatenation with format specifiers in EE execution interface
- fix grasp planner logging to avoid invalid string concatenation

## Testing
- `colcon build --packages-select emd_msgs emd_grasp_execution emd_grasp_planner emd_waypoint_execution` *(failed: ament_cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_689502a34ba883319370d756dd901f00