### PR TITLE
Handle missing packages gracefully in workcell builder

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -93,9 +93,10 @@ def to_urdf(xacro_path, urdf_path=None):
     return urdf_path  # Return path to the urdf file
 
 def load_file(package_name, file_path):
-    package_path = Path(get_package_share_directory(package_name))  # get package filepath
-    absolute_file_path = package_path / file_path
     try:
+        package_path = Path(get_package_share_directory(package_name))  # get package filepath
+        absolute_file_path = package_path / file_path
+
         # Use a temporary directory so the generated URDF does not pollute the
         # package path and to avoid double ``.urdf`` extensions when the input
         # file already contains one.

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -150,3 +150,13 @@ def test_load_file_avoids_double_extension(tmp_path, monkeypatch):
     assert '<robot' in content
     assert captured['path'].endswith('.urdf')
     assert not captured['path'].endswith('.urdf.urdf')
+
+
+def test_load_file_handles_missing_package(monkeypatch):
+    """``load_file`` should return ``None`` when the package is not found."""
+    monkeypatch.setattr(
+        demo,
+        'get_package_share_directory',
+        lambda pkg: (_ for _ in ()).throw(EnvironmentError('missing package')),
+    )
+    assert demo.load_file('does_not_exist', 'file.urdf.xacro') is None


### PR DESCRIPTION
## Summary
- Avoid unhandled exceptions in `load_file` by catching missing packages
- Add regression test for missing package handling

## Testing
- `pytest assets/environment/realsense2_description/tests/test_xacro.py`
- `pytest easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0352746a08331ac3e634b340ad756