### PR TITLE
Handle missing xacro dependency in to_urdf tests

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -22,9 +22,14 @@ aip_mod.packages = packages_mod
 sys.modules.setdefault('ament_index_python', aip_mod)
 sys.modules.setdefault('ament_index_python.packages', packages_mod)
 
-# Skip this test if PyYAML is not available. The demo.launch.py module
-# imports ``yaml`` when it is executed below, and without PyYAML installed
-# the import would raise ``ModuleNotFoundError`` during test collection.
+# Skip this test if required dependencies are not available.  The
+# ``demo.launch.py`` module imports ``xacro`` and ``yaml`` during its
+# initialisation.  When those packages are missing the import would raise
+# ``ModuleNotFoundError`` at collection time which results in a hard
+# failure instead of the test being reported as skipped.  ``importorskip``
+# gracefully skips the entire test module when either dependency is not
+# installed.
+pytest.importorskip("xacro")
 pytest.importorskip("yaml")
 
 module_path = Path(__file__).resolve().parent / 'launch' / 'demo.launch.py'


### PR DESCRIPTION
## Summary
- avoid hard failures in to_urdf tests when xacro or yaml isn't installed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aeddfc42488331a5d2e3de726f9bc9