### PR TITLE
Handle empty URDF output path

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -41,13 +41,16 @@ def to_urdf(xacro_path, urdf_path=None):
         )
         os.close(fd)
     else:
-        # Ensure the output file has a ``.urdf`` extension and the directory
+        # Ensure the output file has a valid name, a ``.urdf`` extension and the directory
         # exists before writing. ``os.path.dirname`` returns an empty string
         # when ``urdf_path`` does not include any directory components (e.g.
         # ``"output"``).  Calling ``os.makedirs('')`` raises a
         # ``FileNotFoundError``.  Guard against this by only attempting to
         # create the directory when a directory path is provided.
-        urdf_path = str(Path(urdf_path).with_suffix(".urdf"))
+        urdf_path = Path(urdf_path)
+        if not urdf_path.name:
+            raise ValueError("urdf_path must not be empty")
+        urdf_path = str(urdf_path.with_suffix(".urdf"))
         directory = os.path.dirname(urdf_path)
         if directory:
             os.makedirs(directory, exist_ok=True)

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -67,3 +67,11 @@ def test_to_urdf_allows_filename_without_directory(tmp_path, monkeypatch):
     assert result == str(expected)
     assert expected.exists()
     assert '<robot' in expected.read_text()
+
+
+def test_to_urdf_rejects_empty_output_path(tmp_path):
+    """to_urdf should raise a clear error when given an empty output path."""
+    xacro_file = tmp_path / 'robot.xacro'
+    xacro_file.write_text("<robot name='test'></robot>")
+    with pytest.raises(ValueError, match="urdf_path must not be empty"):
+        demo.to_urdf(str(xacro_file), '')


### PR DESCRIPTION
## Summary
- guard against empty `urdf_path` in `to_urdf` to prevent cryptic `Path` errors
- add regression test for empty output path handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a844cbfe688331abb8a5ae2c19ed8a