### PR TITLE
Remove dependent_joints injection and use plain joint_state_publisher in scenes/templates

### DIFF
--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -143,6 +143,9 @@ def _validate_ros_param_types(value, path="root"):
 
 
 def _validate_joint_state_configuration(robot_description_config, controller_joints):
+    if not controller_joints:
+        raise RuntimeError("Fake controller joints list is empty; unable to configure joint state publishing")
+
     try:
         urdf_root = ET.fromstring(robot_description_config)
     except ET.ParseError as exc:
@@ -165,35 +168,6 @@ def _validate_joint_state_configuration(robot_description_config, controller_joi
             "Controller joints are not present in robot_description: "
             + ", ".join(missing)
         )
-
-
-def _extract_dependent_joints(robot_description_config):
-    try:
-        urdf_root = ET.fromstring(robot_description_config)
-    except ET.ParseError as exc:
-        raise RuntimeError("Failed to parse robot_description while extracting mimic joints") from exc
-
-    dependent_joints = {}
-    for joint in urdf_root.findall(".//joint"):
-        joint_name = joint.get("name")
-        mimic = joint.find("mimic")
-        if not joint_name or mimic is None:
-            continue
-
-        mimic_joint = mimic.get("joint")
-        if not mimic_joint:
-            continue
-
-        dependent_joint = {"parent": mimic_joint}
-        multiplier = mimic.get("multiplier")
-        offset = mimic.get("offset")
-        if multiplier is not None:
-            dependent_joint["factor"] = float(multiplier)
-        if offset is not None:
-            dependent_joint["offset"] = float(offset)
-        dependent_joints[joint_name] = dependent_joint
-
-    return {"dependent_joints": dependent_joints}
 
 
 def _launch_setup(context):
@@ -262,7 +236,6 @@ def _launch_setup(context):
         robot_description_config,
         moveit_simple_controller_manager["moveit_simple_controller_manager"]["fake_ur5_controller"]["joints"],
     )
-    joint_state_dependent_joints = _extract_dependent_joints(robot_description_config)
 
     trajectory_execution = {
         "allow_trajectory_execution": False,
@@ -287,7 +260,6 @@ def _launch_setup(context):
         validated_trajectory_execution = _param_dict(_normalize_ros_param_types(trajectory_execution))
         validated_moveit_controller_manager = _param_dict(_normalize_ros_param_types(moveit_controller_manager))
         validated_moveit_simple_controller_manager = _param_dict(_normalize_ros_param_types(moveit_simple_controller_manager))
-        validated_joint_state_dependent_joints = _param_dict(_normalize_ros_param_types(joint_state_dependent_joints))
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")
@@ -299,7 +271,6 @@ def _launch_setup(context):
         _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
         _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
         _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
-        _validate_ros_param_types(validated_joint_state_dependent_joints, "joint_state_dependent_joints")
     except TypeError as exc:
         raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 
@@ -342,7 +313,6 @@ def _launch_setup(context):
         parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
-            validated_joint_state_dependent_joints,
         ),
     )
 

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -185,6 +185,9 @@ def _extract_controller_joints(robot_description_semantic_config):
 
 
 def _validate_joint_state_configuration(robot_description_config, controller_joints):
+    if not controller_joints:
+        raise RuntimeError("Fake controller joints list is empty; unable to configure joint state publishing")
+
     try:
         urdf_root = ET.fromstring(robot_description_config)
     except ET.ParseError as exc:
@@ -207,35 +210,6 @@ def _validate_joint_state_configuration(robot_description_config, controller_joi
             "Controller joints are not present in robot_description: "
             + ", ".join(missing)
         )
-
-
-def _extract_dependent_joints(robot_description_config):
-    try:
-        urdf_root = ET.fromstring(robot_description_config)
-    except ET.ParseError as exc:
-        raise RuntimeError("Failed to parse robot_description while extracting mimic joints") from exc
-
-    dependent_joints = {}
-    for joint in urdf_root.findall(".//joint"):
-        joint_name = joint.get("name")
-        mimic = joint.find("mimic")
-        if not joint_name or mimic is None:
-            continue
-
-        mimic_joint = mimic.get("joint")
-        if not mimic_joint:
-            continue
-
-        dependent_joint = {"parent": mimic_joint}
-        multiplier = mimic.get("multiplier")
-        offset = mimic.get("offset")
-        if multiplier is not None:
-            dependent_joint["factor"] = float(multiplier)
-        if offset is not None:
-            dependent_joint["offset"] = float(offset)
-        dependent_joints[joint_name] = dependent_joint
-
-    return {"dependent_joints": dependent_joints}
 
 
 def _launch_setup(context):
@@ -291,7 +265,6 @@ def _launch_setup(context):
             "The generated fake controller cannot be created with an empty joints list."
         )
     _validate_joint_state_configuration(robot_description_config, controller_joints)
-    joint_state_dependent_joints = _extract_dependent_joints(robot_description_config)
     controller_name = f"fake_{controller_group_name}_controller"
 
     moveit_controller_manager = {
@@ -333,7 +306,6 @@ def _launch_setup(context):
         validated_trajectory_execution = _param_dict(_normalize_ros_param_types(trajectory_execution))
         validated_moveit_controller_manager = _param_dict(_normalize_ros_param_types(moveit_controller_manager))
         validated_moveit_simple_controller_manager = _param_dict(_normalize_ros_param_types(moveit_simple_controller_manager))
-        validated_joint_state_dependent_joints = _param_dict(_normalize_ros_param_types(joint_state_dependent_joints))
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")
@@ -345,7 +317,6 @@ def _launch_setup(context):
         _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
         _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
         _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
-        _validate_ros_param_types(validated_joint_state_dependent_joints, "joint_state_dependent_joints")
     except TypeError as exc:
         raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 
@@ -380,7 +351,6 @@ def _launch_setup(context):
         parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
-            validated_joint_state_dependent_joints,
         ),
     )
 

--- a/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -185,6 +185,9 @@ def _extract_controller_joints(robot_description_semantic_config):
 
 
 def _validate_joint_state_configuration(robot_description_config, controller_joints):
+    if not controller_joints:
+        raise RuntimeError("Fake controller joints list is empty; unable to configure joint state publishing")
+
     try:
         urdf_root = ET.fromstring(robot_description_config)
     except ET.ParseError as exc:
@@ -207,35 +210,6 @@ def _validate_joint_state_configuration(robot_description_config, controller_joi
             "Controller joints are not present in robot_description: "
             + ", ".join(missing)
         )
-
-
-def _extract_dependent_joints(robot_description_config):
-    try:
-        urdf_root = ET.fromstring(robot_description_config)
-    except ET.ParseError as exc:
-        raise RuntimeError("Failed to parse robot_description while extracting mimic joints") from exc
-
-    dependent_joints = {}
-    for joint in urdf_root.findall(".//joint"):
-        joint_name = joint.get("name")
-        mimic = joint.find("mimic")
-        if not joint_name or mimic is None:
-            continue
-
-        mimic_joint = mimic.get("joint")
-        if not mimic_joint:
-            continue
-
-        dependent_joint = {"parent": mimic_joint}
-        multiplier = mimic.get("multiplier")
-        offset = mimic.get("offset")
-        if multiplier is not None:
-            dependent_joint["factor"] = float(multiplier)
-        if offset is not None:
-            dependent_joint["offset"] = float(offset)
-        dependent_joints[joint_name] = dependent_joint
-
-    return {"dependent_joints": dependent_joints}
 
 
 def _launch_setup(context):
@@ -291,7 +265,6 @@ def _launch_setup(context):
             "The generated fake controller cannot be created with an empty joints list."
         )
     _validate_joint_state_configuration(robot_description_config, controller_joints)
-    joint_state_dependent_joints = _extract_dependent_joints(robot_description_config)
     controller_name = f"fake_{controller_group_name}_controller"
 
     moveit_controller_manager = {
@@ -333,7 +306,6 @@ def _launch_setup(context):
         validated_trajectory_execution = _param_dict(_normalize_ros_param_types(trajectory_execution))
         validated_moveit_controller_manager = _param_dict(_normalize_ros_param_types(moveit_controller_manager))
         validated_moveit_simple_controller_manager = _param_dict(_normalize_ros_param_types(moveit_simple_controller_manager))
-        validated_joint_state_dependent_joints = _param_dict(_normalize_ros_param_types(joint_state_dependent_joints))
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")
@@ -345,7 +317,6 @@ def _launch_setup(context):
         _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
         _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
         _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
-        _validate_ros_param_types(validated_joint_state_dependent_joints, "joint_state_dependent_joints")
     except TypeError as exc:
         raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 
@@ -380,7 +351,6 @@ def _launch_setup(context):
         parameters=_param_list(
             validated_use_sim_time,
             validated_robot_description,
-            validated_joint_state_dependent_joints,
         ),
     )
 


### PR DESCRIPTION
### Motivation
- Prevent malformed or duplicate JointState messages by stopping manual extraction/injection of mimic/dependent joints into `joint_state_publisher` and ensure generated scenes use plain `joint_state_publisher` with `robot_description` only.
- Ensure newly generated workcell_builder scenes inherit correct behavior by updating both ROS2 templates for Humble and generic ROS2.
- Fail fast on invalid fake-controller configurations by validating that `controller_joints` is non-empty instead of silently creating empty controllers.

### Description
- Removed the `_extract_dependent_joints(...)` helper and all uses of `*_dependent_joints` parameters passed into `joint_state_publisher` in the following files: `scenes/ur5_3f_test/launch/demo.launch.py`, `workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py`, and `workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py`.
- Ensured `joint_state_publisher` nodes only receive `use_sim_time` and `robot_description` parameters and continue to use `package="joint_state_publisher"` / `executable="joint_state_publisher"` (no GUI packages/executables used).
- Added explicit validation that `controller_joints` is non-empty and raise a clear `RuntimeError` when the fake controller would be created with an empty joints list in the three modified files.

### Testing
- Ran `python -m py_compile` on the modified launch/template files and it succeeded with no syntax errors.
- Ran targeted greps to validate absence/presence conditions: no occurrences of `joint_state_publisher_gui`, no `"sensors": []` matches, and no remaining `dependent_joints` references in the updated scenes/templates (searches returned no problematic matches).
- Ran a check for missing sanitizer helpers (`_sanitize_ros_param_types`, `_param_dict`, `_param_list`) across the scene/template files that use them and found no missing definitions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca9867bd8833181475672daa3bbe0)