### PR TITLE
Add ur5_gripper_controller to MoveIt and ros2_control configs for UR5 2F setup

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/controllers.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/controllers.yaml
@@ -1,5 +1,6 @@
 controller_names:
   - ur5_arm_controller
+  - ur5_gripper_controller
 ur5_arm_controller:
   action_ns: follow_joint_trajectory
   type: FollowJointTrajectory
@@ -11,3 +12,9 @@ ur5_arm_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+ur5_gripper_controller:
+  action_ns: follow_joint_trajectory
+  type: FollowJointTrajectory
+  default: false
+  joints:
+    - gripper_finger1_joint

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/ur5_ros_controllers.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/ur5_ros_controllers.yaml
@@ -35,14 +35,4 @@ ur5_gripper_controller:
       - position
       - velocity
     joints:
-      - palm_finger_1_joint
-      - finger_1_joint_1
-      - finger_1_joint_2
-      - finger_1_joint_3
-      - palm_finger_2_joint
-      - finger_2_joint_1
-      - finger_2_joint_2
-      - finger_2_joint_3
-      - finger_middle_joint_1
-      - finger_middle_joint_2
-      - finger_middle_joint_3
+      - gripper_finger1_joint

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -20,19 +20,7 @@ PLANNING_FRAME_ARGUMENT = "planning_frame"
 
 
 
-GRIPPER_CONTROLLER_JOINTS = (
-    "palm_finger_1_joint",
-    "finger_1_joint_1",
-    "finger_1_joint_2",
-    "finger_1_joint_3",
-    "palm_finger_2_joint",
-    "finger_2_joint_1",
-    "finger_2_joint_2",
-    "finger_2_joint_3",
-    "finger_middle_joint_1",
-    "finger_middle_joint_2",
-    "finger_middle_joint_3",
-)
+GRIPPER_CONTROLLER_JOINTS = ("gripper_finger1_joint",)
 
 
 def scene_exposes_gripper_position_interfaces(robot_description_xml):

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -144,8 +144,8 @@ def _launch_setup(context):
 
     moveit_simple_controller_manager = {
         "moveit_simple_controller_manager": {
-            "controller_names": ["fake_ur5_controller"],
-            "fake_ur5_controller": {
+            "controller_names": ["ur5_arm_controller", "ur5_gripper_controller"],
+            "ur5_arm_controller": {
                 "action_ns": "follow_joint_trajectory",
                 "type": "FollowJointTrajectory",
                 "default": True,
@@ -157,6 +157,12 @@ def _launch_setup(context):
                     "wrist_2_joint",
                     "wrist_3_joint",
                 ],
+            },
+            "ur5_gripper_controller": {
+                "action_ns": "follow_joint_trajectory",
+                "type": "FollowJointTrajectory",
+                "default": False,
+                "joints": ["gripper_finger1_joint"],
             },
         }
     }

--- a/scenes/ur5_2f_test/urdf/arm_hand.srdf.xacro
+++ b/scenes/ur5_2f_test/urdf/arm_hand.srdf.xacro
@@ -10,8 +10,6 @@
 
   <xacro:robotiq_85_gripper/>
 
-  <end_effector name="robotiq_2f" parent_link="tool0" group="gripper" parent_group="manipulator" />
-
   <disable_collisions link1="gripper_base_link" link2="base_link" reason="Never" />
   <disable_collisions link1="gripper_base_link" link2="shoulder_link" reason="Never" />
   <disable_collisions link1="gripper_base_link" link2="upper_arm_link" reason="Never" />


### PR DESCRIPTION
### Motivation
- Enable MoveIt to discover and use a gripper controller for the UR5 2F scene by wiring a gripper controller into the MoveIt simple controller manager and ensuring ros2_control exposes the matching joint/interface.
- Make the grasp execution launch logic spawn the gripper controller only when the scene exports the correct gripper joint interface.
- Remove a duplicate SRDF end-effector declaration so the canonical Robotiq SRDF definitions are used and link/chain names remain consistent with the URDF.

### Description
- Added `ur5_gripper_controller` to the MoveIt simple controller config at `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/controllers.yaml` with `action_ns: follow_joint_trajectory`, `type: FollowJointTrajectory`, and `joints: ["gripper_finger1_joint"]`.
- Updated `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/ur5_ros_controllers.yaml` so `ur5_gripper_controller` targets the `gripper_finger1_joint` to match the fake-hardware `ros2_control` joint exported by the URDF.
- Updated the inline MoveIt simple controller manager config in `scenes/ur5_2f_test/launch/demo.launch.py` to return both `ur5_arm_controller` and `ur5_gripper_controller` and to include a matching `ur5_gripper_controller` entry for MoveIt logs to show both controllers.
- Removed a duplicate `end_effector` declaration from `scenes/ur5_2f_test/urdf/arm_hand.srdf.xacro` so the canonical `robotiq_85_gripper.srdf.xacro` definitions provide the end-effector/group configuration.
- Simplified the gripper interface detection in `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` by reducing `GRIPPER_CONTROLLER_JOINTS` to `("gripper_finger1_joint",)` so the gripper spawner is activated for this scene.

### Testing
- Successfully compiled the modified launch files with `python3 -m py_compile scenes/ur5_2f_test/launch/demo.launch.py easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` and the compile step completed without error.
- Attempted YAML parsing of `config/controllers.yaml` and `config/ur5_ros_controllers.yaml` via a small Python script, but the environment is missing `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d75b4c0483318e6a635db1194a12)