### PR TITLE
Fix Humble launch parameter sanitization and joint_state_publisher issues

### DIFF
--- a/scenes/suction_test/launch/demo.launch.py
+++ b/scenes/suction_test/launch/demo.launch.py
@@ -73,6 +73,51 @@ def _normalize_ros_param_types(value):
     return value
 
 
+_DROP_PARAM = object()
+
+
+def _sanitize_ros_param_types(value):
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, item in value.items():
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is _DROP_PARAM:
+                continue
+            sanitized[str(key)] = sanitized_item
+        return sanitized if sanitized else _DROP_PARAM
+
+    if isinstance(value, tuple):
+        value = list(value)
+
+    if isinstance(value, list):
+        sanitized_items = []
+        for item in value:
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is not _DROP_PARAM:
+                sanitized_items.append(sanitized_item)
+        return sanitized_items if sanitized_items else _DROP_PARAM
+
+    if isinstance(value, (bool, int, float, str, bytes)):
+        return value
+
+    return value
+
+
+def _param_dict(value):
+    sanitized = _sanitize_ros_param_types(value)
+    return {} if sanitized is _DROP_PARAM else sanitized
+
+
+def _param_list(*values):
+    result = []
+    for value in values:
+        sanitized = _sanitize_ros_param_types(value)
+        if sanitized is _DROP_PARAM:
+            continue
+        if isinstance(sanitized, dict) and not sanitized:
+            continue
+        result.append(sanitized)
+    return result
 
 
 def _validate_ros_param_types(value, path="root"):
@@ -88,7 +133,7 @@ def _validate_ros_param_types(value, path="root"):
             _validate_ros_param_types(item, f"{path}[{index}]")
         return
 
-    if isinstance(value, (bool, int, float, str)):
+    if isinstance(value, (bool, int, float, str, bytes)):
         return
 
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
@@ -189,17 +234,17 @@ def _launch_setup(context):
     # --- Nodes ---
 
     try:
-        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
-        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
-        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
-        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
-        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
-        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
-        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
-        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
-        validated_occupancy_map_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(occupancy_map_monitor_params)) or {}
-        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
-        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
+        validated_use_sim_time = _param_dict(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"}))
+        validated_robot_description = _param_dict(_normalize_ros_param_types(robot_description))
+        validated_robot_description_semantic = _param_dict(_normalize_ros_param_types(robot_description_semantic))
+        validated_robot_description_kinematics = _param_dict(_normalize_ros_param_types(robot_description_kinematics))
+        validated_planning_pipelines_config = _param_dict(_normalize_ros_param_types(planning_pipelines_config))
+        validated_ompl_planning_pipeline_config = _param_dict(_normalize_ros_param_types(ompl_planning_pipeline_config))
+        validated_planning_scene_monitor_params = _param_dict(_normalize_ros_param_types(planning_scene_monitor_params))
+        validated_trajectory_execution = _param_dict(_normalize_ros_param_types(trajectory_execution))
+        validated_occupancy_map_monitor_params = _param_dict(_normalize_ros_param_types(occupancy_map_monitor_params))
+        validated_moveit_controller_manager = _param_dict(_normalize_ros_param_types(moveit_controller_manager))
+        validated_moveit_simple_controller_manager = _param_dict(_normalize_ros_param_types(moveit_simple_controller_manager))
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")
@@ -232,7 +277,7 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     # IMPORTANT: pass robot_description as a parameter so it does NOT wait on a topic
@@ -240,14 +285,14 @@ def _launch_setup(context):
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     move_group = Node(
         package="moveit_ros_move_group",
         executable="move_group",
         output="screen",
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
@@ -259,7 +304,7 @@ def _launch_setup(context):
             validated_trajectory_execution,
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
-        ],
+        ),
     )
 
     rviz_config_file = os.path.join(get_package_share_directory(scene_pkg), "launch", "demo.rviz")
@@ -269,12 +314,12 @@ def _launch_setup(context):
         name="rviz2",
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
-        ],
+        ),
     )
 
     return [

--- a/scenes/ur10_2f_test/launch/demo.launch.py
+++ b/scenes/ur10_2f_test/launch/demo.launch.py
@@ -73,6 +73,7 @@ def _normalize_ros_param_types(value):
     return value
 
 
+_DROP_PARAM = object()
 
 
 def _sanitize_ros_param_types(value):
@@ -80,22 +81,43 @@ def _sanitize_ros_param_types(value):
         sanitized = {}
         for key, item in value.items():
             sanitized_item = _sanitize_ros_param_types(item)
-            if sanitized_item is None:
+            if sanitized_item is _DROP_PARAM:
                 continue
             sanitized[str(key)] = sanitized_item
-        return sanitized or None
+        return sanitized if sanitized else _DROP_PARAM
 
     if isinstance(value, tuple):
-        value = [_sanitize_ros_param_types(item) for item in value]
-        value = [item for item in value if item is not None]
-        return value or None
+        value = list(value)
 
     if isinstance(value, list):
-        value = [_sanitize_ros_param_types(item) for item in value]
-        value = [item for item in value if item is not None]
-        return value or None
+        sanitized_items = []
+        for item in value:
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is not _DROP_PARAM:
+                sanitized_items.append(sanitized_item)
+        return sanitized_items if sanitized_items else _DROP_PARAM
+
+    if isinstance(value, (bool, int, float, str, bytes)):
+        return value
 
     return value
+
+
+def _param_dict(value):
+    sanitized = _sanitize_ros_param_types(value)
+    return {} if sanitized is _DROP_PARAM else sanitized
+
+
+def _param_list(*values):
+    result = []
+    for value in values:
+        sanitized = _sanitize_ros_param_types(value)
+        if sanitized is _DROP_PARAM:
+            continue
+        if isinstance(sanitized, dict) and not sanitized:
+            continue
+        result.append(sanitized)
+    return result
 
 
 def _validate_ros_param_types(value, path="root"):
@@ -111,7 +133,7 @@ def _validate_ros_param_types(value, path="root"):
             _validate_ros_param_types(item, f"{path}[{index}]")
         return
 
-    if isinstance(value, (bool, int, float, str)):
+    if isinstance(value, (bool, int, float, str, bytes)):
         return
 
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
@@ -198,16 +220,16 @@ def _launch_setup(context):
     }
 
     try:
-        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
-        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
-        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
-        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
-        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
-        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
-        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
-        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
-        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
-        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
+        validated_use_sim_time = _param_dict(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"}))
+        validated_robot_description = _param_dict(_normalize_ros_param_types(robot_description))
+        validated_robot_description_semantic = _param_dict(_normalize_ros_param_types(robot_description_semantic))
+        validated_robot_description_kinematics = _param_dict(_normalize_ros_param_types(robot_description_kinematics))
+        validated_planning_pipelines_config = _param_dict(_normalize_ros_param_types(planning_pipelines_config))
+        validated_ompl_planning_pipeline_config = _param_dict(_normalize_ros_param_types(ompl_planning_pipeline_config))
+        validated_planning_scene_monitor_params = _param_dict(_normalize_ros_param_types(planning_scene_monitor_params))
+        validated_trajectory_execution = _param_dict(_normalize_ros_param_types(trajectory_execution))
+        validated_moveit_controller_manager = _param_dict(_normalize_ros_param_types(moveit_controller_manager))
+        validated_moveit_simple_controller_manager = _param_dict(_normalize_ros_param_types(moveit_simple_controller_manager))
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")
@@ -251,21 +273,21 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     move_group = Node(
         package="moveit_ros_move_group",
         executable="move_group",
         output="screen",
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
@@ -276,7 +298,7 @@ def _launch_setup(context):
             validated_trajectory_execution,
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
-        ],
+        ),
     )
 
     rviz_config_file = os.path.join(get_package_share_directory(scene_pkg), "launch", "demo.rviz")
@@ -286,12 +308,12 @@ def _launch_setup(context):
         name="rviz2",
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
-        ],
+        ),
     )
 
     return [

--- a/scenes/ur3_suction_test/launch/demo.launch.py
+++ b/scenes/ur3_suction_test/launch/demo.launch.py
@@ -73,6 +73,7 @@ def _normalize_ros_param_types(value):
     return value
 
 
+_DROP_PARAM = object()
 
 
 def _sanitize_ros_param_types(value):
@@ -80,22 +81,43 @@ def _sanitize_ros_param_types(value):
         sanitized = {}
         for key, item in value.items():
             sanitized_item = _sanitize_ros_param_types(item)
-            if sanitized_item is None:
+            if sanitized_item is _DROP_PARAM:
                 continue
             sanitized[str(key)] = sanitized_item
-        return sanitized or None
+        return sanitized if sanitized else _DROP_PARAM
 
     if isinstance(value, tuple):
-        value = [_sanitize_ros_param_types(item) for item in value]
-        value = [item for item in value if item is not None]
-        return value or None
+        value = list(value)
 
     if isinstance(value, list):
-        value = [_sanitize_ros_param_types(item) for item in value]
-        value = [item for item in value if item is not None]
-        return value or None
+        sanitized_items = []
+        for item in value:
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is not _DROP_PARAM:
+                sanitized_items.append(sanitized_item)
+        return sanitized_items if sanitized_items else _DROP_PARAM
+
+    if isinstance(value, (bool, int, float, str, bytes)):
+        return value
 
     return value
+
+
+def _param_dict(value):
+    sanitized = _sanitize_ros_param_types(value)
+    return {} if sanitized is _DROP_PARAM else sanitized
+
+
+def _param_list(*values):
+    result = []
+    for value in values:
+        sanitized = _sanitize_ros_param_types(value)
+        if sanitized is _DROP_PARAM:
+            continue
+        if isinstance(sanitized, dict) and not sanitized:
+            continue
+        result.append(sanitized)
+    return result
 
 
 def _validate_ros_param_types(value, path="root"):
@@ -111,7 +133,7 @@ def _validate_ros_param_types(value, path="root"):
             _validate_ros_param_types(item, f"{path}[{index}]")
         return
 
-    if isinstance(value, (bool, int, float, str)):
+    if isinstance(value, (bool, int, float, str, bytes)):
         return
 
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
@@ -203,16 +225,16 @@ def _launch_setup(context):
     # --- Nodes ---
 
     try:
-        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
-        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
-        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
-        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
-        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
-        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
-        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
-        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
-        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
-        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
+        validated_use_sim_time = _param_dict(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"}))
+        validated_robot_description = _param_dict(_normalize_ros_param_types(robot_description))
+        validated_robot_description_semantic = _param_dict(_normalize_ros_param_types(robot_description_semantic))
+        validated_robot_description_kinematics = _param_dict(_normalize_ros_param_types(robot_description_kinematics))
+        validated_planning_pipelines_config = _param_dict(_normalize_ros_param_types(planning_pipelines_config))
+        validated_ompl_planning_pipeline_config = _param_dict(_normalize_ros_param_types(ompl_planning_pipeline_config))
+        validated_planning_scene_monitor_params = _param_dict(_normalize_ros_param_types(planning_scene_monitor_params))
+        validated_trajectory_execution = _param_dict(_normalize_ros_param_types(trajectory_execution))
+        validated_moveit_controller_manager = _param_dict(_normalize_ros_param_types(moveit_controller_manager))
+        validated_moveit_simple_controller_manager = _param_dict(_normalize_ros_param_types(moveit_simple_controller_manager))
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")
@@ -244,21 +266,21 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     move_group = Node(
         package="moveit_ros_move_group",
         executable="move_group",
         output="screen",
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
@@ -269,7 +291,7 @@ def _launch_setup(context):
             validated_trajectory_execution,
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
-        ],
+        ),
     )
 
     rviz_config_file = os.path.join(get_package_share_directory(scene_pkg), "launch", "demo.rviz")
@@ -279,12 +301,12 @@ def _launch_setup(context):
         name="rviz2",
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
-        ],
+        ),
     )
 
     return [

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -74,6 +74,7 @@ def _normalize_ros_param_types(value):
     return value
 
 
+_DROP_PARAM = object()
 
 
 def _sanitize_ros_param_types(value):
@@ -81,22 +82,43 @@ def _sanitize_ros_param_types(value):
         sanitized = {}
         for key, item in value.items():
             sanitized_item = _sanitize_ros_param_types(item)
-            if sanitized_item is None:
+            if sanitized_item is _DROP_PARAM:
                 continue
             sanitized[str(key)] = sanitized_item
-        return sanitized or None
+        return sanitized if sanitized else _DROP_PARAM
 
     if isinstance(value, tuple):
-        value = [_sanitize_ros_param_types(item) for item in value]
-        value = [item for item in value if item is not None]
-        return value or None
+        value = list(value)
 
     if isinstance(value, list):
-        value = [_sanitize_ros_param_types(item) for item in value]
-        value = [item for item in value if item is not None]
-        return value or None
+        sanitized_items = []
+        for item in value:
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is not _DROP_PARAM:
+                sanitized_items.append(sanitized_item)
+        return sanitized_items if sanitized_items else _DROP_PARAM
+
+    if isinstance(value, (bool, int, float, str, bytes)):
+        return value
 
     return value
+
+
+def _param_dict(value):
+    sanitized = _sanitize_ros_param_types(value)
+    return {} if sanitized is _DROP_PARAM else sanitized
+
+
+def _param_list(*values):
+    result = []
+    for value in values:
+        sanitized = _sanitize_ros_param_types(value)
+        if sanitized is _DROP_PARAM:
+            continue
+        if isinstance(sanitized, dict) and not sanitized:
+            continue
+        result.append(sanitized)
+    return result
 
 
 def _validate_ros_param_types(value, path="root"):
@@ -112,7 +134,7 @@ def _validate_ros_param_types(value, path="root"):
             _validate_ros_param_types(item, f"{path}[{index}]")
         return
 
-    if isinstance(value, (bool, int, float, str)):
+    if isinstance(value, (bool, int, float, str, bytes)):
         return
 
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
@@ -205,16 +227,16 @@ def _launch_setup(context):
     }
 
     try:
-        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
-        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
-        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
-        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
-        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
-        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
-        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
-        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
-        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
-        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
+        validated_use_sim_time = _param_dict(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"}))
+        validated_robot_description = _param_dict(_normalize_ros_param_types(robot_description))
+        validated_robot_description_semantic = _param_dict(_normalize_ros_param_types(robot_description_semantic))
+        validated_robot_description_kinematics = _param_dict(_normalize_ros_param_types(robot_description_kinematics))
+        validated_planning_pipelines_config = _param_dict(_normalize_ros_param_types(planning_pipelines_config))
+        validated_ompl_planning_pipeline_config = _param_dict(_normalize_ros_param_types(ompl_planning_pipeline_config))
+        validated_planning_scene_monitor_params = _param_dict(_normalize_ros_param_types(planning_scene_monitor_params))
+        validated_trajectory_execution = _param_dict(_normalize_ros_param_types(trajectory_execution))
+        validated_moveit_controller_manager = _param_dict(_normalize_ros_param_types(moveit_controller_manager))
+        validated_moveit_simple_controller_manager = _param_dict(_normalize_ros_param_types(moveit_simple_controller_manager))
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")
@@ -258,21 +280,21 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     move_group = Node(
         package="moveit_ros_move_group",
         executable="move_group",
         output="screen",
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
@@ -283,7 +305,7 @@ def _launch_setup(context):
             validated_trajectory_execution,
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
-        ],
+        ),
     )
 
     rviz_config_file = os.path.join(get_package_share_directory(scene_pkg), "launch", "demo.rviz")
@@ -293,12 +315,12 @@ def _launch_setup(context):
         name="rviz2",
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
-        ],
+        ),
     )
 
     return [

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -76,6 +76,7 @@ def _normalize_ros_param_types(value):
     return value
 
 
+_DROP_PARAM = object()
 
 
 def _sanitize_ros_param_types(value):
@@ -83,22 +84,43 @@ def _sanitize_ros_param_types(value):
         sanitized = {}
         for key, item in value.items():
             sanitized_item = _sanitize_ros_param_types(item)
-            if sanitized_item is None:
+            if sanitized_item is _DROP_PARAM:
                 continue
             sanitized[str(key)] = sanitized_item
-        return sanitized or None
+        return sanitized if sanitized else _DROP_PARAM
 
     if isinstance(value, tuple):
-        value = [_sanitize_ros_param_types(item) for item in value]
-        value = [item for item in value if item is not None]
-        return value or None
+        value = list(value)
 
     if isinstance(value, list):
-        value = [_sanitize_ros_param_types(item) for item in value]
-        value = [item for item in value if item is not None]
-        return value or None
+        sanitized_items = []
+        for item in value:
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is not _DROP_PARAM:
+                sanitized_items.append(sanitized_item)
+        return sanitized_items if sanitized_items else _DROP_PARAM
+
+    if isinstance(value, (bool, int, float, str, bytes)):
+        return value
 
     return value
+
+
+def _param_dict(value):
+    sanitized = _sanitize_ros_param_types(value)
+    return {} if sanitized is _DROP_PARAM else sanitized
+
+
+def _param_list(*values):
+    result = []
+    for value in values:
+        sanitized = _sanitize_ros_param_types(value)
+        if sanitized is _DROP_PARAM:
+            continue
+        if isinstance(sanitized, dict) and not sanitized:
+            continue
+        result.append(sanitized)
+    return result
 
 
 def _validate_ros_param_types(value, path="root"):
@@ -114,7 +136,7 @@ def _validate_ros_param_types(value, path="root"):
             _validate_ros_param_types(item, f"{path}[{index}]")
         return
 
-    if isinstance(value, (bool, int, float, str)):
+    if isinstance(value, (bool, int, float, str, bytes)):
         return
 
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
@@ -143,6 +165,35 @@ def _validate_joint_state_configuration(robot_description_config, controller_joi
             "Controller joints are not present in robot_description: "
             + ", ".join(missing)
         )
+
+
+def _extract_dependent_joints(robot_description_config):
+    try:
+        urdf_root = ET.fromstring(robot_description_config)
+    except ET.ParseError as exc:
+        raise RuntimeError("Failed to parse robot_description while extracting mimic joints") from exc
+
+    dependent_joints = {}
+    for joint in urdf_root.findall(".//joint"):
+        joint_name = joint.get("name")
+        mimic = joint.find("mimic")
+        if not joint_name or mimic is None:
+            continue
+
+        mimic_joint = mimic.get("joint")
+        if not mimic_joint:
+            continue
+
+        dependent_joint = {"parent": mimic_joint}
+        multiplier = mimic.get("multiplier")
+        offset = mimic.get("offset")
+        if multiplier is not None:
+            dependent_joint["factor"] = float(multiplier)
+        if offset is not None:
+            dependent_joint["offset"] = float(offset)
+        dependent_joints[joint_name] = dependent_joint
+
+    return {"dependent_joints": dependent_joints}
 
 
 def _launch_setup(context):
@@ -211,6 +262,7 @@ def _launch_setup(context):
         robot_description_config,
         moveit_simple_controller_manager["moveit_simple_controller_manager"]["fake_ur5_controller"]["joints"],
     )
+    joint_state_dependent_joints = _extract_dependent_joints(robot_description_config)
 
     trajectory_execution = {
         "allow_trajectory_execution": False,
@@ -225,16 +277,17 @@ def _launch_setup(context):
     }
 
     try:
-        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
-        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
-        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
-        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
-        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
-        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
-        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
-        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
-        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
-        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
+        validated_use_sim_time = _param_dict(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"}))
+        validated_robot_description = _param_dict(_normalize_ros_param_types(robot_description))
+        validated_robot_description_semantic = _param_dict(_normalize_ros_param_types(robot_description_semantic))
+        validated_robot_description_kinematics = _param_dict(_normalize_ros_param_types(robot_description_kinematics))
+        validated_planning_pipelines_config = _param_dict(_normalize_ros_param_types(planning_pipelines_config))
+        validated_ompl_planning_pipeline_config = _param_dict(_normalize_ros_param_types(ompl_planning_pipeline_config))
+        validated_planning_scene_monitor_params = _param_dict(_normalize_ros_param_types(planning_scene_monitor_params))
+        validated_trajectory_execution = _param_dict(_normalize_ros_param_types(trajectory_execution))
+        validated_moveit_controller_manager = _param_dict(_normalize_ros_param_types(moveit_controller_manager))
+        validated_moveit_simple_controller_manager = _param_dict(_normalize_ros_param_types(moveit_simple_controller_manager))
+        validated_joint_state_dependent_joints = _param_dict(_normalize_ros_param_types(joint_state_dependent_joints))
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")
@@ -246,6 +299,7 @@ def _launch_setup(context):
         _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
         _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
         _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
+        _validate_ros_param_types(validated_joint_state_dependent_joints, "joint_state_dependent_joints")
     except TypeError as exc:
         raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 
@@ -278,21 +332,25 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_joint_state_dependent_joints,
+        ),
     )
 
     move_group = Node(
         package="moveit_ros_move_group",
         executable="move_group",
         output="screen",
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
@@ -303,7 +361,7 @@ def _launch_setup(context):
             validated_trajectory_execution,
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
-        ],
+        ),
     )
 
     rviz_config_file = os.path.join(get_package_share_directory(scene_pkg), "launch", "demo.rviz")
@@ -313,12 +371,12 @@ def _launch_setup(context):
         name="rviz2",
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
-        ],
+        ),
     )
 
     return [

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -74,6 +74,7 @@ def _normalize_ros_param_types(value):
     return value
 
 
+_DROP_PARAM = object()
 
 
 def _sanitize_ros_param_types(value):
@@ -81,22 +82,43 @@ def _sanitize_ros_param_types(value):
         sanitized = {}
         for key, item in value.items():
             sanitized_item = _sanitize_ros_param_types(item)
-            if sanitized_item is None:
+            if sanitized_item is _DROP_PARAM:
                 continue
             sanitized[str(key)] = sanitized_item
-        return sanitized or None
+        return sanitized if sanitized else _DROP_PARAM
 
     if isinstance(value, tuple):
-        value = [_sanitize_ros_param_types(item) for item in value]
-        value = [item for item in value if item is not None]
-        return value or None
+        value = list(value)
 
     if isinstance(value, list):
-        value = [_sanitize_ros_param_types(item) for item in value]
-        value = [item for item in value if item is not None]
-        return value or None
+        sanitized_items = []
+        for item in value:
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is not _DROP_PARAM:
+                sanitized_items.append(sanitized_item)
+        return sanitized_items if sanitized_items else _DROP_PARAM
+
+    if isinstance(value, (bool, int, float, str, bytes)):
+        return value
 
     return value
+
+
+def _param_dict(value):
+    sanitized = _sanitize_ros_param_types(value)
+    return {} if sanitized is _DROP_PARAM else sanitized
+
+
+def _param_list(*values):
+    result = []
+    for value in values:
+        sanitized = _sanitize_ros_param_types(value)
+        if sanitized is _DROP_PARAM:
+            continue
+        if isinstance(sanitized, dict) and not sanitized:
+            continue
+        result.append(sanitized)
+    return result
 
 
 def _validate_ros_param_types(value, path="root"):
@@ -112,7 +134,7 @@ def _validate_ros_param_types(value, path="root"):
             _validate_ros_param_types(item, f"{path}[{index}]")
         return
 
-    if isinstance(value, (bool, int, float, str)):
+    if isinstance(value, (bool, int, float, str, bytes)):
         return
 
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
@@ -194,16 +216,16 @@ def _launch_setup(context):
     }
 
     try:
-        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
-        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
-        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
-        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
-        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
-        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
-        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
-        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
-        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
-        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
+        validated_use_sim_time = _param_dict(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"}))
+        validated_robot_description = _param_dict(_normalize_ros_param_types(robot_description))
+        validated_robot_description_semantic = _param_dict(_normalize_ros_param_types(robot_description_semantic))
+        validated_robot_description_kinematics = _param_dict(_normalize_ros_param_types(robot_description_kinematics))
+        validated_planning_pipelines_config = _param_dict(_normalize_ros_param_types(planning_pipelines_config))
+        validated_ompl_planning_pipeline_config = _param_dict(_normalize_ros_param_types(ompl_planning_pipeline_config))
+        validated_planning_scene_monitor_params = _param_dict(_normalize_ros_param_types(planning_scene_monitor_params))
+        validated_trajectory_execution = _param_dict(_normalize_ros_param_types(trajectory_execution))
+        validated_moveit_controller_manager = _param_dict(_normalize_ros_param_types(moveit_controller_manager))
+        validated_moveit_simple_controller_manager = _param_dict(_normalize_ros_param_types(moveit_simple_controller_manager))
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")
@@ -247,21 +269,21 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     move_group = Node(
         package="moveit_ros_move_group",
         executable="move_group",
         output="screen",
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
@@ -272,7 +294,7 @@ def _launch_setup(context):
             validated_trajectory_execution,
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
-        ],
+        ),
     )
 
     rviz_config_file = os.path.join(get_package_share_directory(scene_pkg), "launch", "demo.rviz")
@@ -282,12 +304,12 @@ def _launch_setup(context):
         name="rviz2",
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
-        ],
+        ),
     )
 
     return [

--- a/workcell_builder/examples/ros2/launch/demo.launch.py
+++ b/workcell_builder/examples/ros2/launch/demo.launch.py
@@ -74,6 +74,85 @@ def load_yaml(package_name, rel_path):
         return yaml.safe_load(file) or {}
 
 
+def _normalize_ros_param_types(value):
+    if isinstance(value, dict):
+        return {str(key): _normalize_ros_param_types(item) for key, item in value.items()}
+
+    if isinstance(value, tuple):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    if isinstance(value, list):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    return value
+
+
+_DROP_PARAM = object()
+
+
+def _sanitize_ros_param_types(value):
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, item in value.items():
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is _DROP_PARAM:
+                continue
+            sanitized[str(key)] = sanitized_item
+        return sanitized if sanitized else _DROP_PARAM
+
+    if isinstance(value, tuple):
+        value = list(value)
+
+    if isinstance(value, list):
+        sanitized_items = []
+        for item in value:
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is not _DROP_PARAM:
+                sanitized_items.append(sanitized_item)
+        return sanitized_items if sanitized_items else _DROP_PARAM
+
+    if isinstance(value, (bool, int, float, str, bytes)):
+        return value
+
+    return value
+
+
+def _param_dict(value):
+    sanitized = _sanitize_ros_param_types(value)
+    return {} if sanitized is _DROP_PARAM else sanitized
+
+
+def _param_list(*values):
+    result = []
+    for value in values:
+        sanitized = _sanitize_ros_param_types(value)
+        if sanitized is _DROP_PARAM:
+            continue
+        if isinstance(sanitized, dict) and not sanitized:
+            continue
+        result.append(sanitized)
+    return result
+
+
+def _validate_ros_param_types(value, path="root"):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"Invalid ROS param type at {path}: {type(key).__name__} -> {key!r}")
+            _validate_ros_param_types(item, f"{path}.{key}")
+        return
+
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_ros_param_types(item, f"{path}[{index}]")
+        return
+
+    if isinstance(value, (bool, int, float, str, bytes)):
+        return
+
+    raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -135,6 +214,29 @@ def _launch_setup(context):
     occupancy_map_monitor_params = {
     }
 
+    try:
+        validated_use_sim_time = _param_dict(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"}))
+        validated_robot_description = _param_dict(_normalize_ros_param_types(robot_description))
+        validated_robot_description_semantic = _param_dict(_normalize_ros_param_types(robot_description_semantic))
+        validated_robot_description_kinematics = _param_dict(_normalize_ros_param_types(robot_description_kinematics))
+        validated_planning_pipelines_config = _param_dict(_normalize_ros_param_types(planning_pipelines_config))
+        validated_ompl_planning_pipeline_config = _param_dict(_normalize_ros_param_types(ompl_planning_pipeline_config))
+        validated_planning_scene_monitor_params = _param_dict(_normalize_ros_param_types(planning_scene_monitor_params))
+        validated_trajectory_execution = _param_dict(_normalize_ros_param_types(trajectory_execution))
+        validated_occupancy_map_monitor_params = _param_dict(_normalize_ros_param_types(occupancy_map_monitor_params))
+
+        _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
+        _validate_ros_param_types(validated_robot_description, "robot_description")
+        _validate_ros_param_types(validated_robot_description_semantic, "robot_description_semantic")
+        _validate_ros_param_types(validated_robot_description_kinematics, "robot_description_kinematics")
+        _validate_ros_param_types(validated_planning_pipelines_config, "planning_pipelines_config")
+        _validate_ros_param_types(validated_ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+        _validate_ros_param_types(validated_planning_scene_monitor_params, "planning_scene_monitor_params")
+        _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
+        _validate_ros_param_types(validated_occupancy_map_monitor_params, "occupancy_map_monitor_params")
+    except TypeError as exc:
+        raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
+
     static_tf = Node(
         package="tf2_ros",
         executable="static_transform_publisher",
@@ -156,31 +258,31 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     move_group = Node(
         package="moveit_ros_move_group",
         executable="move_group",
         output="screen",
-        parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
-            planning_pipelines_config,
-            ompl_planning_pipeline_config,
-            planning_scene_monitor_params,
-            occupancy_map_monitor_params,
-            trajectory_execution,
-        ],
+        parameters=_param_list(
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
+            validated_planning_pipelines_config,
+            validated_ompl_planning_pipeline_config,
+            validated_planning_scene_monitor_params,
+            validated_occupancy_map_monitor_params,
+            validated_trajectory_execution,
+        ),
     )
 
     rviz_config_file = os.path.join(
@@ -192,12 +294,12 @@ def _launch_setup(context):
         name="rviz2",
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
-        parameters=[
-            {"use_sim_time": use_sim_time},
-            robot_description,
-            robot_description_semantic,
-            robot_description_kinematics,
-        ],
+        parameters=_param_list(
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
+        ),
     )
 
     return [

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -88,6 +88,7 @@ def _normalize_ros_param_types(value):
     return value
 
 
+_DROP_PARAM = object()
 
 
 def _sanitize_ros_param_types(value):
@@ -95,22 +96,43 @@ def _sanitize_ros_param_types(value):
         sanitized = {}
         for key, item in value.items():
             sanitized_item = _sanitize_ros_param_types(item)
-            if sanitized_item is None:
+            if sanitized_item is _DROP_PARAM:
                 continue
             sanitized[str(key)] = sanitized_item
-        return sanitized or None
+        return sanitized if sanitized else _DROP_PARAM
 
     if isinstance(value, tuple):
-        value = [_sanitize_ros_param_types(item) for item in value]
-        value = [item for item in value if item is not None]
-        return value or None
+        value = list(value)
 
     if isinstance(value, list):
-        value = [_sanitize_ros_param_types(item) for item in value]
-        value = [item for item in value if item is not None]
-        return value or None
+        sanitized_items = []
+        for item in value:
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is not _DROP_PARAM:
+                sanitized_items.append(sanitized_item)
+        return sanitized_items if sanitized_items else _DROP_PARAM
+
+    if isinstance(value, (bool, int, float, str, bytes)):
+        return value
 
     return value
+
+
+def _param_dict(value):
+    sanitized = _sanitize_ros_param_types(value)
+    return {} if sanitized is _DROP_PARAM else sanitized
+
+
+def _param_list(*values):
+    result = []
+    for value in values:
+        sanitized = _sanitize_ros_param_types(value)
+        if sanitized is _DROP_PARAM:
+            continue
+        if isinstance(sanitized, dict) and not sanitized:
+            continue
+        result.append(sanitized)
+    return result
 
 
 def _validate_ros_param_types(value, path="root"):
@@ -126,7 +148,7 @@ def _validate_ros_param_types(value, path="root"):
             _validate_ros_param_types(item, f"{path}[{index}]")
         return
 
-    if isinstance(value, (bool, int, float, str)):
+    if isinstance(value, (bool, int, float, str, bytes)):
         return
 
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
@@ -187,6 +209,35 @@ def _validate_joint_state_configuration(robot_description_config, controller_joi
         )
 
 
+def _extract_dependent_joints(robot_description_config):
+    try:
+        urdf_root = ET.fromstring(robot_description_config)
+    except ET.ParseError as exc:
+        raise RuntimeError("Failed to parse robot_description while extracting mimic joints") from exc
+
+    dependent_joints = {}
+    for joint in urdf_root.findall(".//joint"):
+        joint_name = joint.get("name")
+        mimic = joint.find("mimic")
+        if not joint_name or mimic is None:
+            continue
+
+        mimic_joint = mimic.get("joint")
+        if not mimic_joint:
+            continue
+
+        dependent_joint = {"parent": mimic_joint}
+        multiplier = mimic.get("multiplier")
+        offset = mimic.get("offset")
+        if multiplier is not None:
+            dependent_joint["factor"] = float(multiplier)
+        if offset is not None:
+            dependent_joint["offset"] = float(offset)
+        dependent_joints[joint_name] = dependent_joint
+
+    return {"dependent_joints": dependent_joints}
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -234,7 +285,13 @@ def _launch_setup(context):
     controller_group_name, controller_joints = _extract_controller_joints(
         robot_description_semantic_config
     )
+    if not controller_joints:
+        raise RuntimeError(
+            "No joints were found in the selected SRDF group. "
+            "The generated fake controller cannot be created with an empty joints list."
+        )
     _validate_joint_state_configuration(robot_description_config, controller_joints)
+    joint_state_dependent_joints = _extract_dependent_joints(robot_description_config)
     controller_name = f"fake_{controller_group_name}_controller"
 
     moveit_controller_manager = {
@@ -266,16 +323,17 @@ def _launch_setup(context):
     }
 
     try:
-        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
-        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
-        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
-        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
-        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
-        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
-        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
-        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
-        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
-        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
+        validated_use_sim_time = _param_dict(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"}))
+        validated_robot_description = _param_dict(_normalize_ros_param_types(robot_description))
+        validated_robot_description_semantic = _param_dict(_normalize_ros_param_types(robot_description_semantic))
+        validated_robot_description_kinematics = _param_dict(_normalize_ros_param_types(robot_description_kinematics))
+        validated_planning_pipelines_config = _param_dict(_normalize_ros_param_types(planning_pipelines_config))
+        validated_ompl_planning_pipeline_config = _param_dict(_normalize_ros_param_types(ompl_planning_pipeline_config))
+        validated_planning_scene_monitor_params = _param_dict(_normalize_ros_param_types(planning_scene_monitor_params))
+        validated_trajectory_execution = _param_dict(_normalize_ros_param_types(trajectory_execution))
+        validated_moveit_controller_manager = _param_dict(_normalize_ros_param_types(moveit_controller_manager))
+        validated_moveit_simple_controller_manager = _param_dict(_normalize_ros_param_types(moveit_simple_controller_manager))
+        validated_joint_state_dependent_joints = _param_dict(_normalize_ros_param_types(joint_state_dependent_joints))
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")
@@ -287,6 +345,7 @@ def _launch_setup(context):
         _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
         _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
         _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
+        _validate_ros_param_types(validated_joint_state_dependent_joints, "joint_state_dependent_joints")
     except TypeError as exc:
         raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 
@@ -311,21 +370,25 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_joint_state_dependent_joints,
+        ),
     )
 
     move_group = Node(
         package="moveit_ros_move_group",
         executable="move_group",
         output="screen",
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
@@ -336,7 +399,7 @@ def _launch_setup(context):
             validated_trajectory_execution,
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
-        ],
+        ),
     )
 
     rviz_config_file = os.path.join(
@@ -348,12 +411,12 @@ def _launch_setup(context):
         name="rviz2",
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
-        ],
+        ),
     )
 
     return [

--- a/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -88,6 +88,7 @@ def _normalize_ros_param_types(value):
     return value
 
 
+_DROP_PARAM = object()
 
 
 def _sanitize_ros_param_types(value):
@@ -95,22 +96,43 @@ def _sanitize_ros_param_types(value):
         sanitized = {}
         for key, item in value.items():
             sanitized_item = _sanitize_ros_param_types(item)
-            if sanitized_item is None:
+            if sanitized_item is _DROP_PARAM:
                 continue
             sanitized[str(key)] = sanitized_item
-        return sanitized or None
+        return sanitized if sanitized else _DROP_PARAM
 
     if isinstance(value, tuple):
-        value = [_sanitize_ros_param_types(item) for item in value]
-        value = [item for item in value if item is not None]
-        return value or None
+        value = list(value)
 
     if isinstance(value, list):
-        value = [_sanitize_ros_param_types(item) for item in value]
-        value = [item for item in value if item is not None]
-        return value or None
+        sanitized_items = []
+        for item in value:
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is not _DROP_PARAM:
+                sanitized_items.append(sanitized_item)
+        return sanitized_items if sanitized_items else _DROP_PARAM
+
+    if isinstance(value, (bool, int, float, str, bytes)):
+        return value
 
     return value
+
+
+def _param_dict(value):
+    sanitized = _sanitize_ros_param_types(value)
+    return {} if sanitized is _DROP_PARAM else sanitized
+
+
+def _param_list(*values):
+    result = []
+    for value in values:
+        sanitized = _sanitize_ros_param_types(value)
+        if sanitized is _DROP_PARAM:
+            continue
+        if isinstance(sanitized, dict) and not sanitized:
+            continue
+        result.append(sanitized)
+    return result
 
 
 def _validate_ros_param_types(value, path="root"):
@@ -126,7 +148,7 @@ def _validate_ros_param_types(value, path="root"):
             _validate_ros_param_types(item, f"{path}[{index}]")
         return
 
-    if isinstance(value, (bool, int, float, str)):
+    if isinstance(value, (bool, int, float, str, bytes)):
         return
 
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
@@ -187,6 +209,35 @@ def _validate_joint_state_configuration(robot_description_config, controller_joi
         )
 
 
+def _extract_dependent_joints(robot_description_config):
+    try:
+        urdf_root = ET.fromstring(robot_description_config)
+    except ET.ParseError as exc:
+        raise RuntimeError("Failed to parse robot_description while extracting mimic joints") from exc
+
+    dependent_joints = {}
+    for joint in urdf_root.findall(".//joint"):
+        joint_name = joint.get("name")
+        mimic = joint.find("mimic")
+        if not joint_name or mimic is None:
+            continue
+
+        mimic_joint = mimic.get("joint")
+        if not mimic_joint:
+            continue
+
+        dependent_joint = {"parent": mimic_joint}
+        multiplier = mimic.get("multiplier")
+        offset = mimic.get("offset")
+        if multiplier is not None:
+            dependent_joint["factor"] = float(multiplier)
+        if offset is not None:
+            dependent_joint["offset"] = float(offset)
+        dependent_joints[joint_name] = dependent_joint
+
+    return {"dependent_joints": dependent_joints}
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -234,7 +285,13 @@ def _launch_setup(context):
     controller_group_name, controller_joints = _extract_controller_joints(
         robot_description_semantic_config
     )
+    if not controller_joints:
+        raise RuntimeError(
+            "No joints were found in the selected SRDF group. "
+            "The generated fake controller cannot be created with an empty joints list."
+        )
     _validate_joint_state_configuration(robot_description_config, controller_joints)
+    joint_state_dependent_joints = _extract_dependent_joints(robot_description_config)
     controller_name = f"fake_{controller_group_name}_controller"
 
     moveit_controller_manager = {
@@ -266,16 +323,17 @@ def _launch_setup(context):
     }
 
     try:
-        validated_use_sim_time = _sanitize_ros_param_types(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"})) or {}
-        validated_robot_description = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description)) or {}
-        validated_robot_description_semantic = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_semantic)) or {}
-        validated_robot_description_kinematics = _sanitize_ros_param_types(_normalize_ros_param_types(robot_description_kinematics)) or {}
-        validated_planning_pipelines_config = _sanitize_ros_param_types(_normalize_ros_param_types(planning_pipelines_config)) or {}
-        validated_ompl_planning_pipeline_config = _sanitize_ros_param_types(_normalize_ros_param_types(ompl_planning_pipeline_config)) or {}
-        validated_planning_scene_monitor_params = _sanitize_ros_param_types(_normalize_ros_param_types(planning_scene_monitor_params)) or {}
-        validated_trajectory_execution = _sanitize_ros_param_types(_normalize_ros_param_types(trajectory_execution)) or {}
-        validated_moveit_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_controller_manager)) or {}
-        validated_moveit_simple_controller_manager = _sanitize_ros_param_types(_normalize_ros_param_types(moveit_simple_controller_manager)) or {}
+        validated_use_sim_time = _param_dict(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"}))
+        validated_robot_description = _param_dict(_normalize_ros_param_types(robot_description))
+        validated_robot_description_semantic = _param_dict(_normalize_ros_param_types(robot_description_semantic))
+        validated_robot_description_kinematics = _param_dict(_normalize_ros_param_types(robot_description_kinematics))
+        validated_planning_pipelines_config = _param_dict(_normalize_ros_param_types(planning_pipelines_config))
+        validated_ompl_planning_pipeline_config = _param_dict(_normalize_ros_param_types(ompl_planning_pipeline_config))
+        validated_planning_scene_monitor_params = _param_dict(_normalize_ros_param_types(planning_scene_monitor_params))
+        validated_trajectory_execution = _param_dict(_normalize_ros_param_types(trajectory_execution))
+        validated_moveit_controller_manager = _param_dict(_normalize_ros_param_types(moveit_controller_manager))
+        validated_moveit_simple_controller_manager = _param_dict(_normalize_ros_param_types(moveit_simple_controller_manager))
+        validated_joint_state_dependent_joints = _param_dict(_normalize_ros_param_types(joint_state_dependent_joints))
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")
@@ -287,6 +345,7 @@ def _launch_setup(context):
         _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
         _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
         _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
+        _validate_ros_param_types(validated_joint_state_dependent_joints, "joint_state_dependent_joints")
     except TypeError as exc:
         raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 
@@ -311,21 +370,25 @@ def _launch_setup(context):
         package="robot_state_publisher",
         executable="robot_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=[validated_use_sim_time, validated_robot_description],
+        parameters=_param_list(
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_joint_state_dependent_joints,
+        ),
     )
 
     move_group = Node(
         package="moveit_ros_move_group",
         executable="move_group",
         output="screen",
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
@@ -336,7 +399,7 @@ def _launch_setup(context):
             validated_trajectory_execution,
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
-        ],
+        ),
     )
 
     rviz_config_file = os.path.join(
@@ -348,12 +411,12 @@ def _launch_setup(context):
         name="rviz2",
         output="screen",
         arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
-        parameters=[
+        parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
-        ],
+        ),
     )
 
     return [


### PR DESCRIPTION
### Motivation
- Launch files were calling a missing `_sanitize_ros_param_types()` helper which caused `suction_test` to fail at startup. 
- ROS 2 Humble rejects empty parameter lists/tuples passed to `Node(parameters=[...])`, requiring robust sanitization and removal of empty collections. 
- `ur5_3f_test` published malformed `/joint_states` due to mimic/dependent joints not being represented in the `joint_state_publisher` configuration. 
- Workcell-builder templates needed the same fixes so future generated scenes are Humble-safe and do not silently create empty controllers.

### Description
- Restored and replaced the sanitizer flow in all scene launch files and ROS2 templates by adding `_DROP_PARAM`, `_sanitize_ros_param_types`, `_param_dict`, and `_param_list` helpers and keeping `_normalize_ros_param_types` where present, then wiring Node `parameters` through `_param_list(...)` or `_param_dict(...)` to avoid passing empty lists/dicts. (Updated: scenes/*/launch/demo.launch.py, workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py, workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py, workcell_builder/examples/ros2/launch/demo.launch.py)
- Ensured all sanitizer helpers are defined locally where they are used so `_sanitize_ros_param_types` is always present and used; updated validation to accept `bytes` scalars where appropriate. 
- Kept plain `joint_state_publisher` (no GUI) in every launch file and explicitly preserved required nodes: `robot_state_publisher`, `joint_state_publisher`, `move_group`, `rviz2`, and `static_transform_publisher`. 
- Added `_extract_dependent_joints(...)` to templates and `ur5_3f_test` to convert URDF `mimic` joints into a `dependent_joints` parameter passed to `joint_state_publisher`, and added an explicit runtime error when `_extract_controller_joints(...)` yields an empty joint list to avoid silently creating fake controllers with empty `joints`. 

### Testing
- Compiled the modified Python launch files with `python -m compileall` which succeeded for all updated files. 
- Ran static checks (`rg`) confirming `_sanitize_ros_param_types` is defined where used, no `joint_state_publisher_gui` occurrences, and no literal `"sensors": []` patterns in scenes/templates. 
- Verified each modified launch file was syntactically valid by local edits and re-parsing steps (compile + grep); these checks passed. 
- Attempted the full `colcon build` from the provided instructions but the test environment lacked `~/workcell_ws`, so the build was not executed in this run (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca400a8b88331a8a4a98425ebb19d)