### PR TITLE
Fix run_grasp_execution dependencies and MoveIt header usage

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(emd_grasp_execution REQUIRED)
+find_package(emd_waypoint_execution REQUIRED)
 find_package(emd_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
@@ -21,6 +22,7 @@ add_executable(demo_node src/demo_node.cpp)
 
 ament_target_dependencies(demo_node
   emd_grasp_execution
+  emd_waypoint_execution
   emd_msgs
   rclcpp
   rclcpp_lifecycle

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml
@@ -12,6 +12,7 @@
   <depend>rclcpp_lifecycle</depend>
 
   <depend>emd_grasp_execution</depend>
+  <depend>emd_waypoint_execution</depend>
 
   <exec_depend>xacro</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
@@ -26,10 +26,10 @@
 #include "emd/grasp_execution/grasp_execution.hpp"
 #include "emd/grasp_execution/moveit2/executor.hpp"
 
-#include "moveit/moveit_cpp/moveit_cpp.h"
-#include "moveit/moveit_cpp/planning_component.h"
-#include "moveit/trajectory_processing/iterative_time_parameterization.h"
-#include "moveit/trajectory_processing/time_optimal_trajectory_generation.h"
+#include "moveit/moveit_cpp/moveit_cpp.hpp"
+#include "moveit/moveit_cpp/planning_component.hpp"
+#include "moveit/trajectory_processing/iterative_time_parameterization.hpp"
+#include "moveit/trajectory_processing/time_optimal_trajectory_generation.hpp"
 
 #include "pluginlib/class_loader.hpp"
 


### PR DESCRIPTION
## Summary
- add emd_waypoint_execution as a dependency of run_grasp_execution
- switch MoveIt headers to `.hpp` extensions for Jazzy compatibility

## Testing
- `colcon build --packages-up-to run_grasp_execution --event-handlers console_direct+ --cmake-args -DBUILD_TESTING=OFF` *(fails: moveit/trajectory_processing/iterative_time_parameterization.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fdb924e08331aa22fc1be041fe42