### PR TITLE
Sanitize sensors_3d octomap frame via temp YAML

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -580,9 +580,32 @@ def launch_setup(context, *args, **kwargs):
         "moveit_controller_manager": "moveit_simple_controller_manager/MoveItSimpleControllerManager",
     }
 
+    sensors_3d_config = require_yaml_mapping(
+        load_yaml(PACKAGE_NAME, "config/sensors_3d.yaml"),
+        "grasp_execution_node",
+        PACKAGE_NAME,
+        "config/sensors_3d.yaml",
+    )
+    node_section = require_yaml_mapping(
+        sensors_3d_config.get("grasp_execution_node"),
+        "grasp_execution_node",
+        PACKAGE_NAME,
+        "config/sensors_3d.yaml",
+    )
+    sensor_ros_params = require_yaml_mapping(
+        node_section.get("ros__parameters"),
+        "ros__parameters",
+        PACKAGE_NAME,
+        "config/sensors_3d.yaml",
+    )
+    sensor_ros_params["octomap_frame"] = planning_frame
+    sensors_yaml = write_temp_yaml_params(sensors_3d_config, prefix="sensors_3d_")
+    logger.info(
+        f"Generated sanitized sensors params file at '{sensors_yaml}' with octomap_frame='{planning_frame}'."
+    )
+
     grasp_execution_yaml = os.path.join(run_share, "config", "grasp_execution.yaml")
     rviz_config_file = os.path.join(run_share, "config", "grasp_execution.rviz")
-    sensors_yaml = os.path.join(run_share, "config", "sensors_3d.yaml")
 
     grasp_execution_demo_node = Node(
         name="grasp_execution_node",


### PR DESCRIPTION
### Motivation
- Resolve trailing whitespace in the octomap target frame so MoveIt/PointCloudOctomapUpdater sees `world` (not `world `). 
- Preserve MoveIt sensor plugin loading semantics by ensuring `sensors_3d.yaml` is provided as a YAML file path, not as an in-memory dict. 
- Avoid changing any unrelated launch behavior (octomap enablement, controllers, scene metadata, gripper logic) while fixing only the octomap frame.

### Description
- Load `config/sensors_3d.yaml` with `load_yaml` and validate nested mappings using `require_yaml_mapping` for `grasp_execution_node` and `ros__parameters`.
- Overwrite only `grasp_execution_node.ros__parameters.octomap_frame` with the already-trimmed `planning_frame` value.
- Write the modified sensors mapping to a temporary YAML via `write_temp_yaml_params(..., prefix="sensors_3d_")` and pass that generated file path in the `Node` `parameters` list instead of an in-memory dict.
- Add a launch logger message reporting the generated sanitized sensors params file path and applied `octomap_frame` for runtime verification.

### Testing
- Ran `python -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` and it succeeded."}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edef7f62d48331b376f54cc69916a2)