### PR TITLE
Add dependency checks and rosdep step in build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For installation guidance, see the ROS 2 [Jazzy](https://docs.ros.org/en/jazzy/I
 
 - [vcstool](https://github.com/dirk-thomas/vcstool) for fetching dependency repositories
 - `rosdep` for installing package dependencies
+- `colcon` build tool
 - A ROS 2 environment sourced (Jazzy or Humble)
 
 ---

--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -26,6 +26,19 @@ case "${ROS_DISTRO}" in
   *) echo "Wrong ROS distro: ${ROS_DISTRO}"; exit 1 ;;
 esac
 
+# Ensure required tools are available
+for cmd in git colcon rosdep; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Required tool '$cmd' is not installed." >&2
+    exit 1
+  fi
+done
+
+# Install missing dependencies
+rosdep update
+rosdep install --from-paths "$SRC" --ignore-src -yr --rosdistro "${ROS_DISTRO}" \
+  --skip-keys "tesseract tesseract_process_planners"
+
 # C++17 everywhere
 export AMENT_CMAKE_CXX_STANDARD=17
 CMAKE_STD_ARGS=(-DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF)

--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -14,6 +14,14 @@ ROS_DISTRO=${ROS_DISTRO:-${default_rosdistro}}
 source "/opt/ros/${ROS_DISTRO}/setup.bash"
 if [ -f ~/ws_moveit2/install/setup.bash ]; then source ~/ws_moveit2/install/setup.bash; fi
 
+# Ensure required tools are available
+for cmd in git colcon rosdep; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Required tool '$cmd' is not installed." >&2
+    exit 1
+  fi
+done
+
 # 0.5) Install missing build tools and dependencies
 if [ ! -f "/opt/ros/${ROS_DISTRO}/share/ament_cmake/package.xml" ]; then
   if command -v sudo >/dev/null 2>&1; then
@@ -36,7 +44,7 @@ fi
 
 # 2) Clean fully (start from scratch)
 rm -rf build install log
-find src -name build -o -name install -o -name log | xargs -r rm -rf
+find src \( -name build -o -name install -o -name log \) -print0 | xargs -0 -r rm -rf
 
 # 3) Stage 1: infrastructure vendors first
 colcon build --symlink-install --packages-select \


### PR DESCRIPTION
## Summary
- ensure build scripts check for required tools
- auto-install missing dependencies with rosdep
- document colcon requirement in prerequisites

## Testing
- `shellcheck fix_and_build.sh fix_and_build_humble.sh`
- `bash -n fix_and_build.sh fix_and_build_humble.sh`


------
https://chatgpt.com/codex/tasks/task_e_68af0135c51c833188c04cbc210f9a1a