### PR TITLE
Fix Scheduler locking: snapshot futures and safe read paths

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/core/scheduler.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/core/scheduler.hpp
@@ -60,16 +60,28 @@ public:
   Workflow::Status cancel_workflow(
     const std::string & workflow_id);
 
+  /// \brief Wait for every currently-tracked worker future to complete.
+  /// \details Thread-safe. The function snapshots worker futures while holding
+  /// internal metadata locks, then waits after releasing the lock.
   void wait_till_all_complete() const;
 
+  /// \brief Wait for a specific workflow to complete and return its result.
+  /// \details Thread-safe. Metadata lookups are performed while holding the
+  /// internal metadata mutex, and any selected shared_future is copied before
+  /// releasing the lock and waiting.
   Workflow::Status wait_till_complete(
     const std::string & workflow_id,
     result_t & result) const;
 
+  /// \brief Get current workflow status.
+  /// \details Thread-safe. Status lookup is guarded by the internal metadata
+  /// mutex.
   Workflow::Status get_status(
     const std::string & workflow_id) const;
 
-  const result_t & get_result(const std::string & workflow_id) const;
+  /// \brief Return a snapshot copy of a completed workflow result.
+  /// \details Thread-safe. Access is guarded by the internal metadata mutex.
+  result_t get_result(const std::string & workflow_id) const;
 
   class Impl;
 

--- a/easy_manipulation_deployment/emd_grasp_execution/src/core/scheduler.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/core/scheduler.cpp
@@ -37,7 +37,7 @@ namespace core
 struct Worker
 {
   std::shared_ptr<std::thread> execution_thread;
-  std::future<void> execution_future;
+  std::shared_future<void> execution_future;
 };
 
 class WorkflowImplT
@@ -156,7 +156,7 @@ int Scheduler::Impl::get_available_worker() const
 }
 
 
-const result_t & Scheduler::get_result(const std::string & workflow_id) const
+result_t Scheduler::get_result(const std::string & workflow_id) const
 {
   // Lock scheduler metadata
   std::lock_guard<std::mutex> guard(impl_->metadata_mutex);
@@ -186,7 +186,7 @@ void Scheduler::Impl::start_worker(
   auto sig = std::promise<void>();
 
   // Register future for monitoring signal
-  workers[worker_id].execution_future = sig.get_future();
+  workers[worker_id].execution_future = sig.get_future().share();
 
   // Add workflow id into the ongoing task map
   WorkflowImplT workflow_impl(workflow);
@@ -344,10 +344,19 @@ Workflow::Status Scheduler::cancel_workflow(
 
 void Scheduler::wait_till_all_complete() const
 {
-  for (auto & worker : impl_->workers) {
-    if (worker.execution_future.valid()) {
-      worker.execution_future.wait();
+  std::vector<std::shared_future<void>> worker_futures;
+  {
+    std::lock_guard<std::mutex> guard(impl_->metadata_mutex);
+    worker_futures.reserve(impl_->workers.size());
+    for (const auto & worker : impl_->workers) {
+      if (worker.execution_future.valid()) {
+        worker_futures.emplace_back(worker.execution_future);
+      }
     }
+  }
+
+  for (auto & worker_future : worker_futures) {
+    worker_future.wait();
   }
 }
 
@@ -357,23 +366,29 @@ Workflow::Status Scheduler::wait_till_complete(
   result_t & result) const
 {
   std::shared_future<result_t> future;
-  switch (get_status(workflow_id)) {
-    case Workflow::Status::COMPLETED:
-      result = impl_->finished_task_map[workflow_id];
-      break;
-    case Workflow::Status::ONGOING:
-      future = impl_->ongoing_task_map[workflow_id];
-      future.wait();
-      result = get_result(workflow_id);
-      break;
-    case Workflow::Status::QUEUED:
-      future = impl_->queued_task_map[workflow_id];
-      future.wait();
-      result = get_result(workflow_id);
-      break;
-    default:
-      return Workflow::Status::INVALID;
+  {
+    std::lock_guard<std::mutex> guard(impl_->metadata_mutex);
+
+    auto finished_it = impl_->finished_task_map.find(workflow_id);
+    if (finished_it != impl_->finished_task_map.end()) {
+      result = finished_it->second;
+      return Workflow::Status::COMPLETED;
+    }
+
+    auto ongoing_it = impl_->ongoing_task_map.find(workflow_id);
+    if (ongoing_it != impl_->ongoing_task_map.end()) {
+      future = ongoing_it->second;
+    } else {
+      auto queued_it = impl_->queued_task_map.find(workflow_id);
+      if (queued_it == impl_->queued_task_map.end()) {
+        return Workflow::Status::INVALID;
+      }
+      future = queued_it->second;
+    }
   }
+
+  future.wait();
+  result = get_result(workflow_id);
   return Workflow::Status::COMPLETED;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent races and accidental map insertions in scheduler read paths by performing metadata lookups under a single mutex critical section and waiting on futures only after releasing the lock. 
- Make worker-future waiting safe from const/read codepaths by allowing snapshotting of futures for external waiting. 
- Document the thread-safety expectations for public APIs so callers understand locking and snapshot semantics.

### Description
- Reworked `Scheduler::wait_till_complete` to perform a single locked lookup (check `finished`, `ongoing`, then `queued` via `find()`), copy the selected `std::shared_future<result_t>` while holding `impl_->metadata_mutex`, then `wait()` outside the lock, and finally obtain the result via `get_result` snapshot semantics. 
- Converted `Worker::execution_future` from `std::future<void>` to `std::shared_future<void>` and changed worker startup to use `sig.get_future().share()` so futures can be safely copied for snapshot waiting. 
- Implemented a snapshot pattern in `wait_till_all_complete` by copying valid worker futures under `metadata_mutex` into a local `std::vector<std::shared_future<void>>` and waiting on them after releasing the lock. 
- Changed `get_result` to return a `result_t` by value (snapshot) and added thread-safety documentation comments in `include/emd/grasp_execution/core/scheduler.hpp` for `wait_till_all_complete`, `wait_till_complete`, `get_status`, and `get_result` to clarify locking expectations.

### Testing
- Attempted to build the package with `colcon build --packages-select emd_grasp_execution` but the build tool was not available in the environment so the build could not be run (failure due to missing `colcon`). 
- Ran source inspections and diffs (`rg`/file diffs) to verify the intended edits and ensure read-paths and signatures were updated successfully (these checks succeeded). 
- No automated unit/integration tests were executed in this environment due to missing build tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95cde1d4c83318abf5d4b6fcb9c6b)