### PR TITLE
Handle duplicate ROS packages

### DIFF
--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -39,6 +39,18 @@ rosdep update
 rosdep install --from-paths "$SRC" --ignore-src -yr --rosdistro "${ROS_DISTRO}" \
   --skip-keys "tesseract tesseract_process_planners"
 
+# Remove any duplicate ROS packages within the workspace to avoid colcon errors.
+# Keep the first occurrence of a package name and discard subsequent duplicates.
+declare -A pkg_seen
+while read -r name path _; do
+  if [[ -n "${pkg_seen[$name]:-}" ]]; then
+    echo "Removing duplicate package '$name' from $path (keeping ${pkg_seen[$name]})"
+    rm -rf "$path"
+  else
+    pkg_seen[$name]="$path"
+  fi
+done < <(colcon list --base-paths "$SRC")
+
 # C++17 everywhere
 export AMENT_CMAKE_CXX_STANDARD=17
 CMAKE_STD_ARGS=(-DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF)

--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -38,6 +38,17 @@ rosdep update
 rosdep install --from-paths src --ignore-src -yr --rosdistro "${ROS_DISTRO}" \
   --skip-keys "tesseract tesseract_process_planners"
 
+# Remove any duplicate ROS packages to prevent colcon build failures.
+declare -A pkg_seen
+while read -r name path _; do
+  if [[ -n "${pkg_seen[$name]:-}" ]]; then
+    echo "Removing duplicate package '$name' from $path (keeping ${pkg_seen[$name]})"
+    rm -rf "$path"
+  else
+    pkg_seen[$name]="$path"
+  fi
+done < <(colcon list --base-paths src)
+
 # 1) Ensure boost_plugin_loader exists
 if [ ! -d src/boost_plugin_loader ]; then
   git -C src clone https://github.com/tesseract-robotics/boost_plugin_loader.git


### PR DESCRIPTION
## Summary
- prevent colcon build failures by removing duplicate package names in build scripts

## Testing
- `WS=~/workcell_ws; SRC=$WS/src; declare -A pkg_seen; while read -r name path _; do if [[ -n "${pkg_seen[$name]:-}" ]]; then echo "Removing duplicate package '$name' from $path (keeping ${pkg_seen[$name]})"; rm -rf "$path"; else pkg_seen[$name]="$path"; fi; done < <(colcon list --base-paths "$SRC")`
- `colcon list --base-paths ~/workcell_ws/src`


------
https://chatgpt.com/codex/tasks/task_e_68af65462f348331ad5758edbdd64553