### PR TITLE
Ensure Easy Manipulator builds on Humble and add CI

### DIFF
--- a/.github/workflows/humble-ci.yml
+++ b/.github/workflows/humble-ci.yml
@@ -1,0 +1,46 @@
+name: Humble CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup ROS
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: humble
+
+      - name: Install apt packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-vcstool python3-colcon-common-extensions ros-humble-moveit ros-humble-moveit-visual-tools ros-humble-xacro
+
+      - name: Create workspace
+        run: |
+          mkdir -p ros_ws/src/emd_root
+          rsync -a --exclude ros_ws/ . ros_ws/src/emd_root/
+          if [ -f ros_ws/src/emd_root/tesseract.repos ]; then vcs import ros_ws/src < ros_ws/src/emd_root/tesseract.repos; fi
+
+      - name: Install dependencies
+        working-directory: ros_ws
+        run: |
+          rosdep update
+          rosdep install --from-paths src --ignore-src -r -y
+
+      - name: Build
+        working-directory: ros_ws
+        run: |
+          colcon build --event-handlers console_cohesion+ --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+      - name: Test
+        working-directory: ros_ws
+        run: |
+          colcon test --event-handlers console_cohesion+
+          colcon test-result --verbose
+

--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ It is recommended to run this package on **ROS 2 Jazzy** (Ubuntu 24.04) or **ROS
 For installation guidance, see the ROS 2 [Jazzy](https://docs.ros.org/en/jazzy/Installation.html) or [Humble](https://docs.ros.org/en/humble/Installation.html) documentation.
 
 ---
+## Build on Humble
+
+```
+sudo apt update
+sudo apt install python3-vcstool python3-colcon-common-extensions
+rosdep update
+mkdir -p ~/workcell_ws/src && cd ~/workcell_ws
+git clone https://github.com/Mukaram01/Easy_Manipulator_Improved src/emd
+vcs import src < src/emd/tesseract.repos
+rosdep install --from-paths src --ignore-src -r -y
+colcon build
+source install/setup.bash
+ros2 launch run_grasp_execution grasp_execution.launch.py
+```
+
+---
 ## Full Documentation/Wiki
 
 [Check out the Full Documentation here](https://easy-manipulation-deployment-docs.readthedocs.io/)

--- a/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/launch/run_moveit_cpp.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/launch/run_moveit_cpp.launch.py
@@ -5,7 +5,6 @@ from launch.actions import ExecuteProcess, DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, PythonExpression
 from ament_index_python.packages import get_package_share_directory
 import xacro
-import yaml
 
 
 def load_file(package_name, file_path):
@@ -22,11 +21,7 @@ def load_file(package_name, file_path):
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
-        return None
+    return xacro.load_yaml(absolute_file_path)
 
 
 def generate_launch_description():

--- a/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/package.xml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/package.xml
@@ -17,6 +17,7 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>moveit_resources_panda_moveit_config</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <exec_depend>emd_dynamic_safety</exec_depend>
   

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -22,7 +22,6 @@ from launch.actions import ExecuteProcess, DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, PythonExpression
 
 import xacro
-import yaml
 
 scene_pkg = 'ur5_2f_test'
 robot_base_link = 'base_link'
@@ -60,11 +59,7 @@ def load_file(package_name, file_path, mappings=None):
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
-        return None
+    return xacro.load_yaml(absolute_file_path)
 
 
 def generate_launch_description():

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml
@@ -12,6 +12,12 @@
 
   <depend>emd_grasp_execution</depend>
 
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/launch/grasp_execution.launch.py
@@ -22,7 +22,6 @@ from launch.actions import ExecuteProcess, DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, PythonExpression
 
 import xacro
-import yaml
 
 scene_pkg = 'ur5_2f_test'
 robot_base_link = 'base_link'
@@ -60,11 +59,7 @@ def load_file(package_name, file_path, mappings=None):
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
-        return None
+    return xacro.load_yaml(absolute_file_path)
 
 
 def generate_launch_description():

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/package.xml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/package.xml
@@ -13,6 +13,12 @@
   <depend>emd_grasp_execution</depend>
   <depend>emd_waypoint_execution</depend>
 
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/CMakeLists.txt
@@ -27,18 +27,26 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_eigen REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(moveit_ros_planning_interface REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+find_package(pluginlib REQUIRED)
 find_package(ament_index_cpp REQUIRED)
-set(BOOST_ROOT "/usr/include/boost")
+find_package(yaml-cpp REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem)
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
+
 include_directories(include)
 include_directories(include/attributes)
 include_directories(include/yaml_parser)
-
-set(PKG_CONFIG_EXECUTABLE "/usr/bin/pkg-config")
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(yaml-cpp REQUIRED yaml-cpp)
-
 include_directories(gui)
 
 
@@ -104,9 +112,34 @@ add_executable(workcell_builder
     gui/loadobjects.h
     gui/loadobjects.ui)
 
-ament_target_dependencies(workcell_builder rclcpp ament_index_cpp)
-target_link_libraries(workcell_builder Qt5::Widgets ${Boost_LIBRARIES} yaml-cpp)
-target_include_directories(workcell_builder PUBLIC ${Boost_INCLUDE_DIRS})
+ament_target_dependencies(workcell_builder
+  rclcpp
+  rclcpp_components
+  tf2
+  tf2_ros
+  tf2_eigen
+  tf2_geometry_msgs
+  geometry_msgs
+  sensor_msgs
+  std_msgs
+  moveit_core
+  moveit_ros_planning_interface
+  moveit_visual_tools
+  pluginlib
+  ament_index_cpp
+)
+
+target_link_libraries(workcell_builder
+  PRIVATE
+    Qt5::Widgets
+    yaml-cpp
+    ${Boost_LIBRARIES}
+)
+
+target_include_directories(workcell_builder
+  PRIVATE
+    ${Boost_INCLUDE_DIRS}
+)
 
 
 if(BUILD_TESTING)

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/package.xml
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/package.xml
@@ -8,12 +8,28 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>yaml-cpp</build_depend>
-  <build_depend>boost</build_depend>
-  <build_depend>pkg-config</build_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_eigen</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>moveit_core</depend>
+  <depend>moveit_ros_planning_interface</depend>
+  <depend>moveit_visual_tools</depend>
+  <depend>pluginlib</depend>
+  <depend>ament_index_cpp</depend>
+  <depend>yaml-cpp</depend>
+  <depend>boost</depend>
+
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>qt5-qmake</build_depend>
   <exec_depend>qtbase5-dev</exec_depend>
+  <exec_depend>qt5-qmake</exec_depend>
   <!--test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend-->
 

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -15,7 +15,6 @@
 import os
 import tempfile
 import xacro
-import yaml
 from pathlib import Path
 from launch import LaunchDescription
 from launch_ros.actions import Node
@@ -71,13 +70,7 @@ def load_file(package_name, file_path):
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
-        print(package_path)
-        print(absolute_file_path)
-        return None
+    return xacro.load_yaml(absolute_file_path)
 
 
 def generate_launch_description():

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -15,7 +15,6 @@
 import os
 import tempfile
 import xacro
-import yaml
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
@@ -56,13 +55,7 @@ def load_file(package_name, file_path):
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError:
-        print(package_path)
-        print(absolute_file_path)
-        return None
+    return xacro.load_yaml(absolute_file_path)
 
 
 def generate_launch_description():

--- a/scenes/ur5_2f_test/package.xml
+++ b/scenes/ur5_2f_test/package.xml
@@ -15,6 +15,9 @@
   <exec_depend>robotiq_85_moveit_config</exec_depend>
   <exec_depend>realsense2_description</exec_depend>
   <exec_depend>workbench_description</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -15,7 +15,6 @@
 import os
 import tempfile
 import xacro
-import yaml
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
@@ -56,13 +55,7 @@ def load_file(package_name, file_path):
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError:
-        print(package_path)
-        print(absolute_file_path)
-        return None
+    return xacro.load_yaml(absolute_file_path)
 
 
 def generate_launch_description():

--- a/scenes/ur5_3f_test/package.xml
+++ b/scenes/ur5_3f_test/package.xml
@@ -15,6 +15,9 @@
   <exec_depend>robotiq_3f_moveit_config</exec_depend>
   <exec_depend>realsense2_description</exec_depend>
   <exec_depend>workbench_description</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -15,7 +15,6 @@
 import os
 import tempfile
 import xacro
-import yaml
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
@@ -56,13 +55,7 @@ def load_file(package_name, file_path):
 def load_yaml(package_name, file_path):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, file_path)
-    try:
-        with open(absolute_file_path, 'r') as file:
-            return yaml.safe_load(file)
-    except EnvironmentError:
-        print(package_path)
-        print(absolute_file_path)
-        return None
+    return xacro.load_yaml(absolute_file_path)
 
 
 def generate_launch_description():

--- a/scenes/ur5_airpick4_test/package.xml
+++ b/scenes/ur5_airpick4_test/package.xml
@@ -15,6 +15,9 @@
   <exec_depend>onrobot_airpick4_moveit_config</exec_depend>
   <exec_depend>realsense2_description</exec_depend>
   <exec_depend>workbench_description</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/workbench_description/CMakeLists.txt
+++ b/workbench_description/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5)
+project(workbench_description)
+
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY urdf
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package()
+

--- a/workbench_description/package.xml
+++ b/workbench_description/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>workbench_description</name>
+  <version>0.0.1</version>
+  <description>Simple workbench description used in EMD demos</description>
+  <maintainer email="glenn_tan@artc.a-star.edu.sg">Tan Jing Peng Glenn</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+

--- a/workbench_description/urdf/workbench.urdf.xacro
+++ b/workbench_description/urdf/workbench.urdf.xacro
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<robot name="workbench" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <link name="workbench">
+    <visual>
+      <geometry>
+        <box size="1 1 0.1"/>
+      </geometry>
+      <material name="grey">
+        <color rgba="0.5 0.5 0.5 1"/>
+      </material>
+    </visual>
+    <collision>
+      <geometry>
+        <box size="1 1 0.1"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>
+


### PR DESCRIPTION
## Summary
- fix workcell_builder CMake with keyword link libraries and explicit dependencies
- switch launch files to use `xacro.load_yaml` to avoid deprecation warnings
- vendor minimal `workbench_description` and add Humble build instructions
- add GitHub Actions workflow for Humble

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y python3-vcstool python3-colcon-common-extensions` *(failed: Unable to locate package)*
- `colcon build` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b901e6d48331b2ca062ad13a0283