### PR TITLE
Refactor GenerateYAML to use explicit filesystem paths (avoid cwd changes)

### DIFF
--- a/workcell_builder/workcell_builder/include/yaml_parser/generate_yaml.h
+++ b/workcell_builder/workcell_builder/include/yaml_parser/generate_yaml.h
@@ -77,6 +77,7 @@ public:
     boost::filesystem::path scene_filepath,
     boost::filesystem::path assets_filepath)
   {
+    (void)scene_filepath;
     YAML::Emitter out;
     out << YAML::BeginMap;
 
@@ -151,32 +152,32 @@ public:
       out << YAML::EndSeq;
       out << YAML::EndMap;
     }
-//        boost::filesystem::path scene_filepath = boost::filesystem::current_path();
-//        boost::filesystem::current_path(boost::filesystem::current_path().branch_path().branch_path());
-    boost::filesystem::current_path(assets_filepath);
-    boost::filesystem::current_path("environment");
-    boost::filesystem::path env_assets_filepath = boost::filesystem::current_path();
+    const boost::filesystem::path env_assets_filepath = assets_filepath / "environment";
 
     if (scene.object_vector.size() > 0) {
       out << YAML::Key << "objects";
       out << YAML::Value << YAML::BeginMap;
       for (int i = 0; i < static_cast < int > (scene.object_vector.size()); i++) {
-        if (!boost::filesystem::exists(scene.object_vector[i].name + "_description")) {
-          boost::filesystem::create_directory(scene.object_vector[i].name + "_description");
+        const boost::filesystem::path object_desc_dir =
+          env_assets_filepath / (scene.object_vector[i].name + "_description");
+        const boost::filesystem::path object_yaml_path =
+          object_desc_dir / (scene.object_vector[i].name + ".yaml");
+
+        if (!boost::filesystem::exists(object_desc_dir)) {
+          boost::filesystem::create_directory(object_desc_dir);
         }
-        boost::filesystem::current_path(scene.object_vector[i].name + "_description");
+
         YAML::Emitter temp_obj_out;
         temp_obj_out << YAML::BeginMap;
         ObjectParser::generate_object(&temp_obj_out, scene.object_vector[i]);
         temp_obj_out << YAML::EndMap;
-        std::ofstream objectfile;
-        objectfile.open(scene.object_vector[i].name + ".yaml");
+
+        std::ofstream objectfile(object_yaml_path.string());
         objectfile << temp_obj_out.c_str();
         objectfile.close();
-        boost::filesystem::current_path(env_assets_filepath);
+
         ObjectParser::generate_object(&out, scene.object_vector[i]);
       }
-      boost::filesystem::current_path(scene_filepath);
       out << YAML::EndMap;
     }
 
@@ -214,10 +215,10 @@ public:
     }
 
     out << YAML::EndMap;
-    boost::filesystem::current_path(filepath);
 
-    std::ofstream myfile;
-    myfile.open("environment.yaml");
+    const boost::filesystem::path environment_yaml_path =
+      boost::filesystem::path(filepath) / "environment.yaml";
+    std::ofstream myfile(environment_yaml_path.string());
     myfile << out.c_str();
     myfile.close();
   }


### PR DESCRIPTION
### Motivation
- The prior implementation relied on mutating the process current working directory with `boost::filesystem::current_path`, causing caller-dependent side effects and brittle file creation behavior.
- Generate deterministic output paths for assets, per-object descriptions, and the final `environment.yaml` so behavior is stable regardless of the caller `cwd`.

### Description
- Stop changing the process `cwd` inside `GenerateYAML::generate_yaml` and mark the `scene_filepath` parameter intentionally unused with `(void)scene_filepath;` for API compatibility.
- Construct an explicit assets environment directory as `assets_filepath / "environment"` and use it as the base for per-object directories and files.
- Create per-object description directories at `env_assets_filepath / (name + "_description")` and write each object YAML to an explicit path `... / (name + ".yaml")` via `std::ofstream(object_yaml_path.string())` instead of relying on `current_path`.
- Write the top-level environment YAML to an explicit path `boost::filesystem::path(filepath) / "environment.yaml"` using `std::ofstream(environment_yaml_path.string())`.

### Testing
- Ran `git diff --check` to validate whitespace and trivial diffs, which succeeded.
- Ran `git status --short` to confirm the modified file is staged/changed, which reported the updated header file.
- No automated build/test suite was executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9565c74348331a1ac1336bfb7d64f)