### PR TITLE
Fix duplicated scene-root warning text

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -257,8 +257,8 @@ fs::path select_scene_root(const fs::path & cwd)
 
   RCLCPP_WARN(
     rclcpp::get_logger("workcell_builder"),
-    "Unable to locate a valid 'scenes' directory from %s. Checked default locations plus optional "
-    "--scene-root and %s overrides.",
+    "Unable to locate a valid 'scenes' directory from %s. Checked default locations. "
+    "You can override with --scene-root or %s.",
     cwd.string().c_str(), kSceneRootEnvVar);
   for (const auto & candidate : candidates) {
     RCLCPP_INFO(


### PR DESCRIPTION
### Motivation
- Clarify the log output when no valid `scenes` directory is found by removing a duplicated fragment and keeping explicit guidance for both override mechanisms.

### Description
- Updated the `RCLCPP_WARN` message in `workcell_builder/workcell_builder/gui/scene_select.cpp` inside `select_scene_root(...)` to remove the duplicated sentence fragment and instead use a single clear sentence that still references `--scene-root` and `WORKCELL_BUILDER_SCENE_ROOT`.

### Testing
- No automated tests were run because this is a text-only logging change; the source change was inspected to confirm the warning text was updated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa9de3ee0833187c24c7a93948cde)