### PR TITLE
Fix UR generated scenes to handle base_link_inertia start-state collisions

### DIFF
--- a/assets/robots/universal_robot/ur10_moveit_config/config/ur10.srdf.xacro
+++ b/assets/robots/universal_robot/ur10_moveit_config/config/ur10.srdf.xacro
@@ -38,7 +38,9 @@
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
     <virtual_joint name="fixed_base" type="fixed" parent_frame="world" child_link="base_link" />
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+    <disable_collisions link1="base_link" link2="base_link_inertia" reason="Adjacent" />
     <disable_collisions link1="base_link" link2="shoulder_link" reason="Adjacent" />
+    <disable_collisions link1="base_link_inertia" link2="shoulder_link" reason="Adjacent" />
     <disable_collisions link1="base_link" link2="upper_arm_link" reason="Never" />
     <disable_collisions link1="base_link" link2="wrist_1_link" reason="Never" />
     <disable_collisions link1="tool0" link2="wrist_1_link" reason="Never" />

--- a/assets/robots/universal_robot/ur3_moveit_config/config/ur3.srdf.xacro
+++ b/assets/robots/universal_robot/ur3_moveit_config/config/ur3.srdf.xacro
@@ -38,7 +38,9 @@
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
     <virtual_joint name="fixed_base" type="fixed" parent_frame="world" child_link="base_link" />
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+    <disable_collisions link1="base_link" link2="base_link_inertia" reason="Adjacent" />
     <disable_collisions link1="base_link" link2="shoulder_link" reason="Adjacent" />
+    <disable_collisions link1="base_link_inertia" link2="shoulder_link" reason="Adjacent" />
     <disable_collisions link1="tool0" link2="wrist_1_link" reason="Never" />
     <disable_collisions link1="tool0" link2="wrist_2_link" reason="Never" />
     <disable_collisions link1="tool0" link2="wrist_3_link" reason="Adjacent" />

--- a/assets/robots/universal_robot/ur5_moveit_config/config/ur5.srdf.xacro
+++ b/assets/robots/universal_robot/ur5_moveit_config/config/ur5.srdf.xacro
@@ -38,7 +38,9 @@
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
     <virtual_joint name="fixed_base" type="fixed" parent_frame="world" child_link="base_link" />
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+    <disable_collisions link1="base_link" link2="base_link_inertia" reason="Adjacent" />
     <disable_collisions link1="base_link" link2="shoulder_link" reason="Adjacent" />
+    <disable_collisions link1="base_link_inertia" link2="shoulder_link" reason="Adjacent" />
     <disable_collisions link1="tool0" link2="wrist_1_link" reason="Never" />
     <disable_collisions link1="tool0" link2="wrist_2_link" reason="Never" />
     <disable_collisions link1="tool0" link2="wrist_3_link" reason="Adjacent" />

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/start_positions.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/start_positions.yaml
@@ -1,7 +1,7 @@
 initial_positions:
-  shoulder_pan_joint: 1.57
-  shoulder_lift_joint: -2.35
-  elbow_joint: 1.83
-  wrist_1_joint: -1.03
-  wrist_2_joint: -1.57
+  shoulder_pan_joint: 0.0
+  shoulder_lift_joint: -1.5707
+  elbow_joint: 0.0
+  wrist_1_joint: -1.5707
+  wrist_2_joint: 0.0
   wrist_3_joint: 0.0

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -15,6 +15,7 @@
 import os
 import re
 import tempfile
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
@@ -333,6 +334,55 @@ def _extract_ur_robot_macro_params():
     return {token.lstrip("*") for token in raw_params if token and ":=" not in token}
 
 
+def _extract_link_names_from_urdf(robot_description_xml):
+    try:
+        root = ET.fromstring(robot_description_xml)
+    except ET.ParseError:
+        return set()
+    return {link.attrib.get("name") for link in root.findall("link") if link.attrib.get("name")}
+
+
+def _normalize_srdf_for_ur_base_inertia(robot_description_xml, srdf_xml, logger):
+    required_pairs = (("base_link", "base_link_inertia"), ("base_link_inertia", "shoulder_link"))
+    link_names = _extract_link_names_from_urdf(robot_description_xml)
+    required_links = {"base_link_inertia", "shoulder_link"}
+    if not required_links.issubset(link_names):
+        return srdf_xml
+
+    try:
+        root = ET.fromstring(srdf_xml)
+    except ET.ParseError as exc:
+        logger.warning(
+            f"Skipping UR base_link_inertia SRDF normalization due to parse error: {exc}"
+        )
+        return srdf_xml
+
+    existing_pairs = set()
+    for element in root.findall("disable_collisions"):
+        link1 = element.attrib.get("link1", "")
+        link2 = element.attrib.get("link2", "")
+        if link1 and link2:
+            existing_pairs.add(tuple(sorted((link1, link2))))
+
+    injected_pairs = []
+    for link1, link2 in required_pairs:
+        pair_key = tuple(sorted((link1, link2)))
+        if pair_key in existing_pairs:
+            continue
+        ET.SubElement(root, "disable_collisions", link1=link1, link2=link2, reason="Adjacent")
+        existing_pairs.add(pair_key)
+        injected_pairs.append(f"{link1}<->{link2}")
+
+    if injected_pairs:
+        logger.info(
+            "Injected SRDF disable_collisions pairs for UR base_link_inertia compatibility: "
+            + ", ".join(injected_pairs)
+        )
+        return ET.tostring(root, encoding="unicode")
+
+    return srdf_xml
+
+
 def resolve_required_package_share_dir(package_name, remediation_hint):
     try:
         return get_package_share_directory(package_name)
@@ -355,6 +405,7 @@ def resolve_scene_package_share_dir(scene_package):
 
 
 def launch_setup(context, *args, **kwargs):
+    logger = get_logger(__name__)
     scene_package = LaunchConfiguration(SCENE_PACKAGE_ARGUMENT).perform(context)
     if not scene_package:
         available = ", ".join(DEFAULT_SCENE_PACKAGE_CANDIDATES)
@@ -394,7 +445,7 @@ def launch_setup(context, *args, **kwargs):
             f"Original error: {exc}"
         ) from exc
     workcell_context_params_file = write_temp_yaml_params(scene_workcell_context, prefix="workcell_context_")
-    get_logger(__name__).info(
+    logger.info(
         f"Generated workcell context for scene '{scene_package}': ee={scene_ee_id} "
         f"brand={scene_ee_id} link={scene_ee_link} (file='{workcell_context_params_file}')"
     )
@@ -404,7 +455,7 @@ def launch_setup(context, *args, **kwargs):
     ur_robot_args = _extract_ur_robot_macro_params()
 
     initial_position_mappings = {}
-    if "initial_positions_file" in ur_robot_args:
+    if "initial_positions_file" in ur_robot_args or "initial_positions_file" in scene_args:
         initial_position_path = os.path.join(run_share, "config", "start_positions.yaml")
         initial_position_mappings["initial_positions_file"] = initial_position_path
 
@@ -427,6 +478,12 @@ def launch_setup(context, *args, **kwargs):
             f"{PLANNING_FRAME_ARGUMENT}='{planning_frame}'. "
             "Ensure both URDF/SRDF xacro files exist and are valid."
         ) from exc
+
+    robot_description_semantic_config = _normalize_srdf_for_ur_base_inertia(
+        robot_description_config,
+        robot_description_semantic_config,
+        logger,
+    )
 
     robot_description = {"robot_description": robot_description_config}
     robot_description_semantic = {"robot_description_semantic": robot_description_semantic_config}
@@ -507,7 +564,7 @@ def launch_setup(context, *args, **kwargs):
         scene_supports_gripper_controller,
     )
     ros2_controllers_params_file = write_temp_yaml_params(ros2_controllers_yaml)
-    get_logger(__name__).info(
+    logger.info(
         f"Generated temporary ROS 2 controllers params file at '{ros2_controllers_params_file}'."
     )
     moveit_controller = {
@@ -614,7 +671,7 @@ def launch_setup(context, *args, **kwargs):
         spawn_gripper = TimerAction(period=3.0, actions=[gripper_spawner])
         launch_actions.insert(-1, spawn_gripper)
     else:
-        get_logger(__name__).warning(
+        logger.warning(
             "Skipping ur5_gripper_controller spawner: scene metadata and robot description do not agree on "
             "gripper controller joints/interfaces; dummy gripper driver remains responsible for gripper actions."
         )

--- a/scripts/validate_ur_srdf_collision_pairs.py
+++ b/scripts/validate_ur_srdf_collision_pairs.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Validate UR scene SRDF collision disable entries for base_link_inertia compatibility."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+REQUIRED_PAIRS = {tuple(sorted(("base_link", "base_link_inertia"))), tuple(sorted(("base_link_inertia", "shoulder_link")))}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("urdf", type=Path, help="Path to resolved URDF XML file")
+    parser.add_argument("srdf", type=Path, help="Path to resolved SRDF XML file")
+    return parser.parse_args()
+
+
+def load_xml(path: Path):
+    try:
+        return ET.fromstring(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise RuntimeError(f"Failed parsing XML '{path}': {exc}") from exc
+
+
+def extract_pairs(root):
+    pairs = []
+    for element in root.findall("disable_collisions"):
+        link1 = element.attrib.get("link1")
+        link2 = element.attrib.get("link2")
+        if link1 and link2:
+            pairs.append(tuple(sorted((link1, link2))))
+    return pairs
+
+
+def main():
+    args = parse_args()
+    urdf_root = load_xml(args.urdf)
+    srdf_root = load_xml(args.srdf)
+
+    urdf_links = {link.attrib.get("name") for link in urdf_root.findall("link") if link.attrib.get("name")}
+    srdf_pairs = extract_pairs(srdf_root)
+    srdf_pair_set = set(srdf_pairs)
+
+    if {"base_link_inertia", "shoulder_link"}.issubset(urdf_links):
+        missing = REQUIRED_PAIRS - srdf_pair_set
+        duplicates = [pair for pair in REQUIRED_PAIRS if srdf_pairs.count(pair) > 1]
+        if missing:
+            missing_text = ", ".join([f"{a}<->{b}" for a, b in sorted(missing)])
+            raise RuntimeError(f"Missing required disable_collisions pairs: {missing_text}")
+        if duplicates:
+            duplicate_text = ", ".join([f"{a}<->{b}" for a, b in sorted(duplicates)])
+            raise RuntimeError(f"Duplicate required disable_collisions pairs detected: {duplicate_text}")
+        print("PASS: Required base_link_inertia collision pairs are present exactly once.")
+        return 0
+
+    print("SKIP: URDF does not include both base_link_inertia and shoulder_link.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- Added missing UR MoveIt SRDF collision disables for `base_link_inertia` adjacency in:
  - `assets/robots/universal_robot/ur3_moveit_config/config/ur3.srdf.xacro`
  - `assets/robots/universal_robot/ur5_moveit_config/config/ur5.srdf.xacro`
  - `assets/robots/universal_robot/ur10_moveit_config/config/ur10.srdf.xacro`
- Updated `run_grasp_execution` launch flow to defensively normalize generated SRDF at runtime when URDF includes `base_link_inertia` and `shoulder_link`:
  - injects missing `disable_collisions` for `base_link/base_link_inertia` and `base_link_inertia/shoulder_link`
  - avoids duplicate entries by checking unordered link-pair existence
  - logs injected pairs
  - safely no-ops when links are absent or SRDF parse fails
- Kept existing behavior for:
  - `yaml.safe_load`-based YAML parsing
  - scene-specific workcell context generation from `environment.yaml`
  - non-`ur_tool0` EE mapping for robotiq/suction/airpick
  - temporary ros2_control params generation with controller manager type entries
- Improved UR start pose robustness by aligning `start_positions.yaml` to UR SRDF "up" pose values.
- Added `scripts/validate_ur_srdf_collision_pairs.py` to validate resolved URDF/SRDF pairs for required base inertia collision disables and duplicate prevention.

## Why
Generated scene SRDFs include UR MoveIt semantics, but newer ROS 2 UR descriptions insert `base_link_inertia` between `base_link` and `shoulder_link`. Without updated disable-collision pairs, MoveIt can reject the initial state due to self-collision.

## Validation
- Static inspection only in this environment (no ROS workspace/runtime execution).
- Changes are scoped to SRDF templates, launch-time SRDF normalization, start positions, and a validation helper script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf94e2dcc8331a1e3590220d3077f)