### PR TITLE
Fix AirPick4 SRDF macro name mismatch in generated scenes

### DIFF
--- a/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/onrobot_airpick4_gripper.srdf.xacro
+++ b/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/onrobot_airpick4_gripper.srdf.xacro
@@ -4,7 +4,7 @@
     A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
 -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="robotiq-3f-gripper_articulated">
-<xacro:macro name="onrobot_airpick4" params="parent_group:=manipulator">
+<xacro:macro name="onrobot_airpick4_gripper" params="parent_group:=manipulator">
     <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
     <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
     <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
@@ -18,5 +18,8 @@
     <virtual_joint name="world_joint" type="fixed" parent_frame="world" child_link="gripper_base_link" />
     <!--PASSIVE JOINT: Purpose: this element is used to mark joints that are not actuated-->
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+</xacro:macro>
+<xacro:macro name="onrobot_airpick4" params="parent_group:=manipulator">
+    <xacro:onrobot_airpick4_gripper parent_group="${parent_group}" />
 </xacro:macro>
 </robot>


### PR DESCRIPTION
### Motivation
- Generated scene SRDFs call `xacro:onrobot_airpick4_gripper` but the AirPick4 SRDF xacro only defined `onrobot_airpick4`, causing xacro to fail at launch with `unknown macro name: xacro:onrobot_airpick4_gripper`.

### Description
- Renamed the canonical macro to `onrobot_airpick4_gripper` in `assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/onrobot_airpick4_gripper.srdf.xacro`.
- Added a compatibility alias macro `onrobot_airpick4` that invokes `onrobot_airpick4_gripper` so existing callers remain supported.

### Testing
- Parsed the updated xacro file with `python3` using `xml.etree.ElementTree.parse`, which succeeded without XML syntax errors.
- Verified the file was staged and committed locally using `git status` and a commit, and no automated checks reported failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa871b424833185fc1d019e79d8ff)