### PR TITLE
Fix typos in grasp execution and dynamic safety modules

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
@@ -39,7 +39,7 @@ static const double LOG_RATE = 1;  // This is duration
 template<typename NodeT>
 const Option & Option::load(const std::shared_ptr<NodeT> & node)
 {
-  // Load dyanmic safety parameters
+  // Load dynamic safety parameters
   emd::declare_or_get_param<bool>(
     dynamic_parameterization,
     "dynamic_safety.dynamic_parameterization",
@@ -103,7 +103,7 @@ const Option & Option::load(const std::shared_ptr<NodeT> & node)
       usleep(100000);
     }
     RCLCPP_INFO(
-      LOGGER, "Recieved urdf & srdf from param server, parsing...");
+      LOGGER, "Received urdf & srdf from param server, parsing...");
   } else {
     emd::declare_or_get_param<std::string>(
       robot_description,
@@ -115,19 +115,19 @@ const Option & Option::load(const std::shared_ptr<NodeT> & node)
       node, LOGGER);  // default: "second"
   }
 
-  // Load dyanmic safety parameters
+  // Load dynamic safety parameters
   emd::declare_or_get_param<bool>(
     allow_replan,
     "dynamic_safety.allow_replan",
     node, LOGGER, false);
 
-  // Load dyanmic safety parameters
+  // Load dynamic safety parameters
   emd::declare_or_get_param<bool>(
     benchmark,
     "dynamic_safety.benchmark",
     node, LOGGER, false);
 
-  // Load dyanmic safety parameters
+  // Load dynamic safety parameters
   emd::declare_or_get_param<bool>(
     visualize,
     "dynamic_safety.visualize",

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/grasp_execution.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/grasp_execution.hpp
@@ -52,7 +52,7 @@ struct GraspExecutionContext
   /// Name of end effector link
   std::string ee_link;
 
-  /// How far forward to plan for a trajectory during move unitl collide workflow
+  /// How far forward to plan for a trajectory during move until collide workflow
   double move_to_collide_step_size;
 
   /// Cartesian interpolation resolution used during the first planning strategy.
@@ -90,7 +90,7 @@ public:
   /**
    * Create an empty planning group.
    * \param[in] planning_group group name.
-   * \return true if initialized succesfully, otherwise false.
+   * \return true if initialized successfully, otherwise false.
    */
   virtual bool init(const std::string & planning_group)
   {
@@ -156,7 +156,7 @@ public:
    * \param[in] execution_method execution method name.
    * \param[in] execution_plugin execution method plugin name.
    * \param[in] execution_controller execution method controller.
-   * \return true if loaded succesfully, otherwise false
+   * \return true if loaded successfully, otherwise false
    */
   virtual bool load_execution_method(
     const std::string & group_name,
@@ -178,7 +178,7 @@ public:
    * \param[in] ee_link end effector link for planning.
    * \param[in] ee_driver_plugin end effector driver plugin.
    * \param[in] ee_driver_controller end effector driver controller.
-   * \return true if loaded succesfully, otherwise false
+   * \return true if loaded successfully, otherwise false
    */
   virtual bool load_ee(
     const std::string & group_name,

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -901,7 +901,7 @@ double MoveitCppGraspExecution::cartesian_to(
 
     if (step < std::numeric_limits<double>::epsilon()) {
       RCLCPP_ERROR(
-        LOGGER, "Maximum step to take between consecutive configrations along Cartesian path"
+        LOGGER, "Maximum step to take between consecutive configurations along Cartesian path"
         "was not specified (this value needs to be > 0)");
       return fraction;
     } else {


### PR DESCRIPTION
## Summary
- correct spelling errors in grasp execution interface documentation
- fix typo in MoveIt Cartesian path error log
- clean up repeated misspellings in dynamic safety parameter comments

## Testing
- `codespell easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/grasp_execution.hpp`
- `codespell easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp`
- `codespell easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b17ec312b88331b1057a3bb7d611ac