### PR TITLE
Improve SRDF failure diagnostics in SceneSelect

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -451,6 +451,8 @@ void SceneSelect::generate_scene_files(Scene scene)
   fs::path srdf_path = armhand_srdf_path;
   if (!boost::filesystem::exists(srdf_path)) {
     append_error("Failed to generate urdf/arm_hand.srdf.xacro.");
+    append_error("Expected SRDF at: " + srdf_path.string());
+    append_error("Current working directory: " + fs::current_path().string());
     return;
   }
   fs::path base_template_path = templates_path / ("ros" + std::to_string(workcell.ros_ver));
@@ -686,6 +688,10 @@ bool SceneSelect::check_files()
 
     if (!boost::filesystem::exists(launch_dir)) {
       append_error("Scene status: launch folder missing.");
+      if (!boost::filesystem::exists(urdf_dir / "arm_hand.srdf.xacro")) {
+        append_error(
+          "Scene status: launch not generated because SRDF generation failed earlier.");
+      }
     }
     if (!boost::filesystem::exists(urdf_dir)) {
       append_error("Scene status: urdf folder missing.");


### PR DESCRIPTION
### Motivation
- Improve user diagnostics when SRDF generation fails by making the missing-SRDF error clearer while preserving the existing early-return behavior in `SceneSelect::generate_scene_files` in `workcell_builder/workcell_builder/gui/scene_select.cpp`.

### Description
- Log the expected SRDF path and the current working directory when `urdf/arm_hand.srdf.xacro` is not found in `SceneSelect::generate_scene_files` and preserve the early return; and add an explicit message in `check_files()` indicating `launch not generated because SRDF generation failed earlier` when the `launch` folder is missing and the SRDF is also missing.

### Testing
- Ran `git -C /workspace/Easy_Manipulator_Improved diff --check` which succeeded, `git -C /workspace/Easy_Manipulator_Improved status --short` to inspect changes, and committed the updated `workcell_builder/workcell_builder/gui/scene_select.cpp` file successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38f065d7083319a1d296f9c7f5fc7)