### PR TITLE
Add timeout and error handling for xacro expansion in scene launchers

### DIFF
--- a/scenes/suction_test/launch/demo.launch.py
+++ b/scenes/suction_test/launch/demo.launch.py
@@ -2,7 +2,7 @@
 import os
 import yaml
 import re
-import xacro
+import subprocess
 
 from launch import LaunchDescription
 from launch.actions import OpaqueFunction
@@ -24,17 +24,26 @@ def load_xacro(package_name, rel_path, mappings=None):
 
     effective_mappings = dict(mappings or {})
     while True:
+        cmd = ["xacro", abs_path]
+        cmd.extend(f"{key}:={value}" for key, value in effective_mappings.items())
         try:
-            doc = xacro.process_file(abs_path, mappings=effective_mappings)
-            return doc.toprettyxml(indent="  ")
-        except Exception as exc:
-            match = re.search(r'Invalid parameter "([^"]+)"', str(exc))
+            completed = subprocess.run(cmd, check=True, text=True, capture_output=True, timeout=30)
+            return completed.stdout
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Timed out while expanding xacro file '{abs_path}'. "
+                "This usually means a dependency package is missing from the sourced workspace "
+                "or the xacro include graph is blocking."
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr or ""
+            match = re.search(r'Invalid parameter "([^"]+)"', stderr)
             if not match:
-                raise
+                raise RuntimeError(f"Failed to expand xacro file '{abs_path}':\n{stderr}") from exc
 
             invalid_param = match.group(1)
             if invalid_param not in effective_mappings:
-                raise
+                raise RuntimeError(f"Failed to expand xacro file '{abs_path}':\n{stderr}") from exc
             effective_mappings.pop(invalid_param)
 
 

--- a/scenes/ur10_2f_test/launch/demo.launch.py
+++ b/scenes/ur10_2f_test/launch/demo.launch.py
@@ -2,7 +2,7 @@
 import os
 import yaml
 import re
-import xacro
+import subprocess
 
 from launch import LaunchDescription
 from launch.actions import OpaqueFunction
@@ -24,17 +24,26 @@ def load_xacro(package_name, rel_path, mappings=None):
 
     effective_mappings = dict(mappings or {})
     while True:
+        cmd = ["xacro", abs_path]
+        cmd.extend(f"{key}:={value}" for key, value in effective_mappings.items())
         try:
-            doc = xacro.process_file(abs_path, mappings=effective_mappings)
-            return doc.toprettyxml(indent="  ")
-        except Exception as exc:
-            match = re.search(r'Invalid parameter "([^"]+)"', str(exc))
+            completed = subprocess.run(cmd, check=True, text=True, capture_output=True, timeout=30)
+            return completed.stdout
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Timed out while expanding xacro file '{abs_path}'. "
+                "This usually means a dependency package is missing from the sourced workspace "
+                "or the xacro include graph is blocking."
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr or ""
+            match = re.search(r'Invalid parameter "([^"]+)"', stderr)
             if not match:
-                raise
+                raise RuntimeError(f"Failed to expand xacro file '{abs_path}':\n{stderr}") from exc
 
             invalid_param = match.group(1)
             if invalid_param not in effective_mappings:
-                raise
+                raise RuntimeError(f"Failed to expand xacro file '{abs_path}':\n{stderr}") from exc
             effective_mappings.pop(invalid_param)
 
 

--- a/scenes/ur3_suction_test/launch/demo.launch.py
+++ b/scenes/ur3_suction_test/launch/demo.launch.py
@@ -2,7 +2,7 @@
 import os
 import yaml
 import re
-import xacro
+import subprocess
 
 from launch import LaunchDescription
 from launch.actions import OpaqueFunction
@@ -24,17 +24,26 @@ def load_xacro(package_name, rel_path, mappings=None):
 
     effective_mappings = dict(mappings or {})
     while True:
+        cmd = ["xacro", abs_path]
+        cmd.extend(f"{key}:={value}" for key, value in effective_mappings.items())
         try:
-            doc = xacro.process_file(abs_path, mappings=effective_mappings)
-            return doc.toprettyxml(indent="  ")
-        except Exception as exc:
-            match = re.search(r'Invalid parameter "([^"]+)"', str(exc))
+            completed = subprocess.run(cmd, check=True, text=True, capture_output=True, timeout=30)
+            return completed.stdout
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Timed out while expanding xacro file '{abs_path}'. "
+                "This usually means a dependency package is missing from the sourced workspace "
+                "or the xacro include graph is blocking."
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr or ""
+            match = re.search(r'Invalid parameter "([^"]+)"', stderr)
             if not match:
-                raise
+                raise RuntimeError(f"Failed to expand xacro file '{abs_path}':\n{stderr}") from exc
 
             invalid_param = match.group(1)
             if invalid_param not in effective_mappings:
-                raise
+                raise RuntimeError(f"Failed to expand xacro file '{abs_path}':\n{stderr}") from exc
             effective_mappings.pop(invalid_param)
 
 

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -3,7 +3,7 @@
 import os
 import yaml
 import re
-import xacro
+import subprocess
 
 from launch import LaunchDescription
 from launch.actions import OpaqueFunction
@@ -25,17 +25,26 @@ def load_xacro(package_name, rel_path, mappings=None):
 
     effective_mappings = dict(mappings or {})
     while True:
+        cmd = ["xacro", abs_path]
+        cmd.extend(f"{key}:={value}" for key, value in effective_mappings.items())
         try:
-            doc = xacro.process_file(abs_path, mappings=effective_mappings)
-            return doc.toprettyxml(indent="  ")
-        except Exception as exc:
-            match = re.search(r'Invalid parameter "([^"]+)"', str(exc))
+            completed = subprocess.run(cmd, check=True, text=True, capture_output=True, timeout=30)
+            return completed.stdout
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Timed out while expanding xacro file '{abs_path}'. "
+                "This usually means a dependency package is missing from the sourced workspace "
+                "or the xacro include graph is blocking."
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr or ""
+            match = re.search(r'Invalid parameter "([^"]+)"', stderr)
             if not match:
-                raise
+                raise RuntimeError(f"Failed to expand xacro file '{abs_path}':\n{stderr}") from exc
 
             invalid_param = match.group(1)
             if invalid_param not in effective_mappings:
-                raise
+                raise RuntimeError(f"Failed to expand xacro file '{abs_path}':\n{stderr}") from exc
             effective_mappings.pop(invalid_param)
 
 

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -4,7 +4,7 @@ import os
 import yaml
 import re
 
-import xacro
+import subprocess
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -26,17 +26,26 @@ def load_xacro(package_name, rel_path, mappings=None):
 
     effective_mappings = dict(mappings or {})
     while True:
+        cmd = ["xacro", abs_path]
+        cmd.extend(f"{key}:={value}" for key, value in effective_mappings.items())
         try:
-            doc = xacro.process_file(abs_path, mappings=effective_mappings)
-            return doc.toprettyxml(indent="  ")
-        except Exception as exc:
-            match = re.search(r'Invalid parameter "([^"]+)"', str(exc))
+            completed = subprocess.run(cmd, check=True, text=True, capture_output=True, timeout=30)
+            return completed.stdout
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Timed out while expanding xacro file '{abs_path}'. "
+                "This usually means a dependency package is missing from the sourced workspace "
+                "or the xacro include graph is blocking."
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr or ""
+            match = re.search(r'Invalid parameter "([^"]+)"', stderr)
             if not match:
-                raise
+                raise RuntimeError(f"Failed to expand xacro file '{abs_path}':\n{stderr}") from exc
 
             invalid_param = match.group(1)
             if invalid_param not in effective_mappings:
-                raise
+                raise RuntimeError(f"Failed to expand xacro file '{abs_path}':\n{stderr}") from exc
             effective_mappings.pop(invalid_param)
 
 

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -3,7 +3,7 @@
 import os
 import yaml
 import re
-import xacro
+import subprocess
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -25,17 +25,26 @@ def load_xacro(package_name, rel_path, mappings=None):
 
     effective_mappings = dict(mappings or {})
     while True:
+        cmd = ["xacro", abs_path]
+        cmd.extend(f"{key}:={value}" for key, value in effective_mappings.items())
         try:
-            doc = xacro.process_file(abs_path, mappings=effective_mappings)
-            return doc.toprettyxml(indent="  ")
-        except Exception as exc:
-            match = re.search(r'Invalid parameter "([^"]+)"', str(exc))
+            completed = subprocess.run(cmd, check=True, text=True, capture_output=True, timeout=30)
+            return completed.stdout
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Timed out while expanding xacro file '{abs_path}'. "
+                "This usually means a dependency package is missing from the sourced workspace "
+                "or the xacro include graph is blocking."
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr or ""
+            match = re.search(r'Invalid parameter "([^"]+)"', stderr)
             if not match:
-                raise
+                raise RuntimeError(f"Failed to expand xacro file '{abs_path}':\n{stderr}") from exc
 
             invalid_param = match.group(1)
             if invalid_param not in effective_mappings:
-                raise
+                raise RuntimeError(f"Failed to expand xacro file '{abs_path}':\n{stderr}") from exc
             effective_mappings.pop(invalid_param)
 
 


### PR DESCRIPTION
### Motivation
- Scene `demo.launch.py` files could appear to hang when expanding xacro files inside an `OpaqueFunction`, causing `ros2 launch` to stall with no output. 
- The change aims to make xacro expansion fail fast and produce actionable errors when dependencies are missing or the include graph blocks. 
- Maintain backward-compatibility with differing xacro macro parameter signatures by preserving the retry-on-invalid-parameter behavior.

### Description
- Replaced in-process `xacro.process_file(...)` expansion with a CLI invocation using `subprocess.run([... "xacro", ...])` to avoid silent blocking inside the launch function. 
- Added a 30-second timeout to the `xacro` CLI call so expansion raises a clear `RuntimeError` instead of leaving the launcher appearing stuck. 
- Capture `stderr` from the `xacro` CLI and detect `Invalid parameter "..."` to retry by removing unsupported mapping parameters, preserving the original retry logic; otherwise raise a `RuntimeError` that includes the xacro `stderr`. 
- Applied these changes to all scene launchers under `scenes/*/launch/demo.launch.py` (e.g. `suction_test`, `ur3_suction_test`, `ur5_2f_test`, `ur5_3f_test`, `ur5_airpick4_test`, `ur10_2f_test`).

### Testing
- Ran `python -m py_compile scenes/*/launch/demo.launch.py` to verify the modified launchers are syntactically valid and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4fdc90748331b72a08f417dfefd0)