### PR TITLE
feat: expose collision min distance

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 The following items are pending implementation:
 
-1. Dynamic Safety & Visualizer enhancements (distance-based checks).
+1. Dynamic Safety & Visualizer enhancements (distance-based checks — initial minimum-distance reporting added).
 2. MoveIt Collision Checker plugin loading and multi-axis joint support.
 3. Tesseract Collision Checker plugin mapping and self-collision checks.
 4. Replanner parameterization and joint-limit handling improvements.

--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/collision_checker.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/collision_checker.hpp
@@ -89,6 +89,16 @@ public:
     double look_ahead_time,
     int sample_size = 10);
 
+  /// Retrieve minimum distance between the robot and environment.
+  /**
+   * This value is populated after each run_once() call when distance
+   * computation is enabled in the collision checker options.
+   *
+   * \return Minimum distance found in the last collision checking cycle,
+   *   negative if distance information is unavailable.
+   */
+  double get_min_distance() const;
+
   /// Reset / stop collision checker.
   /**
    * After this is called, configure() has to be called again before running run_once().

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/collision_checker.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/collision_checker.cpp
@@ -69,6 +69,8 @@ public:
 
   void reset();
 
+  double get_min_distance() const;
+
 protected:
   // Main function for running discrete collision checking
   void _runner_fn(int runner_id, bool continuous);
@@ -378,6 +380,14 @@ void CollisionChecker::Impl::reset()
   }
 }
 
+double CollisionChecker::Impl::get_min_distance() const
+{
+  if (distances_.empty()) {
+    return -1.0;
+  }
+  return *std::min_element(distances_.begin(), distances_.end());
+}
+
 CollisionChecker::CollisionChecker()
 : impl_ptr_(std::make_unique<Impl>())
 {
@@ -450,6 +460,11 @@ void CollisionChecker::add_trajectory(
   const trajectory_msgs::msg::JointTrajectory::SharedPtr & rt)
 {
   impl_ptr_->add_trajectory(rt);
+}
+
+double CollisionChecker::get_min_distance() const
+{
+  return impl_ptr_->get_min_distance();
 }
 
 

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
@@ -417,7 +417,7 @@ class DynamicSafety::Impl
 public:
   Impl();
   explicit Impl(const Option & option)
-  : option_(option), activated_(false)
+  : option_(option), activated_(false), min_distance_(-1.0)
   {
     // Reset Cache
     env_state_cache_.initRT(sensor_msgs::msg::JointState());
@@ -514,6 +514,8 @@ private:
 
   double collision_time_point_;
   // double replan_time_point_;
+
+  double min_distance_;
 
   // uint8_t zone;
 
@@ -810,6 +812,11 @@ void DynamicSafety::Impl::_main_loop()
     option_.safety_zone_options.look_ahead_time,
     collision_time_point_
   );
+
+  if (option_.collision_checker_options.distance) {
+    min_distance_ = collision_checker_.get_min_distance();
+    RCLCPP_DEBUG(LOGGER, "Minimum distance to obstacle: %f", min_distance_);
+  }
 
   double scale = *scale_cache_.readFromRT();
 


### PR DESCRIPTION
## Summary
- expose minimum distance from collision checker
- log minimum distance in dynamic safety loop
- roadmap: mark distance-based checks as started

## Testing
- `colcon test --packages-select emd_dynamic_safety` *(fails: command not found: colcon)*

------
https://chatgpt.com/codex/tasks/task_e_689a0cf6b7248331b71f464ff7e17395