### PR TITLE
Reinforce scene-private joint state topic in ROS2 demo templates

### DIFF
--- a/workcell_builder/examples/ros2/launch/demo.launch.py
+++ b/workcell_builder/examples/ros2/launch/demo.launch.py
@@ -169,6 +169,7 @@ def _write_robot_description_file(scene_name, robot_description_config):
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    # Keep joint states isolated per-scene to avoid global topic collisions.
     joint_states_topic = f"/{scene_pkg}/joint_states"
 
     robot_description_config = load_xacro(

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -228,6 +228,7 @@ def _write_robot_description_file(scene_name, robot_description_config):
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    # Keep joint states isolated per-scene to avoid global topic collisions.
     joint_states_topic = f"/{scene_pkg}/joint_states"
 
     robot_description_config = load_xacro(

--- a/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -228,6 +228,7 @@ def _write_robot_description_file(scene_name, robot_description_config):
 def _launch_setup(context):
     use_sim_time = LaunchConfiguration("use_sim_time")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    # Keep joint states isolated per-scene to avoid global topic collisions.
     joint_states_topic = f"/{scene_pkg}/joint_states"
 
     robot_description_config = load_xacro(


### PR DESCRIPTION
### Motivation
- Ensure the scene-private joint-state topic is permanently documented in the generator templates so generated scenes keep joint-state topics isolated at `/{scene_pkg}/joint_states` and avoid collisions with a global `/joint_states`.

### Description
- Added a clarifying comment and ensured `joint_states_topic = f"/{scene_pkg}/joint_states"` is defined in `_launch_setup()` in the following files: `workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py`, `workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py`, and `workcell_builder/examples/ros2/launch/demo.launch.py`.
- Verified that the templates already remap `"joint_states"` and `"/joint_states"` to `joint_states_topic` for `robot_state_publisher`, `joint_state_publisher`, `move_group`, and `rviz2`, preserving runtime behavior.
- No nodes, dependency versions, or parameters (including `dependent_joints`, `sensors`, or `joint_state_publisher_gui`) were removed or altered.

### Testing
- Ran `grep -RIn "joint_states_topic" scenes workcell_builder` and confirmed `joint_states_topic` appears in templates and scene launch files (success).
- Ran `grep -RIn "joint_state_publisher_gui" scenes workcell_builder`, `grep -RIn "dependent_joints" scenes workcell_builder`, and `grep -RIn '"sensors": \[\]' scenes workcell_builder` to ensure no unwanted injections or empty arrays (no matches found).
- Verified syntax of the three modified files with `python -m py_compile <files>` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecce0ea60c8331a71aeec967dc8257)