### PR TITLE
Fix ROS 2 Humble launch robustness: sanitize params, remove joint_state_publisher_gui, validate joint-state config

### DIFF
--- a/scenes/suction_test/launch/demo.launch.py
+++ b/scenes/suction_test/launch/demo.launch.py
@@ -75,26 +75,6 @@ def _normalize_ros_param_types(value):
 
 
 
-def _validate_no_empty_sequences(value, path="root"):
-    if isinstance(value, dict):
-        for key, item in value.items():
-            _validate_no_empty_sequences(item, f"{path}.{key}")
-        return
-
-    if isinstance(value, tuple):
-        if len(value) == 0:
-            raise TypeError(f"Empty tuple values are not allowed in ROS params at {path}")
-        for index, item in enumerate(value):
-            _validate_no_empty_sequences(item, f"{path}[{index}]")
-        return
-
-    if isinstance(value, list):
-        if len(value) == 0:
-            raise TypeError(f"Empty list values are not allowed in ROS params at {path}")
-        for index, item in enumerate(value):
-            _validate_no_empty_sequences(item, f"{path}[{index}]")
-
-
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -209,17 +189,17 @@ def _launch_setup(context):
     # --- Nodes ---
 
     try:
-        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
-        validated_robot_description = _normalize_ros_param_types(robot_description)
-        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
-        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
-        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
-        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
-        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
-        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
-        validated_occupancy_map_monitor_params = _normalize_ros_param_types(occupancy_map_monitor_params)
-        validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
-        validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
+        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
+        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
+        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
+        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
+        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
+        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
+        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
+        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
+        validated_occupancy_map_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(occupancy_map_monitor_params)) or {}
+        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
+        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")
@@ -232,14 +212,6 @@ def _launch_setup(context):
         _validate_ros_param_types(validated_occupancy_map_monitor_params, "occupancy_map_monitor_params")
         _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
         _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
-
-        _validate_no_empty_sequences(validated_planning_pipelines_config, "planning_pipelines_config")
-        _validate_no_empty_sequences(validated_ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
-        _validate_no_empty_sequences(validated_planning_scene_monitor_params, "planning_scene_monitor_params")
-        _validate_no_empty_sequences(validated_occupancy_map_monitor_params, "occupancy_map_monitor_params")
-        _validate_no_empty_sequences(validated_trajectory_execution, "trajectory_execution")
-        _validate_no_empty_sequences(validated_moveit_controller_manager, "moveit_controller_manager")
-        _validate_no_empty_sequences(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
     except TypeError as exc:
         raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 

--- a/scenes/ur10_2f_test/launch/demo.launch.py
+++ b/scenes/ur10_2f_test/launch/demo.launch.py
@@ -73,6 +73,31 @@ def _normalize_ros_param_types(value):
     return value
 
 
+
+
+def _sanitize_ros_param_types(value):
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, item in value.items():
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is None:
+                continue
+            sanitized[str(key)] = sanitized_item
+        return sanitized or None
+
+    if isinstance(value, tuple):
+        value = [_sanitize_ros_param_types(item) for item in value]
+        value = [item for item in value if item is not None]
+        return value or None
+
+    if isinstance(value, list):
+        value = [_sanitize_ros_param_types(item) for item in value]
+        value = [item for item in value if item is not None]
+        return value or None
+
+    return value
+
+
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -173,16 +198,16 @@ def _launch_setup(context):
     }
 
     try:
-        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
-        validated_robot_description = _normalize_ros_param_types(robot_description)
-        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
-        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
-        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
-        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
-        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
-        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
-        validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
-        validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
+        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
+        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
+        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
+        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
+        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
+        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
+        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
+        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
+        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
+        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")

--- a/scenes/ur3_suction_test/launch/demo.launch.py
+++ b/scenes/ur3_suction_test/launch/demo.launch.py
@@ -73,6 +73,31 @@ def _normalize_ros_param_types(value):
     return value
 
 
+
+
+def _sanitize_ros_param_types(value):
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, item in value.items():
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is None:
+                continue
+            sanitized[str(key)] = sanitized_item
+        return sanitized or None
+
+    if isinstance(value, tuple):
+        value = [_sanitize_ros_param_types(item) for item in value]
+        value = [item for item in value if item is not None]
+        return value or None
+
+    if isinstance(value, list):
+        value = [_sanitize_ros_param_types(item) for item in value]
+        value = [item for item in value if item is not None]
+        return value or None
+
+    return value
+
+
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -178,16 +203,16 @@ def _launch_setup(context):
     # --- Nodes ---
 
     try:
-        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
-        validated_robot_description = _normalize_ros_param_types(robot_description)
-        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
-        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
-        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
-        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
-        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
-        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
-        validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
-        validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
+        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
+        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
+        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
+        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
+        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
+        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
+        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
+        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
+        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
+        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -74,6 +74,31 @@ def _normalize_ros_param_types(value):
     return value
 
 
+
+
+def _sanitize_ros_param_types(value):
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, item in value.items():
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is None:
+                continue
+            sanitized[str(key)] = sanitized_item
+        return sanitized or None
+
+    if isinstance(value, tuple):
+        value = [_sanitize_ros_param_types(item) for item in value]
+        value = [item for item in value if item is not None]
+        return value or None
+
+    if isinstance(value, list):
+        value = [_sanitize_ros_param_types(item) for item in value]
+        value = [item for item in value if item is not None]
+        return value or None
+
+    return value
+
+
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -180,16 +205,16 @@ def _launch_setup(context):
     }
 
     try:
-        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
-        validated_robot_description = _normalize_ros_param_types(robot_description)
-        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
-        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
-        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
-        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
-        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
-        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
-        validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
-        validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
+        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
+        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
+        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
+        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
+        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
+        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
+        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
+        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
+        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
+        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -3,6 +3,7 @@
 import os
 import yaml
 import re
+import xml.etree.ElementTree as ET
 
 import subprocess
 
@@ -75,6 +76,31 @@ def _normalize_ros_param_types(value):
     return value
 
 
+
+
+def _sanitize_ros_param_types(value):
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, item in value.items():
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is None:
+                continue
+            sanitized[str(key)] = sanitized_item
+        return sanitized or None
+
+    if isinstance(value, tuple):
+        value = [_sanitize_ros_param_types(item) for item in value]
+        value = [item for item in value if item is not None]
+        return value or None
+
+    if isinstance(value, list):
+        value = [_sanitize_ros_param_types(item) for item in value]
+        value = [item for item in value if item is not None]
+        return value or None
+
+    return value
+
+
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -92,6 +118,31 @@ def _validate_ros_param_types(value, path="root"):
         return
 
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
+
+
+def _validate_joint_state_configuration(robot_description_config, controller_joints):
+    try:
+        urdf_root = ET.fromstring(robot_description_config)
+    except ET.ParseError as exc:
+        raise RuntimeError("Failed to parse robot_description while validating joint states") from exc
+
+    movable_joint_names = []
+    for joint in urdf_root.findall(".//joint"):
+        joint_name = joint.get("name")
+        joint_type = joint.get("type")
+        if not joint_name or joint_type in (None, "fixed"):
+            continue
+        movable_joint_names.append(joint_name)
+
+    if len(movable_joint_names) != len(set(movable_joint_names)):
+        raise RuntimeError("Duplicate movable joint names were found in robot_description")
+
+    missing = [joint for joint in controller_joints if joint not in set(movable_joint_names)]
+    if missing:
+        raise RuntimeError(
+            "Controller joints are not present in robot_description: "
+            + ", ".join(missing)
+        )
 
 
 def _launch_setup(context):
@@ -156,6 +207,10 @@ def _launch_setup(context):
             },
         }
     }
+    _validate_joint_state_configuration(
+        robot_description_config,
+        moveit_simple_controller_manager["moveit_simple_controller_manager"]["fake_ur5_controller"]["joints"],
+    )
 
     trajectory_execution = {
         "allow_trajectory_execution": False,
@@ -170,16 +225,16 @@ def _launch_setup(context):
     }
 
     try:
-        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
-        validated_robot_description = _normalize_ros_param_types(robot_description)
-        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
-        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
-        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
-        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
-        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
-        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
-        validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
-        validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
+        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
+        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
+        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
+        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
+        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
+        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
+        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
+        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
+        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
+        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -74,6 +74,31 @@ def _normalize_ros_param_types(value):
     return value
 
 
+
+
+def _sanitize_ros_param_types(value):
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, item in value.items():
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is None:
+                continue
+            sanitized[str(key)] = sanitized_item
+        return sanitized or None
+
+    if isinstance(value, tuple):
+        value = [_sanitize_ros_param_types(item) for item in value]
+        value = [item for item in value if item is not None]
+        return value or None
+
+    if isinstance(value, list):
+        value = [_sanitize_ros_param_types(item) for item in value]
+        value = [item for item in value if item is not None]
+        return value or None
+
+    return value
+
+
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -169,16 +194,16 @@ def _launch_setup(context):
     }
 
     try:
-        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
-        validated_robot_description = _normalize_ros_param_types(robot_description)
-        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
-        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
-        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
-        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
-        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
-        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
-        validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
-        validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
+        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
+        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
+        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
+        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
+        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
+        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
+        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
+        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
+        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
+        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")

--- a/workcell_builder/examples/ros2/launch/demo.launch.py
+++ b/workcell_builder/examples/ros2/launch/demo.launch.py
@@ -133,7 +133,6 @@ def _launch_setup(context):
     # No depth sensor is configured for this scene, so explicitly disable
     # occupancy map sensor plugins to avoid octomap updater errors.
     occupancy_map_monitor_params = {
-        "sensors": [],
     }
 
     static_tf = Node(

--- a/workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/launch/demo.launch.py
@@ -51,13 +51,6 @@ def generate_launch_description():
         condition=UnlessCondition(use_gui),
     )
 
-    joint_state_publisher_gui = Node(
-        package="joint_state_publisher_gui",
-        executable="joint_state_publisher_gui",
-        output="screen",
-        condition=IfCondition(use_gui),
-    )
-
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
@@ -98,7 +91,6 @@ def generate_launch_description():
                 ),
             ),
             joint_state_publisher,
-            joint_state_publisher_gui,
             robot_state_publisher,
             move_group,
             rviz,

--- a/workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/launch/demo.launch.py
@@ -51,13 +51,6 @@ def generate_launch_description():
         condition=UnlessCondition(use_gui),
     )
 
-    joint_state_publisher_gui = Node(
-        package="joint_state_publisher_gui",
-        executable="joint_state_publisher_gui",
-        output="screen",
-        condition=IfCondition(use_gui),
-    )
-
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
@@ -98,7 +91,6 @@ def generate_launch_description():
                 ),
             ),
             joint_state_publisher,
-            joint_state_publisher_gui,
             robot_state_publisher,
             move_group,
             rviz,

--- a/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/launch/demo.launch.py
@@ -51,13 +51,6 @@ def generate_launch_description():
         condition=UnlessCondition(use_gui),
     )
 
-    joint_state_publisher_gui = Node(
-        package="joint_state_publisher_gui",
-        executable="joint_state_publisher_gui",
-        output="screen",
-        condition=IfCondition(use_gui),
-    )
-
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
@@ -98,7 +91,6 @@ def generate_launch_description():
                 ),
             ),
             joint_state_publisher,
-            joint_state_publisher_gui,
             robot_state_publisher,
             move_group,
             rviz,

--- a/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/launch/demo.launch.py
@@ -51,13 +51,6 @@ def generate_launch_description():
         condition=UnlessCondition(use_gui),
     )
 
-    joint_state_publisher_gui = Node(
-        package="joint_state_publisher_gui",
-        executable="joint_state_publisher_gui",
-        output="screen",
-        condition=IfCondition(use_gui),
-    )
-
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
@@ -98,7 +91,6 @@ def generate_launch_description():
                 ),
             ),
             joint_state_publisher,
-            joint_state_publisher_gui,
             robot_state_publisher,
             move_group,
             rviz,

--- a/workcell_builder/workcell_builder/assets/robots/fanuc/fanuc_moveit_config/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/assets/robots/fanuc/fanuc_moveit_config/launch/demo.launch.py
@@ -76,13 +76,6 @@ def generate_launch_description():
         ],
     )
 
-    joint_state_publisher_gui = Node(
-        package="joint_state_publisher_gui",
-        executable="joint_state_publisher_gui",
-        output="screen",
-        condition=IfCondition(use_gui),
-    )
-
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
@@ -127,7 +120,6 @@ def generate_launch_description():
             DeclareLaunchArgument("use_rviz", default_value="true"),
             DeclareLaunchArgument("rviz_config", default_value=""),
             joint_state_publisher,
-            joint_state_publisher_gui,
             robot_state_publisher,
             move_group,
             rviz,

--- a/workcell_builder/workcell_builder/assets/robots/panda_robot/panda_moveit_config/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/assets/robots/panda_robot/panda_moveit_config/launch/demo.launch.py
@@ -95,13 +95,6 @@ def generate_launch_description():
         ],
     )
 
-    joint_state_publisher_gui = Node(
-        package="joint_state_publisher_gui",
-        executable="joint_state_publisher_gui",
-        output="screen",
-        condition=IfCondition(use_gui),
-    )
-
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
@@ -147,7 +140,6 @@ def generate_launch_description():
             DeclareLaunchArgument("use_rviz", default_value="true"),
             DeclareLaunchArgument("rviz_tutorial", default_value="false"),
             joint_state_publisher,
-            joint_state_publisher_gui,
             robot_state_publisher,
             move_group,
             rviz,

--- a/workcell_builder/workcell_builder/assets/robots/universal_robot/ur10_moveit_config/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/assets/robots/universal_robot/ur10_moveit_config/launch/demo.launch.py
@@ -87,13 +87,6 @@ def generate_launch_description():
         ],
     )
 
-    joint_state_publisher_gui = Node(
-        package="joint_state_publisher_gui",
-        executable="joint_state_publisher_gui",
-        output="screen",
-        condition=IfCondition(use_gui),
-    )
-
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
@@ -146,7 +139,6 @@ def generate_launch_description():
                 ),
             ),
             joint_state_publisher,
-            joint_state_publisher_gui,
             robot_state_publisher,
             move_group,
             rviz,

--- a/workcell_builder/workcell_builder/assets/robots/universal_robot/ur3_moveit_config/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/assets/robots/universal_robot/ur3_moveit_config/launch/demo.launch.py
@@ -87,13 +87,6 @@ def generate_launch_description():
         ],
     )
 
-    joint_state_publisher_gui = Node(
-        package="joint_state_publisher_gui",
-        executable="joint_state_publisher_gui",
-        output="screen",
-        condition=IfCondition(use_gui),
-    )
-
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
@@ -146,7 +139,6 @@ def generate_launch_description():
                 ),
             ),
             joint_state_publisher,
-            joint_state_publisher_gui,
             robot_state_publisher,
             move_group,
             rviz,

--- a/workcell_builder/workcell_builder/assets/robots/universal_robot/ur5_moveit_config/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/assets/robots/universal_robot/ur5_moveit_config/launch/demo.launch.py
@@ -87,13 +87,6 @@ def generate_launch_description():
         ],
     )
 
-    joint_state_publisher_gui = Node(
-        package="joint_state_publisher_gui",
-        executable="joint_state_publisher_gui",
-        output="screen",
-        condition=IfCondition(use_gui),
-    )
-
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
@@ -146,7 +139,6 @@ def generate_launch_description():
                 ),
             ),
             joint_state_publisher,
-            joint_state_publisher_gui,
             robot_state_publisher,
             move_group,
             rviz,

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -88,6 +88,31 @@ def _normalize_ros_param_types(value):
     return value
 
 
+
+
+def _sanitize_ros_param_types(value):
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, item in value.items():
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is None:
+                continue
+            sanitized[str(key)] = sanitized_item
+        return sanitized or None
+
+    if isinstance(value, tuple):
+        value = [_sanitize_ros_param_types(item) for item in value]
+        value = [item for item in value if item is not None]
+        return value or None
+
+    if isinstance(value, list):
+        value = [_sanitize_ros_param_types(item) for item in value]
+        value = [item for item in value if item is not None]
+        return value or None
+
+    return value
+
+
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -110,8 +135,8 @@ def _validate_ros_param_types(value, path="root"):
 def _extract_controller_joints(robot_description_semantic_config):
     try:
         srdf_root = ET.fromstring(robot_description_semantic_config)
-    except ET.ParseError:
-        return "arm", []
+    except ET.ParseError as exc:
+        raise RuntimeError("Failed to parse robot_description_semantic for controller joint extraction") from exc
 
     preferred_group_names = {"manipulator", "arm"}
     first_group_with_joints = None
@@ -131,7 +156,35 @@ def _extract_controller_joints(robot_description_semantic_config):
     if first_group_with_joints:
         return first_group_with_joints
 
-    return "arm", []
+    raise RuntimeError(
+        "No controller joints were found in robot_description_semantic. "
+        "Ensure the SRDF has a manipulator/arm group with explicit <joint> entries."
+    )
+
+
+def _validate_joint_state_configuration(robot_description_config, controller_joints):
+    try:
+        urdf_root = ET.fromstring(robot_description_config)
+    except ET.ParseError as exc:
+        raise RuntimeError("Failed to parse robot_description while validating joint states") from exc
+
+    movable_joint_names = []
+    for joint in urdf_root.findall(".//joint"):
+        joint_name = joint.get("name")
+        joint_type = joint.get("type")
+        if not joint_name or joint_type in (None, "fixed"):
+            continue
+        movable_joint_names.append(joint_name)
+
+    if len(movable_joint_names) != len(set(movable_joint_names)):
+        raise RuntimeError("Duplicate movable joint names were found in robot_description")
+
+    missing = [joint for joint in controller_joints if joint not in set(movable_joint_names)]
+    if missing:
+        raise RuntimeError(
+            "Controller joints are not present in robot_description: "
+            + ", ".join(missing)
+        )
 
 
 def _launch_setup(context):
@@ -181,6 +234,7 @@ def _launch_setup(context):
     controller_group_name, controller_joints = _extract_controller_joints(
         robot_description_semantic_config
     )
+    _validate_joint_state_configuration(robot_description_config, controller_joints)
     controller_name = f"fake_{controller_group_name}_controller"
 
     moveit_controller_manager = {
@@ -212,16 +266,16 @@ def _launch_setup(context):
     }
 
     try:
-        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
-        validated_robot_description = _normalize_ros_param_types(robot_description)
-        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
-        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
-        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
-        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
-        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
-        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
-        validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
-        validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
+        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
+        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
+        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
+        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
+        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
+        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
+        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
+        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
+        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
+        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")

--- a/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -88,6 +88,31 @@ def _normalize_ros_param_types(value):
     return value
 
 
+
+
+def _sanitize_ros_param_types(value):
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, item in value.items():
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is None:
+                continue
+            sanitized[str(key)] = sanitized_item
+        return sanitized or None
+
+    if isinstance(value, tuple):
+        value = [_sanitize_ros_param_types(item) for item in value]
+        value = [item for item in value if item is not None]
+        return value or None
+
+    if isinstance(value, list):
+        value = [_sanitize_ros_param_types(item) for item in value]
+        value = [item for item in value if item is not None]
+        return value or None
+
+    return value
+
+
 def _validate_ros_param_types(value, path="root"):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -110,8 +135,8 @@ def _validate_ros_param_types(value, path="root"):
 def _extract_controller_joints(robot_description_semantic_config):
     try:
         srdf_root = ET.fromstring(robot_description_semantic_config)
-    except ET.ParseError:
-        return "arm", []
+    except ET.ParseError as exc:
+        raise RuntimeError("Failed to parse robot_description_semantic for controller joint extraction") from exc
 
     preferred_group_names = {"manipulator", "arm"}
     first_group_with_joints = None
@@ -131,7 +156,35 @@ def _extract_controller_joints(robot_description_semantic_config):
     if first_group_with_joints:
         return first_group_with_joints
 
-    return "arm", []
+    raise RuntimeError(
+        "No controller joints were found in robot_description_semantic. "
+        "Ensure the SRDF has a manipulator/arm group with explicit <joint> entries."
+    )
+
+
+def _validate_joint_state_configuration(robot_description_config, controller_joints):
+    try:
+        urdf_root = ET.fromstring(robot_description_config)
+    except ET.ParseError as exc:
+        raise RuntimeError("Failed to parse robot_description while validating joint states") from exc
+
+    movable_joint_names = []
+    for joint in urdf_root.findall(".//joint"):
+        joint_name = joint.get("name")
+        joint_type = joint.get("type")
+        if not joint_name or joint_type in (None, "fixed"):
+            continue
+        movable_joint_names.append(joint_name)
+
+    if len(movable_joint_names) != len(set(movable_joint_names)):
+        raise RuntimeError("Duplicate movable joint names were found in robot_description")
+
+    missing = [joint for joint in controller_joints if joint not in set(movable_joint_names)]
+    if missing:
+        raise RuntimeError(
+            "Controller joints are not present in robot_description: "
+            + ", ".join(missing)
+        )
 
 
 def _launch_setup(context):
@@ -181,6 +234,7 @@ def _launch_setup(context):
     controller_group_name, controller_joints = _extract_controller_joints(
         robot_description_semantic_config
     )
+    _validate_joint_state_configuration(robot_description_config, controller_joints)
     controller_name = f"fake_{controller_group_name}_controller"
 
     moveit_controller_manager = {
@@ -212,16 +266,16 @@ def _launch_setup(context):
     }
 
     try:
-        validated_use_sim_time = _normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})
-        validated_robot_description = _normalize_ros_param_types(robot_description)
-        validated_robot_description_semantic = _normalize_ros_param_types(robot_description_semantic)
-        validated_robot_description_kinematics = _normalize_ros_param_types(robot_description_kinematics)
-        validated_planning_pipelines_config = _normalize_ros_param_types(planning_pipelines_config)
-        validated_ompl_planning_pipeline_config = _normalize_ros_param_types(ompl_planning_pipeline_config)
-        validated_planning_scene_monitor_params = _normalize_ros_param_types(planning_scene_monitor_params)
-        validated_trajectory_execution = _normalize_ros_param_types(trajectory_execution)
-        validated_moveit_controller_manager = _normalize_ros_param_types(moveit_controller_manager)
-        validated_moveit_simple_controller_manager = _normalize_ros_param_types(moveit_simple_controller_manager)
+        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
+        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
+        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
+        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
+        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
+        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
+        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
+        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
+        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
+        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")


### PR DESCRIPTION
### Motivation
- Prevent ROS 2 Humble launch failures caused by empty-list/tuple parameters and accidental use of `joint_state_publisher_gui`, and catch invalid controller/joint mismatches early. 
- Make workcell_builder templates generate safe demo launch files so newly created scenes do not reintroduce these issues.

### Description
- Added a recursive sanitizer helper `_sanitize_ros_param_types(...)` and used it before validation so empty dicts/lists/tuples are removed from values passed into `Node(parameters=[...])` (applied in all scene demos and templates). 
- Replaced any `joint_state_publisher_gui` usage with plain `joint_state_publisher` across `scenes/`, `workcell_builder/templates/`, `workcell_builder/examples/`, and assets so no GUI executable is referenced. 
- Hardened controller extraction logic to raise a clear `RuntimeError` when SRDF extraction finds no joints and added `_validate_joint_state_configuration(...)` to verify controller joints appear in the URDF (detects missing/duplicate joints) in templates and the `ur5_3f` scene. 
- Removed the explicit empty `"sensors": []` pattern from the example launch and removed now-redundant empty-sequence validators; preserved all core demo nodes (`static_transform_publisher`, `robot_state_publisher`, `joint_state_publisher`, `move_group`, `rviz2`) and fake-hardware args.

### Testing
- Ran static pattern checks which succeeded: `grep -RIn "joint_state_publisher_gui" scenes workcell_builder` returned no matches and `grep -RIn '"sensors": \[\]' scenes workcell_builder` returned no matches. 
- Verified syntax for modified launch scripts with `python -m py_compile` across updated scene, template, example and asset demo launch files and the check succeeded. 
- Attempted runtime `ros2 launch` smoke tests but they could not be executed in this environment because `/opt/ros/humble/setup.bash` is unavailable (so no live Humble launch verification was performed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca0e7dfb08331aedca45f1a67f7f0)