### PR TITLE
Document staged tesseract_qt build and enforce tesseract_common dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,14 +391,33 @@ cd ~/workcell_ws/src/easy_manipulation_deployment
 
 `fix_workspace_layout.sh` creates `COLCON_IGNORE` markers for `src/tesseract_qt` and `src/qtadvanceddocking` unless you explicitly opt into GUI support. If you prefer to manage that manually, either leave those markers in place or pass `--packages-skip tesseract_qt QtADS` to `colcon build` (optionally also adding `qtadvanceddocking` as a compatibility fallback for folder-based troubleshooting notes). To opt into the GUI-enabled path instead, use `./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh --with-gui` for the manual flow or `./fix_and_build_humble.sh --workspace ~/workcell_ws --check-prereqs --build --profile full --with-gui` for the helper-script flow.
 
-For an explicit GUI-enabled manual build, remove those markers by opting into GUI mode when syncing the workspace layout:
+For an explicit GUI-enabled manual build, remove those markers by opting into GUI mode when syncing the workspace layout. Build in stages so `tesseract_commonConfig.cmake` is exported before `tesseract_qt` configures:
 
 ```bash
 cd ~/workcell_ws
 vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh --with-gui
-colcon build --symlink-install --parallel-workers 2
+
+# 1) Build/install the core package set that exports tesseract_commonConfig.cmake
+colcon build --symlink-install --parallel-workers 2 \
+  --packages-skip tesseract_qt QtADS qtadvanceddocking tesseract_rviz tesseract_planning_server
+
+# 2) Refresh the overlay environment from the staged install
+source install/setup.bash
+
+# 3) Build tesseract_qt and remaining downstream GUI packages
+colcon build --symlink-install --parallel-workers 2 \
+  --packages-up-to tesseract_qt tesseract_rviz tesseract_planning_server
 ```
+
+Before step (3), verify `tesseract_qt` metadata declares a dependency on the package that exports `tesseract_common` so colcon ordering is deterministic:
+
+```bash
+grep -nE "<(depend|build_depend|exec_depend)>tesseract_common</(depend|build_depend|exec_depend)>" \
+  ~/workcell_ws/src/tesseract_qt/package.xml
+```
+
+If that check is empty, run `./src/easy_manipulation_deployment/scripts/apply_upstream_patches.sh` from the workspace root to apply compatibility updates and inject the dependency declaration.
 
 If you use the helper script instead, the equivalent GUI-enabled path is:
 
@@ -574,12 +593,16 @@ If `trajoptConfig.cmake` is still missing, verify `src/trajopt`, `src/trajopt_co
 
 ### Optional GUI package issues
 
-If `tesseract_qt` fails to link because the ADS target name differs on your system, apply the included patch and rebuild:
+If `tesseract_qt` fails to link because the ADS target name differs on your system, apply the included patch, verify metadata, and rebuild in stages:
 
 ```bash
 cd ~/workcell_ws
 ./src/easy_manipulation_deployment/scripts/apply_upstream_patches.sh
-colcon build --symlink-install --parallel-workers 2
+colcon build --symlink-install --parallel-workers 2 \
+  --packages-skip tesseract_qt QtADS qtadvanceddocking tesseract_rviz tesseract_planning_server
+source install/setup.bash
+colcon build --symlink-install --parallel-workers 2 \
+  --packages-up-to tesseract_qt tesseract_rviz tesseract_planning_server
 ```
 
 Qt ADS (`qtadvanceddocking`) may also require Qt private headers on some systems. If the build cannot find `qpa/qplatformnativeinterface.h`, install the distro package that provides the Qt private development headers for your Qt version before rebuilding.

--- a/scripts/apply_upstream_patches.sh
+++ b/scripts/apply_upstream_patches.sh
@@ -48,6 +48,54 @@ if [[ ! -d "${TESSERACT_QT_DIR}" ]]; then
   exit 1
 fi
 
+resolve_tesseract_qt_package_xml() {
+  local candidates=(
+    "${TESSERACT_QT_DIR}/package.xml"
+    "${TESSERACT_QT_DIR}/tesseract_qt/package.xml"
+  )
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "${candidate}" ]]; then
+      echo "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+ensure_tesseract_common_manifest_dependency() {
+  local package_xml="$1"
+  if grep -Eq "<(build_depend|buildtool_depend|exec_depend|depend)>[[:space:]]*tesseract_common[[:space:]]*</(build_depend|buildtool_depend|exec_depend|depend)>" "${package_xml}"; then
+    echo "INFO: ${package_xml} already declares a dependency on tesseract_common."
+    return 0
+  fi
+
+  python3 - "${package_xml}" <<'PY'
+import sys
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+package_xml = Path(sys.argv[1])
+tree = ET.parse(package_xml)
+root = tree.getroot()
+
+depend = ET.Element("depend")
+depend.text = "tesseract_common"
+
+insert_idx = len(root)
+for idx, child in enumerate(list(root)):
+    if child.tag == "export":
+        insert_idx = idx
+        break
+
+root.insert(insert_idx, depend)
+ET.indent(tree, space="  ")
+tree.write(package_xml, encoding="utf-8", xml_declaration=True)
+PY
+
+  echo "SUCCESS: Added '<depend>tesseract_common</depend>' to ${package_xml}."
+}
+
 echo "Workspace root: ${WORKSPACE_ROOT}"
 echo "Applying patch: ${PATCH_FILE}"
 
@@ -60,4 +108,11 @@ else
   echo "ERROR: Patch could not be applied cleanly." >&2
   echo "Inspect local changes in ${TESSERACT_QT_DIR} and apply manually if required." >&2
   exit 1
+fi
+
+PACKAGE_XML="$(resolve_tesseract_qt_package_xml || true)"
+if [[ -z "${PACKAGE_XML}" ]]; then
+  echo "WARNING: Could not find tesseract_qt package.xml to verify tesseract_common dependency." >&2
+else
+  ensure_tesseract_common_manifest_dependency "${PACKAGE_XML}"
 fi


### PR DESCRIPTION
### Motivation
- Prevent `tesseract_qt` from configuring/locking up due to missing `tesseract_commonConfig.cmake` by making the GUI build a staged process. 
- Ensure colcon ordering is deterministic by verifying `tesseract_qt` package metadata declares a dependency on the package that exports `tesseract_common`. 
- Provide a safe helper that can patch upstream `tesseract_qt` checkouts to be compatible in source-overlay workflows.

### Description
- Updated `README.md` to document a three-stage GUI build: (1) build/install core packages that export `tesseract_commonConfig.cmake`, (2) `source install/setup.bash`, and (3) build `tesseract_qt` and downstream GUI packages via `colcon` with `--packages-up-to` to control ordering. 
- Added an explicit metadata verification command to the docs using `grep` to check for a `tesseract_common` dependency in `~/workcell_ws/src/tesseract_qt/package.xml` and guidance to run the helper when missing. 
- Enhanced `scripts/apply_upstream_patches.sh` with `resolve_tesseract_qt_package_xml()` to locate `tesseract_qt/package.xml` and `ensure_tesseract_common_manifest_dependency()` to detect or inject a `<depend>tesseract_common</depend>` entry (implemented via an embedded Python XML edit) so colcon can determine correct ordering. 
- Updated troubleshooting notes and the optional-GUI rebuild sequences to use the staged build flow and to recommend running the helper script if metadata is missing. 

### Testing
- Ran `bash -n scripts/apply_upstream_patches.sh` to validate the script syntax, which succeeded. 
- Ran `rg -n "tesseract_commonConfig|packages-up-to tesseract_qt|metadata declares" README.md scripts/apply_upstream_patches.sh` to confirm the documentation and script changes are present, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f64d5ca48331a6a10cf08906c71f)