### PR TITLE
Isolate scene JointState topics and add joint-state checker

### DIFF
--- a/scenes/suction_test/launch/demo.launch.py
+++ b/scenes/suction_test/launch/demo.launch.py
@@ -155,6 +155,7 @@ def _write_robot_description_file(scene_name, robot_description_config):
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    joint_states_topic = f"/{scene_pkg}/joint_states"
 
     # --- Robot descriptions ---
     robot_description_config = load_xacro(
@@ -296,6 +297,9 @@ def _launch_setup(context):
         executable="robot_state_publisher",
         output="screen",
         parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     joint_state_publisher = Node(
@@ -306,6 +310,9 @@ def _launch_setup(context):
         parameters=_param_list(
             validated_use_sim_time,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     move_group = Node(
@@ -325,6 +332,10 @@ def _launch_setup(context):
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     rviz_config_file = os.path.join(get_package_share_directory(scene_pkg), "launch", "demo.rviz")
@@ -340,6 +351,10 @@ def _launch_setup(context):
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     return [

--- a/scenes/ur10_2f_test/launch/demo.launch.py
+++ b/scenes/ur10_2f_test/launch/demo.launch.py
@@ -155,6 +155,7 @@ def _write_robot_description_file(scene_name, robot_description_config):
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    joint_states_topic = f"/{scene_pkg}/joint_states"
 
     robot_description_config = load_xacro(
         scene_pkg,
@@ -292,6 +293,9 @@ def _launch_setup(context):
         executable="robot_state_publisher",
         output="screen",
         parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     joint_state_publisher = Node(
@@ -302,6 +306,9 @@ def _launch_setup(context):
         parameters=_param_list(
             validated_use_sim_time,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     move_group = Node(
@@ -320,6 +327,10 @@ def _launch_setup(context):
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     rviz_config_file = os.path.join(get_package_share_directory(scene_pkg), "launch", "demo.rviz")
@@ -335,6 +346,10 @@ def _launch_setup(context):
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     return [

--- a/scenes/ur3_suction_test/launch/demo.launch.py
+++ b/scenes/ur3_suction_test/launch/demo.launch.py
@@ -155,6 +155,7 @@ def _write_robot_description_file(scene_name, robot_description_config):
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    joint_states_topic = f"/{scene_pkg}/joint_states"
 
     # --- Robot descriptions ---
     robot_description_config = load_xacro(
@@ -285,6 +286,9 @@ def _launch_setup(context):
         executable="robot_state_publisher",
         output="screen",
         parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     joint_state_publisher = Node(
@@ -295,6 +299,9 @@ def _launch_setup(context):
         parameters=_param_list(
             validated_use_sim_time,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     move_group = Node(
@@ -313,6 +320,10 @@ def _launch_setup(context):
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     rviz_config_file = os.path.join(get_package_share_directory(scene_pkg), "launch", "demo.rviz")
@@ -328,6 +339,10 @@ def _launch_setup(context):
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     return [

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -156,6 +156,7 @@ def _write_robot_description_file(scene_name, robot_description_config):
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    joint_states_topic = f"/{scene_pkg}/joint_states"
 
     robot_description_config = load_xacro(
         scene_pkg,
@@ -299,6 +300,9 @@ def _launch_setup(context):
         executable="robot_state_publisher",
         output="screen",
         parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     joint_state_publisher = Node(
@@ -309,6 +313,9 @@ def _launch_setup(context):
         parameters=_param_list(
             validated_use_sim_time,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     move_group = Node(
@@ -327,6 +334,10 @@ def _launch_setup(context):
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     rviz_config_file = os.path.join(get_package_share_directory(scene_pkg), "launch", "demo.rviz")
@@ -342,6 +353,10 @@ def _launch_setup(context):
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     return [

--- a/scenes/ur5_3f_test/launch/demo.launch.py
+++ b/scenes/ur5_3f_test/launch/demo.launch.py
@@ -186,6 +186,7 @@ def _write_robot_description_file(scene_name, robot_description_config):
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    joint_states_topic = f"/{scene_pkg}/joint_states"
 
     robot_description_config = load_xacro(
         scene_pkg,
@@ -322,6 +323,9 @@ def _launch_setup(context):
         executable="robot_state_publisher",
         output="screen",
         parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     joint_state_publisher = Node(
@@ -332,6 +336,9 @@ def _launch_setup(context):
         parameters=_param_list(
             validated_use_sim_time,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     move_group = Node(
@@ -350,6 +357,10 @@ def _launch_setup(context):
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     rviz_config_file = os.path.join(get_package_share_directory(scene_pkg), "launch", "demo.rviz")
@@ -365,6 +376,10 @@ def _launch_setup(context):
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     return [

--- a/scenes/ur5_airpick4_test/launch/demo.launch.py
+++ b/scenes/ur5_airpick4_test/launch/demo.launch.py
@@ -156,6 +156,7 @@ def _write_robot_description_file(scene_name, robot_description_config):
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    joint_states_topic = f"/{scene_pkg}/joint_states"
 
     robot_description_config = load_xacro(
         scene_pkg,
@@ -288,6 +289,9 @@ def _launch_setup(context):
         executable="robot_state_publisher",
         output="screen",
         parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     joint_state_publisher = Node(
@@ -298,6 +302,9 @@ def _launch_setup(context):
         parameters=_param_list(
             validated_use_sim_time,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     move_group = Node(
@@ -316,6 +323,10 @@ def _launch_setup(context):
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     rviz_config_file = os.path.join(get_package_share_directory(scene_pkg), "launch", "demo.rviz")
@@ -331,6 +342,10 @@ def _launch_setup(context):
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     return [

--- a/scripts/check_scene_joint_states.py
+++ b/scripts/check_scene_joint_states.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Check JointState message shape for a given topic."""
+
+import argparse
+import sys
+from threading import Event
+
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+class JointStateChecker(Node):
+    def __init__(self, topic: str) -> None:
+        super().__init__("check_scene_joint_states")
+        self._topic = topic
+        self._event = Event()
+        self._message = None
+        self.create_subscription(JointState, topic, self._callback, 10)
+
+    def _callback(self, msg: JointState) -> None:
+        self._message = msg
+        self._event.set()
+
+    @property
+    def message(self) -> JointState | None:
+        return self._message
+
+    def wait_for_message(self, timeout_sec: float) -> bool:
+        return self._event.wait(timeout=timeout_sec)
+
+    def publisher_count(self) -> int | None:
+        try:
+            return len(self.get_publishers_info_by_topic(self._topic))
+        except Exception:
+            return None
+
+
+def _validate_message(msg: JointState) -> list[str]:
+    errors = []
+    name_len = len(msg.name)
+    if len(msg.position) != name_len:
+        errors.append("len(name) != len(position)")
+    if msg.velocity and len(msg.velocity) != name_len:
+        errors.append("velocity is non-empty and len(velocity) != len(name)")
+    if msg.effort and len(msg.effort) != name_len:
+        errors.append("effort is non-empty and len(effort) != len(name)")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check a JointState topic for malformed messages.")
+    parser.add_argument("topic", nargs="?", default="/joint_states", help="JointState topic to inspect")
+    parser.add_argument("--timeout", type=float, default=10.0, help="Seconds to wait for a message")
+    args = parser.parse_args()
+
+    rclpy.init()
+    node = JointStateChecker(args.topic)
+
+    try:
+        end_time = node.get_clock().now().nanoseconds + int(args.timeout * 1e9)
+        while rclpy.ok() and not node.wait_for_message(0.1):
+            rclpy.spin_once(node, timeout_sec=0.1)
+            if node.get_clock().now().nanoseconds >= end_time:
+                print(f"No JointState message received on {args.topic} within {args.timeout:.1f}s", file=sys.stderr)
+                return 2
+
+        msg = node.message
+        if msg is None:
+            print(f"No JointState message received on {args.topic}", file=sys.stderr)
+            return 2
+
+        print(f"topic: {args.topic}")
+        publisher_count = node.publisher_count()
+        print(f"publisher_count: {publisher_count if publisher_count is not None else 'unavailable'}")
+        print(f"len(name): {len(msg.name)}")
+        print(f"len(position): {len(msg.position)}")
+        print(f"len(velocity): {len(msg.velocity)}")
+        print(f"len(effort): {len(msg.effort)}")
+        print(f"names: {list(msg.name)}")
+        print(f"positions: {list(msg.position)}")
+
+        errors = _validate_message(msg)
+        if errors:
+            for error in errors:
+                print(f"ERROR: {error}", file=sys.stderr)
+            return 1
+        return 0
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workcell_builder/examples/ros2/launch/demo.launch.py
+++ b/workcell_builder/examples/ros2/launch/demo.launch.py
@@ -169,6 +169,7 @@ def _write_robot_description_file(scene_name, robot_description_config):
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    joint_states_topic = f"/{scene_pkg}/joint_states"
 
     robot_description_config = load_xacro(
         scene_pkg,
@@ -277,6 +278,9 @@ def _launch_setup(context):
         executable="robot_state_publisher",
         output="screen",
         parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     joint_state_publisher = Node(
@@ -287,6 +291,9 @@ def _launch_setup(context):
         parameters=_param_list(
             validated_use_sim_time,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     move_group = Node(
@@ -304,6 +311,10 @@ def _launch_setup(context):
             validated_occupancy_map_monitor_params,
             validated_trajectory_execution,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     rviz_config_file = os.path.join(
@@ -321,6 +332,10 @@ def _launch_setup(context):
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     return [

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -228,6 +228,7 @@ def _write_robot_description_file(scene_name, robot_description_config):
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    joint_states_topic = f"/{scene_pkg}/joint_states"
 
     robot_description_config = load_xacro(
         scene_pkg,
@@ -360,6 +361,9 @@ def _launch_setup(context):
         executable="robot_state_publisher",
         output="screen",
         parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     joint_state_publisher = Node(
@@ -370,6 +374,9 @@ def _launch_setup(context):
         parameters=_param_list(
             validated_use_sim_time,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     move_group = Node(
@@ -388,6 +395,10 @@ def _launch_setup(context):
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     rviz_config_file = os.path.join(
@@ -405,6 +416,10 @@ def _launch_setup(context):
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     return [

--- a/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -228,6 +228,7 @@ def _write_robot_description_file(scene_name, robot_description_config):
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    joint_states_topic = f"/{scene_pkg}/joint_states"
 
     robot_description_config = load_xacro(
         scene_pkg,
@@ -360,6 +361,9 @@ def _launch_setup(context):
         executable="robot_state_publisher",
         output="screen",
         parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     joint_state_publisher = Node(
@@ -370,6 +374,9 @@ def _launch_setup(context):
         parameters=_param_list(
             validated_use_sim_time,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+        ],
     )
 
     move_group = Node(
@@ -388,6 +395,10 @@ def _launch_setup(context):
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     rviz_config_file = os.path.join(
@@ -405,6 +416,10 @@ def _launch_setup(context):
             validated_robot_description_semantic,
             validated_robot_description_kinematics,
         ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
     )
 
     return [


### PR DESCRIPTION
### Motivation
- Scene demos were using the global `/joint_states` topic which made them vulnerable to malformed/stale publishers and caused `robot_state_publisher` / MoveIt to reject JointState messages.
- The intended architecture is for each scene to publish/subscribe on a scene-private topic so scenes are isolated from other background publishers.
- Apply this change to all existing demos and to the launch templates so newly generated scenes follow the same safe pattern.

### Description
- For each demo launch's `_launch_setup()` added `joint_states_topic = f"/{scene_pkg}/joint_states"` and remapped joint-state traffic to that topic.
- Remapped `joint_state_publisher` to publish to the private topic via `remappings=[("joint_states", joint_states_topic)]` and `robot_state_publisher` to subscribe to it via the same remap.
- Remapped both `joint_states` and `/joint_states` for `move_group` and `rviz2` so they listen on the scene-private topic; `static_transform_publisher` left unchanged.
- Updated all existing scene launches under `scenes/*/launch/demo.launch.py` and the generation templates under `workcell_builder/.../templates/ros2/.../demo.launch.py` and added `scripts/check_scene_joint_states.py` which subscribes to a topic, prints message shape/details, and returns non-zero on malformed JointState arrays.

### Testing
- Ran `python3 -m py_compile` over all modified launch files and the new script, which completed without errors.
- Ran `rg` scans to assert there are no occurrences of `joint_state_publisher_gui`, `dependent_joints`, `_extract_dependent_joints`, or `"sensors": []` in `scenes` and `workcell_builder`, and the scans returned no matches.
- Used `rg` to verify the new `joint_states_topic` and remappings are present in the updated files.
- The new `scripts/check_scene_joint_states.py` file is executable and was syntax-checked via `py_compile`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc3e641b483318fbd7a2904bec48f)