### PR TITLE
Add Robotiq 3F gripper ros2_control interfaces and joint-state validation

### DIFF
--- a/assets/robots/universal_robot/ur5_moveit_config/config/ur5.ros2_control.xacro
+++ b/assets/robots/universal_robot/ur5_moveit_config/config/ur5.ros2_control.xacro
@@ -44,6 +44,72 @@
                 <state_interface name="position"/>
                 <state_interface name="velocity"/>
             </joint>
+            <joint name="palm_finger_1_joint">
+                <param name="initial_position">0.0</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="finger_1_joint_1">
+                <param name="initial_position">0.0</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="finger_1_joint_2">
+                <param name="initial_position">0.0</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="finger_1_joint_3">
+                <param name="initial_position">0.0</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="palm_finger_2_joint">
+                <param name="initial_position">0.0</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="finger_2_joint_1">
+                <param name="initial_position">0.0</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="finger_2_joint_2">
+                <param name="initial_position">0.0</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="finger_2_joint_3">
+                <param name="initial_position">0.0</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="finger_middle_joint_1">
+                <param name="initial_position">0.0</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="finger_middle_joint_2">
+                <param name="initial_position">0.0</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
+            <joint name="finger_middle_joint_3">
+                <param name="initial_position">0.0</param>
+                <command_interface name="position" />
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+            </joint>
         </ros2_control>
 
     </xacro:macro>

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/ur5_ros_controllers.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/ur5_ros_controllers.yaml
@@ -5,6 +5,9 @@ controller_manager:
     ur5_arm_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
+    ur5_gripper_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
       publish_rate: 50
@@ -24,3 +27,22 @@ ur5_arm_controller:
       - wrist_2_joint
       - wrist_3_joint
 
+ur5_gripper_controller:
+  ros__parameters:
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    joints:
+      - palm_finger_1_joint
+      - finger_1_joint_1
+      - finger_1_joint_2
+      - finger_1_joint_3
+      - palm_finger_2_joint
+      - finger_2_joint_1
+      - finger_2_joint_2
+      - finger_2_joint_3
+      - finger_middle_joint_1
+      - finger_middle_joint_2
+      - finger_middle_joint_3

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -269,8 +269,18 @@ def launch_setup(context, *args, **kwargs):
         output="screen",
     )
 
+    gripper_spawner = ExecuteProcess(
+        cmd=[
+            "ros2", "run", "controller_manager", "spawner",
+            "ur5_gripper_controller",
+            "--controller-manager", "/controller_manager",
+        ],
+        output="screen",
+    )
+
     spawn_joint_state = TimerAction(period=2.0, actions=[joint_state_spawner])
     spawn_arm = TimerAction(period=2.5, actions=[arm_spawner])
+    spawn_gripper = TimerAction(period=3.0, actions=[gripper_spawner])
 
     return [
         robot_state_publisher,
@@ -278,6 +288,7 @@ def launch_setup(context, *args, **kwargs):
         ros2_control_node,
         spawn_joint_state,
         spawn_arm,
+        spawn_gripper,
         grasp_execution_demo_node,
     ]
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -19,6 +19,9 @@
 #include <vector>
 #include <algorithm>
 #include <filesystem>
+#include <sstream>
+#include <thread>
+#include <set>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
@@ -33,6 +36,7 @@
 #include "emd_msgs/srv/grasp_request.hpp"
 
 #include "moveit/macros/console_colors.h"
+#include "sensor_msgs/msg/joint_state.hpp"
 
 
 namespace grasp_execution
@@ -43,6 +47,65 @@ static const char GRASP_TASK_TOPIC[] = "grasp_tasks";
 static const char GRASP_REQUEST_TOPIC[] = "grasp_requests";
 
 static const char GRASP_EXECUTION_PACKAGE[] = "emd_grasp_execution";
+
+
+static const std::vector<std::string> REQUIRED_FINGER_JOINTS = {
+  "palm_finger_1_joint",
+  "finger_1_joint_1",
+  "finger_1_joint_2",
+  "finger_1_joint_3",
+  "palm_finger_2_joint",
+  "finger_2_joint_1",
+  "finger_2_joint_2",
+  "finger_2_joint_3",
+  "finger_middle_joint_1",
+  "finger_middle_joint_2",
+  "finger_middle_joint_3",
+};
+
+bool wait_for_required_finger_joint_states(
+  const rclcpp::Node::SharedPtr & node,
+  std::chrono::seconds timeout = std::chrono::seconds(15))
+{
+  std::set<std::string> missing_joints(REQUIRED_FINGER_JOINTS.begin(), REQUIRED_FINGER_JOINTS.end());
+
+  auto joint_state_sub = node->create_subscription<sensor_msgs::msg::JointState>(
+    "/joint_states", rclcpp::QoS(10),
+    [&missing_joints](const sensor_msgs::msg::JointState::SharedPtr msg) {
+      for (const auto & joint_name : msg->name) {
+        missing_joints.erase(joint_name);
+      }
+    });
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  const auto end_time = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < end_time) {
+    executor.spin_some();
+    if (missing_joints.empty()) {
+      RCLCPP_INFO(node->get_logger(),
+        "Verified /joint_states includes all required finger joints before grasp execution.");
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  std::ostringstream missing;
+  bool first = true;
+  for (const auto & joint_name : missing_joints) {
+    if (!first) {
+      missing << ", ";
+    }
+    missing << joint_name;
+    first = false;
+  }
+  RCLCPP_ERROR(
+    node->get_logger(),
+    "Timed out waiting for finger joints on /joint_states. Missing joints: [%s]",
+    missing.str().c_str());
+  return false;
+}
 
 class Demo : public moveit2::MoveitCppGraspExecution
 {
@@ -400,6 +463,11 @@ public:
       if (!demo_->init_from_yaml(workcell_context_filepath)) {
         RCLCPP_ERROR(this->get_logger(), "Failed to initialize workcell context from '%s'",
           workcell_context_filepath.c_str());
+        return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
+      }
+      if (!grasp_execution::wait_for_required_finger_joint_states(base_node_)) {
+        RCLCPP_ERROR(this->get_logger(),
+          "Required finger joints were not observed on /joint_states; aborting configure.");
         return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
       }
     } catch (const std::exception & ex) {

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch.test.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch.test.py
@@ -15,9 +15,25 @@ import launch_testing.actions
 from launch_testing_ros.wait_for_topics import WaitForTopics
 import pytest
 import rclpy
+from sensor_msgs.msg import JointState
 
 
 SCENE_PACKAGE = "ur5_3f_test"
+
+
+REQUIRED_FINGER_JOINTS = {
+    "palm_finger_1_joint",
+    "finger_1_joint_1",
+    "finger_1_joint_2",
+    "finger_1_joint_3",
+    "palm_finger_2_joint",
+    "finger_2_joint_1",
+    "finger_2_joint_2",
+    "finger_2_joint_3",
+    "finger_middle_joint_1",
+    "finger_middle_joint_2",
+    "finger_middle_joint_3",
+}
 
 try:
     get_package_share_directory(SCENE_PACKAGE)
@@ -97,6 +113,16 @@ class TestGraspExecutionLaunch(unittest.TestCase):
     def test_required_nodes(self):
         for node_name in ["grasp_execution_node", "robot_state_publisher"]:
             self.assertTrue(self._wait_for(lambda: self._node_available(node_name)))
+
+    def test_joint_state_contains_finger_joints(self):
+        observed_joint_names = set()
+
+        def callback(msg):
+            observed_joint_names.update(msg.name)
+
+        subscription = self.node.create_subscription(JointState, "/joint_states", callback, 10)
+        self.assertTrue(self._wait_for(lambda: REQUIRED_FINGER_JOINTS.issubset(observed_joint_names)))
+        self.node.destroy_subscription(subscription)
 
 
 @launch_testing.post_shutdown_test()


### PR DESCRIPTION
### Motivation
- Ensure the Robotiq 3F finger joints are exported by `ros2_control` so they appear on `/joint_states` for grasp planning and execution. 
- Provide a simple gripper controller so the fake hardware exposes state and command interfaces for the finger joints. 
- Prevent grasp execution from starting when the finger joint states are not present to avoid incorrect or unsafe grasp behavior. 

### Description
- Added finger joint entries to `assets/robots/universal_robot/ur5_moveit_config/config/ur5.ros2_control.xacro` declaring `position` command interfaces and `position`/`velocity` state interfaces for `palm_finger_1_joint`, `finger_1_joint_1..3`, `palm_finger_2_joint`, `finger_2_joint_1..3`, and `finger_middle_joint_1..3`. 
- Added a `ur5_gripper_controller` (a `joint_trajectory_controller`) to `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/ur5_ros_controllers.yaml` covering the finger joints while keeping `joint_state_broadcaster` configured. 
- Updated `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` to spawn the new `ur5_gripper_controller` alongside the existing arm controller and the `joint_state_broadcaster`. 
- Implemented a startup guard in `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp` (`wait_for_required_finger_joint_states`) that waits for `/joint_states` to include all required finger joints and aborts `on_configure` if they are missing, and extended the launch test `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch.test.py` to assert the `/joint_states` topic contains the required finger joint names. 

### Testing
- Ran `python -m py_compile` on the modified Python files which succeeded. 
- Performed repository checks (diff/whitespace) which reported no issues. 
- Attempted to run the launch test with `pytest`, but collection failed in this environment because `*.test.py` launch-test modules require the ROS launch-testing entrypoint (collection error due to module import behavior), so full launch-test execution was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3cc47a010833198b82ef7b90aff6a)