### PR TITLE
Improve grasp planner/execution reliability: gating, logging, workspace filter, planning_time

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml
@@ -27,7 +27,7 @@ grasp_execution_node:
     
     plan_request_params:
       planning_attempts: 1
-      planning_time: 0.5
+      planning_time: 5.0
       planning_pipeline: ompl
       max_velocity_scaling_factor: 1.0
       max_acceleration_scaling_factor: 1.0
@@ -41,3 +41,14 @@ grasp_execution_node:
     # When true the release pose z-height is aligned to the grasped object's
     # z-height so the arm clears any surface on the return move.
     release_use_grasp_z: true
+
+    # Optional simple workspace filter to reject unreachable grasp candidates
+    # before invoking OMPL.
+    grasp_workspace_filter:
+      enabled: false
+      min_x: -1.0
+      max_x: 1.0
+      min_y: -1.0
+      max_y: 1.0
+      min_z: 0.0
+      max_z: 1.5

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -309,6 +309,30 @@ bool validate_required_finger_link_frames_in_robot_description(
   return true;
 }
 
+struct WorkspaceBounds
+{
+  bool enabled{false};
+  double min_x{-1.0};
+  double max_x{1.0};
+  double min_y{-1.0};
+  double max_y{1.0};
+  double min_z{0.0};
+  double max_z{1.5};
+};
+
+bool pose_within_workspace(
+  const geometry_msgs::msg::PoseStamped & pose,
+  const WorkspaceBounds & bounds)
+{
+  if (!bounds.enabled) {
+    return true;
+  }
+  const auto & p = pose.pose.position;
+  return (p.x >= bounds.min_x && p.x <= bounds.max_x) &&
+         (p.y >= bounds.min_y && p.y <= bounds.max_y) &&
+         (p.z >= bounds.min_z && p.z <= bounds.max_z);
+}
+
 class Demo : public moveit2::MoveitCppGraspExecution
 {
 public:
@@ -340,6 +364,20 @@ public:
       release_x_offset_, "release_x_offset", node, node->get_logger(), -0.3);
     grasp_execution::declare_or_get_param<bool>(
       release_use_grasp_z_, "release_use_grasp_z", node, node->get_logger(), true);
+    workspace_bounds_.enabled = node_->declare_parameter<bool>(
+      "grasp_workspace_filter.enabled", false);
+    workspace_bounds_.min_x = node_->declare_parameter<double>(
+      "grasp_workspace_filter.min_x", -1.0);
+    workspace_bounds_.max_x = node_->declare_parameter<double>(
+      "grasp_workspace_filter.max_x", 1.0);
+    workspace_bounds_.min_y = node_->declare_parameter<double>(
+      "grasp_workspace_filter.min_y", -1.0);
+    workspace_bounds_.max_y = node_->declare_parameter<double>(
+      "grasp_workspace_filter.max_y", 1.0);
+    workspace_bounds_.min_z = node_->declare_parameter<double>(
+      "grasp_workspace_filter.min_z", 0.0);
+    workspace_bounds_.max_z = node_->declare_parameter<double>(
+      "grasp_workspace_filter.max_z", 1.5);
 
     grasp_task_sub_ = node_->create_subscription<emd_msgs::msg::GraspTask>(
       grasp_task_topic, 10,
@@ -358,15 +396,17 @@ public:
         auto task = std::make_unique<emd_msgs::msg::GraspTask>();
         task->task_id = gen_uuid();
         task->grasp_targets = req->grasp_targets;
-        order_schedule(std::move(task), true);
-        res->success = true;
+        const bool success = order_schedule(std::move(task), true);
+        res->success = success;
+        res->message = success ? "Execution completed successfully." : "Execution failed.";
       });
   }
 
-  void order_schedule(
+  bool order_schedule(
     const emd_msgs::msg::GraspTask::SharedPtr & msg,
     bool blocking = false)
   {
+    bool all_targets_success = true;
     // target id will be "#<shape>-<task_id>-<target-index>"
 
     // ------------------- Prepare object for grasping --------------------------
@@ -398,10 +438,12 @@ public:
 
       if (blocking) {
         // Wait for the job to finish
-        bool result;
+        bool result = false;
         planning_scheduler.wait_till_complete(target_id, result);
+        all_targets_success = all_targets_success && result;
       }
     }
+    return all_targets_success;
   }
 
   void check_status(
@@ -531,6 +573,36 @@ public:
 
     for (size_t pose_index = 0; pose_index < grasp_method.grasp_poses.size(); ++pose_index) {
       const auto & grasp_pose = grasp_method.grasp_poses[pose_index];
+      geometry_msgs::msg::PoseStamped grasp_pose_in_robot_frame;
+      to_frame(grasp_pose, grasp_pose_in_robot_frame, this->robot_frame_);
+      const auto & p = grasp_pose_in_robot_frame.pose.position;
+      const auto & q = grasp_pose_in_robot_frame.pose.orientation;
+
+      RCLCPP_INFO(
+        node_->get_logger(),
+        "Grasp candidate %zu/%zu target=%s object_name=%s object_pose_frame=%s grasp_pose_frame=%s "
+        "target_xyz=[%.4f, %.4f, %.4f] target_quat=[%.5f, %.5f, %.5f, %.5f]",
+        pose_index + 1,
+        grasp_method.grasp_poses.size(),
+        target_id.c_str(),
+        target->target_type.c_str(),
+        target->target_pose.header.frame_id.c_str(),
+        grasp_pose.header.frame_id.c_str(),
+        p.x, p.y, p.z, q.x, q.y, q.z, q.w);
+
+      if (!pose_within_workspace(grasp_pose_in_robot_frame, workspace_bounds_)) {
+        RCLCPP_WARN(
+          node_->get_logger(),
+          "Rejected candidate %zu/%zu for target %s: outside workspace bounds "
+          "[x:(%.3f, %.3f) y:(%.3f, %.3f) z:(%.3f, %.3f)].",
+          pose_index + 1,
+          grasp_method.grasp_poses.size(),
+          target_id.c_str(),
+          workspace_bounds_.min_x, workspace_bounds_.max_x,
+          workspace_bounds_.min_y, workspace_bounds_.max_y,
+          workspace_bounds_.min_z, workspace_bounds_.max_z);
+        continue;
+      }
 
       result = this->plan_and_execute_job(
         options,
@@ -635,6 +707,7 @@ private:
   std::string planning_frame_;
   double release_x_offset_{-0.3};
   bool release_use_grasp_z_{true};
+  WorkspaceBounds workspace_bounds_;
 };
 
 }  // namespace grasp_execution

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params.yaml
@@ -1,6 +1,7 @@
 grasp_planning_node:
   ros__parameters:
     grasp_output_service: "grasp_requests"
+    execution_in_progress_gate_enabled: true
     table_to_camera_height: 0.65
     easy_perception_deployment:
       epd_enabled: false

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml
@@ -1,6 +1,7 @@
 grasp_planning_node:
   ros__parameters:
     grasp_output_service: "grasp_requests"
+    execution_in_progress_gate_enabled: true
     table_to_camera_height: 0.65
     easy_perception_deployment:
       epd_localization_topic: "/easy_perception_deployment/epd_localize_output"

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml
@@ -1,6 +1,7 @@
 grasp_planning_node:
   ros__parameters:
     grasp_output_service: "grasp_requests"
+    execution_in_progress_gate_enabled: true
     table_to_camera_height: 0.65
     easy_perception_deployment:
       epd_enabled: false

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_airpick4.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_airpick4.yaml
@@ -1,6 +1,7 @@
 grasp_planning_node:
   ros__parameters:
     grasp_output_service: "grasp_requests"
+    execution_in_progress_gate_enabled: true
     table_to_camera_height: 0.65
     easy_perception_deployment:
       epd_enabled: false

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_suction.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_suction.yaml
@@ -1,6 +1,7 @@
 grasp_planning_node:
   ros__parameters:
     grasp_output_service: "grasp_requests"
+    execution_in_progress_gate_enabled: true
     table_to_camera_height: 0.65
     easy_perception_deployment:
       epd_enabled: false

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/grasp_execution.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/grasp_execution.yaml
@@ -25,7 +25,7 @@ grasp_execution_node:
     
     plan_request_params:
       planning_attempts: 1
-      planning_time: 0.5
+      planning_time: 5.0
       planning_pipeline: ompl
       max_velocity_scaling_factor: 1.0
       max_acceleration_scaling_factor: 1.0

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -53,6 +53,7 @@
 #include "moveit_msgs/msg/collision_object.hpp"
 #include "moveit_msgs/msg/constraints.hpp"
 #include "moveit_msgs/msg/robot_trajectory.hpp"
+#include "planning_scene_monitor/planning_scene_monitor.h"
 
 namespace grasp_execution
 {
@@ -97,6 +98,55 @@ geometry_msgs::msg::Pose get_object_pose_from_world_object(
 }  // namespace detail
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("grasp_execution");
+
+namespace
+{
+void log_goal_failure_diagnostics(
+  const rclcpp::Logger & logger,
+  moveit_cpp::MoveItCppPtr moveit_cpp,
+  const std::string & planning_group,
+  const std::string & ee_link,
+  const geometry_msgs::msg::PoseStamped & pose)
+{
+  auto robot_model = moveit_cpp->getRobotModel();
+  const auto * jmg = robot_model->getJointModelGroup(planning_group);
+  if (!jmg) {
+    RCLCPP_WARN(
+      logger,
+      "Failed candidate diagnosis: joint model group '%s' unavailable.",
+      planning_group.c_str());
+    return;
+  }
+
+  moveit::core::RobotState goal_state(robot_model);
+  goal_state.setToDefaultValues();
+  constexpr double kIkTimeoutS = 0.1;
+  const bool ik_ok = goal_state.setFromIK(jmg, pose.pose, ee_link, kIkTimeoutS);
+  if (!ik_ok) {
+    RCLCPP_WARN(
+      logger,
+      "Candidate diagnosis: IK failure for group='%s' ee_link='%s'.",
+      planning_group.c_str(),
+      ee_link.c_str());
+    return;
+  }
+
+  planning_scene_monitor::LockedPlanningSceneRO scene(moveit_cpp->getPlanningSceneMonitor());
+  const bool in_collision = scene->isStateColliding(goal_state, planning_group);
+  if (in_collision) {
+    RCLCPP_WARN(
+      logger,
+      "Candidate diagnosis: IK solution exists but goal state is in collision for group='%s'.",
+      planning_group.c_str());
+    return;
+  }
+
+  RCLCPP_WARN(
+    logger,
+    "Candidate diagnosis: IK valid and collision-free; likely constraints/planner sampling/unreachable "
+    "goal (e.g., OMPL goal tree sampling failure).");
+}
+}  // namespace
 
 MoveitCppGraspExecution::MoveitCppGraspExecution(
   const rclcpp::Node::SharedPtr & node,
@@ -673,6 +723,7 @@ bool MoveitCppGraspExecution::move_to(
 
   // All strategies failed, exiting
   if (!result) {
+    log_goal_failure_diagnostics(LOGGER, moveit_cpp_, option.planning_group, ee_link, pose);
     return false;
   }
 
@@ -791,6 +842,7 @@ bool MoveitCppGraspExecution::move_to(
 
   // All strategies failed, exiting
   if (!result) {
+    log_goal_failure_diagnostics(LOGGER, moveit_cpp_, planning_group, ee_link, pose);
     return false;
   }
 

--- a/easy_manipulation_deployment/emd_grasp_planner/include/emd/grasp_planner/grasp_scene.hpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/include/emd/grasp_planner/grasp_scene.hpp
@@ -61,6 +61,7 @@
 #include <limits>
 #include <future>
 #include <algorithm>
+#include <chrono>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -180,6 +181,13 @@ protected:
  */
   void send_to_execution(const emd_msgs::msg::GraspTask & grasp_task);
 
+  /*! \brief Service wait wrapper to enable deterministic tests */
+  virtual bool wait_for_output_service(const std::chrono::duration<double> & timeout);
+
+  /*! \brief Service request wrapper to enable deterministic tests */
+  virtual std::shared_future<rclcpp::Client<emd_msgs::srv::GraspRequest>::SharedResponse>
+  send_output_request(const std::shared_ptr<emd_msgs::srv::GraspRequest::Request> & request);
+
   #if EPD_ENABLED == 1
 
 /**
@@ -242,6 +250,10 @@ protected:
   rclcpp::Client<emd_msgs::srv::GraspRequest>::SharedPtr output_client;
   /*! \brief Futures for GraspRequest request */
   std::shared_future<rclcpp::Client<emd_msgs::srv::GraspRequest>::SharedResponse> result_future;
+  /*! \brief True while a grasp execution request is in progress */
+  std::atomic_bool execution_in_progress{false};
+  /*! \brief Runtime gate to skip sending new execution requests while busy */
+  bool execution_gate_enabled{true};
 
   #if EPD_ENABLED == 1
   /*! \brief Client that triggers the EPD workflow */

--- a/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
@@ -122,14 +122,48 @@ void grasp_planner::GraspScene<T>::send_to_execution(
     return;
   }
 
-  RCLCPP_INFO(LOGGER, "Sending Grasp Request to grasp execution module");
+  if (execution_gate_enabled && execution_in_progress.load(std::memory_order_acquire)) {
+    RCLCPP_WARN(
+      LOGGER,
+      "Grasp execution still running; dropping new request with %zu targets due to "
+      "'execution_in_progress_gate_enabled'.",
+      grasp_task.grasp_targets.size());
+    this->grasp_objects.clear();
+    return;
+  }
+
+  if (result_future.valid()) {
+    const auto status = result_future.wait_for(std::chrono::nanoseconds(0));
+    if (status == std::future_status::ready) {
+      auto result = result_future.get();
+      const bool success = static_cast<bool>(result && result->success);
+      RCLCPP_INFO(
+        LOGGER,
+        "Previous grasp execution completed: success=%s message='%s'",
+        success ? "true" : "false",
+        result ? result->message.c_str() : "<null response>");
+      execution_in_progress.store(false, std::memory_order_release);
+    } else {
+      execution_in_progress.store(true, std::memory_order_release);
+      if (execution_gate_enabled) {
+        RCLCPP_INFO(LOGGER, "Previous grasp execution request still running; skipping send.");
+        this->grasp_objects.clear();
+        return;
+      }
+      RCLCPP_WARN(
+        LOGGER,
+        "Previous grasp execution request still running but gate disabled; sending another request.");
+    }
+  }
+
+  RCLCPP_INFO(LOGGER, "Sending grasp request to grasp execution module.");
   auto req = std::make_shared<emd_msgs::srv::GraspRequest::Request>();
   req->grasp_targets = grasp_task.grasp_targets;
-  RCLCPP_INFO(LOGGER, "Waiting for grasp execution service");
+  RCLCPP_INFO(LOGGER, "Waiting for grasp execution service.");
 
   constexpr int kMaxWaitAttempts = 5;
   int attempts = 0;
-  while (!output_client->wait_for_service(std::chrono::seconds(1))) {
+  while (!wait_for_output_service(std::chrono::seconds(1))) {
     if (!rclcpp::ok()) {
       RCLCPP_WARN(
         node->get_logger(), "Grasp execution service wait interrupted. Skipping request.");
@@ -149,23 +183,26 @@ void grasp_planner::GraspScene<T>::send_to_execution(
       attempts, kMaxWaitAttempts);
   }
 
-  if (!this->result_future.valid()) {
-    RCLCPP_INFO(LOGGER, "Client Not started");
-    auto request = output_client->async_send_request(req);
-    this->result_future = request.future.share();
-  } else if (this->result_future.wait_for(std::chrono::nanoseconds(0)) ==
-    std::future_status::timeout)
-  {
-    RCLCPP_INFO(LOGGER, "Grasp Execution still Ongoing");
-  } else {
-    auto result = this->result_future.get();
-    RCLCPP_INFO(
-      LOGGER, "Grasp Execution completed! STATUS: %s!!",
-      (result->success) ? "SUCCESS" : "FAILURE");
-    auto request = output_client->async_send_request(req);
-    this->result_future = request.future.share();
-  }
+  this->result_future = send_output_request(req);
+  execution_in_progress.store(true, std::memory_order_release);
+  RCLCPP_INFO(
+    LOGGER, "Grasp execution request accepted/sent (%zu targets).",
+    req->grasp_targets.size());
   this->grasp_objects.clear();
+}
+
+template<typename T>
+bool grasp_planner::GraspScene<T>::wait_for_output_service(const std::chrono::duration<double> & timeout)
+{
+  return output_client->wait_for_service(timeout);
+}
+
+template<typename T>
+std::shared_future<rclcpp::Client<emd_msgs::srv::GraspRequest>::SharedResponse>
+grasp_planner::GraspScene<T>::send_output_request(
+  const std::shared_ptr<emd_msgs::srv::GraspRequest::Request> & request)
+{
+  return output_client->async_send_request(request).future.share();
 }
 
 template<typename T>
@@ -775,6 +812,10 @@ void grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>::setup(std::string
   this->output_client =
     this->node->create_client<emd_msgs::srv::GraspRequest>(
     this->node->get_parameter("grasp_output_service").as_string());
+  node->get_parameter_or(
+    "execution_in_progress_gate_enabled",
+    execution_gate_enabled,
+    true);
 
   std::string selected_reliability;
   const auto perception_qos = build_perception_qos(
@@ -821,6 +862,10 @@ void grasp_planner::GraspScene<T>::setup(std::string topic_name)
   this->output_client =
     this->node->create_client<emd_msgs::srv::GraspRequest>(
     this->node->get_parameter("grasp_output_service").as_string());
+  node->get_parameter_or(
+    "execution_in_progress_gate_enabled",
+    execution_gate_enabled,
+    true);
 
   this->epd_client =
     this->node->create_client<epd_msgs::srv::Perception>(

--- a/easy_manipulation_deployment/emd_grasp_planner/test/grasp_scene_test.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/test/grasp_scene_test.cpp
@@ -32,10 +32,96 @@ GraspSceneTest::GraspSceneTest()
   node = rclcpp::Node::make_shared("grasp_scene_test", "", node_options);
 }
 
+namespace
+{
+class TestableDirectGraspScene : public grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>
+{
+public:
+  explicit TestableDirectGraspScene(const rclcpp::Node::SharedPtr & node)
+  : grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>(node)
+  {
+  }
+
+  void set_gate_enabled(const bool enabled)
+  {
+    execution_gate_enabled = enabled;
+  }
+
+  void set_client_for_test(
+    const rclcpp::Client<emd_msgs::srv::GraspRequest>::SharedPtr & client)
+  {
+    output_client = client;
+  }
+
+  void invoke_send_to_execution(const emd_msgs::msg::GraspTask & task)
+  {
+    send_to_execution(task);
+  }
+
+  std::atomic<int> send_count{0};
+  bool service_available{true};
+  std::shared_ptr<emd_msgs::srv::GraspRequest::Request> last_request;
+  std::shared_ptr<std::promise<rclcpp::Client<emd_msgs::srv::GraspRequest>::SharedResponse>>
+  delayed_promise;
+
+protected:
+  bool wait_for_output_service(const std::chrono::duration<double> &) override
+  {
+    return service_available;
+  }
+
+  std::shared_future<rclcpp::Client<emd_msgs::srv::GraspRequest>::SharedResponse>
+  send_output_request(
+    const std::shared_ptr<emd_msgs::srv::GraspRequest::Request> & request) override
+  {
+    ++send_count;
+    last_request = request;
+    if (delayed_promise) {
+      return delayed_promise->get_future().share();
+    }
+    auto promise = std::make_shared<std::promise<
+      rclcpp::Client<emd_msgs::srv::GraspRequest>::SharedResponse>>();
+    auto response = std::make_shared<emd_msgs::srv::GraspRequest::Response>();
+    response->success = true;
+    response->message = "ok";
+    promise->set_value(response);
+    return promise->get_future().share();
+  }
+};
+}  // namespace
+
 TEST_F(GraspSceneTest, ConstructDirectGraspScene)
 {
   grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2> test_direct(node);
   SUCCEED();
+}
+
+TEST_F(GraspSceneTest, ExecutionGatePreventsRequestSpamWhileBusy)
+{
+  auto fake_client = node->create_client<emd_msgs::srv::GraspRequest>("grasp_requests");
+  TestableDirectGraspScene scene(node);
+  scene.set_client_for_test(fake_client);
+  scene.set_gate_enabled(true);
+  scene.delayed_promise = std::make_shared<std::promise<
+    rclcpp::Client<emd_msgs::srv::GraspRequest>::SharedResponse>>();
+
+  emd_msgs::msg::GraspTask task;
+  task.task_id = "test-task";
+  emd_msgs::msg::GraspTarget target;
+  target.target_type = "mouse";
+  task.grasp_targets.push_back(target);
+
+  scene.invoke_send_to_execution(task);
+  scene.invoke_send_to_execution(task);
+  EXPECT_EQ(scene.send_count.load(), 1);
+
+  auto response = std::make_shared<emd_msgs::srv::GraspRequest::Response>();
+  response->success = true;
+  response->message = "done";
+  scene.delayed_promise->set_value(response);
+
+  scene.invoke_send_to_execution(task);
+  EXPECT_EQ(scene.send_count.load(), 2);
 }
 
 #if EPD_ENABLED == 1


### PR DESCRIPTION
### Motivation
- Prevent the grasp planner from repeatedly sending execution requests while a previous execution is still active and make execution outcome/logging trustworthy.
- Increase MoveIt planning time to reduce spurious OMPL failures for harder/smaller grasp targets.
- Add diagnostic information and a simple reachable-workspace filter to help identify IK/collision/constraints causes for failed grasp candidates.
- Provide a small automated test to guard against request-spam regressions.

### Description
- Increased default planning timeout from `0.5` to `5.0` seconds in `run_grasp_execution` and `run_waypoint_execution` configs by updating `plan_request_params.planning_time`.
- Added an execution-in-progress gate to the planner by extending `GraspScene` with `execution_in_progress`, `execution_gate_enabled`, and testable wrappers `wait_for_output_service()` and `send_output_request()` and used them in `send_to_execution()` to avoid sending new requests while an outstanding request is active.
- Made planner logs explicit about request lifecycle states: request accepted/sent, previous execution still running (and gated), and previous execution completed with explicit `success` and `message` details in `send_to_execution()`.
- Updated `run_grasp_execution` service handling so a blocking service call now returns a meaningful `success` and `message` that reflect real execution result rather than always returning true.
- Added rich per-candidate debug logging in `run_grasp_execution` showing object name, object pose frame, grasp pose frame, target xyz, target quaternion and candidate index/total before attempting execution.
- Implemented an optional simple workspace-box filter (`grasp_workspace_filter.*` parameters and `pose_within_workspace()`) to reject out-of-bounds grasp candidates before invoking OMPL.
- Added candidate failure diagnostics in MoveIt path with `log_goal_failure_diagnostics()` to attempt classifying failures as `ik failure`, `collision`, or likely `constraints/planner sampling/unreachable goal` and invoked this when planning strategies exhaust.
- Added parameter defaults `execution_in_progress_gate_enabled: true` to the demo planner parameter files (`run_grasp_planner/config/params*.yaml`).
- Added a unit test `ExecutionGatePreventsRequestSpamWhileBusy` in `emd_grasp_planner/test/grasp_scene_test.cpp` that simulates a delayed service response and asserts the planner does not send duplicate requests while the gate is active.

### Testing
- Added unit test `ExecutionGatePreventsRequestSpamWhileBusy` in `easy_manipulation_deployment/emd_grasp_planner/test/grasp_scene_test.cpp` but tests were not executed in this environment because `colcon` is not available here (attempted `colcon test --packages-select emd_grasp_planner --ctest-args -R grasptest --output-on-failure` and it failed with `colcon: command not found`).
- Verified local source changes via repository status and diffs (`git status` / `git diff --stat`) in the development environment; no automated CI run was available in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0e8255a083319528aa340da5dd5f)