### PR TITLE
feat: validate xacro path before conversion

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -30,6 +30,14 @@ def to_urdf(xacro_path, urdf_path=None):
     * xacro_path -- the path to the xacro file
     * urdf_path -- the desired path to the URDF file
     """
+    # Validate that the source xacro file exists before attempting to convert
+    # it. ``xacro`` will eventually raise a somewhat cryptic error if the file
+    # is missing; performing an explicit check here gives a clearer
+    # ``FileNotFoundError`` to callers.
+    xacro_path = Path(xacro_path)
+    if not xacro_path.is_file():
+        raise FileNotFoundError(f"xacro file '{xacro_path}' does not exist")
+
     xacro_path = str(xacro_path)
     # If no URDF path is given, generate a temporary filename with a proper
     # ``.urdf`` extension.  ``tempfile.mktemp`` is avoided as it is vulnerable

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -37,6 +37,12 @@ spec = importlib.util.spec_from_file_location('demo_launch', module_path)
 demo = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(demo)
 
+def test_to_urdf_requires_existing_file(tmp_path):
+    """to_urdf should raise ``FileNotFoundError`` if the xacro file is missing."""
+    missing = tmp_path / "missing.xacro"
+    with pytest.raises(FileNotFoundError):
+        demo.to_urdf(missing)
+
 def test_to_urdf_creates_urdf_file(tmp_path):
     xacro_file = tmp_path / 'robot.xacro'
     xacro_file.write_text("<robot name='test'></robot>")


### PR DESCRIPTION
## Summary
- raise clear error when xacro file is missing
- test path validation in to_urdf utility

## Testing
- `python -m pytest easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py`


------
https://chatgpt.com/codex/tasks/task_e_68aef4eb0240833199d8417932f1ec51