### PR TITLE
Propagate execution result in MoveIt named state planner

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -811,11 +811,11 @@ bool MoveitCppGraspExecution::move_to(
     // Execute immediately
     if (execute) {
       RCLCPP_INFO(LOGGER, "Sending the trajectory for execution");
-      arm.planner->execute(true);  // blocked execution
+      return arm.planner->execute(true);  // blocked execution
     } else {
       arm.traj.push_back(plan_solution.trajectory);
+      return true;
     }
-    return true;
   } else {
     return false;
   }


### PR DESCRIPTION
## Summary
- return the outcome of `arm.planner->execute()` when executing a named state so callers can react to execution failures

## Testing
- `colcon build --packages-select emd_grasp_execution` *(fails: Missing emd_msgs package)*
- `colcon build --packages-select emd_msgs` *(fails: Could not find ament_cmake package)*

------
https://chatgpt.com/codex/tasks/task_e_68aef4eb0240833199d8417932f1ec51