### PR TITLE
Harden external joint parent index validation in YAML generation

### DIFF
--- a/workcell_builder/workcell_builder/include/yaml_parser/generate_yaml.h
+++ b/workcell_builder/workcell_builder/include/yaml_parser/generate_yaml.h
@@ -187,13 +187,24 @@ public:
         int parent_object_pos = scene.object_vector[i].ext_joint.parent_obj_pos;
         int parent_link_pos = scene.object_vector[i].ext_joint.parent_link_pos;
 
-        if (parent_object_pos >= 0 && parent_link_pos >= 0) {
+        if (
+          parent_object_pos >= 0 &&
+          parent_object_pos < static_cast<int>(scene.object_vector.size()) &&
+          parent_link_pos >= 0 &&
+          parent_link_pos < static_cast<int>(
+            scene.object_vector[parent_object_pos].link_vector.size()))
+        {
           ExternalJointParser::generate_ext_joints(
             &out, scene.object_vector[i].ext_joint,
             scene.object_vector[parent_object_pos].name,
             scene.object_vector[parent_object_pos].link_vector[
               parent_link_pos].name);
         } else {
+          std::cerr <<
+            "Warning: invalid external joint parent indices for object '" <<
+            scene.object_vector[i].name << "' (parent_obj_pos=" <<
+            parent_object_pos << ", parent_link_pos=" << parent_link_pos <<
+            "). Falling back to world/world." << std::endl;
           ExternalJointParser::generate_ext_joints(
             &out, scene.object_vector[i].ext_joint, "world",
             "world");


### PR DESCRIPTION
### Motivation
- Prevent out-of-range dereferences when serializing external joints from malformed scene data by adding full bounds checks. 
- Make invalid external-joint parent indices diagnosable while preserving deterministic fallback behavior to `"world"/"world"`.

### Description
- Added upper-bound checks for `parent_object_pos` against `scene.object_vector.size()` and for `parent_link_pos` against `scene.object_vector[parent_object_pos].link_vector.size()` before any dereference. 
- Only access `scene.object_vector[parent_object_pos]` and its `link_vector[parent_link_pos]` when all checks pass. 
- Preserve the existing fallback behavior to serialize the parent as `"world"`/`"world"` when indices are invalid. 
- Emit a warning to `std::cerr` including the object name and invalid indices to aid diagnosis of bad scene data.

### Testing
- No automated tests were run for this header-only logic update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d955da19c08331bb21d636a6358a97)