### PR TITLE
Ensure tesseract repos imported if package missing

### DIFF
--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -78,7 +78,8 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_FILE="$SCRIPT_DIR/tesseract.repos"
 if [ -f "$REPO_FILE" ]; then
-  if [ ! -d "$SRC/tesseract" ]; then
+  # Import repositories if tesseract_common package is missing or repo not fetched
+  if [ ! -f "$SRC/tesseract/tesseract_common/package.xml" ]; then
     vcs import --recursive "$SRC" < "$REPO_FILE"
   fi
   for overlay in tesseract trajopt; do


### PR DESCRIPTION
## Summary
- make fix_and_build.sh re-import tesseract repos when `tesseract_common` is missing so builds don't fail due to stale directories

## Testing
- `./fix_and_build.sh` *(fails: ROS 2 distro not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b861be2b44833186f3292bab74dc75