### PR TITLE
Fix run_grasp_execution startup crash from duplicate workspace param declarations

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -391,20 +391,48 @@ public:
       release_x_offset_, "release_x_offset", node, node->get_logger(), -0.3);
     grasp_execution::declare_or_get_param<bool>(
       release_use_grasp_z_, "release_use_grasp_z", node, node->get_logger(), true);
-    workspace_bounds_.enabled = node_->declare_parameter<bool>(
-      "grasp_workspace_filter.enabled", false);
-    workspace_bounds_.min_x = node_->declare_parameter<double>(
-      "grasp_workspace_filter.min_x", -1.0);
-    workspace_bounds_.max_x = node_->declare_parameter<double>(
-      "grasp_workspace_filter.max_x", 1.0);
-    workspace_bounds_.min_y = node_->declare_parameter<double>(
-      "grasp_workspace_filter.min_y", -1.0);
-    workspace_bounds_.max_y = node_->declare_parameter<double>(
-      "grasp_workspace_filter.max_y", 1.0);
-    workspace_bounds_.min_z = node_->declare_parameter<double>(
-      "grasp_workspace_filter.min_z", 0.0);
-    workspace_bounds_.max_z = node_->declare_parameter<double>(
-      "grasp_workspace_filter.max_z", 1.5);
+    grasp_execution::declare_or_get_param<bool>(
+      workspace_bounds_.enabled,
+      "grasp_workspace_filter.enabled",
+      node,
+      node->get_logger(),
+      false);
+    grasp_execution::declare_or_get_param<double>(
+      workspace_bounds_.min_x,
+      "grasp_workspace_filter.min_x",
+      node,
+      node->get_logger(),
+      -1.0);
+    grasp_execution::declare_or_get_param<double>(
+      workspace_bounds_.max_x,
+      "grasp_workspace_filter.max_x",
+      node,
+      node->get_logger(),
+      1.0);
+    grasp_execution::declare_or_get_param<double>(
+      workspace_bounds_.min_y,
+      "grasp_workspace_filter.min_y",
+      node,
+      node->get_logger(),
+      -1.0);
+    grasp_execution::declare_or_get_param<double>(
+      workspace_bounds_.max_y,
+      "grasp_workspace_filter.max_y",
+      node,
+      node->get_logger(),
+      1.0);
+    grasp_execution::declare_or_get_param<double>(
+      workspace_bounds_.min_z,
+      "grasp_workspace_filter.min_z",
+      node,
+      node->get_logger(),
+      0.0);
+    grasp_execution::declare_or_get_param<double>(
+      workspace_bounds_.max_z,
+      "grasp_workspace_filter.max_z",
+      node,
+      node->get_logger(),
+      1.5);
 
     grasp_task_sub_ = node_->create_subscription<emd_msgs::msg::GraspTask>(
       grasp_task_topic, 10,


### PR DESCRIPTION
### Motivation
- Avoid a startup crash caused by double-declaring parameters when YAML/launch overrides pre-declare `grasp_workspace_filter.*` parameters in the Demo constructor.

### Description
- Replace raw `node_->declare_parameter(...)` calls for all `grasp_workspace_filter.*` parameters in `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp` with `grasp_execution::declare_or_get_param(...)`, preserving the original defaults.

### Testing
- Attempted automated build: ran `colcon build --packages-select run_grasp_execution --symlink-install` in this environment and it failed because `colcon` is not available here (failure).
- Attempted automated launch: ran `source install/setup.bash && ros2 launch run_grasp_execution grasp_execution.launch.py scene_package:=ur5_2f_test` in this environment and it failed due to missing install files (failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede69a44f08331a7360651af2a5b97)