### PR TITLE
Handle missing packages in YAML loader

### DIFF
--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -156,11 +156,20 @@ def load_file(package_name: str, file_path: str) -> Optional[str]:
 def load_yaml(package_name: str, file_path: str) -> Any | None:
     """Load a YAML file from the given package.
 
-    Returns the parsed YAML content or ``None`` if parsing fails.
-    Raises ``FileNotFoundError`` when the requested YAML file does not exist.
+    Returns the parsed YAML content or ``None`` if parsing fails or the package
+    cannot be located.  Raises ``FileNotFoundError`` when the requested YAML
+    file does not exist.
     """
 
-    package_path = Path(get_package_share_directory(package_name))
+    try:
+        package_path = Path(get_package_share_directory(package_name))
+    except EnvironmentError:
+        # ``get_package_share_directory`` raises ``EnvironmentError`` when the
+        # package is not found.  For parity with :func:`load_file` return ``None``
+        # instead of propagating the exception so callers can handle the missing
+        # package gracefully.
+        return None
+
     file_path = Path(file_path).expanduser()
     if not file_path.is_absolute():
         yaml_file = package_path / file_path

--- a/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
+++ b/easy_manipulation_deployment/workcell_builder/workcell_builder/templates/ros2/test_to_urdf.py
@@ -241,6 +241,16 @@ def test_load_yaml_returns_none_on_parse_error(tmp_path, monkeypatch):
     assert demo.load_yaml('pkg', bad_yaml.name) is None
 
 
+def test_load_yaml_handles_missing_package(monkeypatch):
+    """``load_yaml`` should return ``None`` when the package cannot be located."""
+    monkeypatch.setattr(
+        demo,
+        'get_package_share_directory',
+        lambda pkg: (_ for _ in ()).throw(EnvironmentError('missing package')),
+    )
+    assert demo.load_yaml('missing_pkg', 'config.yaml') is None
+
+
 def test_load_yaml_expands_user_paths(tmp_path, monkeypatch):
     pkg_dir = tmp_path / 'pkg'
     pkg_dir.mkdir()


### PR DESCRIPTION
## Summary
- gracefully handle missing packages in `load_yaml` by returning `None`
- add regression test for `load_yaml` missing package case

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9596d95b083319028c3cf28edfc21