### PR TITLE
Trim octomap frame from sensors config in grasp launch

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -581,8 +581,20 @@ def launch_setup(context, *args, **kwargs):
     }
 
     grasp_execution_yaml = os.path.join(run_share, "config", "grasp_execution.yaml")
-    sensors_yaml = os.path.join(run_share, "config", "sensors_3d.yaml")
     rviz_config_file = os.path.join(run_share, "config", "grasp_execution.rviz")
+    sensors_3d_config = require_yaml_mapping(
+        load_yaml(PACKAGE_NAME, "config/sensors_3d.yaml"),
+        "grasp_execution_node",
+        PACKAGE_NAME,
+        "config/sensors_3d.yaml",
+    )
+    sensor_ros_params = require_yaml_mapping(
+        sensors_3d_config.get("grasp_execution_node"),
+        "ros__parameters",
+        PACKAGE_NAME,
+        "config/sensors_3d.yaml",
+    )
+    sensor_ros_params["octomap_frame"] = planning_frame
 
     grasp_execution_demo_node = Node(
         name="grasp_execution_node",
@@ -598,7 +610,7 @@ def launch_setup(context, *args, **kwargs):
         ),
         parameters=[
             grasp_execution_yaml,
-            sensors_yaml,
+            sensors_3d_config,
             {"workcell_context": workcell_context_params_file},
             {"planning_frame": planning_frame, "octomap_frame": planning_frame},
             robot_description,


### PR DESCRIPTION
### Motivation
- Runtime logs showed the octomap updater target frame as `world ` (with a trailing space), which would break TF matching when octomap is enabled; the launch should ensure frame IDs are canonical and whitespace-trimmed.

### Description
- Load `config/sensors_3d.yaml` as a YAML mapping in `grasp_execution.launch.py` and extract `grasp_execution_node.ros__parameters` so parameters can be adjusted programmatically.
- Overwrite `grasp_execution_node.ros__parameters.octomap_frame` with the already-trimmed `planning_frame` value to guarantee the octomap target frame is sanitized at launch time.
- Pass the sanitized `sensors_3d_config` mapping to the node parameters instead of the raw sensors YAML file path, preserving the existing `{"planning_frame": planning_frame, "octomap_frame": planning_frame}` override and not changing octomap default enablement.

### Testing
- Ran `python -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py`, which completed successfully.
- Ran the launch helper test suite with `pytest -q easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py`, which executed in this environment with tests skipped (no failures observed in this run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edebcff6108331b3cfc13563c5912a)