### PR TITLE
Fix collision padding for MoveIt dynamic safety

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/src/moveit/collision_checker_moveit.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/moveit/collision_checker_moveit.cpp
@@ -82,7 +82,7 @@ void MoveitCollisionCheckerContext::configure(
   collision_request_.group_name = option.group;
   collision_request_.distance = option.distance;
   collision_request_.contacts = true;
-  scene_->getCollisionEnv()->setPadding(option.padding);
+  scene_->getCollisionEnvNonConst()->setPadding(option.padding);
 }
 
 void MoveitCollisionCheckerContext::run_discrete(


### PR DESCRIPTION
## Summary
- use non-const collision environment to apply padding

## Testing
- `colcon build --packages-select emd_dynamic_safety` *(fails: ament_cmake not found)*
- `colcon test --packages-select emd_dynamic_safety` *(fails: package not built)*

------
https://chatgpt.com/codex/tasks/task_e_689af47614f48331b69e860a3d2e23e8