### PR TITLE
Initialize has_objects before processing objects

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -479,7 +479,7 @@ bool SceneSelect::load_scene_from_yaml(Scene * input_scene)
   }
   YAML::Node objects;
   YAML::Node ext_joints;
-  bool has_objects;
+  bool has_objects = false;
 
 
   for (YAML::iterator it = yaml.begin(); it != yaml.end(); ++it) {


### PR DESCRIPTION
## Summary
- initialize `has_objects` before checking YAML for objects to avoid using an uninitialized boolean

## Testing
- `cppcheck --enable=all --inconclusive --quiet gui include test`


------
https://chatgpt.com/codex/tasks/task_e_68b17ec312b88331b1057a3bb7d611ac