### PR TITLE
Add moveit_ros_planning to moveit_cpp_grasp_execution_interface deps

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt
@@ -70,6 +70,7 @@ target_link_libraries(moveit_cpp_grasp_execution_interface
 
 ament_target_dependencies(moveit_cpp_grasp_execution_interface
   moveit_core
+  moveit_ros_planning
   moveit_ros_planning_interface
   moveit_msgs
   trajectory_msgs


### PR DESCRIPTION
### Motivation
- Ensure include paths and exported usage requirements for `planning_scene_monitor` are provided to the `moveit_cpp_grasp_execution_interface` target.

### Description
- Add `moveit_ros_planning` to the `ament_target_dependencies` block for `moveit_cpp_grasp_execution_interface` in `easy_manipulation_deployment/emd_grasp_execution/CMakeLists.txt` while keeping all existing dependencies unchanged.

### Testing
- Verified the change with `git diff` and `git status` and committed the updated `CMakeLists.txt`; no build or `colcon` tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed219539508331b90305a5cb3556a6)