### PR TITLE
Add validation for grasp target payloads in run_waypoint_execution and unit tests

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/CMakeLists.txt
@@ -12,13 +12,27 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(emd_grasp_execution REQUIRED)
 find_package(emd_waypoint_execution REQUIRED)
 find_package(emd_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
+add_library(target_validation src/target_validation.cpp)
+ament_target_dependencies(target_validation
+  emd_msgs
+  geometry_msgs
+  rclcpp
+)
+target_include_directories(target_validation PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
 add_executable(demo_node src/demo_node.cpp)
+target_link_libraries(demo_node target_validation)
+target_include_directories(demo_node PRIVATE include)
 
 ament_target_dependencies(demo_node
   emd_grasp_execution
@@ -37,6 +51,7 @@ ament_target_dependencies(fake_grasp_pose_publisher
 )
 
 install(TARGETS
+  target_validation
   demo_node
   fake_grasp_pose_publisher
   EXPORT export_${PROJECT_NAME}
@@ -49,7 +64,23 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}
 )
 
+install(DIRECTORY include/
+  DESTINATION include
+)
+
 if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_target_validation test/test_target_validation.cpp)
+  if(TARGET test_target_validation)
+    target_link_libraries(test_target_validation target_validation)
+    target_include_directories(test_target_validation PRIVATE include)
+    ament_target_dependencies(test_target_validation
+      emd_msgs
+      geometry_msgs
+      rclcpp
+    )
+  endif()
+
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/include/run_waypoint_execution/target_validation.hpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/include/run_waypoint_execution/target_validation.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+#include "rclcpp/logger.hpp"
+
+#include "emd_msgs/msg/grasp_method.hpp"
+#include "emd_msgs/msg/grasp_target.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+
+namespace run_waypoint_execution
+{
+
+bool validate_grasp_target_selection(
+  const rclcpp::Logger & logger,
+  const emd_msgs::msg::GraspTarget::SharedPtr & target,
+  const std::string & target_id,
+  const emd_msgs::msg::GraspMethod *& grasp_method,
+  const geometry_msgs::msg::PoseStamped *& grasp_pose);
+
+}  // namespace run_waypoint_execution

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/package.xml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/package.xml
@@ -13,6 +13,7 @@
   <depend>emd_grasp_execution</depend>
   <depend>emd_waypoint_execution</depend>
   <depend>tf2</depend>
+  <depend>geometry_msgs</depend>
 
   <exec_depend>xacro</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
@@ -20,6 +21,7 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>rviz2</exec_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/demo_node.cpp
@@ -30,6 +30,8 @@
 
 #include "moveit/macros/console_colors.h"
 
+#include "run_waypoint_execution/target_validation.hpp"
+
 
 namespace grasp_execution
 {
@@ -164,8 +166,15 @@ public:
     double clearance;
     std::string ee_link = "";
     std::string planning_group = "";
-    auto & grasp_method = target->grasp_methods[0];
-    const std::string & ee_brand = grasp_method.ee_id;
+    const emd_msgs::msg::GraspMethod * grasp_method = nullptr;
+    const geometry_msgs::msg::PoseStamped * grasp_pose = nullptr;
+    if (!run_waypoint_execution::validate_grasp_target_selection(
+        node_->get_logger(), target, target_id, grasp_method, grasp_pose))
+    {
+      return false;
+    }
+
+    const std::string & ee_brand = grasp_method->ee_id;
 
     // Select the group based on ee brand name
     for (auto & group : get_workcell_context().groups) {
@@ -202,16 +211,13 @@ public:
 
     auto release_pose = get_curr_pose(ee_link);
 
-    // TODO(Briancbn): iterate to find the valid grasp_pose within grasp_method
-    const auto & grasp_pose = grasp_method.grasp_poses[0];
-
     bool result;
 
     if (!this->plan_and_execute_job(
         options,
         "Grasp location",
         target_id,
-        grasp_pose))
+        *grasp_pose))
     {
       return false;
     }

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/target_validation.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/target_validation.cpp
@@ -1,0 +1,48 @@
+#include "run_waypoint_execution/target_validation.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace run_waypoint_execution
+{
+
+bool validate_grasp_target_selection(
+  const rclcpp::Logger & logger,
+  const emd_msgs::msg::GraspTarget::SharedPtr & target,
+  const std::string & target_id,
+  const emd_msgs::msg::GraspMethod *& grasp_method,
+  const geometry_msgs::msg::PoseStamped *& grasp_pose)
+{
+  grasp_method = nullptr;
+  grasp_pose = nullptr;
+
+  if (!target) {
+    RCLCPP_ERROR(
+      logger,
+      "Planning target validation failed for target_id '%s': missing target payload (target is null).",
+      target_id.c_str());
+    return false;
+  }
+
+  if (target->grasp_methods.empty()) {
+    RCLCPP_ERROR(
+      logger,
+      "Planning target validation failed for target_id '%s': missing grasp_methods[0] (grasp_methods is empty).",
+      target_id.c_str());
+    return false;
+  }
+
+  grasp_method = &target->grasp_methods[0];
+
+  if (grasp_method->grasp_poses.empty()) {
+    RCLCPP_ERROR(
+      logger,
+      "Planning target validation failed for target_id '%s': missing grasp_methods[0].grasp_poses[0] (grasp_poses is empty).",
+      target_id.c_str());
+    return false;
+  }
+
+  grasp_pose = &grasp_method->grasp_poses[0];
+  return true;
+}
+
+}  // namespace run_waypoint_execution

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/test/test_target_validation.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/test/test_target_validation.cpp
@@ -1,0 +1,87 @@
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "emd_msgs/msg/grasp_method.hpp"
+#include "emd_msgs/msg/grasp_target.hpp"
+#include "run_waypoint_execution/target_validation.hpp"
+
+namespace
+{
+
+TEST(TargetValidation, RejectsNullTarget)
+{
+  const emd_msgs::msg::GraspMethod * grasp_method = nullptr;
+  const geometry_msgs::msg::PoseStamped * grasp_pose = nullptr;
+
+  EXPECT_FALSE(run_waypoint_execution::validate_grasp_target_selection(
+      rclcpp::get_logger("test_target_validation"),
+      nullptr,
+      "target-null",
+      grasp_method,
+      grasp_pose));
+  EXPECT_EQ(grasp_method, nullptr);
+  EXPECT_EQ(grasp_pose, nullptr);
+}
+
+TEST(TargetValidation, RejectsEmptyGraspMethods)
+{
+  auto target = std::make_shared<emd_msgs::msg::GraspTarget>();
+
+  const emd_msgs::msg::GraspMethod * grasp_method = nullptr;
+  const geometry_msgs::msg::PoseStamped * grasp_pose = nullptr;
+
+  EXPECT_FALSE(run_waypoint_execution::validate_grasp_target_selection(
+      rclcpp::get_logger("test_target_validation"),
+      target,
+      "target-empty-methods",
+      grasp_method,
+      grasp_pose));
+  EXPECT_EQ(grasp_method, nullptr);
+  EXPECT_EQ(grasp_pose, nullptr);
+}
+
+TEST(TargetValidation, RejectsEmptyGraspPoses)
+{
+  auto target = std::make_shared<emd_msgs::msg::GraspTarget>();
+  target->grasp_methods.emplace_back();
+  target->grasp_methods[0].ee_id = "test-ee";
+
+  const emd_msgs::msg::GraspMethod * grasp_method = nullptr;
+  const geometry_msgs::msg::PoseStamped * grasp_pose = nullptr;
+
+  EXPECT_FALSE(run_waypoint_execution::validate_grasp_target_selection(
+      rclcpp::get_logger("test_target_validation"),
+      target,
+      "target-empty-poses",
+      grasp_method,
+      grasp_pose));
+  EXPECT_NE(grasp_method, nullptr);
+  EXPECT_EQ(grasp_pose, nullptr);
+}
+
+TEST(TargetValidation, AcceptsValidFirstSelection)
+{
+  auto target = std::make_shared<emd_msgs::msg::GraspTarget>();
+  target->grasp_methods.emplace_back();
+  target->grasp_methods[0].ee_id = "test-ee";
+  target->grasp_methods[0].grasp_poses.emplace_back();
+
+  const emd_msgs::msg::GraspMethod * grasp_method = nullptr;
+  const geometry_msgs::msg::PoseStamped * grasp_pose = nullptr;
+
+  EXPECT_TRUE(run_waypoint_execution::validate_grasp_target_selection(
+      rclcpp::get_logger("test_target_validation"),
+      target,
+      "target-valid",
+      grasp_method,
+      grasp_pose));
+  ASSERT_NE(grasp_method, nullptr);
+  ASSERT_NE(grasp_pose, nullptr);
+  EXPECT_EQ(grasp_method->ee_id, "test-ee");
+}
+
+}  // namespace


### PR DESCRIPTION
### Motivation
- Prevent unsafe indexed access and potential crashes when `grasp_methods[0]` or `grasp_methods[0].grasp_poses[0]` are missing in the waypoint demo planning flow.
- Provide clear error messages including the `target_id` when input payloads are malformed and fail the planning step early.

### Description
- Added a reusable validation helper `validate_grasp_target_selection` (`include/run_waypoint_execution/target_validation.hpp` and `src/target_validation.cpp`) that checks `target` non-null, `target->grasp_methods` non-empty, and the selected `grasp_method.grasp_poses` non-empty and logs `RCLCPP_ERROR` with `target_id` and missing-field details before returning `false`.
- Updated `Demo::planning_workflow` in `src/demo_node.cpp` to call `validate_grasp_target_selection`, use pointer references for the chosen `grasp_method` and `grasp_pose`, and return `false` immediately on validation failure to avoid any indexed access.
- Added unit tests `test/test_target_validation.cpp` (GTest) to cover null `target`, empty `grasp_methods`, empty `grasp_poses`, and a valid-first-selection case.
- Updated `CMakeLists.txt` and `package.xml` to build a `target_validation` library, add `geometry_msgs` and test wiring with `ament_cmake_gtest`, and install public headers so the tests and demo link against the helper.

### Testing
- Added unit tests `TargetValidation.{RejectsNullTarget,RejectsEmptyGraspMethods,RejectsEmptyGraspPoses,AcceptsValidFirstSelection}` which exercise the validation logic and assert graceful failure or success as appropriate.
- Attempted to run the package tests with `colcon test --packages-select run_waypoint_execution --event-handlers console_direct+` but the command failed in this environment because `colcon` is not installed (no tests executed here).
- The `ament_add_gtest` target and tests are included in the package so CI or a developer environment with `colcon` can run the tests and verify the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4e91c9b88331a128723fdaa404af)