### PR TITLE
docs: expand grasp execution interface context

### DIFF
--- a/docs/grasp_execution_interface.md
+++ b/docs/grasp_execution_interface.md
@@ -1,9 +1,19 @@
 # Grasp Execution Interface
 
 The end effector execution interface provides helper methods for attaching
-and detaching objects from the robot's end effector.  It now supports an
+and detaching objects from the robot's end effector. It now supports an
 optional execution context that allows callers to wait for hardware
 operations to complete before proceeding.
+
+The `EndEffectorExecutionContext` exposes two tuning options:
+
+* `post_command_delay` – duration to wait after a command before returning.
+  A zero duration (default) disables the delay.
+* `wait_for_completion` – whether to respect the delay. The default is
+  `false` to match previous behaviour.
+
+Passing a context instance to `grasp_object` or `release_object` applies the
+configured timing to those operations.
 
 ## Usage
 
@@ -11,13 +21,19 @@ operations to complete before proceeding.
 #include "emd/end_effector/ee_execution_interface.hpp"
 
 emd::EndEffectorExecutioninterface ee;
+
+// Operations without a context return immediately
+ee.grasp_object(moveit_execution, "tool0", target_id);
+
 emd::EndEffectorExecutionContext ctx;
 ctx.wait_for_completion = true;
 ctx.post_command_delay = std::chrono::milliseconds(500);
 
 // Attach an object and wait half a second for the gripper to close
- ee.grasp_object(moveit_execution, "tool0", target_id, ctx);
+ee.grasp_object(moveit_execution, "tool0", target_id, ctx);
+// Release the object with the same delay
+ee.release_object(moveit_execution, "tool0", target_id, ctx);
 ```
 
-Setting `wait_for_completion` to `false` skips the delay, matching the
-previous behaviour.
+Setting `wait_for_completion` to `false` or omitting the context parameter
+performs the operation without waiting.


### PR DESCRIPTION
## Summary
- document `EndEffectorExecutionContext` options
- show attach and release examples with optional delays

## Testing
- `colcon test` *(fails: Has this package been built before?)*
- `colcon build` *(fails: Could not find ament_cmake package)*

------
https://chatgpt.com/codex/tasks/task_e_689b0f03f8188331b6d69ac1e282dd72