### PR TITLE
Fix missing cmath includes

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/fake_grasp_pose_publisher.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/fake_grasp_pose_publisher.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <cmath>
 
 #include "tf2/LinearMath/Quaternion.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/fake_grasp_pose_publisher.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/fake_grasp_pose_publisher.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <cmath>
 
 #include "tf2/LinearMath/Quaternion.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"

--- a/easy_manipulation_deployment/emd_dynamic_safety/test/test_collision_checking.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/test/test_collision_checking.cpp
@@ -14,6 +14,8 @@
 
 #include <memory>
 #include <string>
+#include <thread>
+#include <cmath>
 
 #include "test_hardware.hpp"
 #include "emd/dynamic_safety/collision_checker.hpp"

--- a/easy_manipulation_deployment/emd_grasp_planner/test/suction_gripper_test.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/test/suction_gripper_test.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <cmath>
 #include "suction_gripper_test.hpp"
 
 SuctionGripperTest::SuctionGripperTest()


### PR DESCRIPTION
## Summary
- include cmath in fake_grasp_pose_publisher nodes for M_PI constant
- add required cmath and thread headers in collision checking and suction gripper tests

## Testing
- `colcon build --event-handlers console_direct+ --parallel-workers 1`

------
https://chatgpt.com/codex/tasks/task_e_68b831fdb77483319a8bed255ea8d710