### PR TITLE
fix: separate bpmpd link options

### DIFF
--- a/trajopt/trajopt_sco/CMakeLists.txt
+++ b/trajopt/trajopt_sco/CMakeLists.txt
@@ -64,7 +64,8 @@ if(HAVE_BPMPD)
     set(BPMPD_LIBRARY "${CMAKE_CURRENT_SOURCE_DIR}/3rdpartylib/bpmpd_linux32.a")
   endif()
 
-  target_link_libraries(bpmpd_caller PRIVATE ${BPMPD_LIBRARY} -static)
+  target_link_libraries(bpmpd_caller PRIVATE ${BPMPD_LIBRARY})
+  target_link_options(bpmpd_caller PRIVATE -static)
   target_compile_definitions(bpmpd_caller PUBLIC BPMPD_WORKING_DIR="${CMAKE_CURRENT_BINARY_DIR}")
   target_cxx_version(bpmpd_caller PUBLIC VERSION ${TRAJOPT_CXX_VERSION})
   target_include_directories(bpmpd_caller PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"


### PR DESCRIPTION
## Summary
- avoid target_link_libraries keyword/plain mixing by isolating bpmpd_caller link flags

## Testing
- `cmake -S trajopt/trajopt_sco -B trajopt/trajopt_sco/build` *(fails: could not find a package configuration file provided by `ros_industrial_cmake_boilerplate`)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d6bd22d8833197b3e7d4531caf79