### PR TITLE
Add result codes to gripper driver and update roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,8 +12,11 @@ The following items are pending implementation:
 8. Context loading via `rcl_yaml_param_parser` with schema validation.
 9. Demo node lifecycle conversion and grasp method selection.
 10. Default executor watchdog and graceful shutdown.
-11. Gripper driver hardening with result codes.
-12. Finger-gripper sampling strategies for multi-finger configurations.
-13. Additional testing, CI workflows, documentation, and Docker support.
+11. Finger-gripper sampling strategies for multi-finger configurations.
+12. Additional testing, CI workflows, documentation, and Docker support.
 
 These tasks are outlined for future contributions.
+
+## Completed
+
+- Gripper driver interface hardened with explicit result codes.

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/gripper/dummy_gripper_driver.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/gripper/dummy_gripper_driver.hpp
@@ -34,11 +34,11 @@ public:
 
   ~DummyGripperDriver() {}
 
-  bool load(const std::string & /*name*/) override;
+  GripperDriver::Result load(const std::string & /*name*/) override;
 
-  bool activate() override;
+  GripperDriver::Result activate() override;
 
-  bool deactivate() override;
+  GripperDriver::Result deactivate() override;
 
 private:
   const rclcpp::Logger logger_;

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/gripper/gripper_driver.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/gripper/gripper_driver.hpp
@@ -34,18 +34,35 @@ public:
   // cppcheck-suppress unknownMacro
   RCLCPP_SMART_PTR_DEFINITIONS(GripperDriver)
 
+  /// Result codes for driver operations
+  enum class Result
+  {
+    SUCCESS = 0,
+    ERROR = 1
+  };
+
   GripperDriver() {}
 
-  // TODO(anyone): Harden gripper driver interface
-  virtual bool load(const std::string & name) = 0;
+  /// Load gripper driver resources
+  /**
+   * \param[in] name Resource identifier
+   * \return Result of loading procedure
+   */
+  virtual Result load(const std::string & name) = 0;
 
-  ~GripperDriver() {}
+  virtual ~GripperDriver() {}
 
-  // TODO(anyone): Harden gripper driver interface
-  virtual bool activate() = 0;
+  /// Activate the driver
+  /**
+   * \return Result of activation procedure
+   */
+  virtual Result activate() = 0;
 
-  // TODO(anyone): Harden gripper driver interface
-  virtual bool deactivate() = 0;
+  /// Deactivate the driver
+  /**
+   * \return Result of deactivation procedure
+   */
+  virtual Result deactivate() = 0;
 
 private:
   // cppcheck-suppress unknownMacro

--- a/easy_manipulation_deployment/emd_grasp_execution/src/gripper/dummy_gripper_driver.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/gripper/dummy_gripper_driver.cpp
@@ -22,29 +22,29 @@ namespace grasp_execution
 namespace gripper
 {
 
-bool DummyGripperDriver::load(
+GripperDriver::Result DummyGripperDriver::load(
   const std::string & /*name*/)
 {
   RCLCPP_INFO(this->logger_, "Loading dummy gripper driver, sleep 1s.....");
   rclcpp::sleep_for(std::chrono::seconds(1));
   RCLCPP_INFO(this->logger_, "Dummy gripper driver loaded");
-  return true;
+  return GripperDriver::Result::SUCCESS;
 }
 
-bool DummyGripperDriver::activate()
+GripperDriver::Result DummyGripperDriver::activate()
 {
   RCLCPP_INFO(this->logger_, "Activate dummy gripper driver, sleep 2s.....");
   rclcpp::sleep_for(std::chrono::seconds(2));
   RCLCPP_INFO(this->logger_, "Dummy gripper driver activated");
-  return true;
+  return GripperDriver::Result::SUCCESS;
 }
 
-bool DummyGripperDriver::deactivate()
+GripperDriver::Result DummyGripperDriver::deactivate()
 {
   RCLCPP_INFO(this->logger_, "Deactivate dummy gripper driver, sleep 2s.....");
   rclcpp::sleep_for(std::chrono::seconds(2));
   RCLCPP_INFO(this->logger_, "Dummy gripper driver deactivated");
-  return true;
+  return GripperDriver::Result::SUCCESS;
 }
 
 }  // namespace gripper

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -162,7 +162,11 @@ bool MoveitCppGraspExecution::init(const std::string & planning_group)
       // Initialize dummy gripper driver
       auto dummy_gripper_driver = std::unique_ptr<gripper::GripperDriver>(
         gripper_driver_loader_->createUnmanagedInstance("grasp_execution/DummyGripperDriver"));
-      dummy_gripper_driver->load("");
+      if (dummy_gripper_driver->load("") != gripper::GripperDriver::Result::SUCCESS) {
+        RCLCPP_ERROR(LOGGER, "Failed to load dummy gripper driver");
+        prompt_job_end(LOGGER, false);
+        return false;
+      }
       arms_[planning_group].grippers["dummy"] = std::move(dummy_gripper_driver);
 
       prompt_job_end(LOGGER, true);
@@ -271,8 +275,14 @@ bool MoveitCppGraspExecution::load_ee(
   // Initialize customized execution method
   auto gripper_driver = std::unique_ptr<gripper::GripperDriver>(
     gripper_driver_loader_->createUnmanagedInstance(ee_driver_plugin));
-  gripper_driver->load(ee_driver_controller);
-  gripper_driver->activate();
+  if (gripper_driver->load(ee_driver_controller) != gripper::GripperDriver::Result::SUCCESS) {
+    RCLCPP_ERROR(LOGGER, "Failed to load gripper driver for %s", ee_brand.c_str());
+    return false;
+  }
+  if (gripper_driver->activate() != gripper::GripperDriver::Result::SUCCESS) {
+    RCLCPP_ERROR(LOGGER, "Failed to activate gripper driver for %s", ee_brand.c_str());
+    return false;
+  }
   arms_[group_name].grippers[ee_brand] = std::move(gripper_driver);
   return true;
 }


### PR DESCRIPTION
## Summary
- add explicit result codes to gripper driver interface
- update dummy driver and MoveIt integration to use the new result codes
- update roadmap to reflect completed gripper driver hardening

## Testing
- `colcon build --packages-select emd_msgs` *(fails: Could not find a package configuration file provided by "ament_cmake")*
- `colcon build --packages-select emd_grasp_execution` *(fails: Failed to find the following files: install/emd_msgs/share/emd_msgs/package.sh)*
- `colcon test --packages-select emd_grasp_execution` *(fails: Has this package been built before?)*

------
https://chatgpt.com/codex/tasks/task_e_689a0cf6b7248331b71f464ff7e17395