### PR TITLE
Add ROS Jazzy compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For installation guidance, see the ROS 2 [Jazzy](https://docs.ros.org/en/jazzy/I
 - A ROS 2 environment sourced (Jazzy or Humble)
 
 ---
-## Build on Humble
+## Build on Jazzy or Humble
 
 ```
 mkdir -p ~/workcell_ws/src
@@ -35,19 +35,20 @@ mv easy_manipulation_deployment/assets/ .
 mv easy_manipulation_deployment/scenes/ .
 mv easy_manipulation_deployment/easy_manipulation_deployment/workcell_builder ./easy_manipulation_deployment
 cd ~/workcell_ws
-source /opt/ros/humble/setup.bash
+export ROS_DISTRO=humble  # or jazzy
+source /opt/ros/${ROS_DISTRO}/setup.bash
 rosdep install --from-paths src --ignore-src -yr --rosdistro "${ROS_DISTRO}"
 source ~/ws_moveit2/install/setup.bash
 colcon build --symlink-install
 source install/setup.bash
 ```
 
-A convenience script `fix_and_build_humble.sh` is provided in this repository. After cloning into
-`~/workcell_ws`, run:
+A convenience script `fix_and_build.sh` is provided in this repository. It automatically
+detects whether Humble or Jazzy is installed. After cloning into `~/workcell_ws`, run:
 
 ```
 cd easy_manipulation_deployment
-./fix_and_build_humble.sh
+./fix_and_build.sh
 ```
 
 This script ensures required tools such as `ament_cmake` are installed via `rosdep` before building.

--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -7,10 +7,23 @@ SRC=$WS/src
 mkdir -p "$SRC"
 
 # 0) Environment bootstrap
-[ -f /opt/ros/humble/setup.bash ] || { echo "ROS Humble not found"; exit 1; }
-set +u; : "${AMENT_TRACE_SETUP_FILES:=}"; source /opt/ros/humble/setup.bash; set -u
+# Support either Humble or Jazzy depending on what is available or requested
+for d in jazzy humble; do
+  if [ -f "/opt/ros/${d}/setup.bash" ]; then
+    default_rosdistro=${d}
+    break
+  fi
+done
+
+ROS_DISTRO=${ROS_DISTRO:-${default_rosdistro}}
+[ -n "${ROS_DISTRO:-}" ] || { echo "ROS 2 distro not found (expected jazzy or humble)"; exit 1; }
+[ -f "/opt/ros/${ROS_DISTRO}/setup.bash" ] || { echo "ROS ${ROS_DISTRO} not found"; exit 1; }
+set +u; : "${AMENT_TRACE_SETUP_FILES:=}"; source "/opt/ros/${ROS_DISTRO}/setup.bash"; set -u
 export LANG=C.UTF-8 LC_ALL=C.UTF-8
-[ "${ROS_DISTRO:-}" = "humble" ] || { echo "Wrong ROS distro: ${ROS_DISTRO:-unset}"; exit 1; }
+case "${ROS_DISTRO}" in
+  humble|jazzy) ;;
+  *) echo "Wrong ROS distro: ${ROS_DISTRO}"; exit 1 ;;
+esac
 
 # C++17 everywhere
 export AMENT_CMAKE_CXX_STANDARD=17

--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -2,8 +2,16 @@
 set -euo pipefail
 cd ~/workcell_ws
 
-# 0) Source underlays
-source /opt/ros/humble/setup.bash
+# 0) Source underlays (support Humble or Jazzy)
+for d in jazzy humble; do
+  if [ -f "/opt/ros/${d}/setup.bash" ]; then
+    default_rosdistro=${d}
+    break
+  fi
+done
+ROS_DISTRO=${ROS_DISTRO:-${default_rosdistro}}
+[ -n "${ROS_DISTRO:-}" ] || { echo "ROS 2 distro not found (expected jazzy or humble)"; exit 1; }
+source "/opt/ros/${ROS_DISTRO}/setup.bash"
 if [ -f ~/ws_moveit2/install/setup.bash ]; then source ~/ws_moveit2/install/setup.bash; fi
 
 # 0.5) Install missing build tools and dependencies


### PR DESCRIPTION
## Summary
- autodetect Humble or Jazzy in build scripts
- document distro selection in README and script usage

## Testing
- `bash -n fix_and_build.sh`
- `bash -n fix_and_build_humble.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aede1d1b388331aa0975e81c0cfe35