### PR TITLE
fix: symlink trajopt package to workspace

### DIFF
--- a/scripts/fix_workspace_layout.sh
+++ b/scripts/fix_workspace_layout.sh
@@ -24,3 +24,8 @@ fi
 if [ -d "${BACKUP_DIR}/trajopt_common" ] && [ ! -e "${SRC_DIR}/trajopt_common" ]; then
   ln -s "${BACKUP_DIR}/trajopt_common" "${SRC_DIR}/trajopt_common"
 fi
+
+# Link trajopt package from backup if available
+if [ -d "${BACKUP_DIR}/trajopt" ] && [ ! -e "${SRC_DIR}/trajopt" ]; then
+  ln -s "${BACKUP_DIR}/trajopt" "${SRC_DIR}/trajopt"
+fi


### PR DESCRIPTION
## Summary
- ensure `fix_workspace_layout.sh` restores the `trajopt` package after moving it to a backup so CMake can find `trajoptConfig.cmake`

## Testing
- `bash scripts/fix_workspace_layout.sh`
- `bash -n scripts/fix_workspace_layout.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b601e043548331a2183acc3e5a383c