### PR TITLE
Handle missing shape_poses_ in get_object_pose and add unit test

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
@@ -31,6 +31,7 @@
 #include "moveit/moveit_cpp/planning_component.h"
 #include "moveit/trajectory_processing/iterative_time_parameterization.h"
 #include "moveit/trajectory_processing/time_optimal_trajectory_generation.h"
+#include "moveit/collision_detection/world.h"
 
 #include "moveit_msgs/msg/attached_collision_object.hpp"
 #include "moveit_msgs/msg/collision_object.hpp"
@@ -42,6 +43,16 @@ namespace grasp_execution
 
 namespace moveit2
 {
+
+namespace detail
+{
+
+geometry_msgs::msg::Pose get_object_pose_from_world_object(
+  const collision_detection::World::ObjectConstPtr & object,
+  const std::string & object_id,
+  const rclcpp::Logger & logger);
+
+}  // namespace detail
 
 struct JmgContext
 {

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -60,6 +60,42 @@ namespace grasp_execution
 namespace moveit2
 {
 
+namespace detail
+{
+
+geometry_msgs::msg::Pose get_object_pose_from_world_object(
+  const collision_detection::World::ObjectConstPtr & object,
+  const std::string & object_id,
+  const rclcpp::Logger & logger)
+{
+  geometry_msgs::msg::Pose object_pose{};
+  if (!object) {
+    RCLCPP_ERROR(logger, "Object with id '%s' not found in planning scene", object_id.c_str());
+    return object_pose;
+  }
+
+  if (object->shape_poses_.empty()) {
+    RCLCPP_ERROR(
+      logger,
+      "Object with id '%s' has no shape poses in planning scene",
+      object_id.c_str());
+    return object_pose;
+  }
+
+  const auto & pose = object->shape_poses_.front();
+  Eigen::Quaterniond q(pose.linear());
+  object_pose.position.x = pose.translation().x();
+  object_pose.position.y = pose.translation().y();
+  object_pose.position.z = pose.translation().z();
+  object_pose.orientation.x = q.x();
+  object_pose.orientation.y = q.y();
+  object_pose.orientation.z = q.z();
+  object_pose.orientation.w = q.w();
+  return object_pose;
+}
+
+}  // namespace detail
+
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("grasp_execution");
 
 MoveitCppGraspExecution::MoveitCppGraspExecution(
@@ -480,26 +516,11 @@ std::string MoveitCppGraspExecution::register_target_object_mesh(
 geometry_msgs::msg::Pose MoveitCppGraspExecution::get_object_pose(
   const std::string & object_id) const
 {
-  geometry_msgs::msg::Pose object_pose{};
   {    // Lock PlanningScene
     planning_scene_monitor::LockedPlanningSceneRW scene(moveit_cpp_->getPlanningSceneMonitor());
-    collision_detection::World::ObjectConstPtr object = scene->getWorld()->getObject(object_id);
-    if (!object) {
-      RCLCPP_ERROR(LOGGER, "Object with id '%s' not found in planning scene", object_id.c_str());
-      return object_pose;
-    }
-    auto poses = (*object).shape_poses_[0];
-    Eigen::Quaterniond q(poses.linear());
-    object_pose.position.x = poses.translation().x();
-    object_pose.position.y = poses.translation().y();
-    object_pose.position.z = poses.translation().z();
-    object_pose.orientation.x = q.x();
-    object_pose.orientation.y = q.y();
-    object_pose.orientation.z = q.z();
-    object_pose.orientation.w = q.w();
+    return detail::get_object_pose_from_world_object(
+      scene->getWorld()->getObject(object_id), object_id, LOGGER);
   }    // Unlock PlanningScene
-
-  return object_pose;
 }
 
 moveit::core::RobotStatePtr MoveitCppGraspExecution::get_curr_state() const

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
@@ -36,3 +36,14 @@ target_link_libraries(test_cartesian_planning_options
 target_compile_features(test_cartesian_planning_options
   PRIVATE cxx_std_17
 )
+
+# MoveIt object pose utility unit tests
+ament_add_gtest(test_moveit_object_pose_utils
+  test_moveit_object_pose_utils.cpp
+)
+target_link_libraries(test_moveit_object_pose_utils
+  moveit_cpp_grasp_execution_interface
+)
+target_compile_features(test_moveit_object_pose_utils
+  PRIVATE cxx_std_17
+)

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_moveit_object_pose_utils.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_moveit_object_pose_utils.cpp
@@ -1,0 +1,71 @@
+// Copyright 2020 ROS Industrial Consortium Asia Pacific
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+
+#include "emd/grasp_execution/moveit2/moveit_cpp_if.hpp"
+
+namespace grasp_execution
+{
+namespace moveit2
+{
+namespace
+{
+
+TEST(MoveitObjectPoseUtilsTest, ReturnsDefaultPoseWhenObjectHasNoShapePoses)
+{
+  auto object = std::make_shared<collision_detection::World::Object>();
+
+  EXPECT_TRUE(object->shape_poses_.empty());
+
+  const auto pose = detail::get_object_pose_from_world_object(
+    object, "object_without_pose", rclcpp::get_logger("test_logger"));
+
+  EXPECT_DOUBLE_EQ(pose.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(pose.position.y, 0.0);
+  EXPECT_DOUBLE_EQ(pose.position.z, 0.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.x, 0.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.y, 0.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.z, 0.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.w, 0.0);
+}
+
+TEST(MoveitObjectPoseUtilsTest, ConvertsFirstShapePoseWhenAvailable)
+{
+  auto object = std::make_shared<collision_detection::World::Object>();
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.translation().x() = 0.1;
+  transform.translation().y() = -0.2;
+  transform.translation().z() = 0.3;
+  object->shape_poses_.push_back(transform);
+
+  const auto pose = detail::get_object_pose_from_world_object(
+    object, "object_with_pose", rclcpp::get_logger("test_logger"));
+
+  EXPECT_DOUBLE_EQ(pose.position.x, 0.1);
+  EXPECT_DOUBLE_EQ(pose.position.y, -0.2);
+  EXPECT_DOUBLE_EQ(pose.position.z, 0.3);
+  EXPECT_DOUBLE_EQ(pose.orientation.x, 0.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.y, 0.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.z, 0.0);
+  EXPECT_DOUBLE_EQ(pose.orientation.w, 1.0);
+}
+
+}  // namespace
+}  // namespace moveit2
+}  // namespace grasp_execution


### PR DESCRIPTION
### Motivation
- Prevent crashes when querying object pose from the PlanningScene if a world `Object` exists but its `shape_poses_` vector is empty.
- Provide clear diagnostics via logging and return a safe default pose in that failure case to keep callers robust.

### Description
- Added a helper `moveit2::detail::get_object_pose_from_world_object(...)` that centralizes conversion from `collision_detection::World::Object` to `geometry_msgs::msg::Pose` and validates inputs.
- The helper checks for a null object and for `object->shape_poses_.empty()`, emits an `RCLCPP_ERROR` containing the `object_id` when either condition occurs, and returns a default-initialized pose.
- Updated `MoveitCppGraspExecution::get_object_pose` to call the new helper instead of dereferencing `shape_poses_[0]` directly.
- Added a unit test `test_moveit_object_pose_utils` with two gtests that verify non-crashing/default-pose behavior when `shape_poses_` is empty and correct conversion when a pose exists, and registered the test in the package `CMakeLists.txt`.

### Testing
- Added the gtest target `test_moveit_object_pose_utils` to `easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt` and included the test source `test_moveit_object_pose_utils.cpp`.
- Attempted to run `colcon test --packages-select emd_grasp_execution --ctest-args -R test_moveit_object_pose_utils --output-on-failure` but the command was not executed in this environment because `colcon` is not installed (test run failed for that reason).
- The changes are unit-test ready (tests compile targets added) and will run in CI or a development environment with `colcon` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df52d424e083318d6491472abf74e5)