### PR TITLE
Improve grasp demo cleanup

### DIFF
--- a/scripts/grasp_demo.sh
+++ b/scripts/grasp_demo.sh
@@ -2,12 +2,19 @@
 set -euo pipefail
 
 cleanup() {
-  kill "${planner_pid:-}" "${execution_pid:-}" 2>/dev/null || true
+  # Terminate background processes if they were started
+  if [ -n "${planner_pid:-}" ]; then
+    kill "$planner_pid" 2>/dev/null || true
+  fi
+  if [ -n "${execution_pid:-}" ]; then
+    kill "$execution_pid" 2>/dev/null || true
+  fi
 }
 trap cleanup SIGINT SIGTERM ERR EXIT
 
 # Build the workspace and source it
 colcon build --symlink-install
+# shellcheck disable=SC1091
 source install/setup.bash
 
 # Launch grasp planner and execution demos


### PR DESCRIPTION
## Summary
- make grasp demo cleanup more robust by killing background processes individually
- silence shellcheck warning when sourcing workspace setup

## Testing
- `shellcheck scripts/grasp_demo.sh`
- `bash -n scripts/grasp_demo.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b0352746a08331ac3e634b340ad756