### PR TITLE
Fix duplicate package removal before rosdep install

### DIFF
--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -36,11 +36,10 @@ done
 
 # Install missing dependencies
 rosdep update
-rosdep install --from-paths "$SRC" --ignore-src -yr --rosdistro "${ROS_DISTRO}" \
-  --skip-keys "tesseract tesseract_process_planners"
 
-# Remove any duplicate ROS packages within the workspace to avoid colcon errors.
-# Keep the first occurrence of a package name and discard subsequent duplicates.
+# Remove any duplicate ROS packages within the workspace before resolving
+# dependencies to avoid rosdep and colcon errors. Keep the first occurrence of
+# a package name and discard subsequent duplicates.
 declare -A pkg_seen
 while read -r name path _; do
   if [[ -n "${pkg_seen[$name]:-}" ]]; then
@@ -50,6 +49,9 @@ while read -r name path _; do
     pkg_seen[$name]="$path"
   fi
 done < <(colcon list --base-paths "$SRC")
+
+rosdep install --from-paths "$SRC" --ignore-src -yr --rosdistro "${ROS_DISTRO}" \
+  --skip-keys "tesseract tesseract_process_planners"
 
 # C++17 everywhere
 export AMENT_CMAKE_CXX_STANDARD=17

--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -35,10 +35,10 @@ if [ ! -f "/opt/ros/${ROS_DISTRO}/share/ament_cmake/package.xml" ]; then
 fi
 
 rosdep update
-rosdep install --from-paths src --ignore-src -yr --rosdistro "${ROS_DISTRO}" \
-  --skip-keys "tesseract tesseract_process_planners"
 
-# Remove any duplicate ROS packages to prevent colcon build failures.
+# Remove any duplicate ROS packages before resolving dependencies to prevent
+# rosdep and colcon build failures. Keep the first occurrence of a package
+# name and discard subsequent duplicates.
 declare -A pkg_seen
 while read -r name path _; do
   if [[ -n "${pkg_seen[$name]:-}" ]]; then
@@ -48,6 +48,9 @@ while read -r name path _; do
     pkg_seen[$name]="$path"
   fi
 done < <(colcon list --base-paths src)
+
+rosdep install --from-paths src --ignore-src -yr --rosdistro "${ROS_DISTRO}" \
+  --skip-keys "tesseract tesseract_process_planners"
 
 # 1) Ensure boost_plugin_loader exists
 if [ ! -d src/boost_plugin_loader ]; then


### PR DESCRIPTION
## Summary
- run duplicate package cleanup before rosdep installs in both build scripts
- avoid rosdep errors when workspace contains duplicate packages (e.g. trajopt_sco)

## Testing
- `./fix_and_build.sh` *(fails: ROS 2 distro not found)*
- `apt-get install -y python3-colcon-common-extensions` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b067fe47cc8331ba26a34b7277af8c