### PR TITLE
Fix missing kinematics parameter in MoveIt launch

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/launch/run_moveit_cpp.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/launch/run_moveit_cpp.launch.py
@@ -100,7 +100,7 @@ def generate_launch_description():
             moveit_cpp_yaml_file_name,
             robot_description,
             robot_description_semantic,
-            kinematics_yaml,
+            robot_description_kinematics,
             ompl_planning_pipeline_config,
             moveit_controllers,
             joint_limits_yaml,


### PR DESCRIPTION
## Summary
- pass robot_description_kinematics to run_moveit_cpp node so kinematics params are applied

## Testing
- `pyflakes easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/launch/run_moveit_cpp.launch.py`
- `pytest easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef8298ce48331b4c917420d97e179