### PR TITLE
Fix MoveIt include paths for trajectory processing

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
@@ -28,8 +28,8 @@
 
 #include "moveit/moveit_cpp/moveit_cpp.h"
 #include "moveit/moveit_cpp/planning_component.h"
-#include "moveit/trajectory_processing/iterative_time_parameterization.hpp"
-#include "moveit/trajectory_processing/time_optimal_trajectory_generation.hpp"
+#include "moveit/trajectory_processing/iterative_time_parameterization.h"
+#include "moveit/trajectory_processing/time_optimal_trajectory_generation.h"
 
 #include "pluginlib/class_loader.hpp"
 


### PR DESCRIPTION
## Summary
- fix MoveIt include paths for time parameterization headers

## Testing
- `colcon build --packages-select emd_grasp_execution` *(fails: command not found: colcon)*

------
https://chatgpt.com/codex/tasks/task_e_68a303901ea4833182415d00d100044f