### PR TITLE
Centralize MoveIt collision plugin selection, improve validation, and add tests

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/src/moveit/collision_checker_moveit.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/moveit/collision_checker_moveit.cpp
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <cctype>
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 #include <stdexcept>
+#include <sstream>
 
 #include "emd/dynamic_safety/collision_checker_moveit.hpp"
 #include "moveit/collision_detection_fcl/collision_detector_allocator_fcl.h"
@@ -34,6 +37,66 @@ static const rclcpp::Logger LOGGER = rclcpp::get_logger("dynamic_safety_moveit.c
 
 namespace
 {
+using CollisionAllocatorFactory = std::function<void(planning_scene::PlanningScene &)>;
+
+std::string to_ascii_lower(std::string input)
+{
+  std::transform(
+    input.begin(), input.end(), input.begin(),
+    [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+    });
+  return input;
+}
+
+std::unordered_map<std::string, std::string> plugin_aliases()
+{
+  std::unordered_map<std::string, std::string> aliases{
+    {"fcl", "fcl"},
+    {"collision_detection_fcl/collisiondetectorallocatorfcl", "fcl"},
+  };
+#ifndef EMD_DYNAMIC_SAFETY_TESSERACT
+  aliases.emplace("bullet", "bullet");
+  aliases.emplace("collision_detection_bullet/collisiondetectorallocatorbullet", "bullet");
+#endif
+  return aliases;
+}
+
+std::unordered_map<std::string, CollisionAllocatorFactory> plugin_allocators()
+{
+  std::unordered_map<std::string, CollisionAllocatorFactory> allocators{
+    {
+      "fcl",
+      [](planning_scene::PlanningScene & scene) {
+        scene.allocateCollisionDetector(collision_detection::CollisionDetectorAllocatorFCL::create());
+      }
+    },
+  };
+#ifndef EMD_DYNAMIC_SAFETY_TESSERACT
+  allocators.emplace(
+    "bullet",
+    [](planning_scene::PlanningScene & scene) {
+      scene.allocateCollisionDetector(collision_detection::CollisionDetectorAllocatorBullet::create());
+    });
+#endif
+  return allocators;
+}
+
+std::string available_plugin_list()
+{
+  const auto allocators = plugin_allocators();
+  std::ostringstream stream;
+  bool first = true;
+  for (const auto & plugin : allocators) {
+    if (!first) {
+      stream << ", ";
+    }
+    stream << plugin.first;
+    first = false;
+  }
+  return stream.str();
+}
+
 bool state_has_variable(const moveit::core::RobotState & state, const std::string & name)
 {
   const auto & variable_names = state.getVariableNames();
@@ -161,25 +224,27 @@ MoveitCollisionCheckerContext::MoveitCollisionCheckerContext(
   // TODO(anyone): use the mapping file
   // auto loader = pluginlib::ClassLoader<collision_detection::CollisionPlugin>(
   //     "moveit_core", "collision_detection::CollisionPlugin");
-  auto to_all_lower = [](std::string in) -> std::string {
-      std::transform(in.begin(), in.end(), in.begin(), ::tolower);
-      return in;
-    };
+  const auto aliases = plugin_aliases();
+  const auto allocators = plugin_allocators();
+  const std::string plugin_key = to_ascii_lower(collision_checking_plugin);
 
-  std::string plugin_name;
-  // TODO(anyone): use plugin loader after release of fix
-  //               https://github.com/ros-planning/moveit2/pull/658
-  if (to_all_lower(collision_checking_plugin) == "fcl") {
-    scene_->allocateCollisionDetector(
-      collision_detection::CollisionDetectorAllocatorFCL::create()
-    );
-  } else if (to_all_lower(collision_checking_plugin) == "bullet") {
-#ifndef EMD_DYNAMIC_SAFETY_TESSERACT
-    scene_->allocateCollisionDetector(
-      collision_detection::CollisionDetectorAllocatorBullet::create()
-    );
-#endif
+  const auto alias = aliases.find(plugin_key);
+  if (alias == aliases.end()) {
+    const std::string error_message =
+      "Unknown MoveIt collision checking plugin '" + collision_checking_plugin +
+      "'. Accepted identifiers: " + available_plugin_list();
+    RCLCPP_ERROR(LOGGER, "%s", error_message.c_str());
+    throw std::runtime_error(error_message);
   }
+
+  const auto allocator = allocators.find(alias->second);
+  if (allocator == allocators.end()) {
+    const std::string error_message =
+      "MoveIt collision checking plugin '" + alias->second + "' is not available in this build.";
+    RCLCPP_ERROR(LOGGER, "%s", error_message.c_str());
+    throw std::runtime_error(error_message);
+  }
+  allocator->second(*scene_);
 }
 
 void MoveitCollisionCheckerContext::configure(

--- a/easy_manipulation_deployment/emd_dynamic_safety/test/test_collision_checking.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/test/test_collision_checking.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <thread>
 #include <cmath>
+#include <stdexcept>
 
 #include "test_hardware.hpp"
 #include "emd/dynamic_safety/collision_checker.hpp"
@@ -140,6 +141,31 @@ TEST_F(CollisionCheckingTest, MoveitDiscreteFCL)
   // Check the whole trajectory at once
   collision_checker_.run_once(0, 2, collision_time);
   EXPECT_NEAR(collision_time, 1.66, 0.0001);
+}
+
+TEST_F(CollisionCheckingTest, MoveItPluginSelectionIsCaseInsensitive)
+{
+  option_.collision_checking_plugin = "FCL";
+  EXPECT_NO_THROW(
+    collision_checker_.configure(
+      option_,
+      robot_.get_urdf(),
+      robot_.get_srdf()));
+}
+
+TEST_F(CollisionCheckingTest, MoveItUnknownPluginThrowsHelpfulError)
+{
+  option_.collision_checking_plugin = "unknown_plugin";
+  try {
+    collision_checker_.configure(
+      option_,
+      robot_.get_urdf(),
+      robot_.get_srdf());
+    FAIL() << "Expected runtime_error for unknown plugin";
+  } catch (const std::runtime_error & ex) {
+    EXPECT_NE(std::string(ex.what()).find("unknown_plugin"), std::string::npos);
+    EXPECT_NE(std::string(ex.what()).find("Accepted identifiers"), std::string::npos);
+  }
 }
 
 #ifndef EMD_DYNAMIC_SAFETY_TESSERACT


### PR DESCRIPTION
### Motivation
- Replace fragile hardcoded lowercase branching for MoveIt collision plugin selection with a configuration-driven mapping and clearer runtime diagnostics.
- Consolidate accepted plugin identifiers and allocator logic so plugin names and availability are validated centrally and error messages are actionable.
- Ensure character-lowering is safe for non-ASCII input and remove unused local variables left from the previous branching logic.
- Extend tests to assert case-insensitive selection and helpful error handling for unknown plugin names.

### Description
- Added a safe ASCII lowercase helper `to_ascii_lower` and introduced `plugin_aliases`, `plugin_allocators`, and `available_plugin_list` helper functions to centralize plugin identifier mapping and allocator factories in `MoveitCollisionCheckerContext` (file `src/moveit/collision_checker_moveit.cpp`).
- Replaced the previous `if/else` string branching with alias lookup and allocator dispatch, emitting an explicit `std::runtime_error` with an `Accepted identifiers:` list when an unknown or unavailable plugin is requested.
- Introduced `CollisionAllocatorFactory` and small utility includes (`<cctype>`, `<functional>`, `<sstream>`) to support the new mapping and allocator approach, and removed the unused `plugin_name` local flow.
- Extended `easy_manipulation_deployment/emd_dynamic_safety/test/test_collision_checking.cpp` with two tests: `MoveItPluginSelectionIsCaseInsensitive` (ensures mixed-case plugin names like `"FCL"` work) and `MoveItUnknownPluginThrowsHelpfulError` (verifies unknown plugin causes a descriptive `runtime_error`).

### Testing
- Added unit tests in `test/test_collision_checking.cpp` covering case-insensitive plugin selection and unknown-plugin error messaging, but no CI/test run completed in this environment.
- Attempted to run `colcon test --packages-select emd_dynamic_safety --ctest-args -R test_collision_checking --output-on-failure`, which failed because `colcon` is not installed in the current environment, so automated tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1e9c65ec8331b0fb9bb17256fbaf)