### PR TITLE
Use unique base node name in grasp execution demo lifecycle node

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -555,14 +555,15 @@ public:
   {
     // Create a standard rclcpp::Node to interface with MoveIt and other ROS 2 APIs.
     // The lifecycle node itself cannot be directly used where a rclcpp::Node is
-    // required, so we construct a new node that shares the same name and
+    // required, so we construct a new node with a unique name in the same
     // namespace. Parameters are automatically declared from overrides to mirror
     // the lifecycle node behaviour.
     try {
       rclcpp::NodeOptions base_options;
       base_options.automatically_declare_parameters_from_overrides(true);
+      const auto base_node_name = std::string(this->get_name()) + "_worker";
       base_node_ = std::make_shared<rclcpp::Node>(
-        this->get_name(), this->get_namespace(), base_options);
+        base_node_name, this->get_namespace(), base_options);
       demo_ = std::make_shared<grasp_execution::Demo>(
         base_node_, grasp_execution::GRASP_EXECUTION_PACKAGE,
         grasp_execution::GRASP_TASK_TOPIC, grasp_execution::GRASP_REQUEST_TOPIC);


### PR DESCRIPTION
### Motivation
- Avoid duplicate node/logger identity by creating the internal `base_node_` with a unique name while preserving its namespace so existing topics and services remain unaffected.

### Description
- Changed `DemoLifecycleNode::on_configure` to build `base_node_` with `const auto base_node_name = std::string(this->get_name()) + "_worker";` and pass `base_node_name` to `std::make_shared<rclcpp::Node>` instead of `this->get_name()`, and updated the nearby comment to reflect the new behavior.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3dc125e7483319bd64fa9cf2a8a63)