### PR TITLE
Stabilize current Humble simulation/grasp workflows

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,10 +9,8 @@ The following items are pending implementation:
 5. Scheduler workflow prerequisites and queue robustness
 6. MoveIt-based execution improvements for multi-axis joints and path constraints.
 7. Context loading via `rcl_yaml_param_parser` with schema validation.
-8. Demo node lifecycle conversion.
-9. Default executor watchdog and graceful shutdown.
-10. Finger-gripper sampling strategies for multi-finger configurations.
-11. Additional testing, CI workflows, documentation, and Docker support.
+8. Finger-gripper sampling strategies for multi-finger configurations.
+9. Additional testing, CI workflows, documentation, and Docker support.
 
 These tasks are outlined for future contributions.
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/fake_grasp_pose_publisher.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/fake_grasp_pose_publisher.cpp
@@ -162,12 +162,25 @@ int main(int argc, char * argv[])
     auto client = node->create_client<emd_msgs::srv::GraspRequest>("grasp_requests");
 
     // Waiting for service to appear.
+    constexpr int kMaxWaitAttempts = 10;
+    int wait_attempts = 0;
     while (!client->wait_for_service(std::chrono::seconds(1))) {
       if (!rclcpp::ok()) {
         RCLCPP_ERROR(node->get_logger(), "client interrupted while waiting for service to appear.");
         return 1;
       }
-      RCLCPP_INFO(node->get_logger(), "waiting for service to appear...");
+      ++wait_attempts;
+      if (wait_attempts >= kMaxWaitAttempts) {
+        RCLCPP_ERROR(
+          node->get_logger(),
+          "grasp_requests service not available after %d attempts, exiting.",
+          kMaxWaitAttempts);
+        return 1;
+      }
+      RCLCPP_WARN(
+        node->get_logger(),
+        "waiting for grasp_requests service to appear... (%d/%d)",
+        wait_attempts, kMaxWaitAttempts);
     }
 
     auto req = std::make_shared<emd_msgs::srv::GraspRequest::Request>();

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/src/demo_node.cpp
@@ -45,7 +45,9 @@ int main(int argc, char * argv[])
     rclcpp::Node::make_shared("grasp_planner_demo_node", "", node_options);
 
   const auto point_cloud_topic =
-    get_parameter_or(node, "camera_parameters.point_cloud_topic", std::string("/camera/pointcloud"));
+    get_parameter_or(
+      node, "camera_parameters.point_cloud_topic",
+      std::string("/camera/camera/depth/color/points"));
 
   rclcpp::executors::MultiThreadedExecutor executor;
   #if EPD_ENABLED == 1
@@ -61,7 +63,7 @@ int main(int argc, char * argv[])
     std::string("/camera/color/camera_info"));
   const auto localization_topic = get_parameter_or(
     node, "easy_perception_deployment.epd_localization_topic",
-    std::string("/processor/epd_localize_output"));
+    std::string("/easy_perception_deployment/epd_localize_output"));
   const auto tracking_enabled =
     get_parameter_or(node, "easy_perception_deployment.tracking_enabled", false);
   const auto tracking_topic = get_parameter_or(
@@ -116,7 +118,16 @@ int main(int argc, char * argv[])
     executor.spin();
   }
   #else
-  RCLCPP_INFO(LOGGER_DEMO, "epd_msgs not found, Direct Workflow Enabled");
+  const auto epd_enabled =
+    get_parameter_or(node, "easy_perception_deployment.epd_enabled", false);
+  if (epd_enabled) {
+    RCLCPP_ERROR(
+      LOGGER_DEMO,
+      "easy_perception_deployment.epd_enabled is true, but this binary was built without "
+      "epd_msgs support (EPD_ENABLED=0). Falling back to direct point cloud workflow.");
+  } else {
+    RCLCPP_INFO(LOGGER_DEMO, "epd_msgs not found, Direct Workflow Enabled");
+  }
   grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2> demo(node);
   demo.setup(point_cloud_topic);
   executor.add_node(demo.node);

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/fake_grasp_pose_publisher.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/fake_grasp_pose_publisher.cpp
@@ -142,12 +142,25 @@ int main(int argc, char * argv[])
     auto client = node->create_client<emd_msgs::srv::GraspRequest>("grasp_requests");
 
     // Waiting for service to appear.
+    constexpr int kMaxWaitAttempts = 10;
+    int wait_attempts = 0;
     while (!client->wait_for_service(std::chrono::seconds(1))) {
       if (!rclcpp::ok()) {
         RCLCPP_ERROR(node->get_logger(), "client interrupted while waiting for service to appear.");
         return 1;
       }
-      RCLCPP_INFO(node->get_logger(), "waiting for service to appear...");
+      ++wait_attempts;
+      if (wait_attempts >= kMaxWaitAttempts) {
+        RCLCPP_ERROR(
+          node->get_logger(),
+          "grasp_requests service not available after %d attempts, exiting.",
+          kMaxWaitAttempts);
+        return 1;
+      }
+      RCLCPP_WARN(
+        node->get_logger(),
+        "waiting for grasp_requests service to appear... (%d/%d)",
+        wait_attempts, kMaxWaitAttempts);
     }
 
     auto req = std::make_shared<emd_msgs::srv::GraspRequest::Request>();


### PR DESCRIPTION
## Summary
This PR applies small, targeted stability fixes for simulation/fake-hardware grasp flows without changing architecture.

### Fixed
- Added bounded retry loops (with clear failure logs) for `grasp_requests` service waits in both fake grasp publisher demos, so runs fail cleanly instead of waiting forever.
- Aligned `run_grasp_planner` default direct-workflow point-cloud topic with the repo’s current RealSense config defaults (`/camera/camera/depth/color/points`) to avoid silent no-data startup.
- Aligned `run_grasp_planner` default EPD localization topic with existing launch/config defaults (`/easy_perception_deployment/epd_localize_output`).

### Improved diagnostics
- When `easy_perception_deployment.epd_enabled=true` but the binary is compiled without EPD support (`EPD_ENABLED=0`), the demo node now logs a clear error before falling back to direct point-cloud workflow.
- Service wait logs now include attempt counters and explicit terminal error on timeout.

### Docs/config alignment
- Updated `docs/ROADMAP.md` pending list to remove items already listed as completed (lifecycle conversion and watchdog/shutdown).

## Files changed
- `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/fake_grasp_pose_publisher.cpp`
- `easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/fake_grasp_pose_publisher.cpp`
- `easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/src/demo_node.cpp`
- `docs/ROADMAP.md`

## Validation
- `source /opt/ros/humble/setup.bash && colcon build --packages-select run_grasp_planner run_grasp_execution run_waypoint_execution --event-handlers console_direct+`
  - Result: Failed in this container because `/opt/ros/humble/setup.bash` is not present.

## Not changed
- No new features or architecture changes.
- No new dependencies introduced.
- No package renames or workflow removals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5abe7cb4833191f22e952bba9224)