### PR TITLE
Use standard library math functions in trajopt_sco

### DIFF
--- a/trajopt/trajopt_sco/include/trajopt_sco/sco_common.hpp
+++ b/trajopt/trajopt_sco/include/trajopt_sco/sco_common.hpp
@@ -36,7 +36,7 @@ inline double vecAbsSum(const DblVec& v)
 {
   double out = 0;
   for (const double i : v)
-    out += fabs(i);
+    out += std::abs(i);
   return out;
 }
 

--- a/trajopt/trajopt_sco/src/bpmpd_interface.cpp
+++ b/trajopt/trajopt_sco/src/bpmpd_interface.cpp
@@ -3,6 +3,7 @@ TRAJOPT_IGNORE_WARNINGS_PUSH
 #include <cmath>
 #include <csignal>
 #include <array>
+#include <algorithm>
 #include <mutex>
 #include <trajopt_sco/bpmpd_io.hpp>
 TRAJOPT_IGNORE_WARNINGS_POP
@@ -385,8 +386,8 @@ CvxOptStatus BPMPDModel::optimize()
   DBG(m_ubs);
   for (std::size_t iVar = 0; iVar < n; ++iVar)
   {
-    lbound[iVar] = fmax(m_lbs[iVar], -BPMPD_BIG);
-    ubound[iVar] = fmin(m_ubs[iVar], BPMPD_BIG);
+    lbound[iVar] = std::max(m_lbs[iVar], -BPMPD_BIG);
+    ubound[iVar] = std::min(m_ubs[iVar], BPMPD_BIG);
   }
 
   std::vector<IntVec> var2cntinds(n);

--- a/trajopt/trajopt_sco/src/expr_ops.cpp
+++ b/trajopt/trajopt_sco/src/expr_ops.cpp
@@ -88,7 +88,7 @@ AffExpr cleanupAff(const AffExpr& a)
   AffExpr out;
   for (std::size_t i = 0; i < a.size(); ++i)
   {
-    if (fabs(a.coeffs[i]) > 1e-7)
+    if (std::abs(a.coeffs[i]) > 1e-7)
     {
       out.coeffs.push_back(a.coeffs[i]);
       out.vars.push_back(a.vars[i]);

--- a/trajopt/trajopt_sco/src/modeling.cpp
+++ b/trajopt/trajopt_sco/src/modeling.cpp
@@ -134,7 +134,7 @@ DblVec ConvexConstraints::violations(const DblVec& x)
   DblVec out;
   out.reserve(eqs_.size() + ineqs_.size());
   for (const AffExpr& aff : eqs_)
-    out.push_back(fabs(aff.value(x.data())));
+    out.push_back(std::abs(aff.value(x.data())));
   for (const AffExpr& aff : ineqs_)
     out.push_back(pospart(aff.value(x.data())));
   return out;
@@ -155,7 +155,7 @@ DblVec Constraint::violations(const DblVec& x)
   if (type() == EQ)
   {
     for (std::size_t i = 0; i < val.size(); ++i)
-      out[i] = fabs(val[i]);
+      out[i] = std::abs(val[i]);
   }
   else
   {  // type() == INEQ
@@ -264,8 +264,8 @@ DblVec OptProb::getClosestFeasiblePoint(const DblVec& x, const double& delta)
   for (std::size_t i = 0; i < x.size(); i++)
   {
     // Force it a tiny bit inside the bounds
-    y[i] = fmax(lower_bounds_[i] + delta, x[i]);
-    y[i] = fmin(upper_bounds_[i] - delta, x[i]);
+    y[i] = std::max(lower_bounds_[i] + delta, x[i]);
+    y[i] = std::min(upper_bounds_[i] - delta, x[i]);
   }
   return y;
 }

--- a/trajopt/trajopt_sco/src/optimizers.cpp
+++ b/trajopt/trajopt_sco/src/optimizers.cpp
@@ -101,8 +101,8 @@ void BasicTrustRegionSQP::setTrustBoxConstraints(const DblVec& x)
   for (std::size_t i = 0; i < x.size(); ++i)
   {
     // Calculate box constraints, while limiting to variable bounds and maintaining the trust region size
-    lbtrust[i] = fmax(fmin(x[i], ub[i] - param_.trust_box_size) - param_.trust_box_size, lb[i]);
-    ubtrust[i] = fmin(fmax(x[i], lb[i] + param_.trust_box_size) + param_.trust_box_size, ub[i]);
+    lbtrust[i] = std::max(std::min(x[i], ub[i] - param_.trust_box_size) - param_.trust_box_size, lb[i]);
+    ubtrust[i] = std::min(std::max(x[i], lb[i] + param_.trust_box_size) + param_.trust_box_size, ub[i]);
   }
   model_->setVarBounds(vars, lbtrust, ubtrust);
 }
@@ -289,7 +289,7 @@ struct MultiCritFilter {
     for (const DblVec& olderrvec : errvecs) {
       double improvement=0;
       for (int i=0; i < errvec.size(); ++i) improvement += pospart(olderrvec[i] - errvec[i]);
-      leastImprovement = fmin(leastImprovement, improvement);
+      leastImprovement = std::min(leastImprovement, improvement);
     }
     return leastImprovement;
   }
@@ -385,7 +385,7 @@ void BasicTrustRegionSQPResults::print() const
   {
     const double approx_improve = old_cost_vals[i] - model_cost_vals[i];
     const double exact_improve = old_cost_vals[i] - new_cost_vals[i];
-    if (fabs(approx_improve) > 1e-8)
+    if (std::abs(approx_improve) > 1e-8)
       std::printf("| %10s | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %-15s \n",
                   "----------",
                   old_cost_vals[i],
@@ -424,7 +424,7 @@ void BasicTrustRegionSQPResults::print() const
     {
       const double approx_improve = old_cnt_viols[i] - model_cnt_viols[i];
       const double exact_improve = old_cnt_viols[i] - new_cnt_viols[i];
-      if (fabs(approx_improve) > 1e-8)
+      if (std::abs(approx_improve) > 1e-8)
         std::printf("| %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %10.3e | %-15s \n",
                     merit_error_coeffs[i],
                     merit_error_coeffs[i] * old_cnt_viols[i],
@@ -525,7 +525,7 @@ void BasicTrustRegionSQPResults::writeCosts(std::FILE* stream, bool header) cons
   {
     const double approx_improve = old_cost_vals[i] - model_cost_vals[i];
     const double exact_improve = old_cost_vals[i] - new_cost_vals[i];
-    if (fabs(approx_improve) > 1e-8)
+    if (std::abs(approx_improve) > 1e-8)
     {
       std::fprintf(
           stream, ",%e,%e,%e,%e", old_cost_vals[i], approx_improve, exact_improve, exact_improve / approx_improve);
@@ -561,7 +561,7 @@ void BasicTrustRegionSQPResults::writeConstraints(std::FILE* stream, bool header
   {
     const double approx_improve = old_cnt_viols[i] - model_cnt_viols[i];
     const double exact_improve = old_cnt_viols[i] - new_cnt_viols[i];
-    if (fabs(approx_improve) > 1e-8)
+    if (std::abs(approx_improve) > 1e-8)
     {
       std::fprintf(stream,
                    ",%e,%e,%e,%e",
@@ -903,7 +903,7 @@ OptStatus BasicTrustRegionSQP::optimize()
           merit_error_coeff *= param_.merit_coeff_increase_ratio;
       }
       LOG_INFO("New merit_error_coeffs: %s", CSTR(merit_error_coeffs));
-      param_.trust_box_size = fmax(param_.trust_box_size, param_.min_trust_box_size / param_.trust_shrink_ratio * 1.5);
+      param_.trust_box_size = std::max(param_.trust_box_size, param_.min_trust_box_size / param_.trust_shrink_ratio * 1.5);
     }
   } /* merit adjustment loop */
   retval = OPT_PENALTY_ITERATION_LIMIT;

--- a/trajopt/trajopt_sco/src/osqp_interface.cpp
+++ b/trajopt/trajopt_sco/src/osqp_interface.cpp
@@ -185,8 +185,8 @@ bool OSQPModel::updateConstraints(bool check_sparsity)
   sm.reserve(new_inner_sizes);
   for (std::size_t i_bnd = 0; i_bnd < n; ++i_bnd)
   {
-    l_[i_bnd + m] = fmax(lbs_[i_bnd], -OSQP_INFINITY);
-    u_[i_bnd + m] = fmin(ubs_[i_bnd], OSQP_INFINITY);
+    l_[i_bnd + m] = std::max(lbs_[i_bnd], -OSQP_INFINITY);
+    u_[i_bnd + m] = std::min(ubs_[i_bnd], OSQP_INFINITY);
     sm.insert(static_cast<Eigen::Index>(i_bnd + m), static_cast<Eigen::Index>(i_bnd)) = 1.;
   }
 


### PR DESCRIPTION
## Summary
- Replace C math functions with `std::abs`, `std::max`, and `std::min`
- Include `<algorithm>` where needed to support `std::max`/`std::min`

## Testing
- `colcon build --packages-select trajopt_sco` *(fails: command not found)*
- `cmake ..` *(fails: missing ros_industrial_cmake_boilerplate)*

------
https://chatgpt.com/codex/tasks/task_e_68b710fb2fac83319f0c1351b73196d1