### PR TITLE
Normalize attached-object ACM aliases; add executor timeout padding and tests

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml
@@ -32,6 +32,11 @@ grasp_execution_node:
       max_velocity_scaling_factor: 1.0
       max_acceleration_scaling_factor: 1.0
 
+    # Extra timeout headroom (seconds) added by grasp_execution/DefaultExecutor
+    # on top of MoveIt trajectory_execution timeout computation. This prevents
+    # immediate timeout/cancel when the controller has already reported SUCCEEDED.
+    execution_timeout_padding_s: 0.5
+
     # --- Release pose configuration ---
     # x-axis offset (metres) applied to the current end-effector position to
     # determine the drop-off point. Negative values move the arm in the

--- a/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/executor/default_executor.hpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/include/emd/grasp_execution/moveit2/executor/default_executor.hpp
@@ -47,6 +47,7 @@ public:
 private:
   const rclcpp::Logger logger_;
   trajectory_execution_manager::TrajectoryExecutionManagerPtr trajectory_execution_manager_;
+  double execution_timeout_padding_s_{0.5};
 };
 
 }  // namespace moveit2

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/executor/default_executor.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/executor/default_executor.cpp
@@ -22,6 +22,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "emd/grasp_execution/moveit2/executor/default_executor.hpp"
+#include "emd/grasp_execution/utils.hpp"
 #include "moveit_msgs/msg/robot_trajectory.hpp"
 
 namespace grasp_execution
@@ -110,6 +111,15 @@ bool DefaultExecutor::load(
   const std::string & /*name*/)
 {
   trajectory_execution_manager_ = moveit_cpp->getTrajectoryExecutionManagerNonConst();
+  auto node = moveit_cpp->getNode();
+  if (node) {
+    grasp_execution::declare_or_get_param<double>(
+      execution_timeout_padding_s_,
+      "execution_timeout_padding_s",
+      node,
+      logger_,
+      0.5);
+  }
   // Force explicit bool operator
   return trajectory_execution_manager_ ? true : false;
 }
@@ -154,7 +164,8 @@ bool DefaultExecutor::run(
   const double expected_duration = robot_trajectory.getDuration();
   const double requested_timeout =
     expected_duration * get_allowed_execution_duration_scaling(*trajectory_execution_manager_) +
-    get_allowed_goal_duration_margin(*trajectory_execution_manager_);
+    get_allowed_goal_duration_margin(*trajectory_execution_manager_) +
+    execution_timeout_padding_s_;
   std::atomic_bool execution_complete(false);
   std::atomic_bool timed_out(false);
   std::mutex status_mutex;
@@ -179,8 +190,10 @@ bool DefaultExecutor::run(
       const auto last_status = trajectory_execution_manager_->getLastExecutionStatus();
       RCLCPP_WARN(
         logger_,
-        "Execution timed out after %.3f s (requested %.3f s). Last action state: %s",
-        elapsed_seconds, requested_timeout, last_status.asString().c_str());
+        "Execution timed out after %.3f s (requested %.3f s including %.3f s timeout padding). "
+        "Last action state: %s",
+        elapsed_seconds, requested_timeout, execution_timeout_padding_s_,
+        last_status.asString().c_str());
       trajectory_execution_manager_->stopExecution();
       timed_out = true;
       break;

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -99,7 +99,24 @@ geometry_msgs::msg::Pose get_object_pose_from_world_object(
 
 std::vector<std::string> get_attached_object_acm_ids(const std::string & target_id)
 {
-  return {target_id, "#" + target_id};
+  std::vector<std::string> ids;
+  if (target_id.empty()) {
+    return ids;
+  }
+
+  ids.push_back(target_id);
+  if (!target_id.empty() && target_id.front() == '#') {
+    const std::string unprefixed_id = target_id.substr(1);
+    if (!unprefixed_id.empty()) {
+      ids.push_back(unprefixed_id);
+    }
+  } else {
+    ids.push_back("#" + target_id);
+  }
+
+  std::set<std::string> unique_ids(ids.begin(), ids.end());
+  ids.assign(unique_ids.begin(), unique_ids.end());
+  return ids;
 }
 
 std::vector<std::pair<std::string, std::string>> get_grasp_planning_allowed_pairs(
@@ -1498,15 +1515,22 @@ void MoveitCppGraspExecution::detach_object_from_ee(
   // Attach object to ee_link
   {    // Lock PlanningScene
     planning_scene_monitor::LockedPlanningSceneRW scene(moveit_cpp_->getPlanningSceneMonitor());
+    const bool had_attached_body = scene->getCurrentState().hasAttachedBody(target_id);
     scene->processAttachedCollisionObjectMsg(detach_object);
+    if (!had_attached_body) {
+      RCLCPP_INFO(
+        LOGGER,
+        "Detach requested for '%s' but no attached body was present in current scene state. "
+        "This can happen when detach/remove updates were already processed; continuing.",
+        target_id.c_str());
+    }
 
     auto & acm = scene->getAllowedCollisionMatrixNonConst();
-    if (acm.hasEntry(target_id)) {
-      acm.removeEntry(target_id);
-    }
-    const std::string attached_target_id = "#" + target_id;
-    if (acm.hasEntry(attached_target_id)) {
-      acm.removeEntry(attached_target_id);
+    const auto attached_ids = detail::get_attached_object_acm_ids(target_id);
+    for (const auto & id : attached_ids) {
+      if (acm.hasEntry(id)) {
+        acm.removeEntry(id);
+      }
     }
   }    // Unlock PlanningScene
 }
@@ -1543,18 +1567,12 @@ void MoveitCppGraspExecution::apply_grasp_planning_allowed_contacts(const std::s
 
   std::vector<std::pair<std::string, std::string>> allowed_pairs =
     detail::get_grasp_planning_allowed_pairs(target_id, grasp_planning_allowed_touch_links_);
-  const std::string unprefixed_target_id =
-    !target_id.empty() && target_id.front() == '#' ? target_id.substr(1) : target_id;
-  const std::string prefixed_target_id =
-    !target_id.empty() && target_id.front() == '#' ? target_id : ("#" + target_id);
-  if (unprefixed_target_id != target_id) {
+  for (const auto & target_alias : detail::get_attached_object_acm_ids(target_id)) {
+    if (target_alias == target_id) {
+      continue;
+    }
     auto extra_pairs = detail::get_grasp_planning_allowed_pairs(
-      unprefixed_target_id, grasp_planning_allowed_touch_links_);
-    allowed_pairs.insert(allowed_pairs.end(), extra_pairs.begin(), extra_pairs.end());
-  }
-  if (prefixed_target_id != target_id) {
-    auto extra_pairs = detail::get_grasp_planning_allowed_pairs(
-      prefixed_target_id, grasp_planning_allowed_touch_links_);
+      target_alias, grasp_planning_allowed_touch_links_);
     allowed_pairs.insert(allowed_pairs.end(), extra_pairs.begin(), extra_pairs.end());
   }
 
@@ -1593,18 +1611,12 @@ void MoveitCppGraspExecution::clear_grasp_planning_allowed_contacts(const std::s
 
   std::vector<std::pair<std::string, std::string>> allowed_pairs =
     detail::get_grasp_planning_allowed_pairs(target_id, grasp_planning_allowed_touch_links_);
-  const std::string unprefixed_target_id =
-    !target_id.empty() && target_id.front() == '#' ? target_id.substr(1) : target_id;
-  const std::string prefixed_target_id =
-    !target_id.empty() && target_id.front() == '#' ? target_id : ("#" + target_id);
-  if (unprefixed_target_id != target_id) {
+  for (const auto & target_alias : detail::get_attached_object_acm_ids(target_id)) {
+    if (target_alias == target_id) {
+      continue;
+    }
     auto extra_pairs = detail::get_grasp_planning_allowed_pairs(
-      unprefixed_target_id, grasp_planning_allowed_touch_links_);
-    allowed_pairs.insert(allowed_pairs.end(), extra_pairs.begin(), extra_pairs.end());
-  }
-  if (prefixed_target_id != target_id) {
-    auto extra_pairs = detail::get_grasp_planning_allowed_pairs(
-      prefixed_target_id, grasp_planning_allowed_touch_links_);
+      target_alias, grasp_planning_allowed_touch_links_);
     allowed_pairs.insert(allowed_pairs.end(), extra_pairs.begin(), extra_pairs.end());
   }
 
@@ -1622,18 +1634,12 @@ void MoveitCppGraspExecution::apply_release_planning_allowed_contacts(const std:
   std::vector<std::pair<std::string, std::string>> allowed_pairs =
     detail::get_release_planning_allowed_pairs(
     target_id, grasp_planning_allowed_touch_links_, release_allowed_touch_links_);
-  const std::string unprefixed_target_id =
-    !target_id.empty() && target_id.front() == '#' ? target_id.substr(1) : target_id;
-  const std::string prefixed_target_id =
-    !target_id.empty() && target_id.front() == '#' ? target_id : ("#" + target_id);
-  if (unprefixed_target_id != target_id) {
+  for (const auto & target_alias : detail::get_attached_object_acm_ids(target_id)) {
+    if (target_alias == target_id) {
+      continue;
+    }
     auto extra_pairs = detail::get_release_planning_allowed_pairs(
-      unprefixed_target_id, grasp_planning_allowed_touch_links_, release_allowed_touch_links_);
-    allowed_pairs.insert(allowed_pairs.end(), extra_pairs.begin(), extra_pairs.end());
-  }
-  if (prefixed_target_id != target_id) {
-    auto extra_pairs = detail::get_release_planning_allowed_pairs(
-      prefixed_target_id, grasp_planning_allowed_touch_links_, release_allowed_touch_links_);
+      target_alias, grasp_planning_allowed_touch_links_, release_allowed_touch_links_);
     allowed_pairs.insert(allowed_pairs.end(), extra_pairs.begin(), extra_pairs.end());
   }
 
@@ -1677,12 +1683,11 @@ void MoveitCppGraspExecution::remove_object(
     scene->processCollisionObjectMsg(object);
 
     auto & acm = scene->getAllowedCollisionMatrixNonConst();
-    if (acm.hasEntry(target_id)) {
-      acm.removeEntry(target_id);
-    }
-    const std::string attached_target_id = "#" + target_id;
-    if (acm.hasEntry(attached_target_id)) {
-      acm.removeEntry(attached_target_id);
+    const auto attached_ids = detail::get_attached_object_acm_ids(target_id);
+    for (const auto & id : attached_ids) {
+      if (acm.hasEntry(id)) {
+        acm.removeEntry(id);
+      }
     }
   }    // Unlock PlanningScene
 }

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_release_collision_ids.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_release_collision_ids.cpp
@@ -1,14 +1,29 @@
 #include <gtest/gtest.h>
 
+#include <set>
+
 #include "emd/grasp_execution/moveit2/moveit_cpp_if.hpp"
 
-TEST(ReleaseCollisionIds, IncludesTargetAndAttachedTarget)
+TEST(ReleaseCollisionIds, NormalizesUnprefixedTargetIdIntoUniqueAliases)
 {
-  const auto ids = grasp_execution::moveit2::detail::get_attached_object_acm_ids("box_1");
+  const auto ids = grasp_execution::moveit2::detail::get_attached_object_acm_ids("box-abc");
+  const std::set<std::string> unique_ids(ids.begin(), ids.end());
 
-  ASSERT_EQ(ids.size(), 2u);
-  EXPECT_EQ(ids[0], "box_1");
-  EXPECT_EQ(ids[1], "#box_1");
+  EXPECT_EQ(ids.size(), unique_ids.size());
+  EXPECT_EQ(unique_ids.count("box-abc"), 1u);
+  EXPECT_EQ(unique_ids.count("#box-abc"), 1u);
+  EXPECT_EQ(unique_ids.count("##box-abc"), 0u);
+}
+
+TEST(ReleaseCollisionIds, NormalizesPrefixedTargetIdWithoutDoubleHashAliases)
+{
+  const auto ids = grasp_execution::moveit2::detail::get_attached_object_acm_ids("#box-abc");
+  const std::set<std::string> unique_ids(ids.begin(), ids.end());
+
+  EXPECT_EQ(ids.size(), unique_ids.size());
+  EXPECT_EQ(unique_ids.count("#box-abc"), 1u);
+  EXPECT_EQ(unique_ids.count("box-abc"), 1u);
+  EXPECT_EQ(unique_ids.count("##box-abc"), 0u);
 }
 
 TEST(ReleaseCollisionIds, DoesNotIncludeRobotOrSupportLinks)

--- a/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_release_planning_allowed_contacts.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/test/unit/test_release_planning_allowed_contacts.cpp
@@ -57,6 +57,28 @@ TEST(ReleasePlanningAllowedContacts, IncludesOnlyExpectedPairs)
   EXPECT_FALSE(contains_pair(pairs, "wrist_2_link", "camera_link"));
 }
 
+TEST(ReleasePlanningAllowedContacts, PrefixedTargetDoesNotCreateDoubleHashAliases)
+{
+  const auto pairs = grasp_execution::moveit2::detail::get_release_planning_allowed_pairs(
+    "#box-abc",
+    {"gripper_finger1_finger_tip_link", "gripper_finger2_finger_tip_link"},
+    {"table_"});
+
+  EXPECT_TRUE(contains_pair(pairs, "<octomap>", "gripper_finger1_finger_tip_link"));
+  EXPECT_TRUE(contains_pair(pairs, "<octomap>", "gripper_finger2_finger_tip_link"));
+  EXPECT_TRUE(contains_pair(pairs, "#box-abc", "<octomap>"));
+  EXPECT_TRUE(contains_pair(pairs, "box-abc", "<octomap>"));
+  EXPECT_TRUE(contains_pair(pairs, "#box-abc", "table_"));
+  EXPECT_TRUE(contains_pair(pairs, "box-abc", "table_"));
+
+  EXPECT_FALSE(contains_pair(pairs, "##box-abc", "<octomap>"));
+  EXPECT_FALSE(contains_pair(pairs, "##box-abc", "table_"));
+  EXPECT_FALSE(contains_pair(pairs, "forearm_link", "table_"));
+  EXPECT_FALSE(contains_pair(pairs, "upper_arm_link", "table_"));
+  EXPECT_FALSE(contains_pair(pairs, "forearm_link", "<octomap>"));
+  EXPECT_FALSE(contains_pair(pairs, "wrist_2_link", "camera_link"));
+}
+
 TEST(ReleasePlanningAllowedContacts, ACMAllowsExpectedAndRejectsDisallowedPairs)
 {
   collision_detection::AllowedCollisionMatrix acm;


### PR DESCRIPTION
### Motivation
- Prevent generation of duplicate/invalid attached-object ACM aliases such as `##box-...` that appear in release planning logs and can confuse diagnostics.
- Prevent misleading PREEMPTED/timeout messages when controllers already report `SUCCEEDED` by providing a small, configurable timeout headroom in the default executor.
- Reduce a harmless RViz/planning-scene warning after detach by adding a clearer, non-fatal log and ensuring ACM cleanup uses normalized aliases.

### Description
- Normalize attached-object ACM alias generation in `get_attached_object_acm_ids` so it returns unique, sensible aliases for both `target_id` and `#target_id` and never produces `##...`, and use these normalized aliases when computing/clearing allowed-collision pairs and when removing ACM entries in `moveit_cpp_if.cpp`.
- Add an informational log in `MoveitCppGraspExecution::detach_object_from_ee` when a detach is requested but the attached body is already absent in the local planning-scene state to clarify the harmless warning without broad planning-scene changes.
- Add a configurable `execution_timeout_padding_s` (default `0.5` s) to `DefaultExecutor` and include it in the trajectory execution timeout computation and log message to provide conservative headroom and avoid immediate cancellation after controller success; the parameter is read via `declare_or_get_param`.
- Document the new timeout padding parameter in `run_grasp_execution` config and extend unit tests to cover alias normalization and allowed-contact behavior (`test_release_collision_ids.cpp`, `test_release_planning_allowed_contacts.cpp`).

### Testing
- Added unit tests `test_release_collision_ids.cpp` and `test_release_planning_allowed_contacts.cpp` that validate prefixed/unprefixed `target_id` alias normalization, absence of `##...` aliases, and that release ACM still allows fingertip/octomap/target/table pairs while rejecting broad robot/support collisions.
- Attempted to run full build/tests with `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select emd_grasp_execution run_grasp_execution` but the environment lacks `/opt/ros/humble/setup.bash` so build could not be executed here.
- Attempted `colcon build --symlink-install --packages-select emd_grasp_execution run_grasp_execution` directly but `colcon` is not available in the execution environment, so automated tests were not run in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee10cd9e948331b2ce6680a68f8672)