### PR TITLE
Improve demo script cleanup

### DIFF
--- a/scripts/grasp_demo.sh
+++ b/scripts/grasp_demo.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+
+cleanup() {
+  kill "${planner_pid:-}" "${execution_pid:-}" 2>/dev/null || true
+}
+trap cleanup SIGINT SIGTERM ERR EXIT
 
 # Build the workspace and source it
 colcon build --symlink-install
@@ -14,5 +19,4 @@ execution_pid=$!
 
 # Wait for user to terminate
 echo "Demo running. Press Ctrl+C to stop."
-trap "kill $planner_pid $execution_pid" EXIT
 wait


### PR DESCRIPTION
## Summary
- harden grasp_demo.sh with strict error handling
- ensure planner and execution processes are cleaned up on exit

## Testing
- `bash -n scripts/grasp_demo.sh`
- `colcon test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af0135c51c833188c04cbc210f9a1a