### PR TITLE
Enforce ROS 2 Humble-only behavior in workspace build helpers

### DIFF
--- a/scripts/lib/build.sh
+++ b/scripts/lib/build.sh
@@ -14,8 +14,13 @@ BASE_CMAKE_ARGS=(
 )
 
 reset_colcon_environment() {
-    local ros_setup="/opt/ros/humble/setup.bash"
+    local ros_distro="${ROS_DISTRO:-humble}"
+    local ros_setup="/opt/ros/${ros_distro}/setup.bash"
     local local_setup="$WORKSPACE_ROOT/install/local_setup.bash"
+
+    if [[ "$ros_distro" != "humble" ]]; then
+        die "Unsupported ROS_DISTRO='${ros_distro}' for this build helper (expected humble)"
+    fi
 
     unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_PREFIX_PATH
 

--- a/scripts/lib/environment.sh
+++ b/scripts/lib/environment.sh
@@ -27,17 +27,18 @@ detect_workspace() {
 detect_ros_distro() {
     if [[ -n ${ROS_DISTRO:-} ]]; then
         [[ -f "/opt/ros/$ROS_DISTRO/setup.bash" ]] || die "ROS_DISTRO is set to '$ROS_DISTRO' but /opt/ros/$ROS_DISTRO/setup.bash is missing"
+        [[ "$ROS_DISTRO" == "humble" ]] || die "This repository is currently supported via helper scripts on ROS 2 Humble only (received ROS_DISTRO='$ROS_DISTRO')"
         return
     fi
 
-    for distro in humble jazzy; do
+    for distro in humble; do
         if [[ -f "/opt/ros/$distro/setup.bash" ]]; then
             ROS_DISTRO="$distro"
             return
         fi
     done
 
-    die "No supported ROS distro found (expected humble or jazzy under /opt/ros)"
+    die "No supported ROS distro found (expected humble under /opt/ros)"
 }
 
 source_ros() {


### PR DESCRIPTION
### Motivation
- Prevent helper scripts from being run against non-Humble ROS underlays to avoid subtle mixed-distro build and runtime incompatibilities.

### Description
- Require `ROS_DISTRO=humble` in `scripts/lib/environment.sh` (remove jazzy fallback) and update `scripts/lib/build.sh` to derive `/opt/ros/<ROS_DISTRO>/setup.bash` while fail-fast rejecting any non-Humble value.

### Testing
- Ran `bash -n` on `scripts/lib/environment.sh`, `scripts/lib/build.sh`, `scripts/fix_and_build.sh`, and `fix_and_build_humble.sh` and the syntax checks succeeded, and invoking `./scripts/fix_and_build.sh --help` exited early due to a missing workspace root in the container (expected environment constraint).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95858629c83319f9eb80e9d39cf02)