### PR TITLE
Refactor grasp execution components for cleaner analysis

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/src/context.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/context.cpp
@@ -47,7 +47,7 @@ void WorkcellContext::init_from_yaml(const std::string &path) {
 
   // Iterate through to load all the groups.
   for (YAML::const_iterator itr = context_yaml.begin();
-       itr != context_yaml.end(); itr++) {
+       itr != context_yaml.end(); ++itr) {
     const YAML::Node &group_yaml = *itr;
 
     // Parse group name, compulsory.
@@ -71,7 +71,7 @@ void WorkcellContext::init_from_yaml(const std::string &path) {
     } else {
       const YAML::Node &executors_yaml = group_yaml["executors"];
       for (YAML::const_iterator exe_itr = executors_yaml.begin();
-           exe_itr != executors_yaml.end(); exe_itr++) {
+           exe_itr != executors_yaml.end(); ++exe_itr) {
         std::string execution_method = exe_itr->first.as<std::string>();
 
         // Parse plugin name, compulsory.
@@ -94,7 +94,7 @@ void WorkcellContext::init_from_yaml(const std::string &path) {
     if (group_yaml["end_effectors"]) {
       const YAML::Node &ees_yaml = group_yaml["end_effectors"];
       for (YAML::const_iterator ee_itr = ees_yaml.begin();
-           ee_itr != ees_yaml.end(); ee_itr++) {
+           ee_itr != ees_yaml.end(); ++ee_itr) {
         std::string ee_name = ee_itr->first.as<std::string>();
         const YAML::Node &ee_yaml = ee_itr->second;
 

--- a/easy_manipulation_deployment/emd_grasp_execution/src/core/scheduler.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/core/scheduler.cpp
@@ -44,10 +44,8 @@ public:
   }
 
   explicit WorkflowImplT(Scheduler::WorkflowT _workflow)
-  : workflow(_workflow)
+  : workflow(std::move(_workflow)), sig(), future(sig.get_future())
   {
-    sig = std::promise<result_t>();
-    future = sig.get_future();
   }
 
   WorkflowImplT & operator=(const WorkflowImplT &) = delete;
@@ -63,10 +61,10 @@ public:
   WorkflowImplT(const WorkflowImplT &) = delete;
 
   WorkflowImplT(WorkflowImplT && rhs) noexcept
+  : workflow(std::move(rhs.workflow)),
+    sig(std::move(rhs.sig)),
+    future(std::move(rhs.future))
   {
-    sig = std::move(rhs.sig);
-    future = std::move(rhs.future);
-    workflow = std::move(rhs.workflow);
   }
 
   Scheduler::WorkflowT workflow;

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -827,7 +827,7 @@ bool MoveitCppGraspExecution::cartesian_to(
   const std::string & _link, double step, double jump_threshold,
   bool execute)
 {
-  const auto & arm = arms_[planning_group];
+  auto & arm = arms_[planning_group];
   robot_trajectory::RobotTrajectoryPtr rt;
 
   // Get start state
@@ -861,7 +861,6 @@ bool MoveitCppGraspExecution::cartesian_to(
       RCLCPP_INFO(LOGGER, "Sending the trajectory for execution");
       moveit_cpp_->execute(planning_group, rt);
     } else {
-      auto & arm = arms_[planning_group];
       arm.traj.push_back(rt);
     }
     return true;
@@ -1265,7 +1264,7 @@ void MoveitCppGraspExecution::print_trajectory(
   _out << "Total waypoints: " << traj->getWayPointCount() << std::endl;
 
   _out << "Joints: ";
-  for (auto & joint : traj->getGroup()->getVariableNames()) {
+  for (const auto & joint : traj->getGroup()->getVariableNames()) {
     _out << joint << '\t';
   }
 


### PR DESCRIPTION
## Summary
- remove shadowed variables in MoveIt integration
- initialize workflow futures in constructor initializer lists
- prefer prefix increment in YAML configuration loops

## Testing
- `cppcheck --enable=warning,style,performance,portability easy_manipulation_deployment/emd_grasp_execution/src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aece4b0c008331bc12d0d3b19ff425