### PR TITLE
Guard planning_frame parameter declaration in DemoLifecycleNode::on_configure

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -580,7 +580,12 @@ public:
           workcell_context_filepath.c_str());
         return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
       }
-      const auto configured_planning_frame = this->declare_parameter<std::string>("planning_frame", "world");
+      std::string configured_planning_frame;
+      if (this->has_parameter("planning_frame")) {
+        this->get_parameter_or<std::string>("planning_frame", configured_planning_frame, "world");
+      } else {
+        configured_planning_frame = this->declare_parameter<std::string>("planning_frame", "world");
+      }
       const auto planning_frame = grasp_execution::sanitize_frame_id(configured_planning_frame);
       if (planning_frame.empty()) {
         RCLCPP_ERROR(this->get_logger(), "Configured planning_frame is empty after trimming whitespace.");


### PR DESCRIPTION
### Motivation
- Avoid `ParameterAlreadyDeclaredException` when `planning_frame` may be pre-declared (for example via parameter overrides) and align with the repository's existing declare-or-get pattern while preserving the normalized planning frame propagation.

### Description
- Replace the direct `declare_parameter("planning_frame", "world")` call in `DemoLifecycleNode::on_configure` with guarded logic that uses `has_parameter` and `get_parameter_or` when present or calls `declare_parameter` only when missing, then sanitize and validate the value and propagate the normalized `planning_frame` to `base_node_` via `set_parameter` as before.

### Testing
- Performed automated source inspections using `rg` to locate usages and `sed`/`nl` to view the modified region and confirmed the guarded declare-or-get change was applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3db666a98833190d875c56641a1e1)