### PR TITLE
Add pre-command delay to gripper interface

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,13 +7,12 @@ The following items are pending implementation:
 3. Tesseract Collision Checker plugin mapping and self-collision checks.
 4. Replanner parameterization and joint-limit handling improvements.
 5. Scheduler workflow prerequisites and queue robustness.
-6. Grasp Execution Interface documentation and options expansion.
-7. MoveIt-based execution improvements for multi-axis joints and path constraints.
-8. Context loading via `rcl_yaml_param_parser` with schema validation.
-9. Demo node lifecycle conversion.
-10. Default executor watchdog and graceful shutdown.
-11. Finger-gripper sampling strategies for multi-finger configurations.
-12. Additional testing, CI workflows, documentation, and Docker support.
+6. MoveIt-based execution improvements for multi-axis joints and path constraints.
+7. Context loading via `rcl_yaml_param_parser` with schema validation.
+8. Demo node lifecycle conversion.
+9. Default executor watchdog and graceful shutdown.
+10. Finger-gripper sampling strategies for multi-finger configurations.
+11. Additional testing, CI workflows, documentation, and Docker support.
 
 These tasks are outlined for future contributions.
 
@@ -22,3 +21,4 @@ These tasks are outlined for future contributions.
 - Gripper driver interface hardened with explicit result codes
 - End effector execution context supports optional delays for attach and detach operations.
 - Demo node grasp method selection.
+- Grasp Execution Interface documentation expanded with configurable pre- and post-command delays.

--- a/docs/grasp_execution_interface.md
+++ b/docs/grasp_execution_interface.md
@@ -3,14 +3,17 @@
 The end effector execution interface provides helper methods for attaching
 and detaching objects from the robot's end effector. It now supports an
 optional execution context that allows callers to wait for hardware
-operations to complete before proceeding.
+operations to complete before proceeding and to insert delays before
+issuing commands.
 
-The `EndEffectorExecutionContext` exposes two tuning options:
+The `EndEffectorExecutionContext` exposes three tuning options:
 
+* `pre_command_delay` – duration to wait before issuing a command. A zero
+  duration disables the delay.
 * `post_command_delay` – duration to wait after a command before returning.
   A zero duration (default) disables the delay.
-* `wait_for_completion` – whether to respect the delay. The default is
-  `false` to match previous behaviour.
+* `wait_for_completion` – whether to respect the post-command delay. The
+  default is `false` to match previous behaviour.
 
 Passing a context instance to `grasp_object` or `release_object` applies the
 configured timing to those operations.
@@ -26,14 +29,16 @@ emd::EndEffectorExecutioninterface ee;
 ee.grasp_object(moveit_execution, "tool0", target_id);
 
 emd::EndEffectorExecutionContext ctx;
-ctx.wait_for_completion = true;
+ctx.pre_command_delay = std::chrono::milliseconds(250);
 ctx.post_command_delay = std::chrono::milliseconds(500);
+ctx.wait_for_completion = true;
 
-// Attach an object and wait half a second for the gripper to close
+// Attach an object, waiting briefly before and half a second after the command
 ee.grasp_object(moveit_execution, "tool0", target_id, ctx);
-// Release the object with the same delay
+// Release the object with the same delays
 ee.release_object(moveit_execution, "tool0", target_id, ctx);
 ```
 
 Setting `wait_for_completion` to `false` or omitting the context parameter
-performs the operation without waiting.
+performs the operation without waiting after the command. The pre-command
+delay, if specified, is always honoured.

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -53,8 +53,10 @@ public:
     end_effector_interface_ = std::make_shared<emd::EndEffectorExecutioninterface>();
     ee_context_.wait_for_completion = node_->declare_parameter<bool>(
       "ee_wait_for_completion", false);
-    int delay_ms = node_->declare_parameter<int>("ee_post_command_delay_ms", 0);
-    ee_context_.post_command_delay = std::chrono::milliseconds(delay_ms);
+    int pre_delay_ms = node_->declare_parameter<int>("ee_pre_command_delay_ms", 0);
+    int post_delay_ms = node_->declare_parameter<int>("ee_post_command_delay_ms", 0);
+    ee_context_.pre_command_delay = std::chrono::milliseconds(pre_delay_ms);
+    ee_context_.post_command_delay = std::chrono::milliseconds(post_delay_ms);
 
     grasp_task_sub_ = node_->create_subscription<emd_msgs::msg::GraspTask>(
       grasp_task_topic, 10,

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/demo_node.cpp
@@ -53,8 +53,10 @@ public:
     this->end_effector_interface = std::make_shared<emd::EndEffectorExecutioninterface>();
     ee_context_.wait_for_completion = node_->declare_parameter<bool>(
       "ee_wait_for_completion", false);
-    int delay_ms = node_->declare_parameter<int>("ee_post_command_delay_ms", 0);
-    ee_context_.post_command_delay = std::chrono::milliseconds(delay_ms);
+    int pre_delay_ms = node_->declare_parameter<int>("ee_pre_command_delay_ms", 0);
+    int post_delay_ms = node_->declare_parameter<int>("ee_post_command_delay_ms", 0);
+    ee_context_.pre_command_delay = std::chrono::milliseconds(pre_delay_ms);
+    ee_context_.post_command_delay = std::chrono::milliseconds(post_delay_ms);
 
     grasp_task_sub_ = node_->create_subscription<emd_msgs::msg::GraspTask>(
       grasp_task_topic, 10,

--- a/easy_manipulation_deployment/emd_waypoint_execution/include/emd/end_effector/ee_execution_interface.hpp
+++ b/easy_manipulation_deployment/emd_waypoint_execution/include/emd/end_effector/ee_execution_interface.hpp
@@ -28,12 +28,16 @@ namespace emd
 /// Options used by end effector operations.
 struct EndEffectorExecutionContext
 {
+  /// Amount of time to wait before sending a command. A zero duration
+  /// disables the delay.
+  std::chrono::nanoseconds pre_command_delay{std::chrono::nanoseconds{0}};
+
   /// Amount of time to wait after a command to allow the hardware state to
   /// settle. A zero duration disables the delay.
   std::chrono::nanoseconds post_command_delay{std::chrono::nanoseconds{0}};
 
-  /// Whether to wait after sending the command. When false, the delay is
-  /// ignored.
+  /// Whether to wait after sending the command. When false, the post command
+  /// delay is ignored.
   bool wait_for_completion{false};
 };
 
@@ -58,7 +62,9 @@ public:
       LOGGER_EE_INTERFACE,
       "Attaching to robot ee frame: [%s]",
       ee_link.c_str());
-
+    if (options.pre_command_delay.count() > 0) {
+      rclcpp::sleep_for(options.pre_command_delay);
+    }
     execution_interface->attach_object_to_ee(target_id, ee_link);
 
     if (options.wait_for_completion && options.post_command_delay.count() > 0) {
@@ -82,6 +88,9 @@ public:
       LOGGER_EE_INTERFACE,
       "Detaching from robot ee frame: [%s]",
       ee_link.c_str());
+    if (options.pre_command_delay.count() > 0) {
+      rclcpp::sleep_for(options.pre_command_delay);
+    }
     execution_interface->detach_object_from_ee(target_id, ee_link);
 
     if (options.wait_for_completion && options.post_command_delay.count() > 0) {


### PR DESCRIPTION
## Summary
- expand `EndEffectorExecutionContext` with a pre-command delay and apply it in gripper attach/detach
- expose new `ee_pre_command_delay_ms` parameter in demo nodes
- document new behavior and mark roadmap item as complete

## Testing
- `colcon build --packages-select run_grasp_execution run_waypoint_execution` *(fails: missing emd_msgs, emd_grasp_execution, emd_waypoint_execution packages)*

------
https://chatgpt.com/codex/tasks/task_e_689b1350fc7c8331a2d2a5fd5bc504a1