### PR TITLE
Fix sed command for rclcpp dependency insertion

### DIFF
--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -70,7 +70,7 @@ CMAKEL="$SRC/trajopt/trajopt_sco/CMakeLists.txt"
 PKGXML="$SRC/trajopt/trajopt_sco/package.xml"
 
 if [ -f "$CMAKEL" ]; then
-  grep -q 'find_package( *rclcpp' "$CMAKEL" || sed -i '1,/project(/{/project(/a find_package(rclcpp REQUIRED)}' "$CMAKEL"
+  grep -q 'find_package( *rclcpp' "$CMAKEL" || sed -i '/project(/a find_package(rclcpp REQUIRED)' "$CMAKEL"
 
   if grep -q 'ament_target_dependencies( *trajopt_sco' "$CMAKEL"; then
     sed -i '0,/ament_target_dependencies( *trajopt_sco/s//ament_target_dependencies(trajopt_sco\n  rclcpp\n/' "$CMAKEL"


### PR DESCRIPTION
## Summary
- fix `sed` syntax in `fix_and_build.sh` when inserting `find_package(rclcpp REQUIRED)`

## Testing
- `./fix_and_build.sh` *(fails: ROS 2 distro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af59c0452483319e4c4f446da8c06b