### PR TITLE
README: Recommend helper build script and add explicit manual quick-start flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,24 @@ This package was tested with [easy_perception_deployment](https://github.com/ros
 
 ## Quick start (recommended path)
 
-If you want the shortest known-good flow on Ubuntu 22.04 + ROS 2 Humble:
+If you want the shortest known-good flow on Ubuntu 22.04 + ROS 2 Humble, use the helper script:
+
+```bash
+mkdir -p ~/workcell_ws/src
+cd ~/workcell_ws/src
+git clone https://github.com/Mukaram01/Easy_Manipulator_Improved.git easy_manipulation_deployment
+cd easy_manipulation_deployment
+./fix_and_build_humble.sh --workspace ~/workcell_ws --check-prereqs --build --profile full
+```
+
+Then verify:
+
+```bash
+ros2 pkg prefix emd_msgs
+./src/easy_manipulation_deployment/scripts/validate_workspace_assets.sh
+```
+
+If you prefer the explicit manual flow (same intent, no helper wrapper), this is the minimal supported sequence:
 
 ```bash
 mkdir -p ~/workcell_ws/src
@@ -39,25 +56,14 @@ git clone https://github.com/Mukaram01/Easy_Manipulator_Improved.git easy_manipu
 mv easy_manipulation_deployment/assets/ .
 mv easy_manipulation_deployment/scenes/ .
 cd ~/workcell_ws
-
-# One-time rosdep override registration
-echo "yaml file://$HOME/workcell_ws/src/easy_manipulation_deployment/scripts/rosdep_overrides.yaml" | \
-  sudo tee /etc/ros/rosdep/sources.list.d/10-easy-manipulator-overrides.list >/dev/null
-
-# Repeat before each build in source-checkout workflows
+source /opt/ros/humble/setup.bash
+vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
+./src/easy_manipulation_deployment/scripts/ensure_rosdep_overrides.sh
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
-
-# Build
+rosdep install --from-paths src --ignore-src -r -y --rosdistro "${ROS_DISTRO}"
 eval "$(./src/easy_manipulation_deployment/scripts/ensure_taskflow_cmake_package.sh --export)"
 colcon build --parallel-workers 2
 source install/setup.bash
-```
-
-Then verify:
-
-```bash
-ros2 pkg prefix emd_msgs
-./src/easy_manipulation_deployment/scripts/validate_workspace_assets.sh
 ```
 
 ---


### PR DESCRIPTION
### Motivation

- Simplify the recommended quick-start on Ubuntu 22.04 + ROS 2 Humble by providing a single helper script to set up and build the workspace.
- Make the original manual workflow available for users who prefer explicit commands or need to inspect intermediate steps. 

### Description

- Replace the previous one-liner quick-start build steps with a call to the helper script `./fix_and_build_humble.sh --workspace ~/workcell_ws --check-prereqs --build --profile full`.
- Remove the inline sequence of workspace fixes and overrides from the recommended quick path and add a new explicit manual flow showing the same sequence of commands (including `vcs import`, `ensure_rosdep_overrides.sh`, `fix_workspace_layout.sh`, `rosdep install`, `ensure_taskflow_cmake_package.sh`, and `colcon build`).
- Add brief wording clarifying there are two supported options (helper script or manual flow) and keep the verification steps using `ros2 pkg prefix emd_msgs` and `validate_workspace_assets.sh`.

### Testing

- Documentation-only change; no automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e107a01a2c8331a5ea6a2d7d8dd96e)