### PR TITLE
Add dependency installation to humble build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ colcon build --symlink-install
 source install/setup.bash
 ```
 
+A convenience script `fix_and_build_humble.sh` is provided in this repository. After cloning into
+`~/workcell_ws`, run:
+
+```
+cd easy_manipulation_deployment
+./fix_and_build_humble.sh
+```
+
+This script ensures required tools such as `ament_cmake` are installed via `rosdep` before building.
+
 ---
 ## Full Documentation/Wiki
 

--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -6,6 +6,21 @@ cd ~/workcell_ws
 source /opt/ros/humble/setup.bash
 if [ -f ~/ws_moveit2/install/setup.bash ]; then source ~/ws_moveit2/install/setup.bash; fi
 
+# 0.5) Install missing build tools and dependencies
+if [ ! -f "/opt/ros/${ROS_DISTRO}/share/ament_cmake/package.xml" ]; then
+  if command -v sudo >/dev/null 2>&1; then
+    sudo apt-get update -y
+    sudo apt-get install -y "ros-${ROS_DISTRO}-ament-cmake"
+  else
+    apt-get update -y
+    apt-get install -y "ros-${ROS_DISTRO}-ament-cmake"
+  fi
+fi
+
+rosdep update
+rosdep install --from-paths src --ignore-src -yr --rosdistro "${ROS_DISTRO}" \
+  --skip-keys "tesseract tesseract_process_planners"
+
 # 1) Ensure boost_plugin_loader exists
 if [ ! -d src/boost_plugin_loader ]; then
   git -C src clone https://github.com/tesseract-robotics/boost_plugin_loader.git


### PR DESCRIPTION
## Summary
- install missing `ament_cmake` and run `rosdep` in the Humble build helper
- document `fix_and_build_humble.sh` usage

## Testing
- `./fix_and_build_humble.sh` *(fails: /opt/ros/humble/setup.bash missing)*

------
https://chatgpt.com/codex/tasks/task_e_68acbd0df0608331a05c4c7f128de5ce