### PR TITLE
Remove unused MoveIt dependency for tesseract build

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_dynamic_safety/CMakeLists.txt
@@ -113,7 +113,6 @@ if(tesseract_environment_FOUND)
     rclcpp
     tesseract_rosutils
     tesseract_msgs
-    moveit_msgs
   )
 
   ament_export_libraries(


### PR DESCRIPTION
## Summary
- drop moveit_msgs from emd_dynamic_safety's tesseract plugin dependencies to avoid requiring MoveIt when using Tesseract

## Testing
- `./fix_and_build.sh` *(fails: ROS 2 distro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b70926bb2083319b194bbc98d3aa68