### PR TITLE
Pass kinematic parameters to demo RViz launch

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -124,13 +124,18 @@ def generate_launch_description():
 
     # RViz
     rviz_config_file = get_package_share_directory(scene_pkg) + "/launch/demo.rviz"
-    rviz_node = Node(package='rviz2',
-                     executable='rviz2',
-                     name='rviz2',
-                     output='log',
-                     arguments=['-d', rviz_config_file],
-                     parameters=[robot_description,
-                                 robot_description_semantic])
+    rviz_node = Node(
+        package='rviz2',
+        executable='rviz2',
+        name='rviz2',
+        output='log',
+        arguments=['-d', rviz_config_file],
+        parameters=[
+            robot_description,
+            robot_description_semantic,
+            robot_description_kinematics,
+        ],
+    )
     # Publish base link TF
     static_tf = Node(package='tf2_ros',
                      executable='static_transform_publisher',


### PR DESCRIPTION
## Summary
- pass robot kinematics parameter set to RViz node in demo launch

## Testing
- `flake8 easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py`
- `pytest easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeea1387b48331bb7962f5ea542bd2