### PR TITLE
Use size_t for indices in trajopt_sco

### DIFF
--- a/trajopt/trajopt_sco/src/modeling_utils.cpp
+++ b/trajopt/trajopt_sco/src/modeling_utils.cpp
@@ -15,16 +15,16 @@ const double DEFAULT_EPSILON = 1e-5;
 Eigen::VectorXd getVec(const DblVec& x, const VarVector& vars)
 {
   Eigen::VectorXd out(vars.size());
-  for (unsigned i = 0; i < vars.size(); ++i)
-    out[i] = x[static_cast<long unsigned int>(vars[i].var_rep->index)];
+  for (std::size_t i = 0; i < vars.size(); ++i)
+    out[i] = x[static_cast<std::size_t>(vars[i].var_rep->index)];
   return out;
 }
 
 DblVec getDblVec(const DblVec& x, const VarVector& vars)
 {
   DblVec out(vars.size());
-  for (unsigned i = 0; i < vars.size(); ++i)
-    out[i] = x[static_cast<long unsigned int>(vars[i].var_rep->index)];
+  for (std::size_t i = 0; i < vars.size(); ++i)
+    out[i] = x[static_cast<std::size_t>(vars[i].var_rep->index)];
   return out;
 }
 

--- a/trajopt/trajopt_sco/src/solver_interface.cpp
+++ b/trajopt/trajopt_sco/src/solver_interface.cpp
@@ -52,7 +52,7 @@ void simplify2(IntVec& inds, DblVec& vals)
   }
   inds.resize(ind2val.size());
   vals.resize(ind2val.size());
-  long unsigned int i_new = 0;
+  std::size_t i_new = 0;
   for (const Int2Double::value_type& iv : ind2val)
   {
     inds[i_new] = iv.first;


### PR DESCRIPTION
## Summary
- Replace `long unsigned int` with `std::size_t` for index handling in trajopt_sco
- Update loops to use `std::size_t` casts for cleaner, safer access

## Testing
- `cmake ..` *(fails: could not find ros_industrial_cmake_boilerplate)*

------
https://chatgpt.com/codex/tasks/task_e_68b710fb2fac83319f0c1351b73196d1