### PR TITLE
Fix goal-time tolerance handling for scaled trajectories

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety_trajectory_controller.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/dynamic_safety_trajectory_controller.hpp
@@ -71,6 +71,8 @@ private:
   // Atomic vs realtime buffer?
   realtime_tools::RealtimeBuffer<double> scaling_factor_;
   realtime_tools::RealtimeBuffer<TimeData> time_data_;
+  rclcpp::Time execution_window_wall_start_{0, 0, RCL_ROS_TIME};
+  rclcpp::Time execution_window_effective_start_{0, 0, RCL_ROS_TIME};
 
   // Dynamic Safety
   DynamicSafety::UniquePtr safety_officer_;

--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/goal_time_tolerance_utils.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/goal_time_tolerance_utils.hpp
@@ -1,0 +1,28 @@
+#ifndef EMD__DYNAMIC_SAFETY__GOAL_TIME_TOLERANCE_UTILS_HPP_
+#define EMD__DYNAMIC_SAFETY__GOAL_TIME_TOLERANCE_UTILS_HPP_
+
+#include <algorithm>
+
+namespace dynamic_safety
+{
+namespace goal_time_tolerance
+{
+inline bool should_enforce_strict_tolerance(
+  const double current_scale,
+  const double minimum_scale_for_strict_checks)
+{
+  return current_scale >= minimum_scale_for_strict_checks;
+}
+
+inline double inflated_tolerance_from_average_scale(
+  const double base_tolerance,
+  const double average_scale,
+  const double minimum_average_scale)
+{
+  const double clamped_average_scale = std::max(average_scale, minimum_average_scale);
+  return base_tolerance / clamped_average_scale;
+}
+}  // namespace goal_time_tolerance
+}  // namespace dynamic_safety
+
+#endif  // EMD__DYNAMIC_SAFETY__GOAL_TIME_TOLERANCE_UTILS_HPP_

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety_trajectory_controller.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety_trajectory_controller.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "emd/dynamic_safety/dynamic_safety_trajectory_controller.hpp"
+#include "emd/dynamic_safety/goal_time_tolerance_utils.hpp"
 #include "rclcpp_action/create_server.hpp"
 #include "rclcpp_action/server_goal_handle.hpp"
 #include <rclcpp/node.hpp>
@@ -28,6 +29,9 @@ namespace dynamic_safety
 {
 namespace
 {
+constexpr double kStrictGoalToleranceMinScale = 0.05;
+constexpr double kMinimumAverageScale = 1e-3;
+
 static bool check_state_tolerance_per_joint(
   const trajectory_msgs::msg::JointTrajectoryPoint & error,
   size_t index,
@@ -138,6 +142,8 @@ DynamicSafetyTrajectoryController::on_activate(const rclcpp_lifecycle::State & s
   time_data.uptime = node->now();
   this->time_data_.initRT(time_data);
   scaling_factor_.initRT(1.0);
+  execution_window_wall_start_ = time_data.time;
+  execution_window_effective_start_ = time_data.uptime;
   return JointTrajectoryController::on_activate(state);
 }
 
@@ -248,6 +254,8 @@ controller_interface::return_type DynamicSafetyTrajectoryController::update(
     // if sampling the first time, set the point before you sample
     if (!this->traj_external_point_ptr_->is_sampled_already()) {
       this->traj_external_point_ptr_->set_point_before_trajectory_msg(traj_time, state_current);
+      execution_window_wall_start_ = time_data.time;
+      execution_window_effective_start_ = traj_time;
       safety_officer_->start();
     }
     double current_time =
@@ -340,23 +348,40 @@ controller_interface::return_type DynamicSafetyTrajectoryController::update(
 
             RCLCPP_INFO(node->get_logger(), "Goal reached, success!");
           } else if (this->default_tolerances_.goal_time_tolerance != 0.0) {
-            // if we exceed goal_time_toleralance set it to aborted
+            // if we exceed goal_time_tolerance set it to aborted
             const rclcpp::Time traj_start =
               this->traj_external_point_ptr_->time_from_start();
             const rclcpp::Time traj_end = traj_start + start_segment_itr->time_from_start;
-
-            // TODO(anyone): This will break in speed scaling we have to discuss
-            // how to handle the goal time when the robot scales itself down.
-            const double difference = node->now().seconds() - traj_end.seconds();
-            if (difference > this->default_tolerances_.goal_time_tolerance) {
+            const double difference = (traj_time - traj_end).seconds();
+            const bool enforce_strict_tolerance =
+              goal_time_tolerance::should_enforce_strict_tolerance(
+              *scaling_factor_.readFromRT(), kStrictGoalToleranceMinScale);
+            const double elapsed_wall = (time_data.time - execution_window_wall_start_).seconds();
+            const double elapsed_effective =
+              (traj_time - execution_window_effective_start_).seconds();
+            const double average_scale =
+              elapsed_wall > 0.0 ? elapsed_effective / elapsed_wall : *scaling_factor_.readFromRT();
+            const double adjusted_goal_time_tolerance =
+              goal_time_tolerance::inflated_tolerance_from_average_scale(
+              this->default_tolerances_.goal_time_tolerance, average_scale,
+              kMinimumAverageScale);
+            if (enforce_strict_tolerance && difference > adjusted_goal_time_tolerance) {
               auto result = std::make_shared<FollowJTrajAction::Result>();
               result->set__error_code(FollowJTrajAction::Result::GOAL_TOLERANCE_VIOLATED);
               safety_officer_->stop();
               active_goal->setAborted(result);
               this->rt_active_goal_.writeFromNonRT(RealtimeGoalHandlePtr());
               RCLCPP_WARN(
-                node->get_logger(), "Aborted due goal_time_tolerance exceeding by %f seconds",
-                difference);
+                node->get_logger(),
+                "Aborted due goal_time_tolerance exceeding by %f seconds (allowed %f, "
+                "avg_scale %f, strict_scale %f)",
+                difference, adjusted_goal_time_tolerance, average_scale,
+                *scaling_factor_.readFromRT());
+            } else if (!enforce_strict_tolerance) {
+              RCLCPP_DEBUG(
+                node->get_logger(),
+                "Skipping strict goal_time_tolerance check at low scale (%f < %f).",
+                *scaling_factor_.readFromRT(), kStrictGoalToleranceMinScale);
             }
           }
         }

--- a/easy_manipulation_deployment/emd_dynamic_safety/test/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_dynamic_safety/test/CMakeLists.txt
@@ -52,3 +52,10 @@ ament_add_gtest(test_zone_decision_policy
 target_link_libraries(test_zone_decision_policy
   ${PROJECT_NAME}
 )
+
+ament_add_gtest(test_goal_time_tolerance_utils
+  test_goal_time_tolerance_utils.cpp
+)
+target_link_libraries(test_goal_time_tolerance_utils
+  ${PROJECT_NAME}
+)

--- a/easy_manipulation_deployment/emd_dynamic_safety/test/test_goal_time_tolerance_utils.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/test/test_goal_time_tolerance_utils.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+
+#include "emd/dynamic_safety/goal_time_tolerance_utils.hpp"
+
+TEST(GoalTimeToleranceUtils, EnforceStrictToleranceAtNominalScale)
+{
+  EXPECT_TRUE(dynamic_safety::goal_time_tolerance::should_enforce_strict_tolerance(1.0, 0.05));
+}
+
+TEST(GoalTimeToleranceUtils, DisableStrictToleranceAtLowScale)
+{
+  EXPECT_FALSE(dynamic_safety::goal_time_tolerance::should_enforce_strict_tolerance(0.01, 0.05));
+}
+
+TEST(GoalTimeToleranceUtils, KeepToleranceAtScaleOne)
+{
+  constexpr double base_tolerance = 0.2;
+  const double inflated = dynamic_safety::goal_time_tolerance::inflated_tolerance_from_average_scale(
+    base_tolerance, 1.0, 1e-3);
+  EXPECT_DOUBLE_EQ(inflated, base_tolerance);
+}
+
+TEST(GoalTimeToleranceUtils, InflateToleranceAtHalfScale)
+{
+  constexpr double base_tolerance = 0.2;
+  const double inflated = dynamic_safety::goal_time_tolerance::inflated_tolerance_from_average_scale(
+    base_tolerance, 0.5, 1e-3);
+  EXPECT_DOUBLE_EQ(inflated, 0.4);
+}
+
+TEST(GoalTimeToleranceUtils, InflateToleranceWithVaryingScaleProfile)
+{
+  constexpr double base_tolerance = 0.2;
+  constexpr double elapsed_wall = 8.0;
+  constexpr double elapsed_effective = 6.0;  // average scale = 0.75
+  const double average_scale = elapsed_effective / elapsed_wall;
+  const double inflated = dynamic_safety::goal_time_tolerance::inflated_tolerance_from_average_scale(
+    base_tolerance, average_scale, 1e-3);
+  EXPECT_NEAR(inflated, 0.2666666667, 1e-9);
+}


### PR DESCRIPTION
### Motivation
- Goal-time tolerance was previously computed against unscaled wall-clock time which yields false `GOAL_TOLERANCE_VIOLATED` results when trajectory execution is speed-scaled. 
- The controller already integrates a scaled `period` into an effective trajectory time (`time_data.uptime`), so tolerance checks should compare against that effective time.

### Description
- Change the goal-time `difference` computation to use the scaled/effective trajectory time (`traj_time` / integrated `time_data.uptime`) instead of `node->now()` so checks follow scaled progress.
- Track execution window start timestamps (`execution_window_wall_start_` and `execution_window_effective_start_`) at activation and when the first sample of a trajectory is taken to compute average scale over the execution window.
- Add guardrails to goal-time checks by disabling strict checks when instantaneous `scale` is below a configurable threshold and by inflating the allowed `goal_time_tolerance` using the inverse average scale over the execution window when appropriate.
- Introduce `goal_time_tolerance_utils.hpp` with helpers `should_enforce_strict_tolerance` and `inflated_tolerance_from_average_scale`, and add `test_goal_time_tolerance_utils` unit tests exercising scale = 1.0, scale = 0.5 and a varying-scale profile.

### Testing
- Added unit tests in `easy_manipulation_deployment/emd_dynamic_safety/test/test_goal_time_tolerance_utils.cpp` covering nominal, low-scale, half-scale, and varying-scale inflation scenarios as a `gtest` (`test_goal_time_tolerance_utils`).
- Attempted to run the tests with `colcon test --packages-select emd_dynamic_safety --ctest-args -R test_goal_time_tolerance_utils` but the execution environment does not have `colcon` installed so automated tests were not executed here (`/bin/bash: colcon: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da31b812d4833197f1a149d01b609c)