### PR TITLE
Improve grasp method selection based on available end effectors

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,7 +11,7 @@ The following items are pending implementation:
    - Added an execution context with optional delays for attach and detach operations.
 7. MoveIt-based execution improvements for multi-axis joints and path constraints.
 8. Context loading via `rcl_yaml_param_parser` with schema validation.
-9. Demo node lifecycle conversion and grasp method selection.
+9. Demo node lifecycle conversion.
 10. Default executor watchdog and graceful shutdown.
 11. Finger-gripper sampling strategies for multi-finger configurations.
 12. Additional testing, CI workflows, documentation, and Docker support.
@@ -21,3 +21,4 @@ These tasks are outlined for future contributions.
 ## Completed
 
 - Gripper driver interface hardened with explicit result codes.
+- Demo node grasp method selection.

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <algorithm>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -150,24 +151,39 @@ public:
     // Get home state
     moveit::core::RobotStatePtr home_state(get_curr_state());
 
-    // TODO(Briancbn): select grasp method based on end effector availability
-    double clearance;
+    // Select grasp method based on end effector availability
+    double clearance = 0.0;
     std::string ee_link = "";
     std::string planning_group = "";
-    auto & grasp_method = target->grasp_methods[0];
-    const std::string & ee_brand = grasp_method.ee_id;
 
-    // Select the group based on ee brand name
-    for (auto & group : get_workcell_context().groups) {
-      for (auto & ee : group.second.end_effectors) {
-        if (ee.second.brand == ee_brand) {
-          ee_link = ee.second.link;
-          clearance = ee.second.clearance;
-          planning_group = group.first;
+    const emd_msgs::msg::GraspMethod *selected_method = nullptr;
+    for (const auto & method : target->grasp_methods) {
+      for (auto & group : get_workcell_context().groups) {
+        for (auto & ee : group.second.end_effectors) {
+          if (ee.second.brand == method.ee_id) {
+            selected_method = &method;
+            ee_link = ee.second.link;
+            clearance = ee.second.clearance;
+            planning_group = group.first;
+            break;
+          }
+        }
+        if (selected_method) {
           break;
         }
       }
+      if (selected_method) {
+        break;
+      }
     }
+
+    if (!selected_method) {
+      RCLCPP_ERROR(node_->get_logger(), "No valid end effector found for target %s", target_id.c_str());
+      return false;
+    }
+
+    const auto & grasp_method = *selected_method;
+    const std::string & ee_brand = grasp_method.ee_id;
 
     grasp_execution::GraspExecutionContext options;
     options.world_frame = "world";


### PR DESCRIPTION
## Summary
- select grasp method matching available end effectors
- document completed grasp method selection in roadmap

## Testing
- `~/.local/bin/colcon build --packages-select run_grasp_execution` (failed: package dependency files not found)


------
https://chatgpt.com/codex/tasks/task_e_689b0f03f8188331b6d69ac1e282dd72