### PR TITLE
Add moveit_core to emd_grasp_execution CMake target dependencies

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(grasp_execution_interface
 
 ament_target_dependencies(grasp_execution_interface
   emd_msgs
+  moveit_core
   moveit_msgs
   rclcpp
   rcl_yaml_param_parser
@@ -68,6 +69,7 @@ target_link_libraries(moveit_cpp_grasp_execution_interface
 )
 
 ament_target_dependencies(moveit_cpp_grasp_execution_interface
+  moveit_core
   moveit_ros_planning_interface
   moveit_msgs
   trajectory_msgs


### PR DESCRIPTION
### Motivation
- Ensure public headers that include `moveit/core/utils.h` correctly propagate MoveIt Core include/link dependencies so dependent packages do not encounter missing-header build errors.

### Description
- Added `moveit_core` to `ament_target_dependencies(grasp_execution_interface ...)` and to `ament_target_dependencies(moveit_cpp_grasp_execution_interface ...)` in `easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt`.

### Testing
- Attempted to run `colcon build --packages-up-to emd_grasp_execution --event-handlers console_direct+`, but the build could not be executed in this environment because `colcon` is not installed (`/bin/bash: colcon: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da358125d08331a8bb8af71aae0ad1)