### PR TITLE
Add maintainer email to scene package manifests and templates

### DIFF
--- a/assets/environment/workbench_description/package.xml
+++ b/assets/environment/workbench_description/package.xml
@@ -4,7 +4,7 @@
   <name>workbench_description</name>
   <version>2.0.0</version>
   <description>Workbench model and related launch assets for Easy Manipulation Deployment scenes</description>
-  <maintainer email="">Mukaram01</maintainer>
+  <maintainer email="Mukaram01@gmail.com">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/scenes/suction_test/package.xml
+++ b/scenes/suction_test/package.xml
@@ -4,7 +4,7 @@
   <name>suction_test</name>
   <version>2.0.0</version>
   <description>UR5 robot with single-suction gripper scene for Easy Manipulation Deployment</description>
-  <maintainer email="">Mukaram01</maintainer>
+  <maintainer email="Mukaram01@gmail.com">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/scenes/ur10_2f_test/package.xml
+++ b/scenes/ur10_2f_test/package.xml
@@ -4,7 +4,7 @@
   <name>ur10_2f_test</name>
   <version>2.0.0</version>
   <description>UR10 robot with Robotiq 2F gripper scene for Easy Manipulation Deployment</description>
-  <maintainer email="">Mukaram01</maintainer>
+  <maintainer email="Mukaram01@gmail.com">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/scenes/ur3_suction_test/package.xml
+++ b/scenes/ur3_suction_test/package.xml
@@ -4,7 +4,7 @@
   <name>ur3_suction_test</name>
   <version>2.0.0</version>
   <description>UR3 robot with single suction gripper scene for Easy Manipulation Deployment</description>
-  <maintainer email="">Mukaram01</maintainer>
+  <maintainer email="Mukaram01@gmail.com">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/workcell_builder/examples/ros2/package_example.xml
+++ b/workcell_builder/examples/ros2/package_example.xml
@@ -4,7 +4,7 @@
   <name>workcellexample</name>
   <version>2.0.0</version>
   <description>workcellexample description</description>
-  <maintainer email="">Mukaram01</maintainer>
+  <maintainer email="Mukaram01@gmail.com">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/workcell_builder/workcell_builder/templates/ros2/humble/package_example.xml
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/package_example.xml
@@ -4,7 +4,7 @@
   <name>workcellexample</name>
   <version>2.0.0</version>
   <description>workcellexample description</description>
-  <maintainer email="">Mukaram01</maintainer>
+  <maintainer email="Mukaram01@gmail.com">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/workcell_builder/workcell_builder/templates/ros2/package_example.xml
+++ b/workcell_builder/workcell_builder/templates/ros2/package_example.xml
@@ -4,7 +4,7 @@
   <name>workcellexample</name>
   <version>2.0.0</version>
   <description>workcellexample description</description>
-  <maintainer email="">Mukaram01</maintainer>
+  <maintainer email="Mukaram01@gmail.com">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
### Motivation
- Ensure all ROS package manifests include a valid maintainer email instead of an empty `email=""` field for proper project metadata.
- Keep maintainer identity consistent with existing metadata by retaining the name `Mukaram01` while adding a contact email.
- Make sure new scenes generated with `workcell_builder` inherit a valid maintainer email from the provided templates.

### Description
- Replaced `email=""` with `email="Mukaram01@gmail.com"` in the scene/environment manifests: `assets/environment/workbench_description/package.xml`, `scenes/suction_test/package.xml`, `scenes/ur10_2f_test/package.xml`, and `scenes/ur3_suction_test/package.xml`.
- Updated `workcell_builder` templates and example so newly generated ROS2 packages use the same maintainer email in `workcell_builder/examples/ros2/package_example.xml` and `workcell_builder/workcell_builder/templates/ros2/package_example.xml` (including `humble` variant).
- Maintainer name remains `Mukaram01` to preserve consistency with existing project maintainership policy.

### Testing
- Parsed all 7 updated XML manifests with Python `xml.etree.ElementTree.parse(...)` and the parse succeeded for every file.
- Searched the repository with `rg -n 'email=""'` and confirmed there are no remaining empty maintainer email fields.
- Attempted to run `xmllint --noout` for schema-level validation but the command was not available in the environment, so it was not executed.
- Attempted ROS semantic validation using `catkin_pkg.package.parse_package` but `catkin_pkg` was unavailable in the environment, so semantic checks were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3606bcb88331aa4a72b44712c241)