### PR TITLE
Improve profile dictionary lookup in build script

### DIFF
--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -98,7 +98,8 @@ export AMENT_CMAKE_CXX_STANDARD=17
 CMAKE_ARGS=( -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF )
 
 # Minimal include fix for profile_dictionary
-PDH=$(find "$SRC" -path "*/tesseract_command_language/include/tesseract_command_language/profile_dictionary.h" | head -n1 || true)
+# Use find's -print -quit to grab the first match and avoid non-zero exit when not found
+PDH=$(find "$SRC" -path "*/tesseract_command_language/include/tesseract_command_language/profile_dictionary.h" -print -quit 2>/dev/null)
 if [[ -f "$PDH" ]] && grep -q '<shared_mutex>' "$PDH" && ! grep -q '<mutex>' "$PDH"; then
   echo "Patching missing <mutex> include in $PDH"
   sed -i '/<shared_mutex>/a #include <mutex>' "$PDH"


### PR DESCRIPTION
## Summary
- Avoid non-zero exit during profile dictionary lookup in fix_and_build.sh
- Document use of `find -print -quit` for more robust search

## Testing
- `bash -n fix_and_build.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b960248b8c8331af8ddcd3cffce7b2