### PR TITLE
feat: add end effector execution context

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,6 +8,7 @@ The following items are pending implementation:
 4. Replanner parameterization and joint-limit handling improvements.
 5. Scheduler workflow prerequisites and queue robustness.
 6. Grasp Execution Interface documentation and options expansion.
+   - Added an execution context with optional delays for attach and detach operations.
 7. MoveIt-based execution improvements for multi-axis joints and path constraints.
 8. Context loading via `rcl_yaml_param_parser` with schema validation.
 9. Demo node lifecycle conversion and grasp method selection.

--- a/docs/grasp_execution_interface.md
+++ b/docs/grasp_execution_interface.md
@@ -1,0 +1,23 @@
+# Grasp Execution Interface
+
+The end effector execution interface provides helper methods for attaching
+and detaching objects from the robot's end effector.  It now supports an
+optional execution context that allows callers to wait for hardware
+operations to complete before proceeding.
+
+## Usage
+
+```c++
+#include "emd/end_effector/ee_execution_interface.hpp"
+
+emd::EndEffectorExecutioninterface ee;
+emd::EndEffectorExecutionContext ctx;
+ctx.wait_for_completion = true;
+ctx.post_command_delay = std::chrono::milliseconds(500);
+
+// Attach an object and wait half a second for the gripper to close
+ ee.grasp_object(moveit_execution, "tool0", target_id, ctx);
+```
+
+Setting `wait_for_completion` to `false` skips the delay, matching the
+previous behaviour.

--- a/easy_manipulation_deployment/emd_waypoint_execution/include/emd/end_effector/ee_execution_interface.hpp
+++ b/easy_manipulation_deployment/emd_waypoint_execution/include/emd/end_effector/ee_execution_interface.hpp
@@ -16,13 +16,25 @@
 #ifndef EMD__EE_EXECUTION_INTERFACE_HPP_
 #define EMD__EE_EXECUTION_INTERFACE_HPP_
 
+#include <chrono>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
 
 static const rclcpp::Logger & LOGGER_EE_INTERFACE = rclcpp::get_logger(
   "end_effector_execution_interface");
 namespace emd
 {
+/// Options used by end effector operations.
 struct EndEffectorExecutionContext
 {
+  /// Amount of time to wait after a command to allow the hardware state to
+  /// settle. A zero duration disables the delay.
+  std::chrono::nanoseconds post_command_delay{std::chrono::nanoseconds{0}};
+
+  /// Whether to wait after sending the command. When false, the delay is
+  /// ignored.
+  bool wait_for_completion{false};
 };
 
 class EndEffectorExecutioninterface
@@ -34,7 +46,8 @@ public:
   bool grasp_object(
     V execution_interface,
     const std::string ee_link,
-    const std::string target_id)
+    const std::string target_id,
+    const EndEffectorExecutionContext & options = EndEffectorExecutionContext())
   {
     using type = std::remove_pointer_t<V>;
     static_assert(
@@ -47,13 +60,18 @@ public:
       ee_link.c_str());
 
     execution_interface->attach_object_to_ee(target_id, ee_link);
+
+    if (options.wait_for_completion && options.post_command_delay.count() > 0) {
+      rclcpp::sleep_for(options.post_command_delay);
+    }
     return true;
   }
   template<typename V>
   bool release_object(
     V execution_interface,
     const std::string ee_link,
-    const std::string target_id)
+    const std::string target_id,
+    const EndEffectorExecutionContext & options = EndEffectorExecutionContext())
   {
     using type = std::remove_pointer_t<V>;
     static_assert(
@@ -65,6 +83,10 @@ public:
       "Detaching from robot ee frame: [%s]",
       ee_link.c_str());
     execution_interface->detach_object_from_ee(target_id, ee_link);
+
+    if (options.wait_for_completion && options.post_command_delay.count() > 0) {
+      rclcpp::sleep_for(options.post_command_delay);
+    }
 
     return true;
   }


### PR DESCRIPTION
## Summary
- add optional context to end effector execution interface
- document grasp execution interface
- note new option in roadmap

## Testing
- `colcon test --packages-select emd_waypoint_execution` *(fails: Failed to find the following files: install/emd_grasp_execution/share/emd_grasp_execution/package.sh)*

------
https://chatgpt.com/codex/tasks/task_e_689a0cf6b7248331b71f464ff7e17395