### PR TITLE
Apply grasp precheck allowed contacts to MoveIt planning ACM

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -717,11 +717,13 @@ public:
         node_->get_logger(),
         "Candidate %zu/%zu target=%s passed IK/collision precheck. Planning with moveit_link=%s.",
         pose_index + 1, grasp_method.grasp_poses.size(), target_id.c_str(), moveit_link.c_str());
+      this->apply_grasp_planning_allowed_contacts(target_id);
       result = this->plan_and_execute_job(
         options,
         "Grasp location",
         target_id,
         moveit_goal_pose);
+      this->clear_grasp_planning_allowed_contacts(target_id);
 
       if (result) {
         selected_moveit_grasp_pose = moveit_goal_pose;

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/moveit_cpp_if.hpp
@@ -32,6 +32,7 @@
 #include "moveit/trajectory_processing/iterative_time_parameterization.h"
 #include "moveit/trajectory_processing/time_optimal_trajectory_generation.h"
 #include "moveit/collision_detection/world.h"
+#include "moveit/collision_detection/collision_matrix.h"
 
 #include "moveit_msgs/msg/attached_collision_object.hpp"
 #include "moveit_msgs/msg/collision_object.hpp"
@@ -53,6 +54,13 @@ geometry_msgs::msg::Pose get_object_pose_from_world_object(
   const rclcpp::Logger & logger);
 
 std::vector<std::string> get_attached_object_acm_ids(const std::string & target_id);
+std::vector<std::pair<std::string, std::string>> get_grasp_planning_allowed_pairs(
+  const std::string & target_id,
+  const std::vector<std::string> & allowed_touch_links);
+void set_allowed_collision_pairs(
+  collision_detection::AllowedCollisionMatrix & acm,
+  const std::vector<std::pair<std::string, std::string>> & pairs,
+  bool allow);
 
 }  // namespace detail
 
@@ -245,6 +253,8 @@ public:
   void prepare_attached_object_for_release_planning(
     const std::string & target_id,
     const std::string & ee_link);
+  void apply_grasp_planning_allowed_contacts(const std::string & target_id);
+  void clear_grasp_planning_allowed_contacts(const std::string & target_id);
 
   bool execute(
     const robot_trajectory::RobotTrajectoryPtr & traj,
@@ -294,6 +304,7 @@ protected:
   bool load_octomap_requested_{false};
   bool world_geometry_monitor_started_{false};
   std::vector<std::string> release_allowed_touch_links_;
+  std::vector<std::string> grasp_planning_allowed_touch_links_;
 };
 }  // namespace moveit2
 

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -25,6 +25,7 @@
 #include <utility>
 #include <vector>
 #include <sstream>
+#include <set>
 
 #include "emd/grasp_execution/moveit2/moveit_cpp_if.hpp"
 
@@ -101,6 +102,34 @@ std::vector<std::string> get_attached_object_acm_ids(const std::string & target_
   return {target_id, "#" + target_id};
 }
 
+std::vector<std::pair<std::string, std::string>> get_grasp_planning_allowed_pairs(
+  const std::string & target_id,
+  const std::vector<std::string> & allowed_touch_links)
+{
+  std::vector<std::pair<std::string, std::string>> pairs;
+  for (const auto & touch_link : allowed_touch_links) {
+    if (touch_link.empty()) {
+      continue;
+    }
+    pairs.emplace_back("<octomap>", touch_link);
+    pairs.emplace_back(target_id, touch_link);
+  }
+  return pairs;
+}
+
+void set_allowed_collision_pairs(
+  collision_detection::AllowedCollisionMatrix & acm,
+  const std::vector<std::pair<std::string, std::string>> & pairs,
+  bool allow)
+{
+  for (const auto & pair : pairs) {
+    if (pair.first.empty() || pair.second.empty()) {
+      continue;
+    }
+    acm.setEntry(pair.first, pair.second, allow);
+  }
+}
+
 }  // namespace detail
 
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("grasp_execution");
@@ -140,10 +169,44 @@ void log_goal_failure_diagnostics(
   planning_scene_monitor::LockedPlanningSceneRO scene(moveit_cpp->getPlanningSceneMonitor());
   const bool in_collision = scene->isStateColliding(goal_state, planning_group);
   if (in_collision) {
+    collision_detection::CollisionRequest req;
+    req.contacts = true;
+    req.max_contacts = 20;
+    req.group_name = planning_group;
+    collision_detection::CollisionResult res;
+    scene->checkCollision(req, res, goal_state);
+
+    std::vector<std::string> disallowed_contact_pairs;
+    const auto & acm = scene->getAllowedCollisionMatrix();
+    for (const auto & contact : res.contacts) {
+      const auto & first = contact.first.first;
+      const auto & second = contact.first.second;
+      collision_detection::AllowedCollision::Type allowed_type =
+        collision_detection::AllowedCollision::NEVER;
+      if (!acm.getEntry(first, second, allowed_type) ||
+        allowed_type != collision_detection::AllowedCollision::ALWAYS)
+      {
+        disallowed_contact_pairs.emplace_back(first + "<->" + second);
+      }
+    }
+
     RCLCPP_WARN(
       logger,
       "Candidate diagnosis: IK solution exists but goal state is in collision for group='%s'.",
       planning_group.c_str());
+    if (!disallowed_contact_pairs.empty()) {
+      std::ostringstream pairs_stream;
+      for (size_t i = 0; i < disallowed_contact_pairs.size(); ++i) {
+        if (i > 0) {
+          pairs_stream << ", ";
+        }
+        pairs_stream << disallowed_contact_pairs[i];
+      }
+      RCLCPP_WARN(
+        logger,
+        "Candidate diagnosis disallowed contact pairs: [%s].",
+        pairs_stream.str().c_str());
+    }
     return;
   }
 
@@ -209,6 +272,32 @@ MoveitCppGraspExecution::MoveitCppGraspExecution(
     LOGGER,
     "Configured release_allowed_touch_links: [%s]",
     touch_links_stream.str().c_str());
+
+  const std::vector<std::string> default_grasp_planning_allowed_touch_links = {
+    "gripper_finger1_finger_tip_link",
+    "gripper_finger2_finger_tip_link",
+  };
+  if (node->has_parameter("grasp_planning_allowed_touch_links")) {
+    node->get_parameter_or<std::vector<std::string>>(
+      "grasp_planning_allowed_touch_links",
+      grasp_planning_allowed_touch_links_,
+      default_grasp_planning_allowed_touch_links);
+  } else {
+    grasp_planning_allowed_touch_links_ = node->declare_parameter<std::vector<std::string>>(
+      "grasp_planning_allowed_touch_links",
+      default_grasp_planning_allowed_touch_links);
+  }
+  std::ostringstream grasp_touch_links_stream;
+  for (size_t i = 0; i < grasp_planning_allowed_touch_links_.size(); ++i) {
+    if (i > 0) {
+      grasp_touch_links_stream << ", ";
+    }
+    grasp_touch_links_stream << grasp_planning_allowed_touch_links_[i];
+  }
+  RCLCPP_INFO(
+    LOGGER,
+    "Configured grasp_planning_allowed_touch_links: [%s]",
+    grasp_touch_links_stream.str().c_str());
 }
 
 MoveitCppGraspExecution::~MoveitCppGraspExecution()
@@ -1383,6 +1472,84 @@ void MoveitCppGraspExecution::prepare_attached_object_for_release_planning(
       "Allowed attached target contact with support link '%s' during release planning.",
       support_link.c_str());
   }
+}
+
+void MoveitCppGraspExecution::apply_grasp_planning_allowed_contacts(const std::string & target_id)
+{
+  if (target_id.empty()) {
+    return;
+  }
+
+  std::vector<std::pair<std::string, std::string>> allowed_pairs =
+    detail::get_grasp_planning_allowed_pairs(target_id, grasp_planning_allowed_touch_links_);
+  const std::string unprefixed_target_id =
+    !target_id.empty() && target_id.front() == '#' ? target_id.substr(1) : target_id;
+  const std::string prefixed_target_id =
+    !target_id.empty() && target_id.front() == '#' ? target_id : ("#" + target_id);
+  if (unprefixed_target_id != target_id) {
+    auto extra_pairs = detail::get_grasp_planning_allowed_pairs(
+      unprefixed_target_id, grasp_planning_allowed_touch_links_);
+    allowed_pairs.insert(allowed_pairs.end(), extra_pairs.begin(), extra_pairs.end());
+  }
+  if (prefixed_target_id != target_id) {
+    auto extra_pairs = detail::get_grasp_planning_allowed_pairs(
+      prefixed_target_id, grasp_planning_allowed_touch_links_);
+    allowed_pairs.insert(allowed_pairs.end(), extra_pairs.begin(), extra_pairs.end());
+  }
+
+  {
+    planning_scene_monitor::LockedPlanningSceneRW scene(moveit_cpp_->getPlanningSceneMonitor());
+    auto & acm = scene->getAllowedCollisionMatrixNonConst();
+    detail::set_allowed_collision_pairs(acm, allowed_pairs, true);
+  }
+
+  std::set<std::string> unique_log_pairs;
+  auto base_pairs = detail::get_grasp_planning_allowed_pairs(
+    target_id, grasp_planning_allowed_touch_links_);
+  for (const auto & pair : base_pairs) {
+    unique_log_pairs.insert(pair.first + "<->" + pair.second);
+  }
+  std::ostringstream log_stream;
+  size_t index = 0;
+  for (const auto & pair : unique_log_pairs) {
+    if (index++ > 0) {
+      log_stream << ", ";
+    }
+    log_stream << pair;
+  }
+  RCLCPP_INFO(
+    LOGGER,
+    "Applied grasp planning allowed contacts for target %s: [%s]",
+    target_id.c_str(),
+    log_stream.str().c_str());
+}
+
+void MoveitCppGraspExecution::clear_grasp_planning_allowed_contacts(const std::string & target_id)
+{
+  if (target_id.empty()) {
+    return;
+  }
+
+  std::vector<std::pair<std::string, std::string>> allowed_pairs =
+    detail::get_grasp_planning_allowed_pairs(target_id, grasp_planning_allowed_touch_links_);
+  const std::string unprefixed_target_id =
+    !target_id.empty() && target_id.front() == '#' ? target_id.substr(1) : target_id;
+  const std::string prefixed_target_id =
+    !target_id.empty() && target_id.front() == '#' ? target_id : ("#" + target_id);
+  if (unprefixed_target_id != target_id) {
+    auto extra_pairs = detail::get_grasp_planning_allowed_pairs(
+      unprefixed_target_id, grasp_planning_allowed_touch_links_);
+    allowed_pairs.insert(allowed_pairs.end(), extra_pairs.begin(), extra_pairs.end());
+  }
+  if (prefixed_target_id != target_id) {
+    auto extra_pairs = detail::get_grasp_planning_allowed_pairs(
+      prefixed_target_id, grasp_planning_allowed_touch_links_);
+    allowed_pairs.insert(allowed_pairs.end(), extra_pairs.begin(), extra_pairs.end());
+  }
+
+  planning_scene_monitor::LockedPlanningSceneRW scene(moveit_cpp_->getPlanningSceneMonitor());
+  auto & acm = scene->getAllowedCollisionMatrixNonConst();
+  detail::set_allowed_collision_pairs(acm, allowed_pairs, false);
 }
 
 void MoveitCppGraspExecution::remove_object(

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/CMakeLists.txt
@@ -67,3 +67,13 @@ target_link_libraries(test_release_collision_ids
 target_compile_features(test_release_collision_ids
   PRIVATE cxx_std_17
 )
+
+ament_add_gtest(test_grasp_planning_allowed_contacts
+  test_grasp_planning_allowed_contacts.cpp
+)
+target_link_libraries(test_grasp_planning_allowed_contacts
+  moveit_cpp_grasp_execution_interface
+)
+target_compile_features(test_grasp_planning_allowed_contacts
+  PRIVATE cxx_std_17
+)

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_grasp_planning_allowed_contacts.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_grasp_planning_allowed_contacts.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "emd/grasp_execution/moveit2/moveit_cpp_if.hpp"
+
+namespace
+{
+
+bool contains_pair(
+  const std::vector<std::pair<std::string, std::string>> & pairs,
+  const std::string & first,
+  const std::string & second)
+{
+  return std::find(pairs.begin(), pairs.end(), std::make_pair(first, second)) != pairs.end();
+}
+
+}  // namespace
+
+TEST(GraspPlanningAllowedContacts, IncludesOctomapAndTargetPairsForFingertips)
+{
+  const std::vector<std::string> touch_links = {
+    "gripper_finger1_finger_tip_link",
+    "gripper_finger2_finger_tip_link",
+  };
+
+  const auto pairs =
+    grasp_execution::moveit2::detail::get_grasp_planning_allowed_pairs("#box_demo", touch_links);
+
+  EXPECT_TRUE(contains_pair(pairs, "<octomap>", "gripper_finger1_finger_tip_link"));
+  EXPECT_TRUE(contains_pair(pairs, "<octomap>", "gripper_finger2_finger_tip_link"));
+  EXPECT_TRUE(contains_pair(pairs, "#box_demo", "gripper_finger1_finger_tip_link"));
+  EXPECT_TRUE(contains_pair(pairs, "#box_demo", "gripper_finger2_finger_tip_link"));
+}
+
+TEST(GraspPlanningAllowedContacts, DoesNotIncludeArmOrSupportContactPairs)
+{
+  const std::vector<std::string> touch_links = {
+    "gripper_finger1_finger_tip_link",
+    "gripper_finger2_finger_tip_link",
+  };
+
+  const auto pairs =
+    grasp_execution::moveit2::detail::get_grasp_planning_allowed_pairs("#box_demo", touch_links);
+
+  EXPECT_FALSE(contains_pair(pairs, "forearm_link", "table_"));
+  EXPECT_FALSE(contains_pair(pairs, "upper_arm_link", "table_"));
+  EXPECT_FALSE(contains_pair(pairs, "forearm_link", "<octomap>"));
+}


### PR DESCRIPTION
### Motivation
- Grasp candidates that pass precheck because fingertip/object contacts are allowed were still being rejected by MoveIt/OMPL because the planning-scene AllowedCollisionMatrix (ACM) was not updated for planning time. 
- The goal-state collision diagnostic reported a collision even when fingertip/object contact was intentionally allowed, making triage misleading. 
- A scoped, explicit ACM patch is needed to allow only fingertip↔object and fingertip↔`<octomap>` contacts during grasp approach planning and to limit the allowance to the planning scene used by MoveIt. 

### Description
- Added helper APIs and utilities: `detail::get_grasp_planning_allowed_pairs`, `detail::set_allowed_collision_pairs`, `MoveitCppGraspExecution::apply_grasp_planning_allowed_contacts`, and `MoveitCppGraspExecution::clear_grasp_planning_allowed_contacts` to generate and apply explicit allowed-pair ACM entries. 
- Wired the grasp execution flow so the ACM allowances are applied immediately before `plan_and_execute_job(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0982d7808331b200789b7971c892)