### PR TITLE
Add validation for xacro path in URDF converter

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -34,6 +34,10 @@ def to_urdf(xacro_path, urdf_path=None):
     # it. ``xacro`` will eventually raise a somewhat cryptic error if the file
     # is missing; performing an explicit check here gives a clearer
     # ``FileNotFoundError`` to callers.
+    # Ensure a meaningful error is raised when an empty path is supplied.
+    if xacro_path is None or (isinstance(xacro_path, str) and not xacro_path.strip()):
+        raise ValueError("xacro_path must not be empty")
+
     # Expand the user home directory (``~``) in the supplied path so that
     # callers can rely on standard shell semantics.  Without this a path such
     # as ``~/file.xacro`` would be interpreted literally and the subsequent

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -43,6 +43,12 @@ def test_to_urdf_requires_existing_file(tmp_path):
     with pytest.raises(FileNotFoundError):
         demo.to_urdf(missing)
 
+
+def test_to_urdf_rejects_empty_xacro_path():
+    """to_urdf should raise ``ValueError`` when given an empty source path."""
+    with pytest.raises(ValueError, match="xacro_path must not be empty"):
+        demo.to_urdf("")
+
 def test_to_urdf_creates_urdf_file(tmp_path):
     xacro_file = tmp_path / 'robot.xacro'
     xacro_file.write_text("<robot name='test'></robot>")


### PR DESCRIPTION
## Summary
- ensure `to_urdf` rejects empty xacro paths
- add unit test for missing source path

## Testing
- `pytest easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py`


------
https://chatgpt.com/codex/tasks/task_e_68b03d1228148331999bc6f946a4a46c