### PR TITLE
Update MoveIt & ros2_control configs: add solver entries, deprecations, initial state values, and explicit trajectory end behavior

### DIFF
--- a/assets/robots/universal_robot/ur10_moveit_config/config/kinematics.yaml
+++ b/assets/robots/universal_robot/ur10_moveit_config/config/kinematics.yaml
@@ -8,3 +8,16 @@ manipulator:
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
   kinematics_solver_attempts: 3
+
+# Keep explicit solver entries for non-arm planning groups to avoid fallback warnings.
+endeffector:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 1
+
+gripper:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 1

--- a/assets/robots/universal_robot/ur10_moveit_config/config/ur10.ros2_control.xacro
+++ b/assets/robots/universal_robot/ur10_moveit_config/config/ur10.ros2_control.xacro
@@ -11,38 +11,62 @@
             <joint name="shoulder_pan_joint">
                 <param name="initial_position">${initial_positions['shoulder_pan_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['shoulder_pan_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="shoulder_lift_joint">
                 <param name="initial_position">${initial_positions['shoulder_lift_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['shoulder_lift_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="elbow_joint">
                 <param name="initial_position">${initial_positions['elbow_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['elbow_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="wrist_1_joint">
                 <param name="initial_position">${initial_positions['wrist_1_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['wrist_1_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="wrist_2_joint">
                 <param name="initial_position">${initial_positions['wrist_2_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['wrist_2_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="wrist_3_joint">
                 <param name="initial_position">${initial_positions['wrist_3_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['wrist_3_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
         </ros2_control>
 

--- a/assets/robots/universal_robot/ur3_moveit_config/config/kinematics.yaml
+++ b/assets/robots/universal_robot/ur3_moveit_config/config/kinematics.yaml
@@ -8,3 +8,16 @@ manipulator:
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
   kinematics_solver_attempts: 3
+
+# Keep explicit solver entries for non-arm planning groups to avoid fallback warnings.
+endeffector:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 1
+
+gripper:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 1

--- a/assets/robots/universal_robot/ur3_moveit_config/config/ur3.ros2_control.xacro
+++ b/assets/robots/universal_robot/ur3_moveit_config/config/ur3.ros2_control.xacro
@@ -11,38 +11,62 @@
             <joint name="shoulder_pan_joint">
                 <param name="initial_position">${initial_positions['shoulder_pan_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['shoulder_pan_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="shoulder_lift_joint">
                 <param name="initial_position">${initial_positions['shoulder_lift_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['shoulder_lift_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="elbow_joint">
                 <param name="initial_position">${initial_positions['elbow_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['elbow_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="wrist_1_joint">
                 <param name="initial_position">${initial_positions['wrist_1_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['wrist_1_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="wrist_2_joint">
                 <param name="initial_position">${initial_positions['wrist_2_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['wrist_2_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="wrist_3_joint">
                 <param name="initial_position">${initial_positions['wrist_3_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['wrist_3_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
         </ros2_control>
 

--- a/assets/robots/universal_robot/ur5_moveit_config/config/kinematics.yaml
+++ b/assets/robots/universal_robot/ur5_moveit_config/config/kinematics.yaml
@@ -8,3 +8,16 @@ manipulator:
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
   kinematics_solver_attempts: 3
+
+# Keep explicit solver entries for non-arm planning groups to avoid fallback warnings.
+endeffector:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 1
+
+gripper:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 1

--- a/assets/robots/universal_robot/ur5_moveit_config/config/ur5.ros2_control.xacro
+++ b/assets/robots/universal_robot/ur5_moveit_config/config/ur5.ros2_control.xacro
@@ -11,104 +11,172 @@
             <joint name="shoulder_pan_joint">
                 <param name="initial_position">${initial_positions['shoulder_pan_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['shoulder_pan_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="shoulder_lift_joint">
                 <param name="initial_position">${initial_positions['shoulder_lift_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['shoulder_lift_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="elbow_joint">
                 <param name="initial_position">${initial_positions['elbow_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['elbow_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="wrist_1_joint">
                 <param name="initial_position">${initial_positions['wrist_1_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['wrist_1_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="wrist_2_joint">
                 <param name="initial_position">${initial_positions['wrist_2_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['wrist_2_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="wrist_3_joint">
                 <param name="initial_position">${initial_positions['wrist_3_joint']}</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">${initial_positions['wrist_3_joint']}</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="palm_finger_1_joint">
                 <param name="initial_position">0.0</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="finger_1_joint_1">
                 <param name="initial_position">0.0</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="finger_1_joint_2">
                 <param name="initial_position">0.0</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="finger_1_joint_3">
                 <param name="initial_position">0.0</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="palm_finger_2_joint">
                 <param name="initial_position">0.0</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="finger_2_joint_1">
                 <param name="initial_position">0.0</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="finger_2_joint_2">
                 <param name="initial_position">0.0</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="finger_2_joint_3">
                 <param name="initial_position">0.0</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="finger_middle_joint_1">
                 <param name="initial_position">0.0</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="finger_middle_joint_2">
                 <param name="initial_position">0.0</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
             <joint name="finger_middle_joint_3">
                 <param name="initial_position">0.0</param>
                 <command_interface name="position" />
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <state_interface name="position">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
+                <state_interface name="velocity">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
         </ros2_control>
 

--- a/assets/robots/universal_robot/ur5_moveit_config/config/ur5_ros_controllers.yaml
+++ b/assets/robots/universal_robot/ur5_moveit_config/config/ur5_ros_controllers.yaml
@@ -16,6 +16,7 @@ ur5_arm_controller:
     state_interfaces:
       - position
       - velocity
+    allow_nonzero_velocity_at_trajectory_end: false
     joints:
       - shoulder_pan_joint
       - shoulder_lift_joint

--- a/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/launch/run_moveit_cpp.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/launch/run_moveit_cpp.launch.py
@@ -186,7 +186,8 @@ def generate_launch_description():
     ros2_control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[("~/robot_description", "/robot_description")],
         output={
             "stdout": "screen",
             "stderr": "screen",

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/ur5_ros_controllers.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/ur5_ros_controllers.yaml
@@ -19,6 +19,7 @@ ur5_arm_controller:
     state_interfaces:
       - position
       - velocity
+    allow_nonzero_velocity_at_trajectory_end: false
     joints:
       - shoulder_pan_joint
       - shoulder_lift_joint
@@ -34,5 +35,6 @@ ur5_gripper_controller:
     state_interfaces:
       - position
       - velocity
+    allow_nonzero_velocity_at_trajectory_end: false
     joints:
       - gripper_finger1_joint

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -175,6 +175,13 @@ def launch_setup(context, *args, **kwargs):
         initial_position_path = os.path.join(run_share, "config", "start_positions.yaml")
         initial_position_mappings["initial_positions_file"] = initial_position_path
 
+    if "mock_sensor_commands" in ur_robot_args:
+        initial_position_mappings["mock_sensor_commands"] = "true"
+    elif "fake_sensor_commands" in ur_robot_args:
+        # Backward compatibility for older ur_description versions.
+        initial_position_mappings["fake_sensor_commands"] = "true"
+
+
     robot_description_config = load_file(scene_package, "urdf/scene.urdf.xacro", initial_position_mappings)
     robot_description = {"robot_description": robot_description_config}
 
@@ -266,7 +273,8 @@ def launch_setup(context, *args, **kwargs):
         package="controller_manager",
         executable="ros2_control_node",
         output={"stdout": "screen", "stderr": "screen"},
-        parameters=[robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[("~/robot_description", "/robot_description")],
     )
 
     joint_state_spawner = ExecuteProcess(

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/launch/grasp_execution.launch.py
@@ -143,6 +143,12 @@ def generate_launch_description():
         )
         initial_position_mappings['initial_positions_file'] = initial_position_path
 
+    if 'mock_sensor_commands' in ur_robot_args:
+        initial_position_mappings['mock_sensor_commands'] = 'true'
+    elif 'fake_sensor_commands' in ur_robot_args:
+        # Backward compatibility for older ur_description versions.
+        initial_position_mappings['fake_sensor_commands'] = 'true'
+
     # Component yaml files are grouped in separate namespaces
     robot_description_config = load_file(scene_pkg, 'urdf/scene.urdf.xacro',
                                          initial_position_mappings)
@@ -151,7 +157,7 @@ def generate_launch_description():
     robot_description_semantic_config = load_file(scene_pkg, 'urdf/arm_hand.srdf.xacro')
     robot_description_semantic = {'robot_description_semantic': robot_description_semantic_config}
 
-    kinematics_yaml = load_yaml('ur5_moveit_config', 'config/kinematics.yaml')
+    kinematics_yaml = {'robot_description_kinematics': load_yaml('ur5_moveit_config', 'config/kinematics.yaml')}
 
     ompl_planning_pipeline_config = {
         'ompl': {
@@ -243,7 +249,8 @@ def generate_launch_description():
     ros2_control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, ros2_controllers_path],
+        parameters=[ros2_controllers_path],
+        remappings=[("~/robot_description", "/robot_description")],
         output={
             "stdout": "screen",
             "stderr": "screen",


### PR DESCRIPTION
### Motivation
- Ensure each MoveIt planning group has an explicit kinematics solver stanza to avoid fallback warnings and future breakage. 
- Replace deprecated ros2_control usage patterns and parameter names so fake hardware and controller_manager use current expectations. 
- Satisfy `mock_generic_system` warnings by providing explicit initial values for all declared state interfaces. 
- Lock current `allow_nonzero_velocity_at_trajectory_end` behavior to avoid an unexpected behavior change when upstream defaults flip.

### Description
- Added explicit `endeffector` and `gripper` solver stanzas to `assets/robots/universal_robot/{ur3,ur5,ur10}_moveit_config/config/kinematics.yaml` so non-arm groups have defined solvers. 
- Stop passing `robot_description` directly into `ros2_control_node` parameters and instead add a remapping `('~/robot_description', '/robot_description')` in the MoveIt demo launches: `easy_manipulation_deployment/emd_demo_nodes/run_{grasp_execution,waypoint_execution,dynamic_safety}/launch/*.launch.py`. 
- Add compatibility handling for UR xacro arguments by preferring `mock_sensor_commands` and falling back to `fake_sensor_commands` when present in the UR macro parameter set in the affected launch files. 
- Set explicit `<param name="initial_value">...</param>` entries for `position` and `velocity` `state_interface`s in the UR `*.ros2_control.xacro` files for UR3/UR5/UR10 so all declared state interfaces have initial values consumed by `mock_generic_system`. 
- Explicitly set `allow_nonzero_velocity_at_trajectory_end: false` in UR5 controller YAMLs (`assets/.../ur5_ros_controllers.yaml` and demo config) to preserve current trajectory-end semantics. 
- Ensure waypoint demo loads kinematics under the `robot_description_kinematics` namespace instead of a bare YAML object so MoveIt receives kinematics under the expected key.

### Testing
- Ran `python -m compileall` on the modified launch files (`run_grasp_execution.launch.py`, `grasp_execution.launch.py` (waypoint), and `run_moveit_cpp.launch.py`) and compilation succeeded. 
- Verified the updated launch files no longer pass `parameters=[robot_description, ros2_controllers_path]` by searching for that pattern; check returned no remaining occurrences. 
- Attempted YAML parse validation with `yaml.safe_load(...)` but it failed because the environment lacks the `PyYAML` module (`ModuleNotFoundError: No module named 'yaml'`), so full YAML schema validation was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d86974e483319b6de631b5e2d744)