### PR TITLE
Separate scene status snapshots from event-style log messages

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -15,6 +15,7 @@
 
 #include <QKeyEvent>
 #include <QCoreApplication>
+#include <QDateTime>
 #include <boost/filesystem.hpp>
 #include <boost/system/error_code.hpp>
 #include "rclcpp/rclcpp.hpp"
@@ -339,6 +340,15 @@ void SceneSelect::clear_messages()
   ui->error_workcell->clear();
 }
 
+void SceneSelect::refresh_scene_status(bool strict, const std::string & trigger)
+{
+  clear_messages();
+  const std::string timestamp =
+    QDateTime::currentDateTime().toString(Qt::ISODate).toStdString();
+  append_info("Status snapshot [" + trigger + "] @ " + timestamp);
+  check_scene(strict);
+}
+
 void SceneSelect::configure_startup_fallback_paths()
 {
   if (!workcell_path.empty()) {
@@ -657,7 +667,7 @@ void SceneSelect::on_generate_yaml_clicked()
     append_error("No scene selected to generate environment.yaml.");
   }
   scaffold_scene_index_ = -1;
-  check_scene(true);
+  refresh_scene_status(true, "Generate YAML");
 }
 bool SceneSelect::check_yaml()  // Check if scene package has a yaml file to use.
 {
@@ -697,7 +707,7 @@ bool SceneSelect::check_scene(bool strict)
       "Scene files were generated, but without environment.yaml this scene cannot be edited after exit.");
   }
   if (!strict && files_loaded_proper) {
-    append_warning(
+    append_info(
       "Scene status: launch/SRDF files are not generated yet. Use Generate Files when ready.");
   }
   ui->exit->setDisabled(false);
@@ -787,7 +797,7 @@ bool SceneSelect::check_files(bool strict)
 }
 void SceneSelect::on_scene_list_currentIndexChanged(int index)
 {
-  check_scene(index != scaffold_scene_index_);
+  refresh_scene_status(index != scaffold_scene_index_, "Scene Selection Changed");
 }
 void SceneSelect::on_generate_files_clicked()
 {
@@ -814,7 +824,7 @@ void SceneSelect::on_generate_files_clicked()
     append_error("No scene selected to generate files from.");
   }
   scaffold_scene_index_ = -1;
-  check_scene(true);
+  refresh_scene_status(true, "Generate Files");
 }
 bool SceneSelect::load_scene_from_yaml(Scene * input_scene)
 {

--- a/workcell_builder/workcell_builder/gui/scene_select.h
+++ b/workcell_builder/workcell_builder/gui/scene_select.h
@@ -93,6 +93,7 @@ private:
   void append_error(const std::string & message);
   void append_success(const std::string & message);
   void clear_messages();
+  void refresh_scene_status(bool strict, const std::string & trigger);
 
   Ui::SceneSelect * ui;
   boost::filesystem::path scene_dir_for_current_selection() const;


### PR DESCRIPTION
### Motivation
- Prevent repeated `check_scene()` runs from appending new status lines onto older log output so current state is clearly visible.
- Provide a consistent, centralized refresh path for UI actions that query scene status.
- Reduce false-alarm perception for scaffold/transitional states by lowering noisy warnings.

### Description
- Added `refresh_scene_status(bool strict, const std::string & trigger)` which clears the message panel, emits a timestamped `Status snapshot [...]` header, and calls `check_scene()`.
- Declared the new helper in the class header (`scene_select.h`) so UI handlers can share the behavior.
- Replaced direct `check_scene(...)` calls with `refresh_scene_status(...)` in `on_scene_list_currentIndexChanged()`, `on_generate_yaml_clicked()`, and `on_generate_files_clicked()` so all three use the same refresh semantics.
- Downgraded the transitional message about missing launch/SRDF files from a warning to an informational message to reduce unnecessary alarm during scaffold states.

### Testing
- Ran `git -C /workspace/Easy_Manipulator_Improved diff --check` which succeeded with no whitespace/format issues.
- Ran `git -C /workspace/Easy_Manipulator_Improved status --short` to verify the working tree contained the intended changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d3cc3534833185794c282cc955ce)