### PR TITLE
Fix tesseract and trajopt build for ROS 2 Humble

### DIFF
--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd ~/workcell_ws
+
+# 0) Source underlays
+source /opt/ros/humble/setup.bash
+if [ -f ~/ws_moveit2/install/setup.bash ]; then source ~/ws_moveit2/install/setup.bash; fi
+
+# 1) Ensure boost_plugin_loader exists
+if [ ! -d src/boost_plugin_loader ]; then
+  git -C src clone https://github.com/tesseract-robotics/boost_plugin_loader.git
+fi
+
+# 2) Clean fully (start from scratch)
+rm -rf build install log
+find src -name build -o -name install -o -name log | xargs -r rm -rf
+
+# 3) Stage 1: infrastructure vendors first
+colcon build --symlink-install --packages-select \
+  ros_industrial_cmake_boilerplate eigen boost_plugin_loader
+
+# 4) Stage 2: up to tesseract_common/tesseract_msgs with C++17
+colcon build --symlink-install --packages-up-to tesseract_common tesseract_msgs \
+  --cmake-args -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF
+
+# 5) Stage 3: full workspace
+colcon build --symlink-install \
+  --cmake-args -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF

--- a/tesseract/tesseract_common/CMakeLists.txt
+++ b/tesseract/tesseract_common/CMakeLists.txt
@@ -1,0 +1,201 @@
+cmake_minimum_required(VERSION 3.15.0)
+
+find_package(ament_cmake REQUIRED)
+
+# Extract package name and version
+find_package(ros_industrial_cmake_boilerplate REQUIRED)
+extract_package_metadata(pkg)
+project(${pkg_extracted_name} VERSION ${pkg_extracted_version} LANGUAGES CXX)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+add_compile_options(-Wall -Wextra -Wpedantic)
+
+if(WIN32)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
+include(cmake/tesseract_macros.cmake)
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
+
+if(NOT APPLE)
+  find_package(
+    Boost REQUIRED
+    COMPONENTS system
+               filesystem
+               serialization
+               stacktrace_noop
+    OPTIONAL_COMPONENTS stacktrace_backtrace stacktrace_basic)
+else()
+  find_package(
+    Boost REQUIRED
+    COMPONENTS system
+               filesystem
+               serialization
+               stacktrace_noop)
+endif()
+find_package(Eigen3 REQUIRED)
+find_package(TinyXML2 REQUIRED)
+find_package(yaml-cpp REQUIRED)
+find_package(boost_plugin_loader REQUIRED)
+
+if(TARGET Boost::stacktrace_backtrace)
+  find_file(BACKTRACE_INCLUDE_FILE backtrace.h PATHS ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+  if(BACKTRACE_INCLUDE_FILE)
+    set(TESSERACT_BACKTRACE_DEFINITION BOOST_STACKTRACE_USE_BACKTRACE
+                                       BOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE="${BACKTRACE_INCLUDE_FILE}")
+  else()
+    set(TESSERACT_BACKTRACE_DEFINITION BOOST_STACKTRACE_USE_BACKTRACE)
+  endif()
+  set(TESSERACT_BACKTRACE_COMPONENT stacktrace_backtrace)
+  set(TESSERACT_BACKTRACE_LIB Boost::stacktrace_backtrace)
+elseif(TARGET Boost::stacktrace_basic)
+  set(TESSERACT_BACKTRACE_DEFINITION "")
+  set(TESSERACT_BACKTRACE_COMPONENT "stacktrace_basic")
+  set(TESSERACT_BACKTRACE_LIB "Boost::stacktrace_basic")
+elseif(TARGET Boost::stacktrace_noop)
+  set(TESSERACT_BACKTRACE_DEFINITION BOOST_STACKTRACE_USE_NOOP)
+  set(TESSERACT_BACKTRACE_COMPONENT "stacktrace_noop")
+  set(TESSERACT_BACKTRACE_LIB "Boost::stacktrace_noop")
+endif()
+
+find_package(console_bridge REQUIRED)
+if(NOT TARGET console_bridge::console_bridge)
+  add_library(console_bridge::console_bridge INTERFACE IMPORTED)
+  set_target_properties(console_bridge::console_bridge PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                                                  ${console_bridge_INCLUDE_DIRS})
+  set_target_properties(console_bridge::console_bridge PROPERTIES INTERFACE_LINK_LIBRARIES ${console_bridge_LIBRARIES})
+else()
+  get_target_property(CHECK_INCLUDE_DIRECTORIES console_bridge::console_bridge INTERFACE_INCLUDE_DIRECTORIES)
+  if(NOT ${CHECK_INCLUDE_DIRECTORIES})
+    set_target_properties(console_bridge::console_bridge PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                                                    ${console_bridge_INCLUDE_DIRS})
+  endif()
+endif()
+
+# Load variable for clang tidy args, compiler options and cxx version
+tesseract_variables()
+
+initialize_code_coverage(ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
+set(COVERAGE_EXCLUDE
+    /usr/*
+    /opt/*
+    ${CMAKE_CURRENT_LIST_DIR}/test/*
+    /*/install/*
+    /*/devel/*
+    /*/gtest/*)
+add_code_coverage_all_targets(EXCLUDE ${COVERAGE_EXCLUDE} ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
+
+add_library(
+  ${PROJECT_NAME}
+  src/allowed_collision_matrix.cpp
+  src/any_poly.cpp
+  src/calibration_info.cpp
+  src/collision_margin_data.cpp
+  src/contact_allowed_validator.cpp
+  src/joint_state.cpp
+  src/manipulator_info.cpp
+  src/kinematic_limits.cpp
+  src/eigen_serialization.cpp
+  src/utils.cpp
+  src/plugin_info.cpp
+  src/ply_io.cpp
+  src/profile_dictionary.cpp
+  src/profile_plugin_factory.cpp
+  src/profile.cpp
+  src/resource_locator.cpp
+  src/types.cpp
+  src/stopwatch.cpp
+  src/timer.cpp
+  src/yaml_utils.cpp)
+target_link_libraries(
+  ${PROJECT_NAME}
+  PUBLIC Eigen3::Eigen
+         tinyxml2::tinyxml2
+         boost_plugin_loader::boost_plugin_loader
+         ${CMAKE_DL_LIBS}
+         Boost::boost
+         Boost::system
+         Boost::filesystem
+         Boost::serialization
+         ${TESSERACT_BACKTRACE_LIB}
+         console_bridge::console_bridge
+         yaml-cpp)
+ament_target_dependencies(${PROJECT_NAME} boost_plugin_loader)
+target_compile_options(${PROJECT_NAME} PUBLIC ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
+target_compile_definitions(${PROJECT_NAME} PUBLIC ${TESSERACT_COMPILE_DEFINITIONS} ${TESSERACT_BACKTRACE_DEFINITION})
+target_clang_tidy(${PROJECT_NAME} ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
+target_cxx_version(${PROJECT_NAME} PUBLIC VERSION ${TESSERACT_CXX_VERSION})
+target_code_coverage(
+  ${PROJECT_NAME}
+  PRIVATE
+  ALL
+  EXCLUDE ${COVERAGE_EXCLUDE}
+  ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
+target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                                  "$<INSTALL_INTERFACE:include>")
+
+configure_package(NAMESPACE tesseract TARGETS ${PROJECT_NAME})
+if(WIN32)
+  target_link_libraries(${PROJECT_NAME} PUBLIC Bcrypt)
+endif()
+
+# Mark cpp header files for installation
+install(
+  DIRECTORY include/${PROJECT_NAME}
+  DESTINATION include
+  FILES_MATCHING
+  PATTERN "*.h"
+  PATTERN "*.hpp"
+  PATTERN ".svn" EXCLUDE)
+
+install(
+  FILES "${CMAKE_CURRENT_LIST_DIR}/cmake/tesseract_macros.cmake"
+        "${CMAKE_CURRENT_LIST_DIR}/cmake/FindTinyXML2.cmake"
+        "${CMAKE_CURRENT_LIST_DIR}/cmake/Findtcmalloc.cmake"
+        "${CMAKE_CURRENT_LIST_DIR}/cmake/Findtcmalloc_minimal.cmake"
+  DESTINATION lib/cmake/${PROJECT_NAME})
+
+if(TESSERACT_ENABLE_TESTING OR TESSERACT_COMMON_ENABLE_TESTING)
+  enable_testing()
+  add_run_tests_target(ENABLE ${TESSERACT_ENABLE_RUN_TESTING})
+  add_subdirectory(test)
+endif()
+
+if(TESSERACT_PACKAGE)
+  cpack(
+    VERSION ${pkg_extracted_version}
+    MAINTAINER_NAME ${pkg_extracted_maintainer_name}
+    MAINTAINER_EMAIL ${pkg_extracted_maintainer_email}
+    DESCRIPTION ${pkg_extracted_description}
+    LICENSE_FILE ${CMAKE_CURRENT_LIST_DIR}/../LICENSE
+    README_FILE ${CMAKE_CURRENT_LIST_DIR}/../README.md
+    LINUX_DEPENDS
+      "libboost-system-dev"
+      "libboost-filesystem-dev"
+      "libboost-serialization-dev"
+      "libconsole-bridge-dev"
+      "libtinyxml2-dev"
+      "libeigen3-dev"
+      "libyaml-cpp-dev"
+    WINDOWS_DEPENDS
+      "boost_system"
+      "boost_filesystem"
+      "boost_serialization"
+      "console-bridge"
+      "tinyxml2"
+      "Eigen3"
+      "yaml-cpp")
+
+  if(UNIX AND TESSERACT_PACKAGE_SOURCE)
+    cpack_debian_source_package(
+      CHANGLELOG ${CMAKE_CURRENT_LIST_DIR}/CHANGELOG.rst
+      UPLOAD ${TESSERACT_PACKAGE_SOURCE_UPLOAD}
+      DPUT_HOST ${TESSERACT_PACKAGE_SOURCE_DPUT_HOST}
+      DEBIAN_INCREMENT ${TESSERACT_PACKAGE_SOURCE_DEBIAN_INCREMENT}
+      DISTRIBUTIONS ${TESSERACT_PACKAGE_SOURCE_DISTRIBUTIONS})
+  endif()
+endif()

--- a/tesseract/tesseract_common/package.xml
+++ b/tesseract/tesseract_common/package.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>tesseract_common</name>
+  <version>0.31.0</version>
+  <description>Contains common macros, utils and types used throughout</description>
+  <maintainer email="levi.armstrong@gmail.com">Levi Armstrong</maintainer>
+  <license>Apache 2.0</license>
+  <author>Levi Armstrong</author>
+
+  <!-- Following recommendations of REP 136 -->
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>ros_industrial_cmake_boilerplate</build_depend>
+  <build_depend>eigen</build_depend>
+  <build_export_depend>eigen</build_export_depend>
+  <depend>libconsole-bridge-dev</depend>
+  <depend>tinyxml2</depend>
+  <depend>yaml-cpp</depend>
+  <depend>boost_plugin_loader</depend>
+
+  <build_depend>libboost-system-dev</build_depend>
+  <build_export_depend>libboost-system-dev</build_export_depend>
+  <exec_depend>libboost-system</exec_depend>
+
+  <build_depend>libboost-filesystem-dev</build_depend>
+  <build_export_depend>libboost-filesystem-dev</build_export_depend>
+  <exec_depend>libboost-filesystem</exec_depend>
+
+  <build_depend>libboost-serialization-dev</build_depend>
+  <build_export_depend>libboost-serialization-dev</build_export_depend>
+  <exec_depend>libboost-serialization</exec_depend>
+
+  <test_depend>gtest</test_depend>
+  <test_depend>lcov</test_depend>
+  <test_depend>libclang-dev</test_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>

--- a/trajopt/trajopt_sco/CMakeLists.txt
+++ b/trajopt/trajopt_sco/CMakeLists.txt
@@ -1,0 +1,196 @@
+cmake_minimum_required(VERSION 3.10.0)
+
+# Extract package name and version
+find_package(ros_industrial_cmake_boilerplate REQUIRED)
+extract_package_metadata(pkg)
+project(${pkg_extracted_name} VERSION ${pkg_extracted_version} LANGUAGES CXX)
+
+if(WIN32)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+add_compile_options(-Wall -Wextra -Wpedantic)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
+
+find_package(GUROBI QUIET)
+find_package(osqp QUIET)
+find_package(Eigen3 REQUIRED)
+find_package(trajopt_common REQUIRED)
+if(NOT TARGET JsonCpp::JsonCpp)
+  find_package(jsoncpp REQUIRED)
+elseif(NOT TARGET jsoncpp_lib)
+  add_library(jsoncpp_lib ALIAS JsonCpp::JsonCpp)
+endif()
+find_package(ros_industrial_cmake_boilerplate REQUIRED)
+find_package(Boost REQUIRED)
+find_package(OpenMP REQUIRED)
+
+# qpOASES
+option(TRAJOPT_BUILD_qpOASES "Build qpOASES components" ON)
+if(TRAJOPT_BUILD_qpOASES)
+  find_package(qpOASES QUIET)
+endif()
+
+# Load variable for clang tidy args, compiler options and cxx version
+trajopt_variables()
+
+set(SCO_SOURCE_FILES
+    src/solver_interface.cpp
+    src/solver_utils.cpp
+    src/modeling.cpp
+    src/expr_ops.cpp
+    src/expr_vec_ops.cpp
+    src/optimizers.cpp
+    src/modeling_utils.cpp
+    src/num_diff.cpp)
+
+if(NOT APPLE AND NOT WIN32)
+  set(HAVE_BPMPD TRUE)
+endif()
+
+if(HAVE_BPMPD)
+  add_executable(bpmpd_caller src/bpmpd_caller.cpp)
+
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8) # 64 bits
+    set(BPMPD_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/3rdpartylib/bpmpd_linux64.a")
+  else()
+    set(BPMPD_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/3rdpartylib/bpmpd_linux32.a")
+  endif()
+
+  target_link_libraries(bpmpd_caller ${BPMPD_LIBRARY} -static)
+  target_compile_definitions(bpmpd_caller PUBLIC BPMPD_WORKING_DIR="${CMAKE_CURRENT_BINARY_DIR}")
+  target_cxx_version(bpmpd_caller PUBLIC VERSION ${TRAJOPT_CXX_VERSION})
+  target_include_directories(bpmpd_caller PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                                 "$<INSTALL_INTERFACE:include>")
+  target_include_directories(bpmpd_caller SYSTEM
+                             PUBLIC $<TARGET_PROPERTY:trajopt::trajopt_common,INTERFACE_INCLUDE_DIRECTORIES>)
+
+  list(APPEND SCO_SOURCE_FILES src/bpmpd_interface.cpp)
+
+  install(
+    TARGETS bpmpd_caller
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
+endif()
+
+if(GUROBI_FOUND)
+  list(APPEND SCO_SOURCE_FILES src/gurobi_interface.cpp)
+endif(GUROBI_FOUND)
+
+if(osqp_FOUND)
+  list(APPEND SCO_SOURCE_FILES src/osqp_interface.cpp)
+endif()
+
+if(qpOASES_FOUND AND TRAJOPT_BUILD_qpOASES)
+  list(APPEND SCO_SOURCE_FILES src/qpoases_interface.cpp)
+endif()
+
+add_library(${PROJECT_NAME} ${SCO_SOURCE_FILES})
+if(GUROBI_FOUND)
+  target_link_libraries(${PROJECT_NAME} PRIVATE ${GUROBI_LIBRARIES})
+  target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${GUROBI_INCLUDE_DIRS})
+  target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_GUROBI=ON)
+endif()
+if(HAVE_BPMPD)
+  install(FILES src/bpmpd.par DESTINATION bin)
+
+  target_link_libraries(${PROJECT_NAME} PRIVATE ${BPMPD_LIBRARY})
+  target_compile_definitions(${PROJECT_NAME} PRIVATE BPMPD_CALLER="${CMAKE_INSTALL_PREFIX}/bin/bpmpd_caller"
+                                                     HAVE_BPMPD=ON)
+endif()
+if(osqp_FOUND)
+  target_link_libraries(${PROJECT_NAME} PRIVATE osqp::osqp)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_OSQP=ON)
+endif()
+if(qpOASES_FOUND AND TRAJOPT_BUILD_qpOASES)
+  target_link_libraries(${PROJECT_NAME} PRIVATE ${qpOASES_LIBRARIES})
+  target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${qpOASES_INCLUDE_DIRS})
+  target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_QPOASES=ON)
+endif()
+
+target_link_libraries(
+  ${PROJECT_NAME}
+  PUBLIC trajopt::trajopt_common
+         Boost::boost
+         Eigen3::Eigen
+         ${CMAKE_DL_LIBS}
+         jsoncpp_lib
+         OpenMP::OpenMP_CXX)
+target_compile_options(${PROJECT_NAME} PRIVATE ${TRAJOPT_COMPILE_OPTIONS_PRIVATE})
+target_compile_options(${PROJECT_NAME} PUBLIC ${TRAJOPT_COMPILE_OPTIONS_PUBLIC})
+target_compile_definitions(${PROJECT_NAME} PUBLIC ${TRAJOPT_COMPILE_DEFINITIONS})
+target_cxx_version(${PROJECT_NAME} PUBLIC VERSION ${TRAJOPT_CXX_VERSION})
+target_clang_tidy(${PROJECT_NAME} ENABLE ${TRAJOPT_ENABLE_CLANG_TIDY})
+target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                                  "$<INSTALL_INTERFACE:include>")
+
+configure_package(NAMESPACE trajopt TARGETS ${PROJECT_NAME})
+
+# Mark cpp header files for installation
+install(
+  DIRECTORY include/${PROJECT_NAME}
+  DESTINATION include
+  FILES_MATCHING
+  PATTERN "*.h"
+  PATTERN "*.hpp"
+  PATTERN ".svn" EXCLUDE)
+
+install(FILES cmake/FindGUROBI.cmake cmake/FindqpOASES.cmake DESTINATION lib/cmake/${PROJECT_NAME})
+
+if(TRAJOPT_ENABLE_TESTING)
+  enable_testing()
+  add_run_tests_target(ENABLE ${TRAJOPT_ENABLE_RUN_TESTING})
+
+  # if (HAVE_BPMPD) # BPMPD Expects the caller to be in the install location so for # testing it must manually be copied
+  # so tests will run. add_custom_target(test_depend ALL COMMAND ${CMAKE_COMMAND} -E copy_if_different
+  # ${CMAKE_CURRENT_SOURCE_DIR}/src/bpmpd.par ${CMAKE_INSTALL_PREFIX}/bin/bpmpd.par COMMAND ${CMAKE_COMMAND} -E
+  # copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/bpmpd_caller ${CMAKE_INSTALL_PREFIX}/bin/bpmpd_caller)
+  # add_dependencies(test_depend ${PROJECT_NAME})
+
+  # add_dependencies(run_tests test_depend) endif()
+
+  add_subdirectory(test)
+endif()
+
+if(TRAJOPT_PACKAGE)
+  set(LINUX_DEPENDS
+      "libeigen3-dev"
+      "libboost-dev"
+      "libjsoncpp-dev"
+      "${TRAJOPT_PACKAGE_PREFIX}trajopt-common")
+  set(WINDOWS_DEPENDS
+      "Eigen3"
+      "boost"
+      "jsoncpp"
+      "${TRAJOPT_PACKAGE_PREFIX}trajopt-common")
+
+  if(GUROBI_FOUND)
+    # TODO
+  endif()
+
+  if(osqp_FOUND)
+    list(APPEND LINUX_DEPENDS "${TRAJOPT_PACKAGE_PREFIX}osqp")
+    list(APPEND WINDOWS_DEPENDS "${TRAJOPT_PACKAGE_PREFIX}osqp")
+  endif()
+
+  if(qpOASES_FOUND AND TRAJOPT_BUILD_qpOASES)
+    # TODO
+  endif()
+
+  cpack(
+    VERSION ${pkg_extracted_version} MAINTAINER <https://github.com/tesseract-robotics/trajopt>
+    VENDOR "ROS-Industrial"
+    DESCRIPTION ${pkg_extracted_description}
+    LICENSE_FILE ""
+    README_FILE ${CMAKE_CURRENT_LIST_DIR}/../README.md
+    PACKAGE_PREFIX ${TRAJOPT_PACKAGE_PREFIX}
+    LINUX_DEPENDS ${LINUX_DEPENDS}
+    WINDOWS_DEPENDS ${WINDOWS_DEPENDS})
+endif()

--- a/trajopt/trajopt_sco/src/osqp_interface.cpp
+++ b/trajopt/trajopt_sco/src/osqp_interface.cpp
@@ -1,0 +1,500 @@
+#include <osqp/osqp.h>
+#include <trajopt_common/macros.h>
+#include "trajopt_sco/sco_common.hpp"
+TRAJOPT_IGNORE_WARNINGS_PUSH
+#include <cmath>
+#include <Eigen/SparseCore>
+#include <fstream>
+#include <csignal>
+TRAJOPT_IGNORE_WARNINGS_POP
+
+#include <trajopt_sco/osqp_interface.hpp>
+#include <trajopt_sco/solver_utils.hpp>
+#include <trajopt_common/logging.hpp>
+#include <trajopt_common/stl_to_string.hpp>
+
+namespace sco
+{
+const double OSQP_INFINITY = OSQP_INFTY;
+const bool OSQP_COMPARE_DEBUG_MODE = false;
+
+OSQPModelConfig::OSQPModelConfig() { setDefaultOSQPSettings(settings); }
+
+void OSQPModelConfig::setDefaultOSQPSettings(OSQPSettings& settings)
+{
+  // Define Solver settings as default
+  // see https://osqp.org/docs/interfaces/solver_settings.html#solver-settings
+  osqp_set_default_settings(&settings);
+  settings.eps_abs = 1e-4;
+  settings.eps_rel = 1e-6;
+  settings.max_iter = 8192;
+  settings.polish = 1;
+  settings.adaptive_rho = 1;
+  settings.verbose = 0;
+}
+
+Model::Ptr createOSQPModel(const ModelConfig::ConstPtr& config = nullptr)
+{
+  return std::make_shared<OSQPModel>(config);
+}
+
+OSQPModel::OSQPModel(const ModelConfig::ConstPtr& config) : P_(nullptr, free), A_(nullptr, free)
+{
+  // tuning parameters to be less accurate, but add a polishing step
+  if (config != nullptr)
+  {
+    const auto& osqp_config = std::dynamic_pointer_cast<const OSQPModelConfig>(config);
+    config_.settings = osqp_config->settings;
+    config_.update_workspace = osqp_config->update_workspace;
+  }
+}
+
+OSQPModel::~OSQPModel()
+{
+  // The osqp_workspace_ is managed by osqp but its members are not so must clean up.
+  if (osqp_workspace_ != nullptr)
+    osqp_cleanup(osqp_workspace_);
+
+  // Clean up memory
+  for (const Var& var : vars_)
+    var.var_rep->removed = true;
+  for (const Cnt& cnt : cnts_)
+    cnt.cnt_rep->removed = true;
+
+  OSQPModel::update();
+}
+
+Var OSQPModel::addVar(const std::string& name)
+{
+  const std::scoped_lock lock(mutex_);
+  vars_.emplace_back(std::make_shared<VarRep>(vars_.size(), name, this));
+  lbs_.push_back(-OSQP_INFINITY);
+  ubs_.push_back(OSQP_INFINITY);
+  return vars_.back();
+}
+
+Cnt OSQPModel::addEqCnt(const AffExpr& expr, const std::string& /*name*/)
+{
+  const std::scoped_lock lock(mutex_);
+  cnts_.emplace_back(std::make_shared<CntRep>(cnts_.size(), this));
+  cnt_exprs_.push_back(expr);
+  cnt_types_.push_back(EQ);
+  return cnts_.back();
+}
+
+Cnt OSQPModel::addIneqCnt(const AffExpr& expr, const std::string& /*name*/)
+{
+  const std::scoped_lock lock(mutex_);
+  cnts_.emplace_back(std::make_shared<CntRep>(cnts_.size(), this));
+  cnt_exprs_.push_back(expr);
+  cnt_types_.push_back(INEQ);
+  return cnts_.back();
+}
+
+Cnt OSQPModel::addIneqCnt(const QuadExpr&, const std::string& /*name*/) { throw std::runtime_error("NOT IMPLEMENTED"); }
+
+void OSQPModel::removeVars(const VarVector& vars)
+{
+  const std::scoped_lock lock(mutex_);
+  SizeTVec inds;
+  vars2inds(vars, inds);
+  for (const auto& var : vars)
+    var.var_rep->removed = true;
+}
+
+void OSQPModel::removeCnts(const CntVector& cnts)
+{
+  const std::scoped_lock lock(mutex_);
+  SizeTVec inds;
+  cnts2inds(cnts, inds);
+  for (const auto& cnt : cnts)
+    cnt.cnt_rep->removed = true;
+}
+
+bool OSQPModel::updateObjective(bool check_sparsity)
+{
+  const std::size_t n = vars_.size();
+  osqp_data_.n = static_cast<c_int>(n);
+
+  Eigen::SparseMatrix<double> sm;
+  exprToEigen(objective_, sm, q_, static_cast<int>(n), true);
+
+  // Copy triangular upper into empty matrix
+  Eigen::SparseMatrix<double> triangular_sm;
+  triangular_sm = sm.triangularView<Eigen::Upper>();
+
+  eigenToCSC(triangular_sm, P_row_indices_, P_column_pointers_, P_csc_data_);
+
+  // Check if sparsity has changed
+  bool sparsity_equal = false;
+  if (check_sparsity && osqp_data_.P != nullptr && osqp_data_.P->n == osqp_data_.n && osqp_data_.P->m == osqp_data_.n &&
+      osqp_data_.P->nzmax == P_csc_data_.size())
+  {
+    sparsity_equal = memcmp(osqp_data_.P->p, P_column_pointers_.data(), static_cast<size_t>(osqp_data_.P->n) + 1) == 0;
+    sparsity_equal = sparsity_equal &&
+                     (memcmp(osqp_data_.P->i, P_row_indices_.data(), static_cast<size_t>(osqp_data_.P->nzmax)) == 0);
+  }
+
+  P_.reset(csc_matrix(osqp_data_.n,
+                      osqp_data_.n,
+                      static_cast<c_int>(P_csc_data_.size()),
+                      P_csc_data_.data(),
+                      P_row_indices_.data(),
+                      P_column_pointers_.data()));
+
+  osqp_data_.P = P_.get();
+  osqp_data_.q = q_.data();
+
+  return sparsity_equal;
+}
+
+bool OSQPModel::updateConstraints(bool check_sparsity)
+{
+  const std::size_t n = vars_.size();
+  const std::size_t m = cnts_.size();
+  const auto n_int = static_cast<Eigen::Index>(n);
+  const auto m_int = static_cast<Eigen::Index>(m);
+
+  osqp_data_.m = static_cast<c_int>(m) + static_cast<c_int>(n);
+
+  Eigen::SparseMatrix<double> sm;
+  Eigen::VectorXd v;
+  exprToEigen(cnt_exprs_, sm, v, n_int);
+  sm.conservativeResize(m_int + n_int,
+                        Eigen::NoChange_t(n_int));  // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult)
+
+  l_.clear();
+  l_.resize(m + n, -OSQP_INFINITY);
+  u_.clear();
+  u_.resize(m + n, OSQP_INFINITY);
+
+  for (std::size_t i_cnt = 0; i_cnt < m; ++i_cnt)
+  {
+    l_[i_cnt] = (cnt_types_[i_cnt] == INEQ) ? -OSQP_INFINITY : v[static_cast<Eigen::Index>(i_cnt)];
+    u_[i_cnt] = v[static_cast<Eigen::Index>(i_cnt)];
+  }
+
+  std::vector<Eigen::Index> new_inner_sizes(n);
+  for (std::size_t k = 0; k < n; ++k)
+  {
+    new_inner_sizes[k] = sm.innerVector(static_cast<Eigen::Index>(k)).nonZeros() + 1;
+  }
+  sm.reserve(new_inner_sizes);
+  for (std::size_t i_bnd = 0; i_bnd < n; ++i_bnd)
+  {
+    l_[i_bnd + m] = fmax(lbs_[i_bnd], -OSQP_INFINITY);
+    u_[i_bnd + m] = fmin(ubs_[i_bnd], OSQP_INFINITY);
+    sm.insert(static_cast<Eigen::Index>(i_bnd + m), static_cast<Eigen::Index>(i_bnd)) = 1.;
+  }
+
+  eigenToCSC(sm, A_row_indices_, A_column_pointers_, A_csc_data_);
+
+  // Check if sparsity has changed
+  bool sparsity_equal = false;
+  if (check_sparsity && osqp_data_.A != nullptr && osqp_data_.A->n == osqp_data_.n && osqp_data_.A->m == osqp_data_.m &&
+      osqp_data_.A->nzmax == A_csc_data_.size())
+  {
+    sparsity_equal = memcmp(osqp_data_.A->p, A_column_pointers_.data(), static_cast<size_t>(osqp_data_.A->n) + 1) == 0;
+    sparsity_equal = sparsity_equal &&
+                     (memcmp(osqp_data_.A->i, A_row_indices_.data(), static_cast<size_t>(osqp_data_.A->nzmax)) == 0);
+  }
+
+  A_.reset(csc_matrix(osqp_data_.m,
+                      osqp_data_.n,
+                      static_cast<c_int>(A_csc_data_.size()),
+                      A_csc_data_.data(),
+                      A_row_indices_.data(),
+                      A_column_pointers_.data()));
+
+  osqp_data_.A = A_.get();
+
+  osqp_data_.l = l_.data();
+  osqp_data_.u = u_.data();
+
+  return sparsity_equal;
+}
+
+void OSQPModel::createOrUpdateSolver()
+{
+  bool allow_update = false;
+  bool allow_explicit_warm_start = false;
+  if (osqp_workspace_ != nullptr)
+  {
+    const auto status_val = static_cast<int>(osqp_workspace_->info->status_val);
+    // Only warm start or update if the last optimzation was (almost) solved
+    if ((status_val == OSQP_SOLVED) || (status_val == OSQP_SOLVED_INACCURATE))
+    {
+      if (config_.update_workspace)
+      {
+        // When updating, warm start is implicit (depending on the warm_start setting)
+        allow_update = true;
+      }
+      else if (config_.settings.warm_start != 0)
+      {
+        // Only allow explicit warm start if not updating
+        allow_explicit_warm_start = true;
+      }
+    }
+  }
+
+  // Update P and q (only check sparsity if necessary)
+  const bool P_sparsity_equal = updateObjective(allow_update || allow_explicit_warm_start);
+  // Update A and l, u
+  const bool A_sparsity_equal = updateConstraints(P_sparsity_equal);
+
+  // Only allow update or warm start if the sparsity of P and A did not change
+  allow_update = allow_update && P_sparsity_equal && A_sparsity_equal;
+  allow_explicit_warm_start = allow_explicit_warm_start && P_sparsity_equal && A_sparsity_equal;
+
+  // If sparsity did not change, update data, otherwise cleanup and setup
+  bool need_setup = true;
+  if (allow_update)
+  {
+    LOG_DEBUG("OSQP update (warm start = %lli).", config_.settings.warm_start);
+    need_setup = false;
+
+    if (osqp_update_bounds(osqp_workspace_, osqp_data_.l, osqp_data_.u) != 0)
+    {
+      need_setup = true;
+      LOG_WARN("OSQP updating bounds failed.");
+    }
+    if (!need_setup && (osqp_update_lin_cost(osqp_workspace_, osqp_data_.q) != 0))
+    {
+      need_setup = true;
+      LOG_WARN("OSQP updating linear costs failed.");
+    }
+    if (!need_setup && (osqp_update_P_A(osqp_workspace_,
+                                        osqp_data_.P->x,
+                                        OSQP_NULL,
+                                        osqp_data_.P->nzmax,
+                                        osqp_data_.A->x,
+                                        OSQP_NULL,
+                                        osqp_data_.A->nzmax) != 0))
+    {
+      need_setup = true;
+      LOG_WARN("OSQP updating P and A matrices failed.");
+    }
+  }
+
+  // If setup is not required then return
+  if (!need_setup)
+    return;
+
+  DblVec prev_x;
+  DblVec prev_y;
+  double prev_rho = 0.0;
+  if (osqp_workspace_ != nullptr)
+  {
+    if (allow_explicit_warm_start)
+    {
+      LOG_DEBUG("OSQP explicit warm start (warm_start = %lli).", config_.settings.warm_start);
+      // Store previous solution
+      prev_x = DblVec(osqp_workspace_->solution->x, osqp_workspace_->solution->x + osqp_data_.n);
+      prev_y = DblVec(osqp_workspace_->solution->y, osqp_workspace_->solution->y + osqp_data_.m);
+      prev_rho = osqp_workspace_->settings->rho;
+    }
+    osqp_cleanup(osqp_workspace_);
+  }
+
+  // Setup workspace - this should be called only once
+  auto ret = osqp_setup(&osqp_workspace_, &osqp_data_, &config_.settings);
+  if (ret != 0)
+  {
+    // In this case, no data got allocated, so don't try to free it.
+    if (ret == OSQP_DATA_VALIDATION_ERROR || ret == OSQP_SETTINGS_VALIDATION_ERROR)
+      osqp_workspace_ = nullptr;
+    throw std::runtime_error("Could not initialize OSQP: error " + std::to_string(ret));
+  }
+  if (!prev_x.empty() && !prev_y.empty())
+  {
+    // Warm start recreated workspace with previous solution
+    if (osqp_warm_start(osqp_workspace_, prev_x.data(), prev_y.data()) != 0)
+    {
+      LOG_WARN("OSQP warm start failed.");
+    }
+    if (osqp_update_rho(osqp_workspace_, prev_rho) != 0)
+    {
+      LOG_WARN("OSQP rho update failed.");
+    }
+  }
+}
+
+void OSQPModel::update()
+{
+  {
+    std::size_t inew = 0;
+    for (std::size_t iold = 0; iold < vars_.size(); ++iold)
+    {
+      Var& var = vars_[iold];
+      if (!var.var_rep->removed)
+      {
+        vars_[inew] = var;
+        lbs_[inew] = lbs_[iold];
+        ubs_[inew] = ubs_[iold];
+        var.var_rep->index = inew;
+        ++inew;
+      }
+      else
+      {
+        var.var_rep = nullptr;
+      }
+    }
+    vars_.resize(inew);
+    lbs_.resize(inew);
+    ubs_.resize(inew);
+  }
+  {
+    std::size_t inew = 0;
+    for (std::size_t iold = 0; iold < cnts_.size(); ++iold)
+    {
+      Cnt& cnt = cnts_[iold];
+      if (!cnt.cnt_rep->removed)
+      {
+        cnts_[inew] = cnt;
+        cnt_exprs_[inew] = cnt_exprs_[iold];
+        cnt_types_[inew] = cnt_types_[iold];
+        cnt.cnt_rep->index = inew;
+        ++inew;
+      }
+      else
+      {
+        cnt.cnt_rep = nullptr;
+      }
+    }
+    cnts_.resize(inew);
+    cnt_exprs_.resize(inew);
+    cnt_types_.resize(inew);
+  }
+}
+
+void OSQPModel::setVarBounds(const VarVector& vars, const DblVec& lower, const DblVec& upper)
+{
+  for (unsigned i = 0; i < vars.size(); ++i)
+  {
+    const std::size_t varind = vars[i].var_rep->index;
+    lbs_[varind] = lower[i];
+    ubs_[varind] = upper[i];
+  }
+}
+DblVec OSQPModel::getVarValues(const VarVector& vars) const
+{
+  DblVec out(vars.size());
+  for (unsigned i = 0; i < vars.size(); ++i)
+  {
+    const std::size_t varind = vars[i].var_rep->index;
+    out[i] = solution_[varind];
+  }
+  return out;
+}
+
+CvxOptStatus OSQPModel::optimize()
+{
+  update();
+  try
+  {
+    createOrUpdateSolver();  // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult,clang-analyzer-core.uninitialized.Assign)
+  }
+  catch (std::exception& e)
+  {
+    std::cout << "OSQP Setup failed with error: " << e.what() << '\n';
+    return CVX_FAILED;
+  }
+
+  if (OSQP_COMPARE_DEBUG_MODE)
+  {
+    const Eigen::IOFormat format(5);
+    std::cout << "OSQP Number of Variables:" << osqp_data_.n << '\n';
+    std::cout << "OSQP Number of Constraints:" << osqp_data_.m << '\n';
+
+    Eigen::Map<Eigen::Matrix<c_int, Eigen::Dynamic, 1>> P_p_vec(osqp_data_.P->p, osqp_data_.P->n + 1);
+    Eigen::Map<Eigen::Matrix<c_int, Eigen::Dynamic, 1>> P_i_vec(osqp_data_.P->i, osqp_data_.P->nzmax);
+    Eigen::Map<Eigen::Matrix<c_float, Eigen::Dynamic, 1>> P_x_vec(osqp_data_.P->x, osqp_data_.P->nzmax);
+    std::cout << "OSQP Hessian:" << '\n';
+    std::cout << "     nzmax:" << osqp_data_.P->nzmax << '\n';
+    std::cout << "        nz:" << osqp_data_.P->nz << '\n';
+    std::cout << "         m:" << osqp_data_.P->m << '\n';
+    std::cout << "         n:" << osqp_data_.P->n << '\n';
+    std::cout << "         p:" << P_p_vec.transpose().format(format) << '\n';
+    std::cout << "         i:" << P_i_vec.transpose().format(format) << '\n';
+    std::cout << "         x:" << P_x_vec.transpose().format(format) << '\n';
+
+    Eigen::Map<Eigen::VectorXd> q_vec(osqp_data_.q, osqp_data_.n);
+    std::cout << "OSQP Gradient: " << q_vec.transpose().format(format) << '\n';
+
+    Eigen::Map<Eigen::Matrix<c_int, Eigen::Dynamic, 1>> A_p_vec(osqp_data_.A->p, osqp_data_.A->n + 1);
+    Eigen::Map<Eigen::Matrix<c_int, Eigen::Dynamic, 1>> A_i_vec(osqp_data_.A->i, osqp_data_.A->nzmax);
+    Eigen::Map<Eigen::Matrix<c_float, Eigen::Dynamic, 1>> A_x_vec(osqp_data_.A->x, osqp_data_.A->nzmax);
+    std::cout << "OSQP Constraint Matrix:" << '\n';
+    std::cout << "     nzmax:" << osqp_data_.A->nzmax << '\n';
+    std::cout << "         m:" << osqp_data_.A->m << '\n';
+    std::cout << "         n:" << osqp_data_.A->n << '\n';
+    std::cout << "         p:" << A_p_vec.transpose().format(format) << '\n';
+    std::cout << "         i:" << A_i_vec.transpose().format(format) << '\n';
+    std::cout << "         x:" << A_x_vec.transpose().format(format) << '\n';
+
+    Eigen::Map<Eigen::Matrix<c_float, Eigen::Dynamic, 1>> l_vec(osqp_data_.l, osqp_data_.m);
+    Eigen::Map<Eigen::Matrix<c_float, Eigen::Dynamic, 1>> u_vec(osqp_data_.u, osqp_data_.m);
+    std::cout << "OSQP Lower Bounds: " << l_vec.transpose().format(format) << '\n';
+    std::cout << "OSQP Upper Bounds: " << u_vec.transpose().format(format) << '\n';
+
+    std::vector<std::string> vars_names(vars_.size());
+    for (const auto& var : vars_)
+      vars_names[var.var_rep->index] = var.var_rep->name;
+
+    std::cout << "OSQP Variable Names: ";
+    for (const auto& var_name : vars_names)
+      std::cout << var_name << ",";
+    std::cout << '\n';
+  }
+
+  // Solve Problem
+  const c_int retcode = osqp_solve(osqp_workspace_);
+
+  if (retcode == 0)
+  {
+    // opt += m_objective.affexpr.constant;
+    solution_ = DblVec(osqp_workspace_->solution->x, osqp_workspace_->solution->x + vars_.size());
+    auto status = static_cast<int>(osqp_workspace_->info->status_val);
+
+    if (OSQP_COMPARE_DEBUG_MODE)
+    {
+      const Eigen::IOFormat format(5);
+      Eigen::Map<Eigen::VectorXd> solution_vec(solution_.data(), static_cast<Eigen::Index>(solution_.size()));
+      std::cout << "OSQP Status Value: " << status << '\n';
+      std::cout << "OSQP Solution: " << solution_vec.transpose().format(format) << '\n';
+    }
+
+    if (status == OSQP_SOLVED || status == OSQP_SOLVED_INACCURATE)
+      return CVX_SOLVED;
+    if (status == OSQP_PRIMAL_INFEASIBLE || status == OSQP_PRIMAL_INFEASIBLE_INACCURATE ||
+        status == OSQP_DUAL_INFEASIBLE || status == OSQP_DUAL_INFEASIBLE_INACCURATE)
+      return CVX_INFEASIBLE;
+  }
+  return CVX_FAILED;
+}
+void OSQPModel::setObjective(const AffExpr& expr) { objective_.affexpr = expr; }
+void OSQPModel::setObjective(const QuadExpr& expr) { objective_ = expr; }
+
+VarVector OSQPModel::getVars() const { return vars_; }
+
+void OSQPModel::writeToFile(const std::string& fname) const
+{
+  std::ofstream outStream(fname);
+  outStream << "\\ Generated by trajopt_sco with backend OSQP\n";
+  outStream << "Minimize\n";
+  outStream << objective_;
+  outStream << "Subject To\n";
+  for (std::size_t i = 0; i < cnt_exprs_.size(); ++i)
+  {
+    const std::string op = (cnt_types_[i] == INEQ) ? " <= " : " = ";
+    outStream << cnt_exprs_[i] << op << 0 << "\n";
+  }
+
+  outStream << "Bounds\n";
+  for (std::size_t i = 0; i < vars_.size(); ++i)
+  {
+    outStream << lbs_[i] << " <= " << vars_[i] << " <= " << ubs_[i] << "\n";
+  }
+  outStream << "End";
+}
+}  // namespace sco


### PR DESCRIPTION
## Summary
- require ament and boost_plugin_loader for tesseract_common
- enforce C++17 and warnings in tesseract and trajopt_sco
- fix OSQP include to avoid ROS `constants.h`
- add helper script to rebuild workspace on Humble

## Testing
- `bash fix_and_build_humble.sh` *(fails: /opt/ros/humble/setup.bash: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9aa0aca7883318bfaf81846e6badd