### PR TITLE
fix: cast lifecycle node to base node

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -314,8 +314,12 @@ public:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_configure(
     const rclcpp_lifecycle::State &)
   {
+    // shared_from_this() returns a pointer to DemoLifecycleNode (a LifecycleNode).
+    // Demo expects an rclcpp::Node pointer, so explicitly cast to the base type
+    // to avoid template deduction failure during construction.
+    auto base_node = std::static_pointer_cast<rclcpp::Node>(shared_from_this());
     demo_ = std::make_shared<grasp_execution::Demo>(
-      shared_from_this(), grasp_execution::GRASP_EXECUTION_PACKAGE,
+      base_node, grasp_execution::GRASP_EXECUTION_PACKAGE,
       grasp_execution::GRASP_TASK_TOPIC, grasp_execution::GRASP_REQUEST_TOPIC);
     const std::string workcell_context_filepath =
       this->get_parameter("workcell_context").as_string();


### PR DESCRIPTION
## Summary
- ensure `Demo` receives an `rclcpp::Node` by casting `shared_from_this()` to the base type

## Testing
- `colcon build --packages-select run_grasp_execution` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ffe51d4483318fb3efe3a2068984