### PR TITLE
Add point-cloud planning in-flight guard and min processing interval

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params.yaml
@@ -35,6 +35,7 @@ grasp_planning_node:
       normal_estimation_threads: 0
       fcl_voxel_size: 0.02
       octomap_resolution: 0.01
+      min_processing_period_ms: 0
     end_effectors:
       end_effector_names: [suction_cup]
       suction_cup:

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml
@@ -34,6 +34,7 @@ grasp_planning_node:
       normal_estimation_threads: 0
       fcl_voxel_size: 0.01
       octomap_resolution: 0.01
+      min_processing_period_ms: 0
     end_effectors:
       end_effector_names: [robotiq_2f]
       robotiq_2f:

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml
@@ -35,6 +35,7 @@ grasp_planning_node:
       normal_estimation_threads: 0
       fcl_voxel_size: 0.008
       octomap_resolution: 0.01
+      min_processing_period_ms: 0
     end_effectors:
       end_effector_names: [robotiq_3f]
       robotiq_3f:

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_airpick4.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_airpick4.yaml
@@ -35,6 +35,7 @@ grasp_planning_node:
       normal_estimation_threads: 0
       fcl_voxel_size: 0.005
       octomap_resolution: 0.01
+      min_processing_period_ms: 0
     end_effectors:
       end_effector_names: [suction_cup]
       suction_cup:

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_suction.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_suction.yaml
@@ -35,6 +35,7 @@ grasp_planning_node:
       normal_estimation_threads: 0
       fcl_voxel_size: 0.005
       octomap_resolution: 0.01
+      min_processing_period_ms: 0
     end_effectors:
       end_effector_names: [suction_cup]
       suction_cup:

--- a/easy_manipulation_deployment/emd_grasp_planner/include/emd/grasp_planner/grasp_scene.hpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/include/emd/grasp_planner/grasp_scene.hpp
@@ -54,6 +54,7 @@
 // EndTemp
 
 #include <chrono>
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
@@ -263,6 +264,11 @@ protected:
   rclcpp::Time next_epd_trigger_time;
   /*! \brief Vector of objects in the scene to be picked */
   #endif
+
+  /*! \brief True while direct point-cloud planning is running */
+  std::atomic_bool planning_in_progress{false};
+  /*! \brief Last accepted direct point-cloud frame timestamp (steady clock nanoseconds) */
+  std::atomic<int64_t> last_processed_time_ns{0};
 
   /*! \brief Vector of Grasp Objects available */
   std::vector<GraspObject> grasp_objects;

--- a/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
@@ -597,9 +597,47 @@ template<>
 void grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>::start_planning(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)
 {
+  if (planning_in_progress.exchange(true, std::memory_order_acq_rel)) {
+    RCLCPP_WARN_THROTTLE(
+      LOGGER,
+      *node->get_clock(),
+      2000,
+      "Skipping incoming point cloud frame because grasp planning is still in progress.");
+    return;
+  }
+
+  int min_processing_period_ms = 0;
+  node->get_parameter_or(
+    "point_cloud_params.min_processing_period_ms",
+    min_processing_period_ms,
+    0);
+
+  const auto now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+    std::chrono::steady_clock::now().time_since_epoch()).count();
+  const auto last_processed_ns = last_processed_time_ns.load(std::memory_order_acquire);
+
+  if (min_processing_period_ms > 0 && last_processed_ns > 0) {
+    const auto min_period_ns = static_cast<int64_t>(min_processing_period_ms) * 1000000LL;
+    const auto elapsed_ns = now_ns - last_processed_ns;
+    if (elapsed_ns >= 0 && elapsed_ns < min_period_ns) {
+      RCLCPP_WARN_THROTTLE(
+        LOGGER,
+        *node->get_clock(),
+        2000,
+        "Skipping incoming point cloud frame due to minimum processing period (%d ms, elapsed %ld ms).",
+        min_processing_period_ms,
+        elapsed_ns / 1000000LL);
+      planning_in_progress.store(false, std::memory_order_release);
+      return;
+    }
+  }
+
+  last_processed_time_ns.store(now_ns, std::memory_order_release);
+
   RCLCPP_INFO(LOGGER, "Perception input received!");
   if (!process_pointcloud(msg)) {
     RCLCPP_INFO(LOGGER, "Grasp planning skipped: point cloud was empty after filtering.");
+    planning_in_progress.store(false, std::memory_order_release);
     return;
   }
   create_world_collision(msg);
@@ -608,6 +646,7 @@ void grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>::start_planning(
   emd_msgs::msg::GraspTask grasp_task = generate_grasp_task();
   send_to_execution(grasp_task);
   RCLCPP_INFO(LOGGER, "Grasp Planning complete.");
+  planning_in_progress.store(false, std::memory_order_release);
 }
 
 #if EPD_ENABLED == 1


### PR DESCRIPTION
### Motivation
- Prevent overlapping/competing grasp planning runs when point-cloud frames arrive faster than planning can complete, which can cause high CPU usage and unpredictable behavior. 
- Provide an easy throttle to reduce work by enforcing a minimum interval between processed frames via a parameter. 
- Offer observable behavior by logging when frames are intentionally skipped to aid debugging and tuning.

### Description
- Add atomic state to `GraspScene` to track an in-flight planning flag and the last-accepted-frame timestamp (`std::atomic_bool planning_in_progress` and `std::atomic<int64_t> last_processed_time_ns`) and include `<atomic>`. (modified `emd_grasp_planner/include/emd/grasp_planner/grasp_scene.hpp`)
- Update `start_planning` specialization for `sensor_msgs::msg::PointCloud2` to skip new messages while `planning_in_progress` is true, enforce a configurable `point_cloud_params.min_processing_period_ms` between accepted frames, update `last_processed_time_ns` when accepting a frame, and ensure the in-flight flag is cleared on all return paths; skipped frames emit throttled warnings via `RCLCPP_WARN_THROTTLE`. (modified `emd_grasp_planner/src/grasp_scene.cpp`)
- Expose `point_cloud_params.min_processing_period_ms` in all `run_grasp_planner` YAML parameter files with a default of `0` (disabled). (modified `emd_demo_nodes/run_grasp_planner/config/params*.yaml`)

### Testing
- Attempted to build the modified package with `colcon build --packages-select emd_grasp_planner`, but the build could not be executed in this environment because `colcon` is not available (`colcon: command not found`).
- Ran automated repository checks (`rg`/searches) to verify the new symbols and YAML parameter entries are present, and they succeeded (the new atomic members, updated `start_planning` logic, and `min_processing_period_ms` YAML entries were found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf461427083319f409ad94586d188)