### PR TITLE
Fix grasp execution launch configuration

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(emd_waypoint_execution REQUIRED)
 find_package(emd_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 
 add_executable(demo_node src/demo_node.cpp)
 
@@ -26,6 +27,7 @@ ament_target_dependencies(demo_node
   emd_msgs
   rclcpp
   rclcpp_lifecycle
+  ament_index_cpp
 )
 
 add_executable(fake_grasp_pose_publisher src/fake_grasp_pose_publisher.cpp)

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml
@@ -1,5 +1,6 @@
 grasp_execution_node:
   ros__parameters:
+    workcell_context: config/workcell_context.yaml
     planning_scene_monitor_options:
       name: "planning_scene_monitor"
       robot_description: "robot_description"

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -90,7 +90,8 @@ def generate_launch_description():
     robot_description_semantic_config = load_file(scene_pkg, 'urdf/arm_hand.srdf.xacro')
     robot_description_semantic = {'robot_description_semantic': robot_description_semantic_config}
 
-    kinematics_yaml = load_yaml('ur5_moveit_config', 'config/kinematics.yaml')
+    kinematics_yaml = {'robot_description_kinematics':
+                       load_yaml('ur5_moveit_config', 'config/kinematics.yaml')}
 
     ompl_planning_pipeline_config = {
         'ompl': {
@@ -121,10 +122,6 @@ def generate_launch_description():
     joint_limits_yaml = load_yaml('ur5_moveit_config', 'config/joint_limits.yaml')
     joint_limits = {'robot_description_planning': joint_limits_yaml}
 
-    workcell_context_yaml = os.path.join(
-        get_package_share_directory(package_name), 'config', 'workcell_context.yaml')
-    workcell_context = {'workcell_context': workcell_context_yaml}
-
     # MoveItCpp demo executable
     grasp_execution_demo_node = Node(
         name='grasp_execution_node',
@@ -146,7 +143,6 @@ def generate_launch_description():
             kinematics_yaml,
             ompl_planning_pipeline_config,
             trajectory_execution,
-            workcell_context,
             moveit_controller,
         ],
     )
@@ -194,7 +190,7 @@ def generate_launch_description():
     for controller in ["ur5_arm_controller", "joint_state_controller"]:
         load_controllers += [
             ExecuteProcess(
-                cmd=["ros2 run controller_manager spawner.py {}".format(controller)],
+                cmd=["ros2 run controller_manager spawner {}".format(controller)],
                 shell=True,
                 output="screen",
             )

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>ament_index_cpp</depend>
 
   <depend>emd_grasp_execution</depend>
   <depend>emd_waypoint_execution</depend>

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -18,10 +18,12 @@
 #include <utility>
 #include <vector>
 #include <algorithm>
+#include <filesystem>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "lifecycle_msgs/msg/transition.hpp"
+#include "ament_index_cpp/get_package_share_directory.hpp"
 
 #include "emd/grasp_execution/moveit2/moveit_cpp_if.hpp"
 #include "emd/grasp_execution/utils.hpp"
@@ -308,7 +310,9 @@ public:
   explicit DemoLifecycleNode(const rclcpp::NodeOptions & options)
   : rclcpp_lifecycle::LifecycleNode("grasp_execution_demo_node", "", options)
   {
-    this->declare_parameter<std::string>("workcell_context", "");
+    if (!this->has_parameter("workcell_context")) {
+      this->declare_parameter<std::string>("workcell_context", "");
+    }
   }
 
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_configure(
@@ -326,8 +330,15 @@ public:
     demo_ = std::make_shared<grasp_execution::Demo>(
       base_node, grasp_execution::GRASP_EXECUTION_PACKAGE,
       grasp_execution::GRASP_TASK_TOPIC, grasp_execution::GRASP_REQUEST_TOPIC);
-    const std::string workcell_context_filepath =
+    std::string workcell_context_filepath =
       this->get_parameter("workcell_context").as_string();
+    if (!std::filesystem::path(workcell_context_filepath).is_absolute()) {
+      workcell_context_filepath =
+        (std::filesystem::path(
+           ament_index_cpp::get_package_share_directory("run_grasp_execution")) /
+         workcell_context_filepath)
+          .string();
+    }
     demo_->init_from_yaml(workcell_context_filepath);
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }

--- a/scenes/ur5_2f_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_2f_test/urdf/scene.urdf.xacro
@@ -4,7 +4,7 @@
 
  <link name="world"/>
 
- <xacro:include filename="$(find ur_description)/urdf/ur5.urdf.xacro"/>
+ <xacro:include filename="$(find-pkg-share ur_description)/urdf/ur5.urdf.xacro"/>
  <xacro:ur5_robot prefix="" joint_limited="false"/>
   <joint name="world_ur5" type="fixed">
 	<parent link="world" />
@@ -13,12 +13,12 @@
   </joint>
 
  <!-- Import ur5 ros2_control description -->
- <xacro:include filename="$(find ur5_moveit_config)/config/ur5.ros2_control.xacro" />
+ <xacro:include filename="$(find-pkg-share ur5_moveit_config)/config/ur5.ros2_control.xacro" />
 
- <xacro:arg name="initial_positions_file" default="$(find ur5_moveit_config)/config/initial_positions.yaml" />
+ <xacro:arg name="initial_positions_file" default="$(find-pkg-share ur5_moveit_config)/config/initial_positions.yaml" />
  <xacro:ur5_ros2_control name="UR5FakeSystem" initial_positions_file="$(arg initial_positions_file)"/>
 
- <xacro:include filename="$(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro"/>
+ <xacro:include filename="$(find-pkg-share robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro"/>
  <xacro:robotiq_85_gripper prefix="" parent="tool0">
 	<origin xyz="0 0 0" rpy="1.5707 -1.5707 0"/>
  </xacro:robotiq_85_gripper>
@@ -30,7 +30,7 @@
         <origin xyz="0 0 0" rpy="0 0 0"/>
  </joint>
  
- <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro"/>
+ <xacro:include filename="$(find-pkg-share realsense2_description)/urdf/_d415.urdf.xacro"/>
  <xacro:arg name="use_nominal_extrinsics" default="true" />
  <xacro:sensor_d415 parent="workbench_link" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
     <origin xyz="-0.58 0.12 0.655" rpy="0 1.57079506 0"/>


### PR DESCRIPTION
## Summary
- define `workcell_context` only once via grasp_execution.yaml and guard parameter declaration
- ensure URDF includes use ROS 2 `find-pkg-share` and load kinematics plugins
- fix controller spawning command

## Testing
- `colcon build --packages-select run_grasp_execution` *(fails: command not found: colcon)*

------
https://chatgpt.com/codex/tasks/task_e_68a30c76ba008331b606640b9f8e0694