### PR TITLE
Make ee_grasp_frame fallback logic C++17-compatible

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/src/context.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/context.cpp
@@ -189,11 +189,17 @@ void WorkcellContext::init_from_yaml(const std::string &path) {
                                       group_name + ".end_effectors." +
                                           *ee_brand);
       }
-      const std::string ee_grasp_frame =
-        get_string_param(*node_params, ee_prefix + "grasp_frame")
-        .or_else([&]() {return get_string_param(*node_params, ee_prefix + "tcp_link");})
-        .or_else([&]() {return get_string_param(*node_params, ee_prefix + "physical_ee_link");})
-        .value_or(*ee_link);
+      auto ee_grasp_frame_opt =
+        get_string_param(*node_params, ee_prefix + "grasp_frame");
+      if (!ee_grasp_frame_opt) {
+        ee_grasp_frame_opt =
+          get_string_param(*node_params, ee_prefix + "tcp_link");
+      }
+      if (!ee_grasp_frame_opt) {
+        ee_grasp_frame_opt =
+          get_string_param(*node_params, ee_prefix + "physical_ee_link");
+      }
+      const std::string ee_grasp_frame = ee_grasp_frame_opt.value_or(*ee_link);
 
       double ee_clearance =
           get_double_param(*node_params, ee_prefix + "clearance").value_or(


### PR DESCRIPTION
### Motivation
- Ensure compatibility with C++17 by removing use of `std::optional::or_else` while keeping the original fallback behavior for the end-effector grasp frame.

### Description
- Replaced the chained `.or_else(...)` calls in `WorkcellContext::init_from_yaml` with an explicit `auto ee_grasp_frame_opt` `optional` and sequential checks assigning `tcp_link` and `physical_ee_link` when earlier options are not set.
- The final fallback remains `value_or(*ee_link)`, preserving the priority order `grasp_frame` > `tcp_link` > `physical_ee_link` > `link`.
- Change applied in `easy_manipulation_deployment/emd_grasp_execution/src/context.cpp` near the end-effector initialization logic.

### Testing
- No automated build or unit tests were executed for this change; only source-level inspections were performed.
- Verified the replacement with a pattern search (`rg`) and inspected the updated region (`nl`) to confirm the new C++17-compatible logic is present and correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1f92679883319ddfae0769f8cb17)