### PR TITLE
Harden waypoint EE mapping and add deterministic unknown-ee failure test

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 
 add_library(target_validation src/target_validation.cpp)
 ament_target_dependencies(target_validation
+  emd_grasp_execution
   emd_msgs
   geometry_msgs
   rclcpp
@@ -75,6 +76,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_target_validation target_validation)
     target_include_directories(test_target_validation PRIVATE include)
     ament_target_dependencies(test_target_validation
+      emd_grasp_execution
       emd_msgs
       geometry_msgs
       rclcpp

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/include/run_waypoint_execution/target_validation.hpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/include/run_waypoint_execution/target_validation.hpp
@@ -4,6 +4,7 @@
 
 #include "rclcpp/logger.hpp"
 
+#include "emd/grasp_execution/context.hpp"
 #include "emd_msgs/msg/grasp_method.hpp"
 #include "emd_msgs/msg/grasp_target.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -17,5 +18,12 @@ bool validate_grasp_target_selection(
   const std::string & target_id,
   const emd_msgs::msg::GraspMethod *& grasp_method,
   const geometry_msgs::msg::PoseStamped *& grasp_pose);
+
+bool resolve_end_effector_mapping(
+  const grasp_execution::WorkcellContext & workcell_context,
+  const std::string & ee_brand,
+  std::string & planning_group,
+  std::string & ee_link,
+  double & clearance);
 
 }  // namespace run_waypoint_execution

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/demo_node.cpp
@@ -163,7 +163,7 @@ public:
     moveit::core::RobotStatePtr home_state(get_curr_state());
 
     // TODO(Briancbn): select grasp method based on end effector availability
-    double clearance;
+    double clearance = 0.0;
     std::string ee_link = "";
     std::string planning_group = "";
     const emd_msgs::msg::GraspMethod * grasp_method = nullptr;
@@ -176,18 +176,16 @@ public:
 
     const std::string & ee_brand = grasp_method->ee_id;
 
-    // Select the group based on ee brand name
-    for (auto & group : get_workcell_context().groups) {
-      for (auto & ee : group.second.end_effectors) {
-        if (ee.second.brand == ee_brand) {
-          ee_link = ee.second.link;
-          clearance = ee.second.clearance;
-          planning_group = group.first;
-          break;
-        }
-      }
+    // Exit if brand name not found.
+    if (!run_waypoint_execution::resolve_end_effector_mapping(
+        get_workcell_context(), ee_brand, planning_group, ee_link, clearance))
+    {
+      RCLCPP_ERROR(
+        node_->get_logger(),
+        "Failed to map end effector brand '%s' for target '%s' to a planning group and ee link.",
+        ee_brand.c_str(), target_id.c_str());
+      return false;
     }
-
 
     this->options.world_frame = "world";
     this->options.planning_group = planning_group;
@@ -203,11 +201,6 @@ public:
     this->options.non_deterministic_max_attempts = node_->get_parameter(
       "planning_strategy.non_deterministic.max_planning_tries").as_int();
     this->options.clearance = clearance;
-
-    // Exit if brand name not found.
-    if (ee_link.empty()) {
-      RCLCPP_ERROR(node_->get_logger(), "End effector brand: %s", ee_brand.c_str());
-    }
 
     auto release_pose = get_curr_pose(ee_link);
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/target_validation.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/target_validation.cpp
@@ -45,4 +45,34 @@ bool validate_grasp_target_selection(
   return true;
 }
 
+bool resolve_end_effector_mapping(
+  const grasp_execution::WorkcellContext & workcell_context,
+  const std::string & ee_brand,
+  std::string & planning_group,
+  std::string & ee_link,
+  double & clearance)
+{
+  planning_group.clear();
+  ee_link.clear();
+  clearance = 0.0;
+
+  bool found_end_effector = false;
+  for (const auto & group : workcell_context.groups) {
+    for (const auto & ee : group.second.end_effectors) {
+      if (ee.second.brand == ee_brand) {
+        planning_group = group.first;
+        ee_link = ee.second.link;
+        clearance = ee.second.clearance;
+        found_end_effector = true;
+        break;
+      }
+    }
+    if (found_end_effector) {
+      break;
+    }
+  }
+
+  return found_end_effector && !planning_group.empty() && !ee_link.empty();
+}
+
 }  // namespace run_waypoint_execution

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/test/test_target_validation.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/test/test_target_validation.cpp
@@ -5,6 +5,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+#include "emd/grasp_execution/context.hpp"
 #include "emd_msgs/msg/grasp_method.hpp"
 #include "emd_msgs/msg/grasp_target.hpp"
 #include "run_waypoint_execution/target_validation.hpp"
@@ -82,6 +83,24 @@ TEST(TargetValidation, AcceptsValidFirstSelection)
   ASSERT_NE(grasp_method, nullptr);
   ASSERT_NE(grasp_pose, nullptr);
   EXPECT_EQ(grasp_method->ee_id, "test-ee");
+}
+
+TEST(TargetValidation, RejectsUnknownEndEffectorMapping)
+{
+  grasp_execution::WorkcellContext workcell_context;
+  workcell_context.load_ee(
+    "manipulator_a", "known_ee", "known-brand", "known_link", 0.01, "driver_plugin",
+    "driver_controller");
+
+  std::string planning_group = "stale_group";
+  std::string ee_link = "stale_link";
+  double clearance = 0.42;
+
+  EXPECT_FALSE(run_waypoint_execution::resolve_end_effector_mapping(
+      workcell_context, "unknown-ee-id", planning_group, ee_link, clearance));
+  EXPECT_TRUE(planning_group.empty());
+  EXPECT_TRUE(ee_link.empty());
+  EXPECT_DOUBLE_EQ(clearance, 0.0);
 }
 
 }  // namespace


### PR DESCRIPTION
### Motivation
- Ensure `planning_workflow` uses a safe default for `clearance` and fails fast when an end-effector mapping is missing to avoid setting planner options or calling `get_curr_pose` with empty values. 
- Make end-effector lookup explicit and deterministic so downstream planning/execution is not invoked for unknown `ee_id` values. 

### Description
- Initialize `clearance` to `0.0` in `Demo::planning_workflow` and replace inline mapping logic with a helper by adding `resolve_end_effector_mapping(...)` in `target_validation.hpp/.cpp`. 
- Validate both `ee_link` and `planning_group` via the helper and emit an `RCLCPP_ERROR` that includes `ee_brand` and `target_id`, returning `false` immediately if mapping is missing. 
- Track `found_end_effector` inside the helper to make intent explicit and return success only when `planning_group` and `ee_link` are non-empty. 
- Add a negative unit test `RejectsUnknownEndEffectorMapping` in `test_target_validation.cpp` that uses an unknown `ee_id` and verifies the mapping fails and clears `planning_group`, `ee_link`, and `clearance`. 
- Update `CMakeLists.txt` to add `emd_grasp_execution` as a dependency for the `target_validation` library and its test so `WorkcellContext` is available. 

### Testing
- Added a gtest unit test `test_target_validation` which includes `RejectsUnknownEndEffectorMapping` to verify deterministic failure behavior; the test is present but was not executed in this environment. 
- Attempted to run `colcon test --packages-select run_waypoint_execution --event-handlers console_direct+ --return-code-on-test-failure` but the command failed because `colcon` is not installed in the container. 
- Local repository status was clean after committing the changes (no outstanding edits).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4fe05e2c8331a941b5f74e7ce497)