### PR TITLE
Run workspace layout fix during build to prevent tesseract package issues

### DIFF
--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -60,6 +60,9 @@ for overlay in tesseract trajopt; do
   fi
 done
 
+# Ensure workspace layout is sanitized (handles stray trajopt sources)
+WS="$WS" "$REPO_DIR/scripts/fix_workspace_layout.sh"
+
 # Ensure boost_plugin_loader exists
 if [[ ! -d "$SRC/boost_plugin_loader" ]]; then
   git clone https://github.com/tesseract-robotics/boost_plugin_loader.git "$SRC/boost_plugin_loader"

--- a/scripts/fix_workspace_layout.sh
+++ b/scripts/fix_workspace_layout.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SRC_DIR="$HOME/workcell_ws/src"
-BACKUP_DIR="$HOME/trajopt_DISABLED_BACKUP"
+WS=${WS:-$HOME/workcell_ws}
+SRC_DIR="$WS/src"
+BACKUP_DIR="$WS/trajopt_DISABLED_BACKUP"
 
 if [ ! -d "$SRC_DIR" ]; then
   exit 0


### PR DESCRIPTION
## Summary
- sanitize workspace layout before building to avoid stray trajopt packages
- allow layout fixer to respect custom workspace paths via `WS`

## Testing
- `bash -n fix_and_build.sh`
- `bash -n scripts/fix_workspace_layout.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b982cd4c008331b2b5d2da3ebc31dd