### PR TITLE
Fix run_grasp_execution YAML loading for ROS 2 Humble xacro

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -194,7 +194,17 @@ def load_file(package, file_path, mappings=None):
 
 def load_yaml(package, file_path):
     package_path = get_package_share_directory(package)
-    return xacro.load_yaml(os.path.join(package_path, file_path))
+    yaml_path = os.path.join(package_path, file_path)
+    try:
+        try:
+            return xacro.load_yaml(yaml_path, [])
+        except TypeError:
+            return xacro.load_yaml(yaml_path)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to load YAML from resolved path '{yaml_path}' (package='{package}', file='{file_path}'). "
+            f"Original error: {exc}"
+        ) from exc
 
 
 def require_yaml_mapping(data, field_name, package_name, file_name):
@@ -283,13 +293,15 @@ def launch_setup(context, *args, **kwargs):
     try:
         gripper_controller_joints = resolve_gripper_controller_joints(scene_package)
     except Exception as exc:
+        scene_package_path = get_package_share_directory(scene_package)
+        scene_yaml_path = os.path.join(scene_package_path, "environment.yaml")
         raise RuntimeError(
             "Failed while parsing scene metadata for grasp execution launch. "
-            f"package='{scene_package}', file='environment.yaml', args: "
+            f"package='{scene_package}', file='environment.yaml', resolved_path='{scene_yaml_path}', args: "
             f"{SCENE_PACKAGE_ARGUMENT}='{scene_package}', "
             f"{MOVEIT_CONFIG_PACKAGE_ARGUMENT}='{moveit_config_package}', "
             f"{PLANNING_FRAME_ARGUMENT}='{planning_frame}'. "
-            "Please verify that the selected scene package contains a valid environment.yaml."
+            f"Original error: {exc}"
         ) from exc
 
     scene_xacro_path = Path(get_package_share_directory(scene_package)) / "urdf" / "scene.urdf.xacro"


### PR DESCRIPTION
### Motivation
- Prevent launch-time crashes when `xacro.load_yaml` in ROS 2 Humble requires a non-`None` filestack and raises `AttributeError`. 
- Make YAML/xacro failures easier to diagnose by surfacing the resolved absolute path and original exception text.

### Description
- Updated `load_yaml(package, file_path)` to resolve the absolute `yaml_path` and first call `xacro.load_yaml(yaml_path, [])`, falling back to `xacro.load_yaml(yaml_path)` on `TypeError` for older xacro signatures. 
- Wrapped `xacro.load_yaml` calls to raise a `RuntimeError` that includes the resolved `yaml_path`, `package`, `file_path`, and the original exception message when loading fails. 
- Enhanced the scene metadata parsing error in `launch_setup()` to include the resolved absolute `environment.yaml` path and the original exception text instead of a generic validation hint. 

### Testing
- Ran `python3 -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py`, which succeeded. 
- Attempted `colcon build --symlink-install --packages-select run_grasp_execution` in this environment, but `colcon` was not available so a full build could not be executed (command failed with `colcon: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecea2875548331a967af79e4e4f247)