### PR TITLE
Avoid unbound-variable when sourcing ROS setup and hide in-repo assets from package discovery

### DIFF
--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -211,10 +211,13 @@ build_phase() {
   local ros_setup="/opt/ros/humble/setup.bash"
   local build_cmd
 
+  # Some ROS setup scripts reference AMENT_TRACE_SETUP_FILES directly, which can
+  # trip "unbound variable" failures when this script runs with `set -u`.
+  # Temporarily relax nounset while sourcing ROS and provide a default.
   if [[ "$PROFILE" == "full" && $WITH_GUI -eq 0 ]]; then
-    build_cmd="source '$ros_setup' && colcon build --symlink-install --packages-skip tesseract_qt qtadvanceddocking QtADS tesseract_rviz"
+    build_cmd="set +u; : \"\${AMENT_TRACE_SETUP_FILES:=}\"; source '$ros_setup'; set -u; colcon build --symlink-install --packages-skip tesseract_qt qtadvanceddocking QtADS tesseract_rviz"
   else
-    build_cmd="source '$ros_setup' && colcon build --symlink-install"
+    build_cmd="set +u; : \"\${AMENT_TRACE_SETUP_FILES:=}\"; source '$ros_setup'; set -u; colcon build --symlink-install"
   fi
 
   run_cmd "$build_cmd"

--- a/scripts/fix_workspace_layout.sh
+++ b/scripts/fix_workspace_layout.sh
@@ -314,6 +314,28 @@ set_gui_package_state() {
   fi
 }
 
+ensure_repo_asset_tree_ignored() {
+  local assets_root="$REPO_DIR/assets"
+  local marker
+
+  # When this repository is checked out under workspace/src, rosdep/colcon
+  # traversing from src can see packages twice:
+  #   1) under easy_manipulation_deployment/assets/*
+  #   2) as symlinks exposed directly in src/*
+  # Mark the in-repo assets tree as ignored so tooling only discovers the
+  # exposed src/* entries.
+  if [[ ! -d "$assets_root" ]]; then
+    return
+  fi
+
+  for marker in COLCON_IGNORE AMENT_IGNORE; do
+    if [[ ! -e "$assets_root/$marker" ]]; then
+      echo "Hiding in-repo assets tree from package discovery via $assets_root/$marker"
+      touch "$assets_root/$marker"
+    fi
+  done
+}
+
 for duplicate in \
   "$SRC_DIR/trajopt" \
   "$SRC_DIR/trajopt/trajopt" \
@@ -326,6 +348,7 @@ done
 
 expose_repo_packages
 set_gui_package_state
+ensure_repo_asset_tree_ignored
 
 summarize_exposed_repo_packages() {
   local total_assets=0


### PR DESCRIPTION
### Motivation

- Prevent failures when this script runs with `set -u` due to some ROS setup scripts referencing `AMENT_TRACE_SETUP_FILES` without a default.
- Prevent duplicate package discovery by ROS tooling when the repository exposes assets both under `assets/*` and as symlinks in `src/*`.

### Description

- Relax nounset around sourcing the ROS Humble setup by temporarily running `set +u`, providing a default via `: "${AMENT_TRACE_SETUP_FILES:=}"`, then restoring `set -u` before invoking `colcon build` in `fix_and_build_humble.sh`.
- Add a new function `ensure_repo_asset_tree_ignored` in `scripts/fix_workspace_layout.sh` that creates `COLCON_IGNORE` and `AMENT_IGNORE` markers under `REPO_DIR/assets` to hide the in-repo assets tree from package discovery, and call it during the workspace layout fixup.
- Minor adjustments to where the asset-ignore step is invoked so the summary logic accounts for the hidden assets tree.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d22f697c8331bcb4d627e2ef9466)