### PR TITLE
Align run_grasp_execution with arm-only UR5 scene config

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/fake_grasp_pose_publisher.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/fake_grasp_pose_publisher.yaml
@@ -2,7 +2,7 @@ fake_grasp_pose_publisher:
   ros__parameters:
     interface: service
     frame_id: camera_frame
-    ee_id: robotiq_2f
+    ee_id: ur_tool0
     grasp_pose: [0.0126, 0.0322, 0.55,
                  0.0, 0.0, 0.9997, 0.0250]
     

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/workcell_context.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/workcell_context.yaml
@@ -3,10 +3,10 @@ workcell:
     groups: [manipulator]
     groups.manipulator.executors: [default]
     groups.manipulator.executors.default.plugin: grasp_execution/DefaultExecutor
-    groups.manipulator.end_effectors: [robotiq_2f0]
-    groups.manipulator.end_effectors.robotiq_2f0.brand: robotiq_2f
-    groups.manipulator.end_effectors.robotiq_2f0.link: ee_palm
-    groups.manipulator.end_effectors.robotiq_2f0.clearance: 0.1
-    groups.manipulator.end_effectors.robotiq_2f0.driver.plugin:
+    groups.manipulator.end_effectors: [tool0_ee]
+    groups.manipulator.end_effectors.tool0_ee.brand: ur_tool0
+    groups.manipulator.end_effectors.tool0_ee.link: tool0
+    groups.manipulator.end_effectors.tool0_ee.clearance: 0.1
+    groups.manipulator.end_effectors.tool0_ee.driver.plugin:
       grasp_execution/DummyGripperDriver
-    groups.manipulator.end_effectors.robotiq_2f0.driver.controller: ""
+    groups.manipulator.end_effectors.tool0_ee.driver.controller: ""

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -15,6 +15,7 @@ import xacro
 DEFAULT_SCENE_PACKAGE_CANDIDATES = ("ur5_3f_test", "ur5_2f_test", "ur5_airpick4_test", "suction_test")
 PACKAGE_NAME = "run_grasp_execution"
 SCENE_PACKAGE_ARGUMENT = "scene_package"
+MOVEIT_CONFIG_PACKAGE_ARGUMENT = "moveit_config_package"
 
 
 def find_default_scene_package():
@@ -139,12 +140,13 @@ def resolve_scene_package_share_dir(scene_package):
 
 def launch_setup(context, *args, **kwargs):
     scene_package = LaunchConfiguration(SCENE_PACKAGE_ARGUMENT).perform(context)
+    moveit_config_package = LaunchConfiguration(MOVEIT_CONFIG_PACKAGE_ARGUMENT).perform(context)
     run_share = get_package_share_directory(PACKAGE_NAME)
     resolve_scene_package_share_dir(scene_package)
     resolve_required_package_share_dir(
-        "ur5_moveit_config",
-        "Run ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh, rebuild the workspace, "
-        "and source install/setup.bash before launching UR5 demo scenes.",
+        moveit_config_package,
+        "Build/source your selected MoveIt config package and pass it with "
+        f"'{MOVEIT_CONFIG_PACKAGE_ARGUMENT}:=<package_name>' if it is not 'ur5_moveit_config'.",
     )
 
     scene_xacro_path = Path(get_package_share_directory(scene_package)) / "urdf" / "scene.urdf.xacro"
@@ -162,8 +164,8 @@ def launch_setup(context, *args, **kwargs):
     robot_description_semantic_config = load_file(scene_package, "urdf/arm_hand.srdf.xacro")
     robot_description_semantic = {"robot_description_semantic": robot_description_semantic_config}
 
-    kinematics_yaml = {"robot_description_kinematics": load_yaml("ur5_moveit_config", "config/kinematics.yaml")}
-    joint_limits_yaml = load_yaml("ur5_moveit_config", "config/joint_limits.yaml")
+    kinematics_yaml = {"robot_description_kinematics": load_yaml(moveit_config_package, "config/kinematics.yaml")}
+    joint_limits_yaml = load_yaml(moveit_config_package, "config/joint_limits.yaml")
     joint_limits = {"robot_description_planning": joint_limits_yaml}
 
     ompl_planning_pipeline_config = {
@@ -179,7 +181,7 @@ def launch_setup(context, *args, **kwargs):
             "start_state_max_bounds_error": 0.1,
         }
     }
-    ompl_planning_yaml = load_yaml("ur5_moveit_config", "config/ompl_planning.yaml")
+    ompl_planning_yaml = load_yaml(moveit_config_package, "config/ompl_planning.yaml")
     ompl_planning_pipeline_config["ompl"].update(ompl_planning_yaml)
 
     trajectory_execution = {
@@ -291,6 +293,11 @@ def generate_launch_description():
         [
             debug_arg,
             DeclareLaunchArgument(SCENE_PACKAGE_ARGUMENT, **scene_arg_kwargs),
+            DeclareLaunchArgument(
+                MOVEIT_CONFIG_PACKAGE_ARGUMENT,
+                default_value="ur5_moveit_config",
+                description="MoveIt config package containing config/{kinematics,joint_limits,ompl_planning}.yaml",
+            ),
             OpaqueFunction(function=launch_setup),
         ]
     )

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/fake_grasp_pose_publisher.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/fake_grasp_pose_publisher.cpp
@@ -42,7 +42,7 @@ public:
 
     std::string interface = "topic";
     std::string frame_id = "base_link";
-    std::string ee_id = "robotiq_2f";
+    std::string ee_id = "ur_tool0";
 
     std::vector<double> grasp_pose_vector{-0.1, 0.4, 0.07, M_PI, 0, 0};
     std::vector<double> object_pose_vector{-0.1, 0.4, 0.05, 0, 0, 0};

--- a/scenes/ur5_3f_test/urdf/arm_hand.srdf.xacro
+++ b/scenes/ur5_3f_test/urdf/arm_hand.srdf.xacro
@@ -4,33 +4,6 @@
 
   <xacro:include filename="$(find ur5_moveit_config)/config/ur5.srdf.xacro" />
 
-  <xacro:include filename="$(find robotiq_3f_moveit_config)/config/robotiq_3f_gripper.srdf.xacro"/>
-
   <xacro:ur5/>
-
-  <xacro:robotiq-3f-gripper_articulated/>
-
-  <disable_collisions link1="palm" link2="base_link" reason="Never" />
-  <disable_collisions link1="palm" link2="shoulder_link" reason="Never" />
-  <disable_collisions link1="palm" link2="upper_arm_link" reason="Never" />
-  <disable_collisions link1="palm" link2="forearm_link" reason="Never" />
-  <disable_collisions link1="palm" link2="wrist_1_link" reason="Never" />
-  <disable_collisions link1="palm" link2="wrist_2_link" reason="Never" />
-  <disable_collisions link1="palm" link2="wrist_3_link" reason="Never" />
-  <disable_collisions link1="palm" link2="tool0" reason="Never" />
-  <disable_collisions link1="palm" link2="base" reason="Never" />
-  <disable_collisions link1="palm" link2="tool0" reason="Never" />
-  
-  <disable_collisions link1="finger_1_link_0" link2="wrist_3_link" reason="Never" />
-  <disable_collisions link1="finger_2_link_0" link2="wrist_3_link" reason="Never" />
-  <disable_collisions link1="finger_middle_link_0" link2="wrist_3_link" reason="Never" />
-
-  <disable_collisions link1="finger_1_link_0" link2="wrist_2_link" reason="Never" />
-  <disable_collisions link1="finger_2_link_0" link2="wrist_2_link" reason="Never" />
-  <disable_collisions link1="finger_middle_link_0" link2="wrist_2_link" reason="Never" />
-  
-  <disable_collisions link1="finger_1_link_0" link2="tool0" reason="Never" />
-  <disable_collisions link1="finger_2_link_0" link2="tool0" reason="Never" />
-  <disable_collisions link1="finger_middle_link_0" link2="tool0" reason="Never" />
 
 </robot>

--- a/scenes/ur5_3f_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_3f_test/urdf/scene.urdf.xacro
@@ -24,15 +24,7 @@
   <origin xyz="0 0 0" rpy="0 0 0"/>
 </xacro:ur_robot>
    
- <!--xacro:include filename="$(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro"/>
- <xacro:robotiq_85_gripper prefix="" parent="tool0">
-	<origin xyz="0 0 0" rpy="1.5707 -1.5707 0"/>
- </xacro:robotiq_85_gripper-->
- 
- <xacro:include filename="$(find robotiq_3f_gripper_description)/urdf/robotiq-3f-gripper_articulated.urdf.xacro"/>
- <xacro:robotiq-3f-gripper_articulated prefix="" parent="tool0" >
-	<origin xyz="0 0 0.0" rpy="1.5707 0 0"/>
- </xacro:robotiq-3f-gripper_articulated>
+ <!-- Arm-only hardware variant: no physical gripper attached to tool0. -->
 
  <xacro:include filename="$(find workbench_description)/urdf/table.urdf.xacro"/>
  <xacro:table prefix="" parent="world">


### PR DESCRIPTION
### Motivation
- Ensure `robot_state_publisher`, `ros2_control_node`, and MoveIt (MoveItCpp/demo node) all consume the same scene-derived `robot_description` while allowing MoveIt-specific YAML (kinematics/joint_limits/ompl) to be selected separately. 
- Remove stale/incorrect gripper expectations from the `ur5_3f_test` scene so the demo can run with an arm-only hardware setup. 
- Make grasp execution defaults and fake-publisher configuration match an arm-only robot (no gripper joints/links). 

### Description
- Added a new launch argument `moveit_config_package` to `run_grasp_execution` and use it to load MoveIt YAMLs (`kinematics.yaml`, `joint_limits.yaml`, `ompl_planning.yaml`) while continuing to derive `robot_description` from the chosen scene package.  The `robot_description` value is still passed to `robot_state_publisher`, `ros2_control_node`, and the MoveIt node so all nodes share a single source. (`easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py`) 
- Converted `scenes/ur5_3f_test` to an arm-only variant by removing the 3-finger gripper include and gripper SRDF entries and leaving only the UR5 arm + scene peripherals and the helper `ee_palm` link. (`scenes/ur5_3f_test/urdf/scene.urdf.xacro`, `scenes/ur5_3f_test/urdf/arm_hand.srdf.xacro`) 
- Updated workcell configuration to expect an arm-only end-effector named `tool0_ee` with brand `ur_tool0` and link `tool0`, replacing the previous `robotiq_2f0` entry. (`easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/workcell_context.yaml`) 
- Aligned demo defaults and fake grasp publisher to the arm-only tool by changing the fake publisher default `ee_id` to `ur_tool0` and updating the C++ default in `fake_grasp_pose_publisher.cpp`. (`easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/fake_grasp_pose_publisher.yaml`, `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/fake_grasp_pose_publisher.cpp`) 

### Testing
- Ran `python -m compileall easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` and compilation succeeded. 
- Ran `pytest -q easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py` in this environment and the test(s) were skipped (no failures observed). 
- Searched the repository for `ur5_3f_test` occurrences to confirm there were no duplicate/stale URDF/xacro files for that model name using repository search (`rg -n "ur5_3f_test" -S`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c07af8888331a931adc7439382d3)