### PR TITLE
Fix UR scene launch/xacro incompatibility with newer ur_description

### DIFF
--- a/scenes/suction_test/launch/demo.launch.py
+++ b/scenes/suction_test/launch/demo.launch.py
@@ -69,7 +69,6 @@ def _launch_setup(context):
             "name": "ur5",
             "tf_prefix": "",
             "use_fake_hardware": use_fake_hardware.perform(context),
-            "initial_positions_file": os.path.join(get_package_share_directory(robot_moveit_pkg), "config", "initial_positions.yaml"),
         },
     )
     robot_description = {"robot_description": robot_description_config}

--- a/scenes/suction_test/urdf/scene.urdf.xacro
+++ b/scenes/suction_test/urdf/scene.urdf.xacro
@@ -6,7 +6,6 @@
  <xacro:arg name="name" default="$(arg ur_type)"/>
  <xacro:arg name="tf_prefix" default=""/>
  <xacro:arg name="use_fake_hardware" default="true"/>
- <xacro:arg name="initial_positions_file" default="$(find ur5_moveit_config)/config/initial_positions.yaml"/>
 
  <link name="world"/>
 
@@ -21,7 +20,6 @@
   kinematics_parameters_file="$(find ur_description)/config/$(arg ur_type)/default_kinematics.yaml"
   physical_parameters_file="$(find ur_description)/config/$(arg ur_type)/physical_parameters.yaml"
   visual_parameters_file="$(find ur_description)/config/$(arg ur_type)/visual_parameters.yaml"
-  initial_positions_file="$(arg initial_positions_file)"
   use_fake_hardware="$(arg use_fake_hardware)">
   <origin xyz="0 0 0" rpy="0 0 0"/>
 </xacro:ur_robot>

--- a/scenes/ur10_2f_test/launch/demo.launch.py
+++ b/scenes/ur10_2f_test/launch/demo.launch.py
@@ -68,7 +68,6 @@ def _launch_setup(context):
             "name": "ur10",
             "tf_prefix": "",
             "use_fake_hardware": use_fake_hardware.perform(context),
-            "initial_positions_file": os.path.join(get_package_share_directory(robot_moveit_pkg), "config", "initial_positions.yaml"),
         },
     )
     robot_description = {"robot_description": robot_description_config}

--- a/scenes/ur10_2f_test/urdf/scene.urdf.xacro
+++ b/scenes/ur10_2f_test/urdf/scene.urdf.xacro
@@ -6,7 +6,6 @@
  <xacro:arg name="name" default="$(arg ur_type)"/>
  <xacro:arg name="tf_prefix" default=""/>
  <xacro:arg name="use_fake_hardware" default="true"/>
- <xacro:arg name="initial_positions_file" default="$(find ur10_moveit_config)/config/initial_positions.yaml"/>
 
  <link name="world"/>
 
@@ -21,7 +20,6 @@
   kinematics_parameters_file="$(find ur_description)/config/$(arg ur_type)/default_kinematics.yaml"
   physical_parameters_file="$(find ur_description)/config/$(arg ur_type)/physical_parameters.yaml"
   visual_parameters_file="$(find ur_description)/config/$(arg ur_type)/visual_parameters.yaml"
-  initial_positions_file="$(arg initial_positions_file)"
   use_fake_hardware="$(arg use_fake_hardware)">
   <origin xyz="0 0 0" rpy="0 0 0"/>
 </xacro:ur_robot>

--- a/scenes/ur3_suction_test/launch/demo.launch.py
+++ b/scenes/ur3_suction_test/launch/demo.launch.py
@@ -69,7 +69,6 @@ def _launch_setup(context):
             "name": "ur3",
             "tf_prefix": "",
             "use_fake_hardware": use_fake_hardware.perform(context),
-            "initial_positions_file": os.path.join(get_package_share_directory(robot_moveit_pkg), "config", "initial_positions.yaml"),
         },
     )
     robot_description = {"robot_description": robot_description_config}

--- a/scenes/ur3_suction_test/urdf/scene.urdf.xacro
+++ b/scenes/ur3_suction_test/urdf/scene.urdf.xacro
@@ -6,7 +6,6 @@
  <xacro:arg name="name" default="$(arg ur_type)"/>
  <xacro:arg name="tf_prefix" default=""/>
  <xacro:arg name="use_fake_hardware" default="true"/>
- <xacro:arg name="initial_positions_file" default="$(find ur3_moveit_config)/config/initial_positions.yaml"/>
 
  <link name="world"/>
 
@@ -21,7 +20,6 @@
   kinematics_parameters_file="$(find ur_description)/config/$(arg ur_type)/default_kinematics.yaml"
   physical_parameters_file="$(find ur_description)/config/$(arg ur_type)/physical_parameters.yaml"
   visual_parameters_file="$(find ur_description)/config/$(arg ur_type)/visual_parameters.yaml"
-  initial_positions_file="$(arg initial_positions_file)"
   use_fake_hardware="$(arg use_fake_hardware)">
   <origin xyz="0 0 0" rpy="0 0 0"/>
 </xacro:ur_robot>

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -69,7 +69,6 @@ def _launch_setup(context):
             "name": "ur5",
             "tf_prefix": "",
             "use_fake_hardware": use_fake_hardware.perform(context),
-            "initial_positions_file": os.path.join(get_package_share_directory(robot_moveit_pkg), "config", "initial_positions.yaml"),
         },
     )
     robot_description = {"robot_description": robot_description_config}

--- a/scenes/ur5_2f_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_2f_test/urdf/scene.urdf.xacro
@@ -6,7 +6,6 @@
  <xacro:arg name="name" default="$(arg ur_type)"/>
  <xacro:arg name="tf_prefix" default=""/>
  <xacro:arg name="use_fake_hardware" default="true"/>
- <xacro:arg name="initial_positions_file" default="$(find ur5_moveit_config)/config/initial_positions.yaml"/>
 
  <link name="world"/>
 
@@ -21,7 +20,6 @@
   kinematics_parameters_file="$(find ur_description)/config/$(arg ur_type)/default_kinematics.yaml"
   physical_parameters_file="$(find ur_description)/config/$(arg ur_type)/physical_parameters.yaml"
   visual_parameters_file="$(find ur_description)/config/$(arg ur_type)/visual_parameters.yaml"
-  initial_positions_file="$(arg initial_positions_file)"
   use_fake_hardware="$(arg use_fake_hardware)">
   <origin xyz="0 0 0" rpy="0 0 0"/>
 </xacro:ur_robot>

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -65,8 +65,7 @@ def _launch_setup(context):
     robot_description_config = load_xacro(
         scene_pkg,
         "urdf/scene.urdf.xacro",
-        mappings={"ur_type": "ur5", "name": "ur5", "tf_prefix": "", "use_fake_hardware": use_fake_hardware.perform(context),
-                  "initial_positions_file": os.path.join(get_package_share_directory(robot_moveit_pkg), "config", "initial_positions.yaml")},
+        mappings={"ur_type": "ur5", "name": "ur5", "tf_prefix": "", "use_fake_hardware": use_fake_hardware.perform(context)},
     )
     robot_description = {"robot_description": robot_description_config}
 

--- a/scenes/ur5_3f_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_3f_test/urdf/scene.urdf.xacro
@@ -6,7 +6,6 @@
  <xacro:arg name="name" default="$(arg ur_type)"/>
  <xacro:arg name="tf_prefix" default=""/>
  <xacro:arg name="use_fake_hardware" default="true"/>
- <xacro:arg name="initial_positions_file" default="$(find ur5_moveit_config)/config/initial_positions.yaml"/>
 
  <link name="world"/>
 
@@ -21,7 +20,6 @@
   kinematics_parameters_file="$(find ur_description)/config/$(arg ur_type)/default_kinematics.yaml"
   physical_parameters_file="$(find ur_description)/config/$(arg ur_type)/physical_parameters.yaml"
   visual_parameters_file="$(find ur_description)/config/$(arg ur_type)/visual_parameters.yaml"
-  initial_positions_file="$(arg initial_positions_file)"
   use_fake_hardware="$(arg use_fake_hardware)">
   <origin xyz="0 0 0" rpy="0 0 0"/>
 </xacro:ur_robot>

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -64,8 +64,7 @@ def _launch_setup(context):
     robot_description_config = load_xacro(
         scene_pkg,
         "urdf/scene.urdf.xacro",
-        mappings={"ur_type": "ur5", "name": "ur5", "tf_prefix": "", "use_fake_hardware": use_fake_hardware.perform(context),
-                  "initial_positions_file": os.path.join(get_package_share_directory(robot_moveit_pkg), "config", "initial_positions.yaml")},
+        mappings={"ur_type": "ur5", "name": "ur5", "tf_prefix": "", "use_fake_hardware": use_fake_hardware.perform(context)},
     )
     robot_description = {"robot_description": robot_description_config}
 

--- a/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro
@@ -6,7 +6,6 @@
  <xacro:arg name="name" default="$(arg ur_type)"/>
  <xacro:arg name="tf_prefix" default=""/>
  <xacro:arg name="use_fake_hardware" default="true"/>
- <xacro:arg name="initial_positions_file" default="$(find ur5_moveit_config)/config/initial_positions.yaml"/>
 
  <link name="world"/>
 <xacro:include filename="$(find ur_description)/urdf/ur_macro.xacro"/>
@@ -20,7 +19,6 @@
   kinematics_parameters_file="$(find ur_description)/config/$(arg ur_type)/default_kinematics.yaml"
   physical_parameters_file="$(find ur_description)/config/$(arg ur_type)/physical_parameters.yaml"
   visual_parameters_file="$(find ur_description)/config/$(arg ur_type)/visual_parameters.yaml"
-  initial_positions_file="$(arg initial_positions_file)"
   use_fake_hardware="$(arg use_fake_hardware)">
   <origin xyz="0 0 0" rpy="0 0 0"/>
 </xacro:ur_robot>


### PR DESCRIPTION
### Motivation
- Launching bundled UR scenes failed during xacro expansion with errors like `Invalid parameter "initial_positions_file" when instantiating macro: ur_robot` because newer `ur_description` macros no longer accept that parameter. 
- The change removes the now-invalid parameter so scene xacros can be expanded with current `ur_description` packages while preserving fake-hardware behavior.

### Description
- Removed the `initial_positions_file` `xacro:arg` and the `initial_positions_file="$(arg initial_positions_file)"` attribute from the `xacro:ur_robot` invocation in bundled scene URDFs for the scenes `ur5_2f_test`, `suction_test`, `ur3_suction_test`, `ur10_2f_test`, `ur5_airpick4_test`, and `ur5_3f_test`.
- Stopped passing `initial_positions_file` in the `mappings` argument to `load_xacro` inside each scene's `launch/demo.launch.py` so the launch code no longer forwards the removed parameter.
- Preserved the `use_fake_hardware` mapping so `use_fake_hardware:=true` continues to work with the updated scene invocations.
- Fixed a stray mismatched parenthesis introduced during mapping removal in two launch files and normalized mapping formatting where needed.

### Testing
- Ran `python -m py_compile` on all modified `scenes/*/launch/demo.launch.py` files and the compilation succeeded with no syntax errors.
- Verified there are no remaining occurrences of the invalid parameter with `rg -n "initial_positions_file" scenes -S`, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa79bbc388331a5813acd53e51271)