### PR TITLE
Validate MoveIt planner option and harden plugin failure handling

### DIFF
--- a/easy_manipulation_deployment/emd_dynamic_safety/src/moveit/replanner_moveit.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/src/moveit/replanner_moveit.cpp
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 #include <stdexcept>
@@ -121,13 +121,43 @@ MoveitReplannerContext::MoveitReplannerContext(
 
   std::string planner_name = to_all_lower(option.planner);
   std::string plugin_name("");
+  static constexpr std::array<const char *, 1> kSupportedPlanners = {"ompl"};
   if (planner_name == "ompl") {
     plugin_name = "ompl_interface/OMPLPlanner";
     planning_request_.planner_id = option.ompl_planner_id;
   }
   // TODO(anyone): Add in other planning methods.
 
-  planning_manager_ = planner_plugin_loader->createUniqueInstance(plugin_name);
+  if (plugin_name.empty()) {
+    std::string supported_planners;
+    for (size_t i = 0; i < kSupportedPlanners.size(); ++i) {
+      supported_planners += kSupportedPlanners[i];
+      if (i + 1 < kSupportedPlanners.size()) {
+        supported_planners += ", ";
+      }
+    }
+    const std::string error =
+      "Unsupported MoveIt planner '" + option.planner +
+      "'. Supported values: [" + supported_planners + "].";
+    RCLCPP_ERROR(LOGGER, "%s", error.c_str());
+    throw std::invalid_argument(error);
+  }
+
+  try {
+    planning_manager_ = planner_plugin_loader->createUniqueInstance(plugin_name);
+  } catch (const pluginlib::PluginlibException & e) {
+    const std::string error =
+      "Failed to create MoveIt planner plugin '" + plugin_name +
+      "' for planner option '" + option.planner + "': " + e.what();
+    RCLCPP_ERROR(LOGGER, "%s", error.c_str());
+    throw std::runtime_error(error);
+  } catch (const std::exception & e) {
+    const std::string error =
+      "Unexpected error while creating MoveIt planner plugin '" + plugin_name +
+      "': " + e.what();
+    RCLCPP_ERROR(LOGGER, "%s", error.c_str());
+    throw std::runtime_error(error);
+  }
 
   // new node for planning config parameter loading
   auto planner_config_loader_node = std::make_shared<rclcpp::Node>(
@@ -217,11 +247,24 @@ MoveitReplannerContext::MoveitReplannerContext(
     declare_and_set_planner_parameters(f.get());
   }
 
-  if (!planning_manager_->initialize(
-      scene_->getRobotModel(),
-      planner_config_loader_node, option.planner_parameter_namespace))
-  {
-    throw std::runtime_error("Unable to initialize planning plugin");
+  try {
+    if (!planning_manager_->initialize(
+        scene_->getRobotModel(),
+        planner_config_loader_node, option.planner_parameter_namespace))
+    {
+      const std::string error =
+        "Unable to initialize planning plugin '" + plugin_name +
+        "' using parameter namespace '" + option.planner_parameter_namespace + "'.";
+      RCLCPP_ERROR(LOGGER, "%s", error.c_str());
+      throw std::runtime_error(error);
+    }
+  } catch (const std::exception & e) {
+    const std::string error =
+      "Exception while initializing planning plugin '" + plugin_name +
+      "' with namespace '" + option.planner_parameter_namespace +
+      "': " + e.what();
+    RCLCPP_ERROR(LOGGER, "%s", error.c_str());
+    throw std::runtime_error(error);
   }
 
   planning_request_.group_name = option.group;

--- a/easy_manipulation_deployment/emd_dynamic_safety/test/test_replanner_moveit.cpp
+++ b/easy_manipulation_deployment/emd_dynamic_safety/test/test_replanner_moveit.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -86,6 +87,30 @@ TEST_F(ReplannerTest, MoveItOMPLReplannerTimeout)
 
   replanner_.run_async(joint_names_, start_point, end_point);
   EXPECT_EQ(replanner_.get_status(), dynamic_safety::ReplannerStatus::TIMEOUT);
+}
+
+// cppcheck-suppress syntaxError
+TEST_F(ReplannerTest, MoveItUnsupportedPlannerFailsPredictably)
+{
+  auto replanner_node = std::make_shared<rclcpp::Node>("test_replanner_unsupported_planner");
+
+  option_.framework = "moveit";
+  option_.planner = "unsupported_planner";
+  option_.ompl_planner_id = "RRTConnectkConfigDefault";
+  option_.group = "panda_arm";
+  option_.deadline = 1.0;
+
+  try {
+    replanner_.configure(option_, replanner_node, robot_.get_urdf(), robot_.get_srdf());
+    FAIL() << "Expected std::invalid_argument for unsupported planner option";
+  } catch (const std::invalid_argument & e) {
+    const std::string message = e.what();
+    EXPECT_NE(message.find("Unsupported MoveIt planner"), std::string::npos);
+    EXPECT_NE(message.find("unsupported_planner"), std::string::npos);
+    EXPECT_NE(message.find("Supported values: [ompl]"), std::string::npos);
+  } catch (const std::exception & e) {
+    FAIL() << "Expected std::invalid_argument but got: " << e.what();
+  }
 }
 
 #endif


### PR DESCRIPTION
### Motivation
- Ensure an unsupported `option.planner` is detected and reported with a clear, user-facing message rather than allowing opaque `pluginlib` errors to surface at runtime.
- Provide actionable error context when plugin creation or initialization fails so downstream callers/tests can assert predictable failures.

### Description
- After normalizing `option.planner` the code now validates against an explicit list of supported planners and logs & throws `std::invalid_argument` if the planner is unsupported (currently only `ompl`), in `moveit/replanner_moveit.cpp`.
- Wrap `createUniqueInstance` in exception handling to convert `pluginlib::PluginlibException` and other `std::exception`s into contextual `std::runtime_error` messages that include the planner option and plugin class.
- Wrap `planning_manager_->initialize(...)` in a `try/catch` and emit/throw a contextual error message when initialization fails or an exception is raised.
- Add a unit test `MoveItUnsupportedPlannerFailsPredictably` that configures an unsupported planner string and asserts the thrown `std::invalid_argument` contains the expected diagnostic text, in `test/test_replanner_moveit.cpp`.

### Testing
- Added GoogleTest `MoveItUnsupportedPlannerFailsPredictably` which asserts that configuring with `option_.planner = "unsupported_planner"` throws `std::invalid_argument` containing the planner name and supported list; the test compiles with the test suite but was not executed here.
- Attempted to run the test via `colcon test --packages-select emd_dynamic_safety --ctest-args -R MoveItUnsupportedPlannerFailsPredictably` but the command failed in this environment because `colcon` is not installed (so automated test execution could not be completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df53e8bdbc8331878f37c6bae8397c)