### PR TITLE
Expand user path handling for file loading utilities

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -115,7 +115,11 @@ def load_file(package_name: str, file_path: str) -> Optional[str]:
 
     try:
         package_path = Path(get_package_share_directory(package_name))
-        absolute_file_path = package_path / file_path
+        file_path = Path(file_path).expanduser()
+        if not file_path.is_absolute():
+            absolute_file_path = package_path / file_path
+        else:
+            absolute_file_path = file_path
 
         # Use a temporary directory so the generated URDF does not pollute the
         # package path and to avoid double ``.urdf`` extensions when the input
@@ -157,7 +161,11 @@ def load_yaml(package_name: str, file_path: str) -> Any | None:
     """
 
     package_path = Path(get_package_share_directory(package_name))
-    yaml_file = package_path / file_path
+    file_path = Path(file_path).expanduser()
+    if not file_path.is_absolute():
+        yaml_file = package_path / file_path
+    else:
+        yaml_file = file_path
     if not yaml_file.is_file():
         raise FileNotFoundError(f"YAML file '{yaml_file}' does not exist")
     try:

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -211,6 +211,17 @@ def test_load_file_reads_plain_urdf(tmp_path, monkeypatch):
     assert demo.load_file('pkg', urdf_file.name) == '<robot name="test"/>'
 
 
+def test_load_file_expands_user_paths(tmp_path, monkeypatch):
+    pkg_dir = tmp_path / 'pkg'
+    pkg_dir.mkdir()
+    xacro_file = pkg_dir / 'robot.urdf.xacro'
+    xacro_file.write_text("<robot name='test'></robot>")
+    monkeypatch.setenv('HOME', str(tmp_path))
+    monkeypatch.setattr(demo, 'get_package_share_directory', lambda pkg: str(tmp_path))
+    content = demo.load_file('pkg', '~/pkg/robot.urdf.xacro')
+    assert '<robot' in content
+
+
 def test_load_yaml_requires_existing_file(tmp_path, monkeypatch):
     """``load_yaml`` should raise ``FileNotFoundError`` for missing files."""
     monkeypatch.setattr(
@@ -228,3 +239,14 @@ def test_load_yaml_returns_none_on_parse_error(tmp_path, monkeypatch):
     bad_yaml.write_text(": - invalid")
     monkeypatch.setattr(demo, 'get_package_share_directory', lambda pkg: str(pkg_dir))
     assert demo.load_yaml('pkg', bad_yaml.name) is None
+
+
+def test_load_yaml_expands_user_paths(tmp_path, monkeypatch):
+    pkg_dir = tmp_path / 'pkg'
+    pkg_dir.mkdir()
+    yaml_file = pkg_dir / 'data.yaml'
+    yaml_file.write_text('value: 42')
+    monkeypatch.setenv('HOME', str(tmp_path))
+    monkeypatch.setattr(demo, 'get_package_share_directory', lambda pkg: str(tmp_path))
+    data = demo.load_yaml('pkg', '~/pkg/data.yaml')
+    assert data['value'] == 42


### PR DESCRIPTION
## Summary
- expand `load_file` and `load_yaml` to resolve `~` and absolute paths
- test path expansion for `load_file` and `load_yaml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b83cbfe31883318e4c3d20bfcb2471