### PR TITLE
Normalize malformed controller YAML in grasp execution launch helper

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -63,9 +63,34 @@ def align_gripper_controller_joints(
     controllers_yaml, ros2_controllers_yaml, gripper_controller_joints, enable_gripper_controller
 ):
     controller_names = controllers_yaml.setdefault("controller_names", [])
-    controller_manager_ros_params = ros2_controllers_yaml.setdefault("controller_manager", {}).setdefault(
-        "ros__parameters", {}
-    )
+    if controller_names is None:
+        controller_names = []
+        controllers_yaml["controller_names"] = controller_names
+    elif not isinstance(controller_names, list):
+        raise RuntimeError(
+            "Invalid controllers schema: 'controller_names' must be a YAML sequence (list), "
+            f"got {type(controller_names).__name__}."
+        )
+
+    controller_manager = ros2_controllers_yaml.setdefault("controller_manager", {})
+    if controller_manager is None:
+        controller_manager = {}
+        ros2_controllers_yaml["controller_manager"] = controller_manager
+    elif not isinstance(controller_manager, dict):
+        raise RuntimeError(
+            "Invalid ros2 controllers schema: 'controller_manager' must be a YAML mapping (dict), "
+            f"got {type(controller_manager).__name__}."
+        )
+
+    controller_manager_ros_params = controller_manager.setdefault("ros__parameters", {})
+    if controller_manager_ros_params is None:
+        controller_manager_ros_params = {}
+        controller_manager["ros__parameters"] = controller_manager_ros_params
+    elif not isinstance(controller_manager_ros_params, dict):
+        raise RuntimeError(
+            "Invalid ros2 controllers schema: 'controller_manager.ros__parameters' must be a YAML "
+            f"mapping (dict), got {type(controller_manager_ros_params).__name__}."
+        )
 
     if gripper_controller_joints and enable_gripper_controller:
         gripper_joints = list(gripper_controller_joints)

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
@@ -142,3 +142,45 @@ def test_load_file_returns_none_on_xacro_error(module_path, tmp_path, monkeypatc
             module.load_file("pkg", bad_xacro.name)
     else:
         assert module.load_file("pkg", bad_xacro.name) is None
+
+
+def test_align_gripper_controller_joints_normalizes_null_controller_names(grasp_launch_module):
+    controllers_yaml = {"controller_names": None}
+    ros2_controllers_yaml = {"controller_manager": {"ros__parameters": {}}}
+
+    grasp_launch_module.align_gripper_controller_joints(
+        controllers_yaml=controllers_yaml,
+        ros2_controllers_yaml=ros2_controllers_yaml,
+        gripper_controller_joints=("gripper_finger1_joint",),
+        enable_gripper_controller=True,
+    )
+
+    assert controllers_yaml["controller_names"] == ["ur5_gripper_controller"]
+    assert controllers_yaml["ur5_gripper_controller"]["joints"] == ["gripper_finger1_joint"]
+
+
+@pytest.mark.parametrize(
+    ("controllers_yaml", "ros2_controllers_yaml", "expected_error"),
+    [
+        (
+            {"controller_names": "ur5_gripper_controller"},
+            {"controller_manager": {"ros__parameters": {}}},
+            r"'controller_names' must be a YAML sequence",
+        ),
+        (
+            {"controller_names": []},
+            {"controller_manager": {"ros__parameters": "not_a_mapping"}},
+            r"'controller_manager\.ros__parameters' must be a YAML mapping",
+        ),
+    ],
+)
+def test_align_gripper_controller_joints_rejects_invalid_schema_types(
+    grasp_launch_module, controllers_yaml, ros2_controllers_yaml, expected_error
+):
+    with pytest.raises(RuntimeError, match=expected_error):
+        grasp_launch_module.align_gripper_controller_joints(
+            controllers_yaml=controllers_yaml,
+            ros2_controllers_yaml=ros2_controllers_yaml,
+            gripper_controller_joints=("gripper_finger1_joint",),
+            enable_gripper_controller=True,
+        )


### PR DESCRIPTION
### Motivation
- Prevent crashes when YAML fields parsed from controller configuration are malformed (e.g. `controller_names: null`) and used as lists or mappings.
- Fail fast with clear errors when schema types are invalid to aid debugging and avoid obscure `NoneType` or attribute errors.

### Description
- Hardened `align_gripper_controller_joints()` to normalize `controller_names: null` into an empty list and raise a `RuntimeError` when `controller_names` is not a list. (file: `launch/grasp_execution.launch.py`)
- Normalized and validated `controller_manager` and `controller_manager.ros__parameters` to convert `null` to `{}` and raise `RuntimeError` on non-mapping types. (file: `launch/grasp_execution.launch.py`)
- Added unit tests that verify normalization of `controller_names: null` and that invalid schema types produce helpful `RuntimeError` messages. (file: `test/test_grasp_execution_launch_helpers.py`)
- Preserved existing behavior for valid configurations; functional behavior unchanged when inputs are well-formed.

### Testing
- Ran the module unit tests with `pytest -q easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py`, which were skipped in this environment because `xacro` is unavailable; no failures were observed in this run.
- New tests cover: normalization of `controller_names: null` (asserts gripper controller is added) and rejection of invalid types for `controller_names` and `controller_manager.ros__parameters` (asserts `RuntimeError` with clear messages).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e4037730833198683df304d33a2e)