### PR TITLE
Make Humble bootstrap reproducible and headless by default

### DIFF
--- a/.github/workflows/humble-ci.yml
+++ b/.github/workflows/humble-ci.yml
@@ -106,12 +106,21 @@ jobs:
       - name: Install dependencies
         working-directory: ws
         run: |
+          ./src/easy_manipulation_deployment/scripts/ensure_rosdep_overrides.sh
+          ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
           rosdep update
-          rosdep install --from-paths src --ignore-src -yr --rosdistro humble
+          rosdep install --from-paths src --ignore-src -yr --rosdistro humble \
+            --skip-keys "qt_advanced_docking tesseract_visualization"
+
+      - name: Reproducibility guard (workspace discovery)
+        working-directory: ws
+        run: ./src/easy_manipulation_deployment/scripts/verify_workspace_discovery.sh
 
       - name: Build
         working-directory: ws
-        run: colcon build --symlink-install
+        run: |
+          colcon build --symlink-install \
+            --packages-skip tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_planning_server
 
       - name: Test
         working-directory: ws

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This package was tested with [easy_perception_deployment](https://github.com/ros
 - **Supported/tested:** Ubuntu 22.04 + ROS 2 Humble
 - Other platforms and experimental combinations are listed later in [Version notes / advanced compatibility](#version-notes--advanced-compatibility)
 
+> Reproducibility expectation: run bootstrap/build from a clean shell that only sources `/opt/ros/humble/setup.bash`. Do not rely on pre-sourced overlays from other workspaces.
+
 ## Quick start (recommended path)
 
 If you want the shortest known-good flow on Ubuntu 22.04 + ROS 2 Humble, use the helper script:
@@ -47,22 +49,25 @@ ros2 pkg prefix emd_msgs
 ./src/easy_manipulation_deployment/scripts/validate_workspace_assets.sh
 ```
 
-If you prefer the explicit manual flow (same intent, no helper wrapper), this is the minimal supported sequence:
+If you prefer an explicit manual flow, use this **canonical clean-room sequence** (same behavior as the helper script):
 
 ```bash
 mkdir -p ~/workcell_ws/src
 cd ~/workcell_ws/src
 git clone https://github.com/Mukaram01/Easy_Manipulator_Improved.git easy_manipulation_deployment
-mv easy_manipulation_deployment/assets/ .
-mv easy_manipulation_deployment/scenes/ .
 cd ~/workcell_ws
+unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_PREFIX_PATH
 source /opt/ros/humble/setup.bash
 vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
 ./src/easy_manipulation_deployment/scripts/ensure_rosdep_overrides.sh
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
-rosdep install --from-paths src --ignore-src -r -y --rosdistro "${ROS_DISTRO}"
+./src/easy_manipulation_deployment/scripts/preflight_tesseract_apt.sh --ros-distro humble || true
+rosdep install --from-paths src --ignore-src -r -y --rosdistro humble \
+  --skip-keys "qt_advanced_docking tesseract_visualization"
 eval "$(./src/easy_manipulation_deployment/scripts/ensure_taskflow_cmake_package.sh --export)"
-colcon build --parallel-workers 2
+./src/easy_manipulation_deployment/scripts/verify_workspace_discovery.sh
+colcon build --symlink-install --parallel-workers 2 \
+  --packages-skip tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_planning_server
 source install/setup.bash
 ```
 
@@ -96,8 +101,6 @@ rosdep update
 mkdir -p ~/workcell_ws/src
 cd ~/workcell_ws/src
 git clone https://github.com/Mukaram01/Easy_Manipulator_Improved.git easy_manipulation_deployment
-mv easy_manipulation_deployment/assets/ .
-mv easy_manipulation_deployment/scenes/ .
 ```
 
 4. Import the source dependencies.
@@ -147,7 +150,7 @@ For scripted workflows, `./scripts/fix_and_build.sh` now runs the same preflight
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
 eval "$(./src/easy_manipulation_deployment/scripts/ensure_taskflow_cmake_package.sh --export)"
 colcon list --base-paths src --names-only | grep -E '^tesseract_motion_planners($|_)'
-colcon build --parallel-workers 2
+colcon build --symlink-install --parallel-workers 2 --packages-skip tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_planning_server
 source install/setup.bash
 ```
 
@@ -159,8 +162,6 @@ If you prefer not to use `fix_workspace_layout.sh` or other repository helper sc
 mkdir -p ~/workcell_ws/src
 cd ~/workcell_ws/src
 git clone https://github.com/Mukaram01/Easy_Manipulator_Improved.git easy_manipulation_deployment
-mv easy_manipulation_deployment/assets/ .
-mv easy_manipulation_deployment/scenes/ .
 cd ~/workcell_ws
 vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
 

--- a/dependencies/emd_epd_ws.repos
+++ b/dependencies/emd_epd_ws.repos
@@ -2,13 +2,15 @@ repositories:
   tesseract:
     type: git
     url: https://github.com/tesseract-robotics/tesseract.git
+    version: a3984dc75f4e492682f1fd7107e355f1776daf35
   tesseract_ros2:
     type: git
     url: https://github.com/tesseract-robotics/tesseract_ros2.git
-    version: 0.33.0
+    version: 3c1a583725cb37a8bcfafb0103766f4b66ccd5fb
   tesseract_planning:
     type: git
     url: https://github.com/tesseract-robotics/tesseract_planning.git
+    version: 54a4737a371d0ff1f28522b1b9e2f99c34e211c5
   tesseract_qt:
     type: git
     url: https://github.com/tesseract-robotics/tesseract_qt.git
@@ -16,9 +18,11 @@ repositories:
   trajopt:
     type: git
     url: https://github.com/tesseract-robotics/trajopt.git
+    version: 884e6177c4a220fc20a0c43100a0473c180a3bec
   taskflow:
     type: git
     url: https://github.com/taskflow/taskflow.git
+    version: 97aa6eaca3605e16c254eb766e9425d013b05423
   octomap:
     type: git
     url: https://github.com/OctoMap/octomap.git
@@ -31,13 +35,14 @@ repositories:
   ifopt:
     type: git
     url: https://github.com/ethz-adrl/ifopt.git
+    version: 4d6267bfefbaaa97e079c9aa163ebd477fce064d
   descartes_light:
     type: git
     url: https://github.com/swri-robotics/descartes_light.git
   boost_plugin_loader:
     type: git
     url: https://github.com/tesseract-robotics/boost_plugin_loader.git
-    version: 0.4.3
+    version: 742e0de95e6520baa2c3fe208e5040531b4d497e
   opw_kinematics:
     type: git
     url: https://github.com/Jmeyer1292/opw_kinematics.git
@@ -47,4 +52,4 @@ repositories:
   ruckig:
     type: git
     url: https://github.com/pantor/ruckig.git
-    version: 37b6e7a
+    version: 6f73b03f4e155cf931263709eabe6add6afab618

--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -25,7 +25,7 @@ Usage: ./fix_and_build_humble.sh [options]
 Phase options (choose one or more):
   --check-prereqs            Read-only checks. Verifies tooling and ROS prerequisites.
   --install-prereqs          Mutating phase. Installs missing apt/pip prerequisites.
-  --build                    Build phase only. Runs colcon build in the workspace.
+  --build                    Bootstrap + build phase in the workspace.
 
 General options:
   --workspace <path>         Workspace root (default: current working directory)
@@ -209,18 +209,36 @@ build_phase() {
   fi
 
   local ros_setup="/opt/ros/humble/setup.bash"
-  local build_cmd
+  local skip_keys="qt_advanced_docking,tesseract_visualization"
+  local build_skip="tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_planning_server"
 
-  # Some ROS setup scripts reference AMENT_TRACE_SETUP_FILES directly, which can
-  # trip "unbound variable" failures when this script runs with `set -u`.
-  # Temporarily relax nounset while sourcing ROS and provide a default.
-  if [[ "$PROFILE" == "full" && $WITH_GUI -eq 0 ]]; then
-    build_cmd="set +u; : \"\${AMENT_TRACE_SETUP_FILES:=}\"; source '$ros_setup'; set -u; colcon build --symlink-install --packages-skip tesseract_qt qtadvanceddocking QtADS tesseract_rviz"
-  else
-    build_cmd="set +u; : \"\${AMENT_TRACE_SETUP_FILES:=}\"; source '$ros_setup'; set -u; colcon build --symlink-install"
+  run_cmd "unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_PREFIX_PATH"
+  run_cmd "set +u; : \"\${AMENT_TRACE_SETUP_FILES:=}\"; source '$ros_setup'; set -u"
+  run_cmd "vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos"
+  append_unique REPOS_IMPORTED "dependencies/emd_epd_ws.repos"
+
+  run_cmd "./src/easy_manipulation_deployment/scripts/ensure_rosdep_overrides.sh"
+  run_cmd "./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh"
+  run_cmd "./src/easy_manipulation_deployment/scripts/preflight_tesseract_apt.sh --ros-distro humble || true"
+
+  local fallback_keys=""
+  if fallback_keys=$(./src/easy_manipulation_deployment/scripts/preflight_tesseract_apt.sh --ros-distro humble --print-rosdep-skip-keys 2>/dev/null); then
+    true
+  fi
+  if [[ -n "$fallback_keys" ]]; then
+    skip_keys+=",$fallback_keys"
   fi
 
-  run_cmd "$build_cmd"
+  run_cmd "rosdep install --from-paths src --ignore-src -r -y --rosdistro humble --skip-keys '$skip_keys'"
+  run_cmd "eval \"\$(./src/easy_manipulation_deployment/scripts/ensure_taskflow_cmake_package.sh --export)\""
+  run_cmd "./src/easy_manipulation_deployment/scripts/verify_workspace_discovery.sh"
+
+  if [[ "$PROFILE" == "full" && $WITH_GUI -eq 1 ]]; then
+    run_cmd "colcon build --symlink-install --parallel-workers 2"
+  else
+    run_cmd "colcon build --symlink-install --parallel-workers 2 --packages-skip $build_skip"
+  fi
+
   append_unique FILES_TOUCHED "$WORKSPACE/build"
   append_unique FILES_TOUCHED "$WORKSPACE/install"
   append_unique FILES_TOUCHED "$WORKSPACE/log"

--- a/scripts/verify_workspace_discovery.sh
+++ b/scripts/verify_workspace_discovery.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKSPACE_ROOT="${WORKSPACE_ROOT:-$(pwd)}"
+SRC_DIR="${SRC_DIR:-$WORKSPACE_ROOT/src}"
+
+if [[ ! -d "$SRC_DIR" ]]; then
+  echo "Workspace src directory not found: $SRC_DIR" >&2
+  exit 1
+fi
+
+if ! command -v colcon >/dev/null 2>&1; then
+  echo "colcon is required for workspace validation" >&2
+  exit 1
+fi
+
+mapfile -t packages < <(colcon list --base-paths "$SRC_DIR" --names-only 2>/dev/null || true)
+if [[ ${#packages[@]} -eq 0 ]]; then
+  echo "No packages discovered under $SRC_DIR. Run vcs import + fix_workspace_layout first." >&2
+  exit 1
+fi
+
+declare -A present=()
+for pkg in "${packages[@]}"; do
+  present["$pkg"]=1
+done
+
+required=(
+  tesseract_motion_planners
+  tesseract_rosutils
+  trajopt
+  trajopt_common
+  trajopt_sco
+  trajopt_ifopt
+  trajopt_sqp
+)
+
+missing=()
+for pkg in "${required[@]}"; do
+  if [[ -z "${present[$pkg]:-}" ]]; then
+    missing+=("$pkg")
+  fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "Workspace validation failed: required packages are missing from colcon discovery:" >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  echo "Remediation: source /opt/ros/humble/setup.bash, run vcs import --recursive --skip-existing, then run scripts/fix_workspace_layout.sh and retry." >&2
+  exit 1
+fi
+
+echo "Workspace validation passed: required Tesseract/TrajOpt packages are discoverable."


### PR DESCRIPTION
## Summary
- Pin all previously floating Tesseract/TrajOpt-related repos in `dependencies/emd_epd_ws.repos` to known-good SHAs from the working machine snapshot.
- Update `fix_and_build_humble.sh` so `--build` now performs canonical bootstrap steps before building:
  - clean ROS env var reset
  - source `/opt/ros/humble/setup.bash`
  - `vcs import --recursive --skip-existing`
  - `ensure_rosdep_overrides.sh`
  - `fix_workspace_layout.sh`
  - `preflight_tesseract_apt.sh --ros-distro humble`
  - rosdep install with source-overlay skip keys
  - `ensure_taskflow_cmake_package.sh --export`
  - new reproducibility guard script
  - default headless `colcon build` skipping optional GUI packages
- Add `scripts/verify_workspace_discovery.sh` to fail fast when required Tesseract/TrajOpt packages are not discoverable.
- Align `README.md` with one canonical clean-room path and remove instructions that moved tracked directories out of the checkout.
- Extend Humble CI to run layout/rosdep bootstrap and the new reproducibility guard before build, and build with the headless package skip list.

## Why
Fresh Ubuntu 22.04/Humble machines were failing because dependency versions and workspace state were non-deterministic, docs included dirty-checkout move commands, and optional GUI packages were pulled into default headless builds. These changes make the default path deterministic, clean-checkout friendly, and robust without relying on hidden overlays.

## Validation
- `bash -n fix_and_build_humble.sh scripts/verify_workspace_discovery.sh`
- `ruby -e "require 'yaml'; YAML.load_file('dependencies/emd_epd_ws.repos')"`


------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e13d6c4700833197911df4a6539d34)