### PR TITLE
Validate xacro source file extension

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -41,6 +41,13 @@ def to_urdf(xacro_path, urdf_path=None):
     xacro_path = Path(xacro_path).expanduser()
     if not xacro_path.is_file():
         raise FileNotFoundError(f"xacro file '{xacro_path}' does not exist")
+    # ``xacro`` is designed to process files ending with the ``.xacro``
+    # extension.  Accepting other extensions would result in confusing error
+    # messages downstream when ``xacro`` attempts to parse non-xacro input.
+    # Validate the extension early to provide a clear and actionable error to
+    # callers.
+    if xacro_path.suffix != ".xacro":
+        raise ValueError("xacro_path must point to a .xacro file")
 
     xacro_path = str(xacro_path)
     # If no URDF path is given, generate a temporary filename with a proper

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -43,6 +43,14 @@ def test_to_urdf_requires_existing_file(tmp_path):
     with pytest.raises(FileNotFoundError):
         demo.to_urdf(missing)
 
+
+def test_to_urdf_rejects_non_xacro_file(tmp_path):
+    """to_urdf should reject source files that do not end with ``.xacro``."""
+    non_xacro = tmp_path / "robot.urdf"
+    non_xacro.write_text("<robot name='test'></robot>")
+    with pytest.raises(ValueError, match="xacro_path must point to a .xacro file"):
+        demo.to_urdf(non_xacro)
+
 def test_to_urdf_creates_urdf_file(tmp_path):
     xacro_file = tmp_path / 'robot.xacro'
     xacro_file.write_text("<robot name='test'></robot>")


### PR DESCRIPTION
## Summary
- ensure `to_urdf` only accepts `.xacro` source files
- test `to_urdf` rejects non-xacro inputs

## Testing
- `pytest -q` *(fails: xacro or dependencies not installed; tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b03d1228148331999bc6f946a4a46c