### PR TITLE
Fix parameters in fake_grasp_pose_publisher

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/fake_grasp_pose_publisher.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/fake_grasp_pose_publisher.cpp
@@ -39,42 +39,21 @@ public:
     geometry_msgs::msg::PoseStamped grasp_pose, object_pose;
     grasp_pose.header.stamp = this->now();
 
-    declare_parameter("interface");
-    declare_parameter("frame_id");
-    declare_parameter("grasp_pose");
-    declare_parameter("object_pose");
-    declare_parameter("object_dimensions");
-    declare_parameter("delay");
-
-    std::string frame_id;
-    std::string ee_id;
-
-    std::vector<double> grasp_pose_vector{-0.1, 0.4, 0.07, M_PI, 0, 0};
-    std::vector<double> object_pose_vector{-0.1, 0.4, 0.05, 0, 0, 0};
-    std::vector<double> object_dimensions{0.02, 0.02, 0.1};
-
-    double delay;
-
-    get_parameter_or<std::string>("interface", interface, "topic");
-    get_parameter_or<std::string>("frame_id", frame_id, "base_link");
-    get_parameter_or<std::vector<double>>(
-      "grasp_pose", grasp_pose_vector, grasp_pose_vector);
-
-    get_parameter_or<std::vector<double>>(
-      "object_pose", object_pose_vector, object_pose_vector);
-
-    get_parameter_or<std::vector<double>>(
-      "object_dimensions", object_dimensions, object_dimensions);
-
-    get_parameter_or<std::string>("ee_id", ee_id, "robotiq_2f");
-
-    get_parameter_or<double>(
-      "delay", delay, 2.0);
+    interface = this->declare_parameter<std::string>("interface", "topic");
+    auto frame_id = this->declare_parameter<std::string>("frame_id", "base_link");
+    auto grasp_pose_vector = this->declare_parameter<std::vector<double>>(
+      "grasp_pose", std::vector<double>{-0.1, 0.4, 0.07, M_PI, 0, 0});
+    auto object_pose_vector = this->declare_parameter<std::vector<double>>(
+      "object_pose", std::vector<double>{-0.1, 0.4, 0.05, 0, 0, 0});
+    auto object_dimensions = this->declare_parameter<std::vector<double>>(
+      "object_dimensions", std::vector<double>{0.02, 0.02, 0.1});
+    auto ee_id = this->declare_parameter<std::string>("ee_id", "robotiq_2f");
+    double delay = this->declare_parameter<double>("delay", 2.0);
 
     if (!parse_pose_vector(grasp_pose_vector, grasp_pose.pose)) {
       RCLCPP_ERROR(
         this->get_logger(),
-        "Grasp pose should have 6 or 7 arguments, instead %u is found.",
+        "Grasp pose should have 6 or 7 arguments, instead %zu is found.",
         grasp_pose_vector.size());
       return;
     }
@@ -83,7 +62,7 @@ public:
     if (!parse_pose_vector(object_pose_vector, object_pose.pose)) {
       RCLCPP_ERROR(
         this->get_logger(),
-        "Object pose should have 6 or 7 arguments, instead %u is found.",
+        "Object pose should have 6 or 7 arguments, instead %zu is found.",
         object_pose_vector.size());
       return;
     }
@@ -91,7 +70,7 @@ public:
     if (object_dimensions.size() != 3) {
       RCLCPP_ERROR(
         this->get_logger(),
-        "Object dimension shoudl have 3 arguments, instead %u is found.",
+        "Object dimension should have 3 arguments, instead %zu is found.",
         object_dimensions.size());
       return;
     }


### PR DESCRIPTION
## Summary
- use Humble-style parameter declaration with defaults
- correct size_t format specifiers in RCLCPP logging

## Testing
- `colcon build --packages-up-to run_waypoint_execution run_grasp_planner` *(fails: ament_cmake package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68950b523ad483318ecec1d0abcbb1ed