### PR TITLE
Add DAG-aware workflow scheduling, dependency handling, and unit tests

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/core/scheduler.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/core/scheduler.hpp
@@ -21,6 +21,7 @@
 #include <thread>
 #include <utility>
 #include <vector>
+#include <unordered_map>
 
 namespace grasp_execution
 {
@@ -37,9 +38,11 @@ enum class Status : uint8_t
 {
   COMPLETED = 1,
   QUEUED = 2,
-  ONGOING = 3,
-  CANCELLED = 4,
-  INVALID = 5
+  RUNNABLE = 3,
+  ONGOING = 4,
+  FAILED = 5,
+  CANCELLED = 6,
+  INVALID = 7
 };
 
 }  // namespace Workflow
@@ -56,6 +59,17 @@ public:
   Workflow::Status add_workflow(
     const std::string & workflow_id,
     WorkflowT workflow);
+
+  Workflow::Status add_workflow(
+    const std::string & workflow_id,
+    WorkflowT workflow,
+    const std::vector<std::string> & prerequisites,
+    bool allow_if_prerequisite_failed = false);
+
+  Workflow::Status add_workflows(
+    const std::unordered_map<std::string, WorkflowT> & workflows,
+    const std::unordered_map<std::string, std::vector<std::string>> & prerequisites,
+    bool allow_if_prerequisite_failed = false);
 
   Workflow::Status cancel_workflow(
     const std::string & workflow_id);

--- a/easy_manipulation_deployment/emd_grasp_execution/src/core/scheduler.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/core/scheduler.cpp
@@ -12,25 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+#include <chrono>
 #include <deque>
 #include <functional>
+#include <future>
+#include <iostream>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
-#include <algorithm>
 #include <utility>
 #include <vector>
-#include <chrono>
-#include <future>
-#include <thread>
 
 #include "emd/grasp_execution/core/scheduler.hpp"
 
 namespace grasp_execution
 {
-
 namespace core
 {
 
@@ -43,9 +43,7 @@ struct Worker
 class WorkflowImplT
 {
 public:
-  WorkflowImplT()
-  {
-  }
+  WorkflowImplT() = default;
 
   explicit WorkflowImplT(Scheduler::WorkflowT _workflow)
   : workflow(std::move(_workflow)), sig(), future(sig.get_future())
@@ -53,6 +51,7 @@ public:
   }
 
   WorkflowImplT & operator=(const WorkflowImplT &) = delete;
+  WorkflowImplT(const WorkflowImplT &) = delete;
 
   WorkflowImplT & operator=(WorkflowImplT && rhs) noexcept
   {
@@ -61,8 +60,6 @@ public:
     workflow = std::move(rhs.workflow);
     return *this;
   }
-
-  WorkflowImplT(const WorkflowImplT &) = delete;
 
   WorkflowImplT(WorkflowImplT && rhs) noexcept
   : workflow(std::move(rhs.workflow)),
@@ -79,22 +76,22 @@ public:
 class Scheduler::Impl
 {
 public:
-  /// \brief Constructor
+  enum class LifecycleState : uint8_t
+  {
+    QUEUED = 1,
+    RUNNABLE = 2,
+    ONGOING = 3,
+    FINISHED = 4,
+    FAILED = 5,
+    CANCELLED = 6
+  };
+
   explicit Impl(size_t _concurrency)
   : concurrency(_concurrency)
   {
     workers.resize(_concurrency);
-
-    // Clear queue
-    workflow_queue.clear();
-    id_queue.clear();
-
-    // Clear ongoing tasks;
-    ongoing_task_map.clear();
-    finished_task_map.clear();
   }
 
-  /// \brief Constructor
   ~Impl()
   {
     for (auto & worker : workers) {
@@ -104,45 +101,133 @@ public:
     }
   }
 
+  bool would_create_cycle(
+    const std::string & workflow_id,
+    const std::vector<std::string> & prerequisites) const;
+
   void stop_finished_worker();
 
-  void start_worker(
-    size_t worker_id,
-    const WorkflowT & workflow,
-    std::string workflow_id);
-
-  void add_queue(
-    const WorkflowT & workflow,
-    const std::string & workflow_id);
+  void start_worker(size_t worker_id, const std::string & workflow_id);
 
   int get_available_worker() const;
+
+  void try_schedule_runnable();
 
   void execution_ending_cb(
     const std::string & workflow_id,
     std::promise<result_t> & workflow_sig,
-    std::promise<void> & _sig,
+    std::promise<void> & worker_sig,
     result_t result);
+
+  Workflow::Status terminal_status_from_id(const std::string & workflow_id) const;
+
+  void cancel_workflow_and_dependents(const std::string & workflow_id, bool set_result);
 
   size_t concurrency;
 
   std::mutex metadata_mutex;
 
-  std::deque<WorkflowImplT> workflow_queue;
-  std::deque<std::string> id_queue;
+  std::deque<std::string> runnable_queue;
+  std::unordered_map<std::string, std::shared_ptr<WorkflowImplT>> waiting_workflow_map;
   std::unordered_map<std::string, std::shared_future<result_t>> queued_task_map;
   std::unordered_map<std::string, std::shared_future<result_t>> ongoing_task_map;
   std::unordered_map<std::string, result_t> finished_task_map;
 
+  std::unordered_map<std::string, size_t> prerequisite_count;
+  std::unordered_map<std::string, std::vector<std::string>> reverse_dependency_map;
+  std::unordered_map<std::string, LifecycleState> lifecycle_state_map;
+  std::unordered_map<std::string, bool> allow_failed_prerequisite;
+
   std::vector<Worker> workers;
 };
 
-void Scheduler::Impl::add_queue(
-  const WorkflowT & workflow,
-  const std::string & workflow_id)
+bool Scheduler::Impl::would_create_cycle(
+  const std::string & workflow_id,
+  const std::vector<std::string> & prerequisites) const
 {
-  workflow_queue.emplace_back(workflow);
-  id_queue.push_back(workflow_id);
-  queued_task_map[workflow_id] = workflow_queue.back().future;
+  std::unordered_set<std::string> nodes;
+  for (const auto & kv : lifecycle_state_map) {
+    nodes.insert(kv.first);
+  }
+  nodes.insert(workflow_id);
+  for (const auto & prereq : prerequisites) {
+    nodes.insert(prereq);
+  }
+
+  std::unordered_map<std::string, std::vector<std::string>> adjacency = reverse_dependency_map;
+  adjacency[workflow_id];
+  for (const auto & prereq : prerequisites) {
+    adjacency[prereq].push_back(workflow_id);
+  }
+
+  std::unordered_map<std::string, size_t> indegree;
+  for (const auto & node : nodes) {
+    indegree[node] = 0;
+  }
+  for (const auto & kv : adjacency) {
+    for (const auto & to : kv.second) {
+      if (nodes.count(to) != 0U) {
+        indegree[to]++;
+      }
+    }
+  }
+
+  std::deque<std::string> zero_indegree;
+  for (const auto & kv : indegree) {
+    if (kv.second == 0) {
+      zero_indegree.push_back(kv.first);
+    }
+  }
+
+  size_t visited = 0;
+  while (!zero_indegree.empty()) {
+    auto node = std::move(zero_indegree.front());
+    zero_indegree.pop_front();
+    visited++;
+    for (const auto & dep : adjacency[node]) {
+      if (--indegree[dep] == 0) {
+        zero_indegree.push_back(dep);
+      }
+    }
+  }
+
+  return visited != nodes.size();
+}
+
+Workflow::Status Scheduler::Impl::terminal_status_from_id(const std::string & workflow_id) const
+{
+  auto state_it = lifecycle_state_map.find(workflow_id);
+  if (state_it == lifecycle_state_map.end()) {
+    return Workflow::Status::INVALID;
+  }
+
+  switch (state_it->second) {
+    case LifecycleState::FINISHED:
+      return Workflow::Status::COMPLETED;
+    case LifecycleState::FAILED:
+      return Workflow::Status::FAILED;
+    case LifecycleState::CANCELLED:
+      return Workflow::Status::CANCELLED;
+    default:
+      return Workflow::Status::INVALID;
+  }
+}
+
+void Scheduler::Impl::stop_finished_worker()
+{
+  for (auto & worker : workers) {
+    if (!worker.execution_thread) {
+      continue;
+    }
+
+    auto status = worker.execution_future.wait_for(std::chrono::nanoseconds(0));
+    if (status != std::future_status::ready) {
+      continue;
+    }
+
+    worker.execution_thread->join();
+    worker.execution_thread.reset();
+  }
 }
 
 int Scheduler::Impl::get_available_worker() const
@@ -155,62 +240,80 @@ int Scheduler::Impl::get_available_worker() const
   return -1;
 }
 
-
-result_t Scheduler::get_result(const std::string & workflow_id) const
+void Scheduler::Impl::try_schedule_runnable()
 {
-  // Lock scheduler metadata
-  std::lock_guard<std::mutex> guard(impl_->metadata_mutex);
-  return impl_->finished_task_map.at(workflow_id);
-}
-
-void Scheduler::Impl::stop_finished_worker()
-{
-  for (auto & worker : workers) {
-    // Check if there are on going tasks
-    if (worker.execution_thread) {
-      // Check if the ongoing tasks is finished
-      auto status = worker.execution_future.wait_for(std::chrono::nanoseconds(0));
-      if (status != std::future_status::ready) {
-        continue;
-      }
-      worker.execution_thread->join();
-      worker.execution_thread.reset();
+  stop_finished_worker();
+  while (!runnable_queue.empty()) {
+    int worker_id = get_available_worker();
+    if (worker_id == -1) {
+      return;
     }
+    const auto runnable_id = std::move(runnable_queue.front());
+    runnable_queue.pop_front();
+    start_worker(static_cast<size_t>(worker_id), runnable_id);
   }
 }
 
-void Scheduler::Impl::start_worker(
-  size_t worker_id, const WorkflowT & workflow, std::string workflow_id)
+void Scheduler::Impl::start_worker(size_t worker_id, const std::string & workflow_id)
 {
-  // Create signal for workcell result
-  auto sig = std::promise<void>();
+  auto wf_it = waiting_workflow_map.find(workflow_id);
+  if (wf_it == waiting_workflow_map.end()) {
+    return;
+  }
 
-  // Register future for monitoring signal
+  auto workflow_impl = wf_it->second;
+  waiting_workflow_map.erase(wf_it);
+
+  auto sig = std::promise<void>();
   workers[worker_id].execution_future = sig.get_future().share();
 
-  // Add workflow id into the ongoing task map
-  WorkflowImplT workflow_impl(workflow);
-  ongoing_task_map[workflow_id] = workflow_impl.future;
+  queued_task_map.erase(workflow_id);
+  ongoing_task_map[workflow_id] = workflow_impl->future;
+  lifecycle_state_map[workflow_id] = LifecycleState::ONGOING;
 
-  // Start execution thread
   workers[worker_id].execution_thread = std::make_shared<std::thread>(
-    [this, wf = std::move(workflow_impl)](
-      std::promise<void> && _sig,
-      std::string workflow_id) mutable
-    {
-      result_t result = wf.workflow(workflow_id);
+    [this, wf = workflow_impl](std::promise<void> && worker_sig, std::string id) mutable {
+      result_t current_result = wf->workflow(id);
+      execution_ending_cb(id, wf->sig, worker_sig, current_result);
+    }, std::move(sig), workflow_id);
+}
 
-      // Start execution ending callback
-      // This will check if there are additional queue item in task
-      // TODO(Briancbn): setting workflow prerequisite, (DAG)?
-      execution_ending_cb(workflow_id, wf.sig, _sig, result);
-    }, std::move(sig), std::move(workflow_id));
+void Scheduler::Impl::cancel_workflow_and_dependents(const std::string & workflow_id, bool set_result)
+{
+  if (lifecycle_state_map[workflow_id] == LifecycleState::CANCELLED) {
+    return;
+  }
+
+  lifecycle_state_map[workflow_id] = LifecycleState::CANCELLED;
+  finished_task_map[workflow_id] = false;
+  prerequisite_count.erase(workflow_id);
+
+  auto queued_it = queued_task_map.find(workflow_id);
+  if (queued_it != queued_task_map.end()) {
+    auto waiting_it = waiting_workflow_map.find(workflow_id);
+    if (set_result && waiting_it != waiting_workflow_map.end()) {
+      waiting_it->second->sig.set_value(false);
+    }
+    queued_task_map.erase(queued_it);
+    waiting_workflow_map.erase(workflow_id);
+  }
+
+  runnable_queue.erase(
+    std::remove(runnable_queue.begin(), runnable_queue.end(), workflow_id),
+    runnable_queue.end());
+
+  for (const auto & dependent : reverse_dependency_map[workflow_id]) {
+    if (allow_failed_prerequisite[dependent]) {
+      continue;
+    }
+    cancel_workflow_and_dependents(dependent, set_result);
+  }
 }
 
 void Scheduler::Impl::execution_ending_cb(
   const std::string & workflow_id,
   std::promise<result_t> & workflow_sig,
-  std::promise<void> & _sig,
+  std::promise<void> & worker_sig,
   result_t result)
 {
   std::string current_workflow_id = workflow_id;
@@ -218,47 +321,59 @@ void Scheduler::Impl::execution_ending_cb(
   result_t current_result = result;
 
   while (true) {
-    WorkflowImplT next_workflow;
     std::string next_workflow_id;
-    bool has_next_workflow = false;
+    std::shared_ptr<WorkflowImplT> next_workflow;
+
     {
-      // Lock scheduler metadata only while moving lifecycle states:
-      // ongoing -> finished for the current workflow,
-      // queued -> ongoing for the next workflow (if any).
       std::lock_guard<std::mutex> guard(metadata_mutex);
 
-      // Fulfill the current workflow promise with its execution result.
       current_workflow_sig->set_value(current_result);
-
-      // Mark current workflow as finished.
       finished_task_map[current_workflow_id] = current_result;
+      lifecycle_state_map[current_workflow_id] =
+        current_result ? LifecycleState::FINISHED : LifecycleState::FAILED;
       ongoing_task_map.erase(current_workflow_id);
 
-      if (!id_queue.empty()) {
-        has_next_workflow = true;
+      for (const auto & dependent : reverse_dependency_map[current_workflow_id]) {
+        if (lifecycle_state_map[dependent] == LifecycleState::CANCELLED) {
+          continue;
+        }
 
-        // TODO(anyone): setting workflow prerequisite, (DAG)?
-        // Pull the next queued workflow and move it to ongoing.
-        next_workflow_id = std::move(id_queue.front());
-        id_queue.pop_front();
-        next_workflow = std::move(workflow_queue.front());
-        workflow_queue.pop_front();
-        ongoing_task_map[next_workflow_id] = std::move(queued_task_map[next_workflow_id]);
-        queued_task_map.erase(next_workflow_id);
-      } else {
-        // No more queued work: signal the worker chain completion.
-        _sig.set_value();
+        if (!current_result && !allow_failed_prerequisite[dependent]) {
+          cancel_workflow_and_dependents(dependent, true);
+          continue;
+        }
+
+        if (prerequisite_count[dependent] > 0) {
+          prerequisite_count[dependent]--;
+          if (prerequisite_count[dependent] == 0) {
+            lifecycle_state_map[dependent] = LifecycleState::RUNNABLE;
+            runnable_queue.push_back(dependent);
+          }
+        }
+      }
+
+      if (!runnable_queue.empty()) {
+        next_workflow_id = std::move(runnable_queue.front());
+        runnable_queue.pop_front();
+        auto it = waiting_workflow_map.find(next_workflow_id);
+        if (it != waiting_workflow_map.end()) {
+          next_workflow = it->second;
+          waiting_workflow_map.erase(it);
+          queued_task_map.erase(next_workflow_id);
+          ongoing_task_map[next_workflow_id] = next_workflow->future;
+          lifecycle_state_map[next_workflow_id] = LifecycleState::ONGOING;
+        }
+      }
+
+      if (!next_workflow) {
+        worker_sig.set_value();
         return;
       }
-    }  // Unlock scheduler metadata before executing the next workflow.
-
-    if (!has_next_workflow) {
-      return;
     }
 
-    current_result = next_workflow.workflow(next_workflow_id);
+    current_result = next_workflow->workflow(next_workflow_id);
     current_workflow_id = std::move(next_workflow_id);
-    current_workflow_sig = &next_workflow.sig;
+    current_workflow_sig = &next_workflow->sig;
   }
 }
 
@@ -269,9 +384,15 @@ Scheduler::Scheduler(size_t concurrency)
 
 Scheduler::~Scheduler()
 {
-  // Cancel all workflows in queue
-  for (auto & workflow_id : impl_->id_queue) {
-    cancel_workflow(workflow_id);
+  std::lock_guard<std::mutex> guard(impl_->metadata_mutex);
+  std::vector<std::string> to_cancel;
+  to_cancel.reserve(impl_->queued_task_map.size());
+  for (const auto & kv : impl_->queued_task_map) {
+    to_cancel.push_back(kv.first);
+  }
+
+  for (const auto & id : to_cancel) {
+    impl_->cancel_workflow_and_dependents(id, true);
   }
 }
 
@@ -279,73 +400,171 @@ Workflow::Status Scheduler::add_workflow(
   const std::string & workflow_id,
   WorkflowT workflow)
 {
-  // Doesn't allow thread exit, during function call
-  {   // Lock scheduler metadata
-    std::lock_guard<std::mutex> guard(impl_->metadata_mutex);
-
-    // Check if the workflow_id exist in history
-    if (impl_->finished_task_map.find(workflow_id) !=
-      impl_->finished_task_map.end())
-    {
-      return Workflow::Status::INVALID;
-    }
-
-    // Check if the workflow_id is already on-going
-    if (impl_->ongoing_task_map.find(workflow_id) !=
-      impl_->ongoing_task_map.end())
-    {
-      return Workflow::Status::INVALID;
-    }
-
-    impl_->stop_finished_worker();
-
-    int worker_id = impl_->get_available_worker();
-
-    if (worker_id == -1) {
-      // Check if task is already in queue
-      if (impl_->queued_task_map.find(workflow_id) != impl_->queued_task_map.end()) {
-        return Workflow::Status::INVALID;
-      }
-      impl_->add_queue(workflow, workflow_id);
-      return Workflow::Status::QUEUED;
-    } else {
-      impl_->start_worker(worker_id, workflow, std::move(workflow_id));
-      return Workflow::Status::ONGOING;
-    }
-  }   // Unlock scheduler metadata
+  return add_workflow(workflow_id, std::move(workflow), {}, false);
 }
 
-Workflow::Status Scheduler::cancel_workflow(
-  const std::string & workflow_id)
+Workflow::Status Scheduler::add_workflow(
+  const std::string & workflow_id,
+  WorkflowT workflow,
+  const std::vector<std::string> & prerequisites,
+  bool allow_if_prerequisite_failed)
 {
-  // Check if the workflow_id exist in completed history
   std::lock_guard<std::mutex> guard(impl_->metadata_mutex);
-  if (impl_->finished_task_map.find(workflow_id) !=
-    impl_->finished_task_map.end())
-  {
+
+  if (impl_->lifecycle_state_map.find(workflow_id) != impl_->lifecycle_state_map.end()) {
     return Workflow::Status::INVALID;
   }
 
-  // Check if the workflow_id is already on-going
-  if (impl_->ongoing_task_map.find(workflow_id) !=
-    impl_->ongoing_task_map.end())
-  {
+  for (const auto & prereq : prerequisites) {
+    if (impl_->lifecycle_state_map.find(prereq) == impl_->lifecycle_state_map.end()) {
+      std::cerr << "[Scheduler] Rejecting workflow '" << workflow_id
+                << "' due to unknown prerequisite '" << prereq << "'" << std::endl;
+      return Workflow::Status::INVALID;
+    }
+  }
+
+  if (impl_->would_create_cycle(workflow_id, prerequisites)) {
+    std::cerr << "[Scheduler] Rejecting cyclic workflow DAG involving '" << workflow_id << "'"
+              << std::endl;
     return Workflow::Status::INVALID;
   }
 
-  // Check if workflow_id is in queue
-  auto it = std::find(
-    impl_->id_queue.begin(), impl_->id_queue.end(), workflow_id);
-  if (it != impl_->id_queue.end()) {
-    auto idx = std::distance(impl_->id_queue.begin(), it);
-    impl_->id_queue.erase(it);
-    impl_->workflow_queue.erase(impl_->workflow_queue.begin() + idx);
-    impl_->queued_task_map.erase(workflow_id);
-    return Workflow::Status::CANCELLED;
+  auto workflow_impl = std::make_shared<WorkflowImplT>(std::move(workflow));
+  impl_->waiting_workflow_map[workflow_id] = workflow_impl;
+  impl_->queued_task_map[workflow_id] = workflow_impl->future;
+  impl_->allow_failed_prerequisite[workflow_id] = allow_if_prerequisite_failed;
+  impl_->prerequisite_count[workflow_id] = prerequisites.size();
+  impl_->lifecycle_state_map[workflow_id] =
+    prerequisites.empty() ? Impl::LifecycleState::RUNNABLE : Impl::LifecycleState::QUEUED;
+
+  for (const auto & prereq : prerequisites) {
+    impl_->reverse_dependency_map[prereq].push_back(workflow_id);
   }
 
-  // Cannot find workflow_id anywhere
-  return Workflow::Status::INVALID;
+  if (prerequisites.empty()) {
+    impl_->runnable_queue.push_back(workflow_id);
+  }
+
+  impl_->try_schedule_runnable();
+
+  if (impl_->lifecycle_state_map[workflow_id] == Impl::LifecycleState::ONGOING) {
+    return Workflow::Status::ONGOING;
+  }
+  if (impl_->lifecycle_state_map[workflow_id] == Impl::LifecycleState::RUNNABLE) {
+    return Workflow::Status::RUNNABLE;
+  }
+  return Workflow::Status::QUEUED;
+}
+
+Workflow::Status Scheduler::add_workflows(
+  const std::unordered_map<std::string, WorkflowT> & workflows,
+  const std::unordered_map<std::string, std::vector<std::string>> & prerequisites,
+  bool allow_if_prerequisite_failed)
+{
+  std::lock_guard<std::mutex> guard(impl_->metadata_mutex);
+
+  for (const auto & kv : workflows) {
+    if (impl_->lifecycle_state_map.find(kv.first) != impl_->lifecycle_state_map.end()) {
+      return Workflow::Status::INVALID;
+    }
+  }
+
+  std::unordered_map<std::string, std::vector<std::string>> local_adj;
+  std::unordered_map<std::string, size_t> local_indegree;
+  for (const auto & kv : workflows) {
+    local_indegree[kv.first] = 0;
+  }
+
+  for (const auto & kv : workflows) {
+    const auto it = prerequisites.find(kv.first);
+    if (it == prerequisites.end()) {
+      continue;
+    }
+    for (const auto & prereq : it->second) {
+      if (workflows.find(prereq) == workflows.end() &&
+        impl_->lifecycle_state_map.find(prereq) == impl_->lifecycle_state_map.end())
+      {
+        std::cerr << "[Scheduler] Rejecting workflow batch due to unknown prerequisite '" << prereq
+                  << "'" << std::endl;
+        return Workflow::Status::INVALID;
+      }
+      if (workflows.find(prereq) != workflows.end()) {
+        local_adj[prereq].push_back(kv.first);
+        local_indegree[kv.first]++;
+      }
+    }
+  }
+
+  std::deque<std::string> zero;
+  for (const auto & kv : local_indegree) {
+    if (kv.second == 0) {
+      zero.push_back(kv.first);
+    }
+  }
+
+  size_t visited = 0;
+  while (!zero.empty()) {
+    auto n = std::move(zero.front());
+    zero.pop_front();
+    visited++;
+    for (const auto & dep : local_adj[n]) {
+      if (--local_indegree[dep] == 0) {
+        zero.push_back(dep);
+      }
+    }
+  }
+
+  if (visited != workflows.size()) {
+    std::cerr << "[Scheduler] Rejecting cyclic workflow DAG submission" << std::endl;
+    return Workflow::Status::INVALID;
+  }
+
+  Workflow::Status last_status = Workflow::Status::INVALID;
+  for (const auto & kv : workflows) {
+    auto it = prerequisites.find(kv.first);
+    const std::vector<std::string> deps = (it == prerequisites.end()) ? std::vector<std::string>{} : it->second;
+    if (impl_->would_create_cycle(kv.first, deps)) {
+      std::cerr << "[Scheduler] Rejecting cyclic workflow DAG involving '" << kv.first << "'"
+                << std::endl;
+      return Workflow::Status::INVALID;
+    }
+
+    auto workflow_impl = std::make_shared<WorkflowImplT>(kv.second);
+    impl_->waiting_workflow_map[kv.first] = workflow_impl;
+    impl_->queued_task_map[kv.first] = workflow_impl->future;
+    impl_->allow_failed_prerequisite[kv.first] = allow_if_prerequisite_failed;
+    impl_->prerequisite_count[kv.first] = deps.size();
+    impl_->lifecycle_state_map[kv.first] =
+      deps.empty() ? Impl::LifecycleState::RUNNABLE : Impl::LifecycleState::QUEUED;
+
+    for (const auto & prereq : deps) {
+      impl_->reverse_dependency_map[prereq].push_back(kv.first);
+    }
+
+    if (deps.empty()) {
+      impl_->runnable_queue.push_back(kv.first);
+    }
+
+    last_status = deps.empty() ? Workflow::Status::RUNNABLE : Workflow::Status::QUEUED;
+  }
+
+  impl_->try_schedule_runnable();
+  return last_status;
+}
+
+Workflow::Status Scheduler::cancel_workflow(const std::string & workflow_id)
+{
+  std::lock_guard<std::mutex> guard(impl_->metadata_mutex);
+  if (impl_->ongoing_task_map.find(workflow_id) != impl_->ongoing_task_map.end()) {
+    return Workflow::Status::INVALID;
+  }
+
+  if (impl_->queued_task_map.find(workflow_id) == impl_->queued_task_map.end()) {
+    return Workflow::Status::INVALID;
+  }
+
+  impl_->cancel_workflow_and_dependents(workflow_id, true);
+  return Workflow::Status::CANCELLED;
 }
 
 void Scheduler::wait_till_all_complete() const
@@ -366,7 +585,6 @@ void Scheduler::wait_till_all_complete() const
   }
 }
 
-
 Workflow::Status Scheduler::wait_till_complete(
   const std::string & workflow_id,
   result_t & result) const
@@ -378,7 +596,7 @@ Workflow::Status Scheduler::wait_till_complete(
     auto finished_it = impl_->finished_task_map.find(workflow_id);
     if (finished_it != impl_->finished_task_map.end()) {
       result = finished_it->second;
-      return Workflow::Status::COMPLETED;
+      return impl_->terminal_status_from_id(workflow_id);
     }
 
     auto ongoing_it = impl_->ongoing_task_map.find(workflow_id);
@@ -394,37 +612,44 @@ Workflow::Status Scheduler::wait_till_complete(
   }
 
   future.wait();
-  result = get_result(workflow_id);
-  return Workflow::Status::COMPLETED;
+
+  std::lock_guard<std::mutex> guard(impl_->metadata_mutex);
+  result = impl_->finished_task_map.at(workflow_id);
+  return impl_->terminal_status_from_id(workflow_id);
 }
 
-Workflow::Status Scheduler::get_status(
-  const std::string & workflow_id) const
+Workflow::Status Scheduler::get_status(const std::string & workflow_id) const
 {
-  // Check if the workflow_id exist in completed history
   std::lock_guard<std::mutex> guard(impl_->metadata_mutex);
-  if (impl_->finished_task_map.find(workflow_id) !=
-    impl_->finished_task_map.end())
-  {
-    return Workflow::Status::COMPLETED;
+
+  const auto it = impl_->lifecycle_state_map.find(workflow_id);
+  if (it == impl_->lifecycle_state_map.end()) {
+    return Workflow::Status::INVALID;
   }
 
-  // Check if the workflow_id is already on-going
-  if (impl_->ongoing_task_map.find(workflow_id) !=
-    impl_->ongoing_task_map.end())
-  {
-    return Workflow::Status::ONGOING;
+  switch (it->second) {
+    case Impl::LifecycleState::QUEUED:
+      return Workflow::Status::QUEUED;
+    case Impl::LifecycleState::RUNNABLE:
+      return Workflow::Status::RUNNABLE;
+    case Impl::LifecycleState::ONGOING:
+      return Workflow::Status::ONGOING;
+    case Impl::LifecycleState::FINISHED:
+      return Workflow::Status::COMPLETED;
+    case Impl::LifecycleState::FAILED:
+      return Workflow::Status::FAILED;
+    case Impl::LifecycleState::CANCELLED:
+      return Workflow::Status::CANCELLED;
+    default:
+      return Workflow::Status::INVALID;
   }
+}
 
-  // Check if workflow_id is in queue
-  if (impl_->queued_task_map.find(workflow_id) != impl_->queued_task_map.end()) {
-    return Workflow::Status::QUEUED;
-  }
-
-  // Cannot find workflow_id anywhere
-  return Workflow::Status::INVALID;
+result_t Scheduler::get_result(const std::string & workflow_id) const
+{
+  std::lock_guard<std::mutex> guard(impl_->metadata_mutex);
+  return impl_->finished_task_map.at(workflow_id);
 }
 
 }  // namespace core
-
 }  // namespace grasp_execution

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_scheduler.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_scheduler.cpp
@@ -12,31 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
+#include <unordered_map>
+#include <thread>
+#include <chrono>
+#include <algorithm>
+#include <stdexcept>
 #include <string>
 #include <vector>
-#include <stdexcept>
-#include <limits>
 
 #include "gtest/gtest.h"
 #include "emd/grasp_execution/core/scheduler.hpp"
 
 namespace test_scheduler
 {
-bool test_unsafe_workflow(
-  const std::string & id,
-  std::vector<std::string> & flags)
+bool test_unsafe_workflow(const std::string & id, std::vector<std::string> & flags)
 {
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  std::this_thread::sleep_for(std::chrono::milliseconds(40));
   flags.push_back(id);
   return id.size() > 2;
 }
-
 }  // namespace test_scheduler
 
-TEST(TestScheduler, SingleThreadedInit) {
+TEST(TestScheduler, SingleThreadedInit)
+{
   grasp_execution::core::Scheduler * sch_ptr;
-
-  // Test resize failure
   try {
     sch_ptr = new grasp_execution::core::Scheduler(std::numeric_limits<size_t>::max());
     delete sch_ptr;
@@ -46,43 +46,133 @@ TEST(TestScheduler, SingleThreadedInit) {
   grasp_execution::core::Scheduler sch(1);
 }
 
-TEST(TestScheduler, SingleThreadedAddWorkflow) {
-  grasp_execution::core::Scheduler * sch;
-  sch = new grasp_execution::core::Scheduler(1);
+TEST(TestScheduler, SingleThreadedAddWorkflow)
+{
+  grasp_execution::core::Scheduler sch(1);
   using sch_status = grasp_execution::core::Workflow::Status;
+
   std::vector<std::string> flags;
   auto test_workflow = [&flags](const std::string & id) {
       return test_scheduler::test_unsafe_workflow(id, flags);
     };
 
-  // Check if workflow 1 is started
-  ASSERT_EQ(sch->add_workflow("w1", test_workflow), sch_status::ONGOING);
+  ASSERT_EQ(sch.add_workflow("w1", test_workflow), sch_status::ONGOING);
+  EXPECT_EQ(sch.add_workflow("w1", test_workflow), sch_status::INVALID);
 
-  // Check if repeated ongoing workflow is rejected
-  EXPECT_EQ(sch->add_workflow("w1", test_workflow), sch_status::INVALID);
-
-  // Check if workflow 2 is queued
-  EXPECT_EQ(sch->add_workflow("w_2", test_workflow), sch_status::QUEUED);
-
-  // Check if repeated queued workflow is rejected
-  EXPECT_EQ(sch->add_workflow("w_2", test_workflow), sch_status::INVALID);
+  auto w2_status = sch.add_workflow("w_2", test_workflow);
+  EXPECT_TRUE(w2_status == sch_status::RUNNABLE || w2_status == sch_status::QUEUED);
+  EXPECT_EQ(sch.add_workflow("w_2", test_workflow), sch_status::INVALID);
 
   bool result;
-
-  // Wait till ongoing workflow 1 complete
-  EXPECT_EQ(sch->wait_till_complete("w1", result), sch_status::COMPLETED);
+  EXPECT_EQ(sch.wait_till_complete("w1", result), sch_status::FAILED);
   EXPECT_FALSE(result);
 
-  // Check if workflow 3 is queued
-  EXPECT_EQ(sch->add_workflow("w_3", test_workflow), sch_status::QUEUED);
+  auto w3_status = sch.add_workflow("w_3", test_workflow);
+  EXPECT_TRUE(w3_status == sch_status::RUNNABLE || w3_status == sch_status::QUEUED);
+  EXPECT_EQ(sch.add_workflow("w1", test_workflow), sch_status::INVALID);
+}
 
-  // Check if repeated completed workflow is rejected
-  EXPECT_EQ(sch->add_workflow("w1", test_workflow), sch_status::INVALID);
+TEST(TestScheduler, LinearDependencyChainAtoBtoC)
+{
+  grasp_execution::core::Scheduler sch(2);
+  using sch_status = grasp_execution::core::Workflow::Status;
 
-  // Confirm workflow 3 is still in queued status
-  EXPECT_EQ(sch->get_status("w_3"), sch_status::QUEUED);
+  std::vector<std::string> execution_order;
+  auto workflow = [&execution_order](const std::string & id) {
+      execution_order.push_back(id);
+      return true;
+    };
 
-  // Call destructor
-  delete sch;
-  EXPECT_TRUE((flags == std::vector<std::string>{"w1", "w_2"}));
+  EXPECT_EQ(sch.add_workflow("A", workflow), sch_status::ONGOING);
+  EXPECT_EQ(sch.add_workflow("B", workflow, {"A"}), sch_status::QUEUED);
+  EXPECT_EQ(sch.add_workflow("C", workflow, {"B"}), sch_status::QUEUED);
+
+  sch.wait_till_all_complete();
+
+  bool result = false;
+  EXPECT_EQ(sch.wait_till_complete("A", result), sch_status::COMPLETED);
+  EXPECT_TRUE(result);
+  EXPECT_EQ(sch.wait_till_complete("B", result), sch_status::COMPLETED);
+  EXPECT_TRUE(result);
+  EXPECT_EQ(sch.wait_till_complete("C", result), sch_status::COMPLETED);
+  EXPECT_TRUE(result);
+
+  ASSERT_EQ(execution_order.size(), 3U);
+  EXPECT_EQ(execution_order[0], "A");
+  EXPECT_EQ(execution_order[1], "B");
+  EXPECT_EQ(execution_order[2], "C");
+}
+
+TEST(TestScheduler, DiamondFanInOrdering)
+{
+  grasp_execution::core::Scheduler sch(2);
+  using sch_status = grasp_execution::core::Workflow::Status;
+
+  std::vector<std::string> execution_order;
+  auto workflow = [&execution_order](const std::string & id) {
+      if (id == "A") {
+        std::this_thread::sleep_for(std::chrono::milliseconds(80));
+      }
+      execution_order.push_back(id);
+      return true;
+    };
+
+  EXPECT_EQ(sch.add_workflow("A", workflow), sch_status::ONGOING);
+  EXPECT_EQ(sch.add_workflow("B", workflow, {"A"}), sch_status::QUEUED);
+  EXPECT_EQ(sch.add_workflow("C", workflow, {"A"}), sch_status::QUEUED);
+  EXPECT_EQ(sch.add_workflow("D", workflow, {"B", "C"}), sch_status::QUEUED);
+
+  sch.wait_till_all_complete();
+
+  auto d_it = std::find(execution_order.begin(), execution_order.end(), "D");
+  auto b_it = std::find(execution_order.begin(), execution_order.end(), "B");
+  auto c_it = std::find(execution_order.begin(), execution_order.end(), "C");
+
+  ASSERT_NE(d_it, execution_order.end());
+  ASSERT_NE(b_it, execution_order.end());
+  ASSERT_NE(c_it, execution_order.end());
+  EXPECT_GT(std::distance(execution_order.begin(), d_it), std::distance(execution_order.begin(), b_it));
+  EXPECT_GT(std::distance(execution_order.begin(), d_it), std::distance(execution_order.begin(), c_it));
+}
+
+TEST(TestScheduler, FailedPrerequisiteCancelsDependents)
+{
+  grasp_execution::core::Scheduler sch(2);
+  using sch_status = grasp_execution::core::Workflow::Status;
+
+  auto fail_workflow = [](const std::string &) { return false; };
+  auto success_workflow = [](const std::string &) { return true; };
+
+  EXPECT_EQ(sch.add_workflow("A", fail_workflow), sch_status::ONGOING);
+  EXPECT_EQ(sch.add_workflow("B", success_workflow, {"A"}), sch_status::QUEUED);
+
+  sch.wait_till_all_complete();
+
+  bool result = true;
+  EXPECT_EQ(sch.wait_till_complete("A", result), sch_status::FAILED);
+  EXPECT_FALSE(result);
+
+  EXPECT_EQ(sch.get_status("B"), sch_status::CANCELLED);
+  EXPECT_EQ(sch.wait_till_complete("B", result), sch_status::CANCELLED);
+  EXPECT_FALSE(result);
+}
+
+TEST(TestScheduler, CycleRejection)
+{
+  grasp_execution::core::Scheduler sch(1);
+  using sch_status = grasp_execution::core::Workflow::Status;
+
+  std::unordered_map<std::string, grasp_execution::core::Scheduler::WorkflowT> workflows{
+    {"A", [](const std::string &) { return true; }},
+    {"B", [](const std::string &) { return true; }},
+    {"C", [](const std::string &) { return true; }}
+  };
+
+  std::unordered_map<std::string, std::vector<std::string>> prerequisites{
+    {"A", {"C"}},
+    {"B", {"A"}},
+    {"C", {"B"}}
+  };
+
+  EXPECT_EQ(sch.add_workflows(workflows, prerequisites), sch_status::INVALID);
 }


### PR DESCRIPTION
### Motivation
- Make the Scheduler dependency-aware so workflows can declare prerequisites (DAG) and only become runnable when all prerequisites are satisfied.
- Track per-workflow lifecycle and dependency metadata to support correct ordering, failure propagation, and cancellation policies.

### Description
- Extended the public Scheduler API with an overload `add_workflow(..., prerequisites, allow_if_prerequisite_failed)` and a batch `add_workflows(...)` that accepts a DAG adjacency list, and added `RUNNABLE` and `FAILED` statuses to the workflow lifecycle.
- Introduced scheduler metadata: `prerequisite_count`, `reverse_dependency_map`, `lifecycle_state_map`, `allow_failed_prerequisite`, `waiting_workflow_map`, and a `runnable_queue`, and changed queueing so only zero-unsatisfied-dependency workflows enter the runnable queue.
- Implemented completion handling in `execution_ending_cb` to store results, decrement dependent counters, enqueue newly-unblocked workflows, and recursively cancel or propagate dependents based on the failed-prerequisite policy.
- Added cycle detection (Kahn’s algorithm) at submission time for both single and batch submissions and explicit stderr logging on cyclic or unknown-prerequisite rejections, and added a recursive dependent cancellation helper.
- Modified and added unit tests in `test/unit/test_scheduler.cpp` to cover linear chain ordering (A->B->C), diamond fan-in ordering, failed-prerequisite cancellation, and cycle rejection via batch submission.

### Testing
- Successfully compiled the modified scheduler translation unit with `g++ -std=c++17 -Ieasy_manipulation_deployment/emd_grasp_execution/include -c easy_manipulation_deployment/emd_grasp_execution/src/core/scheduler.cpp -o /tmp/scheduler.o` which completed without errors.
- Attempted to run unit tests with `colcon test --packages-select emd_grasp_execution --ctest-args -R test_scheduler` but it could not be executed in this environment because the `colcon` binary is not available (test run not performed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2ba511188331ab628ed2a5b523db)