### PR TITLE
Fix ROS 2 Humble tuple parameter failure in suction_test launch

### DIFF
--- a/scenes/suction_test/launch/demo.launch.py
+++ b/scenes/suction_test/launch/demo.launch.py
@@ -73,6 +73,28 @@ def _normalize_ros_param_types(value):
     return value
 
 
+
+
+def _validate_no_empty_sequences(value, path="root"):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _validate_no_empty_sequences(item, f"{path}.{key}")
+        return
+
+    if isinstance(value, tuple):
+        if len(value) == 0:
+            raise TypeError(f"Empty tuple values are not allowed in ROS params at {path}")
+        for index, item in enumerate(value):
+            _validate_no_empty_sequences(item, f"{path}[{index}]")
+        return
+
+    if isinstance(value, list):
+        if len(value) == 0:
+            raise TypeError(f"Empty list values are not allowed in ROS params at {path}")
+        for index, item in enumerate(value):
+            _validate_no_empty_sequences(item, f"{path}[{index}]")
+
+
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -182,7 +204,6 @@ def _launch_setup(context):
     # Disable occupancy map sensor plugins to suppress octomap warnings.
     occupancy_map_monitor_params = {
         "octomap_resolution": 0.025,
-        "sensors": [],
     }
 
     # --- Nodes ---
@@ -211,6 +232,14 @@ def _launch_setup(context):
         _validate_ros_param_types(validated_occupancy_map_monitor_params, "occupancy_map_monitor_params")
         _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
         _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
+
+        _validate_no_empty_sequences(validated_planning_pipelines_config, "planning_pipelines_config")
+        _validate_no_empty_sequences(validated_ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+        _validate_no_empty_sequences(validated_planning_scene_monitor_params, "planning_scene_monitor_params")
+        _validate_no_empty_sequences(validated_occupancy_map_monitor_params, "occupancy_map_monitor_params")
+        _validate_no_empty_sequences(validated_trajectory_execution, "trajectory_execution")
+        _validate_no_empty_sequences(validated_moveit_controller_manager, "moveit_controller_manager")
+        _validate_no_empty_sequences(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
     except TypeError as exc:
         raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 


### PR DESCRIPTION
### Motivation
- ROS 2 Humble rejects empty tuple/list values when evaluating launch parameters and the scene launch crashed with `TypeError: Expected 'value' to be one of [float, int, str, bool, bytes], but got '()'` due to an empty `sensors` entry in `occupancy_map_monitor_params`.
- The intent is to keep MoveIt and related nodes intact while preventing empty sequences from being passed as ROS parameters.

### Description
- Removed the empty `"sensors": []` entry from `occupancy_map_monitor_params` and kept `"octomap_resolution": 0.025` in `scenes/suction_test/launch/demo.launch.py`.
- Added a `_validate_no_empty_sequences(value, path)` helper to reject empty lists/tuples in validated parameters.
- Wired `_validate_no_empty_sequences(...)` into the existing validation flow so validated parameter dicts are checked before being passed into `Node(parameters=[...])`.
- Preserved `validated_occupancy_map_monitor_params` in the `move_group` node parameter list and did not remove or modify MoveIt, RViz, `robot_state_publisher`, `joint_state_publisher`, or the fake controller config.

### Testing
- Ran `python -m py_compile scenes/suction_test/launch/demo.launch.py`, which succeeded.
- Ran `rg -n 'occupancy_map_monitor_params|"sensors"\s*:' scenes/suction_test/launch/demo.launch.py`, which confirmed the `sensors` entry was removed.
- Attempted `colcon build --symlink-install --packages-select suction_test`, which could not run in this environment because `colcon` is not available (failure/unavailable).
- Attempted `source /opt/ros/humble/setup.bash && ros2 launch --debug suction_test demo.launch.py`, which could not run in this environment because ROS 2 Humble is not installed (failure/unavailable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec9db3a4ac8331960ef2abd64ac1d3)