### PR TITLE
Fix tf_filter_queue_size typing in grasp_scene setup

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
@@ -16,6 +16,7 @@
 // Main PCL files
 #include "emd/grasp_planner/grasp_scene.hpp"
 #include <algorithm>
+#include <cstdint>
 #include <type_traits>
 #include <utility>
 
@@ -688,8 +689,10 @@ void grasp_planner::GraspScene<T>::start_planning(const typename T::ConstSharedP
 template<>
 void grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>::setup(std::string topic_name)
 {
-  const int tf_filter_queue_size = std::max(
-    1, node->get_parameter("camera_parameters.tf_filter_queue_size").as_int());
+  const int64_t raw_queue_size =
+    node->get_parameter("camera_parameters.tf_filter_queue_size").as_int();
+  const int64_t bounded_queue_size = std::max<int64_t>(1, raw_queue_size);
+  const uint32_t tf_filter_queue_size = static_cast<uint32_t>(bounded_queue_size);
   const std::string robot_base_frame =
     node->get_parameter("camera_parameters.robot_base_frame").as_string();
 
@@ -721,8 +724,10 @@ void grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>::setup(std::string
 template<typename T>
 void grasp_planner::GraspScene<T>::setup(std::string topic_name)
 {
-  const int tf_filter_queue_size = std::max(
-    1, node->get_parameter("camera_parameters.tf_filter_queue_size").as_int());
+  const int64_t raw_queue_size =
+    node->get_parameter("camera_parameters.tf_filter_queue_size").as_int();
+  const int64_t bounded_queue_size = std::max<int64_t>(1, raw_queue_size);
+  const uint32_t tf_filter_queue_size = static_cast<uint32_t>(bounded_queue_size);
   const std::string robot_base_frame =
     node->get_parameter("camera_parameters.robot_base_frame").as_string();
 


### PR DESCRIPTION
### Motivation
- Avoid mixed-type arguments to `std::max` when reading `camera_parameters.tf_filter_queue_size` and ensure a well-typed, safe conversion to the `tf2_ros::MessageFilter` constructor argument while preserving the minimum queue size of `1`.

### Description
- Read `camera_parameters.tf_filter_queue_size` into a typed local `int64_t raw_queue_size` before clamping.  
- Clamp using `std::max<int64_t>(1, raw_queue_size)` to avoid mixed-type overload resolution.  
- Convert once to the final constructor type with `static_cast<uint32_t>(bounded_queue_size)` and pass that to `tf2_ros::MessageFilter`.  
- Apply the same changes to both `GraspScene::setup(...)` implementations and add `#include <cstdint>` for the fixed-width integer types.

### Testing
- No automated unit or integration tests were executed for this change; the modification is a small type-safety refactor with behavior unchanged (minimum queue size remains `1`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df46bd5988833199df1e550cf7728f)