### PR TITLE
Fix debug PythonExpression quoting in launch files

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/launch/run_moveit_cpp.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/launch/run_moveit_cpp.launch.py
@@ -89,9 +89,9 @@ def generate_launch_description():
         package="run_dynamic_safety",
         prefix=PythonExpression(
             [
-                '"xterm -e gdb --args" if ',
+                "'xterm -e gdb --args' if '",
                 LaunchConfiguration('debug'),
-                ' == "true" else ""',
+                "' == 'true' else ''",
             ]
         ),
         executable="run_moveit_cpp",

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -131,9 +131,9 @@ def generate_launch_description():
         package=package_name,
         prefix=PythonExpression(
             [
-                '"xterm -e gdb --args" if ',
+                "'xterm -e gdb --args' if '",
                 LaunchConfiguration('debug'),
-                ' == "true" else ""',
+                "' == 'true' else ''",
             ]
         ),
         executable='demo_node',

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/launch/grasp_execution.launch.py
@@ -131,9 +131,9 @@ def generate_launch_description():
         package=package_name,
         prefix=PythonExpression(
             [
-                '"xterm -e gdb --args" if ',
+                "'xterm -e gdb --args' if '",
                 LaunchConfiguration('debug'),
-                ' == "true" else ""',
+                "' == 'true' else ''",
             ]
         ),
         executable='demo_node',


### PR DESCRIPTION
## Summary
- fix NameError in demo launch files by quoting debug LaunchConfiguration

## Testing
- `pytest`
- `python easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` *(fails: ModuleNotFoundError: No module named 'ament_index_python')*


------
https://chatgpt.com/codex/tasks/task_e_68a307acdba88331849f34dc4f57e5b4