### PR TITLE
Auto-detect ROS 2 distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This ROS 2 package provides a modular, easy-to-deploy manipulation pipeline that
 This package was tested with the [easy_perception_deployment](https://github.com/ros-industrial/easy_perception_deployment) ROS 2 package, but any perception system publishing the same ROS 2 message on the expected topic can work with this package as well.
 
 It is recommended to run this package on **ROS 2 Jazzy** (Ubuntu 24.04) or **ROS 2 Humble** (Ubuntu 22.04).
+The provided build scripts and Workcell Builder GUI automatically detect whichever of these distributions is installed.
 For installation guidance, see the ROS 2 [Jazzy](https://docs.ros.org/en/jazzy/Installation.html) or [Humble](https://docs.ros.org/en/humble/Installation.html) documentation.
 
 ---

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -37,8 +37,15 @@ MainWindow::MainWindow(QWidget * parent)
   success = false;
   ui->error_label->setWordWrap(true);
   ui->error_label->setText("<font color='red'>Workcell not available</font>");
-  for (const auto & supported_distro : ros_dist) {
-    ui->ros_distro->addItem(QString::fromStdString(supported_distro));
+  const std::vector<std::string> supported{"jazzy", "humble"};
+  for (const auto & d : supported) {
+    if (boost::filesystem::exists("/opt/ros/" + d)) {
+      ros_dist.push_back(d);
+      ui->ros_distro->addItem(QString::fromStdString(d));
+    }
+  }
+  if (ros_dist.empty()) {
+    ui->error_label->setText("<font color='red'>No supported ROS 2 distro found</font>");
   }
 
   const char * distro = std::getenv("ROS_DISTRO");

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -36,8 +36,8 @@ public:
   boost::filesystem::path workcell_path;
   Workcell workcell;
   bool success;
-  // Supported ROS 2 distributions.
-  std::vector<std::string> ros_dist{"jazzy", "humble"};
+  // Supported ROS 2 distributions detected at runtime.
+  std::vector<std::string> ros_dist;
   bool is_good_scene(boost::filesystem::path original_path, std::string scene_name);
 
   explicit MainWindow(QWidget * parent = nullptr);


### PR DESCRIPTION
## Summary
- Autodetect ROS 2 Humble or Jazzy installations in Workcell Builder
- Mention auto-detection in README

## Testing
- `colcon build --packages-select workcell_builder --base-paths easy_manipulation_deployment/workcell_builder` *(fails: CMake could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68b050a7d01483318ce830380ef54240