### PR TITLE
Use ssize_t for read/write in trajopt_sco

### DIFF
--- a/trajopt/trajopt_sco/include/trajopt_sco/bpmpd_io.hpp
+++ b/trajopt/trajopt_sco/include/trajopt_sco/bpmpd_io.hpp
@@ -48,16 +48,16 @@ void ser(int fp, std::vector<T>& x, SerMode mode)
   {
     case SER:
     {
-      const long n = write(fp, x.data(), sizeof(T) * size);
-      assert(static_cast<unsigned long>(n) == sizeof(T) * size);
+      const ssize_t n = write(fp, x.data(), sizeof(T) * size);
+      assert(static_cast<std::size_t>(n) == sizeof(T) * size);
       UNUSED(n);
       break;
     }
     case DESER:
     {
       x.resize(size);
-      const long n = read(fp, x.data(), sizeof(T) * size);
-      assert(static_cast<unsigned long>(n) == sizeof(T) * size);
+      const ssize_t n = read(fp, x.data(), sizeof(T) * size);
+      assert(static_cast<std::size_t>(n) == sizeof(T) * size);
       UNUSED(n);
       break;
     }

--- a/trajopt/trajopt_sco/src/bpmpd_interface.cpp
+++ b/trajopt/trajopt_sco/src/bpmpd_interface.cpp
@@ -211,7 +211,7 @@ static int gPipeOut = 0;  // NOLINT
 void fexit()
 {
   std::array<char, 1> text{ bpmpd_io::EXIT_CHAR };
-  long const n = write(gPipeIn, text.data(), 1);
+  ssize_t const n = write(gPipeIn, text.data(), 1);
   ALWAYS_ASSERT(n == 1);
 }
 


### PR DESCRIPTION
## Summary
- Use ssize_t instead of long for write/read results in bpmpd interface and IO helper

## Testing
- `cmake ..` *(fails: Could not find package ros_industrial_cmake_boilerplate)*

------
https://chatgpt.com/codex/tasks/task_e_68b710fb2fac83319f0c1351b73196d1