### PR TITLE
Handle unsupported xacro mappings in ur5_3f demo launch

### DIFF
--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -2,6 +2,8 @@
 
 import os
 import yaml
+import re
+
 import xacro
 
 from launch import LaunchDescription
@@ -22,8 +24,20 @@ def load_xacro(package_name, rel_path, mappings=None):
     if not os.path.exists(abs_path):
         raise FileNotFoundError(f"Missing file: {abs_path}")
 
-    doc = xacro.process_file(abs_path, mappings=mappings or {})
-    return doc.toprettyxml(indent="  ")
+    effective_mappings = dict(mappings or {})
+    while True:
+        try:
+            doc = xacro.process_file(abs_path, mappings=effective_mappings)
+            return doc.toprettyxml(indent="  ")
+        except Exception as exc:
+            match = re.search(r'Invalid parameter "([^"]+)"', str(exc))
+            if not match:
+                raise
+
+            invalid_param = match.group(1)
+            if invalid_param not in effective_mappings:
+                raise
+            effective_mappings.pop(invalid_param)
 
 
 def load_yaml(package_name, rel_path):


### PR DESCRIPTION
### Motivation

- Prevent launch failures when xacro macros reject mappings (for example `initial_positions_file`) due to version-specific parameter differences between `ur_description` and the scene xacro. 

### Description

- Updated `scenes/ur5_3f_test/launch/demo.launch.py` to make `load_xacro()` robust to unsupported xacro mapping keys by retrying rendering after removing any mapping named in an `Invalid parameter "..."` error. 
- The change adds an `import re` and uses a loop with an `effective_mappings` dict to call `xacro.process_file()` and to remove unsupported keys reported by xacro before retrying. 
- Behavior is a graceful fallback: if a mapping is unsupported it is removed and processing is retried, otherwise the original exception is re-raised. 

### Testing

- Ran `python -m py_compile scenes/ur5_3f_test/launch/demo.launch.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d679f0cd688331b0756f685296f936)