### PR TITLE
Fix run_grasp_execution ROS 2 controller params passing for Humble

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -208,6 +208,17 @@ def load_yaml(package, file_path):
         ) from exc
 
 
+def write_temp_yaml_params(data, prefix="ros2_controllers_"):
+    import atexit
+
+    fd, path = tempfile.mkstemp(prefix=prefix, suffix=".yaml")
+    os.close(fd)
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+    atexit.register(lambda p=path: Path(p).unlink(missing_ok=True))
+    return path
+
+
 def require_yaml_mapping(data, field_name, package_name, file_name):
     if not isinstance(data, dict):
         raise RuntimeError(
@@ -412,6 +423,10 @@ def launch_setup(context, *args, **kwargs):
         gripper_controller_joints,
         scene_supports_gripper_controller,
     )
+    ros2_controllers_params_file = write_temp_yaml_params(ros2_controllers_yaml)
+    get_logger(__name__).info(
+        f"Generated temporary ROS 2 controllers params file at '{ros2_controllers_params_file}'."
+    )
     moveit_controller = {
         "moveit_simple_controller_manager": controllers_yaml,
         "moveit_controller_manager": "moveit_simple_controller_manager/MoveItSimpleControllerManager",
@@ -468,7 +483,7 @@ def launch_setup(context, *args, **kwargs):
         package="controller_manager",
         executable="ros2_control_node",
         output={"stdout": "screen", "stderr": "screen"},
-        parameters=[ros2_controllers_yaml],
+        parameters=[ros2_controllers_params_file],
         remappings=[("~/robot_description", "/robot_description")],
     )
 


### PR DESCRIPTION
### Motivation
- On ROS 2 Humble passing the modified in-memory controllers dictionary directly to `ros2_control_node` does not preserve node-rooted YAML parameter structure, causing controller spawners to report missing `type` params for controllers such as `joint_state_broadcaster`, `ur5_arm_controller`, and `ur5_gripper_controller`. 
- The change ensures the modified controller params are delivered with the same file-rooted semantics as a real params file so controller_manager can read nested `ros__parameters` fields correctly.

### Description
- Add a helper `write_temp_yaml_params(data, prefix="ros2_controllers_")` in `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` that writes the provided dict to a temporary YAML file using `yaml.safe_dump` and registers cleanup with `atexit`.
- After calling `align_gripper_controller_joints(...)` the launch now calls `write_temp_yaml_params(...)` and logs the generated temporary params file path with `get_logger(__name__).info(...)`.
- Change the `ros2_control_node` launch `Node` to pass the generated temp params file path in `parameters` (i.e. `parameters=[ros2_controllers_params_file]`) instead of the in-memory `ros2_controllers_yaml` dict.
- Preserve the existing `yaml.safe_load` parsing, the dynamic gripper joint alignment logic, and the conditional handling of the gripper controller (do not remove `joint_state_broadcaster` or `ur5_arm_controller`, and only skip `ur5_gripper_controller` when the scene lacks matching interfaces).

### Testing
- Ran `python3 -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` which succeeded.
- Attempted to run the requested workspace build (`colcon build --symlink-install --packages-select run_grasp_execution`) as instructed, but it could not be executed in this environment because the workspace directory referenced in the validation steps was not present. 
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf63a9d708331a2ace5792ad020f1)