### PR TITLE
Fix launch/xacro compatibility issues in all UR scenes

### DIFF
--- a/scenes/suction_test/launch/demo.launch.py
+++ b/scenes/suction_test/launch/demo.launch.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import yaml
+import re
 import xacro
 
 from launch import LaunchDescription
@@ -21,8 +22,20 @@ def load_xacro(package_name, rel_path, mappings=None):
     if not os.path.exists(abs_path):
         raise FileNotFoundError(f"Missing file: {abs_path}")
 
-    doc = xacro.process_file(abs_path, mappings=mappings or {})
-    return doc.toprettyxml(indent="  ")
+    effective_mappings = dict(mappings or {})
+    while True:
+        try:
+            doc = xacro.process_file(abs_path, mappings=effective_mappings)
+            return doc.toprettyxml(indent="  ")
+        except Exception as exc:
+            match = re.search(r'Invalid parameter "([^"]+)"', str(exc))
+            if not match:
+                raise
+
+            invalid_param = match.group(1)
+            if invalid_param not in effective_mappings:
+                raise
+            effective_mappings.pop(invalid_param)
 
 
 def load_yaml(package_name, rel_path):

--- a/scenes/suction_test/urdf/scene.urdf.xacro
+++ b/scenes/suction_test/urdf/scene.urdf.xacro
@@ -6,7 +6,7 @@
  <xacro:arg name="name" default="$(arg ur_type)"/>
  <xacro:arg name="tf_prefix" default=""/>
  <xacro:arg name="use_fake_hardware" default="true"/>
- <xacro:arg name="initial_positions_file" default="$(find-pkg-share ur5_moveit_config)/config/initial_positions.yaml"/>
+ <xacro:arg name="initial_positions_file" default="$(find ur5_moveit_config)/config/initial_positions.yaml"/>
 
  <link name="world"/>
 

--- a/scenes/ur10_2f_test/launch/demo.launch.py
+++ b/scenes/ur10_2f_test/launch/demo.launch.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import yaml
+import re
 import xacro
 
 from launch import LaunchDescription
@@ -21,8 +22,20 @@ def load_xacro(package_name, rel_path, mappings=None):
     if not os.path.exists(abs_path):
         raise FileNotFoundError(f"Missing file: {abs_path}")
 
-    doc = xacro.process_file(abs_path, mappings=mappings or {})
-    return doc.toprettyxml(indent="  ")
+    effective_mappings = dict(mappings or {})
+    while True:
+        try:
+            doc = xacro.process_file(abs_path, mappings=effective_mappings)
+            return doc.toprettyxml(indent="  ")
+        except Exception as exc:
+            match = re.search(r'Invalid parameter "([^"]+)"', str(exc))
+            if not match:
+                raise
+
+            invalid_param = match.group(1)
+            if invalid_param not in effective_mappings:
+                raise
+            effective_mappings.pop(invalid_param)
 
 
 def load_yaml(package_name, rel_path):

--- a/scenes/ur10_2f_test/urdf/scene.urdf.xacro
+++ b/scenes/ur10_2f_test/urdf/scene.urdf.xacro
@@ -6,7 +6,7 @@
  <xacro:arg name="name" default="$(arg ur_type)"/>
  <xacro:arg name="tf_prefix" default=""/>
  <xacro:arg name="use_fake_hardware" default="true"/>
- <xacro:arg name="initial_positions_file" default="$(find-pkg-share ur10_moveit_config)/config/initial_positions.yaml"/>
+ <xacro:arg name="initial_positions_file" default="$(find ur10_moveit_config)/config/initial_positions.yaml"/>
 
  <link name="world"/>
 

--- a/scenes/ur3_suction_test/launch/demo.launch.py
+++ b/scenes/ur3_suction_test/launch/demo.launch.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import yaml
+import re
 import xacro
 
 from launch import LaunchDescription
@@ -21,8 +22,20 @@ def load_xacro(package_name, rel_path, mappings=None):
     if not os.path.exists(abs_path):
         raise FileNotFoundError(f"Missing file: {abs_path}")
 
-    doc = xacro.process_file(abs_path, mappings=mappings or {})
-    return doc.toprettyxml(indent="  ")
+    effective_mappings = dict(mappings or {})
+    while True:
+        try:
+            doc = xacro.process_file(abs_path, mappings=effective_mappings)
+            return doc.toprettyxml(indent="  ")
+        except Exception as exc:
+            match = re.search(r'Invalid parameter "([^"]+)"', str(exc))
+            if not match:
+                raise
+
+            invalid_param = match.group(1)
+            if invalid_param not in effective_mappings:
+                raise
+            effective_mappings.pop(invalid_param)
 
 
 def load_yaml(package_name, rel_path):

--- a/scenes/ur3_suction_test/urdf/scene.urdf.xacro
+++ b/scenes/ur3_suction_test/urdf/scene.urdf.xacro
@@ -6,7 +6,7 @@
  <xacro:arg name="name" default="$(arg ur_type)"/>
  <xacro:arg name="tf_prefix" default=""/>
  <xacro:arg name="use_fake_hardware" default="true"/>
- <xacro:arg name="initial_positions_file" default="$(find-pkg-share ur3_moveit_config)/config/initial_positions.yaml"/>
+ <xacro:arg name="initial_positions_file" default="$(find ur3_moveit_config)/config/initial_positions.yaml"/>
 
  <link name="world"/>
 

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -2,6 +2,7 @@
 
 import os
 import yaml
+import re
 import xacro
 
 from launch import LaunchDescription
@@ -22,8 +23,20 @@ def load_xacro(package_name, rel_path, mappings=None):
     if not os.path.exists(abs_path):
         raise FileNotFoundError(f"Missing file: {abs_path}")
 
-    doc = xacro.process_file(abs_path, mappings=mappings or {})
-    return doc.toprettyxml(indent="  ")
+    effective_mappings = dict(mappings or {})
+    while True:
+        try:
+            doc = xacro.process_file(abs_path, mappings=effective_mappings)
+            return doc.toprettyxml(indent="  ")
+        except Exception as exc:
+            match = re.search(r'Invalid parameter "([^"]+)"', str(exc))
+            if not match:
+                raise
+
+            invalid_param = match.group(1)
+            if invalid_param not in effective_mappings:
+                raise
+            effective_mappings.pop(invalid_param)
 
 
 def load_yaml(package_name, rel_path):

--- a/scenes/ur5_2f_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_2f_test/urdf/scene.urdf.xacro
@@ -6,7 +6,7 @@
  <xacro:arg name="name" default="$(arg ur_type)"/>
  <xacro:arg name="tf_prefix" default=""/>
  <xacro:arg name="use_fake_hardware" default="true"/>
- <xacro:arg name="initial_positions_file" default="$(find-pkg-share ur5_moveit_config)/config/initial_positions.yaml"/>
+ <xacro:arg name="initial_positions_file" default="$(find ur5_moveit_config)/config/initial_positions.yaml"/>
 
  <link name="world"/>
 

--- a/scenes/ur5_3f_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_3f_test/urdf/scene.urdf.xacro
@@ -6,7 +6,7 @@
  <xacro:arg name="name" default="$(arg ur_type)"/>
  <xacro:arg name="tf_prefix" default=""/>
  <xacro:arg name="use_fake_hardware" default="true"/>
- <xacro:arg name="initial_positions_file" default="$(find-pkg-share ur5_moveit_config)/config/initial_positions.yaml"/>
+ <xacro:arg name="initial_positions_file" default="$(find ur5_moveit_config)/config/initial_positions.yaml"/>
 
  <link name="world"/>
 

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -2,6 +2,7 @@
 
 import os
 import yaml
+import re
 import xacro
 
 from launch import LaunchDescription
@@ -22,8 +23,20 @@ def load_xacro(package_name, rel_path, mappings=None):
     if not os.path.exists(abs_path):
         raise FileNotFoundError(f"Missing file: {abs_path}")
 
-    doc = xacro.process_file(abs_path, mappings=mappings or {})
-    return doc.toprettyxml(indent="  ")
+    effective_mappings = dict(mappings or {})
+    while True:
+        try:
+            doc = xacro.process_file(abs_path, mappings=effective_mappings)
+            return doc.toprettyxml(indent="  ")
+        except Exception as exc:
+            match = re.search(r'Invalid parameter "([^"]+)"', str(exc))
+            if not match:
+                raise
+
+            invalid_param = match.group(1)
+            if invalid_param not in effective_mappings:
+                raise
+            effective_mappings.pop(invalid_param)
 
 
 def load_yaml(package_name, rel_path):

--- a/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro
@@ -6,7 +6,7 @@
  <xacro:arg name="name" default="$(arg ur_type)"/>
  <xacro:arg name="tf_prefix" default=""/>
  <xacro:arg name="use_fake_hardware" default="true"/>
- <xacro:arg name="initial_positions_file" default="$(find-pkg-share ur5_moveit_config)/config/initial_positions.yaml"/>
+ <xacro:arg name="initial_positions_file" default="$(find ur5_moveit_config)/config/initial_positions.yaml"/>
 
  <link name="world"/>
 <xacro:include filename="$(find ur_description)/urdf/ur_macro.xacro"/>


### PR DESCRIPTION
## Summary
- Fixed all scene `demo.launch.py` loaders to gracefully handle xacro argument differences across UR description versions.
- Replaced unsupported `$(find-pkg-share ...)` substitutions in scene URDF xacros with `$(find ...)`.

## What changed
### Launch files
Updated `load_xacro()` in these launch files to retry after removing unknown xacro parameters (e.g. `initial_positions_file` when not accepted by the installed `ur_macro.xacro`):
- `scenes/suction_test/launch/demo.launch.py`
- `scenes/ur3_suction_test/launch/demo.launch.py`
- `scenes/ur5_2f_test/launch/demo.launch.py`
- `scenes/ur10_2f_test/launch/demo.launch.py`
- `scenes/ur5_airpick4_test/launch/demo.launch.py`

( `ur5_3f_test` already had this compatibility logic.)

### Scene URDF xacros
Replaced `$(find-pkg-share <pkg>)` with `$(find <pkg>)` in:
- `scenes/suction_test/urdf/scene.urdf.xacro`
- `scenes/ur3_suction_test/urdf/scene.urdf.xacro`
- `scenes/ur5_2f_test/urdf/scene.urdf.xacro`
- `scenes/ur10_2f_test/urdf/scene.urdf.xacro`
- `scenes/ur5_airpick4_test/urdf/scene.urdf.xacro`
- `scenes/ur5_3f_test/urdf/scene.urdf.xacro`

## Why
This addresses failures like:
- `Invalid parameter "initial_positions_file"`
- `Unknown substitution command [find-pkg-share ...]`

across different ROS2/xacro/UR package versions.

## Validation
- Performed static inspection and repository-wide search to ensure `find-pkg-share` is no longer used in scene URDF xacros and that all scene launch loaders now share the same compatibility behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4d2e0bcc8331b0124038e762137a)