### PR TITLE
Handle plain URDF files in load_file

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -122,15 +122,24 @@ def load_file(package_name: str, file_path: str) -> Optional[str]:
         # file already contains one.
         with tempfile.TemporaryDirectory() as tmpdir:
             filename = Path(file_path)
+
+            # Only invoke ``to_urdf`` when the source file is a xacro file.
+            # ``to_urdf`` raises a ``ValueError`` for non-xacro input which
+            # previously caused ``load_file`` to return ``None`` even for valid
+            # URDF files.  By checking the extension up-front we can simply
+            # read URDF files directly.
             if filename.suffix == ".xacro":
                 filename = filename.with_suffix("")
-            if filename.suffix != ".urdf":
-                filename = filename.with_suffix(".urdf")
-            temp_urdf_path = Path(tmpdir) / filename.name
-            temp_urdf_path = Path(
-                to_urdf(str(absolute_file_path), str(temp_urdf_path))
-            )
-            with temp_urdf_path.open("r") as file:
+                if filename.suffix != ".urdf":
+                    filename = filename.with_suffix(".urdf")
+                temp_urdf_path = Path(tmpdir) / filename.name
+                temp_urdf_path = Path(
+                    to_urdf(str(absolute_file_path), str(temp_urdf_path))
+                )
+            else:
+                temp_urdf_path = absolute_file_path
+
+            with Path(temp_urdf_path).open("r") as file:
                 return file.read()
     except Exception:
         # ``to_urdf`` may raise a variety of exceptions when the conversion

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -197,6 +197,20 @@ def test_load_file_returns_none_on_xacro_error(tmp_path, monkeypatch):
     assert demo.load_file('pkg', bad_xacro.name) is None
 
 
+def test_load_file_reads_plain_urdf(tmp_path, monkeypatch):
+    """``load_file`` should read existing URDF files without invoking ``to_urdf``."""
+    pkg_dir = tmp_path / 'pkg'
+    pkg_dir.mkdir()
+    urdf_file = pkg_dir / 'robot.urdf'
+    urdf_file.write_text('<robot name="test"/>')
+
+    # ``to_urdf`` should not be called when the input is already a URDF file.
+    monkeypatch.setattr(demo, 'to_urdf', lambda *a, **kw: (_ for _ in ()).throw(AssertionError('to_urdf called')))
+    monkeypatch.setattr(demo, 'get_package_share_directory', lambda pkg: str(pkg_dir))
+
+    assert demo.load_file('pkg', urdf_file.name) == '<robot name="test"/>'
+
+
 def test_load_yaml_requires_existing_file(tmp_path, monkeypatch):
     """``load_yaml`` should raise ``FileNotFoundError`` for missing files."""
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- avoid running xacro conversion on URDF files
- add regression test for load_file with plain URDF

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b70f09384483319ef98f1a9cb0a876