### PR TITLE
Clarify fail-fast guard in workcell load inspection path

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -257,6 +257,7 @@ void MainWindow::on_load_workcell_clicked()
       boost::system::error_code ec;
       const workcell_builder::WorkcellRootInspection inspection =
         workcell_builder::inspect_selected_workcell_path(fs::path(workcell_file.toStdString()));
+      // Fail fast on invalid workspace; continue otherwise.
       if (!inspection.success) {
         result.error = QString::fromStdString(inspection.error);
         return result;


### PR DESCRIPTION
### Motivation
- Make the control flow around `inspect_selected_workcell_path(...)` explicit so invalid workspaces fail fast while valid inspections proceed into directory/asset/scene setup.

### Description
- Add a short inline comment immediately above the single `if (!inspection.success)` guard in `MainWindow::on_load_workcell_clicked()` to document the intended "fail fast on invalid workspace; continue otherwise" behavior; no functional code changes.

### Testing
- No automated tests were run because this is a comment-only change; behavior was not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa3b195848331a0cd204284ab793d)