### PR TITLE
Fix OSQP interface compatibility with older headers

### DIFF
--- a/trajopt/trajopt_sco/include/trajopt_sco/osqp_interface.hpp
+++ b/trajopt/trajopt_sco/include/trajopt_sco/osqp_interface.hpp
@@ -12,7 +12,7 @@ TRAJOPT_IGNORE_WARNINGS_POP
 namespace sco
 {
 
-#ifdef TRAJOPT_OSQP_V1
+#if defined(OSQP_API_TYPES_H)
 using c_int = OSQPInt;
 using c_float = OSQPFloat;
 using csc = OSQPCscMatrix;

--- a/trajopt/trajopt_sco/src/osqp_interface.cpp
+++ b/trajopt/trajopt_sco/src/osqp_interface.cpp
@@ -29,7 +29,7 @@ void OSQPModelConfig::setDefaultOSQPSettings(OSQPSettings& settings)
   settings.eps_rel = 1e-6;
   settings.max_iter = 8192;
   settings.verbose = 0;
-#ifdef TRAJOPT_OSQP_V1
+#if defined(OSQP_API_TYPES_H)
   settings.polishing = 1;
   settings.warm_starting = 1;
 #else
@@ -225,7 +225,7 @@ void OSQPModel::createOrUpdateSolver()
   const bool need_setup = (osqp_workspace_ == nullptr);
   if (!need_setup)
   {
-#ifdef TRAJOPT_OSQP_V1
+#if defined(OSQP_API_TYPES_H)
     osqp_update_data_vec(osqp_workspace_, osqp_data_.q, osqp_data_.l, osqp_data_.u);
     osqp_update_data_mat(osqp_workspace_,
                          osqp_data_.P->x, OSQP_NULL, osqp_data_.P->nzmax,
@@ -375,11 +375,11 @@ CvxOptStatus OSQPModel::optimize()
   }
 
   // Solve Problem
-  #ifdef TRAJOPT_OSQP_V1
-    OSQPInt retcode = osqp_solve(osqp_workspace_);
-  #else
-    c_int   retcode = osqp_solve(osqp_workspace_);
-  #endif
+#if defined(OSQP_API_TYPES_H)
+  OSQPInt retcode = osqp_solve(osqp_workspace_);
+#else
+  c_int   retcode = osqp_solve(osqp_workspace_);
+#endif
 
   if (retcode == 0)
   {


### PR DESCRIPTION
## Summary
- detect OSQP API version using `OSQP_API_TYPES_H`
- adapt settings and solver updates to work with legacy OSQP

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ros_industrial_cmake_boilerplate"`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fa03f4f083319b8da8ca163991fc