### PR TITLE
Use tesseract boost plugin loader and guard ROS setup

### DIFF
--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -44,8 +44,9 @@ export AMENT_CMAKE_CXX_STANDARD=17
 CMAKE_STD_ARGS=(-DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF)
 
 # 1) Ensure boost_plugin_loader and build it first
+# Ensure the boost_plugin_loader from tesseract-robotics is available
 if [ ! -d "$SRC/boost_plugin_loader" ]; then
-  git clone https://github.com/ros-industrial/boost_plugin_loader.git "$SRC/boost_plugin_loader"
+  git clone https://github.com/tesseract-robotics/boost_plugin_loader.git "$SRC/boost_plugin_loader"
 fi
 cd "$WS"
 colcon build --symlink-install --packages-select boost_plugin_loader

--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 cd ~/workcell_ws
 
 # 0) Source underlays (support Humble or Jazzy)
+default_rosdistro=""
 for d in jazzy humble; do
   if [ -f "/opt/ros/${d}/setup.bash" ]; then
     default_rosdistro=${d}
@@ -11,7 +12,7 @@ for d in jazzy humble; do
 done
 ROS_DISTRO=${ROS_DISTRO:-${default_rosdistro}}
 [ -n "${ROS_DISTRO:-}" ] || { echo "ROS 2 distro not found (expected jazzy or humble)"; exit 1; }
-source "/opt/ros/${ROS_DISTRO}/setup.bash"
+set +u; : "${AMENT_TRACE_SETUP_FILES:=}"; source "/opt/ros/${ROS_DISTRO}/setup.bash"; set -u
 if [ -f ~/ws_moveit2/install/setup.bash ]; then source ~/ws_moveit2/install/setup.bash; fi
 
 # Ensure required tools are available


### PR DESCRIPTION
## Summary
- Clone `boost_plugin_loader` from the tesseract-robotics repository
- Guard ROS setup in `fix_and_build_humble.sh` to avoid AMENT_TRACE_SETUP_FILES errors

## Testing
- `bash -n fix_and_build.sh`
- `bash -n fix_and_build_humble.sh`


------
https://chatgpt.com/codex/tasks/task_e_68af2cf3e3388331904abaced18fae6b