### PR TITLE
Fix URDF filename generation in load_file

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -77,7 +77,12 @@ def load_file(package_name, file_path):
         # package path and to avoid double ``.urdf`` extensions when the input
         # file already contains one.
         with tempfile.TemporaryDirectory() as tmpdir:
-            temp_urdf_path = Path(tmpdir) / Path(file_path).with_suffix(".urdf").name
+            filename = Path(file_path)
+            if filename.suffix == ".xacro":
+                filename = filename.with_suffix("")
+            if filename.suffix != ".urdf":
+                filename = filename.with_suffix(".urdf")
+            temp_urdf_path = Path(tmpdir) / filename.name
             temp_urdf_path = Path(to_urdf(str(absolute_file_path), str(temp_urdf_path)))
             with temp_urdf_path.open('r') as file:
                 return file.read()

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -94,3 +94,25 @@ def test_load_file_does_not_write_urdf_next_to_xacro(tmp_path):
     assert '<robot' in content
     # ``load_file`` should not leave any URDF files in the package directory
     assert list(pkg_dir.glob('*.urdf')) == []
+
+
+def test_load_file_avoids_double_extension(tmp_path, monkeypatch):
+    pkg_dir = tmp_path / 'pkg'
+    pkg_dir.mkdir()
+    xacro_file = pkg_dir / 'robot.urdf.xacro'
+    xacro_file.write_text("<robot name='test'></robot>")
+
+    captured = {}
+    orig_to_urdf = demo.to_urdf
+
+    def capture(xacro_path, urdf_path=None):
+        path = orig_to_urdf(xacro_path, urdf_path)
+        captured['path'] = path
+        return path
+
+    monkeypatch.setattr(demo, 'to_urdf', capture)
+
+    content = demo.load_file(str(pkg_dir), xacro_file.name)
+    assert '<robot' in content
+    assert captured['path'].endswith('.urdf')
+    assert not captured['path'].endswith('.urdf.urdf')


### PR DESCRIPTION
## Summary
- avoid creating URDF files with doubled `.urdf` extensions when processing `.xacro` files
- add regression test to ensure load_file uses a single `.urdf` suffix

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeddfc42488331a5d2e3de726f9bc9