### PR TITLE
Add quick grasp demo instructions and runnable script

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,27 @@ Single Suction Cup
 
 2x2 Suction Array
 
-<img src="./images/2x2_array.png"  width="10%" height="10%"> 
+<img src="./images/2x2_array.png"  width="10%" height="10%">
 
+Quick start:
+
+```
+colcon build --symlink-install
+source install/setup.bash
+ros2 launch run_grasp_planner grasp_planner_3f_launch.py
+```
 
 ### 2) Grasp Execution
 
 A Moveit2 Based Grasp Execution package that incorporates real time dynamic safety components
+
+Quick start:
+
+```
+colcon build --symlink-install
+source install/setup.bash
+ros2 launch run_grasp_execution grasp_execution.launch.py
+```
 
 ### 3) Workcell Builder
 
@@ -109,6 +124,12 @@ The grasp execution example can be started in a similar manner:
 
 ```
 ros2 launch run_grasp_execution grasp_execution.launch.py
+```
+
+To launch both the grasp planner and execution together, use the provided demo script:
+
+```
+./scripts/grasp_demo.sh
 ```
 
 ---

--- a/scripts/grasp_demo.sh
+++ b/scripts/grasp_demo.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+# Build the workspace and source it
+colcon build --symlink-install
+source install/setup.bash
+
+# Launch grasp planner and execution demos
+ros2 launch run_grasp_planner grasp_planner_3f_launch.py &
+planner_pid=$!
+
+ros2 launch run_grasp_execution grasp_execution.launch.py &
+execution_pid=$!
+
+# Wait for user to terminate
+echo "Demo running. Press Ctrl+C to stop."
+trap "kill $planner_pid $execution_pid" EXIT
+wait


### PR DESCRIPTION
## Summary
- document quick start commands for Grasp Planner and Grasp Execution
- add `grasp_demo.sh` script to run planner and execution together
- reference new demo script in README

## Testing
- `colcon test --packages-select run_grasp_planner run_grasp_execution` *(fails: command not found: colcon)*

------
https://chatgpt.com/codex/tasks/task_e_68aef81372c88331aa5a49f6a5034ee1