### PR TITLE
Handle ~ in to_urdf paths

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -34,7 +34,11 @@ def to_urdf(xacro_path, urdf_path=None):
     # it. ``xacro`` will eventually raise a somewhat cryptic error if the file
     # is missing; performing an explicit check here gives a clearer
     # ``FileNotFoundError`` to callers.
-    xacro_path = Path(xacro_path)
+    # Expand the user home directory (``~``) in the supplied path so that
+    # callers can rely on standard shell semantics.  Without this a path such
+    # as ``~/file.xacro`` would be interpreted literally and the subsequent
+    # ``is_file`` check would fail even though the file exists.
+    xacro_path = Path(xacro_path).expanduser()
     if not xacro_path.is_file():
         raise FileNotFoundError(f"xacro file '{xacro_path}' does not exist")
 
@@ -56,7 +60,11 @@ def to_urdf(xacro_path, urdf_path=None):
         # ``FileNotFoundError``.  Guard against this by only attempting to
         # create the directory when a directory path is provided.
         orig_urdf_path = str(urdf_path)
-        urdf_path = Path(urdf_path)
+        # Allow ``~`` in the output path in the same way as the xacro path
+        # above.  ``Path`` would otherwise treat the tilde as a literal
+        # character which leads to confusing paths like ``~/out.urdf`` being
+        # created in the current working directory.
+        urdf_path = Path(urdf_path).expanduser()
         # ``Path.name`` returns ``'.'`` for the current directory and ``'..'``
         # for the parent directory.  Both of those indicate that the provided
         # path refers to a directory rather than a file.  Trailing path

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -104,6 +104,19 @@ def test_to_urdf_rejects_path_with_trailing_separator(tmp_path):
     with pytest.raises(ValueError, match="urdf_path must not be empty"):
         demo.to_urdf(str(xacro_file), str(dir_path) + os.path.sep)
 
+
+def test_to_urdf_expands_user_paths(tmp_path, monkeypatch):
+    """Paths containing ``~`` should resolve to the user's home directory."""
+    # Use a temporary directory as the fake home so that ``~/`` points to a
+    # location we control.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    xacro_file = tmp_path / "robot.xacro"
+    xacro_file.write_text("<robot name='test'></robot>")
+    result = demo.to_urdf("~/robot.xacro", "~/out")
+    expected = tmp_path / "out.urdf"
+    assert result == str(expected)
+    assert expected.exists()
+
 def test_load_file_does_not_write_urdf_next_to_xacro(tmp_path):
     """``load_file`` should place generated URDFs in a temporary location."""
     pkg_dir = tmp_path / 'pkg'


### PR DESCRIPTION
## Summary
- expand `~` to user home in `to_urdf` so tilde paths work
- test `to_urdf` with user home paths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aef8298ce48331b4c917420d97e179