### PR TITLE
Fix MoveIt example scenes and gripper config

### DIFF
--- a/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf
+++ b/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf
@@ -10,7 +10,6 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="gripper">
-        <joint name="kinova_robotiq_coupler_joint" />
         <joint name="gripper_base_joint" />
         <joint name="gripper_finger1_inner_knuckle_joint" />
         <joint name="gripper_finger1_finger_tip_joint" />
@@ -22,7 +21,6 @@
         <joint name="gripper_finger2_finger_joint" />
     </group>
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
-    <virtual_joint name="world_joint" type="fixed" parent_frame="world" child_link="gripper_root_link" />
     <!--PASSIVE JOINT: Purpose: this element is used to mark joints that are not actuated-->
     <passive_joint name="gripper_finger1_inner_knuckle_joint" />
     <passive_joint name="gripper_finger1_finger_tip_joint" />
@@ -38,8 +36,6 @@
     <disable_collisions link1="gripper_base_link" link2="gripper_finger2_finger_tip_link" reason="Never" />
     <disable_collisions link1="gripper_base_link" link2="gripper_finger2_inner_knuckle_link" reason="Adjacent" />
     <disable_collisions link1="gripper_base_link" link2="gripper_finger2_knuckle_link" reason="Adjacent" />
-    <disable_collisions link1="gripper_base_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_base_link" link2="robotiq_coupler_link" reason="Adjacent" />
     <disable_collisions link1="gripper_finger1_finger_link" link2="gripper_finger1_finger_tip_link" reason="Default" />
     <disable_collisions link1="gripper_finger1_finger_link" link2="gripper_finger1_inner_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_finger_link" link2="gripper_finger1_knuckle_link" reason="Adjacent" />
@@ -47,41 +43,24 @@
     <disable_collisions link1="gripper_finger1_finger_link" link2="gripper_finger2_finger_tip_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_finger_link" link2="gripper_finger2_inner_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_finger_link" link2="gripper_finger2_knuckle_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_finger_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_finger_link" link2="robotiq_coupler_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_finger_tip_link" link2="gripper_finger1_inner_knuckle_link" reason="Adjacent" />
     <disable_collisions link1="gripper_finger1_finger_tip_link" link2="gripper_finger1_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_finger_tip_link" link2="gripper_finger2_finger_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_finger_tip_link" link2="gripper_finger2_inner_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_finger_tip_link" link2="gripper_finger2_knuckle_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_finger_tip_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_finger_tip_link" link2="robotiq_coupler_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_inner_knuckle_link" link2="gripper_finger1_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_inner_knuckle_link" link2="gripper_finger2_finger_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_inner_knuckle_link" link2="gripper_finger2_finger_tip_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_inner_knuckle_link" link2="gripper_finger2_inner_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_inner_knuckle_link" link2="gripper_finger2_knuckle_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_inner_knuckle_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_inner_knuckle_link" link2="robotiq_coupler_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_knuckle_link" link2="gripper_finger2_finger_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_knuckle_link" link2="gripper_finger2_finger_tip_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_knuckle_link" link2="gripper_finger2_inner_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_knuckle_link" link2="gripper_finger2_knuckle_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_knuckle_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_knuckle_link" link2="robotiq_coupler_link" reason="Never" />
     <disable_collisions link1="gripper_finger2_finger_link" link2="gripper_finger2_finger_tip_link" reason="Default" />
     <disable_collisions link1="gripper_finger2_finger_link" link2="gripper_finger2_inner_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger2_finger_link" link2="gripper_finger2_knuckle_link" reason="Adjacent" />
-    <disable_collisions link1="gripper_finger2_finger_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger2_finger_link" link2="robotiq_coupler_link" reason="Never" />
     <disable_collisions link1="gripper_finger2_finger_tip_link" link2="gripper_finger2_inner_knuckle_link" reason="Adjacent" />
     <disable_collisions link1="gripper_finger2_finger_tip_link" link2="gripper_finger2_knuckle_link" reason="Never" />
-    <disable_collisions link1="gripper_finger2_finger_tip_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger2_finger_tip_link" link2="robotiq_coupler_link" reason="Never" />
     <disable_collisions link1="gripper_finger2_inner_knuckle_link" link2="gripper_finger2_knuckle_link" reason="Never" />
-    <disable_collisions link1="gripper_finger2_inner_knuckle_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger2_inner_knuckle_link" link2="robotiq_coupler_link" reason="Never" />
-    <disable_collisions link1="gripper_finger2_knuckle_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger2_knuckle_link" link2="robotiq_coupler_link" reason="Never" />
-    <disable_collisions link1="gripper_root_link" link2="robotiq_coupler_link" reason="Adjacent" />
 </robot>

--- a/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf.xacro
+++ b/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf.xacro
@@ -11,7 +11,6 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="gripper">
-        <joint name="kinova_robotiq_coupler_joint" />
         <joint name="gripper_base_joint" />
         <joint name="gripper_finger1_inner_knuckle_joint" />
         <joint name="gripper_finger1_finger_tip_joint" />
@@ -23,7 +22,6 @@
         <joint name="gripper_finger2_finger_joint" />
     </group>
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
-    <!--virtual_joint name="world_joint" type="fixed" parent_frame="world" child_link="gripper_root_link" /-->
 
     <!--PASSIVE JOINT: Purpose: this element is used to mark joints that are not actuated-->
     <passive_joint name="gripper_finger1_inner_knuckle_joint" />
@@ -40,8 +38,6 @@
     <disable_collisions link1="gripper_base_link" link2="gripper_finger2_finger_tip_link" reason="Never" />
     <disable_collisions link1="gripper_base_link" link2="gripper_finger2_inner_knuckle_link" reason="Adjacent" />
     <disable_collisions link1="gripper_base_link" link2="gripper_finger2_knuckle_link" reason="Adjacent" />
-    <disable_collisions link1="gripper_base_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_base_link" link2="robotiq_coupler_link" reason="Adjacent" />
     <disable_collisions link1="gripper_finger1_finger_link" link2="gripper_finger1_finger_tip_link" reason="Default" />
     <disable_collisions link1="gripper_finger1_finger_link" link2="gripper_finger1_inner_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_finger_link" link2="gripper_finger1_knuckle_link" reason="Adjacent" />
@@ -49,42 +45,25 @@
     <disable_collisions link1="gripper_finger1_finger_link" link2="gripper_finger2_finger_tip_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_finger_link" link2="gripper_finger2_inner_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_finger_link" link2="gripper_finger2_knuckle_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_finger_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_finger_link" link2="robotiq_coupler_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_finger_tip_link" link2="gripper_finger1_inner_knuckle_link" reason="Adjacent" />
     <disable_collisions link1="gripper_finger1_finger_tip_link" link2="gripper_finger1_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_finger_tip_link" link2="gripper_finger2_finger_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_finger_tip_link" link2="gripper_finger2_inner_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_finger_tip_link" link2="gripper_finger2_knuckle_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_finger_tip_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_finger_tip_link" link2="robotiq_coupler_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_inner_knuckle_link" link2="gripper_finger1_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_inner_knuckle_link" link2="gripper_finger2_finger_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_inner_knuckle_link" link2="gripper_finger2_finger_tip_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_inner_knuckle_link" link2="gripper_finger2_inner_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_inner_knuckle_link" link2="gripper_finger2_knuckle_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_inner_knuckle_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_inner_knuckle_link" link2="robotiq_coupler_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_knuckle_link" link2="gripper_finger2_finger_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_knuckle_link" link2="gripper_finger2_finger_tip_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_knuckle_link" link2="gripper_finger2_inner_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger1_knuckle_link" link2="gripper_finger2_knuckle_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_knuckle_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger1_knuckle_link" link2="robotiq_coupler_link" reason="Never" />
     <disable_collisions link1="gripper_finger2_finger_link" link2="gripper_finger2_finger_tip_link" reason="Default" />
     <disable_collisions link1="gripper_finger2_finger_link" link2="gripper_finger2_inner_knuckle_link" reason="Never" />
     <disable_collisions link1="gripper_finger2_finger_link" link2="gripper_finger2_knuckle_link" reason="Adjacent" />
-    <disable_collisions link1="gripper_finger2_finger_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger2_finger_link" link2="robotiq_coupler_link" reason="Never" />
     <disable_collisions link1="gripper_finger2_finger_tip_link" link2="gripper_finger2_inner_knuckle_link" reason="Adjacent" />
     <disable_collisions link1="gripper_finger2_finger_tip_link" link2="gripper_finger2_knuckle_link" reason="Never" />
-    <disable_collisions link1="gripper_finger2_finger_tip_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger2_finger_tip_link" link2="robotiq_coupler_link" reason="Never" />
     <disable_collisions link1="gripper_finger2_inner_knuckle_link" link2="gripper_finger2_knuckle_link" reason="Never" />
-    <disable_collisions link1="gripper_finger2_inner_knuckle_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger2_inner_knuckle_link" link2="robotiq_coupler_link" reason="Never" />
-    <disable_collisions link1="gripper_finger2_knuckle_link" link2="gripper_root_link" reason="Never" />
-    <disable_collisions link1="gripper_finger2_knuckle_link" link2="robotiq_coupler_link" reason="Never" />
-    <disable_collisions link1="gripper_root_link" link2="robotiq_coupler_link" reason="Adjacent" />
 </xacro:macro>
 </robot>

--- a/assets/robots/universal_robot/ur10_moveit_config/config/ur10.ros2_control.xacro
+++ b/assets/robots/universal_robot/ur10_moveit_config/config/ur10.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="ur10_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>

--- a/assets/robots/universal_robot/ur3_moveit_config/config/ur3.ros2_control.xacro
+++ b/assets/robots/universal_robot/ur3_moveit_config/config/ur3.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="ur3_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>

--- a/assets/robots/universal_robot/ur5_moveit_config/config/ur5.ros2_control.xacro
+++ b/assets/robots/universal_robot/ur5_moveit_config/config/ur5.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="ur5_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>

--- a/scenes/ur5_2f_test/CMakeLists.txt
+++ b/scenes/ur5_2f_test/CMakeLists.txt
@@ -13,6 +13,12 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_runtime REQUIRED)
+find_package(ur_description REQUIRED)
+find_package(ur5_moveit_config REQUIRED)
+find_package(robotiq_85_description REQUIRED)
+find_package(robotiq_85_moveit_config REQUIRED)
+find_package(realsense2_description REQUIRED)
+find_package(table_description REQUIRED)
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
@@ -20,4 +26,11 @@ install(DIRECTORY launch
 install(DIRECTORY urdf
   DESTINATION share/${PROJECT_NAME}
 )
+ament_export_dependencies(
+  ur_description
+  ur5_moveit_config
+  robotiq_85_description
+  robotiq_85_moveit_config
+  realsense2_description
+  table_description)
 ament_package()

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -20,7 +20,7 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
-scene_pkg = 'ur5_test'
+scene_pkg = 'ur5_2f_test'
 robot_base_link = 'base_link'
 robot_moveit_pkg = 'ur5_moveit_config'
 
@@ -93,7 +93,8 @@ def generate_launch_description():
                      output='log',
                      arguments=['-d', rviz_config_file],
                      parameters=[robot_description,
-                                 robot_description_semantic])
+                                 robot_description_semantic,
+                                 robot_description_kinematics])
     # Publish base link TF
     static_tf = Node(package='tf2_ros',
                      executable='static_transform_publisher',

--- a/scenes/ur5_2f_test/package.xml
+++ b/scenes/ur5_2f_test/package.xml
@@ -9,6 +9,13 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>ur_description</exec_depend>
+  <exec_depend>ur5_moveit_config</exec_depend>
+  <exec_depend>robotiq_85_description</exec_depend>
+  <exec_depend>robotiq_85_moveit_config</exec_depend>
+  <exec_depend>realsense2_description</exec_depend>
+  <exec_depend>table_description</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/scenes/ur5_2f_test/urdf/arm_hand.srdf.xacro
+++ b/scenes/ur5_2f_test/urdf/arm_hand.srdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="ur5_test">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="ur5_2f_test">
 
   <xacro:include filename="$(find ur5_moveit_config)/config/ur5.srdf.xacro" />
 

--- a/scenes/ur5_2f_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_2f_test/urdf/scene.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?> 
 
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="ur5_test">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="ur5_2f_test">
 
  <link name="world"/>
 
@@ -23,7 +23,7 @@
 	<origin xyz="0 0 0" rpy="1.5707 -1.5707 0"/>
  </xacro:robotiq_85_gripper>
 
- <xacro:include filename="$(find workbench_description)/urdf/table.urdf.xacro"/>
+ <xacro:include filename="$(find table_description)/urdf/table.urdf.xacro"/>
  <xacro:table prefix="" parent="world">
 	<origin xyz="0 0 0" rpy="0 0 0"/>
  </xacro:table>

--- a/scenes/ur5_3f_test/CMakeLists.txt
+++ b/scenes/ur5_3f_test/CMakeLists.txt
@@ -13,6 +13,12 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_runtime REQUIRED)
+find_package(ur_description REQUIRED)
+find_package(ur5_moveit_config REQUIRED)
+find_package(robotiq_3f_gripper_description REQUIRED)
+find_package(robotiq_3f_moveit_config REQUIRED)
+find_package(realsense2_description REQUIRED)
+find_package(table_description REQUIRED)
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
@@ -20,4 +26,11 @@ install(DIRECTORY launch
 install(DIRECTORY urdf
   DESTINATION share/${PROJECT_NAME}
 )
+ament_export_dependencies(
+  ur_description
+  ur5_moveit_config
+  robotiq_3f_gripper_description
+  robotiq_3f_moveit_config
+  realsense2_description
+  table_description)
 ament_package()

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -93,7 +93,8 @@ def generate_launch_description():
                      output='log',
                      arguments=['-d', rviz_config_file],
                      parameters=[robot_description,
-                                 robot_description_semantic])
+                                 robot_description_semantic,
+                                 robot_description_kinematics])
     # Publish base link TF
     static_tf = Node(package='tf2_ros',
                      executable='static_transform_publisher',

--- a/scenes/ur5_3f_test/package.xml
+++ b/scenes/ur5_3f_test/package.xml
@@ -9,6 +9,13 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>ur_description</exec_depend>
+  <exec_depend>ur5_moveit_config</exec_depend>
+  <exec_depend>robotiq_3f_gripper_description</exec_depend>
+  <exec_depend>robotiq_3f_moveit_config</exec_depend>
+  <exec_depend>realsense2_description</exec_depend>
+  <exec_depend>table_description</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/scenes/ur5_3f_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_3f_test/urdf/scene.urdf.xacro
@@ -28,7 +28,7 @@
 	<origin xyz="0 0 0.0" rpy="1.5707 0 0"/>
  </xacro:robotiq-3f-gripper_articulated>
 
- <xacro:include filename="$(find workbench_description)/urdf/table.urdf.xacro"/>
+ <xacro:include filename="$(find table_description)/urdf/table.urdf.xacro"/>
  <xacro:table prefix="" parent="world">
 	<origin xyz="0 0 0" rpy="0 0 0"/>
  </xacro:table>

--- a/scenes/ur5_airpick4_test/CMakeLists.txt
+++ b/scenes/ur5_airpick4_test/CMakeLists.txt
@@ -13,6 +13,12 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_runtime REQUIRED)
+find_package(ur_description REQUIRED)
+find_package(ur5_moveit_config REQUIRED)
+find_package(onrobot_airpick4_description REQUIRED)
+find_package(onrobot_airpick4_moveit_config REQUIRED)
+find_package(realsense2_description REQUIRED)
+find_package(table_description REQUIRED)
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
@@ -20,4 +26,11 @@ install(DIRECTORY launch
 install(DIRECTORY urdf
   DESTINATION share/${PROJECT_NAME}
 )
+ament_export_dependencies(
+  ur_description
+  ur5_moveit_config
+  onrobot_airpick4_description
+  onrobot_airpick4_moveit_config
+  realsense2_description
+  table_description)
 ament_package()

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -93,7 +93,8 @@ def generate_launch_description():
                      output='log',
                      arguments=['-d', rviz_config_file],
                      parameters=[robot_description,
-                                 robot_description_semantic])
+                                 robot_description_semantic,
+                                 robot_description_kinematics])
     # Publish base link TF
     static_tf = Node(package='tf2_ros',
                      executable='static_transform_publisher',

--- a/scenes/ur5_airpick4_test/package.xml
+++ b/scenes/ur5_airpick4_test/package.xml
@@ -9,6 +9,13 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>ur_description</exec_depend>
+  <exec_depend>ur5_moveit_config</exec_depend>
+  <exec_depend>onrobot_airpick4_description</exec_depend>
+  <exec_depend>onrobot_airpick4_moveit_config</exec_depend>
+  <exec_depend>realsense2_description</exec_depend>
+  <exec_depend>table_description</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro
@@ -18,7 +18,7 @@
  <xacro:arg name="initial_positions_file" default="$(find ur5_moveit_config)/config/initial_positions.yaml" />
  <xacro:ur5_ros2_control name="UR5FakeSystem" initial_positions_file="$(arg initial_positions_file)"/>
  
- <xacro:include filename="$(find workbench_description)/urdf/table.urdf.xacro"/>
+ <xacro:include filename="$(find table_description)/urdf/table.urdf.xacro"/>
  <xacro:table prefix="" parent="world">
 	<origin xyz="0 0 0" rpy="0 0 0"/>
  </xacro:table>


### PR DESCRIPTION
## Summary
- remove invalid Robotiq 85 coupler joint and link references from SRDF
- point demo scenes to table_description and correct package names
- add missing dependencies and load kinematics parameters in RViz demos
- use `xacro.load_yaml` in UR control files

## Testing
- `rosdep install --from-paths . --ignore-src -yr` *(fails: command not found)*
- `apt-get install -y python3-rosdep` *(fails: Unable to locate package)*
- `colcon build` *(fails: command not found)*
- `ros2 launch new_scene demo.launch.py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6895cdb69a908331b8c095f57e6c404d