### PR TITLE
Ignore vendored trajopt package

### DIFF
--- a/trajopt/COLCON_IGNORE
+++ b/trajopt/COLCON_IGNORE
@@ -1,0 +1,1 @@
+# Ignore vendored trajopt


### PR DESCRIPTION
## Summary
- prevent colcon from building vendored trajopt copy by adding `COLCON_IGNORE`

## Testing
- ❌ `rosdep install --from-paths . --ignore-src -y` *(rosdep not installed; ROS 2 Humble packages unavailable on Ubuntu Noble)*
- ❌ `colcon build --parallel-workers 1 --cmake-args -DCMAKE_CXX_STANDARD=17` *(build could not start due to missing ROS 2 Humble)*


------
https://chatgpt.com/codex/tasks/task_e_68b06fff141083319ce2ada67943d311