### PR TITLE
Make intentional colcon overrides explicit for ruckig/tesseract packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This package was tested with [easy_perception_deployment](https://github.com/ros
 - Other platforms and experimental combinations are listed later in [Version notes / advanced compatibility](#version-notes--advanced-compatibility)
 
 > Reproducibility expectation: run bootstrap/build from a clean shell that only sources `/opt/ros/humble/setup.bash`. Do not rely on pre-sourced overlays from other workspaces.
+>
+> Intentional overlay note: this workspace can intentionally override underlay packages (`ruckig`, `tesseract_monitoring`, `tesseract_msgs`, `tesseract_rosutils`) when using the source-overlay flow. Include `--allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils` in manual `colcon build` commands to avoid duplicate-package confusion and future hard errors.
 
 ## Quick start (recommended path)
 
@@ -67,6 +69,7 @@ rosdep install --from-paths src --ignore-src -r -y --rosdistro humble \
 eval "$(./src/easy_manipulation_deployment/scripts/ensure_taskflow_cmake_package.sh --export)"
 ./src/easy_manipulation_deployment/scripts/verify_workspace_discovery.sh
 colcon build --symlink-install --parallel-workers 2 \
+  --allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils \
   --packages-skip tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_planning_server
 source install/setup.bash
 ```
@@ -150,7 +153,7 @@ For scripted workflows, `./scripts/fix_and_build.sh` now runs the same preflight
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
 eval "$(./src/easy_manipulation_deployment/scripts/ensure_taskflow_cmake_package.sh --export)"
 colcon list --base-paths src --names-only | grep -E '^tesseract_motion_planners($|_)'
-colcon build --symlink-install --parallel-workers 2 --packages-skip tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_planning_server
+colcon build --symlink-install --parallel-workers 2 --allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils --packages-skip tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_planning_server
 source install/setup.bash
 ```
 
@@ -194,6 +197,7 @@ rosdep install --from-paths src --ignore-src -r -y --rosdistro humble \
 colcon list --base-paths src --names-only | grep -E '^tesseract_motion_planners($|_)'
 
 colcon build --symlink-install --parallel-workers 2 \
+  --allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils \
   --packages-skip tesseract_qt QtADS tesseract_rviz tesseract_planning_server
 source install/setup.bash
 ```

--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -211,6 +211,7 @@ build_phase() {
   local ros_setup="/opt/ros/humble/setup.bash"
   local skip_keys="qt_advanced_docking,tesseract_visualization"
   local build_skip="tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_planning_server"
+  local allow_override="--allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils"
 
   run_cmd "unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_PREFIX_PATH"
   run_cmd "set +u; : \"\${AMENT_TRACE_SETUP_FILES:=}\"; source '$ros_setup'; set -u"
@@ -234,9 +235,9 @@ build_phase() {
   run_cmd "./src/easy_manipulation_deployment/scripts/verify_workspace_discovery.sh"
 
   if [[ "$PROFILE" == "full" && $WITH_GUI -eq 1 ]]; then
-    run_cmd "colcon build --symlink-install --parallel-workers 2"
+    run_cmd "colcon build --symlink-install --parallel-workers 2 $allow_override"
   else
-    run_cmd "colcon build --symlink-install --parallel-workers 2 --packages-skip $build_skip"
+    run_cmd "colcon build --symlink-install --parallel-workers 2 $allow_override --packages-skip $build_skip"
   fi
 
   append_unique FILES_TOUCHED "$WORKSPACE/build"

--- a/scripts/grasp_demo.sh
+++ b/scripts/grasp_demo.sh
@@ -14,7 +14,7 @@ trap cleanup SIGINT SIGTERM ERR EXIT
 
 # Expose hidden asset packages, build the workspace, and source it
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
-colcon build --symlink-install
+colcon build --symlink-install --allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils
 # shellcheck disable=SC1091
 source install/setup.bash
 ./src/easy_manipulation_deployment/scripts/validate_workspace_assets.sh

--- a/scripts/lib/build.sh
+++ b/scripts/lib/build.sh
@@ -71,6 +71,22 @@ compose_cmake_args() {
     fi
 }
 
+
+colcon_override_args() {
+    # This workspace intentionally overlays source packages on top of the ROS underlay.
+    # Keep these explicit so duplicate-package warnings stay actionable and future
+    # colcon releases do not fail hard on intentional overrides.
+    local args=(
+        --allow-overriding
+        ruckig
+        tesseract_monitoring
+        tesseract_msgs
+        tesseract_rosutils
+    )
+    printf '%s
+' "${args[@]}"
+}
+
 colcon_base_args() {
     local args=(
         --symlink-install
@@ -153,7 +169,9 @@ build_workspace() {
     local foundation_marker="$STATE_DIR/foundation_built"
     local trajopt_setup="$WORKSPACE_ROOT/install/share/trajopt_sco/local_setup.bash"
     local args
+    local override_args
     mapfile -t args < <(colcon_base_args)
+    mapfile -t override_args < <(colcon_override_args)
 
     pushd "$WORKSPACE_ROOT" >/dev/null
 
@@ -165,7 +183,7 @@ build_workspace() {
     if [[ ! -f "$foundation_marker" ]]; then
         log_info "Building foundation packages (through trajopt_sco)"
         reset_colcon_environment
-        colcon build --base-paths "$SRC_DIR" "${args[@]}" \
+        colcon build --base-paths "$SRC_DIR" "${args[@]}" "${override_args[@]}" \
             --packages-up-to trajopt_sco --cmake-args "${CMAKE_ARGS[@]}"
         touch "$foundation_marker"
     else
@@ -182,7 +200,7 @@ build_workspace() {
 
     log_info "Building full workspace"
     reset_colcon_environment
-    colcon build --base-paths "$SRC_DIR" "${full_args[@]}" --cmake-args "${CMAKE_ARGS[@]}"
+    colcon build --base-paths "$SRC_DIR" "${full_args[@]}" "${override_args[@]}" --cmake-args "${CMAKE_ARGS[@]}"
 
     copy_motion_planner_configs
     ensure_motion_planners_component_configs "$WORKSPACE_ROOT"


### PR DESCRIPTION
### Motivation
- The workspace intentionally overlays some source packages on top of binary underlay packages and recent/future `colcon` behavior may treat duplicate package names more strictly. 
- Making the override intent explicit prevents CI/user confusion and avoids potential future hard errors during `colcon build` when duplicates are discoverable.

### Description
- Added `colcon_override_args()` to `scripts/lib/build.sh` and injected its output into both the foundation and full `colcon build` invocations so the shared build helper passes `--allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils`.
- Added an `allow_override` variable to `fix_and_build_humble.sh` and applied it in both the GUI (`full`) and headless build branches to ensure the helper script passes the same explicit override list.
- Updated `scripts/grasp_demo.sh` to include the explicit `--allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils` on the bootstrap `colcon build` used by the demo flow.
- Documented the chosen approach in `README.md` by adding an “Intentional overlay note” and updating example `colcon build` command lines to include the explicit override flags.

### Testing
- Performed a shell syntax check with `bash -n scripts/lib/build.sh fix_and_build_humble.sh scripts/grasp_demo.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1fbd13848331ad16d532da615cb1)