### PR TITLE
Add minimal workbench description and modernize YAML loading

### DIFF
--- a/assets/environment/workbench_description/CMakeLists.txt
+++ b/assets/environment/workbench_description/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.8)
+project(workbench_description)
+
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY urdf meshes launch
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/assets/environment/workbench_description/package.xml
+++ b/assets/environment/workbench_description/package.xml
@@ -1,0 +1,9 @@
+<package format="3">
+  <name>workbench_description</name>
+  <version>0.0.1</version>
+  <description>Minimal workbench for EMD demos.</description>
+  <maintainer email="dev@example.com">Dev</maintainer>
+  <license>MIT</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>xacro</depend>
+</package>

--- a/assets/environment/workbench_description/urdf/workbench.urdf.xacro
+++ b/assets/environment/workbench_description/urdf/workbench.urdf.xacro
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<robot name="workbench" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <link name="workbench_link">
+    <visual>
+      <geometry><box size="1.2 0.8 0.85"/></geometry>
+      <origin xyz="0 0 0.425" rpy="0 0 0"/>
+    </visual>
+    <collision>
+      <geometry><box size="1.2 0.8 0.85"/></geometry>
+      <origin xyz="0 0 0.425" rpy="0 0 0"/>
+    </collision>
+    <inertial>
+      <mass value="20"/>
+      <inertia ixx="2" iyy="2" izz="2" ixy="0" ixz="0" iyz="0"/>
+    </inertial>
+  </link>
+</robot>

--- a/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/launch/run_moveit_cpp.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/launch/run_moveit_cpp.launch.py
@@ -1,5 +1,4 @@
 import os
-import yaml
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from launch.actions import ExecuteProcess, DeclareLaunchArgument
@@ -24,8 +23,7 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, "r") as file:
-            return yaml.safe_load(file)
+        return xacro.load_yaml(absolute_file_path)
     except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -22,7 +22,6 @@ from launch.actions import ExecuteProcess, DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, PythonExpression
 
 import xacro
-import yaml
 
 scene_pkg = 'ur5_2f_test'
 robot_base_link = 'base_link'
@@ -62,8 +61,7 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
+        return xacro.load_yaml(absolute_file_path)
     except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/launch/grasp_execution.launch.py
@@ -22,7 +22,6 @@ from launch.actions import ExecuteProcess, DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, PythonExpression
 
 import xacro
-import yaml
 
 scene_pkg = 'ur5_2f_test'
 robot_base_link = 'base_link'
@@ -62,8 +61,7 @@ def load_yaml(package_name, file_path):
     absolute_file_path = os.path.join(package_path, file_path)
 
     try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
+        return xacro.load_yaml(absolute_file_path)
     except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
 

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -13,7 +13,6 @@
 ## limitations under the License.
 
 import os
-import yaml
 import xacro
 import tempfile
 from pathlib import Path
@@ -72,8 +71,7 @@ def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
     try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
+        return xacro.load_yaml(absolute_file_path)
     except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
         print(package_path)
         print(absolute_file_path)

--- a/scenes/ur5_2f_test/CMakeLists.txt
+++ b/scenes/ur5_2f_test/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(ur5_moveit_config REQUIRED)
 find_package(robotiq_85_description REQUIRED)
 find_package(robotiq_85_moveit_config REQUIRED)
 find_package(realsense2_description REQUIRED)
-find_package(table_description REQUIRED)
+find_package(workbench_description REQUIRED)
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
@@ -32,5 +32,5 @@ ament_export_dependencies(
   robotiq_85_description
   robotiq_85_moveit_config
   realsense2_description
-  table_description)
+  workbench_description)
 ament_package()

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -13,7 +13,6 @@
 ## limitations under the License.
 
 import os
-import yaml
 import xacro
 import tempfile
 from launch import LaunchDescription
@@ -57,9 +56,8 @@ def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
     try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+        return xacro.load_yaml(absolute_file_path)
+    except EnvironmentError:
         print(package_path)
         print(absolute_file_path)
         return None

--- a/scenes/ur5_2f_test/package.xml
+++ b/scenes/ur5_2f_test/package.xml
@@ -14,7 +14,7 @@
   <exec_depend>robotiq_85_description</exec_depend>
   <exec_depend>robotiq_85_moveit_config</exec_depend>
   <exec_depend>realsense2_description</exec_depend>
-  <exec_depend>table_description</exec_depend>
+  <exec_depend>workbench_description</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/scenes/ur5_2f_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_2f_test/urdf/scene.urdf.xacro
@@ -23,14 +23,16 @@
 	<origin xyz="0 0 0" rpy="1.5707 -1.5707 0"/>
  </xacro:robotiq_85_gripper>
 
- <xacro:include filename="$(find table_description)/urdf/table.urdf.xacro"/>
- <xacro:table prefix="" parent="world">
-	<origin xyz="0 0 0" rpy="0 0 0"/>
- </xacro:table>
+ <xacro:include filename="$(find-pkg-share workbench_description)/urdf/workbench.urdf.xacro"/>
+ <joint name="workbench_base_joint" type="fixed">
+        <parent link="world" />
+        <child link="workbench_link" />
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+ </joint>
  
  <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro"/>
  <xacro:arg name="use_nominal_extrinsics" default="true" />
- <xacro:sensor_d415 parent="table_" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
+ <xacro:sensor_d415 parent="workbench_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
     <origin xyz="-0.58 0.12 0.655" rpy="0 1.57079506 0"/>
  </xacro:sensor_d415>
 

--- a/scenes/ur5_3f_test/CMakeLists.txt
+++ b/scenes/ur5_3f_test/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(ur5_moveit_config REQUIRED)
 find_package(robotiq_3f_gripper_description REQUIRED)
 find_package(robotiq_3f_moveit_config REQUIRED)
 find_package(realsense2_description REQUIRED)
-find_package(table_description REQUIRED)
+find_package(workbench_description REQUIRED)
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
@@ -32,5 +32,5 @@ ament_export_dependencies(
   robotiq_3f_gripper_description
   robotiq_3f_moveit_config
   realsense2_description
-  table_description)
+  workbench_description)
 ament_package()

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -13,7 +13,6 @@
 ## limitations under the License.
 
 import os
-import yaml
 import xacro
 import tempfile
 from launch import LaunchDescription
@@ -57,9 +56,8 @@ def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
     try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+        return xacro.load_yaml(absolute_file_path)
+    except EnvironmentError:
         print(package_path)
         print(absolute_file_path)
         return None

--- a/scenes/ur5_3f_test/package.xml
+++ b/scenes/ur5_3f_test/package.xml
@@ -14,7 +14,7 @@
   <exec_depend>robotiq_3f_gripper_description</exec_depend>
   <exec_depend>robotiq_3f_moveit_config</exec_depend>
   <exec_depend>realsense2_description</exec_depend>
-  <exec_depend>table_description</exec_depend>
+  <exec_depend>workbench_description</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/scenes/ur5_3f_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_3f_test/urdf/scene.urdf.xacro
@@ -28,14 +28,16 @@
 	<origin xyz="0 0 0.0" rpy="1.5707 0 0"/>
  </xacro:robotiq-3f-gripper_articulated>
 
- <xacro:include filename="$(find table_description)/urdf/table.urdf.xacro"/>
- <xacro:table prefix="" parent="world">
-	<origin xyz="0 0 0" rpy="0 0 0"/>
- </xacro:table>
+ <xacro:include filename="$(find-pkg-share workbench_description)/urdf/workbench.urdf.xacro"/>
+ <joint name="workbench_base_joint" type="fixed">
+        <parent link="world" />
+        <child link="workbench_link" />
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+ </joint>
  
  <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro"/>
 <xacro:arg name="use_nominal_extrinsics" default="true" />
-<xacro:sensor_d415 parent="table_" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
+<xacro:sensor_d415 parent="workbench_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
     <origin xyz="-0.58 0.225 0.65" rpy="3.14159 1.57079506 0"/>
 </xacro:sensor_d415>
 

--- a/scenes/ur5_airpick4_test/CMakeLists.txt
+++ b/scenes/ur5_airpick4_test/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(ur5_moveit_config REQUIRED)
 find_package(onrobot_airpick4_description REQUIRED)
 find_package(onrobot_airpick4_moveit_config REQUIRED)
 find_package(realsense2_description REQUIRED)
-find_package(table_description REQUIRED)
+find_package(workbench_description REQUIRED)
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
@@ -32,5 +32,5 @@ ament_export_dependencies(
   onrobot_airpick4_description
   onrobot_airpick4_moveit_config
   realsense2_description
-  table_description)
+  workbench_description)
 ament_package()

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -13,7 +13,6 @@
 ## limitations under the License.
 
 import os
-import yaml
 import xacro
 import tempfile
 from launch import LaunchDescription
@@ -57,9 +56,8 @@ def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
     try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+        return xacro.load_yaml(absolute_file_path)
+    except EnvironmentError:
         print(package_path)
         print(absolute_file_path)
         return None

--- a/scenes/ur5_airpick4_test/package.xml
+++ b/scenes/ur5_airpick4_test/package.xml
@@ -14,7 +14,7 @@
   <exec_depend>onrobot_airpick4_description</exec_depend>
   <exec_depend>onrobot_airpick4_moveit_config</exec_depend>
   <exec_depend>realsense2_description</exec_depend>
-  <exec_depend>table_description</exec_depend>
+  <exec_depend>workbench_description</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro
@@ -18,10 +18,12 @@
  <xacro:arg name="initial_positions_file" default="$(find ur5_moveit_config)/config/initial_positions.yaml" />
  <xacro:ur5_ros2_control name="UR5FakeSystem" initial_positions_file="$(arg initial_positions_file)"/>
  
- <xacro:include filename="$(find table_description)/urdf/table.urdf.xacro"/>
- <xacro:table prefix="" parent="world">
-	<origin xyz="0 0 0" rpy="0 0 0"/>
- </xacro:table>
+ <xacro:include filename="$(find-pkg-share workbench_description)/urdf/workbench.urdf.xacro"/>
+ <joint name="workbench_base_joint" type="fixed">
+        <parent link="world" />
+        <child link="workbench_link" />
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+ </joint>
  
   <!--xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro"/>
  <xacro:arg name="use_nominal_extrinsics" default="true" />
@@ -32,7 +34,7 @@
  
  <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro"/>
  <xacro:arg name="use_nominal_extrinsics" default="true" />
- <xacro:sensor_d415 parent="table_" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
+ <xacro:sensor_d415 parent="workbench_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
 	<origin xyz="-0.58 0.225 0.65" rpy="3.14159 1.57079506 0"/>
  </xacro:sensor_d415>
 


### PR DESCRIPTION
## Summary
- add a minimal `workbench_description` package and link it into demo scenes
- load YAML files through `xacro.load_yaml` across launch files

## Testing
- `rosdep install --from-paths . --ignore-src -yr` *(fails: ROS distro is not set)*
- `colcon build` *(fails: Could not find ament_cmake)*
- `ros2 launch run_grasp_execution grasp_execution.launch.py` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895d22b1de883318dd47b2ef69bd6c7