### PR TITLE
Resolve TODOs in utils and build configuration

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/utils.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/utils.hpp
@@ -41,7 +41,7 @@ inline std::string gen_uuid()
   return boost::uuids::to_string(uuid);
 }
 
-/// Print Pose Message TODO(Briancbn): default std::cout doesn't seems to work here.
+/// Print a pose message to the provided stream.
 inline void print_pose(
   const geometry_msgs::msg::Pose & _pose,
   std::ostream & _out = std::cout,
@@ -71,6 +71,9 @@ inline void print_pose(
     _out << "Z: " << _pose.orientation.z << std::endl;
     _out << "W: " << _pose.orientation.w << std::endl << std::endl;
   }
+
+  // Ensure output is flushed when using the default stream (std::cout)
+  _out.flush();
 }
 
 /// Print PoseStamped Message

--- a/trajopt/trajopt_sco/CMakeLists.txt
+++ b/trajopt/trajopt_sco/CMakeLists.txt
@@ -172,7 +172,8 @@ if(TRAJOPT_PACKAGE)
       "${TRAJOPT_PACKAGE_PREFIX}trajopt-common")
 
   if(GUROBI_FOUND)
-    # TODO
+    list(APPEND LINUX_DEPENDS "${TRAJOPT_PACKAGE_PREFIX}gurobi")
+    list(APPEND WINDOWS_DEPENDS "${TRAJOPT_PACKAGE_PREFIX}gurobi")
   endif()
 
   if(osqp_FOUND)
@@ -181,7 +182,8 @@ if(TRAJOPT_PACKAGE)
   endif()
 
   if(qpOASES_FOUND AND TRAJOPT_BUILD_qpOASES)
-    # TODO
+    list(APPEND LINUX_DEPENDS "${TRAJOPT_PACKAGE_PREFIX}qpoases")
+    list(APPEND WINDOWS_DEPENDS "${TRAJOPT_PACKAGE_PREFIX}qpoases")
   endif()
 
   cpack(


### PR DESCRIPTION
## Summary
- ensure print helper flushes output so default std::cout works
- include optional solver dependencies in trajopt_sco packaging

## Testing
- `colcon test --packages-select emd_grasp_execution trajopt_sco` *(fails: Has this package been built before?)*
- `colcon build --packages-select emd_msgs emd_grasp_execution trajopt_sco` *(fails: Could not find package ros_industrial_cmake_boilerplate)*

------
https://chatgpt.com/codex/tasks/task_e_68aee37eb8208331aa1aa481ff772a8f