### PR TITLE
Improve ROS 2 distro detection

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -17,6 +17,7 @@
 #include <QFileDialog>
 #include <boost/filesystem.hpp>
 #include <stdio.h>
+#include <array>
 #include <cstdlib>
 #include <iostream>
 #include <string>
@@ -37,6 +38,18 @@ MainWindow::MainWindow(QWidget * parent)
   success = false;
   ui->error_label->setWordWrap(true);
   ui->error_label->setText("<font color='red'>Workcell not available</font>");
+
+  // Detect available ROS 2 distributions (currently supports Jazzy and Humble)
+  const std::array<std::string, 2> candidates{"jazzy", "humble"};
+  for (const auto & candidate : candidates) {
+    if (boost::filesystem::exists("/opt/ros/" + candidate)) {
+      ros_dist.push_back(candidate);
+    }
+  }
+  if (ros_dist.empty()) {
+    ros_dist.assign(candidates.begin(), candidates.end());
+  }
+
   for (const auto & supported_distro : ros_dist) {
     ui->ros_distro->addItem(QString::fromStdString(supported_distro));
   }

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -36,8 +36,8 @@ public:
   boost::filesystem::path workcell_path;
   Workcell workcell;
   bool success;
-  // Supported ROS 2 distributions.
-  std::vector<std::string> ros_dist{"jazzy", "humble"};
+  // Supported ROS 2 distributions detected at runtime.
+  std::vector<std::string> ros_dist;
   bool is_good_scene(boost::filesystem::path original_path, std::string scene_name);
 
   explicit MainWindow(QWidget * parent = nullptr);


### PR DESCRIPTION
## Summary
- Detect installed ROS 2 Jazzy or Humble distributions at runtime in Workcell Builder
- Populate ROS distro selector from available installations

## Testing
- `./fix_and_build.sh` *(fails: ROS 2 distro not found)*
- `colcon test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b050a7d01483318ce830380ef54240