### PR TITLE
Handle xacro conversion failures in load_file

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -131,7 +131,11 @@ def load_file(package_name: str, file_path: str) -> Optional[str]:
             )
             with temp_urdf_path.open("r") as file:
                 return file.read()
-    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
+    except Exception:
+        # ``to_urdf`` may raise a variety of exceptions when the conversion
+        # fails (e.g. malformed xacro, missing files or packages).  Swallow
+        # any such error and indicate the failure by returning ``None`` to the
+        # caller.
         return None
 
 

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -170,6 +170,24 @@ def test_load_file_handles_missing_package(monkeypatch):
     assert demo.load_file('does_not_exist', 'file.urdf.xacro') is None
 
 
+def test_load_file_returns_none_for_missing_file(tmp_path, monkeypatch):
+    """``load_file`` should return ``None`` when the target file is missing."""
+    pkg_dir = tmp_path / 'pkg'
+    pkg_dir.mkdir()
+    monkeypatch.setattr(demo, 'get_package_share_directory', lambda pkg: str(pkg_dir))
+    assert demo.load_file('pkg', 'missing.urdf.xacro') is None
+
+
+def test_load_file_returns_none_on_xacro_error(tmp_path, monkeypatch):
+    """Invalid xacro files should cause ``load_file`` to return ``None``."""
+    pkg_dir = tmp_path / 'pkg'
+    pkg_dir.mkdir()
+    bad_xacro = pkg_dir / 'bad.urdf.xacro'
+    bad_xacro.write_text('<robot name="test">')  # malformed XML (no closing tag)
+    monkeypatch.setattr(demo, 'get_package_share_directory', lambda pkg: str(pkg_dir))
+    assert demo.load_file('pkg', bad_xacro.name) is None
+
+
 def test_load_yaml_requires_existing_file(tmp_path, monkeypatch):
     """``load_yaml`` should raise ``FileNotFoundError`` for missing files."""
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- return `None` when `to_urdf` raises during load
- add regression tests for missing and malformed xacro files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b187c809dc83319b6929fd46fe6a62