### PR TITLE
Fix gripper kinematics config noise in UR simulation demos

### DIFF
--- a/assets/robots/universal_robot/ur10_moveit_config/config/kinematics.yaml
+++ b/assets/robots/universal_robot/ur10_moveit_config/config/kinematics.yaml
@@ -9,15 +9,3 @@ manipulator:
   kinematics_solver_timeout: 0.005
   kinematics_solver_attempts: 3
 
-# Keep explicit solver entries for non-arm planning groups to avoid fallback warnings.
-endeffector:
-  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
-  kinematics_solver_search_resolution: 0.005
-  kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 1
-
-gripper:
-  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
-  kinematics_solver_search_resolution: 0.005
-  kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 1

--- a/assets/robots/universal_robot/ur3_moveit_config/config/kinematics.yaml
+++ b/assets/robots/universal_robot/ur3_moveit_config/config/kinematics.yaml
@@ -9,15 +9,3 @@ manipulator:
   kinematics_solver_timeout: 0.005
   kinematics_solver_attempts: 3
 
-# Keep explicit solver entries for non-arm planning groups to avoid fallback warnings.
-endeffector:
-  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
-  kinematics_solver_search_resolution: 0.005
-  kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 1
-
-gripper:
-  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
-  kinematics_solver_search_resolution: 0.005
-  kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 1

--- a/assets/robots/universal_robot/ur5_moveit_config/config/kinematics.yaml
+++ b/assets/robots/universal_robot/ur5_moveit_config/config/kinematics.yaml
@@ -8,9 +8,3 @@ manipulator:
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
   kinematics_solver_attempts: 3
-
-gripper:
-  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
-  kinematics_solver_search_resolution: 0.005
-  kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 1

--- a/scenes/suction_test/launch/demo.launch.py
+++ b/scenes/suction_test/launch/demo.launch.py
@@ -178,6 +178,13 @@ def _launch_setup(context):
         "publish_transforms_updates": True,
     }
 
+    # No depth sensor plugin is configured in this fake-hardware demo.
+    # Disable occupancy map sensor plugins to suppress octomap warnings.
+    occupancy_map_monitor_params = {
+        "octomap_resolution": 0.025,
+        "sensors": [],
+    }
+
     # --- Nodes ---
 
     try:
@@ -189,6 +196,7 @@ def _launch_setup(context):
         validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
         validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
         validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
+        validated_occupancy_map_monitor_params = _normalize_ros_param_types(occupancy_map_monitor_params)
         validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
         validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
 
@@ -200,6 +208,7 @@ def _launch_setup(context):
         _validate_ros_param_types(validated_ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
         _validate_ros_param_types(validated_planning_scene_monitor_params, "planning_scene_monitor_params")
         _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
+        _validate_ros_param_types(validated_occupancy_map_monitor_params, "occupancy_map_monitor_params")
         _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
         _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
     except TypeError as exc:
@@ -245,6 +254,7 @@ def _launch_setup(context):
             validated_planning_pipelines_config,
             validated_ompl_planning_pipeline_config,
             validated_planning_scene_monitor_params,
+            validated_occupancy_map_monitor_params,
             validated_trajectory_execution,
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,


### PR DESCRIPTION
### Motivation
- Suppress MoveIt startup errors where non-serial groups (e.g. `gripper`/`endeffector`) were being assigned a KDL kinematics solver and failing to initialize. 
- Reduce noisy Octomap/occupancy-map warnings in fake-hardware simulation demos when no 3D sensor plugin is configured.

### Description
- Removed `gripper` and `endeffector` kinematics solver entries that used `kdl_kinematics_plugin/KDLKinematicsPlugin` from `assets/robots/universal_robot/ur3_moveit_config/config/kinematics.yaml`, `assets/robots/universal_robot/ur5_moveit_config/config/kinematics.yaml`, and `assets/robots/universal_robot/ur10_moveit_config/config/kinematics.yaml` while preserving the `manipulator` solver settings. 
- Added an explicit minimal occupancy map monitor config to `scenes/suction_test/launch/demo.launch.py` with `sensors: []` and `octomap_resolution: 0.025` and wired `validated_occupancy_map_monitor_params` into the `move_group` node parameters to suppress octomap updater noise in fake-hardware demos. 
- Kept the changes small and conservative (no new packages, no new perception drivers, and no architecture changes). 

### Testing
- `python -m py_compile scenes/suction_test/launch/demo.launch.py` succeeded (basic Python syntax check). 
- Static config checks using `rg` confirmed `gripper`/`endeffector` solver blocks were removed and only `manipulator` entries remain in the UR kinematics files. 
- `colcon build --packages-select ur3_moveit_config ur5_moveit_config ur10_moveit_config suction_test` was attempted but could not be run because `colcon` is not installed in this environment. 
- `ros2 launch suction_test demo.launch.py` was attempted but could not be run because `ros2` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe22d552c8331ab5185149f0812ea)