### PR TITLE
Remove trailing blank line in AirPick4 display launch

### DIFF
--- a/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/launch/display.launch.py
+++ b/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/launch/display.launch.py
@@ -42,4 +42,3 @@ def main(argv=sys.argv[1:]):
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary
- fix flake8 W391 warning by removing trailing blank line in AirPick4 display launch script

## Testing
- `flake8 assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/launch/display.launch.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b187c809dc83319b6929fd46fe6a62