### PR TITLE
Harden grasp execution launch YAML schema checks and error reporting

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -47,6 +47,12 @@ def scene_exposes_gripper_position_interfaces(robot_description_xml, gripper_con
 
 def resolve_gripper_controller_joints(scene_package):
     scene_metadata = load_yaml(scene_package, "environment.yaml")
+    if not isinstance(scene_metadata, dict):
+        raise RuntimeError(
+            "Invalid scene metadata schema in 'environment.yaml': expected a YAML mapping (dict) at the root, "
+            f"got {type(scene_metadata).__name__}. Check '{SCENE_PACKAGE_ARGUMENT}' points to a valid generated "
+            "scene package with a proper environment.yaml structure."
+        )
     end_effector = scene_metadata.get("end_effector", {})
     ee_name = str(end_effector.get("name", "")).lower()
     ee_brand = str(end_effector.get("brand", "")).lower()
@@ -177,6 +183,15 @@ def load_yaml(package, file_path):
     return xacro.load_yaml(os.path.join(package_path, file_path))
 
 
+def require_yaml_mapping(data, field_name, package_name, file_name):
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            f"Invalid YAML schema for package '{package_name}', file '{file_name}': '{field_name}' must be a "
+            f"YAML mapping (dict), got {type(data).__name__}. Please verify the file content and launch arguments."
+        )
+    return data
+
+
 def _extract_scene_xacro_args(xacro_file_path):
     text = Path(xacro_file_path).read_text(encoding="utf-8")
     return set(re.findall(r"<xacro:arg\s+name=['\"]([^'\"]+)['\"]", text))
@@ -251,7 +266,17 @@ def launch_setup(context, *args, **kwargs):
         "Build/source your selected MoveIt config package and pass it with "
         f"'{MOVEIT_CONFIG_PACKAGE_ARGUMENT}:=<package_name>' if it is not 'ur5_moveit_config'.",
     )
-    gripper_controller_joints = resolve_gripper_controller_joints(scene_package)
+    try:
+        gripper_controller_joints = resolve_gripper_controller_joints(scene_package)
+    except Exception as exc:
+        raise RuntimeError(
+            "Failed while parsing scene metadata for grasp execution launch. "
+            f"package='{scene_package}', file='environment.yaml', args: "
+            f"{SCENE_PACKAGE_ARGUMENT}='{scene_package}', "
+            f"{MOVEIT_CONFIG_PACKAGE_ARGUMENT}='{moveit_config_package}', "
+            f"{PLANNING_FRAME_ARGUMENT}='{planning_frame}'. "
+            "Please verify that the selected scene package contains a valid environment.yaml."
+        ) from exc
 
     scene_xacro_path = Path(get_package_share_directory(scene_package)) / "urdf" / "scene.urdf.xacro"
     scene_args = _extract_scene_xacro_args(scene_xacro_path)
@@ -269,15 +294,21 @@ def launch_setup(context, *args, **kwargs):
         initial_position_mappings["fake_sensor_commands"] = "true"
 
 
-    robot_description_config = load_file(scene_package, "urdf/scene.urdf.xacro", initial_position_mappings)
+    try:
+        robot_description_config = load_file(scene_package, "urdf/scene.urdf.xacro", initial_position_mappings)
+        robot_description_semantic_config = load_file(scene_package, "urdf/arm_hand.srdf.xacro")
+    except Exception as exc:
+        raise RuntimeError(
+            "Failed while loading robot description files for grasp execution launch. "
+            f"package='{scene_package}', files='urdf/scene.urdf.xacro, urdf/arm_hand.srdf.xacro', args: "
+            f"{SCENE_PACKAGE_ARGUMENT}='{scene_package}', "
+            f"{MOVEIT_CONFIG_PACKAGE_ARGUMENT}='{moveit_config_package}', "
+            f"{PLANNING_FRAME_ARGUMENT}='{planning_frame}'. "
+            "Ensure both URDF/SRDF xacro files exist and are valid."
+        ) from exc
+
     robot_description = {"robot_description": robot_description_config}
-
-    robot_description_semantic_config = load_file(scene_package, "urdf/arm_hand.srdf.xacro")
     robot_description_semantic = {"robot_description_semantic": robot_description_semantic_config}
-
-    kinematics_yaml = {"robot_description_kinematics": load_yaml(moveit_config_package, "config/kinematics.yaml")}
-    joint_limits_yaml = load_yaml(moveit_config_package, "config/joint_limits.yaml")
-    joint_limits = {"robot_description_planning": joint_limits_yaml}
 
     ompl_planning_pipeline_config = {
         "ompl": {
@@ -292,7 +323,48 @@ def launch_setup(context, *args, **kwargs):
             "start_state_max_bounds_error": 0.1,
         }
     }
-    ompl_planning_yaml = load_yaml(moveit_config_package, "config/ompl_planning.yaml")
+    try:
+        kinematics_data = require_yaml_mapping(
+            load_yaml(moveit_config_package, "config/kinematics.yaml"),
+            "robot_description_kinematics",
+            moveit_config_package,
+            "config/kinematics.yaml",
+        )
+        joint_limits_yaml = require_yaml_mapping(
+            load_yaml(moveit_config_package, "config/joint_limits.yaml"),
+            "robot_description_planning",
+            moveit_config_package,
+            "config/joint_limits.yaml",
+        )
+        ompl_planning_yaml = require_yaml_mapping(
+            load_yaml(moveit_config_package, "config/ompl_planning.yaml"),
+            "ompl",
+            moveit_config_package,
+            "config/ompl_planning.yaml",
+        )
+        controllers_yaml = require_yaml_mapping(
+            load_yaml(PACKAGE_NAME, "config/controllers.yaml"),
+            "moveit_simple_controller_manager",
+            PACKAGE_NAME,
+            "config/controllers.yaml",
+        )
+        ros2_controllers_yaml = require_yaml_mapping(
+            load_yaml(PACKAGE_NAME, "config/ur5_ros_controllers.yaml"),
+            "controller_manager",
+            PACKAGE_NAME,
+            "config/ur5_ros_controllers.yaml",
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            "Failed while parsing YAML configuration for grasp execution launch. "
+            f"args: {SCENE_PACKAGE_ARGUMENT}='{scene_package}', "
+            f"{MOVEIT_CONFIG_PACKAGE_ARGUMENT}='{moveit_config_package}', "
+            f"{PLANNING_FRAME_ARGUMENT}='{planning_frame}'. "
+            "Check YAML schemas in MoveIt and run_grasp_execution config files."
+        ) from exc
+
+    kinematics_yaml = {"robot_description_kinematics": kinematics_data}
+    joint_limits = {"robot_description_planning": joint_limits_yaml}
     ompl_planning_pipeline_config["ompl"].update(ompl_planning_yaml)
 
     trajectory_execution = {
@@ -302,8 +374,6 @@ def launch_setup(context, *args, **kwargs):
         "trajectory_execution.allowed_start_tolerance": 0.01,
     }
 
-    controllers_yaml = load_yaml(PACKAGE_NAME, "config/controllers.yaml")
-    ros2_controllers_yaml = load_yaml(PACKAGE_NAME, "config/ur5_ros_controllers.yaml")
     scene_supports_gripper_controller = bool(
         gripper_controller_joints
         and scene_exposes_gripper_position_interfaces(robot_description_config, gripper_controller_joints)

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
@@ -228,3 +228,65 @@ def test_align_gripper_controller_joints_rejects_invalid_schema_types(
             gripper_controller_joints=("gripper_finger1_joint",),
             enable_gripper_controller=True,
         )
+
+
+def test_resolve_gripper_controller_joints_rejects_non_mapping_scene_metadata(grasp_launch_module, monkeypatch):
+    monkeypatch.setattr(grasp_launch_module, "load_yaml", lambda package, file_path: ["not", "a", "mapping"])
+
+    with pytest.raises(RuntimeError, match=r"Invalid scene metadata schema in 'environment\.yaml'") as exc_info:
+        grasp_launch_module.resolve_gripper_controller_joints("bad_scene_pkg")
+
+    message = str(exc_info.value)
+    assert "expected a YAML mapping (dict) at the root" in message
+    assert "scene_package" in message
+
+
+def test_require_yaml_mapping_reports_package_and_file(grasp_launch_module):
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"Invalid YAML schema for package 'ur5_moveit_config', file 'config/kinematics\.yaml': "
+            r"'robot_description_kinematics' must be a YAML mapping \(dict\), got list"
+        ),
+    ):
+        grasp_launch_module.require_yaml_mapping(
+            ["invalid"],
+            "robot_description_kinematics",
+            "ur5_moveit_config",
+            "config/kinematics.yaml",
+        )
+
+
+def test_launch_setup_wraps_scene_metadata_parse_errors_with_argument_context(grasp_launch_module, monkeypatch):
+    class FakeLaunchConfiguration:
+        def __init__(self, name):
+            self.name = name
+
+        def perform(self, context):
+            return context[self.name]
+
+    monkeypatch.setattr(grasp_launch_module, "LaunchConfiguration", FakeLaunchConfiguration)
+    monkeypatch.setattr(grasp_launch_module, "get_package_share_directory", lambda _package: "/tmp/fake_share")
+    monkeypatch.setattr(grasp_launch_module, "resolve_scene_package_share_dir", lambda _scene_package: "/tmp/fake")
+    monkeypatch.setattr(grasp_launch_module, "resolve_required_package_share_dir", lambda *_args, **_kwargs: "/tmp/fake")
+    monkeypatch.setattr(
+        grasp_launch_module,
+        "resolve_gripper_controller_joints",
+        lambda _scene_package: (_ for _ in ()).throw(RuntimeError("bad environment yaml")),
+    )
+
+    with pytest.raises(RuntimeError, match=r"Failed while parsing scene metadata for grasp execution launch") as exc_info:
+        grasp_launch_module.launch_setup(
+            {
+                grasp_launch_module.SCENE_PACKAGE_ARGUMENT: "scene_pkg",
+                grasp_launch_module.MOVEIT_CONFIG_PACKAGE_ARGUMENT: "moveit_pkg",
+                grasp_launch_module.PLANNING_FRAME_ARGUMENT: "world",
+            }
+        )
+
+    message = str(exc_info.value)
+    assert "package='scene_pkg'" in message
+    assert "file='environment.yaml'" in message
+    assert "scene_package='scene_pkg'" in message
+    assert "moveit_config_package='moveit_pkg'" in message
+    assert "planning_frame='world'" in message


### PR DESCRIPTION
### Motivation
- Prevent low-level `NoneType`/type errors when malformed YAML is loaded by adding explicit schema checks and clearer guidance.
- Make failure messages actionable by including package/file and launch-argument context so users can fix misconfigured scene/MoveIt packages.

### Description
- Added a root-type check in `resolve_gripper_controller_joints` to ensure `environment.yaml` resolves to a `dict` and raise a clear `RuntimeError` with remediation guidance when it does not (`easy_manipulation_deployment/.../grasp_execution.launch.py`).
- Introduced `require_yaml_mapping(data, field_name, package_name, file_name)` to validate YAML mapping inputs and used it to validate `kinematics.yaml`, `joint_limits.yaml`, `ompl_planning.yaml`, `config/controllers.yaml`, and `config/ur5_ros_controllers.yaml` before consumption.
- Wrapped key parsing/loading blocks in `try/except Exception as exc` and re-raised contextual `RuntimeError`s that include `scene_package`, `moveit_config_package`, and `planning_frame` to guide debugging of scene/MoveIt misconfigurations.
- Added unit tests in `test/test_grasp_execution_launch_helpers.py` to assert behavior for non-mapping `environment.yaml`, `require_yaml_mapping` error text, and that `launch_setup` wraps scene parse errors with argument context.

### Testing
- Ran `pytest -q easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py`; the test module is gated by `pytest.importorskip("xacro")` so tests were skipped in this environment (reported as skipped).
- The added tests exercise malformed YAML inputs and assert the improved, contextual `RuntimeError` messages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e62754d083319de58f3eecab9bb4)