### PR TITLE
Fix SRDF end-effector aliasing and duplicate collision entries in UR scenes

### DIFF
--- a/scenes/ur10_2f_test/urdf/arm_hand.srdf.xacro
+++ b/scenes/ur10_2f_test/urdf/arm_hand.srdf.xacro
@@ -10,6 +10,8 @@
 
   <xacro:robotiq_85_gripper/>
 
+  <end_effector name="robotiq_2f" parent_link="tool0" group="gripper" parent_group="manipulator" />
+
   <disable_collisions link1="gripper_base_link" link2="base_link" reason="Never" />
   <disable_collisions link1="gripper_base_link" link2="shoulder_link" reason="Never" />
   <disable_collisions link1="gripper_base_link" link2="upper_arm_link" reason="Never" />

--- a/scenes/ur5_2f_test/urdf/arm_hand.srdf.xacro
+++ b/scenes/ur5_2f_test/urdf/arm_hand.srdf.xacro
@@ -10,6 +10,8 @@
 
   <xacro:robotiq_85_gripper/>
 
+  <end_effector name="robotiq_2f" parent_link="tool0" group="gripper" parent_group="manipulator" />
+
   <disable_collisions link1="gripper_base_link" link2="base_link" reason="Never" />
   <disable_collisions link1="gripper_base_link" link2="shoulder_link" reason="Never" />
   <disable_collisions link1="gripper_base_link" link2="upper_arm_link" reason="Never" />
@@ -19,7 +21,6 @@
   <disable_collisions link1="gripper_base_link" link2="wrist_3_link" reason="Never" />
   <disable_collisions link1="gripper_base_link" link2="tool0" reason="Never" />
   <disable_collisions link1="gripper_base_link" link2="base" reason="Never" />
-  <disable_collisions link1="gripper_base_link" link2="tool0" reason="Never" />
 
 
 </robot>

--- a/scenes/ur5_airpick4_test/urdf/arm_hand.srdf.xacro
+++ b/scenes/ur5_airpick4_test/urdf/arm_hand.srdf.xacro
@@ -19,7 +19,6 @@
   <disable_collisions link1="gripper_base_link" link2="wrist_3_link" reason="Never" />
   <disable_collisions link1="gripper_base_link" link2="tool0" reason="Never" />
   <disable_collisions link1="gripper_base_link" link2="base" reason="Never" />
-  <disable_collisions link1="gripper_base_link" link2="tool0" reason="Never" />
 
 
 </robot>


### PR DESCRIPTION
## Summary
- add explicit `robotiq_2f` end-effector registration to UR scene SRDF xacros that load the Robotiq 85 macro
- remove duplicated `gripper_base_link` ↔ `tool0` collision disable lines in scene SRDF files

## Files
- `scenes/ur5_2f_test/urdf/arm_hand.srdf.xacro`
- `scenes/ur10_2f_test/urdf/arm_hand.srdf.xacro`
- `scenes/ur5_airpick4_test/urdf/arm_hand.srdf.xacro`

## Notes
- This keeps backward-compatible end-effector naming (`robotiq_2f`) used by runtime configs while preserving existing macro usage.
- No runtime/test execution was performed (static config-only update).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd594c5b148331bad3e0813e0a3f91)