### PR TITLE
Improve scheduler queue cancellation lookup

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/src/core/scheduler.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/core/scheduler.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <algorithm>
 #include <utility>
 #include <vector>
 
@@ -325,15 +326,14 @@ Workflow::Status Scheduler::cancel_workflow(
   }
 
   // Check if workflow_id is in queue
-  // TODO(anyone): better way to check queue
-  for (size_t i = 0; i < impl_->id_queue.size(); i++) {
-    // Remove workflow id
-    if (impl_->id_queue[i] == workflow_id) {
-      impl_->id_queue.erase(impl_->id_queue.begin() + i);
-      impl_->workflow_queue.erase(impl_->workflow_queue.begin() + i);
-      impl_->queued_task_map.erase(workflow_id);
-      return Workflow::Status::CANCELLED;
-    }
+  auto it = std::find(
+    impl_->id_queue.begin(), impl_->id_queue.end(), workflow_id);
+  if (it != impl_->id_queue.end()) {
+    auto idx = std::distance(impl_->id_queue.begin(), it);
+    impl_->id_queue.erase(it);
+    impl_->workflow_queue.erase(impl_->workflow_queue.begin() + idx);
+    impl_->queued_task_map.erase(workflow_id);
+    return Workflow::Status::CANCELLED;
   }
 
   // Cannot find workflow_id anywhere


### PR DESCRIPTION
## Summary
- optimize workflow cancellation by searching queued workflows with std::find instead of manual loop

## Testing
- `colcon build --packages-select emd_grasp_execution` *(fails: command not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689b54750a308331888b9a4883ce8c28