### PR TITLE
Fix demo package test failures and Humble launch-test cleanup

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -1,3 +1,17 @@
+# Copyright 2020 ROS Industrial Consortium Asia Pacific
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import re
 import tempfile

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -168,11 +168,14 @@ bool wait_for_required_grasp_readiness(
 
   const std::string normalized_planning_frame = grasp_execution::sanitize_frame_id(planning_frame);
   if (normalized_planning_frame.empty()) {
-    RCLCPP_ERROR(node->get_logger(), "Configured planning_frame is empty after trimming whitespace.");
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Configured planning_frame is empty after trimming whitespace.");
     return false;
   }
 
-  std::set<std::string> missing_joints(REQUIRED_FINGER_JOINTS.begin(), REQUIRED_FINGER_JOINTS.end());
+  std::set<std::string> missing_joints(
+    REQUIRED_FINGER_JOINTS.begin(), REQUIRED_FINGER_JOINTS.end());
   std::set<std::string> missing_frames(
     REQUIRED_FINGER_LINK_FRAMES.begin(), REQUIRED_FINGER_LINK_FRAMES.end());
 
@@ -264,7 +267,9 @@ bool validate_required_finger_link_frames_in_robot_description(
 
   std::string robot_description;
   if (!node->get_parameter("robot_description", robot_description) || robot_description.empty()) {
-    RCLCPP_ERROR(node->get_logger(), "robot_description parameter is missing; cannot validate finger link names.");
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "robot_description parameter is missing; cannot validate finger link names.");
     return false;
   }
 
@@ -439,7 +444,10 @@ public:
     // Get home state
     moveit::core::RobotStatePtr home_state(get_curr_state());
     if (!home_state) {
-      RCLCPP_ERROR(node_->get_logger(), "Failed to get current robot state for target %s", target_id.c_str());
+      RCLCPP_ERROR(
+        node_->get_logger(),
+        "Failed to get current robot state for target %s",
+        target_id.c_str());
       return false;
     }
 
@@ -470,7 +478,10 @@ public:
     }
 
     if (!selected_method) {
-      RCLCPP_ERROR(node_->get_logger(), "No valid end effector found for target %s", target_id.c_str());
+      RCLCPP_ERROR(
+        node_->get_logger(),
+        "No valid end effector found for target %s",
+        target_id.c_str());
       return false;
     }
 
@@ -678,7 +689,9 @@ public:
       }
       const auto planning_frame = grasp_execution::sanitize_frame_id(configured_planning_frame);
       if (planning_frame.empty()) {
-        RCLCPP_ERROR(this->get_logger(), "Configured planning_frame is empty after trimming whitespace.");
+        RCLCPP_ERROR(
+          this->get_logger(),
+          "Configured planning_frame is empty after trimming whitespace.");
         return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
       }
       base_node_->set_parameter(rclcpp::Parameter("planning_frame", planning_frame));
@@ -697,7 +710,8 @@ public:
           "URDF finger link validation failed; frame names must exactly match the installed gripper model.");
         return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
       }
-      const auto readiness_timeout_s = this->declare_parameter<int>("startup_readiness_timeout_s", 15);
+      const auto readiness_timeout_s = this->declare_parameter<int>(
+        "startup_readiness_timeout_s", 15);
       if (!grasp_execution::wait_for_required_grasp_readiness(
           base_node_, planning_frame, readiness_profile.require_robotiq_3f_checks,
           readiness_profile.description, std::chrono::seconds(readiness_timeout_s)))

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch.test.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch.test.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+# Copyright 2020 ROS Industrial Consortium Asia Pacific
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import importlib.util
 import os
@@ -12,7 +25,6 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 import launch_testing
 import launch_testing.actions
-from launch_testing_ros.wait_for_topics import WaitForTopics
 import pytest
 import rclpy
 from sensor_msgs.msg import JointState
@@ -72,9 +84,6 @@ def generate_test_description():
                     PythonLaunchDescriptionSource(launch_path),
                     launch_arguments={"scene_package": SCENE_PACKAGE}.items(),
                 ),
-                WaitForTopics([
-                    ("/joint_states", "sensor_msgs/msg/JointState"),
-                ]),
                 launch_testing.actions.ReadyToTest(),
             ]
         ),
@@ -113,6 +122,16 @@ class TestGraspExecutionLaunch(unittest.TestCase):
     def test_required_nodes(self):
         for node_name in ["grasp_execution_node", "robot_state_publisher"]:
             self.assertTrue(self._wait_for(lambda: self._node_available(node_name)))
+
+    def test_joint_states_topic_published(self):
+        self.assertTrue(
+            self._wait_for(
+                lambda: any(
+                    topic_name == "/joint_states"
+                    for topic_name, _types in self.node.get_topic_names_and_types()
+                )
+            )
+        )
 
     def test_joint_state_contains_finger_joints(self):
         observed_joint_names = set()

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
@@ -1,4 +1,18 @@
-"""Unit tests for ``grasp_execution.launch.py`` helper functions.
+# Copyright 2020 ROS Industrial Consortium Asia Pacific
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for ``grasp_execution.launch.py`` helper functions.
 
 This module is a pytest unit-test helper and **not** a ROS launch entrypoint.
 It intentionally stubs ROS-specific modules so the tests can run in a plain
@@ -37,7 +51,9 @@ launch_substitutions_mod.LaunchConfiguration = object
 launch_substitutions_mod.PythonExpression = object
 sys.modules.setdefault("launch.substitutions", launch_substitutions_mod)
 launch_logging_mod = types.ModuleType("launch.logging")
-launch_logging_mod.get_logger = lambda _name: types.SimpleNamespace(error=lambda *_args, **_kwargs: None)
+launch_logging_mod.get_logger = (
+    lambda _name: types.SimpleNamespace(error=lambda *_args, **_kwargs: None)
+)
 sys.modules.setdefault("launch.logging", launch_logging_mod)
 launch_ros_mod = types.ModuleType("launch_ros")
 actions_mod = types.ModuleType("launch_ros.actions")
@@ -136,7 +152,11 @@ def test_generate_launch_description_uses_safe_default_when_no_scene_is_discover
     launch_description = grasp_launch_module.generate_launch_description()
 
     assert isinstance(launch_description, FakeLaunchDescription)
-    scene_arguments = [kwargs for name, kwargs in captured_arguments if name == grasp_launch_module.SCENE_PACKAGE_ARGUMENT]
+    scene_arguments = [
+        kwargs
+        for name, kwargs in captured_arguments
+        if name == grasp_launch_module.SCENE_PACKAGE_ARGUMENT
+    ]
     assert len(scene_arguments) == 1
     assert scene_arguments[0]["default_value"] == "ur5_3f_test"
 
@@ -219,7 +239,10 @@ def test_align_gripper_controller_joints_normalizes_null_controller_names(grasp_
     ],
 )
 def test_align_gripper_controller_joints_rejects_invalid_schema_types(
-    grasp_launch_module, controllers_yaml, ros2_controllers_yaml, expected_error
+    grasp_launch_module,
+    controllers_yaml,
+    ros2_controllers_yaml,
+    expected_error,
 ):
     with pytest.raises(RuntimeError, match=expected_error):
         grasp_launch_module.align_gripper_controller_joints(
@@ -231,7 +254,11 @@ def test_align_gripper_controller_joints_rejects_invalid_schema_types(
 
 
 def test_resolve_gripper_controller_joints_rejects_non_mapping_scene_metadata(grasp_launch_module, monkeypatch):
-    monkeypatch.setattr(grasp_launch_module, "load_yaml", lambda package, file_path: ["not", "a", "mapping"])
+    monkeypatch.setattr(
+        grasp_launch_module,
+        "load_yaml",
+        lambda package, file_path: ["not", "a", "mapping"],
+    )
 
     with pytest.raises(RuntimeError, match=r"Invalid scene metadata schema in 'environment\.yaml'") as exc_info:
         grasp_launch_module.resolve_gripper_controller_joints("bad_scene_pkg")

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/src/demo_node.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include <string>
+#include <utility>
 
 #include "rclcpp/rclcpp.hpp"
 #include "emd/grasp_planner/grasp_scene.hpp"
@@ -34,6 +35,28 @@ ValueT get_parameter_or(
 }  // namespace
 
 static const rclcpp::Logger & LOGGER_DEMO = rclcpp::get_logger("DemoNode");
+
+template<typename SceneFactoryT, typename TopicT>
+void run_scene_with_executor(
+  rclcpp::executors::MultiThreadedExecutor & executor,
+  SceneFactoryT && scene_factory,
+  TopicT && topic)
+{
+  if (!rclcpp::ok()) {
+    RCLCPP_INFO(LOGGER_DEMO, "Shutdown requested before scene setup; skipping setup.");
+    return;
+  }
+
+  auto demo = scene_factory();
+  demo.setup(std::forward<TopicT>(topic));
+  if (!rclcpp::ok()) {
+    RCLCPP_INFO(LOGGER_DEMO, "Shutdown requested during scene setup; skipping spin.");
+    return;
+  }
+  executor.add_node(demo.node);
+  executor.spin();
+}
+
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
@@ -94,10 +117,12 @@ int main(int argc, char * argv[])
     RCLCPP_INFO(LOGGER_DEMO, "EPD Workflow Enabled");
     if (tracking_enabled && detection_topic.empty()) {
       RCLCPP_INFO(LOGGER_DEMO, "EPD Tracking Enabled");
-      grasp_planner::GraspScene<epd_msgs::msg::EPDObjectTracking> demo(node);
-      demo.setup(tracking_topic);
-      executor.add_node(demo.node);
-      executor.spin();
+      run_scene_with_executor(
+        executor,
+        [&node]() {
+          return grasp_planner::GraspScene<epd_msgs::msg::EPDObjectTracking>(node);
+        },
+        tracking_topic);
     } else {
       if (tracking_enabled && !detection_topic.empty()) {
         RCLCPP_WARN(
@@ -105,17 +130,21 @@ int main(int argc, char * argv[])
           "Detection adapter publishes localization data; falling back to localization workflow.");
       }
       RCLCPP_INFO(LOGGER_DEMO, "EPD Localization Enabled");
-      grasp_planner::GraspScene<epd_msgs::msg::EPDObjectLocalization> demo(node);
-      demo.setup(localization_topic);
-      executor.add_node(demo.node);
-      executor.spin();
+      run_scene_with_executor(
+        executor,
+        [&node]() {
+          return grasp_planner::GraspScene<epd_msgs::msg::EPDObjectLocalization>(node);
+        },
+        localization_topic);
     }
   } else {
     RCLCPP_INFO(LOGGER_DEMO, "Direct Workflow Enabled");
-    grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2> demo(node);
-    demo.setup(point_cloud_topic);
-    executor.add_node(demo.node);
-    executor.spin();
+    run_scene_with_executor(
+      executor,
+      [&node]() {
+        return grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>(node);
+      },
+      point_cloud_topic);
   }
   #else
   const auto epd_enabled =
@@ -128,13 +157,17 @@ int main(int argc, char * argv[])
   } else {
     RCLCPP_INFO(LOGGER_DEMO, "epd_msgs not found, Direct Workflow Enabled");
   }
-  grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2> demo(node);
-  demo.setup(point_cloud_topic);
-  executor.add_node(demo.node);
-  executor.spin();
+  run_scene_with_executor(
+    executor,
+    [&node]() {
+      return grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>(node);
+    },
+    point_cloud_topic);
   #endif
 
-  rclcpp::shutdown();
+  if (rclcpp::ok()) {
+    rclcpp::shutdown();
+  }
   RCLCPP_INFO(LOGGER_DEMO, "Shutting Down");
   return 0;
 }

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/test/test_with_epd_launch.test.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/test/test_with_epd_launch.test.py
@@ -1,10 +1,28 @@
 #!/usr/bin/env python3
+# Copyright 2020 ROS Industrial Consortium Asia Pacific
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 import time
 import unittest
+from pathlib import Path
 
-from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
+from ament_index_python.packages import (
+    PackageNotFoundError,
+    get_package_prefix,
+    get_package_share_directory,
+)
 import launch
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -19,6 +37,22 @@ for pkg in ('run_grasp_planner', 'easy_perception_deployment'):
         get_package_share_directory(pkg)
     except PackageNotFoundError:
         pytest.skip(f'{pkg} package not available', allow_module_level=True)
+
+epd_prefix = Path(get_package_prefix('easy_perception_deployment'))
+epd_executable = epd_prefix / 'lib' / 'easy_perception_deployment' / 'easy_perception_deployment'
+if not epd_executable.exists():
+    pytest.skip('easy_perception_deployment executable not available', allow_module_level=True)
+
+model_candidates = [
+    Path.cwd() / 'data' / 'model' / 'MaskRCNN-10.onnx',
+    epd_prefix / 'data' / 'model' / 'MaskRCNN-10.onnx',
+    epd_prefix / 'share' / 'easy_perception_deployment' / 'data' / 'model' / 'MaskRCNN-10.onnx',
+]
+if not any(model.exists() for model in model_candidates):
+    pytest.skip(
+        'MaskRCNN-10.onnx not available for EPD integration test',
+        allow_module_level=True,
+    )
 
 
 @pytest.mark.launch_test

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/include/run_waypoint_execution/target_validation.hpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/include/run_waypoint_execution/target_validation.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 ROS Industrial Consortium Asia Pacific
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <string>

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/launch/grasp_execution.launch.py
@@ -64,7 +64,6 @@ def to_urdf(xacro_path, urdf_path=None, mappings=None):
 
 def load_file(package_name, file_path, mappings=None):
     """Load a robot description file, converting xacro sources to URDF."""
-
     package_path = Path(get_package_share_directory(package_name))
     target = Path(file_path)
     absolute_file_path = (package_path / target) if not target.is_absolute() else target

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/target_validation.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/target_validation.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 ROS Industrial Consortium Asia Pacific
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "run_waypoint_execution/target_validation.hpp"
 
 #include "rclcpp/rclcpp.hpp"
@@ -18,7 +32,8 @@ bool validate_grasp_target_selection(
   if (!target) {
     RCLCPP_ERROR(
       logger,
-      "Planning target validation failed for target_id '%s': missing target payload (target is null).",
+      "Planning target validation failed for target_id '%s': missing "
+      "target payload (target is null).",
       target_id.c_str());
     return false;
   }
@@ -26,7 +41,8 @@ bool validate_grasp_target_selection(
   if (target->grasp_methods.empty()) {
     RCLCPP_ERROR(
       logger,
-      "Planning target validation failed for target_id '%s': missing grasp_methods[0] (grasp_methods is empty).",
+      "Planning target validation failed for target_id '%s': missing "
+      "grasp_methods[0] (grasp_methods is empty).",
       target_id.c_str());
     return false;
   }
@@ -36,7 +52,8 @@ bool validate_grasp_target_selection(
   if (grasp_method->grasp_poses.empty()) {
     RCLCPP_ERROR(
       logger,
-      "Planning target validation failed for target_id '%s': missing grasp_methods[0].grasp_poses[0] (grasp_poses is empty).",
+      "Planning target validation failed for target_id '%s': missing "
+      "grasp_methods[0].grasp_poses[0] (grasp_poses is empty).",
       target_id.c_str());
     return false;
   }

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/test/test_target_validation.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/test/test_target_validation.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 ROS Industrial Consortium Asia Pacific
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <memory>
 #include <string>
 


### PR DESCRIPTION
### Motivation
- Stabilize demo-package launch tests by preventing crashes during shutdown, avoiding hard failures when EPD model/executable is missing, and fixing Humble launch-testing incompatibilities without adding models or new packages.

### Description
- Add a guarded scene runner (`run_scene_with_executor`) to `run_grasp_planner` that checks `rclcpp::ok()` before setup/spin to avoid creating subscriptions/timers after shutdown has begun and avoid redundant shutdown calls.
- Gate the EPD integration launch test so it is skipped at module load time when the `easy_perception_deployment` executable or a `MaskRCNN-10.onnx` model file cannot be found at common locations, preventing test-process crashes due to missing model files.
- Remove the Humble-incompatible `WaitForTopics` launch action and replace it with an explicit runtime assertion that `/joint_states` is published in the `run_grasp_execution` launch test, preserving the original test intent.
- Add missing Apache-2.0 headers and perform small style/formatting fixes (C++ line wrapping and pep257 docstring spacing) in the files reported by linters.

### Testing
- Ran `python3 -m py_compile` on the modified Python launch/test files and the check completed successfully.
- Attempted the requested `colcon build` and `colcon test` commands, but `colcon` is not installed in this environment so those commands could not be executed here (`/bin/bash: colcon: command not found`).
- Expected outcomes when run in a properly provisioned environment: the EPD integration test will be skipped when runtime artifacts are missing, `run_grasp_planner` will no longer crash on SIGINT during launch teardown, and `run_grasp_execution` launch tests will be Humble-compatible and continue to verify `/joint_states` and joint names.
- A local environment flake8 conflict (`ValueError: 'string' is not callable`) remains an external issue; run tests with `PYTHONNOUSERSITE=1` or remove the user-local `flake8` to avoid it.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebded4ae448331b959e8af5c10e2f3)