### PR TITLE
Fix member initializer order warning in DynamicSafety::Impl

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp
@@ -468,7 +468,7 @@ class DynamicSafety::Impl
 public:
   Impl();
   explicit Impl(const Option & option)
-  : option_(option), activated_(false), min_distance_(-1.0)
+  : option_(option), min_distance_(-1.0), activated_(false)
   {
     // Reset Cache
     env_state_cache_.initRT(sensor_msgs::msg::JointState());


### PR DESCRIPTION
### Motivation
- Reorder the constructor initializer list to match the class member declaration order and suppress the `-Wreorder` warning emitted during builds of `emd_dynamic_safety`.

### Description
- In `easy_manipulation_deployment/emd_dynamic_safety/src/dynamic_safety.cpp` change the `Impl` constructor initializer list from `: option_(option), activated_(false), min_distance_(-1.0)` to `: option_(option), min_distance_(-1.0), activated_(false)`.

### Testing
- Attempted `colcon build --packages-select emd_dynamic_safety --event-handlers console_direct+`, but the command failed in this environment because `colcon` is not installed (no automated build of the modified package was performed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da46896d2c8331882007dd5339bf3d)