### PR TITLE
Fix mixed target_link_libraries usage in trajopt_sco

### DIFF
--- a/trajopt/trajopt_sco/CMakeLists.txt
+++ b/trajopt/trajopt_sco/CMakeLists.txt
@@ -64,7 +64,7 @@ if(HAVE_BPMPD)
     set(BPMPD_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/3rdpartylib/bpmpd_linux32.a")
   endif()
 
-  target_link_libraries(bpmpd_caller ${BPMPD_LIBRARY} -static)
+  target_link_libraries(bpmpd_caller PRIVATE ${BPMPD_LIBRARY} -static)
   target_compile_definitions(bpmpd_caller PUBLIC BPMPD_WORKING_DIR="${CMAKE_CURRENT_BINARY_DIR}")
   target_cxx_version(bpmpd_caller PUBLIC VERSION ${TRAJOPT_CXX_VERSION})
   target_include_directories(bpmpd_caller PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"


### PR DESCRIPTION
## Summary
- use keyword `target_link_libraries` for `bpmpd_caller` to avoid mixed-signature error

## Testing
- `colcon build --packages-select trajopt_sco --parallel-workers 1 --cmake-args -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find a package configuration file provided by `ros_industrial_cmake_boilerplate`)*
- `colcon build --parallel-workers 1 --cmake-args -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find a package configuration file provided by `ros_industrial_cmake_boilerplate`)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d4908138833184a4bfc600277e6d