### PR TITLE
Use temporary URDF path in load_file

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -64,12 +64,15 @@ def to_urdf(xacro_path, urdf_path=None):
 def load_file(package_name, file_path):
     package_path = Path(get_package_share_directory(package_name))  # get package filepath
     absolute_file_path = package_path / file_path
-    temp_urdf_filepath = absolute_file_path.with_suffix('')
-    absolute_file_path = Path(to_urdf(str(absolute_file_path), str(temp_urdf_filepath)))
-
     try:
-        with absolute_file_path.open('r') as file:
-            return file.read()
+        # Use a temporary directory so the generated URDF does not pollute the
+        # package path and to avoid double ``.urdf`` extensions when the input
+        # file already contains one.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_urdf_path = Path(tmpdir) / Path(file_path).with_suffix(".urdf").name
+            temp_urdf_path = Path(to_urdf(str(absolute_file_path), str(temp_urdf_path)))
+            with temp_urdf_path.open('r') as file:
+                return file.read()
     except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
 

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -67,3 +67,16 @@ def test_to_urdf_allows_filename_without_directory(tmp_path, monkeypatch):
     assert result == str(expected)
     assert expected.exists()
     assert '<robot' in expected.read_text()
+
+
+def test_load_file_does_not_write_urdf_next_to_xacro(tmp_path):
+    """``load_file`` should place generated URDFs in a temporary location."""
+    pkg_dir = tmp_path / 'pkg'
+    pkg_dir.mkdir()
+    xacro_file = pkg_dir / 'robot.urdf.xacro'
+    xacro_file.write_text("<robot name='test'></robot>")
+
+    content = demo.load_file(str(pkg_dir), xacro_file.name)
+    assert '<robot' in content
+    # ``load_file`` should not leave any URDF files in the package directory
+    assert list(pkg_dir.glob('*.urdf')) == []


### PR DESCRIPTION
## Summary
- avoid generating `scene.urdf.urdf` by writing xacro output to a temporary path
- ensure generated URDF is cleaned up and add regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a844cbfe688331abb8a5ae2c19ed8a