### PR TITLE
Ensure fix_and_build installs ament_cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cd easy_manipulation_deployment
 ./fix_and_build.sh
 ```
 
-This script ensures required tools such as `ament_cmake` are installed via `rosdep` before building.
+This script checks for required tools and automatically installs base packages like `ament_cmake` if they are missing before running `rosdep`.
 
 ---
 ## Full Documentation/Wiki

--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -34,6 +34,17 @@ for cmd in git colcon rosdep; do
   fi
 done
 
+# Install missing build tools like ament_cmake if absent
+if [ ! -f "/opt/ros/${ROS_DISTRO}/share/ament_cmake/package.xml" ]; then
+  if command -v sudo >/dev/null 2>&1; then
+    sudo apt-get update -y
+    sudo apt-get install -y "ros-${ROS_DISTRO}-ament-cmake"
+  else
+    apt-get update -y
+    apt-get install -y "ros-${ROS_DISTRO}-ament-cmake"
+  fi
+fi
+
 # Install missing dependencies
 rosdep update
 rosdep install --from-paths "$SRC" --ignore-src -yr --rosdistro "${ROS_DISTRO}" \


### PR DESCRIPTION
## Summary
- Ensure `fix_and_build.sh` installs `ament_cmake` if missing for Jazzy/Humble
- Document automatic `ament_cmake` installation in README

## Testing
- `bash -n fix_and_build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b050a7d01483318ce830380ef54240