### PR TITLE
Guarded replanner lifecycle, retries, and safety metrics

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/replanner_common.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/replanner_common.hpp
@@ -69,9 +69,12 @@ namespace ReplannerStatus
 {
 static const uint8_t
   IDLE = 0,
-  ONGOING = 1,
+  RUNNING = 1,
+  ONGOING = RUNNING,  // backwards compatible alias
   SUCCEED = 2,
-  TIMEOUT = 3;    // Not used at the moment
+  TIMEOUT = 3,
+  FAILED = 4,
+  TERMINATING = 5;
 }  // ReplannerStatus
 
 /// Collision checking context to-be-inherited.

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
@@ -24,6 +24,8 @@
 #include <vector>
 #include <stdexcept>
 #include <sstream>
+#include <limits>
+#include <cstdint>
 
 #include "emd/dynamic_safety/dynamic_safety.hpp"
 #include <rclcpp/parameter_client.hpp>
@@ -586,6 +588,20 @@ private:
   realtime_tools::RealtimeBuffer<double> current_time_cache_;
   realtime_tools::RealtimeBuffer<double> scale_cache_;
   ZoneDecisionPolicy zone_decision_policy_{option_.zone_policy};
+  std::atomic<uint64_t> timeout_count_{0};
+  std::atomic<uint64_t> terminate_count_{0};
+  std::atomic<uint64_t> retry_count_{0};
+  std::atomic<uint64_t> success_after_retry_count_{0};
+  size_t max_retries_per_window_{3};
+  double retry_cooldown_s_{0.5};
+  size_t retries_in_window_{0};
+  double last_retry_time_{-std::numeric_limits<double>::infinity()};
+  bool retry_pending_{false};
+  double pending_retry_start_state_time_{0.0};
+  bool timeout_episode_active_{false};
+  bool terminate_requested_for_timeout_episode_{false};
+  bool last_attempt_was_retry_{false};
+  bool conservative_fallback_active_{false};
   // realtime_tools::RealtimeBuffer<octomap::OcTree> env_state_cache_;
 };
 
@@ -655,6 +671,17 @@ void DynamicSafety::Impl::configure_common(const NodePtrT & node)
 
   benchmark_stats.clear();
   zone_decision_policy_.reset();
+  timeout_count_ = 0;
+  terminate_count_ = 0;
+  retry_count_ = 0;
+  success_after_retry_count_ = 0;
+  retries_in_window_ = 0;
+  last_retry_time_ = -std::numeric_limits<double>::infinity();
+  retry_pending_ = false;
+  timeout_episode_active_ = false;
+  terminate_requested_for_timeout_episode_ = false;
+  last_attempt_was_retry_ = false;
+  conservative_fallback_active_ = false;
 
   // Reset Cache
   env_state_cache_.initRT(sensor_msgs::msg::JointState());
@@ -735,6 +762,13 @@ void DynamicSafety::Impl::add_trajectory(
   }
   if (option_.allow_replan) {
     replanner_.add_trajectory(rt);
+    retries_in_window_ = 0;
+    last_retry_time_ = -std::numeric_limits<double>::infinity();
+    retry_pending_ = false;
+    timeout_episode_active_ = false;
+    terminate_requested_for_timeout_episode_ = false;
+    last_attempt_was_retry_ = false;
+    conservative_fallback_active_ = false;
   }
   activated_ = true;
   zone_decision_policy_.reset();
@@ -829,6 +863,14 @@ void DynamicSafety::Impl::stop()
       delete pf_;
     }
   }
+  RCLCPP_INFO(
+    LOGGER,
+    "dynamic_safety_metrics timeout_count=%lu terminate_count=%lu retry_count=%lu "
+    "success_after_retry_count=%lu",
+    timeout_count_.load(),
+    terminate_count_.load(),
+    retry_count_.load(),
+    success_after_retry_count_.load());
   sig_.set_value();
 }
 
@@ -960,6 +1002,9 @@ void DynamicSafety::Impl::_main_loop()
       replanner_.get_result();
     }
   }
+  if (conservative_fallback_active_) {
+    scale = std::min(scale, 0.0001);
+  }
 
   scale_cache_.writeFromNonRT(scale);
 
@@ -1026,9 +1071,38 @@ double DynamicSafety::Impl::_cal_scale_time(
 void DynamicSafety::Impl::_handle_replanner(double start_state_time)
 {
   start_state_time = std::clamp(start_state_time, *current_time_cache_.readFromRT(), full_duration_);
+  const double now = *current_time_cache_.readFromRT();
+  auto maybe_retry = [&](double restart_time) {
+      if (retries_in_window_ >= max_retries_per_window_) {
+        return false;
+      }
+      if (now - last_retry_time_ < retry_cooldown_s_) {
+        return false;
+      }
+      double end_state_time = _back_track_last_collision();
+      replanner_.run_async(restart_time, end_state_time);
+      retries_in_window_++;
+      retry_count_++;
+      last_retry_time_ = now;
+      last_attempt_was_retry_ = true;
+      retry_pending_ = false;
+      conservative_fallback_active_ = false;
+      RCLCPP_WARN(
+        LOGGER, "Retrying replanner (%zu/%zu)", retries_in_window_, max_retries_per_window_);
+      return true;
+    };
   // Replanner not started
   auto status = replanner_.get_status();
   if (status == ReplannerStatus::IDLE) {
+    if (retry_pending_) {
+      if (!maybe_retry(pending_retry_start_state_time_)) {
+        RCLCPP_ERROR(
+          LOGGER,
+          "Retry budget exhausted or cooldown active; entering conservative emergency behavior");
+        conservative_fallback_active_ = true;
+      }
+      return;
+    }
     // Replanner Started
     RCLCPP_WARN_ONCE(
       LOGGER,
@@ -1036,24 +1110,40 @@ void DynamicSafety::Impl::_handle_replanner(double start_state_time)
       option_.replanner_options.planner.c_str());
     double end_state_time = _back_track_last_collision();
     replanner_.run_async(start_state_time, end_state_time);
+    last_attempt_was_retry_ = false;
 
-  } else if (status == ReplannerStatus::ONGOING) {
+  } else if (status == ReplannerStatus::RUNNING) {
     // Just let it run baby.
     // TODO(anyone): Better handling?
   } else if (status == ReplannerStatus::TIMEOUT) {
-    // TODO(anyone): Better termination handling?
-    // There is probably nothing we can do here.
-    // async_terminate() function trigger a detached termination thread
-    // to quietly shut down the process.
-    // Once that is done status would become idle;
-    replanner_.terminate_async();
+    if (!timeout_episode_active_) {
+      timeout_episode_active_ = true;
+      timeout_count_++;
+    }
+    if (!terminate_requested_for_timeout_episode_) {
+      replanner_.terminate_async();
+      terminate_count_++;
+      terminate_requested_for_timeout_episode_ = true;
+      retry_pending_ = true;
+      pending_retry_start_state_time_ = start_state_time;
+    }
+  } else if (status == ReplannerStatus::TERMINATING) {
+    // Wait until replanner reaches IDLE after termination.
+  } else if (status == ReplannerStatus::FAILED) {
+    retry_pending_ = true;
+    pending_retry_start_state_time_ = start_state_time;
   } else if (status == ReplannerStatus::SUCCEED) {
     // Let's see if you really finished, or just failed and gaveup
     auto result = replanner_.get_result();
     if (result->points.empty()) {
-      // Gosh you failure, let's restart
-      double end_state_time = _back_track_last_collision();
-      replanner_.run_async(start_state_time, end_state_time);
+      retry_pending_ = true;
+      pending_retry_start_state_time_ = start_state_time;
+      if (!maybe_retry(start_state_time)) {
+        RCLCPP_ERROR(
+          LOGGER,
+          "Retry budget exhausted or cooldown active; entering conservative emergency behavior");
+        conservative_fallback_active_ = true;
+      }
     } else {
       // Good job replanner, let's add a starting point and
       // do time_parameterization.
@@ -1064,6 +1154,14 @@ void DynamicSafety::Impl::_handle_replanner(double start_state_time)
       auto new_traj = replanner_.flatten_result(current_time, joint_names, current_state);
       if (!new_traj->points.empty()) {
         NewTrajectoryCB(new_traj);
+        if (last_attempt_was_retry_) {
+          success_after_retry_count_++;
+          last_attempt_was_retry_ = false;
+        }
+        timeout_episode_active_ = false;
+        terminate_requested_for_timeout_episode_ = false;
+        retry_pending_ = false;
+        conservative_fallback_active_ = false;
       }
     }
   }

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/replanner.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/replanner.cpp
@@ -20,6 +20,9 @@
 #include <vector>
 #include <future>
 #include <chrono>
+#include <atomic>
+#include <mutex>
+#include <exception>
 
 #include "emd/dynamic_safety/replanner.hpp"
 #include "emd/interpolate.hpp"
@@ -40,6 +43,16 @@ class Replanner::Impl
 public:
   Impl() = default;
   virtual ~Impl() = default;
+
+  enum class LifecycleState : uint8_t
+  {
+    IDLE = ReplannerStatus::IDLE,
+    RUNNING = ReplannerStatus::RUNNING,
+    SUCCEEDED = ReplannerStatus::SUCCEED,
+    FAILED = ReplannerStatus::FAILED,
+    TIMED_OUT = ReplannerStatus::TIMEOUT,
+    TERMINATING = ReplannerStatus::TERMINATING
+  };
 
   void configure(
     const ReplannerOption & option,
@@ -66,6 +79,11 @@ public:
     const trajectory_msgs::msg::JointTrajectoryPoint & start_point,
     const trajectory_msgs::msg::JointTrajectoryPoint & end_point)
   {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    cleanup_terminate_future_locked();
+    termination_requested_for_episode_ = false;
+    future_owned_by_terminator_ = false;
+    lifecycle_state_.store(LifecycleState::RUNNING);
     start_time_ = std::chrono::steady_clock::now();
     plan_future_ = std::async(
       std::launch::async, &Impl::_run, this,
@@ -74,15 +92,18 @@ public:
 
   void terminate_async()
   {
-    if (!terminate_future_.valid()) {
-      _start_async_termination_thread();
-    } else {
-      auto status = terminate_future_.wait_for(std::chrono::nanoseconds(0));
-      if (status == std::future_status::ready) {
-        terminate_future_.get();
-        terminate_future_ = std::future<void>();
-      }
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    cleanup_terminate_future_locked();
+    const LifecycleState state = lifecycle_state_.load();
+    if ((state != LifecycleState::TIMED_OUT && state != LifecycleState::FAILED &&
+      state != LifecycleState::SUCCEEDED && state != LifecycleState::RUNNING) ||
+      termination_requested_for_episode_)
+    {
+      return;
     }
+    termination_requested_for_episode_ = true;
+    lifecycle_state_.store(LifecycleState::TERMINATING);
+    _start_async_termination_thread_locked();
   }
 
   void add_trajectory(
@@ -268,33 +289,63 @@ public:
 
   uint8_t get_status() const
   {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    if (lifecycle_state_.load() == LifecycleState::TERMINATING) {
+      return ReplannerStatus::TERMINATING;
+    }
     if (plan_future_.valid()) {
       auto status = plan_future_.wait_for(std::chrono::nanoseconds(0));
       double time_passed = std::chrono::duration<double, std::ratio<1>>(
         std::chrono::steady_clock::now() - start_time_).count();
       switch (status) {
         case std::future_status::deferred:
+          lifecycle_state_.store(LifecycleState::IDLE);
           return ReplannerStatus::IDLE;
         case std::future_status::ready:
+          if (lifecycle_state_.load() == LifecycleState::RUNNING) {
+            lifecycle_state_.store(LifecycleState::SUCCEEDED);
+          }
           return ReplannerStatus::SUCCEED;
         case std::future_status::timeout:
-          return (time_passed > deadline_) ? ReplannerStatus::TIMEOUT : ReplannerStatus::ONGOING;
+          if (time_passed > deadline_) {
+            lifecycle_state_.store(LifecycleState::TIMED_OUT);
+            return ReplannerStatus::TIMEOUT;
+          }
+          lifecycle_state_.store(LifecycleState::RUNNING);
+          return ReplannerStatus::RUNNING;
         default:
+          lifecycle_state_.store(LifecycleState::IDLE);
           return ReplannerStatus::IDLE;
       }
     } else {
+      lifecycle_state_.store(LifecycleState::IDLE);
       return ReplannerStatus::IDLE;
     }
   }
 
   trajectory_msgs::msg::JointTrajectory::SharedPtr get_result()
   {
-    if (!plan_future_.valid()) {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    if (!plan_future_.valid() || future_owned_by_terminator_) {
       return std::make_shared<trajectory_msgs::msg::JointTrajectory>();
     }
-    plan_ = plan_future_.get();
-    // Reset shared future
+    lifecycle_state_.store(LifecycleState::TERMINATING);
+    try {
+      plan_ = plan_future_.get();
+      lifecycle_state_.store(LifecycleState::SUCCEEDED);
+    } catch (const std::exception & e) {
+      RCLCPP_ERROR(LOGGER, "Replanner future failed: %s", e.what());
+      plan_ = trajectory_msgs::msg::JointTrajectory();
+      lifecycle_state_.store(LifecycleState::FAILED);
+    } catch (...) {
+      RCLCPP_ERROR(LOGGER, "Replanner future failed with unknown exception");
+      plan_ = trajectory_msgs::msg::JointTrajectory();
+      lifecycle_state_.store(LifecycleState::FAILED);
+    }
     plan_future_ = std::shared_future<trajectory_msgs::msg::JointTrajectory>();
+    future_owned_by_terminator_ = false;
+    termination_requested_for_episode_ = false;
+    lifecycle_state_.store(LifecycleState::IDLE);
     RCLCPP_INFO(
       LOGGER,
       "Total time take: %.5fs",
@@ -329,23 +380,53 @@ private:
 
   // Calling blocking get in a new async until it ended
   // This will result the future to invalid
-  void _start_async_termination_thread()
+  void _start_async_termination_thread_locked()
   {
+    if (!plan_future_.valid()) {
+      lifecycle_state_.store(LifecycleState::IDLE);
+      termination_requested_for_episode_ = false;
+      return;
+    }
+    future_owned_by_terminator_ = true;
+    auto plan_future = plan_future_;
+    plan_future_ = std::shared_future<trajectory_msgs::msg::JointTrajectory>();
     terminate_future_ = std::async(
-      [this]() -> void {
-        plan_future_.get();
+      [this, plan_future]() mutable -> void {
+        try {
+          plan_future.get();
+        } catch (...) {
+          // best effort termination
+        }
         RCLCPP_ERROR(
           LOGGER,
           "Unfortunately, Total time take: %.5fs",
           std::chrono::duration<double, std::ratio<1>>(
             std::chrono::steady_clock::now() - start_time_).count());
-        // Make it invalid;
-        plan_future_ = std::shared_future<trajectory_msgs::msg::JointTrajectory>();
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        future_owned_by_terminator_ = false;
+        termination_requested_for_episode_ = false;
+        lifecycle_state_.store(LifecycleState::IDLE);
       });
   }
+  void cleanup_terminate_future_locked()
+  {
+    if (!terminate_future_.valid()) {
+      return;
+    }
+    auto status = terminate_future_.wait_for(std::chrono::nanoseconds(0));
+    if (status == std::future_status::ready) {
+      terminate_future_.get();
+      terminate_future_ = std::future<void>();
+    }
+  }
+
   std::unique_ptr<ReplannerContext> context_;
   std::shared_future<trajectory_msgs::msg::JointTrajectory> plan_future_;
   std::future<void> terminate_future_;
+  mutable std::mutex state_mutex_;
+  std::atomic<LifecycleState> lifecycle_state_{LifecycleState::IDLE};
+  bool termination_requested_for_episode_{false};
+  bool future_owned_by_terminator_{false};
 
   // Specialized planning feature
   trajectory_msgs::msg::JointTrajectory reference_trajectory_;


### PR DESCRIPTION
### Motivation
- Introduce an explicit, observable replanner lifecycle and guard transitions to ensure `terminate_async()` and `get_result()` interactions are serialized and not called multiple times per timeout episode.
- Add a retry budget + cooldown and a conservative fallback so replanning failures/timeouts escalate to safe emergency slowdown instead of unbounded retries.
- Expose simple counters so operator/telemetry systems can monitor timeouts, terminations and retry behavior.

### Description
- Added new statuses to `ReplannerStatus` (`RUNNING`, `FAILED`, `TERMINATING`) while keeping `ONGOING` as an alias for backwards compatibility by changing `easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/replanner_common.hpp`.
- Reworked `Replanner::Impl` in `easy_manipulation_deployment/emd_dynamic_safety/src/replanner.cpp` to track an internal `LifecycleState`, protect transitions with a `std::mutex` and `std::atomic`, and introduce ownership flags so `terminate_async()` and `get_result()` do not consume the same future concurrently; termination is performed via a dedicated async terminator that is started at most once per episode.
- Implemented retry budget, cooldown and timeout-episode handling in `easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp`, including per-trajectory reset of retry state, guarded single `terminate_async()` per timeout episode, scheduling of guarded retries, and a conservative fallback that forces emergency-scale slowdown when retries are exhausted or blocked by cooldown.
- Added atomic metric counters (`timeout_count`, `terminate_count`, `retry_count`, `success_after_retry_count`) and log emission of these metrics on shutdown in `DynamicSafety::Impl::stop()`.

### Testing
- Ran `git diff --check` which reported no issues and passed.
- Attempted to run `colcon build --packages-select emd_dynamic_safety` but the tool is not available in this environment so compilation tests could not be executed here (build tooling missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2fdf55b4833188e87bdfb5f632b8)