### PR TITLE
Handle directory-only output paths in to_urdf

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -48,7 +48,12 @@ def to_urdf(xacro_path, urdf_path=None):
         # ``FileNotFoundError``.  Guard against this by only attempting to
         # create the directory when a directory path is provided.
         urdf_path = Path(urdf_path)
-        if not urdf_path.name:
+        # ``Path.name`` returns ``'.'`` for the current directory and ``'..'``
+        # for the parent directory.  Both of those indicate that the provided
+        # path refers to a directory rather than a file.  ``Path.with_suffix``
+        # would raise ``ValueError`` for such paths, so detect them explicitly
+        # and raise a clearer error message instead.
+        if not urdf_path.name or urdf_path.name in {".", ".."}:
             raise ValueError("urdf_path must not be empty")
         urdf_path = str(urdf_path.with_suffix(".urdf"))
         directory = os.path.dirname(urdf_path)

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -75,6 +75,14 @@ def test_to_urdf_rejects_empty_output_path(tmp_path):
     with pytest.raises(ValueError, match="urdf_path must not be empty"):
         demo.to_urdf(str(xacro_file), '')
 
+
+def test_to_urdf_rejects_directory_only_path(tmp_path):
+    """to_urdf should error when output path points to a directory."""
+    xacro_file = tmp_path / 'robot.xacro'
+    xacro_file.write_text("<robot name='test'></robot>")
+    with pytest.raises(ValueError, match="urdf_path must not be empty"):
+        demo.to_urdf(str(xacro_file), '.')
+
 def test_load_file_does_not_write_urdf_next_to_xacro(tmp_path):
     """``load_file`` should place generated URDFs in a temporary location."""
     pkg_dir = tmp_path / 'pkg'


### PR DESCRIPTION
## Summary
- guard against directory paths in `to_urdf` to avoid crashes
- add regression test for directory-only paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a847948b4c8331893d56bd519c93b1