### PR TITLE
Add rclcpp dependency to trajopt_sco

### DIFF
--- a/trajopt/trajopt_sco/CMakeLists.txt
+++ b/trajopt/trajopt_sco/CMakeLists.txt
@@ -30,6 +30,7 @@ endif()
 find_package(ros_industrial_cmake_boilerplate REQUIRED)
 find_package(Boost REQUIRED)
 find_package(OpenMP REQUIRED)
+find_package(rclcpp REQUIRED)
 
 # qpOASES
 option(TRAJOPT_BUILD_qpOASES "Build qpOASES components" ON)
@@ -120,6 +121,7 @@ target_link_libraries(
   PUBLIC trajopt::trajopt_common
          Boost::boost
          Eigen3::Eigen
+         rclcpp::rclcpp
          ${CMAKE_DL_LIBS}
          jsoncpp_lib
          OpenMP::OpenMP_CXX)


### PR DESCRIPTION
## Summary
- ensure trajopt_sco links against rclcpp to satisfy ros_node_base

## Testing
- `colcon build --packages-select trajopt_sco` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af59ebb3508331939a9ca4e5b749af