### PR TITLE
Allow attached target to touch support table during release

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
@@ -52,6 +52,8 @@ geometry_msgs::msg::Pose get_object_pose_from_world_object(
   const std::string & object_id,
   const rclcpp::Logger & logger);
 
+std::vector<std::string> get_attached_object_acm_ids(const std::string & target_id);
+
 }  // namespace detail
 
 struct JmgContext
@@ -291,6 +293,7 @@ protected:
       grasp_execution::moveit2::Executor>> executor_loader_;
   bool load_octomap_requested_{false};
   bool world_geometry_monitor_started_{false};
+  std::vector<std::string> release_allowed_touch_links_;
 };
 }  // namespace moveit2
 

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <sstream>
 
 #include "emd/grasp_execution/moveit2/moveit_cpp_if.hpp"
 
@@ -93,6 +94,11 @@ geometry_msgs::msg::Pose get_object_pose_from_world_object(
   object_pose.orientation.z = q.z();
   object_pose.orientation.w = q.w();
   return object_pose;
+}
+
+std::vector<std::string> get_attached_object_acm_ids(const std::string & target_id)
+{
+  return {target_id, "#" + target_id};
 }
 
 }  // namespace detail
@@ -181,6 +187,28 @@ MoveitCppGraspExecution::MoveitCppGraspExecution(
   // Initialized octomap if specified
   grasp_execution::declare_or_get_param<bool>(
     load_octomap_requested_, "load_octomap", node, node->get_logger(), false);
+
+  if (node->has_parameter("release_allowed_touch_links")) {
+    node->get_parameter_or<std::vector<std::string>>(
+      "release_allowed_touch_links",
+      release_allowed_touch_links_,
+      std::vector<std::string>{"table_"});
+  } else {
+    release_allowed_touch_links_ = node->declare_parameter<std::vector<std::string>>(
+      "release_allowed_touch_links",
+      std::vector<std::string>{"table_"});
+  }
+  std::ostringstream touch_links_stream;
+  for (size_t i = 0; i < release_allowed_touch_links_.size(); ++i) {
+    if (i > 0) {
+      touch_links_stream << ", ";
+    }
+    touch_links_stream << release_allowed_touch_links_[i];
+  }
+  RCLCPP_INFO(
+    LOGGER,
+    "Configured release_allowed_touch_links: [%s]",
+    touch_links_stream.str().c_str());
 }
 
 MoveitCppGraspExecution::~MoveitCppGraspExecution()
@@ -1332,7 +1360,7 @@ void MoveitCppGraspExecution::prepare_attached_object_for_release_planning(
 
   auto & acm = scene->getAllowedCollisionMatrixNonConst();
   const std::vector<std::string> octomap_ids = {"<octomap>", "octomap"};
-  const std::vector<std::string> attached_ids = {target_id, "#" + target_id};
+  const std::vector<std::string> attached_ids = detail::get_attached_object_acm_ids(target_id);
   for (const auto & attached_id : attached_ids) {
     for (const auto & octomap_id : octomap_ids) {
       acm.setEntry(attached_id, octomap_id, true);
@@ -1342,6 +1370,19 @@ void MoveitCppGraspExecution::prepare_attached_object_for_release_planning(
     LOGGER,
     "Allowed attached target contact with octomap during release start state for target '%s'.",
     target_id.c_str());
+
+  for (const auto & support_link : release_allowed_touch_links_) {
+    if (support_link.empty()) {
+      continue;
+    }
+    for (const auto & attached_id : attached_ids) {
+      acm.setEntry(attached_id, support_link, true);
+    }
+    RCLCPP_INFO(
+      LOGGER,
+      "Allowed attached target contact with support link '%s' during release planning.",
+      support_link.c_str());
+  }
 }
 
 void MoveitCppGraspExecution::remove_object(
@@ -1359,6 +1400,10 @@ void MoveitCppGraspExecution::remove_object(
     auto & acm = scene->getAllowedCollisionMatrixNonConst();
     if (acm.hasEntry(target_id)) {
       acm.removeEntry(target_id);
+    }
+    const std::string attached_target_id = "#" + target_id;
+    if (acm.hasEntry(attached_target_id)) {
+      acm.removeEntry(attached_target_id);
     }
   }    // Unlock PlanningScene
 }

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
@@ -57,3 +57,13 @@ target_link_libraries(test_pose_transform_utils
 target_compile_features(test_pose_transform_utils
   PRIVATE cxx_std_17
 )
+
+ament_add_gtest(test_release_collision_ids
+  test_release_collision_ids.cpp
+)
+target_link_libraries(test_release_collision_ids
+  moveit_cpp_grasp_execution_interface
+)
+target_compile_features(test_release_collision_ids
+  PRIVATE cxx_std_17
+)

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_release_collision_ids.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_release_collision_ids.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+
+#include "emd/grasp_execution/moveit2/moveit_cpp_if.hpp"
+
+TEST(ReleaseCollisionIds, IncludesTargetAndAttachedTarget)
+{
+  const auto ids = grasp_execution::moveit2::detail::get_attached_object_acm_ids("box_1");
+
+  ASSERT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids[0], "box_1");
+  EXPECT_EQ(ids[1], "#box_1");
+}
+
+TEST(ReleaseCollisionIds, DoesNotIncludeRobotOrSupportLinks)
+{
+  const auto ids = grasp_execution::moveit2::detail::get_attached_object_acm_ids("picked_object");
+
+  for (const auto & id : ids) {
+    EXPECT_NE(id, "table_");
+    EXPECT_NE(id, "upper_arm_link");
+    EXPECT_NE(id, "forearm_link");
+    EXPECT_NE(id, "tool0");
+  }
+}


### PR DESCRIPTION
### Motivation
- Release planning failed when an attached object that was picked collided with a support surface link (e.g. `table_`) that is published as a URDF/model link rather than a world collision object.  
- The intent is to allow only the attached object to be permitted to touch configured support links while attached, without globally disabling robot/table collisions or changing grasp generation.  

### Description
- Added `release_allowed_touch_links_` configurable parameter to `MoveitCppGraspExecution` with default `["table_"]` and startup logging of configured values.  
- Introduced helper `detail::get_attached_object_acm_ids(target_id)` to produce the scoped ACM ids (`target_id` and `#target_id`) so allowances are explicitly tied to the attached object only.  
- Extended `prepare_attached_object_for_release_planning(...)` to preserve the existing octomap allowances and additionally add ACM exceptions only between the attached target ids and each configured support link, with per-link logs.  
- Ensured cleanup remains scoped by removing the temporary ACM entries for both `target_id` and `#target_id` in `detach_object_from_ee` and `remove_object`.  
- Added a unit test `test_release_collision_ids.cpp` and registered it in the unit `CMakeLists.txt` to validate the attached-target ACM id behavior.  

### Testing
- Added unit test file `easy_manipulation_deployment/emd_grasp_execution/test/unit/test_release_collision_ids.cpp` and updated `CMakeLists.txt` to include it, but tests were not executed in this environment.  
- Attempted to build with `colcon build --packages-select emd_grasp_execution run_grasp_execution --symlink-install`, but the environment reported `colcon: command not found`, so no build/tests were run here.  
- Verified repository changes and committed the patch with `git status` and `git commit` (commit message: "Allow attached target to touch support table during release").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edfd4f074083319ac6b6d4e7af769c)