### PR TITLE
Route generated arm_hand.srdf.xacro into each scene's urdf directory

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -436,18 +436,19 @@ void SceneSelect::generate_scene_files(Scene scene)
   // generate environment.urdf.xacro
   const fs::path scene_dir = scenes_path / scene.name;
   const fs::path urdf_dir = scene_dir / "urdf";
+  const fs::path armhand_srdf_path = urdf_dir / "arm_hand.srdf.xacro";
   generate_scene_xacro(scene, (urdf_dir / "scene.urdf.xacro").string());
   if (scene.robot_loaded && scene.ee_loaded) {
-    generate_armhand_xacro(scene.robot_vector[0], scene.ee_vector[0], scene.name);
+    generate_armhand_xacro(
+      scene.robot_vector[0], scene.ee_vector[0], scene.name, armhand_srdf_path.string());
   }
   if (scene.robot_loaded && !scene.ee_loaded) {  // no ee
-    generate_armhand_xacro(scene.robot_vector[0], scene.name);
+    generate_armhand_xacro(scene.robot_vector[0], scene.name, armhand_srdf_path.string());
   }
   if (!scene.robot_loaded && !scene.ee_loaded) {  // no robot and ee
-    generate_armhand_xacro(scene.name);
+    generate_armhand_xacro(scene.name, armhand_srdf_path.string());
   }
-  fs::path srdf_path =
-    workcell_path / "scenes" / scene.name / "urdf" / "arm_hand.srdf.xacro";
+  fs::path srdf_path = armhand_srdf_path;
   if (!boost::filesystem::exists(srdf_path)) {
     append_error("Failed to generate urdf/arm_hand.srdf.xacro.");
     return;

--- a/workcell_builder/workcell_builder/include/armhand_xacro_parser.h
+++ b/workcell_builder/workcell_builder/include/armhand_xacro_parser.h
@@ -24,9 +24,10 @@
 #include "attributes/workcell.h"
 
 
-void generate_armhand_xacro(Robot robot, EndEffector ee, std::string scene_name)
+void generate_armhand_xacro(
+  Robot robot, EndEffector ee, std::string scene_name, const std::string & output_path)
 {
-  std::ofstream MyFile("arm_hand.srdf.xacro");
+  std::ofstream MyFile(output_path);
   MyFile << "<?xml version=\"1.0\" ?>\n\n";
   MyFile << "<robot xmlns:xacro=\"http://www.ros.org/wiki/xacro\" name=\"" + scene_name + "\">\n\n";
   MyFile << "  <xacro:include filename=\"$(find " + robot.name +
@@ -47,9 +48,10 @@ void generate_armhand_xacro(Robot robot, EndEffector ee, std::string scene_name)
   MyFile << "\n\n</robot>";
 }
 
-void generate_armhand_xacro(Robot robot, std::string scene_name)
+void generate_armhand_xacro(
+  Robot robot, std::string scene_name, const std::string & output_path)
 {
-  std::ofstream MyFile("arm_hand.srdf.xacro");
+  std::ofstream MyFile(output_path);
   MyFile << "<?xml version=\"1.0\" ?>\n\n";
   MyFile << "<robot xmlns:xacro=\"http://www.ros.org/wiki/xacro\" name=\"" + scene_name + "\">\n\n";
   MyFile << "  <xacro:include filename=\"$(find " + robot.name +
@@ -59,10 +61,10 @@ void generate_armhand_xacro(Robot robot, std::string scene_name)
   MyFile << "\n\n</robot>";
 }
 
-void generate_armhand_xacro(std::string scene_name)
+void generate_armhand_xacro(std::string scene_name, const std::string & output_path)
 {
   std::cout << "No robot or hand" << std::endl;
-  std::ofstream MyFile("arm_hand.srdf.xacro");
+  std::ofstream MyFile(output_path);
   MyFile << "<?xml version=\"1.0\" ?>\n\n";
   MyFile << "<robot xmlns:xacro=\"http://www.ros.org/wiki/xacro\" name=\"" + scene_name + "\">\n\n";
   MyFile << "\n\n</robot>";


### PR DESCRIPTION
### Motivation
- Ensure the generated SRDF (`arm_hand.srdf.xacro`) is written into the per-scene `urdf/` directory (`scenes/<scene>/urdf/`) instead of the fixed working-directory file, while leaving the content-generation logic unchanged.

### Description
- Changed all `generate_armhand_xacro(...)` overloads in `include/armhand_xacro_parser.h` to accept an explicit `const std::string & output_path` and opened `std::ofstream` with that path instead of the fixed `"arm_hand.srdf.xacro"` filename.
- In `SceneSelect::generate_scene_files` computed `armhand_srdf_path = urdf_dir / "arm_hand.srdf.xacro"` and passed `armhand_srdf_path.string()` into every `generate_armhand_xacro(...)` call so output is placed in `scenes/<scene>/urdf/`.
- Updated the post-generation existence check to use the same computed `armhand_srdf_path`.
- Kept all generation content and branching logic intact; only the destination of the generated file was redirected.

### Testing
- Ran `rg -n "generate_armhand_xacro\(" workcell_builder/workcell_builder` to verify all in-repo call sites were updated, and the command returned the updated locations.
- Inspected changes with `git diff -- workcell_builder/workcell_builder/include/armhand_xacro_parser.h workcell_builder/workcell_builder/gui/scene_select.cpp` to confirm the implemented edits.
- Verified repository status with `git status --short` and committed the changes; these verification commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38d52900c8331ae6a3ba17c5d051f)