### PR TITLE
Add watchdog to default executor

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,9 +11,8 @@ The following items are pending implementation:
 7. MoveIt-based execution improvements for multi-axis joints and path constraints.
 8. Context loading via `rcl_yaml_param_parser` with schema validation.
 9. Demo node lifecycle conversion.
-10. Default executor watchdog and graceful shutdown.
-11. Finger-gripper sampling strategies for multi-finger configurations.
-12. Additional testing, CI workflows, documentation, and Docker support.
+10. Finger-gripper sampling strategies for multi-finger configurations.
+11. Additional testing, CI workflows, documentation, and Docker support.
 
 These tasks are outlined for future contributions.
 
@@ -22,3 +21,4 @@ These tasks are outlined for future contributions.
 - Gripper driver interface hardened with explicit result codes
 - End effector execution context supports optional delays for attach and detach operations.
 - Demo node grasp method selection.
+- Default executor watchdog and graceful shutdown.

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/executor/default_executor.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/executor/default_executor.cpp
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
 #include <string>
+#include <thread>
 
+#include "rclcpp/rclcpp.hpp"
 #include "emd/grasp_execution/moveit2/executor/default_executor.hpp"
 
 namespace grasp_execution
@@ -52,10 +55,27 @@ bool DefaultExecutor::run(
   robot_trajectory.getRobotTrajectoryMsg(robot_trajectory_msg);
 
   trajectory_execution_manager_->push(robot_trajectory_msg);
+
+  // Watchdog thread that stops execution when ROS is shutting down
+  std::atomic_bool finished(false);
+  std::thread watchdog([this, &finished]() {
+    rclcpp::Rate r(10);
+    while (rclcpp::ok() && !finished) {
+      r.sleep();
+    }
+    if (!rclcpp::ok()) {
+      RCLCPP_WARN(logger_, "Shutting down - stopping execution");
+      trajectory_execution_manager_->stopExecution();
+    }
+  });
+
   trajectory_execution_manager_->execute();
 
   // ALWAYS BLOCKING !!!
   auto status = trajectory_execution_manager_->waitForExecution();
+
+  finished = true;
+  watchdog.join();
 
   // Allow timeout
   // TODO(anyone): fix doesn't finish in time problem.


### PR DESCRIPTION
## Summary
- ensure DefaultExecutor stops execution cleanly when ROS shuts down
- update roadmap to reflect completion of watchdog task

## Testing
- `colcon test --packages-select emd_grasp_execution --event-handlers console_direct+` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b1350fc7c8331a2d2a5fd5bc504a1