### PR TITLE
Standardize dependency manifest flow across docs and scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,8 @@ ln -s ~/workcell_ws/src/easy_manipulation_deployment/scenes ~/workcell_ws/src/sc
 ### 3) Import dependencies
 
 ```bash
-cd ~/workcell_ws/src
-vcs import < easy_manipulation_deployment/tesseract.repos
+cd ~/workcell_ws
+vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
 ```
 
 ### 4) Apply Humble fixes/skips (from README + scripts)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ mv easy_manipulation_deployment/scenes/ .
 
 ```bash
 cd ~/workcell_ws
-vcs import src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
+vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
 ```
 
 5. Register the repo-local `rosdep` overrides.
@@ -144,7 +144,7 @@ git clone https://github.com/Mukaram01/Easy_Manipulator_Improved.git easy_manipu
 mv easy_manipulation_deployment/assets/ .
 mv easy_manipulation_deployment/scenes/ .
 cd ~/workcell_ws
-vcs import src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
+vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
 
 source /opt/ros/humble/setup.bash
 
@@ -394,9 +394,8 @@ cd ~/workcell_ws/src/easy_manipulation_deployment
 For an explicit GUI-enabled manual build, remove those markers by opting into GUI mode when syncing the workspace layout:
 
 ```bash
-cd ~/workcell_ws/src
-vcs import < easy_manipulation_deployment/dependencies/emd_epd_ws.repos
 cd ~/workcell_ws
+vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh --with-gui
 colcon build --symlink-install --parallel-workers 2
 ```
@@ -480,6 +479,20 @@ colcon build --symlink-install --parallel-workers 2
 ```
 
 Some helper scripts and source-overlay workflows still use `--symlink-install`, especially for full-profile development workspaces.
+
+
+## Dependency manifests
+
+- Canonical manifest: `dependencies/emd_epd_ws.repos`.
+- Legacy compatibility manifest: `tesseract.repos` (root-level).
+- Canonical import command:
+
+```bash
+cd ~/workcell_ws
+vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
+```
+
+Repository scripts now resolve manifests in this order: canonical first, then legacy with a warning so existing workspaces keep working during migration.
 
 ## Troubleshooting
 
@@ -618,7 +631,7 @@ sudo sed -i '/#include <boost\/serialization\/item_version_type.hpp>/a #include 
 - **Supported baseline:** Ubuntu 22.04 + ROS 2 Humble + a C++17/libstdc++ baseline.
 - **Experimental:** Ubuntu 24.04 + ROS 2 Jazzy is not the main supported path for this repository.
 - `scripts/lib/build.sh` intentionally keeps `-DCMAKE_CXX_STANDARD=17` for the supported baseline.
-- `dependencies/emd_epd_ws.repos` and `tesseract.repos` pin `ruckig` to `v0.15.3` (`37b6e7a`) so source builds stay on the pre-`std::format` line that still works with the Humble/Jammy toolchain.
+- `dependencies/emd_epd_ws.repos` (canonical manifest) pins `ruckig` to `v0.15.3` (`37b6e7a`) so source builds stay on the pre-`std::format` line that still works with the Humble/Jammy toolchain. The legacy root-level `tesseract.repos` is retained as a compatibility fallback in scripts.
 - `fix_and_build_humble.sh` reads that pinned revision during preflight so its guardrails match the documented baseline.
 - If you move to a newer `ruckig` release that requires `std::format`, you are also moving beyond the documented Humble/Jammy support envelope.
 

--- a/scripts/fix_workspace_layout.sh
+++ b/scripts/fix_workspace_layout.sh
@@ -201,7 +201,7 @@ PY
   fi
 }
 
-# Ensure external trajopt checkouts fetched via tesseract.repos are ignored
+# Ensure external trajopt checkouts fetched via dependency manifests are ignored
 # before invoking colcon. Some upstream snapshots ship a COLCON_IGNORE.repo
 # marker instead of the expected COLCON_IGNORE file, which causes colcon to
 # discover duplicate packages alongside the patched overlays in
@@ -515,7 +515,7 @@ resolve_trajopt_sco_target() {
   for candidate in "${candidate_targets[@]}"; do
     echo "  - ${candidate}" >&2
   done
-  echo "Remediation: restore trajopt_sco in one of the listed paths (for example via 'vcs import --recursive --skip-existing src < tesseract.repos' or by recovering backup/original snapshots), then rerun scripts/fix_workspace_layout.sh." >&2
+  echo "Remediation: restore trajopt_sco in one of the listed paths (for example via 'vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos' or by recovering backup/original snapshots), then rerun scripts/fix_workspace_layout.sh." >&2
   exit 1
 }
 
@@ -785,8 +785,8 @@ if ! workspace_has_required_packages required_missing; then
   printf '    - %-24s exists=%s type=%s resolved=%s\n' "$trajopt_sco_path" "$(path_exists "$trajopt_sco_path" && echo yes || echo no)" "$(path_type "$trajopt_sco_path")" "$(resolved_path_or_unresolved "$trajopt_sco_path")"
   echo
   echo "Remediation:"
-  echo "  1) Import repositories from tesseract.repos into src/ if not already imported:"
-  echo "       vcs import --recursive --skip-existing src < tesseract.repos"
+  echo "  1) Import repositories from dependencies/emd_epd_ws.repos into src/ if not already imported:"
+  echo "       vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos"
   echo "  2) Rerun workspace layout fix:"
   echo "       ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh"
   echo "  3) Rebuild with foundation-first flow (or equivalent helper script):"

--- a/scripts/lib/dependencies.sh
+++ b/scripts/lib/dependencies.sh
@@ -2,16 +2,36 @@
 # Dependency management helpers
 
 clone_repositories() {
-    if [[ ! -f "$REPO_ROOT/tesseract.repos" ]]; then
-        log_warn "No tesseract.repos file found; skipping repository import"
+    local manifest
+    manifest="$(resolve_dependency_manifest)"
+    if [[ -z "$manifest" ]]; then
+        log_warn "No dependency manifest found (checked dependencies/emd_epd_ws.repos, tesseract.repos); skipping repository import"
         return
     fi
 
-    log_info "Importing repositories from tesseract.repos"
+    log_info "Importing repositories from ${manifest#$REPO_ROOT/}"
     local import_cmd=(vcs import --recursive --skip-existing "$SRC_DIR")
-    if ! GIT_TERMINAL_PROMPT=${GIT_TERMINAL_PROMPT:-0} "${import_cmd[@]}" <"$REPO_ROOT/tesseract.repos"; then
+    if ! GIT_TERMINAL_PROMPT=${GIT_TERMINAL_PROMPT:-0} "${import_cmd[@]}" <"$manifest"; then
         die "vcs import failed; set GIT_TERMINAL_PROMPT=1 or configure credentials to continue"
     fi
+}
+
+resolve_dependency_manifest() {
+    local canonical="$REPO_ROOT/dependencies/emd_epd_ws.repos"
+    local legacy="$REPO_ROOT/tesseract.repos"
+
+    if [[ -f "$canonical" ]]; then
+        echo "$canonical"
+        return 0
+    fi
+
+    if [[ -f "$legacy" ]]; then
+        log_warn "Using legacy manifest tesseract.repos; prefer dependencies/emd_epd_ws.repos"
+        echo "$legacy"
+        return 0
+    fi
+
+    return 1
 }
 
 fix_workspace_layout() {


### PR DESCRIPTION
### Motivation
- Remove mixed instructions around multiple .repos files and present a single canonical manifest path for dependency imports to reduce user confusion.
- Ensure scripts and documentation are consistent while preserving backward compatibility for existing workspaces.
- Point remediation and helper messaging to the maintained manifest so users follow a reproducible, repository-local workflow.

### Description
- Updated documentation in `README.md` and `CONTRIBUTING.md` to use the canonical import command `vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos` and added a `Dependency manifests` section to `README.md` explaining canonical vs legacy behavior.
- Added `resolve_dependency_manifest()` to `scripts/lib/dependencies.sh` and made `clone_repositories()` use the resolved manifest, preferring `dependencies/emd_epd_ws.repos` and falling back to root-level `tesseract.repos` with a warning.
- Replaced legacy `tesseract.repos` text in `scripts/fix_workspace_layout.sh` with canonical manifest references and updated related comments and remediation text.
- Tweaked version/compatibility wording in `README.md` to document that `dependencies/emd_epd_ws.repos` is canonical and that `tesseract.repos` is retained only as a compatibility fallback.

### Testing
- Ran a shell syntax check with `bash -n scripts/lib/dependencies.sh scripts/fix_workspace_layout.sh` which completed successfully.
- Verified doc and script occurrences with `rg -n "vcs import" README.md CONTRIBUTING.md -S` which found the canonical import lines as intended.
- Verified legacy references were limited and the resolver presence with `rg -n "tesseract\.repos" README.md CONTRIBUTING.md scripts/fix_workspace_layout.sh scripts/lib/dependencies.sh -S`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df659c26008331ae1edcb9d8f3fce2)