### PR TITLE
Improve path handling in grasp planner launch files

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_2f_launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_2f_launch.py
@@ -13,16 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# import os
+import os
+
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    # ld = LaunchDescription()
-    config = get_package_share_directory('run_grasp_planner') + '/config/params_2f.yaml'
-    print(config)
+    config = os.path.join(
+        get_package_share_directory('run_grasp_planner'),
+        'config',
+        'params_2f.yaml',
+    )
+
     node = Node(
         package='run_grasp_planner',
         name='grasp_planning_node',
@@ -33,5 +37,4 @@ def generate_launch_description():
         # prefix=['valgrind'],
         parameters=[config]
     )
-    # ld.add_action(node)
     return LaunchDescription([node])

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_3f_launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_3f_launch.py
@@ -13,16 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# import os
+import os
+
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    # ld = LaunchDescription()
-    config = get_package_share_directory('run_grasp_planner') + '/config/params_3f.yaml'
-    print(config)
+    config = os.path.join(
+        get_package_share_directory('run_grasp_planner'),
+        'config',
+        'params_3f.yaml',
+    )
+
     node = Node(
         package='run_grasp_planner',
         name='grasp_planning_node',
@@ -33,5 +37,4 @@ def generate_launch_description():
         # prefix=['valgrind'],
         parameters=[config]
     )
-    # ld.add_action(node)
     return LaunchDescription([node])

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_airpick4_launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_airpick4_launch.py
@@ -13,16 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# import os
+import os
+
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    # ld = LaunchDescription()
-    config = get_package_share_directory('run_grasp_planner') + '/config/params_airpick4.yaml'
-    print(config)
+    config = os.path.join(
+        get_package_share_directory('run_grasp_planner'),
+        'config',
+        'params_airpick4.yaml',
+    )
+
     node = Node(
         package='run_grasp_planner',
         name='grasp_planning_node',
@@ -33,5 +37,4 @@ def generate_launch_description():
         # prefix=['valgrind'],
         parameters=[config]
     )
-    # ld.add_action(node)
     return LaunchDescription([node])

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_launch.py
@@ -13,16 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# import os
+import os
+
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    # ld = LaunchDescription()
-    config = get_package_share_directory('run_grasp_planner') + '/config/params_2f.yaml'
-    print(config)
+    config = os.path.join(
+        get_package_share_directory('run_grasp_planner'),
+        'config',
+        'params_2f.yaml',
+    )
+
     node = Node(
         package='run_grasp_planner',
         name='grasp_planning_node',
@@ -33,5 +37,4 @@ def generate_launch_description():
         # prefix=['valgrind'],
         parameters=[config]
     )
-    # ld.add_action(node)
     return LaunchDescription([node])

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_suction_launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_suction_launch.py
@@ -13,16 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# import os
+import os
+
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    # ld = LaunchDescription()
-    config = get_package_share_directory('run_grasp_planner') + '/config/params_suction.yaml'
-    print(config)
+    config = os.path.join(
+        get_package_share_directory('run_grasp_planner'),
+        'config',
+        'params_suction.yaml',
+    )
+
     node = Node(
         package='run_grasp_planner',
         name='grasp_planning_node',
@@ -33,5 +37,4 @@ def generate_launch_description():
         # prefix=['valgrind'],
         parameters=[config]
     )
-    # ld.add_action(node)
     return LaunchDescription([node])


### PR DESCRIPTION
## Summary
- build parameter file paths with `os.path.join`
- remove leftover debug prints from grasp planner launch scripts

## Testing
- `pytest`
- `python -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_launch.py`
- `python -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_2f_launch.py`
- `python -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_3f_launch.py`
- `python -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_suction_launch.py`
- `python -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/launch/grasp_planner_airpick4_launch.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeddfc42488331a5d2e3de726f9bc9