### PR TITLE
Handle YAML parse errors in demo.launch

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -149,9 +149,10 @@ def load_file(package_name: str, file_path: str) -> Optional[str]:
         return None
 
 
-def load_yaml(package_name: str, file_path: str) -> Any:
+def load_yaml(package_name: str, file_path: str) -> Any | None:
     """Load a YAML file from the given package.
 
+    Returns the parsed YAML content or ``None`` if parsing fails.
     Raises ``FileNotFoundError`` when the requested YAML file does not exist.
     """
 
@@ -159,8 +160,11 @@ def load_yaml(package_name: str, file_path: str) -> Any:
     yaml_file = package_path / file_path
     if not yaml_file.is_file():
         raise FileNotFoundError(f"YAML file '{yaml_file}' does not exist")
-    with yaml_file.open("r") as f:
-        return yaml.safe_load(f)
+    try:
+        with yaml_file.open("r") as f:
+            return yaml.safe_load(f)
+    except yaml.YAMLError:
+        return None
 
 
 def generate_launch_description() -> LaunchDescription:

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -218,3 +218,13 @@ def test_load_yaml_requires_existing_file(tmp_path, monkeypatch):
     )
     with pytest.raises(FileNotFoundError):
         demo.load_yaml('pkg', 'missing.yaml')
+
+
+def test_load_yaml_returns_none_on_parse_error(tmp_path, monkeypatch):
+    """Invalid YAML should cause ``load_yaml`` to return ``None``."""
+    pkg_dir = tmp_path / 'pkg'
+    pkg_dir.mkdir()
+    bad_yaml = pkg_dir / 'bad.yaml'
+    bad_yaml.write_text(": - invalid")
+    monkeypatch.setattr(demo, 'get_package_share_directory', lambda pkg: str(pkg_dir))
+    assert demo.load_yaml('pkg', bad_yaml.name) is None


### PR DESCRIPTION
## Summary
- handle YAML parsing errors gracefully in `load_yaml`
- add regression test for invalid YAML files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b822b443648331896116d1e48dffc9