### PR TITLE
Handle rosdep key gaps and guard sourcing in fix script

### DIFF
--- a/fix_and_build.sh
+++ b/fix_and_build.sh
@@ -99,7 +99,7 @@ fi
 # Install dependencies
 rosdep update
 rosdep install --from-paths "$SRC" --ignore-src -yr --rosdistro "$ROS_DISTRO" \
-  --skip-keys "tesseract tesseract_process_planners trajopt_ifopt trajopt_sqp"
+  --skip-keys "tesseract tesseract_process_planners trajopt_ifopt trajopt_sqp trajopt jsoncpp message_generation"
 
 # Enforce C++17
 export AMENT_CMAKE_CXX_STANDARD=17
@@ -115,24 +115,33 @@ fi
 
 cd "$WS"
 
+source_install() {
+  if [[ -f install/setup.bash ]]; then
+    set +u
+    : "${COLCON_TRACE:=}"
+    source install/setup.bash
+    set -u
+  fi
+}
+
 # Build boost_plugin_loader first
 colcon build --symlink-install --packages-select boost_plugin_loader --cmake-args "${CMAKE_ARGS[@]}"
-source install/setup.bash
+source_install
 find install -name 'tesseract_commonConfig.cmake' || true
 
 # Build up to tesseract_common and tesseract_msgs
 colcon build --symlink-install --packages-up-to tesseract_common tesseract_msgs --cmake-args "${CMAKE_ARGS[@]}"
-source install/setup.bash
+source_install
 find install -name 'tesseract_commonConfig.cmake'
 
 # Build up to trajopt_sco
 colcon build --symlink-install --packages-up-to trajopt_sco --cmake-args "${CMAKE_ARGS[@]}"
-source install/setup.bash
+source_install
 find install -name 'tesseract_commonConfig.cmake'
 
 # Build the whole workspace
 colcon build --symlink-install --cmake-args "${CMAKE_ARGS[@]}"
-source install/setup.bash
+source_install
 find install -name 'tesseract_commonConfig.cmake'
 
 # Print overlay information


### PR DESCRIPTION
## Summary
- skip ROS1-only and unavailable rosdep keys during dependency installation
- guard repeated sourcing of install/setup.bash to avoid COLCON_TRACE errors

## Testing
- bash -n fix_and_build.sh

------
https://chatgpt.com/codex/tasks/task_e_68dbeffcb6e88331a0d2ef6484051d26