### PR TITLE
Fix grasp planner QoS mismatch with EPD best-effort publishers

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params.yaml
@@ -14,11 +14,13 @@ grasp_planning_node:
       epd_detection_camera_info_topic: "/camera/color/camera_info"
       epd_msg_timeout_s: 5.0
       epd_service_wait_timeout_s: 1.0
+      epd_subscription_reliability: "best_effort"
     camera_parameters:
       point_cloud_topic: "/camera/camera/depth/color/points"
       camera_frame: "camera_color_optical_frame"
       # Larger queue sizes trade memory/latency for fewer TF filter drops.
       tf_filter_queue_size: 20
+      point_cloud_subscription_reliability: "best_effort"
       robot_base_frame: "base_link"
       fx: 610.3740844726562
       fy: 609.8685913085938

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml
@@ -13,11 +13,13 @@ grasp_planning_node:
       epd_detection_camera_info_topic: "/camera/color/camera_info"
       epd_msg_timeout_s: 5.0
       epd_service_wait_timeout_s: 1.0
+      epd_subscription_reliability: "best_effort"
     camera_parameters:
       point_cloud_topic: "/camera/camera/depth/color/points"
       camera_frame: "camera_depth_optical_frame"
       # Larger queue sizes trade memory/latency for fewer TF filter drops.
       tf_filter_queue_size: 20
+      point_cloud_subscription_reliability: "best_effort"
       robot_base_frame: "base_link"
       fx: 610.3740844726562
       fy: 609.8685913085938

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml
@@ -14,11 +14,13 @@ grasp_planning_node:
       epd_detection_camera_info_topic: "/camera/color/camera_info"
       epd_msg_timeout_s: 5.0
       epd_service_wait_timeout_s: 1.0
+      epd_subscription_reliability: "best_effort"
     camera_parameters:
       point_cloud_topic: "/camera/camera/depth/color/points"
       camera_frame: "camera_color_optical_frame"
       # Larger queue sizes trade memory/latency for fewer TF filter drops.
       tf_filter_queue_size: 20
+      point_cloud_subscription_reliability: "best_effort"
       robot_base_frame: "base_link"
       fx: 610.3740844726562
       fy: 609.8685913085938

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_airpick4.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_airpick4.yaml
@@ -14,11 +14,13 @@ grasp_planning_node:
       epd_detection_camera_info_topic: "/camera/color/camera_info"
       epd_msg_timeout_s: 5.0
       epd_service_wait_timeout_s: 1.0
+      epd_subscription_reliability: "best_effort"
     camera_parameters:
       point_cloud_topic: "/camera/camera/depth/color/points"
       camera_frame: "camera_color_optical_frame"
       # Larger queue sizes trade memory/latency for fewer TF filter drops.
       tf_filter_queue_size: 20
+      point_cloud_subscription_reliability: "best_effort"
       robot_base_frame: "base_link"
       fx: 610.3740844726562
       fy: 609.8685913085938

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_suction.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_suction.yaml
@@ -14,11 +14,13 @@ grasp_planning_node:
       epd_detection_camera_info_topic: "/camera/color/camera_info"
       epd_msg_timeout_s: 5.0
       epd_service_wait_timeout_s: 1.0
+      epd_subscription_reliability: "best_effort"
     camera_parameters:
       point_cloud_topic: "/camera/camera/depth/color/points"
       camera_frame: "camera_color_optical_frame"
       # Larger queue sizes trade memory/latency for fewer TF filter drops.
       tf_filter_queue_size: 20
+      point_cloud_subscription_reliability: "best_effort"
       robot_base_frame: "base_link"
       fx: 610.3740844726562
       fy: 609.8685913085938

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/test/test_demo_node_parameter_override_launch.test.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/test/test_demo_node_parameter_override_launch.test.py
@@ -33,6 +33,8 @@ def generate_test_description():
         parameters=[
             params_file,
             {'easy_perception_deployment.epd_enabled': True},
+            {'easy_perception_deployment.epd_subscription_reliability': 'best_effort'},
+            {'camera_parameters.point_cloud_subscription_reliability': 'best_effort'},
         ],
     )
 

--- a/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
@@ -16,6 +16,7 @@
 // Main PCL files
 #include "emd/grasp_planner/grasp_scene.hpp"
 #include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <type_traits>
 #include <utility>
@@ -79,6 +80,36 @@ void set_epd_trigger_flag_if_available(RequestT & request)
 
 // Conversion factor: raw 16-bit depth value (millimetres) → metres.
 constexpr double kDepthMmToMeters = 0.001;
+
+std::string to_lower_copy(std::string value)
+{
+  std::transform(
+    value.begin(), value.end(), value.begin(),
+    [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+    });
+  return value;
+}
+
+rclcpp::QoS build_perception_qos(
+  const rclcpp::Node::SharedPtr & node,
+  const std::string & reliability_parameter,
+  std::string & selected_reliability)
+{
+  node->get_parameter_or(reliability_parameter, selected_reliability, std::string("best_effort"));
+  selected_reliability = to_lower_copy(selected_reliability);
+
+  auto perception_qos = rclcpp::SensorDataQoS().keep_last(10);
+  if (selected_reliability == "reliable") {
+    perception_qos.reliable();
+    selected_reliability = "reliable";
+  } else {
+    perception_qos.best_effort();
+    selected_reliability = "best_effort";
+  }
+
+  return perception_qos;
+}
 }  // namespace
 
 template<typename T>
@@ -745,10 +776,21 @@ void grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>::setup(std::string
     this->node->create_client<emd_msgs::srv::GraspRequest>(
     this->node->get_parameter("grasp_output_service").as_string());
 
+  std::string selected_reliability;
+  const auto perception_qos = build_perception_qos(
+    node,
+    "camera_parameters.point_cloud_subscription_reliability",
+    selected_reliability);
+
   RCLCPP_INFO_STREAM(LOGGER, "Listening to: " << topic_name << "...");
-  this->perception_sub = std::make_shared<
-    message_filters::Subscriber<sensor_msgs::msg::PointCloud2>>(
-    node, topic_name);
+  RCLCPP_INFO_STREAM(
+    LOGGER,
+    "Perception subscription QoS: reliability=" << selected_reliability <<
+      ", depth=10");
+
+  this->perception_sub =
+    std::make_shared<message_filters::Subscriber<sensor_msgs::msg::PointCloud2>>();
+  this->perception_sub->subscribe(node, topic_name, perception_qos.get_rmw_qos_profile());
 
   this->tf_perception_sub =
     std::make_shared<tf2_ros::MessageFilter<sensor_msgs::msg::PointCloud2>>(
@@ -784,13 +826,23 @@ void grasp_planner::GraspScene<T>::setup(std::string topic_name)
     this->node->create_client<epd_msgs::srv::Perception>(
     this->node->get_parameter("easy_perception_deployment.epd_service").as_string());
 
+  std::string selected_reliability;
+  const auto perception_qos = build_perception_qos(
+    node,
+    "easy_perception_deployment.epd_subscription_reliability",
+    selected_reliability);
+
   RCLCPP_INFO(
     LOGGER,
     "Listening to: %s...",
     topic_name.c_str());
-  this->perception_sub = std::make_shared<
-    message_filters::Subscriber<T>>(
-    node, topic_name);
+  RCLCPP_INFO(
+    LOGGER,
+    "Perception subscription QoS: reliability=%s, depth=10",
+    selected_reliability.c_str());
+
+  this->perception_sub = std::make_shared<message_filters::Subscriber<T>>();
+  this->perception_sub->subscribe(node, topic_name, perception_qos.get_rmw_qos_profile());
 
   this->tf_perception_sub = std::make_shared<tf2_ros::MessageFilter<T>>(
     *buffer_, robot_base_frame, tf_filter_queue_size,


### PR DESCRIPTION
### Motivation
- Grasp planner subscribers used the default (reliable) QoS while EPD and camera streams publish using BEST_EFFORT, causing RELIABILITY_QOS_POLICY incompatibility and dropped messages between `run_grasp_planner` and EPD.

### Description
- Change `GraspScene::setup(...)` to create perception subscribers using a `rclcpp::SensorDataQoS().keep_last(10)` profile and subscribe via the `rmw_qos_profile()` so the subscriber matches BEST_EFFORT publishers while preserving the existing `tf2_ros::MessageFilter` pipeline (`easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp`).
- Add a small helper `build_perception_qos(...)` and a `to_lower_copy(...)` helper to pick `best_effort` (default) or `reliable` from a parameter and log the selected QoS; startup logs include `Listening to: <topic>` and `Perception subscription QoS: reliability=<...>, depth=10`.
- Add optional YAML parameters to make reliability selectable with sensible defaults: `easy_perception_deployment.epd_subscription_reliability` and `camera_parameters.point_cloud_subscription_reliability`, and add them into the run_grasp_planner configs (`easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/*.yaml`).
- Update the run_grasp_planner launch test to pass the new overrides so CI/launch tests can exercise the new parameters (`easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/test/test_demo_node_parameter_override_launch.test.py`).

### Testing
- `python -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/test/test_demo_node_parameter_override_launch.test.py` succeeded.
- Attempted `colcon build --symlink-install --packages-select emd_grasp_planner run_grasp_planner` but the environment lacks `colcon` so the build could not be executed here (`colcon: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecdd9519a48331b3c43acd7a6e1332)