### PR TITLE
Use secure temporary files when generating URDFs

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -14,6 +14,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -29,18 +30,21 @@ package_name = 'run_grasp_execution'
 
 
 def to_urdf(xacro_path, urdf_path=None, mappings=None):
-    # If no URDF path is given, use a temporary file
+    xacro_path = str(xacro_path)
     if urdf_path is None:
-        urdf_path = tempfile.mktemp(prefix='%s_' % os.path.basename(xacro_path))
+        fd, urdf_path = tempfile.mkstemp(
+            prefix=f"{Path(xacro_path).stem}_", suffix=".urdf"
+        )
+        os.close(fd)
+    else:
+        urdf_path = str(Path(urdf_path).with_suffix(".urdf"))
+        os.makedirs(os.path.dirname(urdf_path), exist_ok=True)
 
-    # open and process file
     doc = xacro.process_file(xacro_path, mappings=mappings)
-    # open the output file
-    print(urdf_path)
-    out = xacro.open_output(urdf_path)
-    out.write(doc.toprettyxml(indent='  '))
+    with xacro.open_output(urdf_path) as out:
+        out.write(doc.toprettyxml(indent='  '))
 
-    return urdf_path  # Return path to the urdf file
+    return urdf_path
 
 
 def load_file(package_name, file_path, mappings=None):

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/launch/grasp_execution.launch.py
@@ -14,6 +14,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -29,18 +30,21 @@ package_name = 'run_waypoint_execution'
 
 
 def to_urdf(xacro_path, urdf_path=None, mappings=None):
-    # If no URDF path is given, use a temporary file
+    xacro_path = str(xacro_path)
     if urdf_path is None:
-        urdf_path = tempfile.mktemp(prefix='%s_' % os.path.basename(xacro_path))
+        fd, urdf_path = tempfile.mkstemp(
+            prefix=f"{Path(xacro_path).stem}_", suffix=".urdf"
+        )
+        os.close(fd)
+    else:
+        urdf_path = str(Path(urdf_path).with_suffix(".urdf"))
+        os.makedirs(os.path.dirname(urdf_path), exist_ok=True)
 
-    # open and process file
     doc = xacro.process_file(xacro_path, mappings=mappings)
-    # open the output file
-    print(urdf_path)
-    out = xacro.open_output(urdf_path)
-    out.write(doc.toprettyxml(indent='  '))
+    with xacro.open_output(urdf_path) as out:
+        out.write(doc.toprettyxml(indent='  '))
 
-    return urdf_path  # Return path to the urdf file
+    return urdf_path
 
 
 def load_file(package_name, file_path, mappings=None):

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -14,6 +14,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 import xacro
 from launch import LaunchDescription
 from launch_ros.actions import Node
@@ -24,21 +25,22 @@ robot_base_link = 'base_link'
 robot_moveit_pkg = 'ur5_moveit_config'
 
 def to_urdf(xacro_path, urdf_path=None):
-    """Convert the given xacro file to URDF file.
-    * xacro_path -- the path to the xacro file
-    * urdf_path -- the path to the urdf file
-    """
-    # If no URDF path is given, use a temporary file
+    """Convert the given xacro file to a URDF file."""
+    xacro_path = str(xacro_path)
     if urdf_path is None:
-        urdf_path = tempfile.mktemp(prefix="%s_" % os.path.basename(xacro_path))
+        fd, urdf_path = tempfile.mkstemp(
+            prefix=f"{Path(xacro_path).stem}_", suffix=".urdf"
+        )
+        os.close(fd)
+    else:
+        urdf_path = str(Path(urdf_path).with_suffix(".urdf"))
+        os.makedirs(os.path.dirname(urdf_path), exist_ok=True)
 
-    # open and process file
     doc = xacro.process_file(xacro_path)
-    # open the output file
-    out = xacro.open_output(urdf_path)
-    out.write(doc.toprettyxml(indent='  '))
+    with xacro.open_output(urdf_path) as out:
+        out.write(doc.toprettyxml(indent='  '))
 
-    return urdf_path  # Return path to the urdf file
+    return urdf_path
 
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name) #get package filepath

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -14,6 +14,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 import xacro
 from launch import LaunchDescription
 from launch_ros.actions import Node
@@ -24,21 +25,22 @@ robot_base_link = 'base_link'
 robot_moveit_pkg = 'ur5_moveit_config'
 
 def to_urdf(xacro_path, urdf_path=None):
-    """Convert the given xacro file to URDF file.
-    * xacro_path -- the path to the xacro file
-    * urdf_path -- the path to the urdf file
-    """
-    # If no URDF path is given, use a temporary file
+    """Convert the given xacro file to a URDF file."""
+    xacro_path = str(xacro_path)
     if urdf_path is None:
-        urdf_path = tempfile.mktemp(prefix="%s_" % os.path.basename(xacro_path))
+        fd, urdf_path = tempfile.mkstemp(
+            prefix=f"{Path(xacro_path).stem}_", suffix=".urdf"
+        )
+        os.close(fd)
+    else:
+        urdf_path = str(Path(urdf_path).with_suffix(".urdf"))
+        os.makedirs(os.path.dirname(urdf_path), exist_ok=True)
 
-    # open and process file
     doc = xacro.process_file(xacro_path)
-    # open the output file
-    out = xacro.open_output(urdf_path)
-    out.write(doc.toprettyxml(indent='  '))
+    with xacro.open_output(urdf_path) as out:
+        out.write(doc.toprettyxml(indent='  '))
 
-    return urdf_path  # Return path to the urdf file
+    return urdf_path
 
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name) #get package filepath

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -14,6 +14,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 import xacro
 from launch import LaunchDescription
 from launch_ros.actions import Node
@@ -24,21 +25,22 @@ robot_base_link = 'base_link'
 robot_moveit_pkg = 'ur5_moveit_config'
 
 def to_urdf(xacro_path, urdf_path=None):
-    """Convert the given xacro file to URDF file.
-    * xacro_path -- the path to the xacro file
-    * urdf_path -- the path to the urdf file
-    """
-    # If no URDF path is given, use a temporary file
+    """Convert the given xacro file to a URDF file."""
+    xacro_path = str(xacro_path)
     if urdf_path is None:
-        urdf_path = tempfile.mktemp(prefix="%s_" % os.path.basename(xacro_path))
+        fd, urdf_path = tempfile.mkstemp(
+            prefix=f"{Path(xacro_path).stem}_", suffix=".urdf"
+        )
+        os.close(fd)
+    else:
+        urdf_path = str(Path(urdf_path).with_suffix(".urdf"))
+        os.makedirs(os.path.dirname(urdf_path), exist_ok=True)
 
-    # open and process file
     doc = xacro.process_file(xacro_path)
-    # open the output file
-    out = xacro.open_output(urdf_path)
-    out.write(doc.toprettyxml(indent='  '))
+    with xacro.open_output(urdf_path) as out:
+        out.write(doc.toprettyxml(indent='  '))
 
-    return urdf_path  # Return path to the urdf file
+    return urdf_path
 
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name) #get package filepath


### PR DESCRIPTION
## Summary
- replace insecure `tempfile.mktemp` with `mkstemp` for URDF generation
- ensure output directories exist and files are written via context managers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b0b270d888331bdaf9fc843f0c488