### PR TITLE
Use explicit World::Object IDs in moveit pose unit tests

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_moveit_object_pose_utils.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_moveit_object_pose_utils.cpp
@@ -29,7 +29,7 @@ namespace
 
 TEST(MoveitObjectPoseUtilsTest, ReturnsDefaultPoseWhenObjectHasNoShapePoses)
 {
-  auto object = std::make_shared<collision_detection::World::Object>();
+  auto object = std::make_shared<collision_detection::World::Object>("object_without_pose");
 
   EXPECT_TRUE(object->shape_poses_.empty());
 
@@ -47,7 +47,7 @@ TEST(MoveitObjectPoseUtilsTest, ReturnsDefaultPoseWhenObjectHasNoShapePoses)
 
 TEST(MoveitObjectPoseUtilsTest, ConvertsFirstShapePoseWhenAvailable)
 {
-  auto object = std::make_shared<collision_detection::World::Object>();
+  auto object = std::make_shared<collision_detection::World::Object>("object_with_pose");
   Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
   transform.translation().x() = 0.1;
   transform.translation().y() = -0.2;


### PR DESCRIPTION
### Motivation
- Ensure the unit tests construct `collision_detection::World::Object` with explicit IDs so pose lookup is unambiguous and the tests better reflect real object usage.

### Description
- Replaced default construction `std::make_shared<collision_detection::World::Object>()` with `std::make_shared<collision_detection::World::Object>("object_without_pose")` in `ReturnsDefaultPoseWhenObjectHasNoShapePoses` and with `std::make_shared<collision_detection::World::Object>("object_with_pose")` in `ConvertsFirstShapePoseWhenAvailable` while leaving `shape_poses_` usage and all assertions unchanged.

### Testing
- Attempted targeted build `colcon build --symlink-install --packages-select emd_grasp_execution`, which could not run in this environment because `colcon` is not installed (`colcon: command not found`), so no automated tests were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0fd1d8c6c8331b56e1923437eea42)