### PR TITLE
Handle Humble rosdep failures for tesseract source-only keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,10 @@ test -L src/workbench_description -o -d src/workbench_description
 
 ```bash
 rosdep install --from-paths src --ignore-src -r -y --rosdistro humble \
-  --skip-keys "taskflow osqp-eigen tesseract_environment tesseract_motion_planners tesseract_motion_planners_core tesseract_motion_planners_simple tesseract_task_composer trajopt trajopt_ifopt trajopt_sco trajopt_sqp"
+  --skip-keys "taskflow osqp-eigen tesseract_environment tesseract_motion_planners tesseract_motion_planners_core tesseract_motion_planners_simple tesseract_task_composer tesseract_visualization tesseract_support tesseract_examples trajopt trajopt_ifopt trajopt_sco trajopt_sqp"
 ```
+
+`tesseract_visualization`, `tesseract_support`, and `tesseract_examples` are intentionally treated as source-overlay dependencies in the Humble flow. Keep them in the default `--skip-keys` list unless you explicitly provide equivalent binary packages in your underlay.
 
 8. Build and source the workspace. The layout helper is a required pre-build step for source checkouts because it exposes hidden asset packages from `assets/` into `src/`.
 
@@ -167,7 +169,7 @@ mkdir -p src/tesseract_qt src/qtadvanceddocking src/ruckig
 touch src/tesseract_qt/COLCON_IGNORE src/qtadvanceddocking/COLCON_IGNORE src/ruckig/COLCON_IGNORE
 
 rosdep install --from-paths src --ignore-src -r -y --rosdistro humble \
-  --skip-keys "tesseract_visualization taskflow osqp-eigen tesseract_environment tesseract_motion_planners tesseract_motion_planners_core tesseract_motion_planners_simple tesseract_task_composer trajopt trajopt_ifopt trajopt_sco trajopt_sqp"
+  --skip-keys "tesseract_visualization tesseract_support tesseract_examples taskflow osqp-eigen tesseract_environment tesseract_motion_planners tesseract_motion_planners_core tesseract_motion_planners_simple tesseract_task_composer trajopt trajopt_ifopt trajopt_sco trajopt_sqp"
 
 colcon build --symlink-install --parallel-workers 2 \
   --packages-skip tesseract_qt QtADS tesseract_rviz tesseract_planning_server
@@ -619,7 +621,7 @@ cd ~/workcell_ws
 rm -rf build install log
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
 rosdep install --from-paths src --ignore-src -r -y --rosdistro humble \
-  --skip-keys "taskflow osqp-eigen tesseract_environment tesseract_motion_planners tesseract_motion_planners_core tesseract_motion_planners_simple tesseract_task_composer trajopt trajopt_ifopt trajopt_sco trajopt_sqp"
+  --skip-keys "taskflow osqp-eigen tesseract_environment tesseract_motion_planners tesseract_motion_planners_core tesseract_motion_planners_simple tesseract_task_composer tesseract_visualization tesseract_support tesseract_examples trajopt trajopt_ifopt trajopt_sco trajopt_sqp"
 colcon build --parallel-workers 2
 ```
 

--- a/scripts/lib/dependencies.sh
+++ b/scripts/lib/dependencies.sh
@@ -196,6 +196,9 @@ install_rosdeps() {
         tesseract_motion_planners_simple
         tesseract_process_planners
         tesseract_task_composer
+        tesseract_visualization
+        tesseract_support
+        tesseract_examples
         trajopt_ifopt
         trajopt_sco
         trajopt_sqp

--- a/scripts/rosdep_overrides.yaml
+++ b/scripts/rosdep_overrides.yaml
@@ -3,7 +3,8 @@
 # Note: the full Humble bootstrap profile intentionally skips several planning/
 # Qt rosdep keys when their provider is an imported source overlay. That skip
 # list includes source-only Humble workflow keys such as `tesseract_visualization`,
-# `qt_advanced_docking`, and the TrajOpt/Tesseract planning stack, so the
+# `tesseract_support`, `tesseract_examples`, `qt_advanced_docking`, and the
+# TrajOpt/Tesseract planning stack, so the
 # overrides below focus on keys that should still resolve to OS/ROS packages.
 cereal:
   ubuntu: [libcereal-dev]
@@ -146,6 +147,18 @@ tesseract_task_composer:
   ubuntu:
     jammy: [ros-humble-tesseract-task-composer]
     noble: [ros-jazzy-tesseract-task-composer]
+
+# Source-overlay-only keys on Humble/Jammy. Keep these explicit no-op mappings
+# so `rosdep install --from-paths src --ignore-src` does not fail when the
+# corresponding packages are expected to come from the imported workspace.
+tesseract_visualization:
+  ubuntu: []
+
+tesseract_support:
+  ubuntu: []
+
+tesseract_examples:
+  ubuntu: []
 
 
 gz-common5:


### PR DESCRIPTION
### Motivation
- `rosdep install --from-paths src --ignore-src` can fail on Humble/Jammy when workspace packages such as `tesseract_visualization`, `tesseract_support`, and `tesseract_examples` are provided from a source overlay instead of distro packages, so explicit handling is needed to avoid unresolved-key errors.
- The scripted install flow should enforce the intended source-overlay behavior and document it for users so they do not mistakenly expect apt packages for those keys.

### Description
- Add explicit no-op rosdep override mappings for `tesseract_visualization`, `tesseract_support`, and `tesseract_examples` in `scripts/rosdep_overrides.yaml` (each mapped to `ubuntu: []`).
- Include `tesseract_visualization`, `tesseract_support`, and `tesseract_examples` in the default `--skip-keys` list in `scripts/lib/dependencies.sh` so scripted `rosdep install` will skip them by default.
- Update `README.md` `rosdep install` examples to include the same skip-key defaults and add a short note documenting these keys are intentionally treated as source-overlay dependencies unless binary packages are provided in an underlay.

### Testing
- Ran `bash -n scripts/lib/dependencies.sh` to validate shell syntax and it succeeded.
- Verified the three keys are present in `scripts/rosdep_overrides.yaml` using a small Python assertion script and it succeeded.
- Performed repository-wide grep checks to confirm `README.md`, `scripts/lib/dependencies.sh`, and `scripts/rosdep_overrides.yaml` were updated as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f62f15308331b691f0eff669f854)