### PR TITLE
Support multiple EPD Perception request schemas in trigger_epd_pipeline

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
@@ -32,6 +32,51 @@ struct has_camera_info<T, std::void_t<decltype(std::declval<T>().camera_info)>> 
 {
 };
 
+template<typename RequestT, typename = void>
+struct has_ready_flag : std::false_type
+{
+};
+
+template<typename RequestT>
+struct has_ready_flag<RequestT, std::void_t<decltype(std::declval<RequestT &>().ready)>>
+  : std::true_type
+{
+};
+
+template<typename RequestT, typename = void>
+struct has_start_flag : std::false_type
+{
+};
+
+template<typename RequestT>
+struct has_start_flag<RequestT, std::void_t<decltype(std::declval<RequestT &>().start)>>
+  : std::true_type
+{
+};
+
+template<typename RequestT, typename = void>
+struct has_trigger_flag : std::false_type
+{
+};
+
+template<typename RequestT>
+struct has_trigger_flag<RequestT, std::void_t<decltype(std::declval<RequestT &>().trigger)>>
+  : std::true_type
+{
+};
+
+template<typename RequestT>
+void set_epd_trigger_flag_if_available(RequestT & request)
+{
+  if constexpr (has_ready_flag<RequestT>::value) {
+    request.ready = true;
+  } else if constexpr (has_start_flag<RequestT>::value) {
+    request.start = true;
+  } else if constexpr (has_trigger_flag<RequestT>::value) {
+    request.trigger = true;
+  }
+}
+
 // Conversion factor: raw 16-bit depth value (millimetres) → metres.
 constexpr double kDepthMmToMeters = 0.001;
 }  // namespace
@@ -796,7 +841,7 @@ void grasp_planner::GraspScene<T>::trigger_epd_pipeline()
   }
 
   auto req = std::make_shared<epd_msgs::srv::Perception::Request>();
-  req->ready = true;
+  set_epd_trigger_flag_if_available(*req);
 
   if (!this->epd_result_future.valid()) {
     RCLCPP_INFO(LOGGER, "Sending EPD trigger request (first request).");

--- a/easy_manipulation_deployment/emd_grasp_planner/test/grasp_scene_test.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/test/grasp_scene_test.cpp
@@ -81,6 +81,7 @@ public:
 
   int trigger_count{0};
   bool service_available{true};
+  std::shared_ptr<epd_msgs::srv::Perception::Request> last_request;
 
 protected:
   bool wait_for_epd_service(const std::chrono::duration<double> &) override
@@ -90,9 +91,10 @@ protected:
 
   std::shared_future<rclcpp::Client<epd_msgs::srv::Perception>::SharedResponse>
   send_epd_trigger_request(
-    const std::shared_ptr<epd_msgs::srv::Perception::Request> &) override
+    const std::shared_ptr<epd_msgs::srv::Perception::Request> & request) override
   {
     ++trigger_count;
+    last_request = request;
     auto promise = std::make_shared<std::promise<
       rclcpp::Client<epd_msgs::srv::Perception>::SharedResponse>>();
     auto response = std::make_shared<epd_msgs::srv::Perception::Response>();
@@ -114,6 +116,7 @@ TEST_F(GraspSceneTest, EpdWatchdogTriggersOncePerTimeoutAndUpdatesTimestamp)
 
   scene.evaluate_watchdog(start + rclcpp::Duration::from_seconds(1.2), 1.0);
   EXPECT_EQ(scene.trigger_count, 1);
+  EXPECT_NE(scene.last_request, nullptr);
   EXPECT_DOUBLE_EQ(scene.get_last_epd_msg_time().seconds(), 2.2);
   EXPECT_DOUBLE_EQ(scene.get_next_epd_trigger_time().seconds(), 3.2);
 


### PR DESCRIPTION
### Motivation

- Remove the hard-coded `req->ready = true;` which assumed a specific `epd_msgs::srv::Perception::Request` shape and fails on distros with a different schema. 
- Make the grasp planner robust to evolving `epd_msgs` request fields (empty request, renamed trigger flag, or alternative flag names). 

### Description

- Added compile-time detection traits `has_ready_flag`, `has_start_flag`, and `has_trigger_flag` and a helper `set_epd_trigger_flag_if_available()` to set whichever trigger-like boolean exists on the active request type. 
- Replaced the explicit `req->ready = true;` call in `GraspScene<T>::trigger_epd_pipeline()` with `set_epd_trigger_flag_if_available(*req);`. 
- Updated the test harness in `easy_manipulation_deployment/emd_grasp_planner/test/grasp_scene_test.cpp` to capture the outbound `epd_msgs::srv::Perception::Request` as `last_request` and assert that a request object is sent without assuming specific payload fields. 
- Modified files: `easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp` and `easy_manipulation_deployment/emd_grasp_planner/test/grasp_scene_test.cpp`.

### Testing

- Attempted to run the unit test with `colcon test --packages-select emd_grasp_planner --ctest-args -R grasp_scene_test`, but the command failed in this environment because `colcon` is not installed. 
- The unit test was updated to no longer assume a particular request field and now asserts that a request object is created (`EXPECT_NE(scene.last_request, nullptr)`), but automated execution was not performed here due to the missing `colcon` tool.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df488fbb448331b6da3b56397f53b9)