### PR TITLE
refactor: add node options override compatibility

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/src/run_moveit_cpp.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/src/run_moveit_cpp.cpp
@@ -44,6 +44,22 @@
 #include <moveit_msgs/msg/display_robot_state.hpp>
 #include <trajectory_msgs/msg/joint_trajectory.hpp>
 
+namespace
+{
+template <class OptionsT>
+auto declare_parameters_from_overrides(OptionsT & options, int)
+    -> decltype(options.declare_parameters_from_overrides(true), void())
+{
+  options.declare_parameters_from_overrides(true);
+}
+
+template <class OptionsT>
+void declare_parameters_from_overrides(OptionsT & options, ...)
+{
+  options.automatically_declare_parameters_from_overrides(true);
+}
+}  // namespace
+
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_cpp_demo");
 
 class MoveItCppDemo
@@ -139,7 +155,7 @@ int main(int argc, char** argv)
   // This enables loading undeclared parameters
   // best practice would be to declare parameters in the corresponding classes
   // and provide descriptions about expected use
-  node_options.automatically_declare_parameters_from_overrides(true);
+  declare_parameters_from_overrides(node_options, 0);
   rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("run_moveit_cpp", "", node_options);
 
   MoveItCppDemo demo(node);

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -34,6 +34,22 @@
 
 #include "moveit/macros/console_colors.h"
 
+namespace
+{
+template <class OptionsT>
+auto declare_parameters_from_overrides(OptionsT & options, int)
+    -> decltype(options.declare_parameters_from_overrides(true), void())
+{
+  options.declare_parameters_from_overrides(true);
+}
+
+template <class OptionsT>
+void declare_parameters_from_overrides(OptionsT & options, ...)
+{
+  options.automatically_declare_parameters_from_overrides(true);
+}
+}  // namespace
+
 namespace grasp_execution
 {
 
@@ -324,7 +340,7 @@ public:
     // namespace. Parameters are automatically declared from overrides to mirror
     // the lifecycle node behaviour.
     rclcpp::NodeOptions base_options;
-    base_options.automatically_declare_parameters_from_overrides(true);
+    declare_parameters_from_overrides(base_options, 0);
     auto base_node = std::make_shared<rclcpp::Node>(
       this->get_name(), this->get_namespace(), base_options);
     demo_ = std::make_shared<grasp_execution::Demo>(
@@ -370,7 +386,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   rclcpp::NodeOptions node_options;
-  node_options.automatically_declare_parameters_from_overrides(true);
+  declare_parameters_from_overrides(node_options, 0);
   auto node = std::make_shared<DemoLifecycleNode>(node_options);
 
   node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/src/demo_node.cpp
@@ -16,6 +16,22 @@
 #include "rclcpp/rclcpp.hpp"
 #include "emd/grasp_planner/grasp_scene.hpp"
 
+namespace
+{
+template <class OptionsT>
+auto declare_parameters_from_overrides(OptionsT & options, int)
+    -> decltype(options.declare_parameters_from_overrides(true), void())
+{
+  options.declare_parameters_from_overrides(true);
+}
+
+template <class OptionsT>
+void declare_parameters_from_overrides(OptionsT & options, ...)
+{
+  options.automatically_declare_parameters_from_overrides(true);
+}
+}  // namespace
+
 static const rclcpp::Logger & LOGGER_DEMO = rclcpp::get_logger("DemoNode");
 int main(int argc, char * argv[])
 {
@@ -23,7 +39,7 @@ int main(int argc, char * argv[])
 
   rclcpp::NodeOptions node_options;
   node_options.allow_undeclared_parameters(true);
-  node_options.automatically_declare_parameters_from_overrides(true);
+  declare_parameters_from_overrides(node_options, 0);
 
   rclcpp::Node::SharedPtr node =
     rclcpp::Node::make_shared("grasp_planner_demo_node", "", node_options);

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/demo_node.cpp
@@ -30,6 +30,22 @@
 
 #include "moveit/macros/console_colors.h"
 
+namespace
+{
+template <class OptionsT>
+auto declare_parameters_from_overrides(OptionsT & options, int)
+    -> decltype(options.declare_parameters_from_overrides(true), void())
+{
+  options.declare_parameters_from_overrides(true);
+}
+
+template <class OptionsT>
+void declare_parameters_from_overrides(OptionsT & options, ...)
+{
+  options.automatically_declare_parameters_from_overrides(true);
+}
+}  // namespace
+
 namespace grasp_execution
 {
 
@@ -314,7 +330,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   rclcpp::NodeOptions node_options;
-  node_options.automatically_declare_parameters_from_overrides(true);
+  declare_parameters_from_overrides(node_options, 0);
   rclcpp::Node::SharedPtr node =
     rclcpp::Node::make_shared("grasp_execution_demo_node", "", node_options);
 

--- a/easy_manipulation_deployment/emd_grasp_planner/test/grasp_scene_test.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/test/grasp_scene_test.cpp
@@ -16,11 +16,27 @@
 #include <gtest/gtest.h>
 #include "grasp_scene_test.hpp"
 
+namespace
+{
+template <class OptionsT>
+auto declare_parameters_from_overrides(OptionsT & options, int)
+    -> decltype(options.declare_parameters_from_overrides(true), void())
+{
+  options.declare_parameters_from_overrides(true);
+}
+
+template <class OptionsT>
+void declare_parameters_from_overrides(OptionsT & options, ...)
+{
+  options.automatically_declare_parameters_from_overrides(true);
+}
+}  // namespace
+
 GraspSceneTest::GraspSceneTest()
 {
   rclcpp::NodeOptions node_options;
   node_options.allow_undeclared_parameters(true);
-  node_options.automatically_declare_parameters_from_overrides(true);
+  declare_parameters_from_overrides(node_options, 0);
   node = rclcpp::Node::make_shared("grasp_scene_test", "", node_options);
 }
 


### PR DESCRIPTION
## Summary
- ensure ROS 2 Humble and Jazzy compatibility by preferring `declare_parameters_from_overrides` when available
- update demo nodes and tests to use compatibility helper

## Testing
- `colcon test --packages-select run_grasp_execution run_waypoint_execution run_dynamic_safety run_grasp_planner emd_grasp_planner` *(fails: Has this package been built before?)*

------
https://chatgpt.com/codex/tasks/task_e_68aede1d1b388331aa0975e81c0cfe35