### PR TITLE
Use PyYAML to load scene YAML in run_grasp_execution (fix Humble xacro bug)

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -25,6 +25,7 @@ from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 
 import xacro
+import yaml
 
 DEFAULT_SCENE_PACKAGE_CANDIDATES = ("ur5_3f_test", "ur5_2f_test", "ur5_airpick4_test", "suction_test")
 PACKAGE_NAME = "run_grasp_execution"
@@ -195,15 +196,15 @@ def load_file(package, file_path, mappings=None):
 def load_yaml(package, file_path):
     package_path = get_package_share_directory(package)
     yaml_path = os.path.join(package_path, file_path)
+
     try:
-        try:
-            return xacro.load_yaml(yaml_path, [])
-        except TypeError:
-            return xacro.load_yaml(yaml_path)
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        return data if data is not None else {}
     except Exception as exc:
         raise RuntimeError(
-            f"Failed to load YAML from resolved path '{yaml_path}' (package='{package}', file='{file_path}'). "
-            f"Original error: {exc}"
+            f"Failed to load YAML from resolved path '{yaml_path}' "
+            f"(package='{package}', file='{file_path}'). Original error: {exc}"
         ) from exc
 
 


### PR DESCRIPTION
### Motivation
- `xacro.load_yaml()` could raise a `'NoneType' object has no attribute 'append'` error on ROS 2 Humble when loading valid scene `.yaml` files, causing the grasp execution launch to fail; the YAML loader needed to be replaced with a Humble-compatible approach.

### Description
- Import `PyYAML` via `import yaml` and replace the old `load_yaml()` implementation in `grasp_execution.launch.py` with a direct file read + `yaml.safe_load()` to parse YAML content.
- Ensure `load_yaml()` returns an empty mapping (`{}`) when `safe_load()` yields `None` so callers expecting a mapping keep working.
- Preserve improved resolved-path context in raised `RuntimeError` messages and remove the `xacro.load_yaml()` fallback entirely.

### Testing
- Ran `python -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py`, which succeeded. 
- Attempted the workspace `colcon build` from the validation steps but the target `~/workcell_ws` was not present in this environment so the build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf3fa7ca083318b44de4cf726cd26)