### PR TITLE
Handle unbound variable when sourcing ROS setup

### DIFF
--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -27,7 +27,12 @@ if [[ -z ${ROS_DISTRO:-} ]]; then
 fi
 
 # shellcheck source=/dev/null
+# Disable nounset while sourcing ROS setup, as it references
+# environment variables that may not be defined.
+set +u
+: "${AMENT_TRACE_SETUP_FILES:=}"
 source "/opt/ros/$ROS_DISTRO/setup.bash"
+set -u
 export LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 # Ensure required tools


### PR DESCRIPTION
## Summary
- prevent `fix_and_build.sh` from failing due to `AMENT_TRACE_SETUP_FILES` being undefined

## Testing
- `./fix_and_build.sh >/tmp/build.log && tail -n 20 /tmp/build.log` (interrupted after verifying progress)


------
https://chatgpt.com/codex/tasks/task_e_68c193c22d0083318ee200c84f920f46