### PR TITLE
Enable building robotiq_85_description without ament

### DIFF
--- a/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/CMakeLists.txt
+++ b/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/CMakeLists.txt
@@ -1,13 +1,21 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(robotiq_85_description)
+
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-find_package(ament_cmake REQUIRED)
 
-install(DIRECTORY meshes DESTINATION "share/${PROJECT_NAME}")
-install(DIRECTORY urdf DESTINATION "share/${PROJECT_NAME}")
-ament_package()
+find_package(ament_cmake QUIET)
+if(NOT ament_cmake_FOUND)
+  message(WARNING "ament_cmake not found. Installing robotiq_85_description as a plain CMake package")
+endif()
+
+install(DIRECTORY meshes DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY urdf DESTINATION share/${PROJECT_NAME})
+
+if(ament_cmake_FOUND)
+  ament_package()
+endif()
 


### PR DESCRIPTION
## Summary
- allow robotiq_85_description package to build even when ament_cmake is unavailable

## Testing
- `colcon build --base-paths assets/end_effectors/robotiq_85_gripper/robotiq_85_description --event-handlers console_cohesion+ --parallel-workers 1`


------
https://chatgpt.com/codex/tasks/task_e_68b831fdb77483319a8bed255ea8d710