### PR TITLE
Set 3f point cloud visualization default to false

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml
@@ -61,4 +61,4 @@ grasp_planning_node:
           world_y_angle_threshold: 0.65
           world_z_angle_threshold: 0.35
     visualization_params:
-      point_cloud_visualization: true
+      point_cloud_visualization: false  # Enable only for debugging/profiling sessions.


### PR DESCRIPTION
### Motivation
- Reduce unnecessary runtime visualization overhead by disabling point cloud visualization by default in the 3f grasp planner config and indicate it should be enabled only for debugging/profiling sessions.

### Description
- Change `visualization_params.point_cloud_visualization` from `true` to `false` in `easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml` and add the inline comment `# Enable only for debugging/profiling sessions.`

### Testing
- Ran the automated update and verification steps: the replacement script updated the file, `git diff` shows the change, `git commit` succeeded, and `git show --stat --oneline` plus `nl` line inspection confirmed the modified line; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf3e56a7c83319a4e518aecdaeb2a)