### PR TITLE
feat: add padding and scene sync options

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 The following items are pending implementation:
 
-1. Dynamic Safety & Visualizer enhancements (padding, distance-based checks, visualizer sync).
+1. Dynamic Safety & Visualizer enhancements (distance-based checks).
 2. MoveIt Collision Checker plugin loading and multi-axis joint support.
 3. Tesseract Collision Checker plugin mapping and self-collision checks.
 4. Replanner parameterization and joint-limit handling improvements.

--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/collision_checker_common.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/collision_checker_common.hpp
@@ -46,6 +46,9 @@ struct CollisionCheckerOption
   /// Enable realtime configuration (not fully implemented).
   bool realtime;
 
+  /// Additional padding distance applied during collision checking.
+  double padding{0.0};
+
   /// Steps (in the unit of time) between states taken from the trajectory (discrete only).
   double step;
   /// Thread count used for collision checking (discrete only).

--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety.hpp
@@ -108,12 +108,15 @@ public:
    *         # distance: false
    *         # continuous: false
    *         step: 0.01
+   *         # padding: 0.0
 
    *       visualizer:
    *         publish_frequency: 10
    *         step: 0.1
    *         topic:  ur3e_dynamic_safety_markers
    *         tcp_link: ur3e_gripper_link
+   *         # publish_scene: false
+   *         # scene_topic: /planning_scene
 
    *       replanner:
    *         framework: moveit

--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/visualizer.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/visualizer.hpp
@@ -21,6 +21,7 @@
 #include "emd/dynamic_safety/safety_zone.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 #include "moveit/planning_scene/planning_scene.h"
+#include "moveit_msgs/msg/planning_scene.hpp"
 
 namespace dynamic_safety
 {
@@ -42,6 +43,12 @@ public:
     std::string topic;
 
     std::string tcp_link;
+
+    /// Whether to publish the planning scene for external synchronization.
+    bool publish_scene{false};
+
+    /// Topic used when publishing the planning scene.
+    std::string scene_topic;
   };
 
   /// Constructor.
@@ -125,6 +132,7 @@ private:
   rclcpp::Node::SharedPtr node_;
   rclcpp::TimerBase::SharedPtr timer_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr pub_;
+  rclcpp::Publisher<moveit_msgs::msg::PlanningScene>::SharedPtr scene_pub_;
 
   visualization_msgs::msg::Marker::SharedPtr marker_msg_;
 

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
@@ -179,7 +179,10 @@ const Option & Option::load(const std::shared_ptr<NodeT> & node)
     "dynamic_safety.collision_checker.group",
     node, LOGGER);  // needed for continuous collision checking
 
-  // TODO(anyone): padding
+  emd::declare_or_get_param<double>(
+    collision_checker_options.padding,
+    "dynamic_safety.collision_checker.padding",
+    node, LOGGER, 0.0);
 
   // -------------- Load overwritable parameters -------------------
   // If the following parameters are defined and greater than zero,
@@ -375,11 +378,10 @@ const Option & Option::load(const std::shared_ptr<NodeT> & node)
   }
 
   if (visualize) {
-    // TODO(Briancbn): scene synchronization
-    // emd::declare_or_get_param<bool>(
-    //   visualizer_options.publish_scene,
-    //   "dynamic_safety.visualize.publish_scene",
-    //   node, LOGGER, false);
+    emd::declare_or_get_param<bool>(
+      visualizer_options.publish_scene,
+      "dynamic_safety.visualizer.publish_scene",
+      node, LOGGER, false);
 
     emd::declare_or_get_param<double>(
       visualizer_options.publish_frequency,
@@ -400,12 +402,10 @@ const Option & Option::load(const std::shared_ptr<NodeT> & node)
       visualizer_options.tcp_link,
       "dynamic_safety.visualizer.tcp_link",
       node, LOGGER);
-
-    // TODO(Briancbn): scene synchronization
-    // emd::declare_or_get_param<std::string>(
-    //   visualizer_options.scene_topic,
-    //   "dynamic_safety.visualize.scene_topic",
-    //   node, LOGGER);
+    emd::declare_or_get_param<std::string>(
+      visualizer_options.scene_topic,
+      "dynamic_safety.visualizer.scene_topic",
+      node, LOGGER, std::string());
   }
 
   // Return idiom

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/moveit/collision_checker_moveit.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/moveit/collision_checker_moveit.cpp
@@ -82,6 +82,7 @@ void MoveitCollisionCheckerContext::configure(
   collision_request_.group_name = option.group;
   collision_request_.distance = option.distance;
   collision_request_.contacts = true;
+  scene_->getCollisionEnv()->setPadding(option.padding);
 }
 
 void MoveitCollisionCheckerContext::run_discrete(

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/tesseract/collision_checker_tesseract.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/tesseract/collision_checker_tesseract.cpp
@@ -78,7 +78,7 @@ void TesseractCollisionCheckerContext::configure(
   collision_check_config_.contact_request.calculate_penetration = false;
   collision_check_config_.contact_request.calculate_distance = option.distance;
   collision_check_config_.type = tesseract_collision::CollisionEvaluatorType::DISCRETE;
-  tesseract_collision::CollisionMarginData margin_data(0.0);
+  tesseract_collision::CollisionMarginData margin_data(option.padding);
   collision_check_config_.collision_margin_data = margin_data;
   if (!option.continuous) {
     // Clone shared object

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/visualizer.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/visualizer.cpp
@@ -78,6 +78,10 @@ void Visualizer::configure(
   start_ = false;
   pub_ = node_->template create_publisher<visualization_msgs::msg::Marker>(
     option.topic, 2);
+  if (option.publish_scene && !option.scene_topic.empty()) {
+    scene_pub_ = node_->template create_publisher<moveit_msgs::msg::PlanningScene>(
+      option.scene_topic, 2);
+  }
   rate_ = option.publish_frequency;
   step_ = option.step;
   tcp_link_ = option.tcp_link;
@@ -190,6 +194,7 @@ void Visualizer::stop()
 void Visualizer::reset()
 {
   pub_.reset();
+  scene_pub_.reset();
 }
 
 void Visualizer::_timer_cb()
@@ -235,6 +240,11 @@ void Visualizer::_timer_cb()
   // Check if timer_ has been reset before publishing the viz markers
   if (pub_) {
     pub_->publish(*marker_msg_);
+  }
+  if (scene_pub_) {
+    moveit_msgs::msg::PlanningScene scene_msg;
+    scene_->getPlanningSceneMsg(scene_msg);
+    scene_pub_->publish(scene_msg);
   }
 }
 


### PR DESCRIPTION
## Summary
- expose padding option for collision checking
- allow publishing planning scene for visualizer synchronization
- update roadmap to reflect remaining distance-based work

## Testing
- `colcon test --packages-select emd_dynamic_safety` *(failed: command not found: colcon)*

------
https://chatgpt.com/codex/tasks/task_e_689a08be65288331813db9042379b3e7