### PR TITLE
Improve GUI feedback and title

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -31,6 +31,7 @@ MainWindow::MainWindow(QWidget * parent)
   ui(new Ui::MainWindow)
 {
   ui->setupUi(this);
+  setWindowTitle("Workcell Builder");
   ui->next->setDisabled(true);
   ui->change_workcell->setDisabled(true);
   success = false;

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -153,6 +153,7 @@ void SceneSelect::generate_scene_files(Scene scene)
 void SceneSelect::refresh_scenes(int latest_scene)
 {
   if (latest_scene < 0) {latest_scene = 0;}
+  ui->error_workcell->clear();
   bool oldState = ui->scene_list->blockSignals(true);
   ui->scene_list->clear();  // Clear the dropdown menu
   if (workcell.scene_vector.size() > 0) {  // There are scenes in the workcell
@@ -172,7 +173,7 @@ void SceneSelect::refresh_scenes(int latest_scene)
     ui->generate_files->setDisabled(true);
     ui->edit_scene->setDisabled(true);
     ui->delete_scene->setDisabled(true);
-    ui->error_workcell->append("<font color='red'> No scenes available. </font>");
+    ui->error_workcell->setText("<font color='red'> No scenes available. </font>");
   }
   ui->scene_list->blockSignals(oldState);
 }


### PR DESCRIPTION
## Summary
- Add descriptive window title to workcell builder
- Clear scene selection errors to avoid duplicate messages

## Testing
- `colcon build --packages-select workcell_builder` *(fails: Could not find package configuration file provided by "ament_cmake")*

------
https://chatgpt.com/codex/tasks/task_e_68a847a522408331ab549f2bc4576222