### PR TITLE
Fix missing mutex includes in dynamic safety

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/replanner_moveit.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/replanner_moveit.hpp
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <vector>
+#include <mutex>
 
 #include "emd/dynamic_safety/replanner_common.hpp"
 #include "moveit/planning_scene/planning_scene.h"

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/collision_checker.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/collision_checker.cpp
@@ -18,6 +18,7 @@
 #include <utility>
 #include <vector>
 #include <stdexcept>
+#include <mutex>
 
 #include "emd/dynamic_safety/collision_checker.hpp"
 #include "emd/interpolate.hpp"


### PR DESCRIPTION
## Summary
- add `<mutex>` include to collision checker
- add `<mutex>` include to MoveIt replanner header

## Testing
- `colcon build --packages-select emd_dynamic_safety` *(fails: command not found: colcon)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a85372d37883318efc20eae22a27d4