### PR TITLE
Harden external-joint parent validation and logging for YAML export

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -561,10 +561,16 @@ void SceneSelect::on_edit_scene_clicked()
         const fs::path scene_yaml_path = scenes_path / scene_window.scene.name;
         if (boost::filesystem::exists(scene_yaml_path)) {     // Scene name nvr change
           // Replace the current environment yaml
-          GenerateYAML::generate_yaml(
-            scene_window.scene,
-            scene_yaml_path.string(), scenes_path, assets_path);
-          generate_scene_files(scene_window.scene);
+          if (GenerateYAML::generate_yaml(
+              scene_window.scene,
+              scene_yaml_path.string(), scenes_path, assets_path))
+          {
+            generate_scene_files(scene_window.scene);
+          } else {
+            append_error(
+              "Failed to generate environment.yaml: invalid external joint parent configuration.");
+            return;
+          }
 
         } else {
           // Delete previous scene folder
@@ -572,10 +578,16 @@ void SceneSelect::on_edit_scene_clicked()
           // Generate new folder
           generate_scene_package(
             scenes_path, scene_window.scene.name, workcell.ros_ver, workcell.ros_distro);
-          GenerateYAML::generate_yaml(
-            scene_window.scene,
-            scene_yaml_path.string(), scenes_path, assets_path);
-          generate_scene_files(scene_window.scene);
+          if (GenerateYAML::generate_yaml(
+              scene_window.scene,
+              scene_yaml_path.string(), scenes_path, assets_path))
+          {
+            generate_scene_files(scene_window.scene);
+          } else {
+            append_error(
+              "Failed to generate environment.yaml: invalid external joint parent configuration.");
+            return;
+          }
         }
         workcell.scene_vector[ui->scene_list->currentIndex()] = scene_window.scene;
         append_warning(
@@ -616,16 +628,28 @@ void SceneSelect::on_generate_yaml_clicked()
         replace_window.setModal(true);
         replace_window.exec();
         if (replace_window.decision) {      // user allows for replacing of current yaml file
-          GenerateYAML::generate_yaml(
-            target_scene,
-            scene_yaml_path.string(), scenes_path, assets_path);
-          append_success("environment.yaml generated successfully.");
+          if (GenerateYAML::generate_yaml(
+              target_scene,
+              scene_yaml_path.string(), scenes_path, assets_path))
+          {
+            append_success("environment.yaml generated successfully.");
+          } else {
+            append_error(
+              "environment.yaml generation failed: invalid external joint parent configuration.");
+            return;
+          }
         }
       } else {   // currently no yaml file, add one to scene folder
-        GenerateYAML::generate_yaml(
-          target_scene, scene_yaml_path.string(), scenes_path,
-          assets_path);
-        append_success("environment.yaml generated successfully.");
+        if (GenerateYAML::generate_yaml(
+            target_scene, scene_yaml_path.string(), scenes_path,
+            assets_path))
+        {
+          append_success("environment.yaml generated successfully.");
+        } else {
+          append_error(
+            "environment.yaml generation failed: invalid external joint parent configuration.");
+          return;
+        }
       }
     }
   } else {

--- a/workcell_builder/workcell_builder/include/yaml_parser/externaljoint_parser.h
+++ b/workcell_builder/workcell_builder/include/yaml_parser/externaljoint_parser.h
@@ -18,7 +18,7 @@
 #define YAML_PARSER__EXTERNALJOINT_PARSER_H_
 
 #include <string>
-#include <iostream>
+#include "rclcpp/rclcpp.hpp"
 
 #include "attributes/external_joint.h"
 #include "attributes/object.h"
@@ -34,13 +34,19 @@ public:
     YAML::Emitter * out, ExternalJoint ext_joint,
     std::string parent_object, std::string parent_link)
   {
-    std::cout << "Populate the ext joint" << std::endl;
+    RCLCPP_DEBUG(
+      rclcpp::get_logger("workcell_builder"),
+      "Generating external joint for child object '%s'.",
+      ext_joint.child_object.c_str());
     *out << YAML::Key << ext_joint.child_object;
     *out << YAML::Value;
     *out << YAML::BeginMap;
 //        *out<<YAML::Key << "type";
 //        *out<<YAML::Value << ext_joint.type;
-    std::cout << "Populate the parent link" << std::endl;
+    RCLCPP_DEBUG(
+      rclcpp::get_logger("workcell_builder"),
+      "Using parent context parent object='%s', parent link='%s'.",
+      parent_object.c_str(), parent_link.c_str());
     *out << YAML::Key << "parent object";
     *out << YAML::Value << parent_object;
     *out << YAML::Key << "parent link";
@@ -48,14 +54,23 @@ public:
 //        *out<<YAML::Key << "child";
 //        *out<<YAML::Value << object_vector[ext_joint.child_link_pos];
     if (ext_joint.origin.is_origin) {
-      std::cout << "Populate the Origin" << std::endl;
+      RCLCPP_DEBUG(
+        rclcpp::get_logger("workcell_builder"),
+        "Serializing external joint origin for child object '%s'.",
+        ext_joint.child_object.c_str());
       OriginParser::generate_origin(&out, ext_joint.origin);
     }
     if (ext_joint.axis.is_axis) {
-      std::cout << "Populate the ext joint" << std::endl;
+      RCLCPP_DEBUG(
+        rclcpp::get_logger("workcell_builder"),
+        "Serializing external joint axis for child object '%s'.",
+        ext_joint.child_object.c_str());
       AxisParser::generate_axis(&out, ext_joint.axis);
     }
-    std::cout << "Done populating" << std::endl;
+    RCLCPP_DEBUG(
+      rclcpp::get_logger("workcell_builder"),
+      "Finished generating external joint for child object '%s'.",
+      ext_joint.child_object.c_str());
     *out << YAML::EndMap;
   }
 };

--- a/workcell_builder/workcell_builder/include/yaml_parser/generate_yaml.h
+++ b/workcell_builder/workcell_builder/include/yaml_parser/generate_yaml.h
@@ -25,11 +25,13 @@
 // General
 #include <algorithm>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
 
 // For Yaml parsing
 #include "yaml-cpp/yaml.h"
+#include "rclcpp/rclcpp.hpp"
 
 #include "attributes/scene.h"
 #include "attributes/environment.h"
@@ -72,7 +74,7 @@ std::vector<std::string> normalize_robot_links(const Robot & robot)
 class GenerateYAML
 {
 public:
-  static void generate_yaml(
+  static bool generate_yaml(
     Scene scene, std::string filepath,
     boost::filesystem::path scene_filepath,
     boost::filesystem::path assets_filepath)
@@ -185,30 +187,63 @@ public:
       out << YAML::Key << "external joints";
       out << YAML::Value << YAML::BeginMap;
       for (int i = 0; i < static_cast < int > (scene.object_vector.size()); i++) {
-        int parent_object_pos = scene.object_vector[i].ext_joint.parent_obj_pos;
-        int parent_link_pos = scene.object_vector[i].ext_joint.parent_link_pos;
+        const int parent_object_pos = scene.object_vector[i].ext_joint.parent_obj_pos;
+        const int parent_link_pos = scene.object_vector[i].ext_joint.parent_link_pos;
+        const std::string & object_name = scene.object_vector[i].name;
+        const bool parent_object_unset = parent_object_pos == -1;
+        const bool parent_link_unset = parent_link_pos == -1;
+        const bool explicitly_free_standing = parent_object_unset && parent_link_unset;
+        const bool expects_parent_attachment = !explicitly_free_standing;
 
-        if (
-          parent_object_pos >= 0 &&
+        if (parent_object_pos >= 0 &&
           parent_object_pos < static_cast<int>(scene.object_vector.size()) &&
           parent_link_pos >= 0 &&
-          parent_link_pos < static_cast<int>(
-            scene.object_vector[parent_object_pos].link_vector.size()))
+          parent_link_pos < static_cast<int>(scene.object_vector[parent_object_pos].link_vector.size()))
         {
           ExternalJointParser::generate_ext_joints(
             &out, scene.object_vector[i].ext_joint,
             scene.object_vector[parent_object_pos].name,
             scene.object_vector[parent_object_pos].link_vector[
               parent_link_pos].name);
-        } else {
-          std::cerr <<
-            "Warning: invalid external joint parent indices for object '" <<
-            scene.object_vector[i].name << "' (parent_obj_pos=" <<
-            parent_object_pos << ", parent_link_pos=" << parent_link_pos <<
-            "). Falling back to world/world." << std::endl;
+        } else if (explicitly_free_standing) {
+          RCLCPP_DEBUG(
+            rclcpp::get_logger("workcell_builder"),
+            "Object '%s' is configured as free-standing (parent object/link unset); using world/world "
+            "fallback.",
+            object_name.c_str());
           ExternalJointParser::generate_ext_joints(
             &out, scene.object_vector[i].ext_joint, "world",
             "world");
+        } else {
+          std::stringstream error_stream;
+          error_stream <<
+            "Cannot generate external joint for object '" << object_name <<
+            "': invalid parent selection context. Expected an attached parent "
+            "(choose a concrete parent object and parent link in Add External Joint). "
+            "Received parent_obj_pos=" << parent_object_pos <<
+            ", parent_link_pos=" << parent_link_pos << ". ";
+
+          if (expects_parent_attachment && (parent_object_unset || parent_link_unset)) {
+            error_stream <<
+              "Parent indices are unset; this means the attachment target was not fully selected. "
+              "If this object should be attached, re-open Add External Joint and set both parent "
+              "object and parent link. If the object should be free-standing, explicitly select "
+              "'Connect to world' so both indices are -1.";
+          } else if (parent_object_pos < 0 ||
+            parent_object_pos >= static_cast<int>(scene.object_vector.size()))
+          {
+            error_stream <<
+              "parent_obj_pos is out of range. Valid range is [0, " <<
+              static_cast<int>(scene.object_vector.size()) - 1 << "].";
+          } else {
+            error_stream <<
+              "parent_link_pos is out of range for parent object '" <<
+              scene.object_vector[parent_object_pos].name << "'. Valid range is [0, " <<
+              static_cast<int>(scene.object_vector[parent_object_pos].link_vector.size()) - 1 << "].";
+          }
+
+          RCLCPP_ERROR(rclcpp::get_logger("workcell_builder"), "%s", error_stream.str().c_str());
+          return false;
         }
       }
       out << YAML::EndMap;
@@ -221,6 +256,7 @@ public:
     std::ofstream myfile(environment_yaml_path.string());
     myfile << out.c_str();
     myfile.close();
+    return true;
   }
 };
 


### PR DESCRIPTION
### Motivation
- Make YAML export robust by validating external-joint parent indices with clear, actionable errors that name the object and expected UI flow. 
- Ensure `world/world` fallback is only used for explicitly free-standing objects and fail generation when an attachment was expected but parent indices are unset. 
- Replace ad-hoc `std::cout` debug prints with structured ROS logging so messages integrate with the node logging system.

### Description
- Add strict parent-index validation in `GenerateYAML::generate_yaml` and change its signature to return `bool` so callers can detect and handle failures. 
- Distinguish unset (`-1`) vs out-of-range indices and emit actionable error text that includes the object name and guidance about using the Add External Joint UI or selecting "Connect to world". 
- Keep `world/world` fallback only when both `parent_obj_pos` and `parent_link_pos` are `-1`, and return `false` (fail generation) for invalid attached-parent configurations. 
- Replace `std::cout` prints in `externaljoint_parser.h` with `RCLCPP_DEBUG` calls and update `scene_select.cpp` call sites to surface generation failure in the UI instead of reporting success.

### Testing
- Ran `git diff --check` to confirm no whitespace/diff issues and it passed. 
- Attempted `colcon build --packages-select workcell_builder --event-handlers console_direct+`, but the build could not be executed in this environment because `colcon` is not installed (build not performed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e392e2cdac8331920139e8cc5f1436)