### PR TITLE
Fix workcell builder target linking

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/CMakeLists.txt
@@ -130,10 +130,9 @@ ament_target_dependencies(workcell_builder
 )
 
 target_link_libraries(workcell_builder
-  PRIVATE
-    Qt5::Widgets
-    yaml-cpp
-    ${Boost_LIBRARIES}
+  Qt5::Widgets
+  yaml-cpp
+  ${Boost_LIBRARIES}
 )
 
 target_include_directories(workcell_builder

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/addendeffector.cpp
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/addendeffector.cpp
@@ -18,6 +18,7 @@
 #include <QKeyEvent>
 #include <boost/filesystem.hpp>
 #include <iostream>
+#include <fstream>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/addrobot.cpp
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/addrobot.cpp
@@ -18,6 +18,7 @@
 #include <boost/filesystem.hpp>
 #include <QKeyEvent>
 #include <iostream>
+#include <fstream>
 #include <sstream>
 #include <string>
 


### PR DESCRIPTION
## Summary
- fix `target_link_libraries` usage by removing mixed keyword form
- include `<fstream>` in GUI source files

## Testing
- `colcon build --packages-select workcell_builder --event-handlers console_cohesion+`
- `colcon test --packages-select workcell_builder --event-handlers console_cohesion+`


------
https://chatgpt.com/codex/tasks/task_e_689b046169488331b33e7e3cd30a2ece