### PR TITLE
Unify planning/frame IDs, sanitize TF frame IDs, and validate gripper link names

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml
@@ -1,5 +1,6 @@
 grasp_execution_node:
   ros__parameters:
+    planning_frame: "world"
     workcell_context: config/workcell_context.yaml
     planning_scene_monitor_options:
       name: "planning_scene_monitor"

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -16,6 +16,7 @@ DEFAULT_SCENE_PACKAGE_CANDIDATES = ("ur5_3f_test", "ur5_2f_test", "ur5_airpick4_
 PACKAGE_NAME = "run_grasp_execution"
 SCENE_PACKAGE_ARGUMENT = "scene_package"
 MOVEIT_CONFIG_PACKAGE_ARGUMENT = "moveit_config_package"
+PLANNING_FRAME_ARGUMENT = "planning_frame"
 
 
 def find_default_scene_package():
@@ -141,6 +142,11 @@ def resolve_scene_package_share_dir(scene_package):
 def launch_setup(context, *args, **kwargs):
     scene_package = LaunchConfiguration(SCENE_PACKAGE_ARGUMENT).perform(context)
     moveit_config_package = LaunchConfiguration(MOVEIT_CONFIG_PACKAGE_ARGUMENT).perform(context)
+    planning_frame = LaunchConfiguration(PLANNING_FRAME_ARGUMENT).perform(context).strip()
+    if not planning_frame:
+        raise RuntimeError(
+            f"Launch argument '{PLANNING_FRAME_ARGUMENT}' resolved to an empty frame after trimming whitespace."
+        )
     run_share = get_package_share_directory(PACKAGE_NAME)
     resolve_scene_package_share_dir(scene_package)
     resolve_required_package_share_dir(
@@ -216,6 +222,7 @@ def launch_setup(context, *args, **kwargs):
         parameters=[
             grasp_execution_yaml,
             sensors_yaml,
+            {"planning_frame": planning_frame, "octomap_frame": planning_frame},
             robot_description,
             robot_description_semantic,
             joint_limits,
@@ -308,6 +315,11 @@ def generate_launch_description():
                 MOVEIT_CONFIG_PACKAGE_ARGUMENT,
                 default_value="ur5_moveit_config",
                 description="MoveIt config package containing config/{kinematics,joint_limits,ompl_planning}.yaml",
+            ),
+            DeclareLaunchArgument(
+                PLANNING_FRAME_ARGUMENT,
+                default_value="world",
+                description="Canonical planning/reference frame shared by grasp execution and octomap.",
             ),
             OpaqueFunction(function=launch_setup),
         ]

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -22,6 +22,9 @@
 #include <sstream>
 #include <thread>
 #include <set>
+#include <regex>
+#include <stdexcept>
+#include <unordered_set>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
@@ -82,8 +85,15 @@ static const std::vector<std::string> REQUIRED_FINGER_LINK_FRAMES = {
 
 bool wait_for_required_grasp_readiness(
   const rclcpp::Node::SharedPtr & node,
+  const std::string & planning_frame,
   std::chrono::seconds timeout = std::chrono::seconds(15))
 {
+  const std::string normalized_planning_frame = grasp_execution::sanitize_frame_id(planning_frame);
+  if (normalized_planning_frame.empty()) {
+    RCLCPP_ERROR(node->get_logger(), "Configured planning_frame is empty after trimming whitespace.");
+    return false;
+  }
+
   std::set<std::string> missing_joints(REQUIRED_FINGER_JOINTS.begin(), REQUIRED_FINGER_JOINTS.end());
   std::set<std::string> missing_frames(
     REQUIRED_FINGER_LINK_FRAMES.begin(), REQUIRED_FINGER_LINK_FRAMES.end());
@@ -108,7 +118,7 @@ bool wait_for_required_grasp_readiness(
     executor.spin_some();
 
     for (auto it = missing_frames.begin(); it != missing_frames.end();) {
-      if (tf_buffer.canTransform("world", *it, tf2::TimePointZero)) {
+      if (tf_buffer.canTransform(normalized_planning_frame, *it, tf2::TimePointZero)) {
         it = missing_frames.erase(it);
       } else {
         ++it;
@@ -117,7 +127,8 @@ bool wait_for_required_grasp_readiness(
 
     if (missing_joints.empty() && missing_frames.empty()) {
       RCLCPP_INFO(node->get_logger(),
-        "Readiness checks passed: all required finger joints and world->finger_*_link_* TF frames are available.");
+        "Readiness checks passed: all required finger joints and %s->finger_*_link_* TF frames are available.",
+        normalized_planning_frame.c_str());
       return true;
     }
 
@@ -152,11 +163,56 @@ bool wait_for_required_grasp_readiness(
   RCLCPP_ERROR(
     node->get_logger(),
     "Timed out waiting for grasp readiness after %.1f s. Missing joints on /joint_states: [%s]. "
-    "Missing TF transforms from world->finger_*_link_*: [%s].",
+    "Missing TF transforms from %s->finger_*_link_*: [%s].",
     std::chrono::duration<double>(timeout).count(),
     missing_joint_stream.str().c_str(),
+    normalized_planning_frame.c_str(),
     missing_frame_stream.str().c_str());
   return false;
+}
+
+bool validate_required_finger_link_frames_in_robot_description(const rclcpp::Node::SharedPtr & node)
+{
+  std::string robot_description;
+  if (!node->get_parameter("robot_description", robot_description) || robot_description.empty()) {
+    RCLCPP_ERROR(node->get_logger(), "robot_description parameter is missing; cannot validate finger link names.");
+    return false;
+  }
+
+  std::unordered_set<std::string> urdf_links;
+  static const std::regex link_regex(R"(<link\s+name\s*=\s*['"]([^'"]+)['"])", std::regex::icase);
+  for (std::sregex_iterator it(robot_description.begin(), robot_description.end(), link_regex), end;
+    it != end; ++it)
+  {
+    urdf_links.insert((*it)[1].str());
+  }
+
+  std::vector<std::string> missing_links;
+  for (const auto & required_frame : REQUIRED_FINGER_LINK_FRAMES) {
+    if (!urdf_links.count(required_frame)) {
+      missing_links.push_back(required_frame);
+    }
+  }
+
+  if (!missing_links.empty()) {
+    std::ostringstream oss;
+    for (size_t i = 0; i < missing_links.size(); ++i) {
+      if (i > 0) {
+        oss << ", ";
+      }
+      oss << missing_links[i];
+    }
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Finger link frame mismatch detected. Required frames missing from URDF: [%s].",
+      oss.str().c_str());
+    return false;
+  }
+
+  RCLCPP_INFO(
+    node->get_logger(),
+    "Finger link frame names match URDF links for the configured gripper model.");
+  return true;
 }
 
 class Demo : public moveit2::MoveitCppGraspExecution
@@ -175,6 +231,12 @@ public:
       "ee_wait_for_completion", false);
     int delay_ms = node_->declare_parameter<int>("ee_post_command_delay_ms", 0);
     ee_context_.post_command_delay = std::chrono::milliseconds(delay_ms);
+    grasp_execution::declare_or_get_param<std::string>(
+      planning_frame_, "planning_frame", node, node->get_logger(), "world");
+    planning_frame_ = grasp_execution::sanitize_frame_id(planning_frame_);
+    if (planning_frame_.empty()) {
+      throw std::runtime_error("Parameter 'planning_frame' is empty after trimming whitespace.");
+    }
 
     // Configurable release pose: x-offset from the current EE position and
     // optional z-height override. Defaults preserve the original behaviour.
@@ -327,7 +389,7 @@ public:
     const std::string & ee_brand = grasp_method.ee_id;
 
     grasp_execution::GraspExecutionContext options;
-    options.world_frame = "world";
+    options.world_frame = planning_frame_;
     options.planning_group = planning_group;
     options.ee_link = ee_link;
     options.move_to_collide_step_size = node_->get_parameter(
@@ -470,6 +532,7 @@ private:
   emd::EndEffectorExecutionContext ee_context_;
   rclcpp::Subscription<emd_msgs::msg::GraspTask>::SharedPtr grasp_task_sub_;
   rclcpp::Service<emd_msgs::srv::GraspRequest>::SharedPtr grasp_req_service_;
+  std::string planning_frame_;
   double release_x_offset_{-0.3};
   bool release_use_grasp_z_{true};
 };
@@ -517,9 +580,22 @@ public:
           workcell_context_filepath.c_str());
         return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
       }
+      const auto configured_planning_frame = this->declare_parameter<std::string>("planning_frame", "world");
+      const auto planning_frame = grasp_execution::sanitize_frame_id(configured_planning_frame);
+      if (planning_frame.empty()) {
+        RCLCPP_ERROR(this->get_logger(), "Configured planning_frame is empty after trimming whitespace.");
+        return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
+      }
+      base_node_->set_parameter(rclcpp::Parameter("planning_frame", planning_frame));
+
+      if (!grasp_execution::validate_required_finger_link_frames_in_robot_description(base_node_)) {
+        RCLCPP_ERROR(this->get_logger(),
+          "URDF finger link validation failed; frame names must exactly match the installed gripper model.");
+        return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
+      }
       const auto readiness_timeout_s = this->declare_parameter<int>("startup_readiness_timeout_s", 15);
       if (!grasp_execution::wait_for_required_grasp_readiness(
-          base_node_, std::chrono::seconds(readiness_timeout_s)))
+          base_node_, planning_frame, std::chrono::seconds(readiness_timeout_s)))
       {
         RCLCPP_ERROR(this->get_logger(),
           "Startup readiness checks failed; aborting configure before enabling octomap/shape masking.");

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/fake_grasp_pose_publisher.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/fake_grasp_pose_publisher.cpp
@@ -65,6 +65,11 @@ public:
     get_parameter("object_dimensions", object_dimensions);
     get_parameter("ee_id", ee_id);
     get_parameter("delay", delay);
+    frame_id = sanitize_frame_id(frame_id);
+    if (frame_id.empty()) {
+      RCLCPP_ERROR(this->get_logger(), "Parameter 'frame_id' is empty after trimming whitespace.");
+      return;
+    }
 
     if (!parse_pose_vector(grasp_pose_vector, grasp_pose.pose)) {
       RCLCPP_ERROR(

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/utils.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/utils.hpp
@@ -17,6 +17,8 @@
 
 #include <iostream>
 #include <sstream>
+#include <cctype>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -33,6 +35,26 @@
 
 namespace grasp_execution
 {
+
+inline std::string trim_ascii_whitespace(const std::string & input)
+{
+  size_t begin = 0;
+  while (begin < input.size() && std::isspace(static_cast<unsigned char>(input[begin]))) {
+    ++begin;
+  }
+
+  size_t end = input.size();
+  while (end > begin && std::isspace(static_cast<unsigned char>(input[end - 1]))) {
+    --end;
+  }
+
+  return input.substr(begin, end - begin);
+}
+
+inline std::string sanitize_frame_id(const std::string & frame_id)
+{
+  return trim_ascii_whitespace(frame_id);
+}
 
 /// Generate UUID
 /// \return UUID in string
@@ -120,10 +142,19 @@ inline void to_frame(
   const std::string & _target_frame,
   const tf2_ros::Buffer & _buffer)
 {
-  auto base_frame2target_frame = _buffer.lookupTransform(
-    _target_frame, in_.header.frame_id, rclcpp::Time());
+  const std::string target_frame = sanitize_frame_id(_target_frame);
+  const std::string source_frame = sanitize_frame_id(in_.header.frame_id);
+  if (target_frame.empty() || source_frame.empty()) {
+    throw std::runtime_error("Pose transform requires non-empty source and target frame IDs.");
+  }
 
-  tf2::doTransform(in_, out_, base_frame2target_frame);
+  auto sanitized_in = in_;
+  sanitized_in.header.frame_id = source_frame;
+
+  auto base_frame2target_frame = _buffer.lookupTransform(
+    target_frame, source_frame, rclcpp::Time());
+
+  tf2::doTransform(sanitized_in, out_, base_frame2target_frame);
 }
 
 /// Parse vector with 6 or 7 variables to a pose


### PR DESCRIPTION
### Motivation
- Eliminate intermittent `Invalid frame ID`/TF lookup failures caused by mismatched or whitespace-polluted frame names and ensure one canonical planning/reference frame is used across grasp execution and octomap code paths. 
- Ensure finger link frames used for transform lookups exactly match the URDF links for the installed gripper so readiness checks fail fast and clearly when misconfigured.

### Description
- Added ASCII-trimming utilities `trim_ascii_whitespace` and `sanitize_frame_id` and applied them in `to_frame(...)` so source/target frame IDs are trimmed before TF lookups and empty IDs raise an explicit error (`easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/utils.hpp`).
- Introduced a configurable canonical `planning_frame` launch argument and node parameter and propagated it into node parameters (also set `octomap_frame` to the same canonical frame) so MoveIt, grasp execution readiness, and octomap use the same reference (`easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py`, `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml`).
- Updated readiness TF checks and grasp-execution options to use the configured `planning_frame` (instead of hardcoded `world`) and improved timeout/diagnostic messages (`easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp`).
- Added runtime URDF finger-link validation that extracts `<link name="...">` entries from `robot_description` and verifies required finger frames are present, and updated the fake grasp pose publisher to sanitize/validate its `frame_id` parameter (`easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp`, `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/fake_grasp_pose_publisher.cpp`).

### Testing
- Ran Python syntax check with `python -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` and it succeeded.
- Ran the helper unit tests via `pytest -q easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py` in this environment and tests were skipped (no integration ROS environment); pytest returned a skip-only result.
- Attempted integration build/launch (e.g. `colcon build` and `ros2 launch`) but `colcon`/`ros2` are not available in the execution environment so full runtime verification could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d4fa9ef4833181449c7b2d4144af)