### PR TITLE
Normalize demo launch parameters before Node creation

### DIFF
--- a/scenes/suction_test/launch/demo.launch.py
+++ b/scenes/suction_test/launch/demo.launch.py
@@ -56,6 +56,18 @@ def load_yaml(package_name, rel_path):
         return yaml.safe_load(f) or {}
 
 
+
+
+def _normalize_ros_param(value, path="root"):
+    if isinstance(value, dict):
+        return {key: _normalize_ros_param(item, f"{path}.{key}") for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    if isinstance(value, tuple):
+        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    return value
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -148,6 +160,19 @@ def _launch_setup(context):
     }
 
     # --- Nodes ---
+
+    normalized_use_sim_time = _normalize_ros_param({"use_sim_time": use_sim_time}, "use_sim_time")
+    normalized_robot_description = _normalize_ros_param(robot_description, "robot_description")
+    normalized_robot_description_semantic = _normalize_ros_param(robot_description_semantic, "robot_description_semantic")
+    normalized_robot_description_kinematics = _normalize_ros_param(robot_description_kinematics, "robot_description_kinematics")
+    normalized_planning_pipelines_config = _normalize_ros_param(planning_pipelines_config, "planning_pipelines_config")
+    normalized_ompl_planning_pipeline_config = _normalize_ros_param(ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+    normalized_planning_scene_monitor_params = _normalize_ros_param(planning_scene_monitor_params, "planning_scene_monitor_params")
+    normalized_occupancy_map_monitor_params = _normalize_ros_param(occupancy_map_monitor_params, "occupancy_map_monitor_params")
+    normalized_trajectory_execution = _normalize_ros_param(trajectory_execution, "trajectory_execution")
+    normalized_moveit_controller_manager = _normalize_ros_param(moveit_controller_manager, "moveit_controller_manager")
+    normalized_moveit_simple_controller_manager = _normalize_ros_param(moveit_simple_controller_manager, "moveit_simple_controller_manager")
+
     static_tf = Node(
         package="tf2_ros",
         executable="static_transform_publisher",
@@ -165,7 +190,7 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[normalized_use_sim_time, normalized_robot_description],
     )
 
     # IMPORTANT: pass robot_description as a parameter so it does NOT wait on a topic
@@ -173,7 +198,7 @@ def _launch_setup(context):
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[normalized_use_sim_time, normalized_robot_description],
     )
 
     move_group = Node(
@@ -181,17 +206,17 @@ def _launch_setup(context):
         executable="move_group",
         output="screen",
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
-            planning_pipelines_config,
-            ompl_planning_pipeline_config,
-            planning_scene_monitor_params,
-            occupancy_map_monitor_params,
-            trajectory_execution,
-            moveit_controller_manager,
-            moveit_simple_controller_manager,
+            normalized_use_sim_time,
+            normalized_robot_description,
+            normalized_robot_description_semantic,
+            normalized_robot_description_kinematics,
+            normalized_planning_pipelines_config,
+            normalized_ompl_planning_pipeline_config,
+            normalized_planning_scene_monitor_params,
+            normalized_occupancy_map_monitor_params,
+            normalized_trajectory_execution,
+            normalized_moveit_controller_manager,
+            normalized_moveit_simple_controller_manager,
         ],
     )
 
@@ -203,10 +228,10 @@ def _launch_setup(context):
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
+            normalized_use_sim_time,
+            normalized_robot_description,
+            normalized_robot_description_semantic,
+            normalized_robot_description_kinematics,
         ],
     )
 

--- a/scenes/ur10_2f_test/launch/demo.launch.py
+++ b/scenes/ur10_2f_test/launch/demo.launch.py
@@ -56,6 +56,18 @@ def load_yaml(package_name, rel_path):
         return yaml.safe_load(file) or {}
 
 
+
+
+def _normalize_ros_param(value, path="root"):
+    if isinstance(value, dict):
+        return {key: _normalize_ros_param(item, f"{path}.{key}") for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    if isinstance(value, tuple):
+        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    return value
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -141,6 +153,19 @@ def _launch_setup(context):
         "sensors": [],
     }
 
+
+    normalized_use_sim_time = _normalize_ros_param({"use_sim_time": use_sim_time}, "use_sim_time")
+    normalized_robot_description = _normalize_ros_param(robot_description, "robot_description")
+    normalized_robot_description_semantic = _normalize_ros_param(robot_description_semantic, "robot_description_semantic")
+    normalized_robot_description_kinematics = _normalize_ros_param(robot_description_kinematics, "robot_description_kinematics")
+    normalized_planning_pipelines_config = _normalize_ros_param(planning_pipelines_config, "planning_pipelines_config")
+    normalized_ompl_planning_pipeline_config = _normalize_ros_param(ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+    normalized_planning_scene_monitor_params = _normalize_ros_param(planning_scene_monitor_params, "planning_scene_monitor_params")
+    normalized_occupancy_map_monitor_params = _normalize_ros_param(occupancy_map_monitor_params, "occupancy_map_monitor_params")
+    normalized_trajectory_execution = _normalize_ros_param(trajectory_execution, "trajectory_execution")
+    normalized_moveit_controller_manager = _normalize_ros_param(moveit_controller_manager, "moveit_controller_manager")
+    normalized_moveit_simple_controller_manager = _normalize_ros_param(moveit_simple_controller_manager, "moveit_simple_controller_manager")
+
     static_tf = Node(
         package="tf2_ros",
         executable="static_transform_publisher",
@@ -170,14 +195,14 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[normalized_use_sim_time, normalized_robot_description],
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[normalized_use_sim_time, normalized_robot_description],
     )
 
     move_group = Node(
@@ -185,17 +210,17 @@ def _launch_setup(context):
         executable="move_group",
         output="screen",
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
-            planning_pipelines_config,
-            ompl_planning_pipeline_config,
-            planning_scene_monitor_params,
-            occupancy_map_monitor_params,
-            trajectory_execution,
-            moveit_controller_manager,
-            moveit_simple_controller_manager,
+            normalized_use_sim_time,
+            normalized_robot_description,
+            normalized_robot_description_semantic,
+            normalized_robot_description_kinematics,
+            normalized_planning_pipelines_config,
+            normalized_ompl_planning_pipeline_config,
+            normalized_planning_scene_monitor_params,
+            normalized_occupancy_map_monitor_params,
+            normalized_trajectory_execution,
+            normalized_moveit_controller_manager,
+            normalized_moveit_simple_controller_manager,
         ],
     )
 
@@ -207,10 +232,10 @@ def _launch_setup(context):
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
+            normalized_use_sim_time,
+            normalized_robot_description,
+            normalized_robot_description_semantic,
+            normalized_robot_description_kinematics,
         ],
     )
 

--- a/scenes/ur3_suction_test/launch/demo.launch.py
+++ b/scenes/ur3_suction_test/launch/demo.launch.py
@@ -56,6 +56,18 @@ def load_yaml(package_name, rel_path):
         return yaml.safe_load(f) or {}
 
 
+
+
+def _normalize_ros_param(value, path="root"):
+    if isinstance(value, dict):
+        return {key: _normalize_ros_param(item, f"{path}.{key}") for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    if isinstance(value, tuple):
+        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    return value
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -145,6 +157,19 @@ def _launch_setup(context):
     }
 
     # --- Nodes ---
+
+    normalized_use_sim_time = _normalize_ros_param({"use_sim_time": use_sim_time}, "use_sim_time")
+    normalized_robot_description = _normalize_ros_param(robot_description, "robot_description")
+    normalized_robot_description_semantic = _normalize_ros_param(robot_description_semantic, "robot_description_semantic")
+    normalized_robot_description_kinematics = _normalize_ros_param(robot_description_kinematics, "robot_description_kinematics")
+    normalized_planning_pipelines_config = _normalize_ros_param(planning_pipelines_config, "planning_pipelines_config")
+    normalized_ompl_planning_pipeline_config = _normalize_ros_param(ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+    normalized_planning_scene_monitor_params = _normalize_ros_param(planning_scene_monitor_params, "planning_scene_monitor_params")
+    normalized_occupancy_map_monitor_params = _normalize_ros_param(occupancy_map_monitor_params, "occupancy_map_monitor_params")
+    normalized_trajectory_execution = _normalize_ros_param(trajectory_execution, "trajectory_execution")
+    normalized_moveit_controller_manager = _normalize_ros_param(moveit_controller_manager, "moveit_controller_manager")
+    normalized_moveit_simple_controller_manager = _normalize_ros_param(moveit_simple_controller_manager, "moveit_simple_controller_manager")
+
     static_tf = Node(
         package="tf2_ros",
         executable="static_transform_publisher",
@@ -162,14 +187,14 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[normalized_use_sim_time, normalized_robot_description],
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[normalized_use_sim_time, normalized_robot_description],
     )
 
     move_group = Node(
@@ -177,17 +202,17 @@ def _launch_setup(context):
         executable="move_group",
         output="screen",
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
-            planning_pipelines_config,
-            ompl_planning_pipeline_config,
-            planning_scene_monitor_params,
-            occupancy_map_monitor_params,
-            trajectory_execution,
-            moveit_controller_manager,
-            moveit_simple_controller_manager,
+            normalized_use_sim_time,
+            normalized_robot_description,
+            normalized_robot_description_semantic,
+            normalized_robot_description_kinematics,
+            normalized_planning_pipelines_config,
+            normalized_ompl_planning_pipeline_config,
+            normalized_planning_scene_monitor_params,
+            normalized_occupancy_map_monitor_params,
+            normalized_trajectory_execution,
+            normalized_moveit_controller_manager,
+            normalized_moveit_simple_controller_manager,
         ],
     )
 
@@ -199,10 +224,10 @@ def _launch_setup(context):
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
+            normalized_use_sim_time,
+            normalized_robot_description,
+            normalized_robot_description_semantic,
+            normalized_robot_description_kinematics,
         ],
     )
 

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -57,6 +57,18 @@ def load_yaml(package_name, rel_path):
         return yaml.safe_load(file) or {}
 
 
+
+
+def _normalize_ros_param(value, path="root"):
+    if isinstance(value, dict):
+        return {key: _normalize_ros_param(item, f"{path}.{key}") for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    if isinstance(value, tuple):
+        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    return value
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -143,6 +155,19 @@ def _launch_setup(context):
         "sensors": [],
     }
 
+
+    normalized_use_sim_time = _normalize_ros_param({"use_sim_time": use_sim_time}, "use_sim_time")
+    normalized_robot_description = _normalize_ros_param(robot_description, "robot_description")
+    normalized_robot_description_semantic = _normalize_ros_param(robot_description_semantic, "robot_description_semantic")
+    normalized_robot_description_kinematics = _normalize_ros_param(robot_description_kinematics, "robot_description_kinematics")
+    normalized_planning_pipelines_config = _normalize_ros_param(planning_pipelines_config, "planning_pipelines_config")
+    normalized_ompl_planning_pipeline_config = _normalize_ros_param(ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+    normalized_planning_scene_monitor_params = _normalize_ros_param(planning_scene_monitor_params, "planning_scene_monitor_params")
+    normalized_occupancy_map_monitor_params = _normalize_ros_param(occupancy_map_monitor_params, "occupancy_map_monitor_params")
+    normalized_trajectory_execution = _normalize_ros_param(trajectory_execution, "trajectory_execution")
+    normalized_moveit_controller_manager = _normalize_ros_param(moveit_controller_manager, "moveit_controller_manager")
+    normalized_moveit_simple_controller_manager = _normalize_ros_param(moveit_simple_controller_manager, "moveit_simple_controller_manager")
+
     static_tf = Node(
         package="tf2_ros",
         executable="static_transform_publisher",
@@ -172,14 +197,14 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[normalized_use_sim_time, normalized_robot_description],
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[normalized_use_sim_time, normalized_robot_description],
     )
 
     move_group = Node(
@@ -187,17 +212,17 @@ def _launch_setup(context):
         executable="move_group",
         output="screen",
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
-            planning_pipelines_config,
-            ompl_planning_pipeline_config,
-            planning_scene_monitor_params,
-            occupancy_map_monitor_params,
-            trajectory_execution,
-            moveit_controller_manager,
-            moveit_simple_controller_manager,
+            normalized_use_sim_time,
+            normalized_robot_description,
+            normalized_robot_description_semantic,
+            normalized_robot_description_kinematics,
+            normalized_planning_pipelines_config,
+            normalized_ompl_planning_pipeline_config,
+            normalized_planning_scene_monitor_params,
+            normalized_occupancy_map_monitor_params,
+            normalized_trajectory_execution,
+            normalized_moveit_controller_manager,
+            normalized_moveit_simple_controller_manager,
         ],
     )
 
@@ -209,10 +234,10 @@ def _launch_setup(context):
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
+            normalized_use_sim_time,
+            normalized_robot_description,
+            normalized_robot_description_semantic,
+            normalized_robot_description_kinematics,
         ],
     )
 

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -58,6 +58,18 @@ def load_yaml(package_name, rel_path):
         return yaml.safe_load(file) or {}
 
 
+
+
+def _normalize_ros_param(value, path="root"):
+    if isinstance(value, dict):
+        return {key: _normalize_ros_param(item, f"{path}.{key}") for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    if isinstance(value, tuple):
+        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    return value
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -138,6 +150,19 @@ def _launch_setup(context):
         "sensors": [],
     }
 
+
+    normalized_use_sim_time = _normalize_ros_param({"use_sim_time": use_sim_time}, "use_sim_time")
+    normalized_robot_description = _normalize_ros_param(robot_description, "robot_description")
+    normalized_robot_description_semantic = _normalize_ros_param(robot_description_semantic, "robot_description_semantic")
+    normalized_robot_description_kinematics = _normalize_ros_param(robot_description_kinematics, "robot_description_kinematics")
+    normalized_planning_pipelines_config = _normalize_ros_param(planning_pipelines_config, "planning_pipelines_config")
+    normalized_ompl_planning_pipeline_config = _normalize_ros_param(ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+    normalized_planning_scene_monitor_params = _normalize_ros_param(planning_scene_monitor_params, "planning_scene_monitor_params")
+    normalized_occupancy_map_monitor_params = _normalize_ros_param(occupancy_map_monitor_params, "occupancy_map_monitor_params")
+    normalized_trajectory_execution = _normalize_ros_param(trajectory_execution, "trajectory_execution")
+    normalized_moveit_controller_manager = _normalize_ros_param(moveit_controller_manager, "moveit_controller_manager")
+    normalized_moveit_simple_controller_manager = _normalize_ros_param(moveit_simple_controller_manager, "moveit_simple_controller_manager")
+
     static_tf = Node(
         package="tf2_ros",
         executable="static_transform_publisher",
@@ -167,14 +192,14 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[normalized_use_sim_time, normalized_robot_description],
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[normalized_use_sim_time, normalized_robot_description],
     )
 
     move_group = Node(
@@ -182,17 +207,17 @@ def _launch_setup(context):
         executable="move_group",
         output="screen",
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
-            planning_pipelines_config,
-            ompl_planning_pipeline_config,
-            planning_scene_monitor_params,
-            occupancy_map_monitor_params,
-            trajectory_execution,
-            moveit_controller_manager,
-            moveit_simple_controller_manager,
+            normalized_use_sim_time,
+            normalized_robot_description,
+            normalized_robot_description_semantic,
+            normalized_robot_description_kinematics,
+            normalized_planning_pipelines_config,
+            normalized_ompl_planning_pipeline_config,
+            normalized_planning_scene_monitor_params,
+            normalized_occupancy_map_monitor_params,
+            normalized_trajectory_execution,
+            normalized_moveit_controller_manager,
+            normalized_moveit_simple_controller_manager,
         ],
     )
 
@@ -204,10 +229,10 @@ def _launch_setup(context):
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
+            normalized_use_sim_time,
+            normalized_robot_description,
+            normalized_robot_description_semantic,
+            normalized_robot_description_kinematics,
         ],
     )
 

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -57,6 +57,18 @@ def load_yaml(package_name, rel_path):
         return yaml.safe_load(file) or {}
 
 
+
+
+def _normalize_ros_param(value, path="root"):
+    if isinstance(value, dict):
+        return {key: _normalize_ros_param(item, f"{path}.{key}") for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    if isinstance(value, tuple):
+        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    return value
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -137,6 +149,19 @@ def _launch_setup(context):
         "sensors": [],
     }
 
+
+    normalized_use_sim_time = _normalize_ros_param({"use_sim_time": use_sim_time}, "use_sim_time")
+    normalized_robot_description = _normalize_ros_param(robot_description, "robot_description")
+    normalized_robot_description_semantic = _normalize_ros_param(robot_description_semantic, "robot_description_semantic")
+    normalized_robot_description_kinematics = _normalize_ros_param(robot_description_kinematics, "robot_description_kinematics")
+    normalized_planning_pipelines_config = _normalize_ros_param(planning_pipelines_config, "planning_pipelines_config")
+    normalized_ompl_planning_pipeline_config = _normalize_ros_param(ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+    normalized_planning_scene_monitor_params = _normalize_ros_param(planning_scene_monitor_params, "planning_scene_monitor_params")
+    normalized_occupancy_map_monitor_params = _normalize_ros_param(occupancy_map_monitor_params, "occupancy_map_monitor_params")
+    normalized_trajectory_execution = _normalize_ros_param(trajectory_execution, "trajectory_execution")
+    normalized_moveit_controller_manager = _normalize_ros_param(moveit_controller_manager, "moveit_controller_manager")
+    normalized_moveit_simple_controller_manager = _normalize_ros_param(moveit_simple_controller_manager, "moveit_simple_controller_manager")
+
     static_tf = Node(
         package="tf2_ros",
         executable="static_transform_publisher",
@@ -166,14 +191,14 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[normalized_use_sim_time, normalized_robot_description],
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[normalized_use_sim_time, normalized_robot_description],
     )
 
     move_group = Node(
@@ -181,17 +206,17 @@ def _launch_setup(context):
         executable="move_group",
         output="screen",
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
-            planning_pipelines_config,
-            ompl_planning_pipeline_config,
-            planning_scene_monitor_params,
-            occupancy_map_monitor_params,
-            trajectory_execution,
-            moveit_controller_manager,
-            moveit_simple_controller_manager,
+            normalized_use_sim_time,
+            normalized_robot_description,
+            normalized_robot_description_semantic,
+            normalized_robot_description_kinematics,
+            normalized_planning_pipelines_config,
+            normalized_ompl_planning_pipeline_config,
+            normalized_planning_scene_monitor_params,
+            normalized_occupancy_map_monitor_params,
+            normalized_trajectory_execution,
+            normalized_moveit_controller_manager,
+            normalized_moveit_simple_controller_manager,
         ],
     )
 
@@ -203,10 +228,10 @@ def _launch_setup(context):
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
+            normalized_use_sim_time,
+            normalized_robot_description,
+            normalized_robot_description_semantic,
+            normalized_robot_description_kinematics,
         ],
     )
 


### PR DESCRIPTION
### Motivation
- Prevent crashes and launch incompatibilities by ensuring complex parameter trees are converted to launch-safe structures before being passed to `Node`.
- Make parameter handling deterministic by normalizing values immediately before node creation in `_launch_setup(context)`.

### Description
- Added a helper `def _normalize_ros_param(value, path="root")` to each demo launch file that recursively walks `dict` and `list` structures and converts `tuple` to `list` for launch compatibility.
- Applied normalization to MoveIt- and demo-related parameter objects (`robot_description_kinematics`, `planning_pipelines_config`, `ompl_planning_pipeline_config`, `planning_scene_monitor_params`, `occupancy_map_monitor_params`, `trajectory_execution`, `moveit_controller_manager`, `moveit_simple_controller_manager`, and `use_sim_time`/`robot_description` wrappers) inside `_launch_setup` immediately before node creation.
- Replaced direct `parameters=[...]` usages in `Node(...)` calls with the corresponding `normalized_*` variables for `robot_state_publisher`, `joint_state_publisher`, `move_group`, and `rviz2` across sibling demo files.
- Changes applied to the following files: `scenes/ur5_2f_test/launch/demo.launch.py`, `scenes/ur10_2f_test/launch/demo.launch.py`, `scenes/ur5_3f_test/launch/demo.launch.py`, `scenes/ur3_suction_test/launch/demo.launch.py`, `scenes/suction_test/launch/demo.launch.py`, and `scenes/ur5_airpick4_test/launch/demo.launch.py`.

### Testing
- Ran Python bytecode compilation with `python -m compileall` on all six updated launch files, and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad3f082148331810e3b745d5505f4)