### PR TITLE
Use context manager for URDF file

### DIFF
--- a/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/launch/display.launch.py
+++ b/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/launch/display.launch.py
@@ -4,6 +4,7 @@
 
 import os
 import sys
+from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
 
@@ -15,10 +16,9 @@ def generate_launch_description():
     """Generate a launch description for the robot_state_publisher."""
     # Load the URDF into a parameter
     bringup_dir = get_package_share_directory("onrobot_airpick4_description")
-    urdf_path = os.path.join(
-        bringup_dir, "urdf", "onrobot_airpick4_gripper.urdf.xacro"
-    )
-    urdf = open(urdf_path).read()
+    urdf_path = Path(bringup_dir) / "urdf" / "onrobot_airpick4_gripper.urdf.xacro"
+    with urdf_path.open() as urdf_file:
+        urdf = urdf_file.read()
 
     return launch.LaunchDescription(
         [


### PR DESCRIPTION
## Summary
- ensure AirPick4 display launch uses Path and context manager when reading URDF

## Testing
- `python -m py_compile assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/launch/display.launch.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9596d95b083319028c3cf28edfc21