### PR TITLE
Include OSQP version header in trajopt_sco interface

### DIFF
--- a/trajopt/trajopt_sco/include/trajopt_sco/osqp_interface.hpp
+++ b/trajopt/trajopt_sco/include/trajopt_sco/osqp_interface.hpp
@@ -10,6 +10,9 @@ TRAJOPT_IGNORE_WARNINGS_PUSH
 #else
 #  error "OSQP headers not found"
 #endif
+#if __has_include(<osqp/version.h>)
+#  include <osqp/version.h>
+#endif
 TRAJOPT_IGNORE_WARNINGS_POP
 
 #ifdef OSQP_VERSION_MAJOR


### PR DESCRIPTION
## Summary
- Include OSQP's version header when available to ensure version macros are visible during compilation

## Testing
- `cmake -S trajopt/trajopt_sco -B build/trajopt_sco` *(fails: Could not find package ros_industrial_cmake_boilerplate)*

------
https://chatgpt.com/codex/tasks/task_e_68b2debabac8833192879a23ef6886e2