### PR TITLE
Transform grasp-frame candidates to MoveIt IK goals; add IK/collision precheck and execution gating

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml
@@ -27,7 +27,7 @@ grasp_execution_node:
     
     plan_request_params:
       planning_attempts: 1
-      planning_time: 5.0
+      planning_time: 1.0
       planning_pipeline: ompl
       max_velocity_scaling_factor: 1.0
       max_acceleration_scaling_factor: 1.0

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -117,13 +117,18 @@ def derive_planner_end_effector_id(end_effector):
 
 
 def derive_workcell_end_effector_link(end_effector):
-    base_link = _normalize_text(end_effector.get("base_link"))
     robot_link = _normalize_text(end_effector.get("robot_link"))
-    if base_link:
-        return base_link
     if robot_link:
         return robot_link
     return "tool0"
+
+
+def derive_workcell_grasp_frame(end_effector):
+    for key in ("grasp_frame", "tcp_link", "physical_ee_link", "base_link", "link"):
+        value = _normalize_text(end_effector.get(key))
+        if value:
+            return value
+    return ""
 
 
 def build_workcell_context_for_scene(scene_package, scene_metadata):
@@ -138,6 +143,7 @@ def build_workcell_context_for_scene(scene_package, scene_metadata):
 
     ee_id = derive_planner_end_effector_id(end_effector)
     ee_link = derive_workcell_end_effector_link(end_effector)
+    ee_grasp_frame = derive_workcell_grasp_frame(end_effector) or ee_link
     return {
         "workcell": {
             "ros__parameters": {
@@ -147,12 +153,13 @@ def build_workcell_context_for_scene(scene_package, scene_metadata):
                 "groups.manipulator.end_effectors": [ee_id],
                 f"groups.manipulator.end_effectors.{ee_id}.brand": ee_id,
                 f"groups.manipulator.end_effectors.{ee_id}.link": ee_link,
+                f"groups.manipulator.end_effectors.{ee_id}.grasp_frame": ee_grasp_frame,
                 f"groups.manipulator.end_effectors.{ee_id}.clearance": 0.1,
                 f"groups.manipulator.end_effectors.{ee_id}.driver.plugin": "grasp_execution/DummyGripperDriver",
                 f"groups.manipulator.end_effectors.{ee_id}.driver.controller": "",
             }
         }
-    }, ee_id, ee_link
+    }, ee_id, ee_link, ee_grasp_frame
 
 
 def align_gripper_controller_joints(
@@ -430,7 +437,7 @@ def launch_setup(context, *args, **kwargs):
     try:
         scene_metadata = load_scene_environment(scene_package)
         gripper_controller_joints = resolve_gripper_controller_joints(scene_package, scene_metadata=scene_metadata)
-        scene_workcell_context, scene_ee_id, scene_ee_link = build_workcell_context_for_scene(
+        scene_workcell_context, scene_ee_id, scene_ee_link, scene_ee_grasp_frame = build_workcell_context_for_scene(
             scene_package, scene_metadata
         )
     except Exception as exc:
@@ -447,7 +454,8 @@ def launch_setup(context, *args, **kwargs):
     workcell_context_params_file = write_temp_yaml_params(scene_workcell_context, prefix="workcell_context_")
     logger.info(
         f"Generated workcell context for scene '{scene_package}': ee={scene_ee_id} "
-        f"brand={scene_ee_id} link={scene_ee_link} (file='{workcell_context_params_file}')"
+        f"brand={scene_ee_id} moveit_link={scene_ee_link} "
+        f"grasp_frame={scene_ee_grasp_frame} (file='{workcell_context_params_file}')"
     )
 
     scene_xacro_path = Path(get_package_share_directory(scene_package)) / "urdf" / "scene.urdf.xacro"

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -26,7 +26,10 @@
 #include <stdexcept>
 #include <unordered_set>
 #include <cctype>
+#include <cmath>
+#include <mutex>
 
+#include <Eigen/Geometry>
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "lifecycle_msgs/msg/transition.hpp"
@@ -43,6 +46,9 @@
 
 #include "moveit/macros/console_colors.h"
 #include "sensor_msgs/msg/joint_state.hpp"
+#include "moveit/collision_detection/collision_common.h"
+#include "planning_scene_monitor/planning_scene_monitor.h"
+#include "tf2_eigen/tf2_eigen.hpp"
 
 
 namespace grasp_execution
@@ -333,6 +339,27 @@ bool pose_within_workspace(
          (p.z >= bounds.min_z && p.z <= bounds.max_z);
 }
 
+bool is_valid_finite(double value)
+{
+  return std::isfinite(value);
+}
+
+std::string format_pose_xyz_quat_rpy(const geometry_msgs::msg::Pose & pose)
+{
+  tf2::Quaternion q_tmp{
+    pose.orientation.x,
+    pose.orientation.y,
+    pose.orientation.z,
+    pose.orientation.w};
+  double yaw{0.0}, pitch{0.0}, roll{0.0};
+  tf2::impl::getEulerYPR(q_tmp, yaw, pitch, roll);
+  std::ostringstream oss;
+  oss << "xyz=[" << pose.position.x << ", " << pose.position.y << ", " << pose.position.z <<
+    "] quat=[" << pose.orientation.x << ", " << pose.orientation.y << ", " << pose.orientation.z <<
+    ", " << pose.orientation.w << "] rpy=[" << roll << ", " << pitch << ", " << yaw << "]";
+  return oss.str();
+}
+
 class Demo : public moveit2::MoveitCppGraspExecution
 {
 public:
@@ -398,7 +425,7 @@ public:
         task->grasp_targets = req->grasp_targets;
         const bool success = order_schedule(std::move(task), true);
         res->success = success;
-        res->message = success ? "Execution completed successfully." : "Execution failed.";
+        res->message = success ? "Execution completed successfully." : get_and_clear_last_failure_message();
       });
   }
 
@@ -495,7 +522,8 @@ public:
 
     // Select grasp method based on end effector availability
     double clearance = 0.0;
-    std::string ee_link = "";
+    std::string moveit_link = "";
+    std::string grasp_frame = "";
     std::string planning_group = "";
 
     const emd_msgs::msg::GraspMethod *selected_method = nullptr;
@@ -504,7 +532,8 @@ public:
         for (auto & ee : group.second.end_effectors) {
           if (ee.second.brand == method.ee_id) {
             selected_method = &method;
-            ee_link = ee.second.link;
+            moveit_link = ee.second.link;
+            grasp_frame = ee.second.grasp_frame.empty() ? ee.second.link : ee.second.grasp_frame;
             clearance = ee.second.clearance;
             planning_group = group.first;
             break;
@@ -533,7 +562,7 @@ public:
     grasp_execution::GraspExecutionContext options;
     options.world_frame = planning_frame_;
     options.planning_group = planning_group;
-    options.ee_link = ee_link;
+    options.ee_link = moveit_link;
     options.move_to_collide_step_size = node_->get_parameter(
       "planning_strategy.cartesian_planning.collide_step_length").as_double();
     options.cartesian_step_size = static_cast<float>(node_->get_parameter(
@@ -547,13 +576,13 @@ public:
     options.clearance = clearance;
 
     // Exit if brand name not found.
-    if (ee_link.empty()) {
+    if (moveit_link.empty()) {
       RCLCPP_ERROR(node_->get_logger(), "End effector brand: %s", ee_brand.c_str());
     }
 
     geometry_msgs::msg::PoseStamped release_pose;
     try {
-      release_pose = get_curr_pose(ee_link);
+      release_pose = get_curr_pose(moveit_link);
     } catch (const std::exception & ex) {
       RCLCPP_ERROR(node_->get_logger(), "Failed to get current pose for target %s: %s",
         target_id.c_str(), ex.what());
@@ -569,28 +598,31 @@ public:
     }
 
     bool result = false;
-    const geometry_msgs::msg::PoseStamped * selected_grasp_pose = nullptr;
+    geometry_msgs::msg::PoseStamped selected_moveit_grasp_pose;
+    bool selected_moveit_grasp_pose_valid = false;
+    bool any_candidate_passed_precheck = false;
 
     for (size_t pose_index = 0; pose_index < grasp_method.grasp_poses.size(); ++pose_index) {
+      if (!rclcpp::ok()) {
+        set_last_failure_message("Execution interrupted during candidate evaluation.");
+        return false;
+      }
       const auto & grasp_pose = grasp_method.grasp_poses[pose_index];
-      geometry_msgs::msg::PoseStamped grasp_pose_in_robot_frame;
-      to_frame(grasp_pose, grasp_pose_in_robot_frame, this->robot_frame_);
-      const auto & p = grasp_pose_in_robot_frame.pose.position;
-      const auto & q = grasp_pose_in_robot_frame.pose.orientation;
+      geometry_msgs::msg::PoseStamped moveit_goal_pose;
+      std::string rejection_reason;
+      const bool precheck_ok = precheck_and_prepare_grasp_candidate(
+        target_id, pose_index, grasp_method.grasp_poses.size(), planning_group, moveit_link, grasp_frame,
+        grasp_pose, moveit_goal_pose, rejection_reason);
+      if (!precheck_ok) {
+        RCLCPP_WARN(
+          node_->get_logger(),
+          "Candidate %zu/%zu rejected for target %s: %s",
+          pose_index + 1, grasp_method.grasp_poses.size(), target_id.c_str(), rejection_reason.c_str());
+        continue;
+      }
+      any_candidate_passed_precheck = true;
 
-      RCLCPP_INFO(
-        node_->get_logger(),
-        "Grasp candidate %zu/%zu target=%s object_name=%s object_pose_frame=%s grasp_pose_frame=%s "
-        "target_xyz=[%.4f, %.4f, %.4f] target_quat=[%.5f, %.5f, %.5f, %.5f]",
-        pose_index + 1,
-        grasp_method.grasp_poses.size(),
-        target_id.c_str(),
-        target->target_type.c_str(),
-        target->target_pose.header.frame_id.c_str(),
-        grasp_pose.header.frame_id.c_str(),
-        p.x, p.y, p.z, q.x, q.y, q.z, q.w);
-
-      if (!pose_within_workspace(grasp_pose_in_robot_frame, workspace_bounds_)) {
+      if (!pose_within_workspace(moveit_goal_pose, workspace_bounds_)) {
         RCLCPP_WARN(
           node_->get_logger(),
           "Rejected candidate %zu/%zu for target %s: outside workspace bounds "
@@ -604,14 +636,19 @@ public:
         continue;
       }
 
+      RCLCPP_INFO(
+        node_->get_logger(),
+        "Candidate %zu/%zu target=%s passed IK/collision precheck. Planning with moveit_link=%s.",
+        pose_index + 1, grasp_method.grasp_poses.size(), target_id.c_str(), moveit_link.c_str());
       result = this->plan_and_execute_job(
         options,
         "Grasp location",
         target_id,
-        grasp_pose);
+        moveit_goal_pose);
 
       if (result) {
-        selected_grasp_pose = &grasp_pose;
+        selected_moveit_grasp_pose = moveit_goal_pose;
+        selected_moveit_grasp_pose_valid = true;
         RCLCPP_INFO(
           node_->get_logger(),
           "Grasp planning/execution succeeded for target %s using candidate %zu/%zu.",
@@ -625,7 +662,17 @@ public:
         target_id.c_str(), pose_index + 1, grasp_method.grasp_poses.size());
     }
 
-    if (!selected_grasp_pose) {
+    if (!any_candidate_passed_precheck) {
+      set_last_failure_message("All grasp pose candidates failed IK/collision precheck.");
+      RCLCPP_ERROR(
+        node_->get_logger(),
+        "All %zu grasp pose candidates failed IK/collision precheck for target %s.",
+        grasp_method.grasp_poses.size(), target_id.c_str());
+      return false;
+    }
+
+    if (!selected_moveit_grasp_pose_valid) {
+      set_last_failure_message("Execution failed after candidate planning attempts.");
       RCLCPP_ERROR(
         node_->get_logger(),
         "All %zu grasp pose candidates failed for target %s.",
@@ -635,22 +682,20 @@ public:
     // ------------------- Attach grasp object to robot --------------------------
     prompt_job_start(
       node_->get_logger(), target_id,
-      "Attaching to robot ee frame: [" + ee_link + "]");
+      "Attaching to robot ee frame: [" + moveit_link + "]");
 
-    end_effector_interface_->grasp_object(this, ee_link, target_id, ee_context_);
+    end_effector_interface_->grasp_object(this, moveit_link, target_id, ee_context_);
 
     prompt_job_end(node_->get_logger(), true);
 
     // Apply configurable release pose offsets. The x_offset is applied to the
     // current EE position. Optionally the z-height is aligned to the grasp
     // pose so the object clears any surface obstacle on approach.
-    geometry_msgs::msg::PoseStamped base_grasp_pose;
-    to_frame(*selected_grasp_pose, base_grasp_pose, this->robot_frame_);
     release_pose.pose.position.x += release_x_offset_;
     if (release_use_grasp_z_) {
-      release_pose.pose.position.z = base_grasp_pose.pose.position.z;
+      release_pose.pose.position.z = selected_moveit_grasp_pose.pose.position.z;
     }
-    release_pose.pose.orientation = base_grasp_pose.pose.orientation;
+    release_pose.pose.orientation = selected_moveit_grasp_pose.pose.orientation;
 
     if(!this->plan_and_execute_job(
         options,
@@ -663,9 +708,9 @@ public:
     // ------------------- detach grasp object from robot --------------------------
     prompt_job_start(
       node_->get_logger(), target_id,
-      "Detaching from robot ee frame: [" + ee_link + "]");
+      "Detaching from robot ee frame: [" + moveit_link + "]");
 
-    end_effector_interface_->release_object(this, ee_link, target_id, ee_context_);
+    end_effector_interface_->release_object(this, moveit_link, target_id, ee_context_);
 
     prompt_job_end(node_->get_logger(), true);
 
@@ -699,6 +744,149 @@ public:
   }
 
 private:
+  void set_last_failure_message(const std::string & message)
+  {
+    std::lock_guard<std::mutex> lock(last_failure_mutex_);
+    last_failure_message_ = message;
+  }
+
+  std::string get_and_clear_last_failure_message()
+  {
+    std::lock_guard<std::mutex> lock(last_failure_mutex_);
+    const std::string message = last_failure_message_.empty() ? "Execution failed." : last_failure_message_;
+    last_failure_message_.clear();
+    return message;
+  }
+
+  bool precheck_and_prepare_grasp_candidate(
+    const std::string & target_id,
+    size_t candidate_index,
+    size_t candidate_total,
+    const std::string & planning_group,
+    const std::string & moveit_link,
+    const std::string & grasp_frame,
+    const geometry_msgs::msg::PoseStamped & original_candidate_pose,
+    geometry_msgs::msg::PoseStamped & out_moveit_goal_pose,
+    std::string & rejection_reason)
+  {
+    auto candidate_pose = original_candidate_pose;
+    if (!normalize_quaternion(candidate_pose.pose.orientation)) {
+      rejection_reason = "invalid candidate quaternion (NaN or zero length).";
+      return false;
+    }
+
+    geometry_msgs::msg::PoseStamped desired_grasp_frame_pose;
+    to_frame(candidate_pose, desired_grasp_frame_pose, this->robot_frame_);
+    out_moveit_goal_pose = desired_grasp_frame_pose;
+
+    auto current_state = get_curr_state();
+    if (!current_state) {
+      rejection_reason = "could not retrieve current robot state for IK precheck.";
+      return false;
+    }
+    const auto robot_model = current_state->getRobotModel();
+    const auto * jmg = robot_model->getJointModelGroup(planning_group);
+    if (!jmg) {
+      rejection_reason = "planning group not found in robot model.";
+      return false;
+    }
+
+    if (grasp_frame != moveit_link) {
+      const auto * moveit_link_model = robot_model->getLinkModel(moveit_link);
+      const auto * grasp_frame_model = robot_model->getLinkModel(grasp_frame);
+      if (!moveit_link_model || !grasp_frame_model) {
+        RCLCPP_WARN(
+          node_->get_logger(),
+          "Candidate %zu/%zu target=%s: grasp frame conversion unavailable "
+          "(moveit_link='%s' exists=%s, grasp_frame='%s' exists=%s). Falling back to legacy behaviour.",
+          candidate_index + 1, candidate_total, target_id.c_str(),
+          moveit_link.c_str(), moveit_link_model ? "true" : "false",
+          grasp_frame.c_str(), grasp_frame_model ? "true" : "false");
+      } else {
+        const Eigen::Isometry3d world_moveit =
+          current_state->getGlobalLinkTransform(moveit_link);
+        const Eigen::Isometry3d world_grasp =
+          current_state->getGlobalLinkTransform(grasp_frame);
+        const Eigen::Isometry3d moveit_to_grasp = world_moveit.inverse() * world_grasp;
+        out_moveit_goal_pose.pose = convert_grasp_frame_pose_to_moveit_link_pose(
+          desired_grasp_frame_pose.pose, moveit_to_grasp);
+      }
+    }
+
+    if (!is_pose_finite(out_moveit_goal_pose.pose)) {
+      rejection_reason = "transformed moveit goal pose contains non-finite values.";
+      return false;
+    }
+
+    moveit::core::RobotState ik_state(robot_model);
+    ik_state.setToDefaultValues();
+    constexpr double kIkTimeoutS = 0.1;
+    const bool ik_ok = ik_state.setFromIK(jmg, out_moveit_goal_pose.pose, moveit_link, kIkTimeoutS);
+
+    geometry_msgs::msg::PoseStamped current_moveit_pose;
+    try {
+      current_moveit_pose = get_curr_pose(moveit_link);
+    } catch (const std::exception & ex) {
+      rejection_reason = std::string("failed to read current moveit link pose: ") + ex.what();
+      return false;
+    }
+    const double dx = out_moveit_goal_pose.pose.position.x - current_moveit_pose.pose.position.x;
+    const double dy = out_moveit_goal_pose.pose.position.y - current_moveit_pose.pose.position.y;
+    const double dz = out_moveit_goal_pose.pose.position.z - current_moveit_pose.pose.position.z;
+    const double translation_distance = std::sqrt(dx * dx + dy * dy + dz * dz);
+
+    RCLCPP_INFO(
+      node_->get_logger(),
+      "Candidate diag target=%s idx=%zu/%zu original_frame=%s original_pose=%s moveit_link=%s "
+      "grasp_frame=%s transformed_moveit_pose=%s current_to_goal_distance=%.5f ik_ok=%s",
+      target_id.c_str(), candidate_index + 1, candidate_total,
+      original_candidate_pose.header.frame_id.c_str(),
+      format_pose_xyz_quat_rpy(desired_grasp_frame_pose.pose).c_str(),
+      moveit_link.c_str(), grasp_frame.c_str(),
+      format_pose_xyz_quat_rpy(out_moveit_goal_pose.pose).c_str(),
+      translation_distance, ik_ok ? "true" : "false");
+
+    if (!ik_ok) {
+      rejection_reason = "IK failed for transformed moveit goal.";
+      return false;
+    }
+
+    planning_scene_monitor::LockedPlanningSceneRO scene(moveit_cpp_->getPlanningSceneMonitor());
+    collision_detection::CollisionRequest req;
+    req.contacts = true;
+    req.max_contacts = 20;
+    req.group_name = planning_group;
+    collision_detection::CollisionResult res;
+    scene->checkCollision(req, res, ik_state);
+    if (res.collision) {
+      std::ostringstream contact_links;
+      bool first = true;
+      for (const auto & contact_pair : res.contacts) {
+        if (!first) {
+          contact_links << ", ";
+        }
+        contact_links << contact_pair.first.first << "<->" << contact_pair.first.second;
+        first = false;
+      }
+      rejection_reason = "IK solution in collision: " + contact_links.str();
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "Candidate %zu/%zu target=%s rejected: %s",
+        candidate_index + 1, candidate_total, target_id.c_str(), rejection_reason.c_str());
+      return false;
+    }
+
+    return true;
+  }
+
+  bool is_pose_finite(const geometry_msgs::msg::Pose & pose) const
+  {
+    return is_valid_finite(pose.position.x) && is_valid_finite(pose.position.y) &&
+           is_valid_finite(pose.position.z) && is_valid_finite(pose.orientation.x) &&
+           is_valid_finite(pose.orientation.y) && is_valid_finite(pose.orientation.z) &&
+           is_valid_finite(pose.orientation.w);
+  }
+
   rclcpp::Node::SharedPtr node_;
   std::shared_ptr<emd::EndEffectorExecutioninterface> end_effector_interface_;
   emd::EndEffectorExecutionContext ee_context_;
@@ -708,6 +896,8 @@ private:
   double release_x_offset_{-0.3};
   bool release_use_grasp_z_{true};
   WorkspaceBounds workspace_bounds_;
+  std::mutex last_failure_mutex_;
+  std::string last_failure_message_;
 };
 
 }  // namespace grasp_execution

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
@@ -299,16 +299,16 @@ def test_load_scene_environment_supports_known_generated_scene_packages(grasp_la
 
 
 @pytest.mark.parametrize(
-    ("scene_package", "expected_brand", "expected_link"),
+    ("scene_package", "expected_brand", "expected_moveit_link", "expected_grasp_frame"),
     [
-        ("ur5_2f_test", "robotiq_2f", "gripper_base_link"),
-        ("ur5_3f_test", "robotiq_3f", "palm"),
-        ("suction_test", "suction_cup", "wrist_fixture"),
-        ("ur5_airpick4_test", "suction_cup", "gripper_base_link"),
+        ("ur5_2f_test", "robotiq_2f", "tool0", "gripper_base_link"),
+        ("ur5_3f_test", "robotiq_3f", "tool0", "palm"),
+        ("suction_test", "suction_cup", "tool0", "wrist_fixture"),
+        ("ur5_airpick4_test", "suction_cup", "tool0", "gripper_base_link"),
     ],
 )
 def test_build_workcell_context_maps_scene_end_effector_to_planner_brand_and_link(
-    grasp_launch_module, monkeypatch, scene_package, expected_brand, expected_link
+    grasp_launch_module, monkeypatch, scene_package, expected_brand, expected_moveit_link, expected_grasp_frame
 ):
     repo_root = Path(__file__).resolve().parents[4]
     scenes_root = repo_root / "scenes"
@@ -320,20 +320,22 @@ def test_build_workcell_context_maps_scene_end_effector_to_planner_brand_and_lin
     )
 
     scene_metadata = grasp_launch_module.load_scene_environment(scene_package)
-    workcell_context, ee_id, ee_link = grasp_launch_module.build_workcell_context_for_scene(
+    workcell_context, ee_id, ee_link, ee_grasp_frame = grasp_launch_module.build_workcell_context_for_scene(
         scene_package, scene_metadata
     )
 
     ros_params = workcell_context["workcell"]["ros__parameters"]
     assert ee_id == expected_brand
-    assert ee_link == expected_link
+    assert ee_link == expected_moveit_link
+    assert ee_grasp_frame == expected_grasp_frame
     assert ros_params["groups.manipulator.end_effectors"] == [expected_brand]
     assert ros_params[f"groups.manipulator.end_effectors.{expected_brand}.brand"] == expected_brand
-    assert ros_params[f"groups.manipulator.end_effectors.{expected_brand}.link"] == expected_link
+    assert ros_params[f"groups.manipulator.end_effectors.{expected_brand}.link"] == expected_moveit_link
+    assert ros_params[f"groups.manipulator.end_effectors.{expected_brand}.grasp_frame"] == expected_grasp_frame
 
 
 def test_build_workcell_context_falls_back_to_ur_tool0_only_when_scene_has_no_end_effector(grasp_launch_module):
-    workcell_context, ee_id, ee_link = grasp_launch_module.build_workcell_context_for_scene(
+    workcell_context, ee_id, ee_link, ee_grasp_frame = grasp_launch_module.build_workcell_context_for_scene(
         "scene_without_ee",
         {"robot": {"name": "ur5"}},
     )
@@ -341,6 +343,7 @@ def test_build_workcell_context_falls_back_to_ur_tool0_only_when_scene_has_no_en
     ros_params = workcell_context["workcell"]["ros__parameters"]
     assert ee_id == "ur_tool0"
     assert ee_link == "tool0"
+    assert ee_grasp_frame == "tool0"
     assert ros_params["groups.manipulator.end_effectors"] == ["ur_tool0"]
 
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml
@@ -14,6 +14,7 @@ grasp_planning_node:
       epd_detection_camera_info_topic: "/camera/color/camera_info"
       epd_msg_timeout_s: 5.0
       epd_service_wait_timeout_s: 1.0
+      pause_epd_triggers_while_execution_in_progress: true
       epd_subscription_reliability: "best_effort"
     camera_parameters:
       point_cloud_topic: "/camera/camera/depth/color/points"

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/test/test_target_validation.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/test/test_target_validation.cpp
@@ -103,7 +103,7 @@ TEST(TargetValidation, RejectsUnknownEndEffectorMapping)
 {
   grasp_execution::WorkcellContext workcell_context;
   workcell_context.load_ee(
-    "manipulator_a", "known_ee", "known-brand", "known_link", 0.01, "driver_plugin",
+    "manipulator_a", "known_ee", "known-brand", "known_link", "known_link", 0.01, "driver_plugin",
     "driver_controller");
 
   std::string planning_group = "stale_group";

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/context.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/context.hpp
@@ -44,12 +44,18 @@ struct WorkcellContext
      */
     std::string brand;
 
-    /// gripper ee link.
+    /// MoveIt planning link / robot link used as IK target.
     /**
      * example: "ee_palm".
      * This will be used as the ee link for planning.
      */
     std::string link;
+
+    /// Physical grasp frame (TCP/gripper base) where grasp candidates are defined.
+    /**
+     * If empty, planning falls back to using `link`.
+     */
+    std::string grasp_frame;
 
     /// clearance needed for gripping action
     /**
@@ -164,6 +170,7 @@ struct WorkcellContext
     const std::string & ee_name,
     const std::string & ee_brand,
     const std::string & ee_link,
+    const std::string & ee_grasp_frame,
     double ee_clearance,
     const std::string & ee_driver_plugin,
     const std::string & ee_driver_controller)
@@ -177,6 +184,7 @@ struct WorkcellContext
       ees.emplace(ee_name, Gripper());
       ees[ee_name].brand = ee_brand;
       ees[ee_name].link = ee_link;
+      ees[ee_name].grasp_frame = ee_grasp_frame;
       ees[ee_name].clearance = ee_clearance;
       ees[ee_name].driver.plugin = ee_driver_plugin;
       ees[ee_name].driver.controller = ee_driver_controller;

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/grasp_execution.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/grasp_execution.hpp
@@ -186,12 +186,13 @@ public:
     const std::string & ee_name,
     const std::string & ee_brand,
     const std::string & ee_link,
+    const std::string & ee_grasp_frame,
     double ee_clearance,
     const std::string & ee_driver_plugin,
     const std::string & ee_driver_controller = "")
   {
     workcell_context_->load_ee(
-      group_name, ee_name, ee_brand, ee_link, ee_clearance,
+      group_name, ee_name, ee_brand, ee_link, ee_grasp_frame, ee_clearance,
       ee_driver_plugin, ee_driver_controller);
     return true;
   }

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
@@ -92,6 +92,7 @@ public:
     const std::string & ee_name,
     const std::string & ee_brand,
     const std::string & ee_link,
+    const std::string & ee_grasp_frame,
     double ee_clearance,
     const std::string & ee_driver_plugin,
     const std::string & ee_driver_controller = "") override;

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/utils.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/utils.hpp
@@ -21,7 +21,9 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <cmath>
 
+#include <Eigen/Geometry>
 #include "boost/uuid/uuid.hpp"
 #include "boost/uuid/random_generator.hpp"
 #include "boost/uuid/uuid_io.hpp"
@@ -32,6 +34,7 @@
 #include "tf2_ros/buffer.h"
 #include "tf2/impl/utils.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2_eigen/tf2_eigen.hpp"
 
 namespace grasp_execution
 {
@@ -190,6 +193,32 @@ inline bool parse_pose_vector(
     // Location invalid
     return false;
   }
+}
+
+inline bool normalize_quaternion(geometry_msgs::msg::Quaternion & quat)
+{
+  const double norm_sq =
+    quat.x * quat.x + quat.y * quat.y + quat.z * quat.z + quat.w * quat.w;
+  if (!std::isfinite(norm_sq) || norm_sq <= 1e-12) {
+    return false;
+  }
+  const double norm = std::sqrt(norm_sq);
+  quat.x /= norm;
+  quat.y /= norm;
+  quat.z /= norm;
+  quat.w /= norm;
+  return true;
+}
+
+inline geometry_msgs::msg::Pose convert_grasp_frame_pose_to_moveit_link_pose(
+  const geometry_msgs::msg::Pose & desired_grasp_frame_pose,
+  const Eigen::Isometry3d & moveit_link_to_grasp_frame)
+{
+  Eigen::Isometry3d world_desired_grasp = Eigen::Isometry3d::Identity();
+  tf2::fromMsg(desired_grasp_frame_pose, world_desired_grasp);
+  const Eigen::Isometry3d world_moveit_goal =
+    world_desired_grasp * moveit_link_to_grasp_frame.inverse();
+  return tf2::toMsg(world_moveit_goal);
 }
 
 template<typename T>

--- a/easy_manipulation_deployment/emd_grasp_execution/src/context.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/context.cpp
@@ -189,6 +189,11 @@ void WorkcellContext::init_from_yaml(const std::string &path) {
                                       group_name + ".end_effectors." +
                                           *ee_brand);
       }
+      const std::string ee_grasp_frame =
+        get_string_param(*node_params, ee_prefix + "grasp_frame")
+        .or_else([&]() {return get_string_param(*node_params, ee_prefix + "tcp_link");})
+        .or_else([&]() {return get_string_param(*node_params, ee_prefix + "physical_ee_link");})
+        .value_or(*ee_link);
 
       double ee_clearance =
           get_double_param(*node_params, ee_prefix + "clearance").value_or(
@@ -197,13 +202,14 @@ void WorkcellContext::init_from_yaml(const std::string &path) {
       auto driver_plugin =
           get_string_param(*node_params, driver_prefix + "plugin");
       if (!driver_plugin) {
-        this->load_ee(group_name, ee_name, *ee_brand, *ee_link, ee_clearance,
+        this->load_ee(group_name, ee_name, *ee_brand, *ee_link, ee_grasp_frame, ee_clearance,
                       "grasp_execution/DummyGripperDriverPlugin", "");
       } else {
         std::string driver_controller =
             get_string_param(*node_params, driver_prefix + "controller")
                 .value_or("");
-        this->load_ee(group_name, ee_name, *ee_brand, *ee_link, ee_clearance,
+        this->load_ee(
+          group_name, ee_name, *ee_brand, *ee_link, ee_grasp_frame, ee_clearance,
                       *driver_plugin, driver_controller);
       }
     }

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -321,7 +321,7 @@ bool MoveitCppGraspExecution::init_from_yaml(const std::string & path)
     for (auto & ee : group.end_effectors) {
       if (!this->load_ee(
           group_name, ee.first,
-          ee.second.brand, ee.second.link, ee.second.clearance,
+          ee.second.brand, ee.second.link, ee.second.grasp_frame, ee.second.clearance,
           ee.second.driver.plugin, ee.second.driver.controller))
       {
         return false;
@@ -370,12 +370,13 @@ bool MoveitCppGraspExecution::load_ee(
   const std::string & ee_name,
   const std::string & ee_brand,
   const std::string & ee_link,
+  const std::string & ee_grasp_frame,
   double ee_clearance,
   const std::string & ee_driver_plugin,
   const std::string & ee_driver_controller)
 {
   if (!GraspExecutionInterface::load_ee(
-      group_name, ee_name, ee_brand, ee_link, ee_clearance,
+      group_name, ee_name, ee_brand, ee_link, ee_grasp_frame, ee_clearance,
       ee_driver_plugin, ee_driver_controller))
   {
     return false;
@@ -671,7 +672,7 @@ bool MoveitCppGraspExecution::move_to(
     moveit_cpp::PlanningComponent::PlanSolution plan_solution;
     int count = 0;
 
-    while (!plan_solution && count < option.hybrid_max_attempts) {
+    while (rclcpp::ok() && !plan_solution && count < option.hybrid_max_attempts) {
       arm.planner->setGoal(pose, ee_link);
       plan_solution = arm.planner->plan();  // PlanningComponent::PlanSolution
       count++;
@@ -709,7 +710,7 @@ bool MoveitCppGraspExecution::move_to(
     moveit_cpp::PlanningComponent::PlanSolution plan_solution;
     int count = 0;
 
-    while (!plan_solution && count < option.non_deterministic_max_attempts) {
+    while (rclcpp::ok() && !plan_solution && count < option.non_deterministic_max_attempts) {
       arm.planner->setGoal(pose, ee_link);
       plan_solution = arm.planner->plan();  // PlanningComponent::PlanSolution
       count++;
@@ -790,7 +791,7 @@ bool MoveitCppGraspExecution::move_to(
     moveit_cpp::PlanningComponent::PlanSolution plan_solution;
     int count = 0;
 
-    while (!plan_solution && count < hybrid_max_attempts) {
+    while (rclcpp::ok() && !plan_solution && count < hybrid_max_attempts) {
       arm.planner->setGoal(pose, ee_link);
       plan_solution = arm.planner->plan();  // PlanningComponent::PlanSolution
       count++;
@@ -828,7 +829,7 @@ bool MoveitCppGraspExecution::move_to(
     moveit_cpp::PlanningComponent::PlanSolution plan_solution;
     int count = 0;
 
-    while (!plan_solution && count < non_deterministic_max_attempts) {
+    while (rclcpp::ok() && !plan_solution && count < non_deterministic_max_attempts) {
       arm.planner->setGoal(pose, ee_link);
       plan_solution = arm.planner->plan();  // PlanningComponent::PlanSolution
       count++;
@@ -899,7 +900,7 @@ bool MoveitCppGraspExecution::move_to(
   moveit_cpp::PlanningComponent::PlanSolution plan_solution;
   int count = 0;
 
-  while (!plan_solution && count < non_deterministic_max_attempts) {
+  while (rclcpp::ok() && !plan_solution && count < non_deterministic_max_attempts) {
     arm.planner->setGoal(state);
     plan_solution = arm.planner->plan();  // PlanningComponent::PlanSolution
     count++;
@@ -940,7 +941,7 @@ bool MoveitCppGraspExecution::move_to(
   moveit_cpp::PlanningComponent::PlanSolution plan_solution;
   int count = 0;
 
-  while (!plan_solution && count < non_deterministic_max_attempts) {
+  while (rclcpp::ok() && !plan_solution && count < non_deterministic_max_attempts) {
     arm.planner->setGoal(named_state);
     plan_solution = arm.planner->plan();
     count++;

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
@@ -47,3 +47,13 @@ target_link_libraries(test_moveit_object_pose_utils
 target_compile_features(test_moveit_object_pose_utils
   PRIVATE cxx_std_17
 )
+
+ament_add_gtest(test_pose_transform_utils
+  test_pose_transform_utils.cpp
+)
+target_link_libraries(test_pose_transform_utils
+  grasp_execution_interface
+)
+target_compile_features(test_pose_transform_utils
+  PRIVATE cxx_std_17
+)

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_pose_transform_utils.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_pose_transform_utils.cpp
@@ -1,0 +1,49 @@
+// Copyright 2026
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <Eigen/Geometry>
+
+#include "emd/grasp_execution/utils.hpp"
+
+namespace
+{
+
+TEST(PoseTransformUtils, ConvertsDesiredGraspPoseBackToOriginalDesiredMoveitPose)
+{
+  Eigen::Isometry3d desired_tool0 = Eigen::Isometry3d::Identity();
+  desired_tool0.translation() = Eigen::Vector3d(0.31, -0.12, 0.44);
+  desired_tool0.linear() = (Eigen::AngleAxisd(0.3, Eigen::Vector3d::UnitX()) *
+    Eigen::AngleAxisd(-0.2, Eigen::Vector3d::UnitY()) *
+    Eigen::AngleAxisd(0.5, Eigen::Vector3d::UnitZ())).toRotationMatrix();
+
+  Eigen::Isometry3d tool0_to_gripper = Eigen::Isometry3d::Identity();
+  tool0_to_gripper.translation() = Eigen::Vector3d(0.0, 0.0, 0.17);
+  tool0_to_gripper.linear() =
+    Eigen::AngleAxisd(-1.5707963267948966, Eigen::Vector3d::UnitY()).toRotationMatrix();
+
+  const Eigen::Isometry3d desired_gripper = desired_tool0 * tool0_to_gripper;
+  const auto desired_gripper_pose = tf2::toMsg(desired_gripper);
+
+  const auto converted_tool0_pose =
+    grasp_execution::convert_grasp_frame_pose_to_moveit_link_pose(
+    desired_gripper_pose, tool0_to_gripper);
+
+  Eigen::Isometry3d converted_tool0 = Eigen::Isometry3d::Identity();
+  tf2::fromMsg(converted_tool0_pose, converted_tool0);
+
+  EXPECT_TRUE(converted_tool0.isApprox(desired_tool0, 1e-9));
+}
+
+TEST(PoseTransformUtils, RejectsInvalidQuaternionNormalization)
+{
+  geometry_msgs::msg::Quaternion quat;
+  quat.x = 0.0;
+  quat.y = 0.0;
+  quat.z = 0.0;
+  quat.w = 0.0;
+  EXPECT_FALSE(grasp_execution::normalize_quaternion(quat));
+}
+
+}  // namespace

--- a/easy_manipulation_deployment/emd_grasp_planner/include/emd/grasp_planner/grasp_scene.hpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/include/emd/grasp_planner/grasp_scene.hpp
@@ -266,6 +266,8 @@ protected:
   rclcpp::Time last_epd_msg_time;
   /*! \brief Earliest time when EPD trigger retries are allowed */
   rclcpp::Time next_epd_trigger_time;
+  /*! \brief Pause EPD watchdog/trigger while grasp execution is still in progress */
+  bool pause_epd_triggers_while_execution_in_progress{true};
   /*! \brief Vector of objects in the scene to be picked */
   #endif
 

--- a/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
@@ -731,6 +731,14 @@ template<>
 void grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>::start_planning(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)
 {
+  if (execution_gate_enabled && execution_in_progress.load(std::memory_order_acquire)) {
+    RCLCPP_WARN_THROTTLE(
+      LOGGER,
+      *node->get_clock(),
+      2000,
+      "Execution is in progress; skipping direct point-cloud planning callback.");
+    return;
+  }
   if (planning_in_progress.exchange(true, std::memory_order_acq_rel)) {
     RCLCPP_WARN_THROTTLE(
       LOGGER,
@@ -787,6 +795,14 @@ void grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>::start_planning(
 template<typename T>
 void grasp_planner::GraspScene<T>::start_planning(const typename T::ConstSharedPtr & msg)
 {
+  if (execution_gate_enabled && execution_in_progress.load(std::memory_order_acquire)) {
+    RCLCPP_WARN_THROTTLE(
+      LOGGER,
+      *node->get_clock(),
+      2000,
+      "Execution is in progress; skipping EPD planning callback.");
+    return;
+  }
   RCLCPP_INFO(LOGGER, "Perception input received!");
   last_epd_msg_time = node->get_clock()->now();
   create_world_collision(msg);
@@ -815,6 +831,10 @@ void grasp_planner::GraspScene<sensor_msgs::msg::PointCloud2>::setup(std::string
   node->get_parameter_or(
     "execution_in_progress_gate_enabled",
     execution_gate_enabled,
+    true);
+  node->get_parameter_or(
+    "easy_perception_deployment.pause_epd_triggers_while_execution_in_progress",
+    pause_epd_triggers_while_execution_in_progress,
     true);
 
   std::string selected_reliability;
@@ -923,6 +943,19 @@ void grasp_planner::GraspScene<T>::setup(std::string topic_name)
 template<typename T>
 void grasp_planner::GraspScene<T>::trigger_epd_pipeline()
 {
+  if (
+    pause_epd_triggers_while_execution_in_progress &&
+    execution_gate_enabled &&
+    execution_in_progress.load(std::memory_order_acquire))
+  {
+    RCLCPP_INFO_THROTTLE(
+      LOGGER,
+      *node->get_clock(),
+      2000,
+      "Skipping EPD trigger while grasp execution is in progress.");
+    return;
+  }
+
   const double epd_service_wait_timeout_s = std::max(
     0.0, node->get_parameter("easy_perception_deployment.epd_service_wait_timeout_s").as_double());
   const auto wait_timeout = std::chrono::duration<double>(epd_service_wait_timeout_s);
@@ -967,6 +1000,13 @@ void grasp_planner::GraspScene<T>::evaluate_epd_watchdog(
   double epd_msg_timeout_s)
 {
   if (epd_msg_timeout_s <= 0.0) {
+    return;
+  }
+  if (
+    pause_epd_triggers_while_execution_in_progress &&
+    execution_gate_enabled &&
+    execution_in_progress.load(std::memory_order_acquire))
+  {
     return;
   }
   if (now < next_epd_trigger_time) {


### PR DESCRIPTION
### Motivation
- Grasp candidates are expressed in the gripper/TCP frame while MoveIt IK uses the manipulator end-link (e.g. `tool0`), causing invalid IK goals and OMPL failures.  
- The planner was repeatedly re-triggering execution while a grasp request was in progress, flooding the execution module and masking candidate-level failures.

### Description
- Extend workcell context and loader to carry both the MoveIt IK link and the physical grasp frame (`grasp_frame` / `tcp_link` / `physical_ee_link`) while preserving backward compatibility with existing `link` entries, and log both values on launch (e.g. `moveit_link=tool0 grasp_frame=gripper_base_link`).
- In grasp execution, add candidate prechecks that: validate/normalize quaternions, convert a desired `grasp_frame` pose into the equivalent `moveit_link` target using the fixed transform computed from `getGlobalLinkTransform`, perform a quick `setFromIK` precheck and planning-scene collision check, and skip candidates that fail IK/collision before invoking OMPL.
- Add detailed candidate diagnostics (target id, index, original pose frame + xyz/quaternion/RPY, `moveit_link`, `grasp_frame`, transformed `moveit_link` target, distance to current `moveit_link` pose, IK result, colliding links) and fast-fail behavior returning a clear message when all candidates fail precheck.
- Make planning retry loops responsive to shutdown by checking `rclcpp::ok()` inside planning loops; wire optional suppression of EPD triggers while execution is in progress (param `easy_perception_deployment.pause_epd_triggers_while_execution_in_progress`, default `true`) and add an early guard to drop new planner requests when `execution_in_progress` + gate are active.
- Add utility helpers: `normalize_quaternion(...)` and `convert_grasp_frame_pose_to_moveit_link_pose(...)`, update release motion to use the transformed MoveIt goal, and lower default `planning_time` in demo config to `1.0` to avoid masking invalid candidate issues.
- Tests and launch helpers updated: launch helper now returns `ee_id`, `moveit_link`, and `grasp_frame`; added a C++ unit test that verifies the grasp-frame→MoveIt-link transform identity and quaternion normalization; updated Python unit test expectations for the launch helper.

### Testing
- `python -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` succeeded to validate the updated launch helper syntax. (success)
- `pytest -q easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py` was executed in this environment and the module reported as skipped (environmental dependency `xacro` causes skip in CI-local run). (skipped)
- Attempted to run `colcon build --symlink-install --packages-select run_grasp_execution run_grasp_planner emd_grasp_execution emd_grasp_planner` but `colcon` is not available in this environment so full C++ unit tests / integration build could not be performed here; new GTests were added and are expected to run in a standard CI/build environment. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed14507f448331a9338cc7910cf20c)