### PR TITLE
Use absolute asset/workcell paths in scene dialogs and guard cwd switches

### DIFF
--- a/workcell_builder/workcell_builder/gui/addendeffector.cpp
+++ b/workcell_builder/workcell_builder/gui/addendeffector.cpp
@@ -16,6 +16,7 @@
 #include "gui/addendeffector.h"
 #include <QString>
 #include <QKeyEvent>
+#include <QMessageBox>
 #include <QProcess>
 #include <QRegularExpression>
 #include <QTemporaryFile>
@@ -24,6 +25,7 @@
 #include <iostream>
 #include <fstream>
 #include <iterator>
+#include <memory>
 #include <set>
 #include <sstream>
 #include <string>
@@ -32,6 +34,37 @@
 #include "ament_index_cpp/get_package_share_directory.hpp"
 #include "gui/ui_addendeffector.h"
 #include "attributes/robot.h"
+
+namespace
+{
+class ScopedCurrentPath
+{
+public:
+  explicit ScopedCurrentPath(const boost::filesystem::path & destination)
+  : original_path_(boost::filesystem::current_path()),
+    active_(false)
+  {
+    if (!boost::filesystem::exists(destination) || !boost::filesystem::is_directory(destination)) {
+      throw boost::filesystem::filesystem_error(
+              "ScopedCurrentPath destination is invalid", destination,
+              boost::system::error_code());
+    }
+    boost::filesystem::current_path(destination);
+    active_ = true;
+  }
+
+  ~ScopedCurrentPath()
+  {
+    if (active_) {
+      boost::filesystem::current_path(original_path_);
+    }
+  }
+
+private:
+  boost::filesystem::path original_path_;
+  bool active_;
+};
+}  // namespace
 
 AddEndEffector::AddEndEffector(QWidget * parent)
 : QDialog(parent),
@@ -48,95 +81,69 @@ AddEndEffector::AddEndEffector(QWidget * parent)
 
 int AddEndEffector::LoadAvailableEE(Robot robot, const boost::filesystem::path & end_effector_path)
 {
-  original_path = boost::filesystem::current_path();
   ui->parent_object->setText(QString::fromStdString(robot.name));
   ui->parent_link->setText(QString::fromStdString(robot.ee_link));
-  boost::filesystem::path ee_path = end_effector_path;
-  if (!boost::filesystem::exists(ee_path) || boost::filesystem::is_empty(ee_path)) {
-    const auto share =
-      ament_index_cpp::get_package_share_directory("workcell_builder");
-    ee_path = boost::filesystem::path(share) / "assets" / "end_effectors";
-  }
+  const boost::filesystem::path resolved_assets_path = assets_path.empty() ?
+    (workcell_path / "assets") : assets_path;
+  boost::filesystem::path ee_path = end_effector_path.empty() ?
+    (resolved_assets_path / "end_effectors") : end_effector_path;
+  ui->ee_brand->clear();
+  ui->ee_model->clear();
+  ui->ee_links->clear();
   available_brands.clear();
   available_ee.clear();
-  if (!boost::filesystem::exists(ee_path) || boost::filesystem::is_empty(ee_path)) {
-    return 0;
-  } else {
-    boost::filesystem::current_path(ee_path);
-    for (auto & filepath :
-      boost::filesystem::directory_iterator(ee_path))
-    {
-      std::string temp_brand;
+  try {
+    if (!boost::filesystem::exists(ee_path) || boost::filesystem::is_empty(ee_path)) {
+      const auto share =
+        ament_index_cpp::get_package_share_directory("workcell_builder");
+      ee_path = boost::filesystem::path(share) / "assets" / "end_effectors";
+    }
+    if (!boost::filesystem::exists(ee_path) || boost::filesystem::is_empty(ee_path)) {
+      return 0;
+    }
+
+    for (const auto & filepath : boost::filesystem::directory_iterator(ee_path)) {
+      if (!boost::filesystem::is_directory(filepath.path())) {
+        continue;
+      }
+      const boost::filesystem::path brand_path = filepath.path();
+      const std::string temp_brand = brand_path.filename().string();
       std::vector<EndEffector> brand_ee_vector;
 
-      // Iterate brand
-      for (auto it = filepath.path().string().crbegin(); it != filepath.path().string().crend();
-        ++it)
-      {
-        if (*it != '/') {
-          temp_brand = std::string(1, *it) + temp_brand;
-        } else {
-          boost::filesystem::current_path(temp_brand);
-          std::vector<std::string> moveit_configs;
-          std::vector<std::string> descriptions;
-          for (auto & filepath_model :
-            boost::filesystem::directory_iterator(boost::filesystem::current_path()))
-          {
-            bool is_moveit_config = false;
-            bool is_description = false;
-            std::string temp_model;
-            int char_count = 0;
-
-            for (auto it = filepath_model.path().string().crbegin();
-              it != filepath_model.path().string().crend(); ++it)
-            {
-              if (*it != '/') {
-                temp_model = std::string(1, *it) + temp_model;
-                char_count++;
-                if (char_count == 11) {
-                  if (temp_model.compare("description") == 0) {
-                    is_description = true;
-                  }
-                }
-                if (char_count == 13) {
-                  if (temp_model.compare("moveit_config") == 0) {
-                    is_moveit_config = true;
-                  }
-                }
-              } else {
-                break;
-              }
-            }
-            if (is_description) {
-              descriptions.push_back(temp_model.substr(0, temp_model.size() - 12));
-            }
-            if (is_moveit_config) {
-              moveit_configs.push_back(temp_model.substr(0, temp_model.size() - 14));
-            }
-          }
-          if (moveit_configs.size() < descriptions.size()) {
-            for (int i = 0; i < static_cast<int>(descriptions.size()); i++) {
-              if (std::find(
-                  moveit_configs.begin(), moveit_configs.end(),
-                  descriptions[i]) != moveit_configs.end())
-              {
-                brand_ee_vector.push_back(LoadEE(descriptions[i] + "_description", temp_brand));
-              }
-            }
-          } else {
-            for (int i = 0; i < static_cast<int>(moveit_configs.size()); i++) {
-              if (std::find(
-                  descriptions.begin(), descriptions.end(),
-                  moveit_configs[i]) != descriptions.end())
-              {
-                brand_ee_vector.push_back(LoadEE(moveit_configs[i] + "_description", temp_brand));
-              }
-            }
-          }
-          boost::filesystem::current_path(boost::filesystem::current_path().branch_path());
-          break;
+      std::vector<std::string> moveit_configs;
+      std::vector<std::string> descriptions;
+      for (const auto & filepath_model : boost::filesystem::directory_iterator(brand_path)) {
+        const std::string temp_model = filepath_model.path().filename().string();
+        if (temp_model.size() > 12 && temp_model.substr(temp_model.size() - 12) == "_description") {
+          descriptions.push_back(temp_model.substr(0, temp_model.size() - 12));
+        }
+        if (temp_model.size() > 14 && temp_model.substr(temp_model.size() - 14) == "_moveit_config") {
+          moveit_configs.push_back(temp_model.substr(0, temp_model.size() - 14));
         }
       }
+
+      if (moveit_configs.size() < descriptions.size()) {
+        for (int i = 0; i < static_cast<int>(descriptions.size()); i++) {
+          if (std::find(
+              moveit_configs.begin(), moveit_configs.end(),
+              descriptions[i]) != moveit_configs.end())
+          {
+            brand_ee_vector.push_back(
+              LoadEE((brand_path / (descriptions[i] + "_description")), temp_brand));
+          }
+        }
+      } else {
+        for (int i = 0; i < static_cast<int>(moveit_configs.size()); i++) {
+          if (std::find(
+              descriptions.begin(), descriptions.end(),
+              moveit_configs[i]) != descriptions.end())
+          {
+            brand_ee_vector.push_back(
+              LoadEE((brand_path / (moveit_configs[i] + "_description")), temp_brand));
+          }
+        }
+      }
+
       if (!brand_ee_vector.empty()) {
         available_ee.push_back(brand_ee_vector);
         available_brands.push_back(temp_brand);
@@ -160,6 +167,18 @@ int AddEndEffector::LoadAvailableEE(Robot robot, const boost::filesystem::path &
     on_ee_model_currentIndexChanged(0);
     ui->ee_links->setCurrentIndex(0);
     return total_ee;
+  } catch (const boost::filesystem::filesystem_error & error) {
+    QMessageBox::warning(
+      this,
+      "End Effector Discovery Error",
+      QString("Filesystem error while loading end effectors:\n%1")
+      .arg(QString::fromStdString(error.what())));
+  } catch (const std::exception & error) {
+    QMessageBox::warning(
+      this,
+      "End Effector Discovery Error",
+      QString("Error while loading end effectors:\n%1")
+      .arg(QString::fromStdString(error.what())));
   }
   return 0;
 }
@@ -266,22 +285,23 @@ void AddEndEffector::on_ee_type_currentIndexChanged(int index)
   ui->attribute_2->blockSignals(oldState2);
 }
 
-EndEffector AddEndEffector::LoadEE(std::string file, std::string brand)
+EndEffector AddEndEffector::LoadEE(const boost::filesystem::path & description_path, std::string brand)
 {
   EndEffector temp_ee;
-  temp_ee.filepath = boost::filesystem::current_path().string() + "/" + file;
-  boost::filesystem::current_path(file);
-  boost::filesystem::current_path("urdf");
+  temp_ee.filepath = description_path.string();
   temp_ee.brand = brand;
-  temp_ee.name = file.erase(file.length() - 12);
+  temp_ee.name = description_path.filename().string();
+  if (temp_ee.name.size() > 12 && temp_ee.name.substr(temp_ee.name.size() - 12) == "_description") {
+    temp_ee.name.erase(temp_ee.name.length() - 12);
+  }
+  const boost::filesystem::path urdf_dir = description_path / "urdf";
   const std::string macro_filename = temp_ee.name + "_gripper.urdf.xacro";
   const std::string standalone_filename = temp_ee.name + "_gripper_standalone.urdf.xacro";
-  if (boost::filesystem::exists(standalone_filename)) {
-    temp_ee.ee_links = GetLinks(standalone_filename);
+  if (boost::filesystem::exists(urdf_dir / standalone_filename)) {
+    temp_ee.ee_links = GetLinks((urdf_dir / standalone_filename).string());
   } else {
-    temp_ee.ee_links = GetLinks(macro_filename);
+    temp_ee.ee_links = GetLinks((urdf_dir / macro_filename).string());
   }
-  boost::filesystem::current_path(boost::filesystem::current_path().branch_path().branch_path());
   return temp_ee;
 }
 namespace
@@ -316,10 +336,21 @@ std::vector<std::string> AddEndEffector::GetLinks(
   const std::vector<std::string> & xacro_arguments)
 {
   std::vector<std::string> links;
-  if (!boost::filesystem::exists(filename)) {
+  const boost::filesystem::path file_path = boost::filesystem::absolute(filename);
+  if (!boost::filesystem::exists(file_path)) {
     ui->errorlist->append(
       QString::fromStdString(
-        "<font color='red'> End effector xacro file not found: " + filename + " </font>"));
+        "<font color='red'> End effector xacro file not found: " + file_path.string() + " </font>"));
+    return links;
+  }
+  std::unique_ptr<ScopedCurrentPath> path_guard;
+  try {
+    path_guard = std::make_unique<ScopedCurrentPath>(file_path.parent_path());
+  } catch (const boost::filesystem::filesystem_error & error) {
+    ui->errorlist->append(
+      QString::fromStdString(
+        "<font color='red'> Cannot open end-effector directory: " + std::string(error.what()) +
+        " </font>"));
     return links;
   }
 
@@ -349,8 +380,7 @@ std::vector<std::string> AddEndEffector::GetLinks(
     return false;
   };
 
-  const QString xacro_filename =
-    QString::fromStdString(boost::filesystem::absolute(filename).string());
+  const QString xacro_filename = QString::fromStdString(file_path.string());
   QString xacro_stderr;
   if (!run_xacro(build_xacro_args(xacro_filename), &urdf_xml, &xacro_stderr)) {
     QString error_message =
@@ -617,7 +647,6 @@ int AddEndEffector::ErrorCheckOrigin()
 
 AddEndEffector::~AddEndEffector()
 {
-  boost::filesystem::current_path(original_path);
   delete ui;
 }
 

--- a/workcell_builder/workcell_builder/gui/addendeffector.h
+++ b/workcell_builder/workcell_builder/gui/addendeffector.h
@@ -42,9 +42,10 @@ public:
   std::vector < std::vector < EndEffector >> available_ee;
   std::vector < std::string > supported_types {"finger", "suction"};
   std::vector < std::vector < std::vector < int >> > supported_attributes {{{2}}, {{1}, {1}}};
-  boost::filesystem::path original_path;
+  boost::filesystem::path workcell_path;
+  boost::filesystem::path assets_path;
 
-  EndEffector LoadEE(std::string file, std::string brand);
+  EndEffector LoadEE(const boost::filesystem::path & description_path, std::string brand);
   int LoadAvailableEE(Robot robot, const boost::filesystem::path & end_effector_path);
   void LoadExistingEE(EndEffector ee_input);
   std::vector<std::string> GetLinks(

--- a/workcell_builder/workcell_builder/gui/addrobot.cpp
+++ b/workcell_builder/workcell_builder/gui/addrobot.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <fstream>
 #include <iterator>
+#include <memory>
 #include <set>
 #include <sstream>
 #include <string>
@@ -33,6 +34,34 @@
 
 namespace
 {
+class ScopedCurrentPath
+{
+public:
+  explicit ScopedCurrentPath(const boost::filesystem::path & destination)
+  : original_path_(boost::filesystem::current_path()),
+    active_(false)
+  {
+    if (!boost::filesystem::exists(destination) || !boost::filesystem::is_directory(destination)) {
+      throw boost::filesystem::filesystem_error(
+              "ScopedCurrentPath destination is invalid", destination,
+              boost::system::error_code());
+    }
+    boost::filesystem::current_path(destination);
+    active_ = true;
+  }
+
+  ~ScopedCurrentPath()
+  {
+    if (active_) {
+      boost::filesystem::current_path(original_path_);
+    }
+  }
+
+private:
+  boost::filesystem::path original_path_;
+  bool active_;
+};
+
 constexpr const char * kMissingUrdfLabel = "Missing URDF";
 const std::unordered_map<std::string, std::vector<std::string>> kDescriptionPackagesByBrand = {
   {"fanuc", {"moveit_resources_fanuc_description", "fanuc_description"}},
@@ -118,7 +147,6 @@ AddRobot::AddRobot(QWidget * parent)
 
 AddRobot::~AddRobot()
 {
-  boost::filesystem::current_path(original_path);
   delete ui;
 }
 void AddRobot::LoadExistingRobot(Robot robot_input)
@@ -166,118 +194,78 @@ void AddRobot::LoadExistingRobot(Robot robot_input)
 
 int AddRobot::LoadAvailableRobots()
 {
-  original_path = boost::filesystem::current_path();
-  boost::filesystem::current_path(boost::filesystem::current_path().branch_path());  //
-  boost::filesystem::current_path("assets");
-  boost::filesystem::current_path("robots");
+  ui->robot_brand->clear();
+  ui->robot_model->clear();
+  ui->robot_links->clear();
+  ui->robot_ee_link->clear();
   available_brands.clear();
   available_robots.clear();
-  if (boost::filesystem::is_empty(boost::filesystem::current_path())) {
-    return 0;
-  } else {
-    boost::filesystem::path temp_path(boost::filesystem::current_path());
-    for (auto & filepath :
-      boost::filesystem::directory_iterator(boost::filesystem::current_path()))
-    {
-      std::string temp_brand;
+  try {
+    const boost::filesystem::path resolved_assets_path = assets_path.empty() ?
+      (workcell_path / "assets") : assets_path;
+    const boost::filesystem::path robots_path = resolved_assets_path / "robots";
+    if (!boost::filesystem::exists(robots_path) || !boost::filesystem::is_directory(robots_path)) {
+      QMessageBox::warning(
+        this, "Robot Assets Missing",
+        QString("Robot assets directory does not exist:\n%1")
+        .arg(QString::fromStdString(robots_path.string())));
+      return 0;
+    }
+    if (boost::filesystem::is_empty(robots_path)) {
+      return 0;
+    }
+
+    for (const auto & filepath : boost::filesystem::directory_iterator(robots_path)) {
+      if (!boost::filesystem::is_directory(filepath.path())) {
+        continue;
+      }
+      const boost::filesystem::path brand_path = filepath.path();
+      const std::string temp_brand = brand_path.filename().string();
       std::vector<Robot> brand_robot_vector;
-      for (auto it = filepath.path().string().crbegin(); it != filepath.path().string().crend();
-        ++it)
-      {
-        if (*it != '/') {
-          temp_brand = std::string(1, *it) + temp_brand;
-        } else {
-          boost::filesystem::current_path(temp_brand);
-          if (temp_brand.compare("universal_robot") == 0) {
-            std::vector<std::string> valid_robots;
-            for (auto & filepath :
-              boost::filesystem::directory_iterator(boost::filesystem::current_path()))
-            {
-              std::string temp_model;
-              bool is_moveit = false;
-              int char_count = 0;
-              for (auto it = filepath.path().string().crbegin();
-                it != filepath.path().string().crend(); ++it)
-              {
-                if (*it != '/') {
-                  temp_model = std::string(1, *it) + temp_model;
-                  char_count++;
-                  if (char_count == 13) {
-                    if (temp_model.compare("moveit_config") == 0) {
-                      is_moveit = true;
-                    }
-                  }
-                }
-                if (*it == '/') {
-                  break;
-                }
-              }
-              if (is_moveit) {
-                valid_robots.push_back(temp_model.substr(0, temp_model.size() - 14));
-              }
-            }
-            brand_robot_vector = LoadUR(valid_robots);
-          } else {
-            std::vector<std::string> moveit_configs;
-            const boost::filesystem::path brand_path = boost::filesystem::current_path();
-            for (auto & filepath :
-              boost::filesystem::directory_iterator(boost::filesystem::current_path()))
-            {
-              bool is_moveit = false;
 
-              std::string temp_model;
-              int char_count = 0;
-              for (auto it = filepath.path().string().crbegin();
-                it != filepath.path().string().crend(); ++it)
-              {
-                if (*it != '/') {
-                  temp_model = std::string(1, *it) + temp_model;
-                  char_count++;
-                  if (char_count == 13) {
-                    if (temp_model.compare("moveit_config") == 0) {
-                      is_moveit = true;
-                    }
-                  }
-                } else {
-                  break;
-                }
-              }
-
-              if (is_moveit) {
-                moveit_configs.push_back(temp_model.substr(0, temp_model.size() - 14));
-              }
-            }
-            boost::filesystem::current_path(boost::filesystem::current_path().branch_path());
-
-            for (const auto & moveit_config : moveit_configs) {
-              const std::string description_folder = moveit_config + "_description";
-              boost::filesystem::path description_path = brand_path / description_folder;
-              if (!boost::filesystem::exists(description_path)) {
-                description_path = resolve_description_package_path(temp_brand);
-              }
-              if (description_path.empty()) {
-                std::cerr
-                  << "No description folder found for " << moveit_config
-                  << " under assets/robots/" << temp_brand
-                  << " and no matching ROS 2 description package is installed."
-                  << std::endl;
-                continue;
-              }
-              brand_robot_vector.push_back(
-                LoadRobot(
-                  description_folder,
-                  temp_brand,
-                  description_path));
-            }
+      if (temp_brand.compare("universal_robot") == 0) {
+        std::vector<std::string> valid_robots;
+        for (const auto & model_path : boost::filesystem::directory_iterator(brand_path)) {
+          std::string temp_model = model_path.path().filename().string();
+          if (temp_model.size() > 14 && temp_model.substr(temp_model.size() - 14) == "_moveit_config") {
+            valid_robots.push_back(temp_model.substr(0, temp_model.size() - 14));
           }
-          break;
+        }
+        brand_robot_vector = LoadUR(valid_robots);
+      } else {
+        std::vector<std::string> moveit_configs;
+        for (const auto & model_path : boost::filesystem::directory_iterator(brand_path)) {
+          std::string temp_model = model_path.path().filename().string();
+          if (temp_model.size() > 14 && temp_model.substr(temp_model.size() - 14) == "_moveit_config") {
+            moveit_configs.push_back(temp_model.substr(0, temp_model.size() - 14));
+          }
+        }
+
+        for (const auto & moveit_config : moveit_configs) {
+          const std::string description_folder = moveit_config + "_description";
+          boost::filesystem::path description_path = brand_path / description_folder;
+          if (!boost::filesystem::exists(description_path)) {
+            description_path = resolve_description_package_path(temp_brand);
+          }
+          if (description_path.empty()) {
+            std::cerr
+              << "No description folder found for " << moveit_config
+              << " under assets/robots/" << temp_brand
+              << " and no matching ROS 2 description package is installed."
+              << std::endl;
+            continue;
+          }
+          brand_robot_vector.push_back(
+            LoadRobot(
+              description_folder,
+              temp_brand,
+              description_path));
         }
       }
       if (!brand_robot_vector.empty()) {
         available_robots.push_back(brand_robot_vector);
         available_brands.push_back(temp_brand);
       }
-      boost::filesystem::current_path(temp_path);
     }
     for (int i3 = 0; i3 < static_cast<int>(available_brands.size()); i3++) {
       ui->robot_brand->addItem(QString::fromStdString(available_brands[i3]));
@@ -296,6 +284,16 @@ int AddRobot::LoadAvailableRobots()
       }
     }
     return total_count;
+  } catch (const boost::filesystem::filesystem_error & error) {
+    QMessageBox::warning(
+      this, "Robot Discovery Error",
+      QString("Filesystem error while loading robots:\n%1")
+      .arg(QString::fromStdString(error.what())));
+  } catch (const std::exception & error) {
+    QMessageBox::warning(
+      this, "Robot Discovery Error",
+      QString("Error while loading robots:\n%1")
+      .arg(QString::fromStdString(error.what())));
   }
   return 0;
 }
@@ -306,8 +304,10 @@ Robot AddRobot::LoadRobot(
   const boost::filesystem::path & description_path)
 {
   Robot temp_robot;
+  const boost::filesystem::path robots_root = assets_path.empty() ?
+    (workcell_path / "assets" / "robots") : (assets_path / "robots");
   const boost::filesystem::path resolved_description_path = description_path.empty() ?
-    (boost::filesystem::current_path() / brand / file) : description_path;
+    (robots_root / brand / file) : description_path;
   temp_robot.filepath = resolved_description_path.string();
   temp_robot.brand = brand;
   temp_robot.name = file.erase(file.length() - 12);
@@ -332,7 +332,9 @@ Robot AddRobot::LoadRobot(
 std::vector<Robot> AddRobot::LoadUR(std::vector<std::string> robot_list)
 // load ur robots based on the way it is structured
 {
-  const boost::filesystem::path base_path = boost::filesystem::current_path();
+  const boost::filesystem::path base_path = assets_path.empty() ?
+    (workcell_path / "assets" / "robots" / "universal_robot") :
+    (assets_path / "robots" / "universal_robot");
   const boost::filesystem::path ur_description_path = base_path / "ur_description";
   boost::filesystem::path resolved_ur_description_path = ur_description_path;
   if (!boost::filesystem::exists(ur_description_path)) {
@@ -348,7 +350,6 @@ std::vector<Robot> AddRobot::LoadUR(std::vector<std::string> robot_list)
           << "Resolved ur_description via package share directory: "
           << share_path.string() << std::endl;
         resolved_ur_description_path = share_path;
-        boost::filesystem::current_path(share_path);
         resolved_package = true;
       }
     } catch (const std::exception & e) {
@@ -368,17 +369,28 @@ std::vector<Robot> AddRobot::LoadUR(std::vector<std::string> robot_list)
       return {};
     }
   } else {
-    boost::filesystem::current_path(ur_description_path);
+    resolved_ur_description_path = ur_description_path;
   }
-  boost::filesystem::current_path("urdf");
 
   std::vector<Robot> ur_robot_vector;
+  const boost::filesystem::path urdf_path = resolved_ur_description_path / "urdf";
+  if (!boost::filesystem::exists(urdf_path) || !boost::filesystem::is_directory(urdf_path)) {
+    QMessageBox::warning(
+      this,
+      "UR Description Missing",
+      QString("URDF folder not found under ur_description:\n%1")
+      .arg(QString::fromStdString(urdf_path.string())));
+    return {};
+  }
   for (int i = 0; i < static_cast<int>(robot_list.size()); i++) {
     Robot temp_robot;
     temp_robot.brand = "universal_robot";
     temp_robot.name = robot_list[i];
+    const boost::filesystem::path resolved_xacro =
+      urdf_path / resolve_universal_robot_xacro_filename(
+      resolved_ur_description_path, temp_robot.name);
     temp_robot.robot_links = GetLinks(
-      resolve_universal_robot_xacro_filename(resolved_ur_description_path, temp_robot.name),
+      resolved_xacro.string(),
       {
         "ur_type:=" + temp_robot.name,
         "name:=" + temp_robot.name
@@ -393,7 +405,17 @@ std::vector<std::string> AddRobot::GetLinks(
   const std::vector<std::string> & xacro_arguments)
 {
   std::vector<std::string> links;
-  const boost::filesystem::path file_path = boost::filesystem::absolute(filename);
+  boost::filesystem::path file_path;
+  try {
+    file_path = boost::filesystem::absolute(filename);
+  } catch (const boost::filesystem::filesystem_error & error) {
+    QMessageBox::warning(
+      this,
+      "URDF Path Error",
+      QString("Failed to resolve URDF/xacro path:\n%1")
+      .arg(QString::fromStdString(error.what())));
+    return links;
+  }
   if (!boost::filesystem::exists(file_path)) {
     std::cerr << "URDF/xacro file not found: " << file_path.string() << std::endl;
     QMessageBox::warning(
@@ -401,6 +423,17 @@ std::vector<std::string> AddRobot::GetLinks(
       "URDF Missing",
       QString("URDF/xacro file not found:\n%1")
       .arg(QString::fromStdString(file_path.string())));
+    return links;
+  }
+  std::unique_ptr<ScopedCurrentPath> path_guard;
+  try {
+    path_guard = std::make_unique<ScopedCurrentPath>(file_path.parent_path());
+  } catch (const boost::filesystem::filesystem_error & error) {
+    QMessageBox::warning(
+      this,
+      "URDF Path Error",
+      QString("Cannot switch to URDF directory:\n%1")
+      .arg(QString::fromStdString(error.what())));
     return links;
   }
 

--- a/workcell_builder/workcell_builder/gui/addrobot.h
+++ b/workcell_builder/workcell_builder/gui/addrobot.h
@@ -35,7 +35,8 @@ class AddRobot: public QDialog
 public:
   std::vector < std::vector < Robot >> available_robots;
   std::vector < std::string > available_brands;
-  boost::filesystem::path original_path;
+  boost::filesystem::path workcell_path;
+  boost::filesystem::path assets_path;
   Robot robot;
   bool success;
   bool editing_mode = false;

--- a/workcell_builder/workcell_builder/gui/addscene.cpp
+++ b/workcell_builder/workcell_builder/gui/addscene.cpp
@@ -310,13 +310,13 @@ void AddScene::on_delete_object_clicked()
 
 void AddScene::on_add_robot_clicked()
 {
-  if (!resolve_directory_paths() || !validate_directory(scenes_path, "scenes")) {
+  if (!resolve_directory_paths() || !validate_directory(assets_path, "assets")) {
     return;
   }
 
-  const boost::filesystem::path previous_path = boost::filesystem::current_path();
-  boost::filesystem::current_path(scenes_path);
   AddRobot robot_window;
+  robot_window.workcell_path = workcell_path;
+  robot_window.assets_path = assets_path;
   int num_robots_loaded = robot_window.LoadAvailableRobots();
   if (num_robots_loaded <= 0) {
     ui->robot_brand->setText(
@@ -351,7 +351,6 @@ void AddScene::on_add_robot_clicked()
       }
     }
   }
-  boost::filesystem::current_path(previous_path);
 }
 
 void AddScene::on_add_ee_clicked()
@@ -361,6 +360,8 @@ void AddScene::on_add_ee_clicked()
   }
 
   AddEndEffector ee_window;
+  ee_window.workcell_path = workcell_path;
+  ee_window.assets_path = assets_path;
   int num_ee = ee_window.LoadAvailableEE(scene.robot_vector[0], assets_path / "end_effectors");
   if (num_ee <= 0) {
     ui->ee_brand->setText(
@@ -603,9 +604,10 @@ void AddScene::on_load_object_clicked()
     available_object_names.push_back(scene.object_vector[i].name);
   }
 
-  const boost::filesystem::path previous_path = boost::filesystem::current_path();
-  boost::filesystem::current_path(assets_path);
   LoadObjects load_obj_window;
+  load_obj_window.workcell_path = workcell_path;
+  load_obj_window.assets_path = assets_path;
+  load_obj_window.refresh_available_objects();
   load_obj_window.current_object_names = available_object_names;
   load_obj_window.setWindowTitle("Load Existing Objects");
   load_obj_window.setModal(true);
@@ -617,7 +619,6 @@ void AddScene::on_load_object_clicked()
     ui->parent_link->addItem("");
     scene.object_vector.push_back(load_obj_window.chosen_object);
   }
-  boost::filesystem::current_path(previous_path);
 }
 
 void AddScene::append_path_error(const std::string & message)

--- a/workcell_builder/workcell_builder/gui/loadobjects.cpp
+++ b/workcell_builder/workcell_builder/gui/loadobjects.cpp
@@ -15,6 +15,7 @@
 
 #include "gui/loadobjects.h"
 #include <boost/filesystem.hpp>
+#include <QMessageBox>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -27,21 +28,7 @@ LoadObjects::LoadObjects(QWidget * parent)
   ui(new Ui::LoadObjects)
 {
   ui->setupUi(this);
-  boost::filesystem::current_path("environment");
-  get_all_objects();
-  if (available_objects.size() <= 0) {
-    ui->object_name->setDisabled(true);
-    ui->available_objects->setDisabled(true);
-    ui->ok->setDisabled(true);
-    ui->error_message->append(
-      "<font color='red'> Error: No object to be loaded."
-      " Is the object initially created with the Workcell Builder? </font>");
-  } else {
-    for (int i = 0; i < static_cast<int>(available_objects.size()); i++) {
-      ui->available_objects->addItem(QString::fromStdString(available_objects[i]));
-    }
-    ui->object_name->setText(ui->available_objects->currentText());
-  }
+  success = false;
 }
 
 LoadObjects::~LoadObjects()
@@ -75,41 +62,85 @@ void LoadObjects::on_exit_clicked()
   this->close();
 }
 
-void LoadObjects::get_all_objects()
+void LoadObjects::refresh_available_objects()
 {
-  boost::filesystem::path temp_path(boost::filesystem::current_path());
-  for (auto & filepath : boost::filesystem::directory_iterator(boost::filesystem::current_path())) {
-    boost::filesystem::current_path(filepath.path());
-    std::string temp_name;
-    for (auto it = filepath.path().string().crbegin(); it != filepath.path().string().crend();
-      ++it)
-    {
-      if (*it != '/') {
-        temp_name = std::string(1, *it) + temp_name;
-      } else {
-        temp_name = temp_name.substr(0, temp_name.size() - 12);
-        break;
-      }
-    }
+  ui->available_objects->clear();
+  get_all_objects();
+  const bool has_objects = !available_objects.empty();
+  ui->object_name->setDisabled(!has_objects);
+  ui->available_objects->setDisabled(!has_objects);
+  ui->ok->setDisabled(!has_objects);
 
-    if (boost::filesystem::exists(temp_name + ".yaml")) {
-      available_objects.push_back(temp_name);
-    }
+  if (!has_objects) {
+    ui->error_message->append(
+      "<font color='red'> Error: No object to be loaded."
+      " Is the object initially created with the Workcell Builder? </font>");
+    return;
   }
-  boost::filesystem::current_path(temp_path);
+
+  for (const auto & available_object : available_objects) {
+    ui->available_objects->addItem(QString::fromStdString(available_object));
+  }
+  ui->object_name->setText(ui->available_objects->currentText());
 }
 
-// Assumes you are at the environment directory
+void LoadObjects::get_all_objects()
+{
+  available_objects.clear();
+  try {
+    const boost::filesystem::path resolved_assets_path = assets_path.empty() ?
+      (workcell_path / "assets") : assets_path;
+    const boost::filesystem::path environment_path = resolved_assets_path / "environment";
+    if (!boost::filesystem::exists(environment_path) ||
+      !boost::filesystem::is_directory(environment_path))
+    {
+      append_error(
+        "Environment assets folder not found: " + environment_path.string());
+      return;
+    }
+
+    for (const auto & filepath : boost::filesystem::directory_iterator(environment_path)) {
+      if (!boost::filesystem::is_directory(filepath.path())) {
+        continue;
+      }
+      std::string temp_name = filepath.path().filename().string();
+      if (temp_name.size() <= 12 || temp_name.substr(temp_name.size() - 12) != "_description") {
+        continue;
+      }
+      temp_name = temp_name.substr(0, temp_name.size() - 12);
+      if (boost::filesystem::exists(filepath.path() / (temp_name + ".yaml"))) {
+        available_objects.push_back(temp_name);
+      }
+    }
+  } catch (const boost::filesystem::filesystem_error & error) {
+    append_error("Filesystem error while enumerating objects: " + std::string(error.what()));
+  } catch (const std::exception & error) {
+    append_error("Error while enumerating objects: " + std::string(error.what()));
+  }
+}
+
 bool LoadObjects::load_object_from_yaml(std::string object_name)
 {
-  boost::filesystem::path temp_path(boost::filesystem::current_path());
-  boost::filesystem::current_path(object_name + "_description");
   Object temp_object;
   YAML::Node yaml;
-  // Load Yaml File.
+  const boost::filesystem::path resolved_assets_path = assets_path.empty() ?
+    (workcell_path / "assets") : assets_path;
+  const boost::filesystem::path object_directory =
+    resolved_assets_path / "environment" / (object_name + "_description");
+  const boost::filesystem::path yaml_path = object_directory / (object_name + ".yaml");
+
+  if (!boost::filesystem::exists(yaml_path)) {
+    append_error("Object YAML file not found: " + yaml_path.string());
+    return false;
+  }
+
   try {
-    yaml = YAML::LoadFile(object_name + ".yaml");
+    yaml = YAML::LoadFile(yaml_path.string());
   } catch (YAML::BadFile & error) {
+    append_error("Cannot load object YAML file: " + yaml_path.string());
+    return false;
+  } catch (const std::exception & error) {
+    append_error("Error parsing object YAML file: " + std::string(error.what()));
     return false;
   }
 
@@ -159,7 +190,6 @@ bool LoadObjects::load_object_from_yaml(std::string object_name)
     }
   }
 
-  boost::filesystem::current_path(temp_path);
   chosen_object = temp_object;
   chosen_object.name = ui->object_name->text().toStdString();
   return true;
@@ -168,5 +198,13 @@ bool LoadObjects::load_object_from_yaml(std::string object_name)
 
 void LoadObjects::on_available_objects_currentIndexChanged(int index)
 {
-  ui->object_name->setText(QString::fromStdString(available_objects[index]));
+  if (index >= 0 && index < static_cast<int>(available_objects.size())) {
+    ui->object_name->setText(QString::fromStdString(available_objects[index]));
+  }
+}
+
+void LoadObjects::append_error(const std::string & message)
+{
+  ui->error_message->append(QString::fromStdString("<font color='red'> " + message + " </font>"));
+  QMessageBox::warning(this, "Load Object Error", QString::fromStdString(message));
 }

--- a/workcell_builder/workcell_builder/gui/loadobjects.h
+++ b/workcell_builder/workcell_builder/gui/loadobjects.h
@@ -17,6 +17,7 @@
 #define EASY_MANIPULATION_DEPLOYMENT__WORKCELL_BUILDER__WORKCELL_BUILDER__GUI__LOADOBJECTS_H_
 
 #include <QDialog>
+#include <boost/filesystem.hpp>
 #include <string>
 #include <vector>
 
@@ -36,7 +37,10 @@ public:
   std::vector < std::string > available_objects;
   Object chosen_object;
   std::vector < std::string > current_object_names;
+  boost::filesystem::path workcell_path;
+  boost::filesystem::path assets_path;
 
+  void refresh_available_objects();
   void get_all_objects();
   bool load_object_from_yaml(std::string object_name);
 
@@ -51,6 +55,7 @@ private slots:
   void on_available_objects_currentIndexChanged(int index);
 
 private:
+  void append_error(const std::string & message);
   Ui::LoadObjects * ui;
 };
 

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -544,6 +544,9 @@ void SceneSelect::on_edit_scene_clicked()
     }
     // Scene loaded
     AddScene scene_window;
+    scene_window.scenes_path = scenes_path;
+    scene_window.assets_path = assets_path;
+    scene_window.workcell_path = workcell_path;
     scene_window.LoadScene(curr_scene);
     scene_window.setWindowTitle("Edit Scene");
     scene_window.setModal(true);


### PR DESCRIPTION
### Motivation
- Eliminate fragile reliance on `boost::filesystem::current_path(...)` and ambient CWD when discovering and loading assets (objects, robots, end-effectors) from dialogs. 
- Surface filesystem/parse failures to the user instead of allowing uncontrolled exceptions or process-level failures.
- Make dialogs deterministic by accepting explicit `workcell_path`/`assets_path` inputs from the caller.

### Description
- Added explicit dialog path members `workcell_path` and `assets_path` to `LoadObjects`, `AddRobot`, and `AddEndEffector` so callers provide absolute base paths (headers: `loadobjects.h`, `addrobot.h`, `addendeffector.h`).
- Replaced relative `current_path` traversal with absolute path joins to resolve assets under `assets/environment`, `assets/robots`, and `assets/end_effectors` (implementations: `loadobjects.cpp`, `addrobot.cpp`, `addendeffector.cpp`).
- Introduced `ScopedCurrentPath` RAII helper to locally switch CWD only when unavoidable for legacy helpers, validating target directories before switching and restoring previous CWD on scope exit (in `addrobot.cpp` and `addendeffector.cpp`).
- Converted filesystem/YAML/xacro failures into user-visible messages: `QMessageBox::warning` and dialog error lists are used instead of aborting; added `append_error` and `refresh_available_objects` helpers in `LoadObjects` to centralize UI feedback.
- Reworked parsing/discovery logic to enumerate directories using `directory_iterator` and filename-based checks (e.g. `*_description`, `_moveit_config`) instead of string-reversal CWD hacks, and validated required directories before use.
- Wired callers to provide paths: `AddScene` now sets `workcell_path`/`assets_path` on child dialogs and calls `refresh_available_objects()` instead of changing global CWD, and `SceneSelect` injects paths into `AddScene` in the edit flow as well as add flow.

### Testing
- Attempted to build the package with `colcon build --packages-select workcell_builder --cmake-args -DCMAKE_BUILD_TYPE=Release`, but the environment lacks `colcon` so the build could not be executed (error: `colcon: command not found`).
- Ran repository searches and file inspections (`rg`, `sed`) to verify that prior uses of `boost::filesystem::current_path(...)` in the targeted dialog files were removed or restricted behind `ScopedCurrentPath` and that new path members and validations are present; these checks succeeded.
- Performed local static checks (file diffs and `git status`) to ensure the changes were applied to the intended files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e389a1ac44833193a6410bf86b69e7)