### PR TITLE
Improve non-3f grasp robustness with fallback candidates and diagnostics

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
@@ -66,6 +66,12 @@ if(BUILD_TESTING)
   ament_add_gtest(test_grasp_precheck_collision_filter
     test/test_grasp_precheck_collision_filter.cpp)
   target_include_directories(test_grasp_precheck_collision_filter PUBLIC include)
+  ament_add_gtest(test_grasp_candidate_utils
+    test/test_grasp_candidate_utils.cpp)
+  target_include_directories(test_grasp_candidate_utils PUBLIC include)
+  ament_target_dependencies(test_grasp_candidate_utils
+    tf2_geometry_msgs
+  )
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/grasp_candidate_utils.hpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/grasp_candidate_utils.hpp
@@ -1,0 +1,118 @@
+#ifndef RUN_GRASP_EXECUTION__GRASP_CANDIDATE_UTILS_HPP_
+#define RUN_GRASP_EXECUTION__GRASP_CANDIDATE_UTILS_HPP_
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iomanip>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "tf2/LinearMath/Quaternion.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+
+namespace run_grasp_execution
+{
+
+inline std::string pose_dedup_key(const geometry_msgs::msg::PoseStamped & pose)
+{
+  std::ostringstream oss;
+  oss << std::fixed << std::setprecision(5)
+      << pose.pose.position.x << "," << pose.pose.position.y << "," << pose.pose.position.z << ","
+      << pose.pose.orientation.x << "," << pose.pose.orientation.y << ","
+      << pose.pose.orientation.z << "," << pose.pose.orientation.w;
+  return oss.str();
+}
+
+inline std::vector<geometry_msgs::msg::PoseStamped> expand_grasp_candidates_with_fallbacks(
+  const std::vector<geometry_msgs::msg::PoseStamped> & input_candidates,
+  std::size_t min_candidate_count)
+{
+  std::vector<geometry_msgs::msg::PoseStamped> candidates = input_candidates;
+  if (candidates.empty() || candidates.size() >= min_candidate_count) {
+    return candidates;
+  }
+
+  std::set<std::string> seen_keys;
+  for (const auto & candidate : candidates) {
+    seen_keys.insert(pose_dedup_key(candidate));
+  }
+
+  const std::vector<double> yaw_offsets_deg = {15.0, -15.0, 30.0, -30.0, 45.0, -45.0, 60.0, -60.0};
+  const std::vector<double> pitch_offsets_deg = {0.0, 8.0, -8.0, 12.0, -12.0};
+  const std::vector<double> z_offsets_m = {0.0, 0.01, 0.02};
+  constexpr double kDegToRad = 3.14159265358979323846 / 180.0;
+
+  for (const auto & base : input_candidates) {
+    tf2::Quaternion base_q;
+    tf2::fromMsg(base.pose.orientation, base_q);
+    if (base_q.length2() <= 0.0) {
+      continue;
+    }
+    base_q.normalize();
+    for (const double z_offset : z_offsets_m) {
+      for (const double pitch_deg : pitch_offsets_deg) {
+        for (const double yaw_deg : yaw_offsets_deg) {
+          if (candidates.size() >= min_candidate_count) {
+            return candidates;
+          }
+
+          tf2::Quaternion yaw_q;
+          yaw_q.setRPY(0.0, 0.0, yaw_deg * kDegToRad);
+          tf2::Quaternion pitch_q;
+          pitch_q.setRPY(0.0, pitch_deg * kDegToRad, 0.0);
+          tf2::Quaternion candidate_q = base_q * yaw_q * pitch_q;
+          candidate_q.normalize();
+
+          geometry_msgs::msg::PoseStamped variant = base;
+          variant.pose.position.z += z_offset;
+          variant.pose.orientation = tf2::toMsg(candidate_q);
+          const std::string key = pose_dedup_key(variant);
+          if (seen_keys.insert(key).second) {
+            candidates.push_back(std::move(variant));
+          }
+        }
+      }
+    }
+  }
+
+  return candidates;
+}
+
+inline std::string categorize_candidate_rejection_reason(const std::string & reason)
+{
+  if (reason.find("IK failed") != std::string::npos ||
+    reason.find("invalid candidate quaternion") != std::string::npos ||
+    reason.find("planning group not found") != std::string::npos ||
+    reason.find("could not retrieve current robot state") != std::string::npos)
+  {
+    return "IK failure";
+  }
+
+  if (reason.find("IK solution in collision:") != std::string::npos) {
+    const bool has_table = reason.find("table_") != std::string::npos;
+    const bool has_octomap = reason.find("<octomap>") != std::string::npos;
+    const bool has_finger_tip = reason.find("finger_tip_link") != std::string::npos;
+    if (has_table) {
+      return "broad robot/table collision";
+    }
+    if (has_octomap && !has_finger_tip) {
+      return "broad robot/octomap collision";
+    }
+    return "self-collision";
+  }
+
+  if (reason.find("outside workspace bounds") != std::string::npos) {
+    return "planner failure";
+  }
+
+  return "planner failure";
+}
+
+}  // namespace run_grasp_execution
+
+#endif  // RUN_GRASP_EXECUTION__GRASP_CANDIDATE_UTILS_HPP_

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <thread>
 #include <set>
+#include <map>
 #include <regex>
 #include <stdexcept>
 #include <unordered_set>
@@ -51,6 +52,7 @@
 #include "moveit/planning_scene_monitor/planning_scene_monitor.h"
 #include "tf2_eigen/tf2_eigen.hpp"
 #include "run_grasp_execution/grasp_precheck_collision_filter.hpp"
+#include "run_grasp_execution/grasp_candidate_utils.hpp"
 
 
 namespace grasp_execution
@@ -393,6 +395,24 @@ public:
       release_x_offset_, "release_x_offset", node, node->get_logger(), -0.3);
     grasp_execution::declare_or_get_param<bool>(
       release_use_grasp_z_, "release_use_grasp_z", node, node->get_logger(), true);
+    grasp_execution::declare_or_get_param<int>(
+      min_grasp_candidate_count_,
+      "min_grasp_candidate_count",
+      node,
+      node->get_logger(),
+      8);
+    grasp_execution::declare_or_get_param<double>(
+      grasp_min_tool_z_warn_,
+      "grasp_min_tool_z_warn",
+      node,
+      node->get_logger(),
+      0.18);
+    grasp_execution::declare_or_get_param<bool>(
+      reject_below_grasp_min_tool_z_warn_,
+      "grasp_reject_below_min_tool_z_warn",
+      node,
+      node->get_logger(),
+      false);
     grasp_execution::declare_or_get_param<bool>(
       workspace_bounds_.enabled,
       "grasp_workspace_filter.enabled",
@@ -674,27 +694,50 @@ public:
       return false;
     }
 
+    auto candidate_poses = run_grasp_execution::expand_grasp_candidates_with_fallbacks(
+      grasp_method.grasp_poses, static_cast<std::size_t>(std::max(1, min_grasp_candidate_count_)));
+    if (candidate_poses.size() != grasp_method.grasp_poses.size()) {
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "Expanded grasp candidates for target %s from %zu to %zu (min_grasp_candidate_count=%d).",
+        target_id.c_str(),
+        grasp_method.grasp_poses.size(),
+        candidate_poses.size(),
+        min_grasp_candidate_count_);
+    } else {
+      RCLCPP_INFO(
+        node_->get_logger(),
+        "Using %zu grasp candidates for target %s (min_grasp_candidate_count=%d).",
+        candidate_poses.size(),
+        target_id.c_str(),
+        min_grasp_candidate_count_);
+    }
+
     bool result = false;
     geometry_msgs::msg::PoseStamped selected_moveit_grasp_pose;
     bool selected_moveit_grasp_pose_valid = false;
     bool any_candidate_passed_precheck = false;
+    std::map<std::string, std::size_t> rejection_summary;
+    std::string last_rejection_reason;
 
-    for (size_t pose_index = 0; pose_index < grasp_method.grasp_poses.size(); ++pose_index) {
+    for (size_t pose_index = 0; pose_index < candidate_poses.size(); ++pose_index) {
       if (!rclcpp::ok()) {
         set_last_failure_message("Execution interrupted during candidate evaluation.");
         return false;
       }
-      const auto & grasp_pose = grasp_method.grasp_poses[pose_index];
+      const auto & grasp_pose = candidate_poses[pose_index];
       geometry_msgs::msg::PoseStamped moveit_goal_pose;
       std::string rejection_reason;
       const bool precheck_ok = precheck_and_prepare_grasp_candidate(
-        target_id, pose_index, grasp_method.grasp_poses.size(), planning_group, moveit_link, grasp_frame,
+        target_id, pose_index, candidate_poses.size(), planning_group, moveit_link, grasp_frame,
         grasp_pose, moveit_goal_pose, rejection_reason);
       if (!precheck_ok) {
+        ++rejection_summary[run_grasp_execution::categorize_candidate_rejection_reason(rejection_reason)];
+        last_rejection_reason = rejection_reason;
         RCLCPP_WARN(
           node_->get_logger(),
           "Candidate %zu/%zu rejected for target %s: %s",
-          pose_index + 1, grasp_method.grasp_poses.size(), target_id.c_str(), rejection_reason.c_str());
+          pose_index + 1, candidate_poses.size(), target_id.c_str(), rejection_reason.c_str());
         continue;
       }
       any_candidate_passed_precheck = true;
@@ -705,18 +748,20 @@ public:
           "Rejected candidate %zu/%zu for target %s: outside workspace bounds "
           "[x:(%.3f, %.3f) y:(%.3f, %.3f) z:(%.3f, %.3f)].",
           pose_index + 1,
-          grasp_method.grasp_poses.size(),
+          candidate_poses.size(),
           target_id.c_str(),
           workspace_bounds_.min_x, workspace_bounds_.max_x,
           workspace_bounds_.min_y, workspace_bounds_.max_y,
           workspace_bounds_.min_z, workspace_bounds_.max_z);
+        ++rejection_summary["planner failure"];
+        last_rejection_reason = "outside workspace bounds";
         continue;
       }
 
       RCLCPP_INFO(
         node_->get_logger(),
         "Candidate %zu/%zu target=%s passed IK/collision precheck. Planning with moveit_link=%s.",
-        pose_index + 1, grasp_method.grasp_poses.size(), target_id.c_str(), moveit_link.c_str());
+        pose_index + 1, candidate_poses.size(), target_id.c_str(), moveit_link.c_str());
       this->apply_grasp_planning_allowed_contacts(target_id);
       result = this->plan_and_execute_job(
         options,
@@ -731,22 +776,43 @@ public:
         RCLCPP_INFO(
           node_->get_logger(),
           "Grasp planning/execution succeeded for target %s using candidate %zu/%zu.",
-          target_id.c_str(), pose_index + 1, grasp_method.grasp_poses.size());
+          target_id.c_str(), pose_index + 1, candidate_poses.size());
         break;
       }
 
+      ++rejection_summary["planner failure"];
+      last_rejection_reason = "planner failure";
       RCLCPP_WARN(
         node_->get_logger(),
         "Grasp planning/execution failed for target %s using candidate %zu/%zu. Trying next candidate.",
-        target_id.c_str(), pose_index + 1, grasp_method.grasp_poses.size());
+        target_id.c_str(), pose_index + 1, candidate_poses.size());
+    }
+
+    if (!rejection_summary.empty()) {
+      std::vector<std::string> grouped_reasons;
+      grouped_reasons.reserve(rejection_summary.size());
+      for (const auto & entry : rejection_summary) {
+        grouped_reasons.push_back(entry.first + "=" + std::to_string(entry.second));
+      }
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "Candidate rejection summary for target %s: %s",
+        target_id.c_str(),
+        boost::algorithm::join(grouped_reasons, ", ").c_str());
     }
 
     if (!any_candidate_passed_precheck) {
-      set_last_failure_message("All grasp pose candidates failed IK/collision precheck.");
+      if (grasp_method.grasp_poses.size() == 1 && !last_rejection_reason.empty()) {
+        set_last_failure_message(
+          "All candidates rejected because only 1 candidate was available and it failed: " +
+          last_rejection_reason);
+      } else {
+        set_last_failure_message("All grasp pose candidates failed IK/collision precheck.");
+      }
       RCLCPP_ERROR(
         node_->get_logger(),
         "All %zu grasp pose candidates failed IK/collision precheck for target %s.",
-        grasp_method.grasp_poses.size(), target_id.c_str());
+        candidate_poses.size(), target_id.c_str());
       return false;
     }
 
@@ -755,7 +821,7 @@ public:
       RCLCPP_ERROR(
         node_->get_logger(),
         "All %zu grasp pose candidates failed for target %s.",
-        grasp_method.grasp_poses.size(), target_id.c_str());
+        candidate_poses.size(), target_id.c_str());
       return false;
     }
     // ------------------- Attach grasp object to robot --------------------------
@@ -926,6 +992,24 @@ private:
       format_pose_xyz_quat_rpy(out_moveit_goal_pose.pose).c_str(),
       translation_distance, ik_ok ? "true" : "false");
 
+    if (out_moveit_goal_pose.pose.position.z < grasp_min_tool_z_warn_) {
+      const char * severity = reject_below_grasp_min_tool_z_warn_ ? "rejecting" : "warning-only";
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "Low-height grasp candidate target=%s idx=%zu/%zu transformed_tool_z=%.6f below "
+        "grasp_min_tool_z_warn=%.6f (%s).",
+        target_id.c_str(),
+        candidate_index + 1,
+        candidate_total,
+        out_moveit_goal_pose.pose.position.z,
+        grasp_min_tool_z_warn_,
+        severity);
+      if (reject_below_grasp_min_tool_z_warn_) {
+        rejection_reason = "transformed moveit goal pose below configured minimum safe tool z.";
+        return false;
+      }
+    }
+
     if (!ik_ok) {
       rejection_reason = "IK failed for transformed moveit goal.";
       return false;
@@ -1038,6 +1122,9 @@ private:
   std::string planning_frame_;
   double release_x_offset_{-0.3};
   bool release_use_grasp_z_{true};
+  int min_grasp_candidate_count_{8};
+  double grasp_min_tool_z_warn_{0.18};
+  bool reject_below_grasp_min_tool_z_warn_{false};
   WorkspaceBounds workspace_bounds_;
   std::vector<std::string> grasp_precheck_allowed_touch_links_;
   std::vector<std::string> grasp_precheck_allowed_collision_ids_;

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_candidate_utils.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_candidate_utils.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include "run_grasp_execution/grasp_candidate_utils.hpp"
+
+namespace
+{
+
+geometry_msgs::msg::PoseStamped make_candidate(double x, double y, double z)
+{
+  geometry_msgs::msg::PoseStamped pose;
+  pose.header.frame_id = "camera_color_optical_frame";
+  pose.pose.position.x = x;
+  pose.pose.position.y = y;
+  pose.pose.position.z = z;
+  pose.pose.orientation.w = 1.0;
+  return pose;
+}
+
+}  // namespace
+
+TEST(GraspCandidateUtils, ExpandsWhenCountBelowMinimumAndKeepsFirstCandidate)
+{
+  const std::vector<geometry_msgs::msg::PoseStamped> input = {
+    make_candidate(-0.55, 0.11, 0.04)};
+
+  const auto expanded = run_grasp_execution::expand_grasp_candidates_with_fallbacks(input, 8);
+
+  EXPECT_GE(expanded.size(), 8u);
+  EXPECT_EQ(expanded.front().pose.position.x, input.front().pose.position.x);
+  EXPECT_EQ(expanded.front().pose.position.y, input.front().pose.position.y);
+  EXPECT_EQ(expanded.front().pose.position.z, input.front().pose.position.z);
+  EXPECT_EQ(expanded.front().pose.orientation.w, input.front().pose.orientation.w);
+}
+
+TEST(GraspCandidateUtils, FallbackGenerationAvoidsDuplicatePoses)
+{
+  const std::vector<geometry_msgs::msg::PoseStamped> input = {
+    make_candidate(-0.55, 0.11, 0.04)};
+
+  const auto expanded = run_grasp_execution::expand_grasp_candidates_with_fallbacks(input, 12);
+
+  std::set<std::string> dedup;
+  for (const auto & pose : expanded) {
+    dedup.insert(run_grasp_execution::pose_dedup_key(pose));
+  }
+  EXPECT_EQ(dedup.size(), expanded.size());
+}
+
+TEST(GraspCandidateUtils, CollisionReasonCategorizedAsRobotTable)
+{
+  const std::string reason =
+    "IK solution in collision: forearm_link<->table_, table_<->upper_arm_link";
+  EXPECT_EQ(
+    run_grasp_execution::categorize_candidate_rejection_reason(reason),
+    "broad robot/table collision");
+}


### PR DESCRIPTION
### Motivation
- The non-3f `ur5_2f_test` flow failed when only a single grasp candidate was produced and that candidate caused a real robot/table collision, so the node should try safe alternatives before giving up. 
- The change aims to preserve strict rejection of real robot/table and self-collisions while improving robustness against sparse planner output. 
- Additional diagnostics are needed to make failures clearer (grouped rejection reasons and low-height warnings) to aid debugging and tuning.

### Description
- Added a helper `expand_grasp_candidates_with_fallbacks` in `run_grasp_execution::grasp_candidate_utils.hpp` that preserves the original candidate, synthesizes orientation and small `z` variants, and deduplicates poses to reach a configurable minimum candidate count. 
- Introduced new parameters in `demo_node.cpp`: `min_grasp_candidate_count` (default `8`), `grasp_min_tool_z_warn` (default `0.18`), and `grasp_reject_below_min_tool_z_warn` (default `false`) and used them when expanding and evaluating candidates. 
- Modified the candidate evaluation loop in `demo_node.cpp` to evaluate the expanded list, collect grouped rejection counts using `categorize_candidate_rejection_reason`, and log a compact rejection summary after evaluation. 
- Added a low-height diagnostic that logs when a transformed grasp `tool0`/goal `z` is below `grasp_min_tool_z_warn` and optionally rejects such candidates when `grasp_reject_below_min_tool_z_warn` is enabled, without loosening collision checks. 
- Kept existing allowed-contact behavior unchanged so that real invalid collisions (e.g. `forearm_link<->table_`, `upper_arm_link<->table_`, robot/octomap self-collisions) remain rejected via the existing filter. 
- Added unit tests `test_grasp_candidate_utils.cpp` to verify fallback expansion preserves the original candidate, avoids duplicates, and categorizes collision reasons, and wired the test into the package `CMakeLists.txt`.

### Testing
- Added unit tests `test/test_grasp_candidate_utils.cpp` (not executed in this environment) which validate expansion, deduplication, and rejection categorization. 
- Attempted to run the ROS build with `colcon build --symlink-install --packages-select emd_grasp_execution run_grasp_execution`, but the container environment lacks ROS Humble and `colcon`, so the build could not be executed here. 
- Performed repository checks and inspection of modified files and logging messages to verify the new control flow and parameter wiring are in place and that collision precheck logic remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2da6a00c8331a714e90bc8fbb130)