### PR TITLE
Fix MoveIt include paths for MoveItCpp interface

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
@@ -26,8 +26,8 @@
 #include "emd/grasp_execution/grasp_execution.hpp"
 #include "emd/grasp_execution/moveit2/executor.hpp"
 
-#include "moveit/moveit_cpp/moveit_cpp.hpp"
-#include "moveit/moveit_cpp/planning_component.hpp"
+#include "moveit/moveit_cpp/moveit_cpp.h"
+#include "moveit/moveit_cpp/planning_component.h"
 #include "moveit/trajectory_processing/iterative_time_parameterization.hpp"
 #include "moveit/trajectory_processing/time_optimal_trajectory_generation.hpp"
 


### PR DESCRIPTION
## Summary
- include MoveItCpp headers using .h extensions for compatibility with older MoveIt releases

## Testing
- `colcon build --packages-select emd_grasp_execution` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3027ad2ac8331ba42d0b767cdff65