### PR TITLE
Refine run_grasp_execution launch install rules and move helper tests out of launch

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
@@ -48,6 +48,11 @@ install(TARGETS
 
 install(DIRECTORY
   launch
+  DESTINATION share/${PROJECT_NAME}
+  FILES_MATCHING PATTERN "*.launch.py" PATTERN "*.launch.xml"
+)
+
+install(DIRECTORY
   config
   DESTINATION share/${PROJECT_NAME}
 )

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/README.md
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/README.md
@@ -1,0 +1,8 @@
+# run_grasp_execution
+
+## Launching and launch tests
+
+- Use `ros2 launch run_grasp_execution grasp_execution.launch.py` for normal runtime launch.
+- Run launch tests with `colcon test --packages-select run_grasp_execution --ctest-args -R test_grasp_execution_launch`.
+
+The helper test module in `test/test_grasp_execution_launch_helpers.py` is **not** a ROS launch entrypoint.

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
@@ -1,8 +1,8 @@
-"""Tests for the grasp_execution launch utilities.
+"""Unit tests for ``grasp_execution.launch.py`` helper functions.
 
-These tests focus on the helper functions defined in
-``grasp_execution.launch.py``. They intentionally stub out ROS specific
-modules so they can run in a plain Python environment.
+This module is a pytest unit-test helper and **not** a ROS launch entrypoint.
+It intentionally stubs ROS-specific modules so the tests can run in a plain
+Python environment.
 """
 
 from __future__ import annotations
@@ -75,7 +75,7 @@ def import_launch_module(path: Path):
 
 @pytest.fixture()
 def grasp_launch_module():
-    module_path = Path(__file__).resolve().parent / "grasp_execution.launch.py"
+    module_path = Path(__file__).resolve().parent.parent / "launch" / "grasp_execution.launch.py"
     return import_launch_module(module_path)
 
 
@@ -118,7 +118,7 @@ def test_resolve_scene_package_share_dir_reports_missing_scene(grasp_launch_modu
 @pytest.mark.parametrize(
     "module_path",
     [
-        Path(__file__).resolve().parent / "grasp_execution.launch.py",
+        Path(__file__).resolve().parent.parent / "launch" / "grasp_execution.launch.py",
         Path(__file__).resolve()
         .parents[2]
         .joinpath("run_waypoint_execution", "launch", "grasp_execution.launch.py"),


### PR DESCRIPTION
### Motivation

- Prevent non-launch helper test modules from being installed into `share/.../launch` so users don't see test helpers as runtime launch entrypoints.
- Keep the `launch/` directory containing only real launch entrypoints and place test utilities under `test/` to match ROS packaging expectations.

### Description

- Restrict installation of `launch/` contents in `run_grasp_execution/CMakeLists.txt` to only true launch entrypoints by adding `FILES_MATCHING PATTERN "*.launch.py" PATTERN "*.launch.xml"` to the `install(DIRECTORY launch ...)` rule.
- Move the helper test module from `launch/test_grasp_execution_launch.py` to `test/test_grasp_execution_launch_helpers.py` and update its internal path resolution to reference the `launch/` file from the new location.
- Add a clear module header to the moved helper indicating it is "not a ROS launch entrypoint" to avoid accidental use with `ros2 launch`.
- Add `run_grasp_execution/README.md` documenting the `ros2 launch` entrypoint (`grasp_execution.launch.py`) and the command to run launch tests (`colcon test --packages-select run_grasp_execution --ctest-args -R test_grasp_execution_launch`).

### Testing

- Ran `pytest -q easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py`, which reported the test module as skipped because the optional dependency `xacro` was not available in this environment.
- Committed changes and verified the CMake and file layout diffs to ensure the helper test is no longer in the installed `launch/` directory.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d677b0091883319836ae8d20221bea)