### PR TITLE
Add robust YAML context loading

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/exception.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/exception.hpp
@@ -57,6 +57,27 @@ struct ContextLoadingException : public std::runtime_error
   }
 };
 
+/// Context file loading exception.
+/**
+ * Thrown when a workcell context YAML file cannot be opened or parsed.
+ */
+struct ContextFileLoadingException : public std::runtime_error
+{
+  /// Constructor
+  /**
+   * \param[in] path path to the YAML file that failed to load.
+   * \param[in] error_message additional error information.
+   */
+  ContextFileLoadingException(
+    const std::string & path,
+    const std::string & error_message = "")
+  : std::runtime_error(
+      "failed to load workcell context file [" + path + "]" +
+      (error_message.empty() ? "" : ": " + error_message))
+  {
+  }
+};
+
 
 }  // namespace grasp_execution
 

--- a/easy_manipulation_deployment/emd_grasp_execution/src/context.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/context.cpp
@@ -36,7 +36,12 @@ T _parse_optional_field(const std::string &field_name, const YAML::Node &node,
 void WorkcellContext::init_from_yaml(const std::string &path) {
   // TODO(anyone): use rcl_yaml_param_parser instead.
   // https://github.com/ros2/rcl/tree/master/rcl_yaml_param_parser
-  YAML::Node config_yaml = YAML::LoadFile(path);
+  YAML::Node config_yaml;
+  try {
+    config_yaml = YAML::LoadFile(path);
+  } catch (const YAML::Exception & e) {
+    throw ContextFileLoadingException(path, e.what());
+  }
 
   // Check whether yaml starts with workcell namespace.
   if (!config_yaml["workcell"]) {

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
@@ -19,3 +19,18 @@ target_include_directories(test_scheduler
 target_compile_features(test_scheduler
   PRIVATE cxx_std_17
 )
+
+# Context Unit Test
+ament_add_gtest(test_context
+  test_context.cpp
+)
+target_link_libraries(test_context
+  grasp_execution_interface
+  yaml-cpp
+)
+target_include_directories(test_context
+  SYSTEM PRIVATE ${YAML_CPP_INCLUDE_DIRS}
+)
+target_compile_features(test_context
+  PRIVATE cxx_std_17
+)

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_context.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_context.cpp
@@ -1,0 +1,26 @@
+// Copyright 2021 ROS Industrial Consortium Asia Pacific
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "emd/grasp_execution/context.hpp"
+#include "emd/grasp_execution/exception.hpp"
+
+TEST(TestContext, MissingFileThrows)
+{
+  grasp_execution::WorkcellContext ctx;
+  EXPECT_THROW(ctx.init_from_yaml("nonexistent_file.yaml"),
+               grasp_execution::ContextFileLoadingException);
+}
+


### PR DESCRIPTION
## Summary
- handle file loading errors in `WorkcellContext::init_from_yaml`
- add `ContextFileLoadingException` and unit test

## Testing
- `colcon build --packages-select emd_grasp_execution` *(fails: Failed to find the following files: install/emd_msgs/share/emd_msgs/package.sh)*
- `colcon test --packages-select emd_grasp_execution` *(fails: Has this package been built before?)*

------
https://chatgpt.com/codex/tasks/task_e_68aeea1387b48331bb7962f5ea542bd2