### PR TITLE
Fix temporary string lifetime in logging

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/src/collision_checker.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/collision_checker.cpp
@@ -443,7 +443,8 @@ double CollisionChecker::polling(
   }
   std::ostringstream oss;
   poller.print(oss);
-  RCLCPP_INFO(LOGGER, oss.str().c_str());
+  auto msg = oss.str();
+  RCLCPP_INFO(LOGGER, msg.c_str());
   return collision_checking_duration / sample_size;
 }
 

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/grasp_execution.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/grasp_execution.hpp
@@ -302,7 +302,8 @@ public:
     std::ostringstream oss;
     oss << std::endl;
     prompt_job_start(job_id, message, separator, oss);
-    RCLCPP_INFO(logger, oss.str().c_str());
+    auto msg = oss.str();
+    RCLCPP_INFO(logger, msg.c_str());
   }
 
   virtual void prompt_job_end(
@@ -318,7 +319,8 @@ public:
     std::ostringstream oss;
     oss << std::endl;
     prompt_job_end(end_result, separator, oss);
-    RCLCPP_INFO(logger, oss.str().c_str());
+    auto msg = oss.str();
+    RCLCPP_INFO(logger, msg.c_str());
   }
 
 protected:

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
@@ -240,7 +240,8 @@ protected:
     std::ostringstream oss;
     oss << std::endl;
     print_trajectory(traj, oss);
-    RCLCPP_INFO(logger, oss.str().c_str());
+    auto msg = oss.str();
+    RCLCPP_INFO(logger, msg.c_str());
   }
 
   void print_trajectory(

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/utils.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/utils.hpp
@@ -92,7 +92,8 @@ inline void print_pose_ros(
 {
   std::ostringstream oss;
   print_pose(_pose, oss, _euler);
-  RCLCPP_INFO(logger, oss.str().c_str());
+  auto msg = oss.str();
+  RCLCPP_INFO(logger, msg.c_str());
 }
 
 /// Use ROS to print PoseStamped message
@@ -104,7 +105,8 @@ inline void print_pose_ros(
   std::ostringstream oss;
   oss << std::endl;
   print_pose(_pose, oss, _euler);
-  RCLCPP_INFO(logger, oss.str().c_str());
+  auto msg = oss.str();
+  RCLCPP_INFO(logger, msg.c_str());
 }
 
 /// Transform pose to target end reference frame


### PR DESCRIPTION
## Summary
- Prevent use-after-free by avoiding temporary string pointers in logging calls
- Apply consistent logging message handling across collision checker, grasp utilities, grasp executor, and MoveIt interface

## Testing
- `colcon build --packages-select emd_dynamic_safety emd_grasp_execution` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aece4b0c008331bc12d0d3b19ff425