### PR TITLE
Load URDF from temp file for joint_state_publisher (ROS 2 Humble scenes)

### DIFF
--- a/scenes/suction_test/launch/demo.launch.py
+++ b/scenes/suction_test/launch/demo.launch.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import tempfile
 import yaml
 import re
 import subprocess
@@ -139,6 +140,18 @@ def _validate_ros_param_types(value, path="root"):
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
 
 
+
+
+def _write_robot_description_file(scene_name, robot_description_config):
+    path = os.path.join(
+        tempfile.gettempdir(),
+        f"{scene_name}_robot_description.urdf",
+    )
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(robot_description_config)
+    return path
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -155,6 +168,11 @@ def _launch_setup(context):
         },
     )
     robot_description = {"robot_description": robot_description_config}
+
+    robot_description_file = _write_robot_description_file(
+        scene_pkg,
+        robot_description_config,
+    )
 
     robot_description_semantic_config = load_xacro(scene_pkg, "urdf/arm_hand.srdf.xacro")
     robot_description_semantic = {"robot_description_semantic": robot_description_semantic_config}
@@ -280,12 +298,14 @@ def _launch_setup(context):
         parameters=_param_list(validated_use_sim_time, validated_robot_description),
     )
 
-    # IMPORTANT: pass robot_description as a parameter so it does NOT wait on a topic
     joint_state_publisher = Node(
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        arguments=[robot_description_file],
+        parameters=_param_list(
+            validated_use_sim_time,
+        ),
     )
 
     move_group = Node(

--- a/scenes/ur10_2f_test/launch/demo.launch.py
+++ b/scenes/ur10_2f_test/launch/demo.launch.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import tempfile
 import yaml
 import re
 import subprocess
@@ -139,6 +140,18 @@ def _validate_ros_param_types(value, path="root"):
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
 
 
+
+
+def _write_robot_description_file(scene_name, robot_description_config):
+    path = os.path.join(
+        tempfile.gettempdir(),
+        f"{scene_name}_robot_description.urdf",
+    )
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(robot_description_config)
+    return path
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -154,6 +167,11 @@ def _launch_setup(context):
         },
     )
     robot_description = {"robot_description": robot_description_config}
+
+    robot_description_file = _write_robot_description_file(
+        scene_pkg,
+        robot_description_config,
+    )
 
     robot_description_semantic_config = load_xacro(scene_pkg, "urdf/arm_hand.srdf.xacro")
     robot_description_semantic = {"robot_description_semantic": robot_description_semantic_config}
@@ -280,7 +298,10 @@ def _launch_setup(context):
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        arguments=[robot_description_file],
+        parameters=_param_list(
+            validated_use_sim_time,
+        ),
     )
 
     move_group = Node(

--- a/scenes/ur3_suction_test/launch/demo.launch.py
+++ b/scenes/ur3_suction_test/launch/demo.launch.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import tempfile
 import yaml
 import re
 import subprocess
@@ -139,6 +140,18 @@ def _validate_ros_param_types(value, path="root"):
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
 
 
+
+
+def _write_robot_description_file(scene_name, robot_description_config):
+    path = os.path.join(
+        tempfile.gettempdir(),
+        f"{scene_name}_robot_description.urdf",
+    )
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(robot_description_config)
+    return path
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -155,6 +168,11 @@ def _launch_setup(context):
         },
     )
     robot_description = {"robot_description": robot_description_config}
+
+    robot_description_file = _write_robot_description_file(
+        scene_pkg,
+        robot_description_config,
+    )
 
     robot_description_semantic_config = load_xacro(scene_pkg, "urdf/arm_hand.srdf.xacro")
     robot_description_semantic = {"robot_description_semantic": robot_description_semantic_config}
@@ -273,7 +291,10 @@ def _launch_setup(context):
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        arguments=[robot_description_file],
+        parameters=_param_list(
+            validated_use_sim_time,
+        ),
     )
 
     move_group = Node(

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import tempfile
 import yaml
 import re
 import subprocess
@@ -140,6 +141,18 @@ def _validate_ros_param_types(value, path="root"):
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
 
 
+
+
+def _write_robot_description_file(scene_name, robot_description_config):
+    path = os.path.join(
+        tempfile.gettempdir(),
+        f"{scene_name}_robot_description.urdf",
+    )
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(robot_description_config)
+    return path
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -155,6 +168,11 @@ def _launch_setup(context):
         },
     )
     robot_description = {"robot_description": robot_description_config}
+
+    robot_description_file = _write_robot_description_file(
+        scene_pkg,
+        robot_description_config,
+    )
 
     robot_description_semantic_config = load_xacro(scene_pkg, "urdf/arm_hand.srdf.xacro")
     robot_description_semantic = {"robot_description_semantic": robot_description_semantic_config}
@@ -287,7 +305,10 @@ def _launch_setup(context):
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        arguments=[robot_description_file],
+        parameters=_param_list(
+            validated_use_sim_time,
+        ),
     )
 
     move_group = Node(

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import tempfile
 import yaml
 import re
 import xml.etree.ElementTree as ET
@@ -170,6 +171,18 @@ def _validate_joint_state_configuration(robot_description_config, controller_joi
         )
 
 
+
+
+def _write_robot_description_file(scene_name, robot_description_config):
+    path = os.path.join(
+        tempfile.gettempdir(),
+        f"{scene_name}_robot_description.urdf",
+    )
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(robot_description_config)
+    return path
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -180,6 +193,11 @@ def _launch_setup(context):
         mappings={"ur_type": "ur5", "name": "ur5", "tf_prefix": "", "use_fake_hardware": use_fake_hardware.perform(context)},
     )
     robot_description = {"robot_description": robot_description_config}
+
+    robot_description_file = _write_robot_description_file(
+        scene_pkg,
+        robot_description_config,
+    )
 
     robot_description_semantic_config = load_xacro(scene_pkg, "urdf/arm_hand.srdf.xacro")
     robot_description_semantic = {"robot_description_semantic": robot_description_semantic_config}
@@ -310,9 +328,9 @@ def _launch_setup(context):
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
+        arguments=[robot_description_file],
         parameters=_param_list(
             validated_use_sim_time,
-            validated_robot_description,
         ),
     )
 

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import tempfile
 import yaml
 import re
 import subprocess
@@ -140,6 +141,18 @@ def _validate_ros_param_types(value, path="root"):
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
 
 
+
+
+def _write_robot_description_file(scene_name, robot_description_config):
+    path = os.path.join(
+        tempfile.gettempdir(),
+        f"{scene_name}_robot_description.urdf",
+    )
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(robot_description_config)
+    return path
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -150,6 +163,11 @@ def _launch_setup(context):
         mappings={"ur_type": "ur5", "name": "ur5", "tf_prefix": "", "use_fake_hardware": use_fake_hardware.perform(context)},
     )
     robot_description = {"robot_description": robot_description_config}
+
+    robot_description_file = _write_robot_description_file(
+        scene_pkg,
+        robot_description_config,
+    )
 
     robot_description_semantic_config = load_xacro(scene_pkg, "urdf/arm_hand.srdf.xacro")
     robot_description_semantic = {"robot_description_semantic": robot_description_semantic_config}
@@ -276,7 +294,10 @@ def _launch_setup(context):
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        arguments=[robot_description_file],
+        parameters=_param_list(
+            validated_use_sim_time,
+        ),
     )
 
     move_group = Node(

--- a/workcell_builder/examples/ros2/launch/demo.launch.py
+++ b/workcell_builder/examples/ros2/launch/demo.launch.py
@@ -13,6 +13,7 @@
 ## limitations under the License.
 
 import os
+import tempfile
 import re
 import subprocess
 import yaml
@@ -153,6 +154,18 @@ def _validate_ros_param_types(value, path="root"):
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
 
 
+
+
+def _write_robot_description_file(scene_name, robot_description_config):
+    path = os.path.join(
+        tempfile.gettempdir(),
+        f"{scene_name}_robot_description.urdf",
+    )
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(robot_description_config)
+    return path
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -163,6 +176,11 @@ def _launch_setup(context):
         mappings={"use_fake_hardware": use_fake_hardware.perform(context)},
     )
     robot_description = {"robot_description": robot_description_config}
+
+    robot_description_file = _write_robot_description_file(
+        scene_pkg,
+        robot_description_config,
+    )
 
     robot_description_semantic_config = load_xacro(scene_pkg, "urdf/arm_hand.srdf.xacro")
     robot_description_semantic = {
@@ -265,7 +283,10 @@ def _launch_setup(context):
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
-        parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        arguments=[robot_description_file],
+        parameters=_param_list(
+            validated_use_sim_time,
+        ),
     )
 
     move_group = Node(

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -13,6 +13,7 @@
 ## limitations under the License.
 
 import os
+import tempfile
 import re
 import subprocess
 import xml.etree.ElementTree as ET
@@ -212,6 +213,18 @@ def _validate_joint_state_configuration(robot_description_config, controller_joi
         )
 
 
+
+
+def _write_robot_description_file(scene_name, robot_description_config):
+    path = os.path.join(
+        tempfile.gettempdir(),
+        f"{scene_name}_robot_description.urdf",
+    )
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(robot_description_config)
+    return path
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -222,6 +235,11 @@ def _launch_setup(context):
         mappings={"use_fake_hardware": use_fake_hardware.perform(context)},
     )
     robot_description = {"robot_description": robot_description_config}
+
+    robot_description_file = _write_robot_description_file(
+        scene_pkg,
+        robot_description_config,
+    )
 
     robot_description_semantic_config = load_xacro(scene_pkg, "urdf/arm_hand.srdf.xacro")
     robot_description_semantic = {
@@ -348,9 +366,9 @@ def _launch_setup(context):
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
+        arguments=[robot_description_file],
         parameters=_param_list(
             validated_use_sim_time,
-            validated_robot_description,
         ),
     )
 

--- a/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -13,6 +13,7 @@
 ## limitations under the License.
 
 import os
+import tempfile
 import re
 import subprocess
 import xml.etree.ElementTree as ET
@@ -212,6 +213,18 @@ def _validate_joint_state_configuration(robot_description_config, controller_joi
         )
 
 
+
+
+def _write_robot_description_file(scene_name, robot_description_config):
+    path = os.path.join(
+        tempfile.gettempdir(),
+        f"{scene_name}_robot_description.urdf",
+    )
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(robot_description_config)
+    return path
+
+
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -222,6 +235,11 @@ def _launch_setup(context):
         mappings={"use_fake_hardware": use_fake_hardware.perform(context)},
     )
     robot_description = {"robot_description": robot_description_config}
+
+    robot_description_file = _write_robot_description_file(
+        scene_pkg,
+        robot_description_config,
+    )
 
     robot_description_semantic_config = load_xacro(scene_pkg, "urdf/arm_hand.srdf.xacro")
     robot_description_semantic = {
@@ -348,9 +366,9 @@ def _launch_setup(context):
         package="joint_state_publisher",
         executable="joint_state_publisher",
         output="screen",
+        arguments=[robot_description_file],
         parameters=_param_list(
             validated_use_sim_time,
-            validated_robot_description,
         ),
     )
 


### PR DESCRIPTION
### Motivation
- Plain `joint_state_publisher` was inconsistently loading the `robot_description` parameter/topic which caused malformed `/joint_states` and errors from `robot_state_publisher` and MoveIt. 

### Description
- Import `tempfile` and add `_write_robot_description_file(scene_name, robot_description_config)` helper to write the expanded URDF to a temporary `.urdf` file. 
- For each scene and template launch (`scenes/*/launch/demo.launch.py`, `workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py`, `workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py`, and `workcell_builder/examples/ros2/launch/demo.launch.py`) write `robot_description_config` to a temp file and set `robot_description_file` in `_launch_setup`. 
- Change `joint_state_publisher` nodes to pass `arguments=[robot_description_file]` and only the `use_sim_time` parameter, while keeping `robot_state_publisher`, `move_group`, and `rviz2` receiving `robot_description` as parameters. 
- Retain the sanitizer helpers and avoided adding empty parameter arrays or GUI usage; removed waiting-for-topic comment and ensured no `joint_state_publisher_gui` or dependent-joint injection remains.

### Testing
- Ran repository scans to confirm no `joint_state_publisher_gui`, `dependent_joints`, `_extract_dependent_joints`, or empty `"sensors": []` remain and verified `arguments=[robot_description_file]` is present in modified files. 
- Compiled all modified launch files with `python -m py_compile` which succeeded. 
- Attempted the provided `colcon build` sequence but it could not be executed in this environment because `~/workcell_ws` was not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb4c1dc208331b0219f10bf27f292)