### PR TITLE
Fix Robotiq 2F grasp frame to use ee_palm TCP

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -124,6 +124,15 @@ def derive_workcell_end_effector_link(end_effector):
 
 
 def derive_workcell_grasp_frame(end_effector):
+    ee_name = _normalize_text(end_effector.get("name"))
+    ee_brand = _normalize_text(end_effector.get("brand"))
+    ee_type = _normalize_text(end_effector.get("ee_type"))
+    ee_fingers = end_effector.get("attributes", {}).get("fingers")
+    search_blob = " ".join((ee_name, ee_brand, ee_type))
+
+    if any(marker in search_blob for marker in ("robotiq_2f", "robotiq_85")) or ee_fingers == 2:
+        return "ee_palm"
+
     for key in ("grasp_frame", "tcp_link", "physical_ee_link", "base_link", "link"):
         value = _normalize_text(end_effector.get(key))
         if value:

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
@@ -301,7 +301,7 @@ def test_load_scene_environment_supports_known_generated_scene_packages(grasp_la
 @pytest.mark.parametrize(
     ("scene_package", "expected_brand", "expected_moveit_link", "expected_grasp_frame"),
     [
-        ("ur5_2f_test", "robotiq_2f", "tool0", "gripper_base_link"),
+        ("ur5_2f_test", "robotiq_2f", "tool0", "ee_palm"),
         ("ur5_3f_test", "robotiq_3f", "tool0", "palm"),
         ("suction_test", "suction_cup", "tool0", "wrist_fixture"),
         ("ur5_airpick4_test", "suction_cup", "tool0", "gripper_base_link"),
@@ -332,6 +332,18 @@ def test_build_workcell_context_maps_scene_end_effector_to_planner_brand_and_lin
     assert ros_params[f"groups.manipulator.end_effectors.{expected_brand}.brand"] == expected_brand
     assert ros_params[f"groups.manipulator.end_effectors.{expected_brand}.link"] == expected_moveit_link
     assert ros_params[f"groups.manipulator.end_effectors.{expected_brand}.grasp_frame"] == expected_grasp_frame
+
+
+def test_derive_workcell_grasp_frame_prefers_ee_palm_for_robotiq_85_two_finger_metadata(grasp_launch_module):
+    end_effector = {
+        "name": "custom_gripper",
+        "brand": "robotiq_85",
+        "ee_type": "parallel",
+        "attributes": {"fingers": 2},
+        "base_link": "gripper_base_link",
+    }
+
+    assert grasp_launch_module.derive_workcell_grasp_frame(end_effector) == "ee_palm"
 
 
 def test_build_workcell_context_falls_back_to_ur_tool0_only_when_scene_has_no_end_effector(grasp_launch_module):


### PR DESCRIPTION
### Motivation
- 2-finger Robotiq scenes were selecting `gripper_base_link` as the grasp frame which places the wrist area at the object because `gripper_base_link -> ee_palm` has a non-zero TCP offset (0.140 m), causing collision precheck failures during execution. 
- The intended TCP for Robotiq 2F/85 and any 2-finger end-effectors is the palm (`ee_palm`), so the generated workcell should use `ee_palm` to avoid false collisions.

### Description
- Updated `derive_workcell_grasp_frame(end_effector)` in `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` to return `ee_palm` when the end effector is identified as `robotiq_2f`/`robotiq_85` (via `name`/`brand`/`ee_type`) or when `attributes.fingers == 2`, before falling back to metadata keys.
- Kept existing fallback order (`grasp_frame`, `tcp_link`, `physical_ee_link`, `base_link`, `link`) unchanged for other end-effectors.
- Updated the unit test expectation for `ur5_2f_test` from `gripper_base_link` to `ee_palm` and added a focused test `test_derive_workcell_grasp_frame_prefers_ee_palm_for_robotiq_85_two_finger_metadata` to assert `robotiq_85` + `attributes.fingers == 2` returns `ee_palm` even when `base_link` is `gripper_base_link` in `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py`.

### Testing
- Ran `pytest easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py`, which was skipped in this environment due to optional test gating (collected 0 items / 1 skipped); no test failures were observed locally in the modified test file.
- Attempted `colcon build --packages-select run_grasp_execution --symlink-install`, which could not be executed in this environment because `colcon` is not installed.
- Changes are limited to the launch helper logic and unit tests and do not modify planner generation, controller YAML, or 3-finger/suction behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf91a271883319135b435919d0dc1)