### PR TITLE
Fix non-UR robots showing Missing URDF in Add Scene GUI

### DIFF
--- a/workcell_builder/workcell_builder/gui/addrobot.cpp
+++ b/workcell_builder/workcell_builder/gui/addrobot.cpp
@@ -90,8 +90,8 @@ std::vector<boost::filesystem::path> robot_description_candidates(
   const std::string & robot_name)
 {
   return {
-    urdf_path / (robot_name + ".urdf.xacro"),
-    urdf_path / (robot_name + ".urdf")
+    urdf_path / (robot_name + ".urdf"),
+    urdf_path / (robot_name + ".urdf.xacro")
   };
 }
 
@@ -313,8 +313,19 @@ Robot AddRobot::LoadRobot(
   temp_robot.name = file.erase(file.length() - 12);
   const boost::filesystem::path urdf_path = resolved_description_path / "urdf";
   const auto candidates = robot_description_candidates(urdf_path, temp_robot.name);
-  const boost::filesystem::path urdf_file = select_existing_description_file(candidates);
-  temp_robot.robot_links = GetLinks(urdf_file.string());
+  for (const auto & candidate : candidates) {
+    if (!boost::filesystem::exists(candidate)) {
+      continue;
+    }
+    temp_robot.robot_links = GetLinks(candidate.string());
+    if (!temp_robot.robot_links.empty()) {
+      break;
+    }
+  }
+  if (temp_robot.robot_links.empty()) {
+    const boost::filesystem::path urdf_file = select_existing_description_file(candidates);
+    temp_robot.robot_links = GetLinks(urdf_file.string());
+  }
   return temp_robot;
 }
 


### PR DESCRIPTION
### Motivation
- The scene-builder GUI showed "Missing URDF" for non-universal_robot robots when `.urdf.xacro` was selected first but xacro expansion produced no parsed links in this context. 
- The intent is to ensure all robot descriptions present in `assets/robots` (e.g., Fanuc, Panda) are visible when creating a new scene by preferring directly-parsed `.urdf` files where available.

### Description
- Reordered description candidates in `workcell_builder/workcell_builder/gui/addrobot.cpp` to try `"<robot>.urdf"` before `"<robot>.urdf.xacro"` by changing `robot_description_candidates` to return `.urdf` first.  
- Updated `AddRobot::LoadRobot()` to iterate over all candidate files and call `GetLinks()` on each existing candidate until one returns a non-empty link list, and to fall back to the previous `select_existing_description_file` behavior only if no candidate yielded links.  
- Changes are localized to `AddRobot::LoadRobot()` and helper `robot_description_candidates` in `addrobot.cpp` to avoid altering other robot-loading logic.

### Testing
- Attempted to build the `workcell_builder` package with `colcon build --packages-select workcell_builder --cmake-args -DCMAKE_BUILD_TYPE=Release`, but the build could not run in this environment because `colcon` is not installed (build failed).  
- No other automated tests were executed in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95b17eebc833184ad35562022c6c9)