### PR TITLE
Remove invalid `endeffector` kinematics solver entry from UR5 MoveIt config

### DIFF
--- a/assets/robots/universal_robot/ur5_moveit_config/config/kinematics.yaml
+++ b/assets/robots/universal_robot/ur5_moveit_config/config/kinematics.yaml
@@ -9,13 +9,6 @@ manipulator:
   kinematics_solver_timeout: 0.005
   kinematics_solver_attempts: 3
 
-# Keep explicit solver entries for non-arm planning groups to avoid fallback warnings.
-endeffector:
-  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
-  kinematics_solver_search_resolution: 0.005
-  kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 1
-
 gripper:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005


### PR DESCRIPTION
### Motivation
- The `ur5_3f_test` scene loads MoveIt kinematics from `ur5_moveit_config`, and the SRDF defines `endeffector` as a single-link group while `manipulator` is a chain, which makes an IK solver entry for `endeffector` invalid.
- Removing the `endeffector` solver entry prevents incorrect solver-group pairing while preserving the arm (`manipulator`) solver behavior.

### Description
- Deleted the `endeffector` solver block from `assets/robots/universal_robot/ur5_moveit_config/config/kinematics.yaml` and left the `manipulator` and `gripper` solver entries unchanged.
- Confirmed the scene launch references `ur5_moveit_config` via `scenes/ur5_3f_test/launch/demo.launch.py` and verified the SRDF group types in `assets/robots/universal_robot/ur5_moveit_config/config/ur5.srdf`.

### Testing
- Ran `rg` and `sed` inspections to locate and view `endeffector` and `manipulator` declarations and confirmed `endeffector` is a link-only group (succeeded).
- Executed a small Python edit script that removed the `endeffector` block from `kinematics.yaml` (succeeded) and rechecked the YAML text to ensure the entry is gone (succeeded).
- Attempted to parse the YAML with `PyYAML` in the environment but the import failed with `ModuleNotFoundError: No module named 'yaml'`, so automated YAML parsing was not completed (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3dc7b68c08331b399bb057e05b3bb)