### PR TITLE
Remove unnecessary roslaunch dependency from xacro test

### DIFF
--- a/assets/environment/realsense2_description/tests/test_xacro.py
+++ b/assets/environment/realsense2_description/tests/test_xacro.py
@@ -9,8 +9,8 @@ available and ``yield`` based tests are no longer supported by ``pytest``.
 
 To make the check robust we compute the package path relative to this
 file and generate individual parametrised tests for every ``.xacro``
-file.  The test is skipped automatically when the ``xacro``/``roslaunch``
-dependencies are missing.
+file.  The test is skipped automatically when required ROS utilities
+are missing.
 """
 
 from pathlib import Path
@@ -18,9 +18,11 @@ import subprocess
 
 import pytest
 
-# Skip the entire test module if required ROS tools are not available.
+# Skip the entire test module if ``xacro`` is not available.  Additional
+# ROS dependencies such as ``roslaunch`` are handled dynamically within
+# the individual test cases to avoid unnecessarily skipping the entire
+# suite when only some tools are missing.
 pytest.importorskip("xacro")
-pytest.importorskip("roslaunch")
 
 # Determine the root of the realsense2_description package using the file
 # location instead of relying on ROS environment variables.  ``__file__`` may


### PR DESCRIPTION
## Summary
- relax test_xacro dependency so xacro files are validated even when roslaunch isn't installed

## Testing
- `pytest assets/environment/realsense2_description/tests/test_xacro.py -q`
- `pytest easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef8298ce48331b4c917420d97e179