### PR TITLE
Fix grasp scene warning format specifier for elapsed time

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
@@ -690,9 +690,9 @@ void grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>::start_planning(
         LOGGER,
         *node->get_clock(),
         2000,
-        "Skipping incoming point cloud frame due to minimum processing period (%d ms, elapsed %ld ms).",
+        "Skipping incoming point cloud frame due to minimum processing period (%d ms, elapsed %lld ms).",
         min_processing_period_ms,
-        elapsed_ns / 1000000LL);
+        static_cast<long long>(elapsed_ns / 1000000LL));
       planning_in_progress.store(false, std::memory_order_release);
       return;
     }


### PR DESCRIPTION
### Motivation
- Ensure the printf-style format in a throttled warning exactly matches the argument type to eliminate `-Wformat` warnings when logging elapsed milliseconds.

### Description
- Updated the throttled warning in `easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp` to use `%lld` and cast the elapsed milliseconds expression to `long long` with `static_cast<long long>(elapsed_ns / 1000000LL)` so the format specifier matches the argument type.

### Testing
- No automated tests were run; the change was validated by inspecting the source diff to confirm the format string and argument type were updated consistently.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4a9839688331bf092656547c93d9)