### PR TITLE
Include boost_plugin_loader in tesseract dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ colcon build --symlink-install
 source install/setup.bash
 ```
 
+The `tesseract.repos` file now also fetches the
+[`boost_plugin_loader`](https://github.com/tesseract-robotics/boost_plugin_loader)
+dependency, which provides headers such as `boost_plugin_loader/fwd.h`
+required by `tesseract_common`.
+
 A convenience script `fix_and_build.sh` is provided in this repository. It automatically
 detects whether Humble or Jazzy is installed. After cloning into `~/workcell_ws`, run:
 

--- a/tesseract.repos
+++ b/tesseract.repos
@@ -32,6 +32,11 @@ repositories:
     url: https://github.com/ethz-adrl/ifopt
     version: 27451ce3212d3c0ccd3a0db9a1ee9a9963466674
 
+  boost_plugin_loader:
+    type: git
+    url: https://github.com/tesseract-robotics/boost_plugin_loader
+    version: 0168d4277a96854de18bbb9fbeb5e13f401fe468
+
   # Fork on Bainian's account
   tesseract_ros2:
     type: git


### PR DESCRIPTION
## Summary
- add boost_plugin_loader repository to tesseract.repos so Tesseract builds include required headers
- document boost_plugin_loader dependency in build instructions

## Testing
- `python3 - <<'PY'
import yaml
with open('tesseract.repos') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c18c60fe8083319a4b702fff2995fa