### PR TITLE
Skip UR5 gripper controller spawn when scene lacks gripper interfaces

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -19,6 +19,29 @@ MOVEIT_CONFIG_PACKAGE_ARGUMENT = "moveit_config_package"
 PLANNING_FRAME_ARGUMENT = "planning_frame"
 
 
+
+GRIPPER_CONTROLLER_JOINTS = (
+    "palm_finger_1_joint",
+    "finger_1_joint_1",
+    "finger_1_joint_2",
+    "finger_1_joint_3",
+    "palm_finger_2_joint",
+    "finger_2_joint_1",
+    "finger_2_joint_2",
+    "finger_2_joint_3",
+    "finger_middle_joint_1",
+    "finger_middle_joint_2",
+    "finger_middle_joint_3",
+)
+
+
+def scene_exposes_gripper_position_interfaces(robot_description_xml):
+    for joint_name in GRIPPER_CONTROLLER_JOINTS:
+        joint_tag = f'<joint name="{joint_name}">'
+        if joint_tag not in robot_description_xml:
+            return False
+    return True
+
 def find_default_scene_package():
     for package_name in DEFAULT_SCENE_PACKAGE_CANDIDATES:
         try:
@@ -287,17 +310,26 @@ def launch_setup(context, *args, **kwargs):
 
     spawn_joint_state = TimerAction(period=2.0, actions=[joint_state_spawner])
     spawn_arm = TimerAction(period=2.5, actions=[arm_spawner])
-    spawn_gripper = TimerAction(period=3.0, actions=[gripper_spawner])
 
-    return [
+    launch_actions = [
         robot_state_publisher,
         rviz_node,
         ros2_control_node,
         spawn_joint_state,
         spawn_arm,
-        spawn_gripper,
         grasp_execution_demo_node,
     ]
+
+    if scene_exposes_gripper_position_interfaces(robot_description_config):
+        spawn_gripper = TimerAction(period=3.0, actions=[gripper_spawner])
+        launch_actions.insert(-1, spawn_gripper)
+    else:
+        get_logger(__name__).warning(
+            "Skipping ur5_gripper_controller spawner: scene does not export gripper joints/interfaces; "
+            "dummy gripper driver remains responsible for gripper actions."
+        )
+
+    return launch_actions
 
 
 def generate_launch_description():


### PR DESCRIPTION
### Motivation
- Prevent launching the `ur5_gripper_controller` in scenes that do not expose the gripper joints/ros2_control position interfaces, which can cause controller activation failures such as "Not acceptable command interfaces combination".

### Description
- Added a `GRIPPER_CONTROLLER_JOINTS` tuple in `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` that lists the expected gripper joint names.
- Implemented `scene_exposes_gripper_position_interfaces(robot_description_xml)` to check whether the generated `robot_description` contains the gripper `<joint name="...">` tags.
- Changed `launch_setup` to make the `ur5_gripper_controller` spawner conditional: the gripper controller is spawned only when the presence check passes; otherwise a warning is logged and the dummy gripper driver remains responsible for gripper actions.
- The change keeps existing arm controller spawning and other behavior unchanged and limits the modification to the launch logic.

### Testing
- Ran `python -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` which completed successfully (no syntax errors).
- Attempted to run a runtime launch test with `ros2 launch run_grasp_execution grasp_execution.launch.py scene_package:=ur5_3f_test`, but the `ros2` CLI is not available in this environment so the runtime verification could not be executed here (launch attempt failed with `ros2: No such file or directory`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d6b40d6c83318c368d16a40eb583)