### PR TITLE
Use plain target_link_libraries in workcell_builder

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/CMakeLists.txt
@@ -105,7 +105,7 @@ add_executable(workcell_builder
     gui/loadobjects.ui)
 
 ament_target_dependencies(workcell_builder rclcpp ament_index_cpp)
-target_link_libraries(workcell_builder PRIVATE Qt5::Widgets ${Boost_LIBRARIES} yaml-cpp)
+target_link_libraries(workcell_builder Qt5::Widgets ${Boost_LIBRARIES} yaml-cpp)
 target_include_directories(workcell_builder PUBLIC ${Boost_INCLUDE_DIRS})
 
 


### PR DESCRIPTION
## Summary
- fix `target_link_libraries` call in workcell_builder to use plain signature

## Testing
- `~/.pyenv/versions/3.12.10/bin/colcon build --packages-select workcell_builder` *(fails: Could not find package configuration file provided by `ament_cmake`)*

------
https://chatgpt.com/codex/tasks/task_e_6895b83f93708331abc25c7aea801a4f