### PR TITLE
Handle optional ament_cmake

### DIFF
--- a/workbench_description/CMakeLists.txt
+++ b/workbench_description/CMakeLists.txt
@@ -3,11 +3,6 @@ project(workbench_description)
 
 find_package(ament_cmake QUIET)
 
-if(NOT ament_cmake_FOUND)
-  message(WARNING "ament_cmake not found. Installing workbench_description as a
-  plain CMake package")
-endif()
-
 install(DIRECTORY urdf
   DESTINATION share/${PROJECT_NAME})
 


### PR DESCRIPTION
## Summary
- allow workbench_description to build cleanly even when ament_cmake isn't installed

## Testing
- `colcon build --symlink-install`
- `colcon test`


------
https://chatgpt.com/codex/tasks/task_e_68b831fdb77483319a8bed255ea8d710