### PR TITLE
Handle URDF generation safely

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -30,15 +30,23 @@ package_name = 'run_grasp_execution'
 
 
 def to_urdf(xacro_path, urdf_path=None, mappings=None):
+    """Convert the given xacro file to a URDF file."""
+
     xacro_path = str(xacro_path)
+
     if urdf_path is None:
         fd, urdf_path = tempfile.mkstemp(
             prefix=f"{Path(xacro_path).stem}_", suffix=".urdf"
         )
         os.close(fd)
     else:
-        urdf_path = str(Path(urdf_path).with_suffix(".urdf"))
-        os.makedirs(os.path.dirname(urdf_path), exist_ok=True)
+        urdf_path = Path(urdf_path)
+        if not urdf_path.name or urdf_path.name in {".", ".."}:
+            raise ValueError("urdf_path must not be empty")
+        urdf_path = str(urdf_path.with_suffix(".urdf"))
+        directory = os.path.dirname(urdf_path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
 
     doc = xacro.process_file(xacro_path, mappings=mappings)
     with xacro.open_output(urdf_path) as out:
@@ -48,15 +56,20 @@ def to_urdf(xacro_path, urdf_path=None, mappings=None):
 
 
 def load_file(package_name, file_path, mappings=None):
-    package_path = get_package_share_directory(package_name)  # get package filepath
-    absolute_file_path = os.path.join(package_path, file_path)
-    temp_urdf_filepath = absolute_file_path.replace('.xacro', '')
-    absolute_file_path = to_urdf(absolute_file_path, temp_urdf_filepath, mappings)
+    """Load a xacro file from a package and return its processed XML."""
+
+    package_path = Path(get_package_share_directory(package_name))
+    absolute_file_path = package_path / file_path
 
     try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_urdf_path = Path(tmpdir) / Path(file_path).with_suffix(".urdf").name
+            temp_urdf_path = Path(
+                to_urdf(str(absolute_file_path), str(temp_urdf_path), mappings)
+            )
+            with temp_urdf_path.open('r') as file:
+                return file.read()
+    except EnvironmentError:
         return None
 
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/launch/grasp_execution.launch.py
@@ -30,15 +30,23 @@ package_name = 'run_waypoint_execution'
 
 
 def to_urdf(xacro_path, urdf_path=None, mappings=None):
+    """Convert the given xacro file to a URDF file."""
+
     xacro_path = str(xacro_path)
+
     if urdf_path is None:
         fd, urdf_path = tempfile.mkstemp(
             prefix=f"{Path(xacro_path).stem}_", suffix=".urdf"
         )
         os.close(fd)
     else:
-        urdf_path = str(Path(urdf_path).with_suffix(".urdf"))
-        os.makedirs(os.path.dirname(urdf_path), exist_ok=True)
+        urdf_path = Path(urdf_path)
+        if not urdf_path.name or urdf_path.name in {".", ".."}:
+            raise ValueError("urdf_path must not be empty")
+        urdf_path = str(urdf_path.with_suffix(".urdf"))
+        directory = os.path.dirname(urdf_path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
 
     doc = xacro.process_file(xacro_path, mappings=mappings)
     with xacro.open_output(urdf_path) as out:
@@ -48,15 +56,20 @@ def to_urdf(xacro_path, urdf_path=None, mappings=None):
 
 
 def load_file(package_name, file_path, mappings=None):
-    package_path = get_package_share_directory(package_name)  # get package filepath
-    absolute_file_path = os.path.join(package_path, file_path)
-    temp_urdf_filepath = absolute_file_path.replace('.xacro', '')
-    absolute_file_path = to_urdf(absolute_file_path, temp_urdf_filepath, mappings)
+    """Load a xacro file from a package and return its processed XML."""
+
+    package_path = Path(get_package_share_directory(package_name))
+    absolute_file_path = package_path / file_path
 
     try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_urdf_path = Path(tmpdir) / Path(file_path).with_suffix(".urdf").name
+            temp_urdf_path = Path(
+                to_urdf(str(absolute_file_path), str(temp_urdf_path), mappings)
+            )
+            with temp_urdf_path.open('r') as file:
+                return file.read()
+    except EnvironmentError:
         return None
 
 

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -26,32 +26,57 @@ robot_moveit_pkg = 'ur5_moveit_config'
 
 def to_urdf(xacro_path, urdf_path=None):
     """Convert the given xacro file to a URDF file."""
+
     xacro_path = str(xacro_path)
+
+    # If no URDF path is given, create a secure temporary file with the proper
+    # ``.urdf`` extension. ``mkstemp`` is used instead of the deprecated and
+    # insecure ``mktemp`` to avoid race conditions.  The returned file descriptor
+    # is immediately closed so that ``xacro`` can write to the path later on.
     if urdf_path is None:
         fd, urdf_path = tempfile.mkstemp(
             prefix=f"{Path(xacro_path).stem}_", suffix=".urdf"
         )
         os.close(fd)
     else:
-        urdf_path = str(Path(urdf_path).with_suffix(".urdf"))
-        os.makedirs(os.path.dirname(urdf_path), exist_ok=True)
+        urdf_path = Path(urdf_path)
+        # ``Path.name`` returns ``'.'`` for the current directory and ``'..'``
+        # for the parent directory.  Both cases indicate that ``urdf_path``
+        # refers to a directory instead of a file which would later cause
+        # confusing errors.  Raise a clearer message for such inputs.
+        if not urdf_path.name or urdf_path.name in {".", ".."}:
+            raise ValueError("urdf_path must not be empty")
+        urdf_path = str(urdf_path.with_suffix(".urdf"))
+        directory = os.path.dirname(urdf_path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
 
+    # Process the xacro file and write the resulting URDF to disk using a
+    # context manager to guarantee that the file handle is properly closed.
     doc = xacro.process_file(xacro_path)
     with xacro.open_output(urdf_path) as out:
         out.write(doc.toprettyxml(indent='  '))
 
     return urdf_path
 
+
 def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name) #get package filepath
-    absolute_file_path = os.path.join(package_path, file_path)
-    temp_urdf_filepath = absolute_file_path.replace('.xacro','')
-    absolute_file_path = to_urdf(absolute_file_path,temp_urdf_filepath)
-    
+    """Load a xacro file from *package_name*/*file_path* and return its XML."""
+
+    package_path = Path(get_package_share_directory(package_name))
+    absolute_file_path = package_path / file_path
+
     try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+        # Use a temporary directory so the generated URDF does not pollute the
+        # package directory and to avoid double ``.urdf`` extensions when the
+        # input already contains one.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_urdf_path = Path(tmpdir) / Path(file_path).with_suffix(".urdf").name
+            temp_urdf_path = Path(to_urdf(str(absolute_file_path), str(temp_urdf_path)))
+            with temp_urdf_path.open('r') as file:
+                return file.read()
+    except EnvironmentError:
+        # parent of IOError, OSError *and* WindowsError where available
         return None
 
 def load_yaml(package_name, file_path):

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -26,15 +26,22 @@ robot_moveit_pkg = 'ur5_moveit_config'
 
 def to_urdf(xacro_path, urdf_path=None):
     """Convert the given xacro file to a URDF file."""
+
     xacro_path = str(xacro_path)
+
     if urdf_path is None:
         fd, urdf_path = tempfile.mkstemp(
             prefix=f"{Path(xacro_path).stem}_", suffix=".urdf"
         )
         os.close(fd)
     else:
-        urdf_path = str(Path(urdf_path).with_suffix(".urdf"))
-        os.makedirs(os.path.dirname(urdf_path), exist_ok=True)
+        urdf_path = Path(urdf_path)
+        if not urdf_path.name or urdf_path.name in {".", ".."}:
+            raise ValueError("urdf_path must not be empty")
+        urdf_path = str(urdf_path.with_suffix(".urdf"))
+        directory = os.path.dirname(urdf_path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
 
     doc = xacro.process_file(xacro_path)
     with xacro.open_output(urdf_path) as out:
@@ -42,16 +49,20 @@ def to_urdf(xacro_path, urdf_path=None):
 
     return urdf_path
 
+
 def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name) #get package filepath
-    absolute_file_path = os.path.join(package_path, file_path)
-    temp_urdf_filepath = absolute_file_path.replace('.xacro','')
-    absolute_file_path = to_urdf(absolute_file_path,temp_urdf_filepath)
-    
+    """Load a xacro file and return its processed XML."""
+
+    package_path = Path(get_package_share_directory(package_name))
+    absolute_file_path = package_path / file_path
+
     try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_urdf_path = Path(tmpdir) / Path(file_path).with_suffix(".urdf").name
+            temp_urdf_path = Path(to_urdf(str(absolute_file_path), str(temp_urdf_path)))
+            with temp_urdf_path.open('r') as file:
+                return file.read()
+    except EnvironmentError:
         return None
 
 def load_yaml(package_name, file_path):

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -26,15 +26,22 @@ robot_moveit_pkg = 'ur5_moveit_config'
 
 def to_urdf(xacro_path, urdf_path=None):
     """Convert the given xacro file to a URDF file."""
+
     xacro_path = str(xacro_path)
+
     if urdf_path is None:
         fd, urdf_path = tempfile.mkstemp(
             prefix=f"{Path(xacro_path).stem}_", suffix=".urdf"
         )
         os.close(fd)
     else:
-        urdf_path = str(Path(urdf_path).with_suffix(".urdf"))
-        os.makedirs(os.path.dirname(urdf_path), exist_ok=True)
+        urdf_path = Path(urdf_path)
+        if not urdf_path.name or urdf_path.name in {".", ".."}:
+            raise ValueError("urdf_path must not be empty")
+        urdf_path = str(urdf_path.with_suffix(".urdf"))
+        directory = os.path.dirname(urdf_path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
 
     doc = xacro.process_file(xacro_path)
     with xacro.open_output(urdf_path) as out:
@@ -42,16 +49,20 @@ def to_urdf(xacro_path, urdf_path=None):
 
     return urdf_path
 
+
 def load_file(package_name, file_path):
-    package_path = get_package_share_directory(package_name) #get package filepath
-    absolute_file_path = os.path.join(package_path, file_path)
-    temp_urdf_filepath = absolute_file_path.replace('.xacro','')
-    absolute_file_path = to_urdf(absolute_file_path,temp_urdf_filepath)
-    
+    """Load a xacro file and return its processed XML."""
+
+    package_path = Path(get_package_share_directory(package_name))
+    absolute_file_path = package_path / file_path
+
     try:
-        with open(absolute_file_path, 'r') as file:
-            return file.read()
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_urdf_path = Path(tmpdir) / Path(file_path).with_suffix(".urdf").name
+            temp_urdf_path = Path(to_urdf(str(absolute_file_path), str(temp_urdf_path)))
+            with temp_urdf_path.open('r') as file:
+                return file.read()
+    except EnvironmentError:
         return None
 
 def load_yaml(package_name, file_path):


### PR DESCRIPTION
## Summary
- validate and normalize output paths when converting xacro to URDF
- write URDFs to temporary locations during loading to avoid polluting package directories
- apply these safeguards across demo launch scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aecc2d944c8331941102ee7569f00f