### PR TITLE
Refactor dynamic safety zone handling into policy decision state machine

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety.hpp
@@ -32,6 +32,7 @@
 // #include "emd/dynamic_safety/next_point_publisher.hpp"
 #include "emd/dynamic_safety/replanner.hpp"
 #include "emd/dynamic_safety/visualizer.hpp"
+#include "emd/dynamic_safety/zone_decision_policy.hpp"
 #include "emd/profiler.hpp"
 #include "realtime_tools/realtime_buffer.hpp"
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
@@ -76,6 +77,8 @@ struct Option
   ReplannerOption replanner_options;
 
   Visualizer::Option visualizer_options;
+
+  ZonePolicyParameters zone_policy;
 
     template<typename NodeT>
     const Option & load(const std::shared_ptr<NodeT> & node);

--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/zone_decision_policy.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/zone_decision_policy.hpp
@@ -1,0 +1,188 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <string>
+
+#include "emd/dynamic_safety/replanner.hpp"
+#include "emd/dynamic_safety/safety_zone.hpp"
+
+namespace dynamic_safety
+{
+
+struct ZonePolicyParameters
+{
+  double min_replan_interval{0.25};
+  double emergency_hysteresis{0.05};
+  double slowdown_hysteresis{0.08};
+  double replan_hysteresis{0.10};
+  double safe_hysteresis{0.0};
+  double scale_floor{0.0001};
+  double scale_ceiling{1.0};
+  double scale_ramp_down_rate{1.5};
+  double scale_ramp_up_rate{0.75};
+  double collision_persistence_window{0.10};
+  double replan_start_time_epsilon{0.02};
+};
+
+struct ZoneDecisionInput
+{
+  double now{0.0};
+  double control_period{0.01};
+  double current_time{0.0};
+  double full_duration{0.0};
+  double collision_time_point{-1.0};
+  uint8_t raw_zone{SafetyZone::SAFE};
+  bool collision_detected{false};
+  bool allow_replan{false};
+  double current_scale{1.0};
+  double emergency_zone_limit{0.0};
+  double slowdown_zone_limit{0.0};
+  ReplannerStatus replanner_status{ReplannerStatus::IDLE};
+};
+
+struct ZoneDecision
+{
+  uint8_t zone{SafetyZone::SAFE};
+  double next_scale{1.0};
+  bool start_replanner{false};
+  bool terminate_replanner{false};
+  bool consume_replan_result{false};
+  double start_state_time{0.0};
+  std::string action{"none"};
+};
+
+class ZoneDecisionPolicy
+{
+public:
+  explicit ZoneDecisionPolicy(const ZonePolicyParameters & parameters)
+  : parameters_(parameters) {}
+
+  void reset();
+  ZoneDecision decide(const ZoneDecisionInput & input);
+
+private:
+  double get_hysteresis(uint8_t zone) const;
+
+  ZonePolicyParameters parameters_;
+  bool initialized_{false};
+  double last_decision_time_{0.0};
+  double last_collision_observed_time_{-std::numeric_limits<double>::infinity()};
+  double last_replan_start_time_{-std::numeric_limits<double>::infinity()};
+  double last_replan_wall_time_{-std::numeric_limits<double>::infinity()};
+  uint8_t prior_zone_{SafetyZone::SAFE};
+};
+
+inline void ZoneDecisionPolicy::reset()
+{
+  initialized_ = false;
+  prior_zone_ = SafetyZone::SAFE;
+  last_decision_time_ = 0.0;
+  last_collision_observed_time_ = -std::numeric_limits<double>::infinity();
+  last_replan_start_time_ = -std::numeric_limits<double>::infinity();
+  last_replan_wall_time_ = -std::numeric_limits<double>::infinity();
+}
+
+inline double ZoneDecisionPolicy::get_hysteresis(uint8_t zone) const
+{
+  if (zone <= SafetyZone::EMERGENCY) {
+    return parameters_.emergency_hysteresis;
+  }
+  if (zone == SafetyZone::SLOWDOWN) {
+    return parameters_.slowdown_hysteresis;
+  }
+  if (zone == SafetyZone::REPLAN) {
+    return parameters_.replan_hysteresis;
+  }
+  return parameters_.safe_hysteresis;
+}
+
+inline ZoneDecision ZoneDecisionPolicy::decide(const ZoneDecisionInput & input)
+{
+  ZoneDecision out;
+  const double dt = initialized_ ? std::max(input.now - last_decision_time_, 1e-6) :
+    std::max(input.control_period, 1e-6);
+  initialized_ = true;
+  last_decision_time_ = input.now;
+
+  if (input.collision_detected) {
+    last_collision_observed_time_ = input.now;
+  }
+  const bool collision_persistent =
+    (input.now - last_collision_observed_time_) <= parameters_.collision_persistence_window;
+
+  out.zone = input.raw_zone;
+  const double ttc = input.collision_time_point - input.current_time;
+  if (collision_persistent && input.raw_zone > prior_zone_) {
+    const double hysteresis_limit = get_hysteresis(prior_zone_);
+    if (prior_zone_ == SafetyZone::EMERGENCY && ttc <= input.emergency_zone_limit + hysteresis_limit) {
+      out.zone = SafetyZone::EMERGENCY;
+    } else if (prior_zone_ == SafetyZone::SLOWDOWN &&
+      ttc <= input.slowdown_zone_limit + hysteresis_limit)
+    {
+      out.zone = SafetyZone::SLOWDOWN;
+    } else if (prior_zone_ == SafetyZone::REPLAN &&
+      ttc <= input.slowdown_zone_limit + hysteresis_limit)
+    {
+      out.zone = SafetyZone::REPLAN;
+    }
+  }
+
+  out.next_scale = std::clamp(input.current_scale, parameters_.scale_floor, parameters_.scale_ceiling);
+
+  if (collision_persistent) {
+    if (out.zone <= SafetyZone::EMERGENCY) {
+      out.next_scale = parameters_.scale_floor;
+      out.action = "emergency_stop";
+    } else if (out.zone == SafetyZone::SLOWDOWN) {
+      out.next_scale = std::max(parameters_.scale_floor, input.current_scale - parameters_.scale_ramp_down_rate * dt);
+      out.action = "slowdown";
+    }
+  } else {
+    out.next_scale = std::min(parameters_.scale_ceiling, input.current_scale + parameters_.scale_ramp_up_rate * dt);
+    out.action = "recover";
+  }
+
+  if (input.allow_replan) {
+    if (collision_persistent && (out.zone == SafetyZone::SLOWDOWN || out.zone == SafetyZone::REPLAN)) {
+      double start_state_time = input.current_time;
+      if (out.zone == SafetyZone::SLOWDOWN) {
+        start_state_time = (input.current_time + input.emergency_zone_limit + input.collision_time_point) / 2.0;
+      } else {
+        start_state_time = (input.current_time + input.slowdown_zone_limit + input.collision_time_point) / 2.0;
+      }
+      start_state_time = std::clamp(start_state_time, input.current_time, input.full_duration);
+      const bool min_interval_ok =
+        (input.now - last_replan_wall_time_) >= parameters_.min_replan_interval;
+      const bool not_duplicate =
+        std::fabs(start_state_time - last_replan_start_time_) > parameters_.replan_start_time_epsilon;
+      if (min_interval_ok && not_duplicate &&
+        (input.replanner_status == ReplannerStatus::IDLE ||
+        input.replanner_status == ReplannerStatus::TIMEOUT))
+      {
+        out.start_replanner = true;
+        out.start_state_time = start_state_time;
+        out.action = "start_replanner";
+        last_replan_wall_time_ = input.now;
+        last_replan_start_time_ = start_state_time;
+      }
+    } else if (!collision_persistent || out.zone == SafetyZone::SAFE) {
+      if (input.replanner_status == ReplannerStatus::ONGOING ||
+        input.replanner_status == ReplannerStatus::TIMEOUT)
+      {
+        out.terminate_replanner = true;
+        out.action = "terminate_replanner";
+      } else if (input.replanner_status == ReplannerStatus::SUCCEED) {
+        out.consume_replan_result = true;
+        out.action = "consume_replanner_result";
+      }
+    }
+  }
+
+  prior_zone_ = out.zone;
+  return out;
+}
+
+}  // namespace dynamic_safety

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 #include <stdexcept>
+#include <sstream>
 
 #include "emd/dynamic_safety/dynamic_safety.hpp"
 #include <rclcpp/parameter_client.hpp>
@@ -210,6 +211,51 @@ const Option & Option::load(const std::shared_ptr<NodeT> & node)
     collision_checker_options.thread_count,
     "dynamic_safety.collision_checker.thread_count",
     node, LOGGER);
+
+  emd::declare_or_get_param<double>(
+    zone_policy.min_replan_interval,
+    "dynamic_safety.policy.min_replan_interval",
+    node, LOGGER, zone_policy.min_replan_interval);
+  emd::declare_or_get_param<double>(
+    zone_policy.emergency_hysteresis,
+    "dynamic_safety.policy.hysteresis.emergency",
+    node, LOGGER, zone_policy.emergency_hysteresis);
+  emd::declare_or_get_param<double>(
+    zone_policy.slowdown_hysteresis,
+    "dynamic_safety.policy.hysteresis.slowdown",
+    node, LOGGER, zone_policy.slowdown_hysteresis);
+  emd::declare_or_get_param<double>(
+    zone_policy.replan_hysteresis,
+    "dynamic_safety.policy.hysteresis.replan",
+    node, LOGGER, zone_policy.replan_hysteresis);
+  emd::declare_or_get_param<double>(
+    zone_policy.safe_hysteresis,
+    "dynamic_safety.policy.hysteresis.safe",
+    node, LOGGER, zone_policy.safe_hysteresis);
+  emd::declare_or_get_param<double>(
+    zone_policy.scale_floor,
+    "dynamic_safety.policy.scale.floor",
+    node, LOGGER, zone_policy.scale_floor);
+  emd::declare_or_get_param<double>(
+    zone_policy.scale_ceiling,
+    "dynamic_safety.policy.scale.ceiling",
+    node, LOGGER, zone_policy.scale_ceiling);
+  emd::declare_or_get_param<double>(
+    zone_policy.scale_ramp_down_rate,
+    "dynamic_safety.policy.scale.ramp_down_rate",
+    node, LOGGER, zone_policy.scale_ramp_down_rate);
+  emd::declare_or_get_param<double>(
+    zone_policy.scale_ramp_up_rate,
+    "dynamic_safety.policy.scale.ramp_up_rate",
+    node, LOGGER, zone_policy.scale_ramp_up_rate);
+  emd::declare_or_get_param<double>(
+    zone_policy.collision_persistence_window,
+    "dynamic_safety.policy.collision_persistence_window",
+    node, LOGGER, zone_policy.collision_persistence_window);
+  emd::declare_or_get_param<double>(
+    zone_policy.replan_start_time_epsilon,
+    "dynamic_safety.policy.replan_start_time_epsilon",
+    node, LOGGER, zone_policy.replan_start_time_epsilon);
 
   // -------------- Static parameters -------------------
   if (!dynamic_parameterization) {
@@ -490,6 +536,7 @@ protected:
     double target_scale);
 
   void _handle_replanner(double start_state_time);
+  static const char * _zone_to_str(uint8_t zone);
 
   // Temporary functions to be moved into collision checker
   double _back_track_last_collision();
@@ -538,6 +585,7 @@ private:
   realtime_tools::RealtimeBuffer<CurrentState> current_state_cache_;
   realtime_tools::RealtimeBuffer<double> current_time_cache_;
   realtime_tools::RealtimeBuffer<double> scale_cache_;
+  ZoneDecisionPolicy zone_decision_policy_{option_.zone_policy};
   // realtime_tools::RealtimeBuffer<octomap::OcTree> env_state_cache_;
 };
 
@@ -606,6 +654,7 @@ void DynamicSafety::Impl::configure_common(const NodePtrT & node)
   }
 
   benchmark_stats.clear();
+  zone_decision_policy_.reset();
 
   // Reset Cache
   env_state_cache_.initRT(sensor_msgs::msg::JointState());
@@ -688,6 +737,7 @@ void DynamicSafety::Impl::add_trajectory(
     replanner_.add_trajectory(rt);
   }
   activated_ = true;
+  zone_decision_policy_.reset();
 }
 
 
@@ -865,94 +915,68 @@ void DynamicSafety::Impl::_main_loop()
     }
   }
 
-  // Collision Happens in the future
-  if (collision_time_point_ >= current_time_point) {
-    double scale_step = 0;
-    if (option_.safety_zone_options.slow_down_time <= 0 && option_.dynamic_parameterization) {
-      // Dynamically adjust slow down time
-      double slow_down_time =
-        _cal_scale_time(*current_state_cache_.readFromRT(), scale, 0.0001);
+  const bool collision_detected = collision_time_point_ >= current_time_point;
+  const uint8_t raw_zone = collision_detected ?
+    safety_zone_.get_zone(collision_time_point_ - current_time_point) : SafetyZone::SAFE;
+  const auto replanner_status = option_.allow_replan ? replanner_.get_status() : ReplannerStatus::IDLE;
+  const ZoneDecision decision = zone_decision_policy_.decide(
+    ZoneDecisionInput{
+      *current_time_cache_.readFromRT(),
+      1.0 / option_.rate,
+      current_time_point,
+      full_duration_,
+      collision_time_point_,
+      raw_zone,
+      collision_detected,
+      option_.allow_replan,
+      scale,
+      safety_zone_.get_zone_limit(SafetyZone::EMERGENCY),
+      safety_zone_.get_zone_limit(SafetyZone::SLOWDOWN),
+      replanner_status
+    });
 
-      scale_step = (scale - 0.0001) * (1.0 / option_.rate) / slow_down_time;
-      scale_step = 2 * option_.rate;
-    } else {
-      // Static Scale step
-      scale_step = 1 * (1.0 / option_.rate) / option_.safety_zone_options.slow_down_time;
-    }
-    uint8_t zone = safety_zone_.get_zone(collision_time_point_ - current_time_point);
+  if (decision.zone != raw_zone || decision.action != "none" ||
+    std::fabs(decision.next_scale - scale) > 1e-6)
+  {
+    RCLCPP_INFO_STREAM(
+      LOGGER,
+      "zone_transition raw=" << _zone_to_str(raw_zone) <<
+        " effective=" << _zone_to_str(decision.zone) <<
+        " action=" << decision.action <<
+        " start_state_time=" << decision.start_state_time <<
+        " collision_time=" << collision_time_point_ <<
+        " scale:" << scale << "->" << decision.next_scale);
+  }
 
-    if (!option_.allow_replan) {
-      // No replanning
-      if (zone <= SafetyZone::EMERGENCY) {
-        // Emergency stop
-        RCLCPP_ERROR_ONCE(
-          LOGGER,
-          "Emergency stop!!");
-        scale = 0.0001;
-      } else {
-        // Slow down
-        RCLCPP_WARN_ONCE(
-          LOGGER,
-          "Slowing down!!");
-        scale -= scale_step;
-        scale = std::max<double>(scale, 0.0001);
-      }
-    } else {
-      // Replanning
-      double current_time = *current_time_cache_.readFromRT();
-      if (zone <= SafetyZone::EMERGENCY) {
-        // Emergency stop
-        RCLCPP_ERROR_ONCE(
-          LOGGER,
-          "Emergency stop!!");
-        scale = 0.0001;
-      } else if (zone == SafetyZone::SLOWDOWN) {
-        // TODO(anyone): Better Heuristic
-        scale -= scale_step;
-        double start_state_time =
-          (current_time + safety_zone_.get_zone_limit(SafetyZone::EMERGENCY) +
-          collision_time_point_) / 2;
-        _handle_replanner(start_state_time);
-      } else if (zone == SafetyZone::REPLAN) {
-        double start_state_time =
-          (current_time + safety_zone_.get_zone_limit(SafetyZone::SLOWDOWN) +
-          collision_time_point_) / 2;
-        _handle_replanner(start_state_time);
-      } else if (zone == SafetyZone::SAFE) {
-        auto status = replanner_.get_status();
-        if (status == ReplannerStatus::IDLE) {
-          // Replanner Starte
-          // Nothing to do here
-        } else if (status == ReplannerStatus::ONGOING) {
-          replanner_.terminate_async();
-        } else if (status == ReplannerStatus::TIMEOUT) {
-          replanner_.terminate_async();
-        } else if (status == ReplannerStatus::SUCCEED) {
-          // stop it regularly
-          replanner_.get_result();
-        }
-      }
+  scale = decision.next_scale;
+  if (option_.allow_replan) {
+    if (decision.start_replanner) {
+      _handle_replanner(decision.start_state_time);
     }
-  } else {
-    // No Collision
-    if (scale < 1.0) {
-      // Gradually rescale back to 1
-      double scale_time;
-      if (option_.safety_zone_options.slow_down_time <= 0 && option_.dynamic_parameterization) {
-        scale_time = _cal_scale_time(*current_state_cache_.readFromRT(), scale, 1.0);
-        scale += (1.0 - scale) * (1.0 / option_.rate) / scale_time;
-      } else {
-        scale_time = option_.safety_zone_options.slow_down_time;
-        scale += 1.0 * (1.0 / option_.rate) / scale_time;
-      }
-      scale = std::min<double>(scale, 1);
-      RCLCPP_WARN_ONCE(LOGGER, "Speeding up");
+    if (decision.terminate_replanner) {
+      replanner_.terminate_async();
+    }
+    if (decision.consume_replan_result) {
+      replanner_.get_result();
     }
   }
+
   scale_cache_.writeFromNonRT(scale);
 
   if (option_.visualize) {
     visualizer_.update(current_time_point, collision_time_point_);
+  }
+}
+
+const char * DynamicSafety::Impl::_zone_to_str(uint8_t zone)
+{
+  switch (zone) {
+    case SafetyZone::BLIND: return "BLIND";
+    case SafetyZone::EMERGENCY: return "EMERGENCY";
+    case SafetyZone::SLOWDOWN: return "SLOWDOWN";
+    case SafetyZone::REPLAN: return "REPLAN";
+    case SafetyZone::SAFE: return "SAFE";
+    default: return "UNKNOWN";
   }
 }
 
@@ -1001,6 +1025,7 @@ double DynamicSafety::Impl::_cal_scale_time(
 
 void DynamicSafety::Impl::_handle_replanner(double start_state_time)
 {
+  start_state_time = std::clamp(start_state_time, *current_time_cache_.readFromRT(), full_duration_);
   // Replanner not started
   auto status = replanner_.get_status();
   if (status == ReplannerStatus::IDLE) {

--- a/easy_manipulation_deployment/emd_dynamic_safety/test/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_dynamic_safety/test/CMakeLists.txt
@@ -45,3 +45,10 @@ target_link_libraries(test_replanner_tesseract
   test_hardware
   ${PROJECT_NAME}
 )
+
+ament_add_gtest(test_zone_decision_policy
+  test_zone_decision_policy.cpp
+)
+target_link_libraries(test_zone_decision_policy
+  ${PROJECT_NAME}
+)

--- a/easy_manipulation_deployment/emd_dynamic_safety/test/test_zone_decision_policy.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/test/test_zone_decision_policy.cpp
@@ -1,0 +1,97 @@
+#include <gtest/gtest.h>
+
+#include "emd/dynamic_safety/zone_decision_policy.hpp"
+
+using dynamic_safety::ReplannerStatus;
+using dynamic_safety::SafetyZone;
+using dynamic_safety::ZoneDecisionInput;
+using dynamic_safety::ZoneDecisionPolicy;
+using dynamic_safety::ZonePolicyParameters;
+
+TEST(ZoneDecisionPolicy, NoisyCollisionStreamDoesNotFlapReplanner)
+{
+  ZonePolicyParameters params;
+  params.min_replan_interval = 0.25;
+  params.collision_persistence_window = 0.2;
+  params.replan_start_time_epsilon = 0.05;
+  ZoneDecisionPolicy policy(params);
+
+  int start_calls = 0;
+  int terminate_calls = 0;
+  ReplannerStatus status = ReplannerStatus::IDLE;
+
+  double now = 0.0;
+  for (int i = 0; i < 80; ++i) {
+    now += 0.05;
+    const bool noisy_collision = (i % 3 != 0);
+    const uint8_t zone = noisy_collision ? SafetyZone::REPLAN : SafetyZone::SAFE;
+
+    const auto decision = policy.decide(ZoneDecisionInput{
+      now,
+      0.05,
+      2.0,
+      6.0,
+      noisy_collision ? 2.5 : -1.0,
+      zone,
+      noisy_collision,
+      true,
+      1.0,
+      0.5,
+      1.0,
+      status
+    });
+
+    if (decision.start_replanner) {
+      ++start_calls;
+      status = ReplannerStatus::ONGOING;
+    }
+    if (decision.terminate_replanner) {
+      ++terminate_calls;
+      status = ReplannerStatus::IDLE;
+    }
+  }
+
+  EXPECT_LE(start_calls, 2);
+  EXPECT_LE(terminate_calls, 1);
+}
+
+TEST(ZoneDecisionPolicy, ReplanStartTimeIsClampedAndDeduplicated)
+{
+  ZonePolicyParameters params;
+  params.min_replan_interval = 0.3;
+  params.replan_start_time_epsilon = 0.1;
+  ZoneDecisionPolicy policy(params);
+
+  const auto d1 = policy.decide(ZoneDecisionInput{
+    1.0,
+    0.1,
+    4.8,
+    5.0,
+    5.5,
+    SafetyZone::REPLAN,
+    true,
+    true,
+    1.0,
+    0.4,
+    1.0,
+    ReplannerStatus::IDLE
+  });
+  EXPECT_TRUE(d1.start_replanner);
+  EXPECT_LE(d1.start_state_time, 5.0);
+
+  const auto d2 = policy.decide(ZoneDecisionInput{
+    1.05,
+    0.05,
+    4.8,
+    5.0,
+    5.45,
+    SafetyZone::REPLAN,
+    true,
+    true,
+    1.0,
+    0.4,
+    1.0,
+    ReplannerStatus::IDLE
+  });
+  EXPECT_FALSE(d2.start_replanner);
+}


### PR DESCRIPTION
### Motivation
- Centralize and harden SAFE/REPLAN/SLOWDOWN/EMERGENCY handling into a single decision module to reduce flapping and make behavior configurable.
- Expose explicit policy parameters (replan interval, per-zone hysteresis, scale floor/ceiling and ramp rates, collision persistence window, replanner start dedup epsilon) for easier tuning and postmortem analysis.
- Prevent repeated near-identical replanner invocations by caching prior zone/state and clamping replanner start times to valid trajectory windows.

### Description
- Added a new decision module `ZoneDecisionPolicy` in `include/emd/dynamic_safety/zone_decision_policy.hpp` that encapsulates policy parameters and a single `decide()` function which returns scale, zone, and replanner actions.
- Extended `Option` to carry `ZonePolicyParameters` and wired ROS parameter loading under `dynamic_safety.policy.*` in `Option::load` so policy fields are configurable at runtime.
- Integrated the policy into `DynamicSafety::Impl` by adding `zone_decision_policy_`, resetting it on `configure()` and `add_trajectory()`, and replacing the inline zone/action logic in `_main_loop()` with a call to `zone_decision_policy_.decide(...)` and application of its `ZoneDecision` (scale adjustment, start/terminate/consume replanner actions).
- Clamped `start_state_time` in `_handle_replanner()` to the valid trajectory window and added a structured info log in `_main_loop()` that records raw/effective zone, chosen action, start time, collision time, and scale change to support postmortem tracing.
- Added unit tests `test_zone_decision_policy.cpp` and registered the GTest target in the package test CMake; tests cover noisy collision streams (anti-flapping) and start-time clamping/deduplication.

### Testing
- Added two automated GTest cases: `NoisyCollisionStreamDoesNotFlapReplanner` and `ReplanStartTimeIsClampedAndDeduplicated` (registered as `test_zone_decision_policy`).
- Attempted to run the package tests with `colcon test --packages-select emd_dynamic_safety --ctest-args -R test_zone_decision_policy`, but `colcon` is not available in the execution environment so tests were not executed here (command failed).
- No other automated test runs were performed in this environment; the new tests are included and ready to run in a CI or a developer environment with `colcon`/ROS build tools available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2e84aa3c83318a2c9e366e3bd81d)