### PR TITLE
Restore sensors_3d.yaml file-path parameter loading and preserve trimmed octomap_frame

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -582,19 +582,7 @@ def launch_setup(context, *args, **kwargs):
 
     grasp_execution_yaml = os.path.join(run_share, "config", "grasp_execution.yaml")
     rviz_config_file = os.path.join(run_share, "config", "grasp_execution.rviz")
-    sensors_3d_config = require_yaml_mapping(
-        load_yaml(PACKAGE_NAME, "config/sensors_3d.yaml"),
-        "grasp_execution_node",
-        PACKAGE_NAME,
-        "config/sensors_3d.yaml",
-    )
-    sensor_ros_params = require_yaml_mapping(
-        sensors_3d_config.get("grasp_execution_node"),
-        "ros__parameters",
-        PACKAGE_NAME,
-        "config/sensors_3d.yaml",
-    )
-    sensor_ros_params["octomap_frame"] = planning_frame
+    sensors_yaml = os.path.join(run_share, "config", "sensors_3d.yaml")
 
     grasp_execution_demo_node = Node(
         name="grasp_execution_node",
@@ -610,7 +598,7 @@ def launch_setup(context, *args, **kwargs):
         ),
         parameters=[
             grasp_execution_yaml,
-            sensors_3d_config,
+            sensors_yaml,
             {"workcell_context": workcell_context_params_file},
             {"planning_frame": planning_frame, "octomap_frame": planning_frame},
             robot_description,


### PR DESCRIPTION
### Motivation
- A previous change loaded `config/sensors_3d.yaml` into a Python dict and passed the node-shaped mapping as a parameter, which prevented MoveIt from discovering 3D sensor plugins and caused the regression `No 3D sensor plugin(s) defined for octomap updates`.
- The intent is to restore the original behavior of passing the YAML file path to the Node so MoveIt reads sensor plugin configuration, while still removing any trailing whitespace from the planning/octomap frame.

### Description
- Replace the in-memory `sensors_3d_config` mapping with a file-path variable `sensors_yaml = os.path.join(run_share, "config", "sensors_3d.yaml")` so the Node receives the YAML file path instead of a dict.
- Remove the code that loaded/mutated `sensors_3d.yaml` into `sensors_3d_config` and its `ros__parameters` modification.
- Keep `planning_frame = LaunchConfiguration(PLANNING_FRAME_ARGUMENT).perform(context).strip()` and retain the override `{"planning_frame": planning_frame, "octomap_frame": planning_frame}` after `sensors_yaml` in the Node `parameters` list so `octomap_frame` is sanitized and still overrides any value from the YAML.

### Testing
- Ran `python3 -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` which succeeded.
- Static diff/inspection confirmed `sensors_3d.yaml` is now passed as a path in the Node `parameters` list and the `planning_frame` trimming and override ordering are preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ededf8f10c8331afcd404670e02b60)