### PR TITLE
feat: expand end effector delay options

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,13 +7,12 @@ The following items are pending implementation:
 3. Tesseract Collision Checker plugin mapping and self-collision checks.
 4. Replanner parameterization and joint-limit handling improvements.
 5. Scheduler workflow prerequisites and queue robustness.
-6. Grasp Execution Interface documentation and options expansion.
-7. MoveIt-based execution improvements for multi-axis joints and path constraints.
-8. Context loading via `rcl_yaml_param_parser` with schema validation.
-9. Demo node lifecycle conversion.
-10. Default executor watchdog and graceful shutdown.
-11. Finger-gripper sampling strategies for multi-finger configurations.
-12. Additional testing, CI workflows, documentation, and Docker support.
+6. MoveIt-based execution improvements for multi-axis joints and path constraints.
+7. Context loading via `rcl_yaml_param_parser` with schema validation.
+8. Demo node lifecycle conversion.
+9. Default executor watchdog and graceful shutdown.
+10. Finger-gripper sampling strategies for multi-finger configurations.
+11. Additional testing, CI workflows, documentation, and Docker support.
 
 These tasks are outlined for future contributions.
 
@@ -22,3 +21,4 @@ These tasks are outlined for future contributions.
 - Gripper driver interface hardened with explicit result codes
 - End effector execution context supports optional delays for attach and detach operations.
 - Demo node grasp method selection.
+- Grasp Execution Interface documented and supports pre- and post-command delays.

--- a/docs/grasp_execution_interface.md
+++ b/docs/grasp_execution_interface.md
@@ -5,11 +5,13 @@ and detaching objects from the robot's end effector. It now supports an
 optional execution context that allows callers to wait for hardware
 operations to complete before proceeding.
 
-The `EndEffectorExecutionContext` exposes two tuning options:
+The `EndEffectorExecutionContext` exposes several tuning options:
 
+* `pre_command_delay` – duration to wait before sending a command. A zero
+  duration (default) disables the delay.
 * `post_command_delay` – duration to wait after a command before returning.
   A zero duration (default) disables the delay.
-* `wait_for_completion` – whether to respect the delay. The default is
+* `wait_for_completion` – whether to respect the delays. The default is
   `false` to match previous behaviour.
 
 Passing a context instance to `grasp_object` or `release_object` applies the
@@ -27,11 +29,12 @@ ee.grasp_object(moveit_execution, "tool0", target_id);
 
 emd::EndEffectorExecutionContext ctx;
 ctx.wait_for_completion = true;
+ctx.pre_command_delay = std::chrono::milliseconds(200);
 ctx.post_command_delay = std::chrono::milliseconds(500);
 
-// Attach an object and wait half a second for the gripper to close
+// Wait 200 ms, attach an object and wait half a second for the gripper to close
 ee.grasp_object(moveit_execution, "tool0", target_id, ctx);
-// Release the object with the same delay
+// Wait 200 ms then release the object with the same post-command delay
 ee.release_object(moveit_execution, "tool0", target_id, ctx);
 ```
 

--- a/easy_manipulation_deployment/emd_waypoint_execution/include/emd/end_effector/ee_execution_interface.hpp
+++ b/easy_manipulation_deployment/emd_waypoint_execution/include/emd/end_effector/ee_execution_interface.hpp
@@ -28,12 +28,15 @@ namespace emd
 /// Options used by end effector operations.
 struct EndEffectorExecutionContext
 {
+  /// Amount of time to wait before sending a command. A zero duration
+  /// disables the delay.
+  std::chrono::nanoseconds pre_command_delay{std::chrono::nanoseconds{0}};
+
   /// Amount of time to wait after a command to allow the hardware state to
   /// settle. A zero duration disables the delay.
   std::chrono::nanoseconds post_command_delay{std::chrono::nanoseconds{0}};
 
-  /// Whether to wait after sending the command. When false, the delay is
-  /// ignored.
+  /// Whether to respect the delays. When false, the delays are ignored.
   bool wait_for_completion{false};
 };
 
@@ -58,6 +61,9 @@ public:
       LOGGER_EE_INTERFACE,
       "Attaching to robot ee frame: [%s]",
       ee_link.c_str());
+    if (options.wait_for_completion && options.pre_command_delay.count() > 0) {
+      rclcpp::sleep_for(options.pre_command_delay);
+    }
 
     execution_interface->attach_object_to_ee(target_id, ee_link);
 
@@ -82,6 +88,10 @@ public:
       LOGGER_EE_INTERFACE,
       "Detaching from robot ee frame: [%s]",
       ee_link.c_str());
+    if (options.wait_for_completion && options.pre_command_delay.count() > 0) {
+      rclcpp::sleep_for(options.pre_command_delay);
+    }
+
     execution_interface->detach_object_from_ee(target_id, ee_link);
 
     if (options.wait_for_completion && options.post_command_delay.count() > 0) {


### PR DESCRIPTION
## Summary
- support pre-command delays in end effector execution
- document new delay options
- mark Grasp Execution Interface roadmap item as complete

## Testing
- `colcon build --packages-select emd_waypoint_execution` *(fails: Failed to find the following files: ...)*

------
https://chatgpt.com/codex/tasks/task_e_689b1350fc7c8331a2d2a5fd5bc504a1