### PR TITLE
Convert grasp execution demo to LifecycleNode

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,10 +10,9 @@ The following items are pending implementation:
 6. Grasp Execution Interface documentation and options expansion.
 7. MoveIt-based execution improvements for multi-axis joints and path constraints.
 8. Context loading via `rcl_yaml_param_parser` with schema validation.
-9. Demo node lifecycle conversion.
-10. Default executor watchdog and graceful shutdown.
-11. Finger-gripper sampling strategies for multi-finger configurations.
-12. Additional testing, CI workflows, documentation, and Docker support.
+9. Default executor watchdog and graceful shutdown.
+10. Finger-gripper sampling strategies for multi-finger configurations.
+11. Additional testing, CI workflows, documentation, and Docker support.
 
 These tasks are outlined for future contributions.
 
@@ -22,3 +21,4 @@ These tasks are outlined for future contributions.
 - Gripper driver interface hardened with explicit result codes
 - End effector execution context supports optional delays for attach and detach operations.
 - Demo node grasp method selection.
+- Demo node lifecycle conversion.

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(ament_cmake REQUIRED)
 find_package(emd_grasp_execution REQUIRED)
 find_package(emd_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 
 add_executable(demo_node src/demo_node.cpp)
 
@@ -22,6 +23,7 @@ ament_target_dependencies(demo_node
   emd_grasp_execution
   emd_msgs
   rclcpp
+  rclcpp_lifecycle
 )
 
 add_executable(fake_grasp_pose_publisher src/fake_grasp_pose_publisher.cpp)

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
 
   <depend>emd_grasp_execution</depend>
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -20,6 +20,8 @@
 #include <algorithm>
 
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "lifecycle_msgs/msg/transition.hpp"
 
 #include "emd/grasp_execution/moveit2/moveit_cpp_if.hpp"
 #include "emd/grasp_execution/utils.hpp"
@@ -300,27 +302,62 @@ private:
 
 }  // namespace grasp_execution
 
+class DemoLifecycleNode : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  explicit DemoLifecycleNode(const rclcpp::NodeOptions & options)
+  : rclcpp_lifecycle::LifecycleNode("grasp_execution_demo_node", "", options)
+  {
+    this->declare_parameter<std::string>("workcell_context", "");
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_configure(
+    const rclcpp_lifecycle::State &)
+  {
+    demo_ = std::make_shared<grasp_execution::Demo>(
+      shared_from_this(), grasp_execution::GRASP_EXECUTION_PACKAGE,
+      grasp_execution::GRASP_TASK_TOPIC, grasp_execution::GRASP_REQUEST_TOPIC);
+    const std::string workcell_context_filepath =
+      this->get_parameter("workcell_context").as_string();
+    demo_->init_from_yaml(workcell_context_filepath);
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_activate(
+    const rclcpp_lifecycle::State &)
+  {
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_deactivate(
+    const rclcpp_lifecycle::State &)
+  {
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_cleanup(
+    const rclcpp_lifecycle::State &)
+  {
+    demo_.reset();
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+private:
+  std::shared_ptr<grasp_execution::Demo> demo_;
+};
+
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   rclcpp::NodeOptions node_options;
   node_options.automatically_declare_parameters_from_overrides(true);
-  rclcpp::Node::SharedPtr node =
-    rclcpp::Node::make_shared("grasp_execution_demo_node", "", node_options);
+  auto node = std::make_shared<DemoLifecycleNode>(node_options);
 
-  const std::string workcell_context_filepath =
-    node->get_parameter("workcell_context").as_string();
-
-  grasp_execution::Demo demo(
-    node, grasp_execution::GRASP_EXECUTION_PACKAGE,
-    grasp_execution::GRASP_TASK_TOPIC, grasp_execution::GRASP_REQUEST_TOPIC);
-
-  // const std::string planning_strategies_filepath =
-  //   node->get_parameter("planning_strategy").as_string();
-  demo.init_from_yaml(workcell_context_filepath);
+  node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
 
   rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(node);
+  executor.add_node(node->get_node_base_interface());
   executor.spin();
 
   rclcpp::shutdown();


### PR DESCRIPTION
## Summary
- convert grasp execution demo to a lifecycle-aware node
- add rclcpp_lifecycle dependency to demo package
- update roadmap to mark lifecycle conversion complete

## Testing
- `colcon test --packages-select run_grasp_execution` *(fails: command not found: colcon)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package python3-colcon-common-extensions)*

------
https://chatgpt.com/codex/tasks/task_e_689b1350fc7c8331a2d2a5fd5bc504a1