### PR TITLE
Harden Humble/Jazzy CI for security and reproducibility

### DIFF
--- a/.github/workflows/humble-ci.yml
+++ b/.github/workflows/humble-ci.yml
@@ -5,15 +5,75 @@ on:
     branches: [main, master]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  humble-ci:
+  security-checks:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Validate shell scripts and embedded Python
+        run: |
+          bash -n fix_and_build_humble.sh scripts/fix_workspace_layout.sh
+          python3 scripts/check_python_heredocs.py fix_and_build_humble.sh scripts/fix_workspace_layout.sh
+          ./scripts/check_disallowed_artifact_names.sh
+
+      - name: Validate dependency manifests
+        run: |
+          ruby - <<'RUBY'
+          require 'yaml'
+
+          manifest = 'dependencies/emd_epd_ws.repos'
+          data = YAML.load_file(manifest)
+          repos = data.is_a?(Hash) ? data['repositories'] : nil
+
+          abort("#{manifest} must contain a top-level 'repositories' mapping") unless repos.is_a?(Hash)
+          abort("#{manifest} has no repository entries") if repos.empty?
+
+          required_fields = %w[type url]
+          missing = {}
+
+          repos.each do |name, info|
+            unless info.is_a?(Hash)
+              missing[name] = required_fields
+              next
+            end
+
+            absent = required_fields.select do |field|
+              value = info[field]
+              value.nil? || value.to_s.strip.empty?
+            end
+            missing[name] = absent unless absent.empty?
+          end
+
+          unless missing.empty?
+            missing.each { |repo, fields| warn("#{repo}: missing required fields #{fields.join(', ')}") }
+            abort('Dependency manifest validation failed')
+          end
+
+          puts "Validated #{repos.length} dependency entries in #{manifest}"
+          RUBY
+
+  humble-ci:
+    needs: security-checks
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up ROS 2 Humble
-        uses: ros-tooling/setup-ros@v0.7
+        uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30 # v0.7
         with:
           required-ros-distributions: humble
 
@@ -26,7 +86,7 @@ jobs:
           touch ws/COLCON_IGNORE ws/AMENT_IGNORE
 
       - name: Cache rosdep database
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/.ros/rosdep
           key: rosdep-humble-${{ hashFiles('**/package.xml') }}
@@ -34,7 +94,7 @@ jobs:
             rosdep-humble-
 
       - name: Cache colcon build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: |
             ws/build
@@ -42,12 +102,6 @@ jobs:
           key: colcon-humble-${{ hashFiles('**/CMakeLists.txt', '**/package.xml', '**/setup.py') }}
           restore-keys: |
             colcon-humble-
-
-      - name: Validate shell scripts and embedded Python
-        run: |
-          bash -n fix_and_build_humble.sh scripts/fix_workspace_layout.sh
-          python3 scripts/check_python_heredocs.py fix_and_build_humble.sh scripts/fix_workspace_layout.sh
-          ./scripts/check_disallowed_artifact_names.sh
 
       - name: Install dependencies
         working-directory: ws

--- a/.github/workflows/jazzy-ci.yml
+++ b/.github/workflows/jazzy-ci.yml
@@ -5,15 +5,75 @@ on:
     branches: [main, master]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  jazzy-ci:
+  security-checks:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Validate shell scripts and embedded Python
+        run: |
+          bash -n fix_and_build_humble.sh scripts/fix_workspace_layout.sh
+          python3 scripts/check_python_heredocs.py fix_and_build_humble.sh scripts/fix_workspace_layout.sh
+          ./scripts/check_disallowed_artifact_names.sh
+
+      - name: Validate dependency manifests
+        run: |
+          ruby - <<'RUBY'
+          require 'yaml'
+
+          manifest = 'dependencies/emd_epd_ws.repos'
+          data = YAML.load_file(manifest)
+          repos = data.is_a?(Hash) ? data['repositories'] : nil
+
+          abort("#{manifest} must contain a top-level 'repositories' mapping") unless repos.is_a?(Hash)
+          abort("#{manifest} has no repository entries") if repos.empty?
+
+          required_fields = %w[type url]
+          missing = {}
+
+          repos.each do |name, info|
+            unless info.is_a?(Hash)
+              missing[name] = required_fields
+              next
+            end
+
+            absent = required_fields.select do |field|
+              value = info[field]
+              value.nil? || value.to_s.strip.empty?
+            end
+            missing[name] = absent unless absent.empty?
+          end
+
+          unless missing.empty?
+            missing.each { |repo, fields| warn("#{repo}: missing required fields #{fields.join(', ')}") }
+            abort('Dependency manifest validation failed')
+          end
+
+          puts "Validated #{repos.length} dependency entries in #{manifest}"
+          RUBY
+
+  jazzy-ci:
+    needs: security-checks
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up ROS 2 Jazzy
-        uses: ros-tooling/setup-ros@v0.7
+        uses: ros-tooling/setup-ros@2b7b7e10fd30ff131dfb33248ddd71c5ba31dd30 # v0.7
         with:
           required-ros-distributions: jazzy
 
@@ -26,7 +86,7 @@ jobs:
           touch ws/COLCON_IGNORE ws/AMENT_IGNORE
 
       - name: Cache rosdep database
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/.ros/rosdep
           key: rosdep-jazzy-${{ hashFiles('**/package.xml') }}
@@ -34,7 +94,7 @@ jobs:
             rosdep-jazzy-
 
       - name: Cache colcon build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: |
             ws/build
@@ -42,12 +102,6 @@ jobs:
           key: colcon-jazzy-${{ hashFiles('**/CMakeLists.txt', '**/package.xml', '**/setup.py') }}
           restore-keys: |
             colcon-jazzy-
-
-      - name: Validate shell scripts and embedded Python
-        run: |
-          bash -n fix_and_build_humble.sh scripts/fix_workspace_layout.sh
-          python3 scripts/check_python_heredocs.py fix_and_build_humble.sh scripts/fix_workspace_layout.sh
-          ./scripts/check_disallowed_artifact_names.sh
 
       - name: Install dependencies
         working-directory: ws

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,31 @@ build/test flow used in CI and helper scripts.
 - **Compiler/dependency baseline**: keep workspace changes compatible with the repository's C++17-era Humble/Jammy toolchain expectations; do not assume newer `ruckig` / `std::format` requirements unless the baseline docs and CI are updated together.
 - **Jazzy (Ubuntu 24.04)**: experimental (no CI coverage).
 
+
+## CI security and reproducibility policy
+
+Our GitHub Actions workflows follow a security-first baseline:
+
+- **Pin third-party actions by commit SHA** (not floating tags).
+- **Use least-privilege `permissions`** (`contents: read` by default, elevate only when a job requires it).
+- **Enable `concurrency` cancellation** to stop superseded runs on the same branch/PR.
+- **Keep a lightweight security gate** in CI (script lint + dependency-manifest validation) before full build/test jobs.
+
+### Updating pinned action SHAs
+
+Rotate pinned SHAs on a regular cadence (recommended: **monthly**, or immediately for high/critical CVEs):
+
+1. Identify the action tag/version you intend to track (for example `v4.2.2`).
+2. Resolve the commit SHA from the action upstream:
+   ```bash
+   git ls-remote https://github.com/actions/checkout.git refs/tags/v4.2.2
+   ```
+3. Update workflow `uses:` references to `owner/repo@<commit_sha>` and keep an inline comment with the semantic version.
+4. Run local workflow lint checks (or open a PR and verify CI passes).
+5. Merge via PR so SHA rotations are reviewed and auditable.
+
+If a pinned SHA is compromised or revoked, rotate immediately in all workflow files and reference the incident/CVE in the PR description.
+
 ## Workspace layout
 
 Use a ROS 2 workspace that mirrors the layout in the README and helper scripts:


### PR DESCRIPTION
### Motivation

- Reduce supply‑chain and privilege risk in CI by pinning third‑party actions to immutable SHAs and restricting token scopes.
- Avoid wasted runner time and noisy results by cancelling superseded runs on the same PR/branch.
- Gate full build/test runs with a lightweight security job to catch script issues and malformed dependency manifests early.

### Description

- Updated `.github/workflows/humble-ci.yml` and `.github/workflows/jazzy-ci.yml` to pin `actions/checkout`, `ros-tooling/setup-ros`, and `actions/cache` to specific commit SHAs and to add inline comments with the tracked semantic versions. 
- Added least‑privilege `permissions: contents: read` at workflow and job scopes and introduced `concurrency` with `cancel-in-progress: true` to cancel superseded runs. 
- Introduced a `security-checks` job that runs script linting/filename hygiene checks and a dependency manifest validator for `dependencies/emd_epd_ws.repos`, and made the main build/test job depend on this gate via `needs:`. 
- Reworked the manifest validator to use a lightweight Ruby check (validates presence of `type` and `url` per repository entry) to avoid requiring Python YAML dependencies, and documented the CI pinning/rotation policy in `CONTRIBUTING.md` with a recommended update cadence and `git ls-remote` instructions for resolving SHAs.

### Testing

- Parsed both updated workflow YAML files with Ruby's YAML loader, and both parsed successfully (`OK: .github/workflows/humble-ci.yml`, `OK: .github/workflows/jazzy-ci.yml`).
- Ran the repository's shell/heredoc and filename hygiene checks used by CI and they passed (filename hygiene check passed). 
- Executed the Ruby dependency manifest validator against `dependencies/emd_epd_ws.repos` and it validated `15` repository entries after adjusting required fields to `type` and `url`. 
- Resolved upstream action SHAs with `git ls-remote` for `actions/checkout`, `actions/cache`, and `ros-tooling/setup-ros` and confirmed the referenced tags map to commit SHAs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df67d2a9a08331a9ea9021fe79435b)