### PR TITLE
Allow expected fingertip contact during grasp precheck collision checks

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 
 add_executable(demo_node src/demo_node.cpp)
+target_include_directories(demo_node PUBLIC include)
 
 ament_target_dependencies(demo_node
   emd_grasp_execution
@@ -31,6 +32,7 @@ ament_target_dependencies(demo_node
 )
 
 add_executable(fake_grasp_pose_publisher src/fake_grasp_pose_publisher.cpp)
+target_include_directories(fake_grasp_pose_publisher PUBLIC include)
 ament_target_dependencies(fake_grasp_pose_publisher
   emd_grasp_execution
   emd_msgs
@@ -58,8 +60,12 @@ install(DIRECTORY
 )
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
   find_package(launch_testing_ament_cmake REQUIRED)
   add_launch_test(test/test_grasp_execution_launch.test.py TIMEOUT 120)
+  ament_add_gtest(test_grasp_precheck_collision_filter
+    test/test_grasp_precheck_collision_filter.cpp)
+  target_include_directories(test_grasp_precheck_collision_filter PUBLIC include)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/README.md
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/README.md
@@ -6,3 +6,13 @@
 - Run launch tests with `colcon test --packages-select run_grasp_execution --ctest-args -R test_grasp_execution_launch`.
 
 The helper test module in `test/test_grasp_execution_launch_helpers.py` is **not** a ROS launch entrypoint.
+
+## Grasp candidate precheck collision filtering
+
+- Grasp precheck now allows expected gripper fingertip contact with the perceived target occupancy during IK collision checks.
+- This filtering is scoped only to grasp candidate precheck, and does **not** change global collision behavior used for planning/execution.
+- Default precheck parameters:
+  - `grasp_precheck_allowed_touch_links: [gripper_finger1_finger_tip_link, gripper_finger2_finger_tip_link]`
+  - `grasp_precheck_allowed_collision_ids: [<octomap>]`
+- The current `target_id` (and attached form `#<target_id>`) is always added dynamically for the candidate being checked.
+- Arm/support collisions (for example `forearm_link<->table_`, `upper_arm_link<->table_`, or arm links vs octomap) remain invalid and still reject the candidate.

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/grasp_precheck_collision_filter.hpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/grasp_precheck_collision_filter.hpp
@@ -1,0 +1,60 @@
+#ifndef RUN_GRASP_EXECUTION__GRASP_PRECHECK_COLLISION_FILTER_HPP_
+#define RUN_GRASP_EXECUTION__GRASP_PRECHECK_COLLISION_FILTER_HPP_
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace run_grasp_execution
+{
+
+struct CollisionFilterResult
+{
+  std::vector<std::string> allowed_pairs;
+  std::vector<std::string> invalid_pairs;
+};
+
+inline std::string pair_to_string(const std::string & first, const std::string & second)
+{
+  return first + "<->" + second;
+}
+
+inline bool pair_contains(
+  const std::string & first,
+  const std::string & second,
+  const std::set<std::string> & ids)
+{
+  return ids.find(first) != ids.end() || ids.find(second) != ids.end();
+}
+
+inline CollisionFilterResult filter_grasp_precheck_collision_pairs(
+  const std::vector<std::pair<std::string, std::string>> & collision_pairs,
+  const std::set<std::string> & allowed_touch_links,
+  const std::set<std::string> & allowed_collision_ids)
+{
+  CollisionFilterResult result;
+  for (const auto & pair : collision_pairs) {
+    const bool first_is_touch_link = allowed_touch_links.find(pair.first) != allowed_touch_links.end();
+    const bool second_is_touch_link = allowed_touch_links.find(pair.second) != allowed_touch_links.end();
+    const bool first_is_allowed_id = allowed_collision_ids.find(pair.first) != allowed_collision_ids.end();
+    const bool second_is_allowed_id = allowed_collision_ids.find(pair.second) != allowed_collision_ids.end();
+
+    const bool is_allowed_pair =
+      (first_is_touch_link && second_is_allowed_id) ||
+      (second_is_touch_link && first_is_allowed_id);
+
+    if (is_allowed_pair) {
+      result.allowed_pairs.push_back(pair_to_string(pair.first, pair.second));
+    } else {
+      result.invalid_pairs.push_back(pair_to_string(pair.first, pair.second));
+    }
+  }
+
+  return result;
+}
+
+}  // namespace run_grasp_execution
+
+#endif  // RUN_GRASP_EXECUTION__GRASP_PRECHECK_COLLISION_FILTER_HPP_

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -30,6 +30,7 @@
 #include <mutex>
 
 #include <Eigen/Geometry>
+#include <boost/algorithm/string/join.hpp>
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "lifecycle_msgs/msg/transition.hpp"
@@ -49,6 +50,7 @@
 #include "moveit/collision_detection/collision_common.h"
 #include "moveit/planning_scene_monitor/planning_scene_monitor.h"
 #include "tf2_eigen/tf2_eigen.hpp"
+#include "run_grasp_execution/grasp_precheck_collision_filter.hpp"
 
 
 namespace grasp_execution
@@ -433,6 +435,33 @@ public:
       node,
       node->get_logger(),
       1.5);
+    if (node_->has_parameter("grasp_precheck_allowed_touch_links")) {
+      node_->get_parameter_or<std::vector<std::string>>(
+        "grasp_precheck_allowed_touch_links",
+        grasp_precheck_allowed_touch_links_,
+        std::vector<std::string>{});
+    } else {
+      grasp_precheck_allowed_touch_links_ = node_->declare_parameter<std::vector<std::string>>(
+        "grasp_precheck_allowed_touch_links",
+        {"gripper_finger1_finger_tip_link", "gripper_finger2_finger_tip_link"});
+    }
+    if (node_->has_parameter("grasp_precheck_allowed_collision_ids")) {
+      node_->get_parameter_or<std::vector<std::string>>(
+        "grasp_precheck_allowed_collision_ids",
+        grasp_precheck_allowed_collision_ids_,
+        std::vector<std::string>{});
+    } else {
+      grasp_precheck_allowed_collision_ids_ = node_->declare_parameter<std::vector<std::string>>(
+        "grasp_precheck_allowed_collision_ids", {"<octomap>"});
+    }
+    RCLCPP_INFO(
+      node_->get_logger(),
+      "Configured grasp_precheck_allowed_touch_links: [%s]",
+      boost::algorithm::join(grasp_precheck_allowed_touch_links_, ", ").c_str());
+    RCLCPP_INFO(
+      node_->get_logger(),
+      "Configured grasp_precheck_allowed_collision_ids: [%s]",
+      boost::algorithm::join(grasp_precheck_allowed_collision_ids_, ", ").c_str());
 
     grasp_task_sub_ = node_->create_subscription<emd_msgs::msg::GraspTask>(
       grasp_task_topic, 10,
@@ -888,21 +917,35 @@ private:
     collision_detection::CollisionResult res;
     scene->checkCollision(req, res, ik_state);
     if (res.collision) {
-      std::ostringstream contact_links;
-      bool first = true;
+      std::vector<std::pair<std::string, std::string>> collision_pairs;
       for (const auto & contact_pair : res.contacts) {
-        if (!first) {
-          contact_links << ", ";
-        }
-        contact_links << contact_pair.first.first << "<->" << contact_pair.first.second;
-        first = false;
+        collision_pairs.emplace_back(contact_pair.first.first, contact_pair.first.second);
       }
-      rejection_reason = "IK solution in collision: " + contact_links.str();
-      RCLCPP_WARN(
-        node_->get_logger(),
-        "Candidate %zu/%zu target=%s rejected: %s",
-        candidate_index + 1, candidate_total, target_id.c_str(), rejection_reason.c_str());
-      return false;
+      std::set<std::string> allowed_touch_links(
+        grasp_precheck_allowed_touch_links_.begin(), grasp_precheck_allowed_touch_links_.end());
+      std::set<std::string> allowed_collision_ids(
+        grasp_precheck_allowed_collision_ids_.begin(), grasp_precheck_allowed_collision_ids_.end());
+      allowed_collision_ids.insert(target_id);
+      allowed_collision_ids.insert("#" + target_id);
+
+      const auto filter_result = run_grasp_execution::filter_grasp_precheck_collision_pairs(
+        collision_pairs, allowed_touch_links, allowed_collision_ids);
+      if (!filter_result.allowed_pairs.empty() && filter_result.invalid_pairs.empty()) {
+        RCLCPP_INFO(
+          node_->get_logger(),
+          "Candidate %zu/%zu target=%s allowed expected grasp contact: %s",
+          candidate_index + 1, candidate_total, target_id.c_str(),
+          boost::algorithm::join(filter_result.allowed_pairs, ", ").c_str());
+      }
+      if (!filter_result.invalid_pairs.empty()) {
+        rejection_reason = "IK solution in collision: " +
+          boost::algorithm::join(filter_result.invalid_pairs, ", ");
+        RCLCPP_WARN(
+          node_->get_logger(),
+          "Candidate %zu/%zu target=%s rejected: %s",
+          candidate_index + 1, candidate_total, target_id.c_str(), rejection_reason.c_str());
+        return false;
+      }
     }
 
     return true;
@@ -970,6 +1013,8 @@ private:
   double release_x_offset_{-0.3};
   bool release_use_grasp_z_{true};
   WorkspaceBounds workspace_bounds_;
+  std::vector<std::string> grasp_precheck_allowed_touch_links_;
+  std::vector<std::string> grasp_precheck_allowed_collision_ids_;
   std::mutex last_failure_mutex_;
   std::string last_failure_message_;
 };

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_precheck_collision_filter.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_precheck_collision_filter.cpp
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "run_grasp_execution/grasp_precheck_collision_filter.hpp"
+
+TEST(GraspPrecheckCollisionFilter, AllowsOctomapToFingertipPair)
+{
+  const std::vector<std::pair<std::string, std::string>> pairs = {
+    {"<octomap>", "gripper_finger1_finger_tip_link"}};
+  const std::set<std::string> allowed_touch_links = {
+    "gripper_finger1_finger_tip_link", "gripper_finger2_finger_tip_link"};
+  const std::set<std::string> allowed_collision_ids = {"<octomap>", "#box-1"};
+  const auto result = run_grasp_execution::filter_grasp_precheck_collision_pairs(
+    pairs, allowed_touch_links, allowed_collision_ids);
+
+  ASSERT_EQ(result.allowed_pairs.size(), 1u);
+  EXPECT_TRUE(result.invalid_pairs.empty());
+}
+
+TEST(GraspPrecheckCollisionFilter, AllowsTargetToFingertipPair)
+{
+  const std::vector<std::pair<std::string, std::string>> pairs = {
+    {"#box-123", "gripper_finger2_finger_tip_link"}};
+  const std::set<std::string> allowed_touch_links = {
+    "gripper_finger1_finger_tip_link", "gripper_finger2_finger_tip_link"};
+  const std::set<std::string> allowed_collision_ids = {"<octomap>", "#box-123"};
+  const auto result = run_grasp_execution::filter_grasp_precheck_collision_pairs(
+    pairs, allowed_touch_links, allowed_collision_ids);
+
+  ASSERT_EQ(result.allowed_pairs.size(), 1u);
+  EXPECT_TRUE(result.invalid_pairs.empty());
+}
+
+TEST(GraspPrecheckCollisionFilter, RejectsForearmTablePair)
+{
+  const std::vector<std::pair<std::string, std::string>> pairs = {
+    {"forearm_link", "table_"}};
+  const std::set<std::string> allowed_touch_links = {
+    "gripper_finger1_finger_tip_link", "gripper_finger2_finger_tip_link"};
+  const std::set<std::string> allowed_collision_ids = {"<octomap>", "#box-123"};
+  const auto result = run_grasp_execution::filter_grasp_precheck_collision_pairs(
+    pairs, allowed_touch_links, allowed_collision_ids);
+
+  EXPECT_TRUE(result.allowed_pairs.empty());
+  ASSERT_EQ(result.invalid_pairs.size(), 1u);
+  EXPECT_EQ(result.invalid_pairs.front(), "forearm_link<->table_");
+}
+
+TEST(GraspPrecheckCollisionFilter, MixedPairsKeepOnlyInvalidCollisions)
+{
+  const std::vector<std::pair<std::string, std::string>> pairs = {
+    {"<octomap>", "gripper_finger1_finger_tip_link"},
+    {"forearm_link", "table_"}};
+  const std::set<std::string> allowed_touch_links = {
+    "gripper_finger1_finger_tip_link", "gripper_finger2_finger_tip_link"};
+  const std::set<std::string> allowed_collision_ids = {"<octomap>", "#box-123"};
+  const auto result = run_grasp_execution::filter_grasp_precheck_collision_pairs(
+    pairs, allowed_touch_links, allowed_collision_ids);
+
+  ASSERT_EQ(result.allowed_pairs.size(), 1u);
+  ASSERT_EQ(result.invalid_pairs.size(), 1u);
+  EXPECT_EQ(result.invalid_pairs.front(), "forearm_link<->table_");
+}


### PR DESCRIPTION
### Motivation
- Grasp candidate IK prechecks were rejecting valid grasps because expected fingertip contact with the perceived target (or `<octomap>`) appeared as collisions.
- The goal is to allow only expected fingertip<->target/octomap contacts for the candidate precheck while keeping all other collision rejections (arm/table, arm/octomap) unchanged.

### Description
- Added a small, focused helper `filter_grasp_precheck_collision_pairs` in `include/run_grasp_execution/grasp_precheck_collision_filter.hpp` to classify collision pairs into `allowed_pairs` and `invalid_pairs` based on configured touch links and collision IDs.
- Updated `run_grasp_execution/src/demo_node.cpp` to declare/load two new parameters with sane defaults: `grasp_precheck_allowed_touch_links` (defaults to `['gripper_finger1_finger_tip_link','gripper_finger2_finger_tip_link']`) and `grasp_precheck_allowed_collision_ids` (defaults to `['<octomap>']`), and to dynamically add the current `target_id` and `#target_id` to allowed IDs during each candidate check.
- Integrated the filter into `precheck_and_prepare_grasp_candidate` so IK checking is unchanged but collision contacts are filtered: if only allowed fingertip<->target/octomap contacts are present the candidate is accepted (with an info log), otherwise the candidate is rejected and only remaining invalid collision pairs are reported in the rejection log.
- Added unit tests `test/test_grasp_precheck_collision_filter.cpp` exercising allowed `<octomap><->fingertip>`, allowed `target_id<->fingertip`, invalid `forearm_link<->table_`, and mixed allowed+invalid behavior, and updated `CMakeLists.txt` to compile the test target and ensure includes are available.
- Updated `run_grasp_execution/README.md` to document the precheck behavior and parameter defaults, and preserved existing `release_allowed_touch_links` semantics.

### Testing
- Added unit tests under `run_grasp_execution/test/test_grasp_precheck_collision_filter.cpp` covering allowed and invalid collision-pair classification (tests added but not executed in this environment).
- Attempted to run `colcon build --symlink-install --packages-select run_grasp_execution --cmake-args -DBUILD_TESTING=ON`, but the environment lacked `colcon` and the build failed with `colcon: command not found` so tests were not executed here.
- The changes are intentionally scoped and unit-testable; running CI or a local workspace with ROS2/colcon available should build and run the new gtests and the package as usual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee05de4d3c8331b7df989308912fa4)