### PR TITLE
Refine find_replace diagnostics and search progression

### DIFF
--- a/workcell_builder/workcell_builder/include/file_functions.h
+++ b/workcell_builder/workcell_builder/include/file_functions.h
@@ -64,17 +64,16 @@ void find_replace(
 
   // This searches the file for the first occurence of the morn string.
   auto pos = file_contents.find(current_text);
-  int counter = 0;
   // std::cout<<file_contents<<std::endl;
   while (pos != std::string::npos) {
     file_contents.replace(pos, current_text.length(), replaced_text);
-    pos = file_contents.find(current_text);
-    std::cout << "position: " << pos << std::endl;
-    counter++;
-    if (counter > 100) {
-      break;
-    }
+    const auto next_search_pos = pos + replaced_text.length();
+    pos = file_contents.find(current_text, next_search_pos);
   }
+  RCLCPP_DEBUG(
+    rclcpp::get_logger("workcell_builder"),
+    "find_replace: no more matches found for '%s'",
+    current_text.c_str());
   fileout << file_contents;
   std::remove(example_text.c_str());
 }


### PR DESCRIPTION
### Motivation
- Remove unconditional console logging from `find_replace` and avoid printing `std::string::npos` as a normal position value. 
- Improve the search progression so replacements do not repeatedly rescan the file from the start while preserving replacement behavior.

### Description
- Removed the unconditional `std::cout << "position: " << pos` and the manual counter/early-break guard from `find_replace` in `workcell_builder/workcell_builder/include/file_functions.h`.
- Advance the search using `pos + replaced_text.length()` and call `file_contents.find(current_text, next_search_pos)` to continue scanning safely after each replacement.
- Emit a debug-level ROS log with `RCLCPP_DEBUG` stating "find_replace: no more matches found for '%s'" when the scan completes, avoiding numeric sentinel output.

### Testing
- No automated unit tests were run for this header-only change because there is no dedicated fast unit target in this environment. 
- Repository checks (`git diff -- workcell_builder/workcell_builder/include/file_functions.h` and `git status --short`) completed successfully. 
- The change is a small, localized logic adjustment intended to be low risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3928d52b483319eae4ddc426d4267)