### PR TITLE
fix: address shellcheck warnings in build scripts

### DIFF
--- a/.docker/ci/moveit2_entrypoint.sh
+++ b/.docker/ci/moveit2_entrypoint.sh
@@ -2,5 +2,6 @@
 set -e
 
 # setup moveit2 environment
+# shellcheck disable=SC1091
 source /opt/moveit2/install/setup.bash
 exec "$@"

--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -19,7 +19,11 @@ done
 ROS_DISTRO=${ROS_DISTRO:-${default_rosdistro}}
 [ -n "${ROS_DISTRO:-}" ] || { echo "ROS 2 distro not found (expected jazzy or humble)"; exit 1; }
 [ -f "/opt/ros/${ROS_DISTRO}/setup.bash" ] || { echo "ROS ${ROS_DISTRO} not found"; exit 1; }
-set +u; : "${AMENT_TRACE_SETUP_FILES:=}"; source "/opt/ros/${ROS_DISTRO}/setup.bash"; set -u
+set +u
+: "${AMENT_TRACE_SETUP_FILES:=}"
+# shellcheck source=/dev/null
+source "/opt/ros/${ROS_DISTRO}/setup.bash"
+set -u
 export LANG=C.UTF-8 LC_ALL=C.UTF-8
 case "${ROS_DISTRO}" in
   humble|jazzy) ;;

--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -12,8 +12,15 @@ for d in jazzy humble; do
 done
 ROS_DISTRO=${ROS_DISTRO:-${default_rosdistro}}
 [ -n "${ROS_DISTRO:-}" ] || { echo "ROS 2 distro not found (expected jazzy or humble)"; exit 1; }
-set +u; : "${AMENT_TRACE_SETUP_FILES:=}"; source "/opt/ros/${ROS_DISTRO}/setup.bash"; set -u
-if [ -f ~/ws_moveit2/install/setup.bash ]; then source ~/ws_moveit2/install/setup.bash; fi
+set +u
+: "${AMENT_TRACE_SETUP_FILES:=}"
+# shellcheck source=/dev/null
+source "/opt/ros/${ROS_DISTRO}/setup.bash"
+set -u
+if [ -f ~/ws_moveit2/install/setup.bash ]; then
+  # shellcheck source=/dev/null
+  source ~/ws_moveit2/install/setup.bash
+fi
 
 # Ensure required tools are available (install common ones if missing)
 for cmd in git colcon rosdep; do


### PR DESCRIPTION
## Summary
- silence shellcheck's non-constant source warnings in setup scripts
- add directives to Docker entrypoint to avoid shellcheck SC1091

## Testing
- `shellcheck fix_and_build.sh fix_and_build_humble.sh .docker/ci/moveit2_entrypoint.sh scripts/grasp_demo.sh`
- `python3 -m py_compile $(git ls-files '*.py')`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b17ec312b88331b1057a3bb7d611ac