### PR TITLE
Enable colcon to detect emd_msgs package

### DIFF
--- a/emd_msgs/COLCON_IGNORE.disabled
+++ b/emd_msgs/COLCON_IGNORE.disabled
@@ -1,0 +1,1 @@
+# This file disables the previous COLCON_IGNORE sentinel so the package is included in builds.


### PR DESCRIPTION
## Summary
- rename the COLCON_IGNORE sentinel so the `emd_msgs` package is picked up by colcon builds

## Testing
- colcon list --packages-select emd_msgs *(fails: `colcon` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d36ecb3883319fe6788f9d4ef3d5