### PR TITLE
Normalize and validate ROS launch parameter types in demo launches

### DIFF
--- a/scenes/suction_test/launch/demo.launch.py
+++ b/scenes/suction_test/launch/demo.launch.py
@@ -58,6 +58,21 @@ def load_yaml(package_name, rel_path):
 
 
 
+
+
+def _normalize_ros_param_types(value):
+    if isinstance(value, dict):
+        return {str(key): _normalize_ros_param_types(item) for key, item in value.items()}
+
+    if isinstance(value, tuple):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    if isinstance(value, list):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    return value
+
+
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -171,17 +186,17 @@ def _launch_setup(context):
     # --- Nodes ---
 
     try:
-        validated_use_sim_time = {"use_sim_time": use_sim_time.perform(context).lower() == "true"}
-        validated_robot_description = robot_description
-        validated_robot_description_semantic = robot_description_semantic
-        validated_robot_description_kinematics = robot_description_kinematics
-        validated_planning_pipelines_config = planning_pipelines_config
-        validated_ompl_planning_pipeline_config = ompl_planning_pipeline_config
-        validated_planning_scene_monitor_params = planning_scene_monitor_params
-        validated_occupancy_map_monitor_params = occupancy_map_monitor_params
-        validated_trajectory_execution = trajectory_execution
-        validated_moveit_controller_manager = moveit_controller_manager
-        validated_moveit_simple_controller_manager = moveit_simple_controller_manager
+        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
+        validated_robot_description = _normalize_ros_param_types(robot_description)
+        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
+        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
+        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
+        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
+        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
+        validated_occupancy_map_monitor_params = _normalize_ros_param_types(occupancy_map_monitor_params)
+        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
+        validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
+        validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")

--- a/scenes/ur10_2f_test/launch/demo.launch.py
+++ b/scenes/ur10_2f_test/launch/demo.launch.py
@@ -58,6 +58,21 @@ def load_yaml(package_name, rel_path):
 
 
 
+
+
+def _normalize_ros_param_types(value):
+    if isinstance(value, dict):
+        return {str(key): _normalize_ros_param_types(item) for key, item in value.items()}
+
+    if isinstance(value, tuple):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    if isinstance(value, list):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    return value
+
+
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -164,17 +179,17 @@ def _launch_setup(context):
 
 
     try:
-        validated_use_sim_time = {"use_sim_time": use_sim_time.perform(context).lower() == "true"}
-        validated_robot_description = robot_description
-        validated_robot_description_semantic = robot_description_semantic
-        validated_robot_description_kinematics = robot_description_kinematics
-        validated_planning_pipelines_config = planning_pipelines_config
-        validated_ompl_planning_pipeline_config = ompl_planning_pipeline_config
-        validated_planning_scene_monitor_params = planning_scene_monitor_params
-        validated_occupancy_map_monitor_params = occupancy_map_monitor_params
-        validated_trajectory_execution = trajectory_execution
-        validated_moveit_controller_manager = moveit_controller_manager
-        validated_moveit_simple_controller_manager = moveit_simple_controller_manager
+        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
+        validated_robot_description = _normalize_ros_param_types(robot_description)
+        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
+        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
+        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
+        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
+        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
+        validated_occupancy_map_monitor_params = _normalize_ros_param_types(occupancy_map_monitor_params)
+        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
+        validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
+        validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")

--- a/scenes/ur3_suction_test/launch/demo.launch.py
+++ b/scenes/ur3_suction_test/launch/demo.launch.py
@@ -58,6 +58,21 @@ def load_yaml(package_name, rel_path):
 
 
 
+
+
+def _normalize_ros_param_types(value):
+    if isinstance(value, dict):
+        return {str(key): _normalize_ros_param_types(item) for key, item in value.items()}
+
+    if isinstance(value, tuple):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    if isinstance(value, list):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    return value
+
+
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -168,17 +183,17 @@ def _launch_setup(context):
     # --- Nodes ---
 
     try:
-        validated_use_sim_time = {"use_sim_time": use_sim_time.perform(context).lower() == "true"}
-        validated_robot_description = robot_description
-        validated_robot_description_semantic = robot_description_semantic
-        validated_robot_description_kinematics = robot_description_kinematics
-        validated_planning_pipelines_config = planning_pipelines_config
-        validated_ompl_planning_pipeline_config = ompl_planning_pipeline_config
-        validated_planning_scene_monitor_params = planning_scene_monitor_params
-        validated_occupancy_map_monitor_params = occupancy_map_monitor_params
-        validated_trajectory_execution = trajectory_execution
-        validated_moveit_controller_manager = moveit_controller_manager
-        validated_moveit_simple_controller_manager = moveit_simple_controller_manager
+        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
+        validated_robot_description = _normalize_ros_param_types(robot_description)
+        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
+        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
+        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
+        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
+        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
+        validated_occupancy_map_monitor_params = _normalize_ros_param_types(occupancy_map_monitor_params)
+        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
+        validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
+        validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -59,6 +59,21 @@ def load_yaml(package_name, rel_path):
 
 
 
+
+
+def _normalize_ros_param_types(value):
+    if isinstance(value, dict):
+        return {str(key): _normalize_ros_param_types(item) for key, item in value.items()}
+
+    if isinstance(value, tuple):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    if isinstance(value, list):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    return value
+
+
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -166,17 +181,17 @@ def _launch_setup(context):
 
 
     try:
-        validated_use_sim_time = {"use_sim_time": use_sim_time.perform(context).lower() == "true"}
-        validated_robot_description = robot_description
-        validated_robot_description_semantic = robot_description_semantic
-        validated_robot_description_kinematics = robot_description_kinematics
-        validated_planning_pipelines_config = planning_pipelines_config
-        validated_ompl_planning_pipeline_config = ompl_planning_pipeline_config
-        validated_planning_scene_monitor_params = planning_scene_monitor_params
-        validated_occupancy_map_monitor_params = occupancy_map_monitor_params
-        validated_trajectory_execution = trajectory_execution
-        validated_moveit_controller_manager = moveit_controller_manager
-        validated_moveit_simple_controller_manager = moveit_simple_controller_manager
+        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
+        validated_robot_description = _normalize_ros_param_types(robot_description)
+        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
+        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
+        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
+        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
+        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
+        validated_occupancy_map_monitor_params = _normalize_ros_param_types(occupancy_map_monitor_params)
+        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
+        validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
+        validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -60,6 +60,21 @@ def load_yaml(package_name, rel_path):
 
 
 
+
+
+def _normalize_ros_param_types(value):
+    if isinstance(value, dict):
+        return {str(key): _normalize_ros_param_types(item) for key, item in value.items()}
+
+    if isinstance(value, tuple):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    if isinstance(value, list):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    return value
+
+
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -161,17 +176,17 @@ def _launch_setup(context):
 
 
     try:
-        validated_use_sim_time = {"use_sim_time": use_sim_time.perform(context).lower() == "true"}
-        validated_robot_description = robot_description
-        validated_robot_description_semantic = robot_description_semantic
-        validated_robot_description_kinematics = robot_description_kinematics
-        validated_planning_pipelines_config = planning_pipelines_config
-        validated_ompl_planning_pipeline_config = ompl_planning_pipeline_config
-        validated_planning_scene_monitor_params = planning_scene_monitor_params
-        validated_occupancy_map_monitor_params = occupancy_map_monitor_params
-        validated_trajectory_execution = trajectory_execution
-        validated_moveit_controller_manager = moveit_controller_manager
-        validated_moveit_simple_controller_manager = moveit_simple_controller_manager
+        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
+        validated_robot_description = _normalize_ros_param_types(robot_description)
+        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
+        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
+        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
+        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
+        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
+        validated_occupancy_map_monitor_params = _normalize_ros_param_types(occupancy_map_monitor_params)
+        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
+        validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
+        validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -59,6 +59,21 @@ def load_yaml(package_name, rel_path):
 
 
 
+
+
+def _normalize_ros_param_types(value):
+    if isinstance(value, dict):
+        return {str(key): _normalize_ros_param_types(item) for key, item in value.items()}
+
+    if isinstance(value, tuple):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    if isinstance(value, list):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    return value
+
+
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -160,17 +175,17 @@ def _launch_setup(context):
 
 
     try:
-        validated_use_sim_time = {"use_sim_time": use_sim_time.perform(context).lower() == "true"}
-        validated_robot_description = robot_description
-        validated_robot_description_semantic = robot_description_semantic
-        validated_robot_description_kinematics = robot_description_kinematics
-        validated_planning_pipelines_config = planning_pipelines_config
-        validated_ompl_planning_pipeline_config = ompl_planning_pipeline_config
-        validated_planning_scene_monitor_params = planning_scene_monitor_params
-        validated_occupancy_map_monitor_params = occupancy_map_monitor_params
-        validated_trajectory_execution = trajectory_execution
-        validated_moveit_controller_manager = moveit_controller_manager
-        validated_moveit_simple_controller_manager = moveit_simple_controller_manager
+        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
+        validated_robot_description = _normalize_ros_param_types(robot_description)
+        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
+        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
+        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
+        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
+        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
+        validated_occupancy_map_monitor_params = _normalize_ros_param_types(occupancy_map_monitor_params)
+        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
+        validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
+        validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -74,6 +74,38 @@ def load_yaml(package_name, rel_path):
         return yaml.safe_load(file) or {}
 
 
+def _normalize_ros_param_types(value):
+    if isinstance(value, dict):
+        return {str(key): _normalize_ros_param_types(item) for key, item in value.items()}
+
+    if isinstance(value, tuple):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    if isinstance(value, list):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    return value
+
+
+def _validate_ros_param_types(value, path="root"):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"Invalid ROS param type at {path}: {type(key).__name__} -> {key!r}")
+            _validate_ros_param_types(item, f"{path}.{key}")
+        return
+
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_ros_param_types(item, f"{path}[{index}]")
+        return
+
+    if isinstance(value, (bool, int, float, str)):
+        return
+
+    raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -136,6 +168,29 @@ def _launch_setup(context):
         "sensors": [],
     }
 
+    try:
+        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
+        validated_robot_description = _normalize_ros_param_types(robot_description)
+        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
+        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
+        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
+        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
+        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
+        validated_occupancy_map_monitor_params = _normalize_ros_param_types(occupancy_map_monitor_params)
+        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
+
+        _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
+        _validate_ros_param_types(validated_robot_description, "robot_description")
+        _validate_ros_param_types(validated_robot_description_semantic, "robot_description_semantic")
+        _validate_ros_param_types(validated_robot_description_kinematics, "robot_description_kinematics")
+        _validate_ros_param_types(validated_planning_pipelines_config, "planning_pipelines_config")
+        _validate_ros_param_types(validated_ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+        _validate_ros_param_types(validated_planning_scene_monitor_params, "planning_scene_monitor_params")
+        _validate_ros_param_types(validated_occupancy_map_monitor_params, "occupancy_map_monitor_params")
+        _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
+    except TypeError as exc:
+        raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
+
     static_tf = Node(
         package="tf2_ros",
         executable="static_transform_publisher",
@@ -157,14 +212,14 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     move_group = Node(
@@ -172,15 +227,15 @@ def _launch_setup(context):
         executable="move_group",
         output="screen",
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
-            planning_pipelines_config,
-            ompl_planning_pipeline_config,
-            planning_scene_monitor_params,
-            occupancy_map_monitor_params,
-            trajectory_execution,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
+            validated_planning_pipelines_config,
+            validated_ompl_planning_pipeline_config,
+            validated_planning_scene_monitor_params,
+            validated_occupancy_map_monitor_params,
+            validated_trajectory_execution,
         ],
     )
 
@@ -194,10 +249,10 @@ def _launch_setup(context):
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
         ],
     )
 

--- a/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -74,6 +74,38 @@ def load_yaml(package_name, rel_path):
         return yaml.safe_load(file) or {}
 
 
+def _normalize_ros_param_types(value):
+    if isinstance(value, dict):
+        return {str(key): _normalize_ros_param_types(item) for key, item in value.items()}
+
+    if isinstance(value, tuple):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    if isinstance(value, list):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    return value
+
+
+def _validate_ros_param_types(value, path="root"):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"Invalid ROS param type at {path}: {type(key).__name__} -> {key!r}")
+            _validate_ros_param_types(item, f"{path}.{key}")
+        return
+
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_ros_param_types(item, f"{path}[{index}]")
+        return
+
+    if isinstance(value, (bool, int, float, str)):
+        return
+
+    raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -136,6 +168,29 @@ def _launch_setup(context):
         "sensors": [],
     }
 
+    try:
+        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
+        validated_robot_description = _normalize_ros_param_types(robot_description)
+        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
+        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
+        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
+        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
+        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
+        validated_occupancy_map_monitor_params = _normalize_ros_param_types(occupancy_map_monitor_params)
+        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
+
+        _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
+        _validate_ros_param_types(validated_robot_description, "robot_description")
+        _validate_ros_param_types(validated_robot_description_semantic, "robot_description_semantic")
+        _validate_ros_param_types(validated_robot_description_kinematics, "robot_description_kinematics")
+        _validate_ros_param_types(validated_planning_pipelines_config, "planning_pipelines_config")
+        _validate_ros_param_types(validated_ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+        _validate_ros_param_types(validated_planning_scene_monitor_params, "planning_scene_monitor_params")
+        _validate_ros_param_types(validated_occupancy_map_monitor_params, "occupancy_map_monitor_params")
+        _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
+    except TypeError as exc:
+        raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
+
     static_tf = Node(
         package="tf2_ros",
         executable="static_transform_publisher",
@@ -157,14 +212,14 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=[validated_use_sim_time, validated_robot_description],
     )
 
     move_group = Node(
@@ -172,15 +227,15 @@ def _launch_setup(context):
         executable="move_group",
         output="screen",
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
-            planning_pipelines_config,
-            ompl_planning_pipeline_config,
-            planning_scene_monitor_params,
-            occupancy_map_monitor_params,
-            trajectory_execution,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
+            validated_planning_pipelines_config,
+            validated_ompl_planning_pipeline_config,
+            validated_planning_scene_monitor_params,
+            validated_occupancy_map_monitor_params,
+            validated_trajectory_execution,
         ],
     )
 
@@ -194,10 +249,10 @@ def _launch_setup(context):
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
         parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
         ],
     )
 


### PR DESCRIPTION
### Motivation
- Prevent invalid ROS parameter types from causing launch-time errors by normalizing container types and map keys before validation.
- Ensure parameters passed to nodes are valid ROS param types (string keys, lists rather than tuples, etc.) to avoid runtime failures in various scene demos and generated templates.

### Description
- Added a helper `_normalize_ros_param_types` that converts dict keys to `str`, turns `tuple` into `list`, and recursively normalizes values, and integrated it into multiple `demo.launch.py` files. 
- Call `_normalize_ros_param_types` to produce `validated_*` parameter dictionaries which are then checked with the existing `_validate_ros_param_types` function before being passed to nodes. 
- Replaced direct parameter usage (e.g. `{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad81247f883318ec2d50aa7492772)