### PR TITLE
feat: auto install build tools

### DIFF
--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -26,11 +26,29 @@ case "${ROS_DISTRO}" in
   *) echo "Wrong ROS distro: ${ROS_DISTRO}"; exit 1 ;;
 esac
 
-# Ensure required tools are available
+# Ensure required tools are available (install common ones if missing)
 for cmd in git colcon rosdep; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "Required tool '$cmd' is not installed." >&2
-    exit 1
+    case "$cmd" in
+      colcon)
+        python3 -m pip install -U colcon-common-extensions >/dev/null 2>&1 || {
+          echo "Failed to install colcon" >&2
+          exit 1
+        }
+        ;;
+      rosdep)
+        if command -v sudo >/dev/null 2>&1; then
+          sudo apt-get update -y && sudo apt-get install -y python3-rosdep >/dev/null 2>&1
+        else
+          apt-get update -y && apt-get install -y python3-rosdep >/dev/null 2>&1
+        fi
+        rosdep init >/dev/null 2>&1 || true
+        ;;
+      *)
+        echo "Required tool '$cmd' is not installed." >&2
+        exit 1
+        ;;
+    esac
   fi
 done
 

--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -15,11 +15,29 @@ ROS_DISTRO=${ROS_DISTRO:-${default_rosdistro}}
 set +u; : "${AMENT_TRACE_SETUP_FILES:=}"; source "/opt/ros/${ROS_DISTRO}/setup.bash"; set -u
 if [ -f ~/ws_moveit2/install/setup.bash ]; then source ~/ws_moveit2/install/setup.bash; fi
 
-# Ensure required tools are available
+# Ensure required tools are available (install common ones if missing)
 for cmd in git colcon rosdep; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "Required tool '$cmd' is not installed." >&2
-    exit 1
+    case "$cmd" in
+      colcon)
+        python3 -m pip install -U colcon-common-extensions >/dev/null 2>&1 || {
+          echo "Failed to install colcon" >&2
+          exit 1
+        }
+        ;;
+      rosdep)
+        if command -v sudo >/dev/null 2>&1; then
+          sudo apt-get update -y && sudo apt-get install -y python3-rosdep >/dev/null 2>&1
+        else
+          apt-get update -y && apt-get install -y python3-rosdep >/dev/null 2>&1
+        fi
+        rosdep init >/dev/null 2>&1 || true
+        ;;
+      *)
+        echo "Required tool '$cmd' is not installed." >&2
+        exit 1
+        ;;
+    esac
   fi
 done
 


### PR DESCRIPTION
## Summary
- auto-install colcon and rosdep when missing in fix_and_build scripts

## Testing
- `bash fix_and_build.sh` (fails: ROS 2 distro not found (expected jazzy or humble))
- `bash fix_and_build_humble.sh` (fails: ROS 2 distro not found (expected jazzy or humble))


------
https://chatgpt.com/codex/tasks/task_e_68b176f4a61883318d3da3f4238d0f42