### PR TITLE
Fix attached-object octomap collision during release planning

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -730,6 +730,7 @@ public:
         "Grasp release",
         target_id,
         release_pose)){
+          log_release_octomap_collision_diagnostic(target_id, planning_group);
           return false;
       }
 
@@ -913,6 +914,51 @@ private:
            is_valid_finite(pose.position.z) && is_valid_finite(pose.orientation.x) &&
            is_valid_finite(pose.orientation.y) && is_valid_finite(pose.orientation.z) &&
            is_valid_finite(pose.orientation.w);
+  }
+
+  void log_release_octomap_collision_diagnostic(
+    const std::string & target_id,
+    const std::string & planning_group)
+  {
+    auto current_state = get_curr_state();
+    if (!current_state) {
+      return;
+    }
+    planning_scene_monitor::LockedPlanningSceneRO scene(moveit_cpp_->getPlanningSceneMonitor());
+    collision_detection::CollisionRequest req;
+    req.contacts = true;
+    req.max_contacts = 50;
+    req.group_name = planning_group;
+    collision_detection::CollisionResult res;
+    scene->checkCollision(req, res, *current_state);
+    if (!res.collision) {
+      return;
+    }
+
+    bool attached_octomap_contact_found = false;
+    const std::string attached_target = "#" + target_id;
+    for (const auto & contact_pair : res.contacts) {
+      const auto & first = contact_pair.first.first;
+      const auto & second = contact_pair.first.second;
+      const bool has_octomap =
+        first.find("octomap") != std::string::npos || second.find("octomap") != std::string::npos;
+      const bool has_target =
+        first.find(target_id) != std::string::npos || second.find(target_id) != std::string::npos ||
+        first.find(attached_target) != std::string::npos ||
+        second.find(attached_target) != std::string::npos;
+      if (has_octomap && has_target) {
+        attached_octomap_contact_found = true;
+        break;
+      }
+    }
+
+    if (attached_octomap_contact_found) {
+      RCLCPP_ERROR(
+        node_->get_logger(),
+        "Release planning failed because attached target object is still colliding with "
+        "octomap/world geometry. This usually means the picked object's world/octomap "
+        "representation was not cleared or allowed after attach.");
+    }
   }
 
   rclcpp::Node::SharedPtr node_;

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
@@ -236,6 +236,14 @@ public:
   void remove_object(
     const std::string & target_id) override;
 
+  /// Prepare planning-scene collision handling for a freshly attached object.
+  /// This removes any stale world representation of the same object id and
+  /// temporarily allows collisions against octomap entries so immediate
+  /// post-grasp planning does not fail with an invalid start state.
+  void prepare_attached_object_for_release_planning(
+    const std::string & target_id,
+    const std::string & ee_link);
+
   bool execute(
     const robot_trajectory::RobotTrajectoryPtr & traj,
     const std::string & method = "default");

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -1252,6 +1252,8 @@ void MoveitCppGraspExecution::attach_object_to_ee(
     planning_scene_monitor::LockedPlanningSceneRW scene(moveit_cpp_->getPlanningSceneMonitor());
     scene->processAttachedCollisionObjectMsg(attach_object);
   }    // Unlock PlanningScene
+
+  prepare_attached_object_for_release_planning(target_id, ee_link);
 }
 
 void MoveitCppGraspExecution::detach_object_from_ee(
@@ -1295,7 +1297,51 @@ void MoveitCppGraspExecution::detach_object_from_ee(
   {    // Lock PlanningScene
     planning_scene_monitor::LockedPlanningSceneRW scene(moveit_cpp_->getPlanningSceneMonitor());
     scene->processAttachedCollisionObjectMsg(detach_object);
+
+    auto & acm = scene->getAllowedCollisionMatrixNonConst();
+    if (acm.hasEntry(target_id)) {
+      acm.removeEntry(target_id);
+    }
+    const std::string attached_target_id = "#" + target_id;
+    if (acm.hasEntry(attached_target_id)) {
+      acm.removeEntry(attached_target_id);
+    }
   }    // Unlock PlanningScene
+}
+
+void MoveitCppGraspExecution::prepare_attached_object_for_release_planning(
+  const std::string & target_id,
+  const std::string & ee_link)
+{
+  RCLCPP_INFO(
+    LOGGER,
+    "Preparing attached object '%s' for release planning (ee_link=%s).",
+    target_id.c_str(),
+    ee_link.c_str());
+
+  planning_scene_monitor::LockedPlanningSceneRW scene(moveit_cpp_->getPlanningSceneMonitor());
+
+  moveit_msgs::msg::CollisionObject remove_world_object;
+  remove_world_object.id = target_id;
+  remove_world_object.operation = moveit_msgs::msg::CollisionObject::REMOVE;
+  scene->processCollisionObjectMsg(remove_world_object);
+  RCLCPP_INFO(
+    LOGGER,
+    "Removed world collision object for attached target '%s' (if present).",
+    target_id.c_str());
+
+  auto & acm = scene->getAllowedCollisionMatrixNonConst();
+  const std::vector<std::string> octomap_ids = {"<octomap>", "octomap"};
+  const std::vector<std::string> attached_ids = {target_id, "#" + target_id};
+  for (const auto & attached_id : attached_ids) {
+    for (const auto & octomap_id : octomap_ids) {
+      acm.setEntry(attached_id, octomap_id, true);
+    }
+  }
+  RCLCPP_INFO(
+    LOGGER,
+    "Allowed attached target contact with octomap during release start state for target '%s'.",
+    target_id.c_str());
 }
 
 void MoveitCppGraspExecution::remove_object(


### PR DESCRIPTION
### Motivation

- Release planning failed immediately after a successful attach because the attached collision object (#<id>) remained in collision with the world/octomap representation (`<octomap><->#box-*`), causing MoveIt to treat the start state as invalid. 
- The intent is to make attach/release robust for the attached target alone by synchronizing the planning scene and adjusting only the necessary ACM entries, without disabling global robot/world collision checking.

### Description

- Added `prepare_attached_object_for_release_planning(const std::string & target_id, const std::string & ee_link)` to `MoveitCppGraspExecution` (header `moveit_cpp_if.hpp`) and implemented it in `moveit_cpp_if.cpp`. 
- `attach_object_to_ee(target_id, ee_link)` now calls the new helper immediately after attaching the object so the planning scene is synchronized for release planning. 
- The helper removes any stale world collision object for `target_id` and sets ACM allowances so the attached object (`target_id` and `#target_id`) is allowed to contact octomap ids (`"<octomap>"`, `"octomap"`) during the immediate post-grasp start state, and logs informative messages about the actions taken. 
- `detach_object_from_ee(target_id, ee_link)` now removes the temporary ACM entries for `target_id` and `#target_id` to avoid leaking allowances. 
- Added targeted diagnostics in `run_grasp_execution/src/demo_node.cpp` to detect and log a clear error when release planning fails due to attached-target vs octomap/world collisions, and call that diagnostic when `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edfaffd9908331b5224b0345e676bf)