### PR TITLE
Handle bare URDF output filenames

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -42,9 +42,15 @@ def to_urdf(xacro_path, urdf_path=None):
         os.close(fd)
     else:
         # Ensure the output file has a ``.urdf`` extension and the directory
-        # exists before writing.
+        # exists before writing. ``os.path.dirname`` returns an empty string
+        # when ``urdf_path`` does not include any directory components (e.g.
+        # ``"output"``).  Calling ``os.makedirs('')`` raises a
+        # ``FileNotFoundError``.  Guard against this by only attempting to
+        # create the directory when a directory path is provided.
         urdf_path = str(Path(urdf_path).with_suffix(".urdf"))
-        os.makedirs(os.path.dirname(urdf_path), exist_ok=True)
+        directory = os.path.dirname(urdf_path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
 
     # open and process file
     doc = xacro.process_file(xacro_path)

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -54,3 +54,16 @@ def test_to_urdf_respects_output_path(tmp_path):
     assert expected.exists()
     with open(expected) as f:
         assert '<robot' in f.read()
+
+
+def test_to_urdf_allows_filename_without_directory(tmp_path, monkeypatch):
+    """Ensure to_urdf works when the output path has no directory component."""
+    xacro_file = tmp_path / 'robot.xacro'
+    xacro_file.write_text("<robot name='test'></robot>")
+    # Change to the temporary directory so that a bare filename is valid
+    monkeypatch.chdir(tmp_path)
+    result = demo.to_urdf(str(xacro_file), 'out')
+    expected = Path('out.urdf')
+    assert result == str(expected)
+    assert expected.exists()
+    assert '<robot' in expected.read_text()


### PR DESCRIPTION
## Summary
- prevent `to_urdf` from failing when the output filename has no directory
- add regression test for bare URDF filenames

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a33ffe3a508331ae004b1a83d4b693