### PR TITLE
Include current state in flatten_result, add reorder/validation utilities and tests

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/replanner_flatten_utils.hpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/include/emd/dynamic_safety/replanner_flatten_utils.hpp
@@ -1,0 +1,121 @@
+// Copyright 2021 ROS Industrial Consortium Asia Pacific
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EMD__DYNAMIC_SAFETY__REPLANNER_FLATTEN_UTILS_HPP_
+#define EMD__DYNAMIC_SAFETY__REPLANNER_FLATTEN_UTILS_HPP_
+
+#include <algorithm>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "trajectory_msgs/msg/joint_trajectory_point.hpp"
+
+namespace dynamic_safety
+{
+
+inline bool have_same_joint_names(
+  const std::vector<std::string> & expected,
+  const std::vector<std::string> & actual)
+{
+  if (expected.size() != actual.size()) {
+    return false;
+  }
+  std::unordered_map<std::string, size_t> histogram;
+  for (const auto & name : expected) {
+    histogram[name]++;
+  }
+  for (const auto & name : actual) {
+    auto it = histogram.find(name);
+    if (it == histogram.end() || it->second == 0) {
+      return false;
+    }
+    it->second--;
+  }
+  return std::all_of(
+    histogram.begin(), histogram.end(), [](const auto & item) {return item.second == 0;});
+}
+
+inline bool reorder_joint(
+  const std::vector<std::string> & reference_joint_order,
+  std::vector<std::string> & current_joint_order,
+  trajectory_msgs::msg::JointTrajectoryPoint & state)
+{
+  if (!have_same_joint_names(reference_joint_order, current_joint_order)) {
+    return false;
+  }
+
+  std::unordered_map<std::string, size_t> ref_joint_idx_map;
+  std::vector<size_t> joint_permutation;
+  ref_joint_idx_map.reserve(reference_joint_order.size());
+  joint_permutation.reserve(current_joint_order.size());
+  for (size_t i = 0; i < reference_joint_order.size(); i++) {
+    ref_joint_idx_map[reference_joint_order[i]] = i;
+  }
+  for (const auto & joint_name : current_joint_order) {
+    joint_permutation.push_back(ref_joint_idx_map[joint_name]);
+  }
+
+  for (size_t i = 0; i < current_joint_order.size(); i++) {
+    while (joint_permutation[i] != i) {
+      std::swap(current_joint_order[joint_permutation[i]], current_joint_order[i]);
+      if (!state.positions.empty()) {
+        std::swap(state.positions[joint_permutation[i]], state.positions[i]);
+      }
+      if (!state.velocities.empty()) {
+        std::swap(state.velocities[joint_permutation[i]], state.velocities[i]);
+      }
+      if (!state.accelerations.empty()) {
+        std::swap(state.accelerations[joint_permutation[i]], state.accelerations[i]);
+      }
+      std::swap(joint_permutation[joint_permutation[i]], joint_permutation[i]);
+    }
+  }
+
+  return true;
+}
+
+inline void set_start_kinematics(
+  trajectory_msgs::msg::JointTrajectoryPoint & start,
+  const trajectory_msgs::msg::JointTrajectoryPoint & current)
+{
+  if (!current.velocities.empty() && current.velocities.size() == start.positions.size()) {
+    start.velocities = current.velocities;
+  }
+  if (!current.accelerations.empty() && current.accelerations.size() == start.positions.size()) {
+    start.accelerations = current.accelerations;
+  }
+}
+
+inline bool has_monotonic_timestamps(
+  const std::vector<trajectory_msgs::msg::JointTrajectoryPoint> & points)
+{
+  if (points.empty()) {
+    return false;
+  }
+  double prev = -1.0;
+  for (const auto & p : points) {
+    const double t = rclcpp::Duration(p.time_from_start).seconds();
+    if (t < prev) {
+      return false;
+    }
+    prev = t;
+  }
+  return true;
+}
+
+}  // namespace dynamic_safety
+
+#endif  // EMD__DYNAMIC_SAFETY__REPLANNER_FLATTEN_UTILS_HPP_

--- a/easy_manipulation_deployment/emd_dynamic_safety/src/replanner.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/replanner.cpp
@@ -25,6 +25,7 @@
 #include <exception>
 
 #include "emd/dynamic_safety/replanner.hpp"
+#include "emd/dynamic_safety/replanner_flatten_utils.hpp"
 #include "emd/interpolate.hpp"
 #ifdef EMD_DYNAMIC_SAFETY_MOVEIT
 #include "emd/dynamic_safety/replanner_moveit.hpp"
@@ -182,82 +183,52 @@ public:
   trajectory_msgs::msg::JointTrajectory::SharedPtr flatten_result(
     double current_time,
     const std::vector<std::string> & joint_names,
-    const trajectory_msgs::msg::JointTrajectoryPoint & /*current_state*/)
+    const trajectory_msgs::msg::JointTrajectoryPoint & current_state)
   {
-    // Sort current state to plan joint_names
-    // gather current name ordering of plan joint name
-    // O(n^2) vs O(n) -> current algo
-    auto reorder_joint = [](
-      const std::vector<std::string> & reference_joint_order,
-      std::vector<std::string> & current_joint_order,
-      trajectory_msgs::msg::JointTrajectoryPoint & state) {
-        std::unordered_map<std::string, size_t> ref_joint_idx_map;
-        std::vector<size_t> joint_permutation;
-        for (size_t i = 0; i < reference_joint_order.size(); i++) {
-          ref_joint_idx_map[reference_joint_order[i]] = i;
-        }
-        // check the order that joint names is in
-        for (auto & joint_name : current_joint_order) {
-          joint_permutation.push_back(ref_joint_idx_map[joint_name]);
-        }
-        // Apply permutation order
-        for (size_t i = 0; i < current_joint_order.size(); i++) {
-          while (joint_permutation[i] != i) {
-            std::swap(current_joint_order[joint_permutation[i]], current_joint_order[i]);
-            if (!state.positions.empty()) {
-              std::swap(
-                state.positions[joint_permutation[i]],
-                state.positions[i]);
-            }
-            if (!state.velocities.empty()) {
-              std::swap(
-                state.velocities[joint_permutation[i]],
-                state.velocities[i]);
-            }
-            if (!state.accelerations.empty()) {
-              std::swap(
-                state.accelerations[joint_permutation[i]],
-                state.accelerations[i]);
-            }
-            std::swap(joint_permutation[joint_permutation[i]], joint_permutation[i]);
-          }
-        }
-      };
+    if (!have_same_joint_names(plan_.joint_names, joint_names)) {
+      RCLCPP_ERROR(LOGGER, "flatten_result joint name mismatch against plan joint names");
+      return std::make_shared<trajectory_msgs::msg::JointTrajectory>();
+    }
+
     size_t i = 0;
     size_t num_points = reference_trajectory_.points.size();
     std::vector<trajectory_msgs::msg::JointTrajectoryPoint> start_segment;
     std::vector<std::string> sorted_joint_names = joint_names;
-
-    // TODO(Briancbn): add current state
-    /*
     trajectory_msgs::msg::JointTrajectoryPoint sorted_current_states = current_state;
-    if (plan_.joint_names != joint_names) {
-      reorder_joint(plan_.joint_names, sorted_joint_names, sorted_current_states);
+    if (plan_.joint_names != joint_names &&
+      !reorder_joint(plan_.joint_names, sorted_joint_names, sorted_current_states))
+    {
+      RCLCPP_ERROR(LOGGER, "Failed to reorder current state to plan joint order");
+      return std::make_shared<trajectory_msgs::msg::JointTrajectory>();
     }
-    */
+
     if (current_time < start_state_time_) {
       for (; i < num_points; i++) {
         double time_from_start =
           rclcpp::Duration(reference_trajectory_.points[i].time_from_start).seconds();
         if (current_time <= time_from_start && start_state_time_ > time_from_start) {
           if (reference_trajectory_.joint_names != plan_.joint_names) {
-            // Re-order joint if necessary
             std::vector<std::string> sorted_ref_joint_names = reference_trajectory_.joint_names;
             trajectory_msgs::msg::JointTrajectoryPoint sorted_point =
               reference_trajectory_.points[i];
-            reorder_joint(plan_.joint_names, sorted_ref_joint_names, sorted_point);
+            if (!reorder_joint(plan_.joint_names, sorted_ref_joint_names, sorted_point)) {
+              RCLCPP_ERROR(LOGGER, "Failed to reorder start segment point to plan joint order");
+              return std::make_shared<trajectory_msgs::msg::JointTrajectory>();
+            }
             start_segment.push_back(sorted_point);
           } else {
             start_segment.push_back(reference_trajectory_.points[i]);
           }
-          // Clear time
           start_segment.back().time_from_start = rclcpp::Duration::from_seconds(0.0);
         } else if (time_from_start >= start_state_time_) {
           break;
         }
       }
-      plan_.points.insert(plan_.points.begin(), start_segment.begin(), start_segment.end());
     }
+
+    sorted_current_states.time_from_start = rclcpp::Duration::from_seconds(0.0);
+    start_segment.push_back(sorted_current_states);
+    plan_.points.insert(plan_.points.begin(), start_segment.begin(), start_segment.end());
 
     std::vector<trajectory_msgs::msg::JointTrajectoryPoint> end_segment;
     for (; i < num_points; i++) {
@@ -265,27 +236,68 @@ public:
         rclcpp::Duration(reference_trajectory_.points[i].time_from_start).seconds();
       if (time_from_start > end_state_time_) {
         if (reference_trajectory_.joint_names != plan_.joint_names) {
-          // Re-order joint if necessary
           std::vector<std::string> sorted_ref_joint_names = reference_trajectory_.joint_names;
           trajectory_msgs::msg::JointTrajectoryPoint sorted_point = reference_trajectory_.points[i];
-          reorder_joint(plan_.joint_names, sorted_ref_joint_names, sorted_point);
+          if (!reorder_joint(plan_.joint_names, sorted_ref_joint_names, sorted_point)) {
+            RCLCPP_ERROR(LOGGER, "Failed to reorder end segment point to plan joint order");
+            return std::make_shared<trajectory_msgs::msg::JointTrajectory>();
+          }
           end_segment.push_back(sorted_point);
         } else {
           end_segment.push_back(reference_trajectory_.points[i]);
         }
-        // Clear time
         end_segment.back().time_from_start = rclcpp::Duration::from_seconds(0.0);
       }
     }
     plan_.points.insert(plan_.points.end(), end_segment.begin(), end_segment.end());
 
-    // TODO(anyone): Update start state speed
-    if (context_->time_parameterize(plan_)) {
-      return std::make_shared<trajectory_msgs::msg::JointTrajectory>(plan_);
-    } else {
+    if (plan_.points.empty()) {
+      RCLCPP_ERROR(LOGGER, "Flattened plan contains no points before time parameterization");
       return std::make_shared<trajectory_msgs::msg::JointTrajectory>();
     }
+
+    set_start_kinematics(plan_.points.front(), sorted_current_states);
+
+    if (!start_segment.empty() && plan_.points.size() > start_segment.size()) {
+      const size_t first_replan_idx = start_segment.size();
+      if (plan_.points[first_replan_idx].velocities.size() == plan_.points.front().positions.size()) {
+        plan_.points.front().velocities = plan_.points[first_replan_idx].velocities;
+      }
+      if (
+        plan_.points[first_replan_idx].accelerations.size() ==
+        plan_.points.front().positions.size())
+      {
+        plan_.points.front().accelerations = plan_.points[first_replan_idx].accelerations;
+      }
+    }
+
+    if (!end_segment.empty()) {
+      const size_t first_end_idx = plan_.points.size() - end_segment.size();
+      if (first_end_idx > 0) {
+        const size_t last_replan_idx = first_end_idx - 1;
+        if (plan_.points[last_replan_idx].velocities.size() == plan_.points[first_end_idx].positions.size()) {
+          plan_.points[first_end_idx].velocities = plan_.points[last_replan_idx].velocities;
+        }
+        if (
+          plan_.points[last_replan_idx].accelerations.size() ==
+          plan_.points[first_end_idx].positions.size())
+        {
+          plan_.points[first_end_idx].accelerations = plan_.points[last_replan_idx].accelerations;
+        }
+      }
+    }
+
+    if (context_->time_parameterize(plan_)) {
+      if (!has_monotonic_timestamps(plan_.points)) {
+        RCLCPP_ERROR(LOGGER, "Flattened plan has non-monotonic timestamps after insertion");
+        return std::make_shared<trajectory_msgs::msg::JointTrajectory>();
+      }
+      return std::make_shared<trajectory_msgs::msg::JointTrajectory>(plan_);
+    }
+
+    return std::make_shared<trajectory_msgs::msg::JointTrajectory>();
   }
+
 
   uint8_t get_status() const
   {

--- a/easy_manipulation_deployment/emd_dynamic_safety/test/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_dynamic_safety/test/CMakeLists.txt
@@ -59,3 +59,11 @@ ament_add_gtest(test_goal_time_tolerance_utils
 target_link_libraries(test_goal_time_tolerance_utils
   ${PROJECT_NAME}
 )
+
+
+ament_add_gtest(test_replanner_flatten_utils
+  test_replanner_flatten_utils.cpp
+)
+target_link_libraries(test_replanner_flatten_utils
+  ${PROJECT_NAME}
+)

--- a/easy_manipulation_deployment/emd_dynamic_safety/test/test_replanner_flatten_utils.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/test/test_replanner_flatten_utils.cpp
@@ -1,0 +1,56 @@
+#include <vector>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "emd/dynamic_safety/replanner_flatten_utils.hpp"
+
+namespace
+{
+using dynamic_safety::has_monotonic_timestamps;
+using dynamic_safety::reorder_joint;
+using dynamic_safety::set_start_kinematics;
+
+TEST(ReplannerFlattenUtils, ReorderJointStateReordersVelocitiesAndAccelerations)
+{
+  std::vector<std::string> reference{"j1", "j2", "j3"};
+  std::vector<std::string> current{"j3", "j1", "j2"};
+
+  trajectory_msgs::msg::JointTrajectoryPoint state;
+  state.positions = {3.0, 1.0, 2.0};
+  state.velocities = {0.3, 0.1, 0.2};
+  state.accelerations = {3.0, 1.0, 2.0};
+
+  ASSERT_TRUE(reorder_joint(reference, current, state));
+  EXPECT_EQ(current, reference);
+  EXPECT_EQ(state.positions, (std::vector<double>{1.0, 2.0, 3.0}));
+  EXPECT_EQ(state.velocities, (std::vector<double>{0.1, 0.2, 0.3}));
+  EXPECT_EQ(state.accelerations, (std::vector<double>{1.0, 2.0, 3.0}));
+}
+
+TEST(ReplannerFlattenUtils, SetStartKinematicsUsesNonZeroInitialVelocity)
+{
+  trajectory_msgs::msg::JointTrajectoryPoint start;
+  start.positions = {0.0, 0.0};
+
+  trajectory_msgs::msg::JointTrajectoryPoint current;
+  current.positions = {0.1, -0.2};
+  current.velocities = {0.5, -0.1};
+  current.accelerations = {1.2, -0.3};
+
+  set_start_kinematics(start, current);
+  EXPECT_EQ(start.velocities, current.velocities);
+  EXPECT_EQ(start.accelerations, current.accelerations);
+}
+
+TEST(ReplannerFlattenUtils, MonotonicTimestampValidationHandlesShortSegments)
+{
+  std::vector<trajectory_msgs::msg::JointTrajectoryPoint> short_points(2);
+  short_points[0].time_from_start = rclcpp::Duration::from_seconds(0.0);
+  short_points[1].time_from_start = rclcpp::Duration::from_seconds(0.0);
+  EXPECT_TRUE(has_monotonic_timestamps(short_points));
+
+  short_points[1].time_from_start = rclcpp::Duration::from_seconds(-0.1);
+  EXPECT_FALSE(has_monotonic_timestamps(short_points));
+}
+
+}  // namespace


### PR DESCRIPTION
### Motivation
- Ensure replanner stitching uses the actual measured joint state as the first stitch point so time-parameterization and continuity can be seeded from the real robot state.
- Make the flattening step robust to differing joint name orders and to malformed/degenerate trajectories by validating names and timestamps and preserving kinematic continuity at stitch boundaries.

### Description
- Add a reusable header `replanner_flatten_utils.hpp` with helpers for joint-name consistency checks, joint reordering, seeding start kinematics, and monotonic timestamp validation.
- Update `flatten_result(...)` to reorder and insert the provided `current_state` as the first point, to reorder stitched reference points using the shared utility, and to seed start-point velocities/accelerations and preserve continuity at start/end stitch boundaries before time-parameterization.
- Add runtime validations for joint-name consistency between plan and measured joints, non-empty points prior to time-parameterization, and monotonic timestamps after insertion.
- Add unit tests `test_replanner_flatten_utils.cpp` (and register them in CMake) that cover reordered joints, non-zero initial velocities being seeded, and monotonic timestamp checks for short segments.

### Testing
- New unit tests added: `test_replanner_flatten_utils` which exercises `reorder_joint`, `set_start_kinematics`, and `has_monotonic_timestamps` and were wired into `test/CMakeLists.txt`.
- Attempted to run the targeted tests with `colcon test --packages-select emd_dynamic_safety --ctest-args -R test_replanner_flatten_utils --output-on-failure` but the environment lacks `colcon` so automated test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3299fba88331b8fda8d1edf6da04)