### PR TITLE
Improve robustness of fix_and_build script

### DIFF
--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e -o pipefail
+set -euo pipefail
 
 # Workspace setup
 WS=~/workcell_ws
@@ -8,6 +8,7 @@ mkdir -p "$SRC"
 
 # 0) Environment bootstrap
 # Support either Humble or Jazzy depending on what is available or requested
+default_rosdistro=""
 for d in jazzy humble; do
   if [ -f "/opt/ros/${d}/setup.bash" ]; then
     default_rosdistro=${d}


### PR DESCRIPTION
## Summary
- tighten error handling in fix_and_build.sh with `set -euo pipefail`
- initialize default_rosdistro to avoid unbound variable when no ROS distro is found

## Testing
- `bash -n fix_and_build.sh`
- `shellcheck fix_and_build.sh` *(SC1090 warning about dynamic source path)*

------
https://chatgpt.com/codex/tasks/task_e_68aeea1387b48331bb7962f5ea542bd2