### PR TITLE
Make TF filter queue size configurable in grasp planner

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params.yaml
@@ -17,6 +17,8 @@ grasp_planning_node:
     camera_parameters:
       point_cloud_topic: "/camera/camera/depth/color/points"
       camera_frame: "camera_color_optical_frame"
+      # Larger queue sizes trade memory/latency for fewer TF filter drops.
+      tf_filter_queue_size: 20
       fx: 610.3740844726562
       fy: 609.8685913085938
       ppx: 323.3077697753906

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml
@@ -16,6 +16,8 @@ grasp_planning_node:
     camera_parameters:
       point_cloud_topic: "/camera/camera/depth/color/points"
       camera_frame: "camera_depth_optical_frame"
+      # Larger queue sizes trade memory/latency for fewer TF filter drops.
+      tf_filter_queue_size: 20
       fx: 610.3740844726562
       fy: 609.8685913085938
       ppx: 323.3077697753906

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml
@@ -17,6 +17,8 @@ grasp_planning_node:
     camera_parameters:
       point_cloud_topic: "/camera/camera/depth/color/points"
       camera_frame: "camera_color_optical_frame"
+      # Larger queue sizes trade memory/latency for fewer TF filter drops.
+      tf_filter_queue_size: 20
       fx: 610.3740844726562
       fy: 609.8685913085938
       ppx: 323.3077697753906

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_airpick4.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_airpick4.yaml
@@ -17,6 +17,8 @@ grasp_planning_node:
     camera_parameters:
       point_cloud_topic: "/camera/camera/depth/color/points"
       camera_frame: "camera_color_optical_frame"
+      # Larger queue sizes trade memory/latency for fewer TF filter drops.
+      tf_filter_queue_size: 20
       fx: 610.3740844726562
       fy: 609.8685913085938
       ppx: 323.3077697753906

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_suction.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_suction.yaml
@@ -17,6 +17,8 @@ grasp_planning_node:
     camera_parameters:
       point_cloud_topic: "/camera/camera/depth/color/points"
       camera_frame: "camera_color_optical_frame"
+      # Larger queue sizes trade memory/latency for fewer TF filter drops.
+      tf_filter_queue_size: 20
       fx: 610.3740844726562
       fy: 609.8685913085938
       ppx: 323.3077697753906

--- a/easy_manipulation_deployment/emd_grasp_planner/README.md
+++ b/easy_manipulation_deployment/emd_grasp_planner/README.md
@@ -4,3 +4,12 @@
 
 If OpenMP is available, the build enables parallel octomap generation in
 `src/common/fcl_functions.cpp` for faster collision setup.
+
+## Camera parameter notes
+
+Under `camera_parameters`, `tf_filter_queue_size` controls the TF message filter
+queue depth used by grasp planning subscriptions.
+
+- Default: `20` in the demo `run_grasp_planner` parameter files.
+- Increase this value to reduce dropped messages when TF data arrives late.
+- Larger values trade memory usage and latency for fewer drops.

--- a/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
@@ -15,6 +15,7 @@
 
 // Main PCL files
 #include "emd/grasp_planner/grasp_scene.hpp"
+#include <algorithm>
 #include <type_traits>
 #include <utility>
 
@@ -628,6 +629,9 @@ void grasp_planner::GraspScene<T>::start_planning(const typename T::ConstSharedP
 template<>
 void grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>::setup(std::string topic_name)
 {
+  const int tf_filter_queue_size = std::max(
+    1, node->get_parameter("camera_parameters.tf_filter_queue_size").as_int());
+
   this->output_client =
     this->node->create_client<emd_msgs::srv::GraspRequest>(
     this->node->get_parameter("grasp_output_service").as_string());
@@ -639,7 +643,7 @@ void grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>::setup(std::string
 
   this->tf_perception_sub =
     std::make_shared<tf2_ros::MessageFilter<sensor_msgs::msg::PointCloud2>>(
-    *buffer_, "base_link", 5,
+    *buffer_, "base_link", tf_filter_queue_size,
     node->get_node_logging_interface(),
     node->get_node_clock_interface(),
     std::chrono::seconds(1));
@@ -656,6 +660,9 @@ void grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>::setup(std::string
 template<typename T>
 void grasp_planner::GraspScene<T>::setup(std::string topic_name)
 {
+  const int tf_filter_queue_size = std::max(
+    1, node->get_parameter("camera_parameters.tf_filter_queue_size").as_int());
+
   this->output_client =
     this->node->create_client<emd_msgs::srv::GraspRequest>(
     this->node->get_parameter("grasp_output_service").as_string());
@@ -674,7 +681,7 @@ void grasp_planner::GraspScene<T>::setup(std::string topic_name)
     node, topic_name);
 
   this->tf_perception_sub = std::make_shared<tf2_ros::MessageFilter<T>>(
-    *buffer_, "base_link", 5,
+    *buffer_, "base_link", tf_filter_queue_size,
     node->get_node_logging_interface(),
     node->get_node_clock_interface(),
     std::chrono::seconds(1));


### PR DESCRIPTION
### Motivation

- Prevent hardcoded TF message-filter queue depth from causing dropped messages in environments with variable TF latency by making the queue depth configurable.

### Description

- Replace hardcoded `5` with a parameter read from `camera_parameters.tf_filter_queue_size` in both `GraspScene<sensor_msgs::msg::PointCloud2>::setup` and the templated `GraspScene<T>::setup` paths and clamp the value to a minimum of `1` before use (`easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp`).
- Add `# Larger queue sizes trade memory/latency for fewer TF filter drops.` and `tf_filter_queue_size: 20` under `camera_parameters` in all demo `run_grasp_planner` params YAMLs (`easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params*.yaml`).
- Document the new `camera_parameters.tf_filter_queue_size` parameter and tuning guidance in `easy_manipulation_deployment/emd_grasp_planner/README.md`.
- Add a missing `<algorithm>` include required for `std::max` usage.

### Testing

- Attempted a local package build with `colcon build --packages-select emd_grasp_planner --cmake-args -DBUILD_TESTING=OFF`, but it failed in this environment because `colcon` is not installed; no compile or unit tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf2fd12ec83318e75432b70023f1a)