### PR TITLE
Narrow rosdep skip-keys to GUI-only fallbacks and verify tesseract_motion_planners presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ test -L src/workbench_description -o -d src/workbench_description
 
 ```bash
 rosdep install --from-paths src --ignore-src -r -y --rosdistro humble \
-  --skip-keys "taskflow osqp-eigen tesseract_environment tesseract_motion_planners tesseract_motion_planners_core tesseract_motion_planners_simple tesseract_task_composer tesseract_visualization tesseract_support tesseract_examples trajopt trajopt_ifopt trajopt_sco trajopt_sqp"
+  --skip-keys "qt_advanced_docking tesseract_visualization"
 ```
 
 For scripted workflows, `./scripts/fix_and_build.sh` now runs the same preflight automatically before its rosdep phase and appends fallback skip-keys (for example `qt_advanced_docking`, `tesseract_visualization`) when binary packages are unavailable.
@@ -140,6 +140,7 @@ For scripted workflows, `./scripts/fix_and_build.sh` now runs the same preflight
 ```bash
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
 eval "$(./src/easy_manipulation_deployment/scripts/ensure_taskflow_cmake_package.sh --export)"
+colcon list --base-paths src --names-only | grep -E '^tesseract_motion_planners($|_)'
 colcon build --parallel-workers 2
 source install/setup.bash
 ```
@@ -181,7 +182,9 @@ mkdir -p src/tesseract_qt src/qtadvanceddocking src/ruckig
 touch src/tesseract_qt/COLCON_IGNORE src/qtadvanceddocking/COLCON_IGNORE src/ruckig/COLCON_IGNORE
 
 rosdep install --from-paths src --ignore-src -r -y --rosdistro humble \
-  --skip-keys "tesseract_visualization tesseract_support tesseract_examples taskflow osqp-eigen tesseract_environment tesseract_motion_planners tesseract_motion_planners_core tesseract_motion_planners_simple tesseract_task_composer trajopt trajopt_ifopt trajopt_sco trajopt_sqp"
+  --skip-keys "qt_advanced_docking tesseract_visualization"
+
+colcon list --base-paths src --names-only | grep -E '^tesseract_motion_planners($|_)'
 
 colcon build --symlink-install --parallel-workers 2 \
   --packages-skip tesseract_qt QtADS tesseract_rviz tesseract_planning_server
@@ -656,7 +659,8 @@ cd ~/workcell_ws
 rm -rf build install log
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
 rosdep install --from-paths src --ignore-src -r -y --rosdistro humble \
-  --skip-keys "taskflow osqp-eigen tesseract_environment tesseract_motion_planners tesseract_motion_planners_core tesseract_motion_planners_simple tesseract_task_composer tesseract_visualization tesseract_support tesseract_examples trajopt trajopt_ifopt trajopt_sco trajopt_sqp"
+  --skip-keys "qt_advanced_docking tesseract_visualization"
+colcon list --base-paths src --names-only | grep -E '^tesseract_motion_planners($|_)'
 colcon build --parallel-workers 2
 ```
 

--- a/scripts/lib/dependencies.sh
+++ b/scripts/lib/dependencies.sh
@@ -44,6 +44,12 @@ verify_workspace_packages() {
     if ! colcon list --base-paths "$SRC_DIR" >/dev/null; then
         log_warn "colcon list failed (possibly due to cyclic dependencies); continuing"
     fi
+
+    if colcon list --base-paths "$SRC_DIR" --names-only 2>/dev/null | grep -E '^tesseract_motion_planners($|_)' >/dev/null; then
+        log_info "Verified tesseract motion planner source packages are present in workspace"
+    else
+        log_warn "No tesseract_motion_planners* packages discovered in workspace package list"
+    fi
 }
 
 install_system_packages() {
@@ -186,26 +192,8 @@ install_rosdeps() {
 
 
     local skip_keys=(
-        rviz
-        roslib
-        taskflow
-        tesseract
-        tesseract_environment
-        tesseract_motion_planners
-        tesseract_motion_planners_core
-        tesseract_motion_planners_simple
-        tesseract_process_planners
-        tesseract_task_composer
         tesseract_visualization
-        tesseract_support
-        tesseract_examples
-        trajopt_ifopt
-        trajopt_sco
-        trajopt_sqp
-        trajopt
-        osqp-eigen
-        jsoncpp
-        message_generation
+        qt_advanced_docking
     )
 
     local preflight_helper="$REPO_ROOT/scripts/preflight_tesseract_apt.sh"


### PR DESCRIPTION
### Motivation

- Prevent planner-core/source-overlay keys (for example `tesseract_motion_planners*` and `trajopt*`) from being globally skipped during `rosdep install` so source-built planners are installed from source when present.
- Only exclude binary GUI/Qt providers that are optional for headless builds (e.g., QtADS/visualization) to avoid masking missing source packages.
- Add an explicit planner-package presence check before build steps so the workflow can warn when planner sources are not exposed in the workspace.

### Description

- Reduced the default rosdep `--skip-keys` in `scripts/lib/dependencies.sh` to the minimal GUI-only keys `tesseract_visualization` and `qt_advanced_docking`, while preserving the preflight fallback merge from `preflight_tesseract_apt.sh` into `skip_keys`.
- Added a workspace verification step in `verify_workspace_packages()` that runs `colcon list --base-paths "$SRC_DIR" --names-only | grep -E '^tesseract_motion_planners($|_)'` and logs whether `tesseract_motion_planners*` packages are present.
- Updated the README examples to use the revised `--skip-keys "qt_advanced_docking tesseract_visualization"` lines and to run `colcon list --base-paths src --names-only | grep -E '^tesseract_motion_planners($|_)'` before build commands.

### Testing

- Ran `colcon list --base-paths . --names-only | grep tesseract_motion_planners` to validate planner visibility, but it failed in this environment because `colcon` is not installed (`colcon: command not found`).
- Ran `rosdep install --from-paths . --ignore-src -r -y --rosdistro humble --skip-keys "qt_advanced_docking tesseract_visualization"` to validate the modified skip list, but it failed in this environment because `rosdep` is not installed (`rosdep: command not found`).
- Attempted `colcon build --base-paths . --parallel-workers 2` to verify build behavior, but it failed for the same reason (`colcon: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10625aaec8331a4261759544bcfad)