### PR TITLE
Normalize demo sleep to chrono duration and configurable ROS parameter

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/demo_node.cpp
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <chrono>
 #include <memory>
+#include <thread>
 #include <string>
 #include <utility>
 #include <vector>
@@ -58,6 +60,16 @@ public:
       "ee_wait_for_completion", false);
     int delay_ms = node_->declare_parameter<int>("ee_post_command_delay_ms", 0);
     ee_context_.post_command_delay = std::chrono::milliseconds(delay_ms);
+
+    constexpr int kPostReleaseDelayDefaultMs = 500;
+    constexpr int kPostReleaseDelayMinMs = 0;
+    constexpr int kPostReleaseDelayMaxMs = 60 * 1000;
+    const int configured_post_release_delay_ms = node_->declare_parameter<int>(
+      "post_release_delay_ms", kPostReleaseDelayDefaultMs);
+    post_release_delay_ms_ = std::clamp(
+      configured_post_release_delay_ms,
+      kPostReleaseDelayMinMs,
+      kPostReleaseDelayMaxMs);
 
     grasp_task_sub_ = node_->create_subscription<emd_msgs::msg::GraspTask>(
       grasp_task_topic, 10,
@@ -254,7 +266,7 @@ public:
     }
 
 
-    sleep(500000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(post_release_delay_ms_));
 
     // ------------------ Remove Object from world -------------------
 
@@ -304,6 +316,7 @@ private:
   grasp_execution::GraspExecutionContext options;
   std::shared_ptr<emd::EndEffectorExecutioninterface> end_effector_interface;
   emd::EndEffectorExecutionContext ee_context_;
+  int post_release_delay_ms_;
   rclcpp::Subscription<emd_msgs::msg::GraspTask>::SharedPtr grasp_task_sub_;
   rclcpp::Service<emd_msgs::srv::GraspRequest>::SharedPtr grasp_req_service_;
 };


### PR DESCRIPTION
### Motivation
- Remove an ambiguous raw `sleep(500000)` call in the demo node and make the pause explicit and configurable to avoid unit mistakes and hardcoded delays.
- Provide a safe, bounded ROS parameter so users can tune the post-release delay without changing source.

### Description
- Replaced `sleep(500000)` with `std::this_thread::sleep_for(std::chrono::milliseconds(post_release_delay_ms_))` in `easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/demo_node.cpp`.
- Added includes for `<thread>` and `<algorithm>` and introduced a new class member `int post_release_delay_ms_` to store the configured delay.
- Declared a new ROS parameter `post_release_delay_ms` (default `500` ms) and clamp its value to the range `0..60000` ms using `std::clamp`.
- Searched demo/runtime sources for raw `sleep(...)`/`usleep(...)` usages and left existing ROS rate sleeps (`r.sleep()` / `wait_rate.sleep()`) unchanged.

### Testing
- Ran a repository search for raw sleeps using `rg -n "\b(usleep|sleep)\s*\("` and verified the raw call was removed from `demo_node.cpp` and no other raw `sleep`/`usleep` exist in the checked demo/runtime areas; this succeeded.
- Inspected the diff with `git diff` and committed the change; the commit succeeded.
- Verified `easy_manipulation_deployment/emd_grasp_execution` sleep-like usages are ROS rate `r.sleep()`/`wait_rate.sleep()` and were not modified; this validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df522dd8f8833186bbb6b7fad83713)