### PR TITLE
Standardize package metadata and update package template generation

### DIFF
--- a/assets/environment/workbench_description/package.xml
+++ b/assets/environment/workbench_description/package.xml
@@ -3,9 +3,9 @@
 <package format="3">
   <name>workbench_description</name>
   <version>2.0.0</version>
-  <description>table_description description</description>
-  <maintainer email="example@gmail.com">name</maintainer>
-  <license>TODO: License declaration</license>
+  <description>Workbench model and related launch assets for Easy Manipulation Deployment scenes</description>
+  <maintainer email="">Mukaram01</maintainer>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/scenes/suction_test/package.xml
+++ b/scenes/suction_test/package.xml
@@ -4,8 +4,8 @@
   <name>suction_test</name>
   <version>2.0.0</version>
   <description>UR5 robot with single-suction gripper scene for Easy Manipulation Deployment</description>
-  <maintainer email="example@gmail.com">name</maintainer>
-  <license>Apache License 2.0</license>
+  <maintainer email="">Mukaram01</maintainer>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/scenes/ur10_2f_test/package.xml
+++ b/scenes/ur10_2f_test/package.xml
@@ -4,8 +4,8 @@
   <name>ur10_2f_test</name>
   <version>2.0.0</version>
   <description>UR10 robot with Robotiq 2F gripper scene for Easy Manipulation Deployment</description>
-  <maintainer email="example@gmail.com">name</maintainer>
-  <license>Apache License 2.0</license>
+  <maintainer email="">Mukaram01</maintainer>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/scenes/ur3_suction_test/package.xml
+++ b/scenes/ur3_suction_test/package.xml
@@ -4,8 +4,8 @@
   <name>ur3_suction_test</name>
   <version>2.0.0</version>
   <description>UR3 robot with single suction gripper scene for Easy Manipulation Deployment</description>
-  <maintainer email="example@gmail.com">name</maintainer>
-  <license>Apache License 2.0</license>
+  <maintainer email="">Mukaram01</maintainer>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/workcell_builder/examples/ros2/package_example.xml
+++ b/workcell_builder/examples/ros2/package_example.xml
@@ -4,7 +4,7 @@
   <name>workcellexample</name>
   <version>2.0.0</version>
   <description>workcellexample description</description>
-  <maintainer email="example@gmail.com">name</maintainer>
+  <maintainer email="">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/workcell_builder/workcell_builder/include/file_functions.h
+++ b/workcell_builder/workcell_builder/include/file_functions.h
@@ -206,7 +206,7 @@ void generate_package_xml(
         "  <name>%s</name>\n"
         "  <version>2.0.0</version>\n"
         "  <description>%s description</description>\n"
-        "  <maintainer email=\"example@gmail.com\">name</maintainer>\n"
+        "  <maintainer email=\"\">Mukaram01</maintainer>\n"
         "  <license>Apache-2.0</license>\n"
         "\n"
         "  <buildtool_depend>ament_cmake</buildtool_depend>\n"

--- a/workcell_builder/workcell_builder/templates/ros2/humble/package_example.xml
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/package_example.xml
@@ -4,7 +4,7 @@
   <name>workcellexample</name>
   <version>2.0.0</version>
   <description>workcellexample description</description>
-  <maintainer email="example@gmail.com">name</maintainer>
+  <maintainer email="">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/workcell_builder/workcell_builder/templates/ros2/package_example.xml
+++ b/workcell_builder/workcell_builder/templates/ros2/package_example.xml
@@ -4,7 +4,7 @@
   <name>workcellexample</name>
   <version>2.0.0</version>
   <description>workcellexample description</description>
-  <maintainer email="example@gmail.com">name</maintainer>
+  <maintainer email="">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
### Motivation
- Ensure package metadata is consistent across scenes and templates by normalizing maintainer, license, and descriptions.
- Provide a correct description for the `workbench_description` package to better reflect its purpose.
- Make generated `package.xml` content from the workcell builder match the repository conventions.

### Description
- Updated multiple `package.xml` files to set the maintainer to `Mukaram01`, clear the maintainer email, and standardize the license to `Apache-2.0` (files include `assets/environment/workbench_description/package.xml`, `scenes/*/package.xml`, and example packages).
- Rewrote the `workbench_description` package description to: "Workbench model and related launch assets for Easy Manipulation Deployment scenes".
- Updated the workcell builder templates (`workcell_builder/workcell_builder/templates/ros2/*/package_example.xml` and `workcell_builder/examples/ros2/package_example.xml`) to use the new maintainer and license values.
- Adjusted the package generation logic in `workcell_builder/workcell_builder/include/file_functions.h` to emit the updated maintainer and license when creating a `package.xml` programmatically.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95e64159083319581a96596eab013)