### PR TITLE
docs: keep COLCON_IGNORE markers limited to optional GUI packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ ln -sfn easy_manipulation_deployment/assets/end_effectors/single_suction_gripper
 ln -sfn easy_manipulation_deployment/assets/end_effectors/single_suction_gripper/single_suction_description src/single_suction_description
 
 # Optional GUI packages are disabled in this simple/headless path
-mkdir -p src/tesseract_qt src/qtadvanceddocking src/ruckig
-touch src/tesseract_qt/COLCON_IGNORE src/qtadvanceddocking/COLCON_IGNORE src/ruckig/COLCON_IGNORE
+mkdir -p src/tesseract_qt src/qtadvanceddocking
+touch src/tesseract_qt/COLCON_IGNORE src/qtadvanceddocking/COLCON_IGNORE
 
 rosdep install --from-paths src --ignore-src -r -y --rosdistro humble \
   --skip-keys "tesseract_visualization tesseract_support tesseract_examples taskflow osqp-eigen tesseract_environment tesseract_motion_planners tesseract_motion_planners_core tesseract_motion_planners_simple tesseract_task_composer trajopt trajopt_ifopt trajopt_sco trajopt_sqp"


### PR DESCRIPTION
### Motivation
- The headless/manual setup snippet in `README.md` created `src/ruckig/COLCON_IGNORE`, which hides a workspace-provided `ruckig` checkout and prevents it from being discoverable during package discovery and builds.

### Description
- Removed the `mkdir`/`touch` for `src/ruckig` and its `COLCON_IGNORE` entry from the README headless setup snippet so only the optional GUI packages `tesseract_qt` and `qtadvanceddocking` remain ignored.

### Testing
- Verified the README change with `nl -ba README.md | sed -n '176,186p'` and searched for remaining `ruckig` ignore lines with `rg -n 'ruckig/COLCON_IGNORE|touch .*ruckig' README.md scripts -S`, and could not run full `colcon`/workspace discovery checks because `~/workcell_ws` and ROS build tools were not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1061bce808331b84de66b9ecd0e18)