### PR TITLE
Fix missing ee_execution_interface include for run_grasp_execution

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(emd_grasp_execution REQUIRED)
+find_package(emd_waypoint_execution REQUIRED)
 find_package(emd_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
@@ -21,6 +22,7 @@ add_executable(demo_node src/demo_node.cpp)
 
 ament_target_dependencies(demo_node
   emd_grasp_execution
+  emd_waypoint_execution
   emd_msgs
   rclcpp
   rclcpp_lifecycle

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml
@@ -12,6 +12,7 @@
   <depend>rclcpp_lifecycle</depend>
 
   <depend>emd_grasp_execution</depend>
+  <depend>emd_waypoint_execution</depend>
 
   <exec_depend>xacro</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>


### PR DESCRIPTION
## Summary
- add emd_waypoint_execution dependency so run_grasp_execution can include ee_execution_interface

## Testing
- `colcon build --packages-up-to run_grasp_execution` *(fails: CMake could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fdb924e08331aa22fc1be041fe42