### PR TITLE
Fix MoveIt planning_scene_monitor include paths

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -47,7 +47,7 @@
 #include "moveit/macros/console_colors.h"
 #include "sensor_msgs/msg/joint_state.hpp"
 #include "moveit/collision_detection/collision_common.h"
-#include "planning_scene_monitor/planning_scene_monitor.h"
+#include "moveit/planning_scene_monitor/planning_scene_monitor.h"
 #include "tf2_eigen/tf2_eigen.hpp"
 
 

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -53,7 +53,7 @@
 #include "moveit_msgs/msg/collision_object.hpp"
 #include "moveit_msgs/msg/constraints.hpp"
 #include "moveit_msgs/msg/robot_trajectory.hpp"
-#include "planning_scene_monitor/planning_scene_monitor.h"
+#include "moveit/planning_scene_monitor/planning_scene_monitor.h"
 
 namespace grasp_execution
 {


### PR DESCRIPTION
### Motivation
- Prevent build failures caused by an outdated include path by updating the MoveIt planning scene monitor header reference to the current location.

### Description
- Replaced `"planning_scene_monitor/planning_scene_monitor.h"` with `"moveit/planning_scene_monitor/planning_scene_monitor.h"` in `easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp` and `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp`.

### Testing
- No automated tests were run for this header-path-only change; verification consisted of updating the include strings and confirming the replacements succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed211d7e2c8331a22c11e578e79bc5)