### PR TITLE
Add explicit ROS parameter validation in scene demo launches

### DIFF
--- a/scenes/suction_test/launch/demo.launch.py
+++ b/scenes/suction_test/launch/demo.launch.py
@@ -58,14 +58,23 @@ def load_yaml(package_name, rel_path):
 
 
 
-def _normalize_ros_param(value, path="root"):
+def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
-        return {key: _normalize_ros_param(item, f"{path}.{key}") for key, item in value.items()}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"Invalid ROS param type at {path}: {type(key).__name__} -> {key!r}")
+            _validate_ros_param_types(item, f"{path}.{key}")
+        return
+
     if isinstance(value, list):
-        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
-    if isinstance(value, tuple):
-        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
-    return value
+        for index, item in enumerate(value):
+            _validate_ros_param_types(item, f"{path}[{index}]")
+        return
+
+    if isinstance(value, (bool, int, float, str)):
+        return
+
+    raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
 
 
 def _launch_setup(context):
@@ -161,17 +170,32 @@ def _launch_setup(context):
 
     # --- Nodes ---
 
-    normalized_use_sim_time = _normalize_ros_param({"use_sim_time": use_sim_time}, "use_sim_time")
-    normalized_robot_description = _normalize_ros_param(robot_description, "robot_description")
-    normalized_robot_description_semantic = _normalize_ros_param(robot_description_semantic, "robot_description_semantic")
-    normalized_robot_description_kinematics = _normalize_ros_param(robot_description_kinematics, "robot_description_kinematics")
-    normalized_planning_pipelines_config = _normalize_ros_param(planning_pipelines_config, "planning_pipelines_config")
-    normalized_ompl_planning_pipeline_config = _normalize_ros_param(ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
-    normalized_planning_scene_monitor_params = _normalize_ros_param(planning_scene_monitor_params, "planning_scene_monitor_params")
-    normalized_occupancy_map_monitor_params = _normalize_ros_param(occupancy_map_monitor_params, "occupancy_map_monitor_params")
-    normalized_trajectory_execution = _normalize_ros_param(trajectory_execution, "trajectory_execution")
-    normalized_moveit_controller_manager = _normalize_ros_param(moveit_controller_manager, "moveit_controller_manager")
-    normalized_moveit_simple_controller_manager = _normalize_ros_param(moveit_simple_controller_manager, "moveit_simple_controller_manager")
+    try:
+        validated_use_sim_time = {"use_sim_time": use_sim_time.perform(context).lower() == "true"}
+        validated_robot_description = robot_description
+        validated_robot_description_semantic = robot_description_semantic
+        validated_robot_description_kinematics = robot_description_kinematics
+        validated_planning_pipelines_config = planning_pipelines_config
+        validated_ompl_planning_pipeline_config = ompl_planning_pipeline_config
+        validated_planning_scene_monitor_params = planning_scene_monitor_params
+        validated_occupancy_map_monitor_params = occupancy_map_monitor_params
+        validated_trajectory_execution = trajectory_execution
+        validated_moveit_controller_manager = moveit_controller_manager
+        validated_moveit_simple_controller_manager = moveit_simple_controller_manager
+
+        _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
+        _validate_ros_param_types(validated_robot_description, "robot_description")
+        _validate_ros_param_types(validated_robot_description_semantic, "robot_description_semantic")
+        _validate_ros_param_types(validated_robot_description_kinematics, "robot_description_kinematics")
+        _validate_ros_param_types(validated_planning_pipelines_config, "planning_pipelines_config")
+        _validate_ros_param_types(validated_ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+        _validate_ros_param_types(validated_planning_scene_monitor_params, "planning_scene_monitor_params")
+        _validate_ros_param_types(validated_occupancy_map_monitor_params, "occupancy_map_monitor_params")
+        _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
+        _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
+        _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
+    except TypeError as exc:
+        raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 
     static_tf = Node(
         package="tf2_ros",
@@ -190,7 +214,7 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[normalized_use_sim_time, normalized_robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     # IMPORTANT: pass robot_description as a parameter so it does NOT wait on a topic
@@ -198,7 +222,7 @@ def _launch_setup(context):
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[normalized_use_sim_time, normalized_robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     move_group = Node(
@@ -206,17 +230,17 @@ def _launch_setup(context):
         executable="move_group",
         output="screen",
         parameters=[
-            normalized_use_sim_time,
-            normalized_robot_description,
-            normalized_robot_description_semantic,
-            normalized_robot_description_kinematics,
-            normalized_planning_pipelines_config,
-            normalized_ompl_planning_pipeline_config,
-            normalized_planning_scene_monitor_params,
-            normalized_occupancy_map_monitor_params,
-            normalized_trajectory_execution,
-            normalized_moveit_controller_manager,
-            normalized_moveit_simple_controller_manager,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
+            validated_planning_pipelines_config,
+            validated_ompl_planning_pipeline_config,
+            validated_planning_scene_monitor_params,
+            validated_occupancy_map_monitor_params,
+            validated_trajectory_execution,
+            validated_moveit_controller_manager,
+            validated_moveit_simple_controller_manager,
         ],
     )
 
@@ -228,10 +252,10 @@ def _launch_setup(context):
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=[
-            normalized_use_sim_time,
-            normalized_robot_description,
-            normalized_robot_description_semantic,
-            normalized_robot_description_kinematics,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
         ],
     )
 

--- a/scenes/ur10_2f_test/launch/demo.launch.py
+++ b/scenes/ur10_2f_test/launch/demo.launch.py
@@ -58,14 +58,23 @@ def load_yaml(package_name, rel_path):
 
 
 
-def _normalize_ros_param(value, path="root"):
+def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
-        return {key: _normalize_ros_param(item, f"{path}.{key}") for key, item in value.items()}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"Invalid ROS param type at {path}: {type(key).__name__} -> {key!r}")
+            _validate_ros_param_types(item, f"{path}.{key}")
+        return
+
     if isinstance(value, list):
-        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
-    if isinstance(value, tuple):
-        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
-    return value
+        for index, item in enumerate(value):
+            _validate_ros_param_types(item, f"{path}[{index}]")
+        return
+
+    if isinstance(value, (bool, int, float, str)):
+        return
+
+    raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
 
 
 def _launch_setup(context):
@@ -154,17 +163,32 @@ def _launch_setup(context):
     }
 
 
-    normalized_use_sim_time = _normalize_ros_param({"use_sim_time": use_sim_time}, "use_sim_time")
-    normalized_robot_description = _normalize_ros_param(robot_description, "robot_description")
-    normalized_robot_description_semantic = _normalize_ros_param(robot_description_semantic, "robot_description_semantic")
-    normalized_robot_description_kinematics = _normalize_ros_param(robot_description_kinematics, "robot_description_kinematics")
-    normalized_planning_pipelines_config = _normalize_ros_param(planning_pipelines_config, "planning_pipelines_config")
-    normalized_ompl_planning_pipeline_config = _normalize_ros_param(ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
-    normalized_planning_scene_monitor_params = _normalize_ros_param(planning_scene_monitor_params, "planning_scene_monitor_params")
-    normalized_occupancy_map_monitor_params = _normalize_ros_param(occupancy_map_monitor_params, "occupancy_map_monitor_params")
-    normalized_trajectory_execution = _normalize_ros_param(trajectory_execution, "trajectory_execution")
-    normalized_moveit_controller_manager = _normalize_ros_param(moveit_controller_manager, "moveit_controller_manager")
-    normalized_moveit_simple_controller_manager = _normalize_ros_param(moveit_simple_controller_manager, "moveit_simple_controller_manager")
+    try:
+        validated_use_sim_time = {"use_sim_time": use_sim_time.perform(context).lower() == "true"}
+        validated_robot_description = robot_description
+        validated_robot_description_semantic = robot_description_semantic
+        validated_robot_description_kinematics = robot_description_kinematics
+        validated_planning_pipelines_config = planning_pipelines_config
+        validated_ompl_planning_pipeline_config = ompl_planning_pipeline_config
+        validated_planning_scene_monitor_params = planning_scene_monitor_params
+        validated_occupancy_map_monitor_params = occupancy_map_monitor_params
+        validated_trajectory_execution = trajectory_execution
+        validated_moveit_controller_manager = moveit_controller_manager
+        validated_moveit_simple_controller_manager = moveit_simple_controller_manager
+
+        _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
+        _validate_ros_param_types(validated_robot_description, "robot_description")
+        _validate_ros_param_types(validated_robot_description_semantic, "robot_description_semantic")
+        _validate_ros_param_types(validated_robot_description_kinematics, "robot_description_kinematics")
+        _validate_ros_param_types(validated_planning_pipelines_config, "planning_pipelines_config")
+        _validate_ros_param_types(validated_ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+        _validate_ros_param_types(validated_planning_scene_monitor_params, "planning_scene_monitor_params")
+        _validate_ros_param_types(validated_occupancy_map_monitor_params, "occupancy_map_monitor_params")
+        _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
+        _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
+        _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
+    except TypeError as exc:
+        raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 
     static_tf = Node(
         package="tf2_ros",
@@ -195,14 +219,14 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[normalized_use_sim_time, normalized_robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[normalized_use_sim_time, normalized_robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     move_group = Node(
@@ -210,17 +234,17 @@ def _launch_setup(context):
         executable="move_group",
         output="screen",
         parameters=[
-            normalized_use_sim_time,
-            normalized_robot_description,
-            normalized_robot_description_semantic,
-            normalized_robot_description_kinematics,
-            normalized_planning_pipelines_config,
-            normalized_ompl_planning_pipeline_config,
-            normalized_planning_scene_monitor_params,
-            normalized_occupancy_map_monitor_params,
-            normalized_trajectory_execution,
-            normalized_moveit_controller_manager,
-            normalized_moveit_simple_controller_manager,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
+            validated_planning_pipelines_config,
+            validated_ompl_planning_pipeline_config,
+            validated_planning_scene_monitor_params,
+            validated_occupancy_map_monitor_params,
+            validated_trajectory_execution,
+            validated_moveit_controller_manager,
+            validated_moveit_simple_controller_manager,
         ],
     )
 
@@ -232,10 +256,10 @@ def _launch_setup(context):
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=[
-            normalized_use_sim_time,
-            normalized_robot_description,
-            normalized_robot_description_semantic,
-            normalized_robot_description_kinematics,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
         ],
     )
 

--- a/scenes/ur3_suction_test/launch/demo.launch.py
+++ b/scenes/ur3_suction_test/launch/demo.launch.py
@@ -58,14 +58,23 @@ def load_yaml(package_name, rel_path):
 
 
 
-def _normalize_ros_param(value, path="root"):
+def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
-        return {key: _normalize_ros_param(item, f"{path}.{key}") for key, item in value.items()}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"Invalid ROS param type at {path}: {type(key).__name__} -> {key!r}")
+            _validate_ros_param_types(item, f"{path}.{key}")
+        return
+
     if isinstance(value, list):
-        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
-    if isinstance(value, tuple):
-        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
-    return value
+        for index, item in enumerate(value):
+            _validate_ros_param_types(item, f"{path}[{index}]")
+        return
+
+    if isinstance(value, (bool, int, float, str)):
+        return
+
+    raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
 
 
 def _launch_setup(context):
@@ -158,17 +167,32 @@ def _launch_setup(context):
 
     # --- Nodes ---
 
-    normalized_use_sim_time = _normalize_ros_param({"use_sim_time": use_sim_time}, "use_sim_time")
-    normalized_robot_description = _normalize_ros_param(robot_description, "robot_description")
-    normalized_robot_description_semantic = _normalize_ros_param(robot_description_semantic, "robot_description_semantic")
-    normalized_robot_description_kinematics = _normalize_ros_param(robot_description_kinematics, "robot_description_kinematics")
-    normalized_planning_pipelines_config = _normalize_ros_param(planning_pipelines_config, "planning_pipelines_config")
-    normalized_ompl_planning_pipeline_config = _normalize_ros_param(ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
-    normalized_planning_scene_monitor_params = _normalize_ros_param(planning_scene_monitor_params, "planning_scene_monitor_params")
-    normalized_occupancy_map_monitor_params = _normalize_ros_param(occupancy_map_monitor_params, "occupancy_map_monitor_params")
-    normalized_trajectory_execution = _normalize_ros_param(trajectory_execution, "trajectory_execution")
-    normalized_moveit_controller_manager = _normalize_ros_param(moveit_controller_manager, "moveit_controller_manager")
-    normalized_moveit_simple_controller_manager = _normalize_ros_param(moveit_simple_controller_manager, "moveit_simple_controller_manager")
+    try:
+        validated_use_sim_time = {"use_sim_time": use_sim_time.perform(context).lower() == "true"}
+        validated_robot_description = robot_description
+        validated_robot_description_semantic = robot_description_semantic
+        validated_robot_description_kinematics = robot_description_kinematics
+        validated_planning_pipelines_config = planning_pipelines_config
+        validated_ompl_planning_pipeline_config = ompl_planning_pipeline_config
+        validated_planning_scene_monitor_params = planning_scene_monitor_params
+        validated_occupancy_map_monitor_params = occupancy_map_monitor_params
+        validated_trajectory_execution = trajectory_execution
+        validated_moveit_controller_manager = moveit_controller_manager
+        validated_moveit_simple_controller_manager = moveit_simple_controller_manager
+
+        _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
+        _validate_ros_param_types(validated_robot_description, "robot_description")
+        _validate_ros_param_types(validated_robot_description_semantic, "robot_description_semantic")
+        _validate_ros_param_types(validated_robot_description_kinematics, "robot_description_kinematics")
+        _validate_ros_param_types(validated_planning_pipelines_config, "planning_pipelines_config")
+        _validate_ros_param_types(validated_ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+        _validate_ros_param_types(validated_planning_scene_monitor_params, "planning_scene_monitor_params")
+        _validate_ros_param_types(validated_occupancy_map_monitor_params, "occupancy_map_monitor_params")
+        _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
+        _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
+        _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
+    except TypeError as exc:
+        raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 
     static_tf = Node(
         package="tf2_ros",
@@ -187,14 +211,14 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[normalized_use_sim_time, normalized_robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[normalized_use_sim_time, normalized_robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     move_group = Node(
@@ -202,17 +226,17 @@ def _launch_setup(context):
         executable="move_group",
         output="screen",
         parameters=[
-            normalized_use_sim_time,
-            normalized_robot_description,
-            normalized_robot_description_semantic,
-            normalized_robot_description_kinematics,
-            normalized_planning_pipelines_config,
-            normalized_ompl_planning_pipeline_config,
-            normalized_planning_scene_monitor_params,
-            normalized_occupancy_map_monitor_params,
-            normalized_trajectory_execution,
-            normalized_moveit_controller_manager,
-            normalized_moveit_simple_controller_manager,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
+            validated_planning_pipelines_config,
+            validated_ompl_planning_pipeline_config,
+            validated_planning_scene_monitor_params,
+            validated_occupancy_map_monitor_params,
+            validated_trajectory_execution,
+            validated_moveit_controller_manager,
+            validated_moveit_simple_controller_manager,
         ],
     )
 
@@ -224,10 +248,10 @@ def _launch_setup(context):
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=[
-            normalized_use_sim_time,
-            normalized_robot_description,
-            normalized_robot_description_semantic,
-            normalized_robot_description_kinematics,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
         ],
     )
 

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -59,14 +59,23 @@ def load_yaml(package_name, rel_path):
 
 
 
-def _normalize_ros_param(value, path="root"):
+def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
-        return {key: _normalize_ros_param(item, f"{path}.{key}") for key, item in value.items()}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"Invalid ROS param type at {path}: {type(key).__name__} -> {key!r}")
+            _validate_ros_param_types(item, f"{path}.{key}")
+        return
+
     if isinstance(value, list):
-        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
-    if isinstance(value, tuple):
-        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
-    return value
+        for index, item in enumerate(value):
+            _validate_ros_param_types(item, f"{path}[{index}]")
+        return
+
+    if isinstance(value, (bool, int, float, str)):
+        return
+
+    raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
 
 
 def _launch_setup(context):
@@ -156,17 +165,32 @@ def _launch_setup(context):
     }
 
 
-    normalized_use_sim_time = _normalize_ros_param({"use_sim_time": use_sim_time}, "use_sim_time")
-    normalized_robot_description = _normalize_ros_param(robot_description, "robot_description")
-    normalized_robot_description_semantic = _normalize_ros_param(robot_description_semantic, "robot_description_semantic")
-    normalized_robot_description_kinematics = _normalize_ros_param(robot_description_kinematics, "robot_description_kinematics")
-    normalized_planning_pipelines_config = _normalize_ros_param(planning_pipelines_config, "planning_pipelines_config")
-    normalized_ompl_planning_pipeline_config = _normalize_ros_param(ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
-    normalized_planning_scene_monitor_params = _normalize_ros_param(planning_scene_monitor_params, "planning_scene_monitor_params")
-    normalized_occupancy_map_monitor_params = _normalize_ros_param(occupancy_map_monitor_params, "occupancy_map_monitor_params")
-    normalized_trajectory_execution = _normalize_ros_param(trajectory_execution, "trajectory_execution")
-    normalized_moveit_controller_manager = _normalize_ros_param(moveit_controller_manager, "moveit_controller_manager")
-    normalized_moveit_simple_controller_manager = _normalize_ros_param(moveit_simple_controller_manager, "moveit_simple_controller_manager")
+    try:
+        validated_use_sim_time = {"use_sim_time": use_sim_time.perform(context).lower() == "true"}
+        validated_robot_description = robot_description
+        validated_robot_description_semantic = robot_description_semantic
+        validated_robot_description_kinematics = robot_description_kinematics
+        validated_planning_pipelines_config = planning_pipelines_config
+        validated_ompl_planning_pipeline_config = ompl_planning_pipeline_config
+        validated_planning_scene_monitor_params = planning_scene_monitor_params
+        validated_occupancy_map_monitor_params = occupancy_map_monitor_params
+        validated_trajectory_execution = trajectory_execution
+        validated_moveit_controller_manager = moveit_controller_manager
+        validated_moveit_simple_controller_manager = moveit_simple_controller_manager
+
+        _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
+        _validate_ros_param_types(validated_robot_description, "robot_description")
+        _validate_ros_param_types(validated_robot_description_semantic, "robot_description_semantic")
+        _validate_ros_param_types(validated_robot_description_kinematics, "robot_description_kinematics")
+        _validate_ros_param_types(validated_planning_pipelines_config, "planning_pipelines_config")
+        _validate_ros_param_types(validated_ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+        _validate_ros_param_types(validated_planning_scene_monitor_params, "planning_scene_monitor_params")
+        _validate_ros_param_types(validated_occupancy_map_monitor_params, "occupancy_map_monitor_params")
+        _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
+        _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
+        _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
+    except TypeError as exc:
+        raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 
     static_tf = Node(
         package="tf2_ros",
@@ -197,14 +221,14 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[normalized_use_sim_time, normalized_robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[normalized_use_sim_time, normalized_robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     move_group = Node(
@@ -212,17 +236,17 @@ def _launch_setup(context):
         executable="move_group",
         output="screen",
         parameters=[
-            normalized_use_sim_time,
-            normalized_robot_description,
-            normalized_robot_description_semantic,
-            normalized_robot_description_kinematics,
-            normalized_planning_pipelines_config,
-            normalized_ompl_planning_pipeline_config,
-            normalized_planning_scene_monitor_params,
-            normalized_occupancy_map_monitor_params,
-            normalized_trajectory_execution,
-            normalized_moveit_controller_manager,
-            normalized_moveit_simple_controller_manager,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
+            validated_planning_pipelines_config,
+            validated_ompl_planning_pipeline_config,
+            validated_planning_scene_monitor_params,
+            validated_occupancy_map_monitor_params,
+            validated_trajectory_execution,
+            validated_moveit_controller_manager,
+            validated_moveit_simple_controller_manager,
         ],
     )
 
@@ -234,10 +258,10 @@ def _launch_setup(context):
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=[
-            normalized_use_sim_time,
-            normalized_robot_description,
-            normalized_robot_description_semantic,
-            normalized_robot_description_kinematics,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
         ],
     )
 

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -60,14 +60,23 @@ def load_yaml(package_name, rel_path):
 
 
 
-def _normalize_ros_param(value, path="root"):
+def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
-        return {key: _normalize_ros_param(item, f"{path}.{key}") for key, item in value.items()}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"Invalid ROS param type at {path}: {type(key).__name__} -> {key!r}")
+            _validate_ros_param_types(item, f"{path}.{key}")
+        return
+
     if isinstance(value, list):
-        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
-    if isinstance(value, tuple):
-        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
-    return value
+        for index, item in enumerate(value):
+            _validate_ros_param_types(item, f"{path}[{index}]")
+        return
+
+    if isinstance(value, (bool, int, float, str)):
+        return
+
+    raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
 
 
 def _launch_setup(context):
@@ -151,17 +160,32 @@ def _launch_setup(context):
     }
 
 
-    normalized_use_sim_time = _normalize_ros_param({"use_sim_time": use_sim_time}, "use_sim_time")
-    normalized_robot_description = _normalize_ros_param(robot_description, "robot_description")
-    normalized_robot_description_semantic = _normalize_ros_param(robot_description_semantic, "robot_description_semantic")
-    normalized_robot_description_kinematics = _normalize_ros_param(robot_description_kinematics, "robot_description_kinematics")
-    normalized_planning_pipelines_config = _normalize_ros_param(planning_pipelines_config, "planning_pipelines_config")
-    normalized_ompl_planning_pipeline_config = _normalize_ros_param(ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
-    normalized_planning_scene_monitor_params = _normalize_ros_param(planning_scene_monitor_params, "planning_scene_monitor_params")
-    normalized_occupancy_map_monitor_params = _normalize_ros_param(occupancy_map_monitor_params, "occupancy_map_monitor_params")
-    normalized_trajectory_execution = _normalize_ros_param(trajectory_execution, "trajectory_execution")
-    normalized_moveit_controller_manager = _normalize_ros_param(moveit_controller_manager, "moveit_controller_manager")
-    normalized_moveit_simple_controller_manager = _normalize_ros_param(moveit_simple_controller_manager, "moveit_simple_controller_manager")
+    try:
+        validated_use_sim_time = {"use_sim_time": use_sim_time.perform(context).lower() == "true"}
+        validated_robot_description = robot_description
+        validated_robot_description_semantic = robot_description_semantic
+        validated_robot_description_kinematics = robot_description_kinematics
+        validated_planning_pipelines_config = planning_pipelines_config
+        validated_ompl_planning_pipeline_config = ompl_planning_pipeline_config
+        validated_planning_scene_monitor_params = planning_scene_monitor_params
+        validated_occupancy_map_monitor_params = occupancy_map_monitor_params
+        validated_trajectory_execution = trajectory_execution
+        validated_moveit_controller_manager = moveit_controller_manager
+        validated_moveit_simple_controller_manager = moveit_simple_controller_manager
+
+        _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
+        _validate_ros_param_types(validated_robot_description, "robot_description")
+        _validate_ros_param_types(validated_robot_description_semantic, "robot_description_semantic")
+        _validate_ros_param_types(validated_robot_description_kinematics, "robot_description_kinematics")
+        _validate_ros_param_types(validated_planning_pipelines_config, "planning_pipelines_config")
+        _validate_ros_param_types(validated_ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+        _validate_ros_param_types(validated_planning_scene_monitor_params, "planning_scene_monitor_params")
+        _validate_ros_param_types(validated_occupancy_map_monitor_params, "occupancy_map_monitor_params")
+        _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
+        _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
+        _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
+    except TypeError as exc:
+        raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 
     static_tf = Node(
         package="tf2_ros",
@@ -192,14 +216,14 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[normalized_use_sim_time, normalized_robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[normalized_use_sim_time, normalized_robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     move_group = Node(
@@ -207,17 +231,17 @@ def _launch_setup(context):
         executable="move_group",
         output="screen",
         parameters=[
-            normalized_use_sim_time,
-            normalized_robot_description,
-            normalized_robot_description_semantic,
-            normalized_robot_description_kinematics,
-            normalized_planning_pipelines_config,
-            normalized_ompl_planning_pipeline_config,
-            normalized_planning_scene_monitor_params,
-            normalized_occupancy_map_monitor_params,
-            normalized_trajectory_execution,
-            normalized_moveit_controller_manager,
-            normalized_moveit_simple_controller_manager,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
+            validated_planning_pipelines_config,
+            validated_ompl_planning_pipeline_config,
+            validated_planning_scene_monitor_params,
+            validated_occupancy_map_monitor_params,
+            validated_trajectory_execution,
+            validated_moveit_controller_manager,
+            validated_moveit_simple_controller_manager,
         ],
     )
 
@@ -229,10 +253,10 @@ def _launch_setup(context):
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=[
-            normalized_use_sim_time,
-            normalized_robot_description,
-            normalized_robot_description_semantic,
-            normalized_robot_description_kinematics,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
         ],
     )
 

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -59,14 +59,23 @@ def load_yaml(package_name, rel_path):
 
 
 
-def _normalize_ros_param(value, path="root"):
+def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
-        return {key: _normalize_ros_param(item, f"{path}.{key}") for key, item in value.items()}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"Invalid ROS param type at {path}: {type(key).__name__} -> {key!r}")
+            _validate_ros_param_types(item, f"{path}.{key}")
+        return
+
     if isinstance(value, list):
-        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
-    if isinstance(value, tuple):
-        return [_normalize_ros_param(item, f"{path}[{index}]") for index, item in enumerate(value)]
-    return value
+        for index, item in enumerate(value):
+            _validate_ros_param_types(item, f"{path}[{index}]")
+        return
+
+    if isinstance(value, (bool, int, float, str)):
+        return
+
+    raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
 
 
 def _launch_setup(context):
@@ -150,17 +159,32 @@ def _launch_setup(context):
     }
 
 
-    normalized_use_sim_time = _normalize_ros_param({"use_sim_time": use_sim_time}, "use_sim_time")
-    normalized_robot_description = _normalize_ros_param(robot_description, "robot_description")
-    normalized_robot_description_semantic = _normalize_ros_param(robot_description_semantic, "robot_description_semantic")
-    normalized_robot_description_kinematics = _normalize_ros_param(robot_description_kinematics, "robot_description_kinematics")
-    normalized_planning_pipelines_config = _normalize_ros_param(planning_pipelines_config, "planning_pipelines_config")
-    normalized_ompl_planning_pipeline_config = _normalize_ros_param(ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
-    normalized_planning_scene_monitor_params = _normalize_ros_param(planning_scene_monitor_params, "planning_scene_monitor_params")
-    normalized_occupancy_map_monitor_params = _normalize_ros_param(occupancy_map_monitor_params, "occupancy_map_monitor_params")
-    normalized_trajectory_execution = _normalize_ros_param(trajectory_execution, "trajectory_execution")
-    normalized_moveit_controller_manager = _normalize_ros_param(moveit_controller_manager, "moveit_controller_manager")
-    normalized_moveit_simple_controller_manager = _normalize_ros_param(moveit_simple_controller_manager, "moveit_simple_controller_manager")
+    try:
+        validated_use_sim_time = {"use_sim_time": use_sim_time.perform(context).lower() == "true"}
+        validated_robot_description = robot_description
+        validated_robot_description_semantic = robot_description_semantic
+        validated_robot_description_kinematics = robot_description_kinematics
+        validated_planning_pipelines_config = planning_pipelines_config
+        validated_ompl_planning_pipeline_config = ompl_planning_pipeline_config
+        validated_planning_scene_monitor_params = planning_scene_monitor_params
+        validated_occupancy_map_monitor_params = occupancy_map_monitor_params
+        validated_trajectory_execution = trajectory_execution
+        validated_moveit_controller_manager = moveit_controller_manager
+        validated_moveit_simple_controller_manager = moveit_simple_controller_manager
+
+        _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
+        _validate_ros_param_types(validated_robot_description, "robot_description")
+        _validate_ros_param_types(validated_robot_description_semantic, "robot_description_semantic")
+        _validate_ros_param_types(validated_robot_description_kinematics, "robot_description_kinematics")
+        _validate_ros_param_types(validated_planning_pipelines_config, "planning_pipelines_config")
+        _validate_ros_param_types(validated_ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+        _validate_ros_param_types(validated_planning_scene_monitor_params, "planning_scene_monitor_params")
+        _validate_ros_param_types(validated_occupancy_map_monitor_params, "occupancy_map_monitor_params")
+        _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
+        _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
+        _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
+    except TypeError as exc:
+        raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 
     static_tf = Node(
         package="tf2_ros",
@@ -191,14 +215,14 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[normalized_use_sim_time, normalized_robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[normalized_use_sim_time, normalized_robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     move_group = Node(
@@ -206,17 +230,17 @@ def _launch_setup(context):
         executable="move_group",
         output="screen",
         parameters=[
-            normalized_use_sim_time,
-            normalized_robot_description,
-            normalized_robot_description_semantic,
-            normalized_robot_description_kinematics,
-            normalized_planning_pipelines_config,
-            normalized_ompl_planning_pipeline_config,
-            normalized_planning_scene_monitor_params,
-            normalized_occupancy_map_monitor_params,
-            normalized_trajectory_execution,
-            normalized_moveit_controller_manager,
-            normalized_moveit_simple_controller_manager,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
+            validated_planning_pipelines_config,
+            validated_ompl_planning_pipeline_config,
+            validated_planning_scene_monitor_params,
+            validated_occupancy_map_monitor_params,
+            validated_trajectory_execution,
+            validated_moveit_controller_manager,
+            validated_moveit_simple_controller_manager,
         ],
     )
 
@@ -228,10 +252,10 @@ def _launch_setup(context):
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=[
-            normalized_use_sim_time,
-            normalized_robot_description,
-            normalized_robot_description_semantic,
-            normalized_robot_description_kinematics,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
         ],
     )
 


### PR DESCRIPTION
### Motivation
- Prevent invalid/non-ROS-compatible Python types (notably `tuple`) from being passed as launch parameters to `Node` actions and provide clearer diagnostics when a scene launch assembles parameters.
- Ensure consistent validation and error messages across all scene demo launch scripts for easier debugging of parameter issues.

### Description
- Added a `_validate_ros_param_types(value, path="root")` helper to each scene `demo.launch.py` that allows only ROS-compatible primitives (`bool`, `int`, `float`, `str`) and nested `dict`/`list`, and that raises `TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")` for invalid types (including explicit rejection of `tuple`).
- Validates that dictionary keys are strings and recurses into nested containers to produce path-aware diagnostics (`path` shows the location of the offending value).
- Replaced prior implicit normalization with an explicit assembly of `validated_*` parameter bundles and called `_validate_ros_param_types(...)` on each bundle before using them in `Node(...).parameters`.
- Wrapped the parameter assembly/validation block in `_launch_setup` with a `try/except` that re-raises a contextual message like `"<scene_pkg> demo.launch parameter validation failed: ..."` for easier scene/package-scoped diagnostics; applied this pattern across all scene launch scripts updated.

### Testing
- Ran `python -m py_compile scenes/*/launch/demo.launch.py` to verify syntax, and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad598f2b08331afd7d9b781c78108)