### PR TITLE
Fix trajopt relocation to include hidden files

### DIFF
--- a/scripts/fix_workspace_layout.sh
+++ b/scripts/fix_workspace_layout.sh
@@ -4,29 +4,46 @@ set -euo pipefail
 WS=${WS:-$HOME/workcell_ws}
 SRC_DIR="$WS/src"
 BACKUP_DIR="$WS/trajopt_DISABLED_BACKUP"
+ORIG_DIR="$BACKUP_DIR/original"
 
 if [ ! -d "$SRC_DIR" ]; then
   exit 0
 fi
 
-# Move old trajopt directory to backup if it exists
+# Move old trajopt directory to backup if it exists. The previous implementation
+# only moved non-hidden files which left behind the .git directory and prevented
+# the symlinks below from being created on subsequent runs. This ensured the
+# trajopt CMake package was never visible to colcon, which later caused build
+# failures when tesseract_motion_planners attempted to find the trajopt package.
 if [ -d "${SRC_DIR}/trajopt" ] && [ ! -L "${SRC_DIR}/trajopt" ]; then
   mkdir -p "${BACKUP_DIR}"
-  mv "${SRC_DIR}/trajopt"/* "${BACKUP_DIR}"/ 2>/dev/null || true
-  rmdir "${SRC_DIR}/trajopt" 2>/dev/null || true
+  if [ ! -d "${ORIG_DIR}" ]; then
+    mv "${SRC_DIR}/trajopt" "${ORIG_DIR}"
+  else
+    rm -rf "${SRC_DIR}/trajopt"
+  fi
 fi
+
+link_from_backup() {
+  local pkg="$1"
+  local target=""
+  for candidate in "${BACKUP_DIR}/${pkg}" "${ORIG_DIR}/${pkg}"; do
+    if [ -d "${candidate}" ]; then
+      target="${candidate}"
+      break
+    fi
+  done
+
+  if [ -n "${target}" ] && [ ! -e "${SRC_DIR}/${pkg}" ]; then
+    ln -s "${target}" "${SRC_DIR}/${pkg}"
+  fi
+}
 
 # Ensure symlink for trajopt_sco pointing to nested package
 if [ ! -e "${SRC_DIR}/trajopt_sco" ]; then
   ln -s "${SRC_DIR}/easy_manipulation_deployment/trajopt/trajopt_sco" "${SRC_DIR}/trajopt_sco"
 fi
 
-# Link trajopt_common from backup if available
-if [ -d "${BACKUP_DIR}/trajopt_common" ] && [ ! -e "${SRC_DIR}/trajopt_common" ]; then
-  ln -s "${BACKUP_DIR}/trajopt_common" "${SRC_DIR}/trajopt_common"
-fi
-
-# Link trajopt package from backup if available
-if [ -d "${BACKUP_DIR}/trajopt" ] && [ ! -e "${SRC_DIR}/trajopt" ]; then
-  ln -s "${BACKUP_DIR}/trajopt" "${SRC_DIR}/trajopt"
-fi
+# Link trajopt-related packages from the backup if available
+link_from_backup trajopt_common
+link_from_backup trajopt


### PR DESCRIPTION
## Summary
- move the trajopt repository into the backup directory so hidden files do not block symlink creation
- add a helper to restore trajopt-related symlinks from either the original or legacy backup layout

## Testing
- bash -n scripts/fix_workspace_layout.sh

------
https://chatgpt.com/codex/tasks/task_e_68dbf3375d208331ad72735df6cbd2a6