### PR TITLE
Enable/disallow ur5_gripper_controller based on scene URDF interfaces

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -59,13 +59,15 @@ def resolve_gripper_controller_joints(scene_package):
     return ()
 
 
-def align_gripper_controller_joints(controllers_yaml, ros2_controllers_yaml, gripper_controller_joints):
+def align_gripper_controller_joints(
+    controllers_yaml, ros2_controllers_yaml, gripper_controller_joints, enable_gripper_controller
+):
     controller_names = controllers_yaml.setdefault("controller_names", [])
     controller_manager_ros_params = ros2_controllers_yaml.setdefault("controller_manager", {}).setdefault(
         "ros__parameters", {}
     )
 
-    if gripper_controller_joints:
+    if gripper_controller_joints and enable_gripper_controller:
         gripper_joints = list(gripper_controller_joints)
         controllers_yaml.setdefault("ur5_gripper_controller", {})["joints"] = gripper_joints
         ros2_controllers_yaml.setdefault("ur5_gripper_controller", {}).setdefault("ros__parameters", {})[
@@ -270,7 +272,17 @@ def launch_setup(context, *args, **kwargs):
 
     controllers_yaml = load_yaml(PACKAGE_NAME, "config/controllers.yaml")
     ros2_controllers_yaml = load_yaml(PACKAGE_NAME, "config/ur5_ros_controllers.yaml")
-    align_gripper_controller_joints(controllers_yaml, ros2_controllers_yaml, gripper_controller_joints)
+    scene_supports_gripper_controller = bool(
+        gripper_controller_joints
+        and scene_exposes_gripper_position_interfaces(robot_description_config, gripper_controller_joints)
+    )
+
+    align_gripper_controller_joints(
+        controllers_yaml,
+        ros2_controllers_yaml,
+        gripper_controller_joints,
+        scene_supports_gripper_controller,
+    )
     moveit_controller = {
         "moveit_simple_controller_manager": controllers_yaml,
         "moveit_controller_manager": "moveit_simple_controller_manager/MoveItSimpleControllerManager",
@@ -370,9 +382,7 @@ def launch_setup(context, *args, **kwargs):
         grasp_execution_demo_node,
     ]
 
-    if gripper_controller_joints and scene_exposes_gripper_position_interfaces(
-        robot_description_config, gripper_controller_joints
-    ):
+    if scene_supports_gripper_controller:
         spawn_gripper = TimerAction(period=3.0, actions=[gripper_spawner])
         launch_actions.insert(-1, spawn_gripper)
     else:


### PR DESCRIPTION
### Motivation
- Ensure MoveIt controller configuration only includes the gripper controller when the expanded scene URDF actually exposes the gripper position interfaces. 
- Avoid spawning a `ur5_gripper_controller` or listing it in `moveit_simple_controller_manager.controller_names` when the scene does not provide the required joints/interfaces.

### Description
- Added an `enable_gripper_controller` flag parameter to `align_gripper_controller_joints(...)` so the function can add or remove `ur5_gripper_controller` entries from both the `controller_names` list and the controller maps. 
- Compute `scene_supports_gripper_controller` in `launch_setup(...)` using `scene_exposes_gripper_position_interfaces(robot_description_config, gripper_controller_joints)` after the xacro has been expanded, and pass that boolean into `align_gripper_controller_joints(...)` when building MoveIt params. 
- Reused `scene_supports_gripper_controller` to gate spawning of the gripper spawner so the spawn decision and controller parameterization remain consistent.

### Testing
- Ran `python -m compileall easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e1eab87c8331af97059f34560c8a)