### PR TITLE
Harden scene package handling in grasp execution launch

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -231,6 +231,13 @@ def resolve_scene_package_share_dir(scene_package):
 
 def launch_setup(context, *args, **kwargs):
     scene_package = LaunchConfiguration(SCENE_PACKAGE_ARGUMENT).perform(context)
+    if not scene_package:
+        available = ", ".join(DEFAULT_SCENE_PACKAGE_CANDIDATES)
+        raise RuntimeError(
+            f"Launch argument '{SCENE_PACKAGE_ARGUMENT}' was empty. Pass a valid '{SCENE_PACKAGE_ARGUMENT}' "
+            f"launch argument, for example '{SCENE_PACKAGE_ARGUMENT}:={available.split(', ')[0]}', or build/source "
+            "your generated scene package first."
+        )
     moveit_config_package = LaunchConfiguration(MOVEIT_CONFIG_PACKAGE_ARGUMENT).perform(context)
     planning_frame = LaunchConfiguration(PLANNING_FRAME_ARGUMENT).perform(context).strip()
     if not planning_frame:
@@ -422,9 +429,10 @@ def launch_setup(context, *args, **kwargs):
 def generate_launch_description():
     debug_arg = DeclareLaunchArgument("debug", default_value="false", description="Launch in debug mode")
     scene_description = "Scene package containing urdf/scene.urdf.xacro and urdf/arm_hand.srdf.xacro"
-    scene_arg_kwargs = {"description": scene_description}
-    if DEFAULT_SCENE_PACKAGE is not None:
-        scene_arg_kwargs["default_value"] = DEFAULT_SCENE_PACKAGE
+    scene_arg_kwargs = {
+        "description": scene_description,
+        "default_value": DEFAULT_SCENE_PACKAGE if DEFAULT_SCENE_PACKAGE is not None else "ur5_3f_test",
+    }
 
     return LaunchDescription(
         [

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
@@ -115,6 +115,50 @@ def test_resolve_scene_package_share_dir_reports_missing_scene(grasp_launch_modu
     assert "scene_package:=ur5_3f_test" in str(exc_info.value)
 
 
+def test_generate_launch_description_uses_safe_default_when_no_scene_is_discovered(grasp_launch_module, monkeypatch):
+    captured_arguments = []
+
+    class FakeDeclareLaunchArgument:
+        def __init__(self, name, **kwargs):
+            captured_arguments.append((name, kwargs))
+            self.name = name
+            self.kwargs = kwargs
+
+    class FakeLaunchDescription:
+        def __init__(self, entities):
+            self.entities = entities
+
+    monkeypatch.setattr(grasp_launch_module, "DeclareLaunchArgument", FakeDeclareLaunchArgument)
+    monkeypatch.setattr(grasp_launch_module, "LaunchDescription", FakeLaunchDescription)
+    monkeypatch.setattr(grasp_launch_module, "OpaqueFunction", lambda function: ("opaque", function))
+    monkeypatch.setattr(grasp_launch_module, "DEFAULT_SCENE_PACKAGE", None)
+
+    launch_description = grasp_launch_module.generate_launch_description()
+
+    assert isinstance(launch_description, FakeLaunchDescription)
+    scene_arguments = [kwargs for name, kwargs in captured_arguments if name == grasp_launch_module.SCENE_PACKAGE_ARGUMENT]
+    assert len(scene_arguments) == 1
+    assert scene_arguments[0]["default_value"] == "ur5_3f_test"
+
+
+def test_launch_setup_rejects_empty_scene_package_with_deterministic_error(grasp_launch_module, monkeypatch):
+    class FakeLaunchConfiguration:
+        def __init__(self, name):
+            self.name = name
+
+        def perform(self, context):
+            return context.get(self.name)
+
+    monkeypatch.setattr(grasp_launch_module, "LaunchConfiguration", FakeLaunchConfiguration)
+
+    with pytest.raises(RuntimeError, match=r"Launch argument 'scene_package' was empty") as exc_info:
+        grasp_launch_module.launch_setup({grasp_launch_module.SCENE_PACKAGE_ARGUMENT: ""})
+
+    error_text = str(exc_info.value)
+    assert "scene_package:=ur5_3f_test" in error_text
+    assert "build/source your generated scene package first" in error_text
+
+
 @pytest.mark.parametrize(
     "module_path",
     [


### PR DESCRIPTION
### Motivation
- Ensure the `scene_package` launch argument always resolves to a safe, deterministic value so launches and error messages are predictable when auto-discovery finds no installed example scene. 
- Fail fast with a clear, user-facing error when `scene_package` resolves to an empty value instead of letting later code raise unclear exceptions.

### Description
- In `launch_setup()` validate `scene_package = LaunchConfiguration("scene_package").perform(context)` and raise a deterministic `RuntimeError` when it is empty, preserving the existing remediation wording style including `scene_package:=...` and the build/source guidance.
- In `generate_launch_description()` always provide `DeclareLaunchArgument` a `default_value` by using `DEFAULT_SCENE_PACKAGE` when discovered or falling back to the safe default string `"ur5_3f_test"` when `DEFAULT_SCENE_PACKAGE` is `None` (Option A behavior).
- Add unit tests in `test/test_grasp_execution_launch_helpers.py` to assert that `generate_launch_description()` uses the safe fallback default when no scene is discovered and that `launch_setup()` rejects an empty `scene_package` with the expected deterministic error text.

### Testing
- Ran `pytest -q easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py`; the run in this environment reported `1 skipped` because the test module gates execution on `xacro` via `pytest.importorskip("xacro")` and that dependency is not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e5a160888331b5b15014a925bec0)