### PR TITLE
Fix to_urdf directory path handling

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -47,13 +47,20 @@ def to_urdf(xacro_path, urdf_path=None):
         # ``"output"``).  Calling ``os.makedirs('')`` raises a
         # ``FileNotFoundError``.  Guard against this by only attempting to
         # create the directory when a directory path is provided.
+        orig_urdf_path = str(urdf_path)
         urdf_path = Path(urdf_path)
         # ``Path.name`` returns ``'.'`` for the current directory and ``'..'``
         # for the parent directory.  Both of those indicate that the provided
-        # path refers to a directory rather than a file.  ``Path.with_suffix``
-        # would raise ``ValueError`` for such paths, so detect them explicitly
-        # and raise a clearer error message instead.
-        if not urdf_path.name or urdf_path.name in {".", ".."}:
+        # path refers to a directory rather than a file.  Trailing path
+        # separators or references to an existing directory should likewise be
+        # rejected to avoid writing ``*.urdf`` files with unexpected names such
+        # as ``dir.urdf`` when a directory was intended.
+        if (
+            not urdf_path.name
+            or urdf_path.name in {".", ".."}
+            or orig_urdf_path.endswith(os.path.sep)
+            or urdf_path.is_dir()
+        ):
             raise ValueError("urdf_path must not be empty")
         urdf_path = str(urdf_path.with_suffix(".urdf"))
         directory = os.path.dirname(urdf_path)

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -83,6 +83,16 @@ def test_to_urdf_rejects_directory_only_path(tmp_path):
     with pytest.raises(ValueError, match="urdf_path must not be empty"):
         demo.to_urdf(str(xacro_file), '.')
 
+
+def test_to_urdf_rejects_path_with_trailing_separator(tmp_path):
+    """Ensure directories specified with a trailing slash are rejected."""
+    xacro_file = tmp_path / 'robot.xacro'
+    xacro_file.write_text("<robot name='test'></robot>")
+    dir_path = tmp_path / 'outdir'
+    dir_path.mkdir()
+    with pytest.raises(ValueError, match="urdf_path must not be empty"):
+        demo.to_urdf(str(xacro_file), str(dir_path) + os.path.sep)
+
 def test_load_file_does_not_write_urdf_next_to_xacro(tmp_path):
     """``load_file`` should place generated URDFs in a temporary location."""
     pkg_dir = tmp_path / 'pkg'


### PR DESCRIPTION
## Summary
- prevent `to_urdf` from treating directories as output files
- add regression test for directory paths with trailing separators

## Testing
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68aeddfc42488331a5d2e3de726f9bc9