### PR TITLE
Improve 2F grasp planner collision filtering and diagnostics

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml
@@ -3,6 +3,12 @@ grasp_planning_node:
     grasp_output_service: "grasp_requests"
     execution_in_progress_gate_enabled: true
     table_to_camera_height: 0.65
+    grasp_planner_allow_target_fingertip_contact: true
+    grasp_planner_allowed_target_touch_links:
+      - gripper_finger1_finger_tip_link
+      - gripper_finger2_finger_tip_link
+    grasp_planner_allowed_target_touch_link_patterns:
+      - gripper_finger*_finger_tip_link
     easy_perception_deployment:
       epd_localization_topic: "/easy_perception_deployment/epd_localize_output"
       epd_tracking_topic: "/easy_perception_deployment/epd_tracking_output"

--- a/easy_manipulation_deployment/emd_grasp_planner/include/emd/grasp_planner/end_effectors/finger_gripper.hpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/include/emd/grasp_planner/end_effectors/finger_gripper.hpp
@@ -48,6 +48,8 @@
 #include <string>
 #include <vector>
 #include <limits>
+#include <unordered_map>
+#include <unordered_set>
 
 // For Multithreading
 #include <future>
@@ -134,6 +136,10 @@ struct MultiFingerGripper
   std::shared_ptr<SingleFinger> base_point_2;
   /*! \brief True if colliding with world */
   bool collides_with_world;
+  /*! \brief Collision reason classification (if rejected) */
+  std::string collision_reason;
+  /*! \brief Collision pair classification (if available) */
+  std::string collision_pair;
   /*! \brief Unit vector of grasping direction */
   Eigen::Vector3f grasping_direction;
   /*! \brief Unit vector perpendicular to grasping direction */
@@ -250,6 +256,14 @@ struct GraspPlaneSample
 class FingerGripper : public EndEffector
 {
 public:
+  struct CollisionSummary
+  {
+    int raw_samples{0};
+    int valid{0};
+    std::unordered_map<std::string, int> rejection_counts;
+    std::unordered_map<std::string, int> collision_pairs;
+  };
+
   /**
    * Finger Gripper Constructor
    *
@@ -300,7 +314,10 @@ public:
     const float & worldZAngleThreshold_,
     const std::string & grasp_stroke_direction_,
     const std::string & grasp_stroke_normal_direction_,
-    const std::string & grasp_approach_direction_);
+    const std::string & grasp_approach_direction_,
+    const bool allow_target_fingertip_contact_ = true,
+    const std::vector<std::string> & allowed_target_touch_links_ = {},
+    const std::vector<std::string> & allowed_target_touch_link_patterns_ = {});
 
 
   /// Get the derived gripper attributes that will be used in the grasp samples generation
@@ -383,6 +400,14 @@ protected:
   const char grasp_stroke_normal_direction;
   /*! \brief Axis in which the gripper approaches the object */
   const char grasp_approach_direction;
+  /*! \brief Allow expected target-object contact at fingertip links during planning */
+  bool allow_target_fingertip_contact;
+  /*! \brief Allowed fingertip link names for expected target contact */
+  std::unordered_set<std::string> allowed_target_touch_links;
+  /*! \brief Allowed fingertip link wildcard patterns for expected target contact */
+  std::vector<std::string> allowed_target_touch_link_patterns;
+  /*! \brief Diagnostics for the most recent planning attempt */
+  CollisionSummary last_collision_summary;
 
   /*! \brief Coefficients of the cutting plane through the object */
   Eigen::Vector4f center_cutting_plane;  // grasp Plane vector coeff: a, b, c ,d
@@ -557,13 +582,15 @@ protected:
    */
   std::shared_ptr<MultiFingerGripper> generate_gripper_open_config(
     const std::shared_ptr<CollisionObject> & world_collision_object,
+    const GraspObject & object,
     const std::shared_ptr<SingleFinger> & closed_center_finger_1,
     const std::shared_ptr<SingleFinger> & closed_center_finger_2,
     const Eigen::Vector3f & open_center_finger_1,
     const Eigen::Vector3f & open_center_finger_2,
     const Eigen::Vector3f & plane_normal_normalized,
     const Eigen::Vector3f & grasp_direction,
-    const std::string & camera_frame);
+    const std::string & camera_frame,
+    const bool allow_expected_target_contact);
 
   /**
    * Function to check the finger collision with the world
@@ -573,7 +600,19 @@ protected:
    */
   bool check_finger_collision(
     const Eigen::Vector3f & finger_point,
-    const std::shared_ptr<CollisionObject> & world_collision_object);
+    const std::shared_ptr<CollisionObject> & world_collision_object,
+    const GraspObject & object,
+    const std::string & touch_link_name,
+    const bool allow_expected_target_contact,
+    std::string * rejection_reason,
+    std::string * collision_pair);
+  bool is_expected_target_contact(
+    const Eigen::Vector3f & finger_point,
+    const GraspObject & object,
+    const std::string & touch_link_name) const;
+  bool is_touch_link_allowed(const std::string & touch_link_name) const;
+  static bool wildcard_match(const std::string & pattern, const std::string & value);
+  void log_collision_summary(const GraspObject & object) const;
 
   /**
    * Method that generates the grasp sample for a particular plane vector

--- a/easy_manipulation_deployment/emd_grasp_planner/src/end_effectors/finger_gripper.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/end_effectors/finger_gripper.cpp
@@ -16,6 +16,8 @@
 
 // Main PCL files
 #include <mutex>
+#include <algorithm>
+#include <sstream>
 
 #include "emd/grasp_planner/end_effectors/finger_gripper.hpp"
 static const rclcpp::Logger & LOGGER = rclcpp::get_logger("FingerGripper");
@@ -43,7 +45,10 @@ FingerGripper::FingerGripper(
   const float & worldZAngleThreshold_,
   const std::string & grasp_stroke_direction_,
   const std::string & grasp_stroke_normal_direction_,
-  const std::string & grasp_approach_direction_)
+  const std::string & grasp_approach_direction_,
+  const bool allow_target_fingertip_contact_,
+  const std::vector<std::string> & allowed_target_touch_links_,
+  const std::vector<std::string> & allowed_target_touch_link_patterns_)
 : id(id_),
   num_fingers_side_1(num_fingers_side_1_),
   num_fingers_side_2(num_fingers_side_2_),
@@ -66,7 +71,10 @@ FingerGripper::FingerGripper(
   worldZAngleThreshold(worldZAngleThreshold_),
   grasp_stroke_direction(grasp_stroke_direction_[0]),
   grasp_stroke_normal_direction(grasp_stroke_normal_direction_[0]),
-  grasp_approach_direction(grasp_approach_direction_[0])
+  grasp_approach_direction(grasp_approach_direction_[0]),
+  allow_target_fingertip_contact(allow_target_fingertip_contact_),
+  allowed_target_touch_links(allowed_target_touch_links_.begin(), allowed_target_touch_links_.end()),
+  allowed_target_touch_link_patterns(allowed_target_touch_link_patterns_)
 {
   if (num_fingers_side_1_ <= 0 || num_fingers_side_2_ <= 0) {
     RCLCPP_ERROR(LOGGER, "Each side needs to have a minimum of 1 finger");
@@ -677,6 +685,7 @@ std::vector<std::shared_ptr<MultiFingerGripper>> FingerGripper::get_all_gripper_
   const std::string & camera_frame)
 {
   std::vector<std::shared_ptr<MultiFingerGripper>> valid_open_gripper_configs;
+  last_collision_summary = CollisionSummary();
   // Query the gripping points at the center cutting plane
   if (this->grasp_samples.empty()) {
     return valid_open_gripper_configs;
@@ -722,18 +731,54 @@ std::vector<std::shared_ptr<MultiFingerGripper>> FingerGripper::get_all_gripper_
 
         /* With the open configuration of the center fingers, generate the rest of the open configuration grippers */
         std::shared_ptr<MultiFingerGripper> gripper_sample = generate_gripper_open_config(
-          world_collision_object, finger_sample_1, finger_sample_2,
+          world_collision_object, object, finger_sample_1, finger_sample_2,
           open_coords[0], open_coords[1], perpendicular_grasp_direction,
-          grasp_direction, camera_frame);
+          grasp_direction, camera_frame, allow_target_fingertip_contact);
+        last_collision_summary.raw_samples++;
         if (!gripper_sample->collides_with_world) {
           valid_open_gripper_configs.push_back(gripper_sample);
+          last_collision_summary.valid++;
+        } else {
+          last_collision_summary.rejection_counts[gripper_sample->collision_reason]++;
+          if (!gripper_sample->collision_pair.empty()) {
+            last_collision_summary.collision_pairs[gripper_sample->collision_pair]++;
+          }
         }
       }
     }
     if (valid_open_gripper_configs.empty()) {
-      RCLCPP_ERROR(
-        LOGGER,
-        "All Possible Grasp sample collides with something in the scene! No grasps available");
+      const int expected_contact_rejects =
+        last_collision_summary.rejection_counts["object_fingertip_expected_contact"];
+      if (expected_contact_rejects > 0 &&
+        expected_contact_rejects >= (last_collision_summary.raw_samples / 2))
+      {
+        RCLCPP_WARN(
+          LOGGER,
+          "Dominant rejection reason is expected fingertip-target contact. Retrying with "
+          "target fingertip contact allowed.");
+        for (auto & finger_sample_1 : this->grasp_samples[0]->sample_side_1->finger_samples) {
+          for (auto & finger_sample_2 : this->grasp_samples[0]->sample_side_2->finger_samples) {
+            Eigen::Vector3f centerpoint_side1_vector =
+              PCLFunctions::convert_pcl_to_eigen(finger_sample_1->finger_point);
+            Eigen::Vector3f centerpoint_side2_vector =
+              PCLFunctions::convert_pcl_to_eigen(finger_sample_2->finger_point);
+            Eigen::Vector3f grasp_direction = Eigen::ParametrizedLine<float, 3>::Through(
+              centerpoint_side1_vector, centerpoint_side2_vector).direction();
+            Eigen::Vector3f perpendicular_grasp_direction = get_gripper_plane(
+              finger_sample_1, finger_sample_2, grasp_direction, object);
+            std::vector<Eigen::Vector3f> open_coords = get_open_finger_coordinates(
+              grasp_direction, centerpoint_side1_vector, centerpoint_side2_vector);
+            auto fallback_gripper_sample = generate_gripper_open_config(
+              world_collision_object, object, finger_sample_1, finger_sample_2,
+              open_coords[0], open_coords[1], perpendicular_grasp_direction,
+              grasp_direction, camera_frame, true);
+            if (!fallback_gripper_sample->collides_with_world) {
+              valid_open_gripper_configs.push_back(fallback_gripper_sample);
+            }
+          }
+        }
+      }
+      log_collision_summary(object);
     }
   } else {
     RCLCPP_ERROR(
@@ -745,13 +790,15 @@ std::vector<std::shared_ptr<MultiFingerGripper>> FingerGripper::get_all_gripper_
 
 std::shared_ptr<MultiFingerGripper> FingerGripper::generate_gripper_open_config(
   const std::shared_ptr<CollisionObject> & world_collision_object,
+  const GraspObject & object,
   const std::shared_ptr<SingleFinger> & closed_center_finger_1,
   const std::shared_ptr<SingleFinger> & closed_center_finger_2,
   const Eigen::Vector3f & open_center_finger_1,
   const Eigen::Vector3f & open_center_finger_2,
   const Eigen::Vector3f & plane_normal,
   const Eigen::Vector3f & grasp_direction,
-  const std::string & camera_frame)
+  const std::string & camera_frame,
+  const bool allow_expected_target_contact)
 {
   // Create an instance of the multifinger gripper.
   MultiFingerGripper gripper(
@@ -760,6 +807,8 @@ std::shared_ptr<MultiFingerGripper> FingerGripper::generate_gripper_open_config(
     grasp_direction,
     plane_normal);
   gripper.collides_with_world = false;
+  gripper.collision_reason.clear();
+  gripper.collision_pair.clear();
   bool is_even_1 = this->num_fingers_side_1 % 2 == 0;
   bool is_even_2 = this->num_fingers_side_2 % 2 == 0;
 
@@ -784,11 +833,21 @@ std::shared_ptr<MultiFingerGripper> FingerGripper::generate_gripper_open_config(
   }
 
   // Check Initial middle fingers if they collide with world
-  if (check_finger_collision(open_center_finger_1, world_collision_object)) {
+  if (check_finger_collision(
+      open_center_finger_1, world_collision_object, object,
+      "gripper_finger1_finger_tip_link", allow_expected_target_contact,
+      &gripper.collision_reason, &gripper.collision_pair))
+  {
     gripper.collides_with_world = true;
+    return std::make_shared<MultiFingerGripper>(gripper);
   }
-  if (check_finger_collision(open_center_finger_2, world_collision_object)) {
+  if (check_finger_collision(
+      open_center_finger_2, world_collision_object, object,
+      "gripper_finger2_finger_tip_link", allow_expected_target_contact,
+      &gripper.collision_reason, &gripper.collision_pair))
+  {
     gripper.collides_with_world = true;
+    return std::make_shared<MultiFingerGripper>(gripper);
   }
 
   // Iterate through the points on side 1
@@ -811,8 +870,12 @@ std::shared_ptr<MultiFingerGripper> FingerGripper::generate_gripper_open_config(
     /* Check if this current open configuration for the finger collides with the world,
        since the end effector will approach the object in its open state.*/
 
-    if (check_finger_collision(finger_1_open_temp, world_collision_object)) {
+    if (check_finger_collision(
+        finger_1_open_temp, world_collision_object, object, "gripper_finger1_finger_tip_link",
+        allow_expected_target_contact, &gripper.collision_reason, &gripper.collision_pair))
+    {
       gripper.collides_with_world = true;
+      return std::make_shared<MultiFingerGripper>(gripper);
     }
 
     /* Ranking of grasp quality involves the positions of the gripper fingers ON the object,
@@ -876,8 +939,12 @@ std::shared_ptr<MultiFingerGripper> FingerGripper::generate_gripper_open_config(
     Eigen::Vector3f finger_2_open_temp = MathFunctions::get_point_in_direction(
       open_center_finger_2,
       plane_normal, gap2);
-    if (check_finger_collision(finger_2_open_temp, world_collision_object)) {
+    if (check_finger_collision(
+        finger_2_open_temp, world_collision_object, object, "gripper_finger2_finger_tip_link",
+        allow_expected_target_contact, &gripper.collision_reason, &gripper.collision_pair))
+    {
       gripper.collides_with_world = true;
+      return std::make_shared<MultiFingerGripper>(gripper);
     }
     gripper.open_fingers_2.push_back(finger_2_open_temp);
 
@@ -962,7 +1029,12 @@ std::shared_ptr<MultiFingerGripper> FingerGripper::generate_gripper_open_config(
 
 bool FingerGripper::check_finger_collision(
   const Eigen::Vector3f & finger_point,
-  const std::shared_ptr<CollisionObject> & world_collision_object)
+  const std::shared_ptr<CollisionObject> & world_collision_object,
+  const GraspObject & object,
+  const std::string & touch_link_name,
+  const bool allow_expected_target_contact,
+  std::string * rejection_reason,
+  std::string * collision_pair)
 {
   auto finger_shape =
     std::make_shared<grasp_planner::collision::Sphere>(this->finger_thickness / 2);
@@ -992,7 +1064,125 @@ bool FingerGripper::check_finger_collision(
   // result will be returned via the collision result structure
   grasp_planner::collision::CollisionResult result;
   fcl::collide(world_collision_object.get(), finger_ptr.get(), request, result);
-  return result.isCollision();
+  if (!result.isCollision()) {
+    return false;
+  }
+
+  const bool expected_contact = is_expected_target_contact(finger_point, object, touch_link_name);
+  if (expected_contact && allow_expected_target_contact) {
+    return false;
+  }
+
+  if (collision_pair != nullptr) {
+    *collision_pair = expected_contact ? "finger_tip<->object_cloud" : "finger_tip<->world_collision_object";
+  }
+  if (rejection_reason != nullptr) {
+    if (expected_contact) {
+      *rejection_reason = "object_fingertip_expected_contact";
+    } else {
+      float object_min_z = finger_point(2);
+      if (object.cloud != nullptr && !object.cloud->empty()) {
+        object_min_z = object.cloud->points.front().z;
+        for (const auto & p : object.cloud->points) {
+          object_min_z = std::min(object_min_z, p.z);
+        }
+      }
+      *rejection_reason =
+        (finger_point(2) < object_min_z - this->finger_thickness) ?
+        "table_or_support_collision" : "unknown_world_collision";
+      if (collision_pair != nullptr && *rejection_reason == "table_or_support_collision") {
+        *collision_pair = "finger_tip<->table_or_support";
+      }
+    }
+  }
+  return true;
+}
+
+bool FingerGripper::is_expected_target_contact(
+  const Eigen::Vector3f & finger_point,
+  const GraspObject & object,
+  const std::string & touch_link_name) const
+{
+  if (!is_touch_link_allowed(touch_link_name) || object.cloud == nullptr || object.cloud->empty()) {
+    return false;
+  }
+
+  const float max_sq_dist = (this->finger_thickness * this->finger_thickness) * 1.5f;
+  for (const auto & p : object.cloud->points) {
+    const float dx = p.x - finger_point(0);
+    const float dy = p.y - finger_point(1);
+    const float dz = p.z - finger_point(2);
+    const float sq_dist = dx * dx + dy * dy + dz * dz;
+    if (sq_dist <= max_sq_dist) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool FingerGripper::is_touch_link_allowed(const std::string & touch_link_name) const
+{
+  if (allowed_target_touch_links.find(touch_link_name) != allowed_target_touch_links.end()) {
+    return true;
+  }
+  for (const auto & pattern : allowed_target_touch_link_patterns) {
+    if (wildcard_match(pattern, touch_link_name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool FingerGripper::wildcard_match(const std::string & pattern, const std::string & value)
+{
+  const auto star = pattern.find('*');
+  if (star == std::string::npos) {
+    return pattern == value;
+  }
+  const std::string prefix = pattern.substr(0, star);
+  const std::string suffix = pattern.substr(star + 1);
+  if (value.size() < prefix.size() + suffix.size()) {
+    return false;
+  }
+  return value.rfind(prefix, 0) == 0 &&
+         value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+void FingerGripper::log_collision_summary(const GraspObject & object) const
+{
+  std::ostringstream pairs_stream;
+  int count = 0;
+  for (const auto & pair_count : last_collision_summary.collision_pairs) {
+    if (count++ > 0) {
+      pairs_stream << ", ";
+    }
+    pairs_stream << pair_count.first;
+    if (count >= 5) {
+      break;
+    }
+  }
+
+  RCLCPP_ERROR(
+    LOGGER,
+    "FingerGripper collision summary for object='%s', gripper='%s': raw_samples=%d, valid=%d, "
+    "reject.object_fingertip_expected_contact=%d, reject.table_or_support_collision=%d, "
+    "reject.robot_or_camera_collision=%d, reject.gripper_self_collision=%d, "
+    "reject.unknown_world_collision=%d, top_pairs=[%s]",
+    object.object_name.c_str(),
+    id.c_str(),
+    last_collision_summary.raw_samples,
+    last_collision_summary.valid,
+    last_collision_summary.rejection_counts.count("object_fingertip_expected_contact") ?
+    last_collision_summary.rejection_counts.at("object_fingertip_expected_contact") : 0,
+    last_collision_summary.rejection_counts.count("table_or_support_collision") ?
+    last_collision_summary.rejection_counts.at("table_or_support_collision") : 0,
+    last_collision_summary.rejection_counts.count("robot_or_camera_collision") ?
+    last_collision_summary.rejection_counts.at("robot_or_camera_collision") : 0,
+    last_collision_summary.rejection_counts.count("gripper_self_collision") ?
+    last_collision_summary.rejection_counts.at("gripper_self_collision") : 0,
+    last_collision_summary.rejection_counts.count("unknown_world_collision") ?
+    last_collision_summary.rejection_counts.at("unknown_world_collision") : 0,
+    pairs_stream.str().c_str());
 }
 
 void FingerGripper::get_max_min_values(const GraspObject & object)

--- a/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp
@@ -286,6 +286,23 @@ void grasp_planner::GraspScene<T>::load_end_effectors()
         node->get_parameter("end_effectors." + end_effector + ".type").as_string();
       RCLCPP_INFO_STREAM(LOGGER, "Loading " << end_effector_type << " gripper " << end_effector);
       if (end_effector_type.compare("finger") == 0) {
+        bool allow_target_fingertip_contact = true;
+        node->get_parameter_or(
+          "grasp_planner_allow_target_fingertip_contact",
+          allow_target_fingertip_contact,
+          true);
+        std::vector<std::string> allowed_target_touch_links{
+          "gripper_finger1_finger_tip_link",
+          "gripper_finger2_finger_tip_link"};
+        node->get_parameter_or(
+          "grasp_planner_allowed_target_touch_links",
+          allowed_target_touch_links,
+          allowed_target_touch_links);
+        std::vector<std::string> allowed_target_touch_link_patterns;
+        node->get_parameter_or(
+          "grasp_planner_allowed_target_touch_link_patterns",
+          allowed_target_touch_link_patterns,
+          allowed_target_touch_link_patterns);
         FingerGripper gripper(
           end_effector,
           node->get_parameter("end_effectors." + end_effector + ".num_fingers_side_1").as_int(),
@@ -348,7 +365,10 @@ void grasp_planner::GraspScene<T>::load_end_effectors()
             ".gripper_coordinate_system.grasp_stroke_normal_direction").as_string(),
           node->get_parameter(
             "end_effectors." + end_effector +
-            ".gripper_coordinate_system.grasp_approach_direction").as_string()
+            ".gripper_coordinate_system.grasp_approach_direction").as_string(),
+          allow_target_fingertip_contact,
+          allowed_target_touch_links,
+          allowed_target_touch_link_patterns
         );
         this->end_effectors.push_back(std::make_shared<FingerGripper>(std::move(gripper)));
       } else if (end_effector_type.compare("suction") == 0) {
@@ -686,7 +706,35 @@ bool grasp_planner::GraspScene<T>::process_pointcloud(
   RCLCPP_INFO(LOGGER, "Processing Point Cloud... ");
   pcl::PCLPointCloud2 pcl_pc2;
   PCLFunctions::sensor_msg_to_pcl_pointcloud2(*msg, pcl_pc2);
-  pcl::fromPCLPointCloud2(pcl_pc2, *(this->cloud));
+  bool has_rgb_field = false;
+  for (const auto & field : pcl_pc2.fields) {
+    if (field.name == "rgb" || field.name == "rgba") {
+      has_rgb_field = true;
+      break;
+    }
+  }
+  if (has_rgb_field) {
+    pcl::fromPCLPointCloud2(pcl_pc2, *(this->cloud));
+  } else {
+    pcl::PointCloud<pcl::PointXYZ> xyz_cloud;
+    pcl::fromPCLPointCloud2(pcl_pc2, xyz_cloud);
+    this->cloud->clear();
+    this->cloud->reserve(xyz_cloud.size());
+    for (const auto & point : xyz_cloud.points) {
+      pcl::PointXYZRGB point_rgb;
+      point_rgb.x = point.x;
+      point_rgb.y = point.y;
+      point_rgb.z = point.z;
+      point_rgb.r = 255;
+      point_rgb.g = 255;
+      point_rgb.b = 255;
+      this->cloud->push_back(point_rgb);
+    }
+    RCLCPP_WARN_THROTTLE(
+      LOGGER, *node->get_clock(), 10000,
+      "Input cloud has no rgb/rgba field; converted XYZ points with default color. "
+      "This is harmless for collision/grasp planning.");
+  }
   RCLCPP_INFO(LOGGER, "Applying Passthrough filters");
   PCLFunctions::passthrough_filter(
     this->cloud,

--- a/easy_manipulation_deployment/emd_grasp_planner/test/multifinger_test.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/test/multifinger_test.cpp
@@ -1721,11 +1721,64 @@ TEST_F(MultiFingerTest, checkFingerCollisionTest)
 
   Eigen::Vector3f finger_point_sample_center(0.005, 0.025, 0.01);
   Eigen::Vector3f finger_point_far_away(0.1, 0.25, 0.1);
+  std::string rejection_reason;
+  std::string collision_pair;
   EXPECT_TRUE(
     gripper->check_finger_collision_public(
       finger_point_sample_center,
-      collision_object_ptr));
-  EXPECT_FALSE(gripper->check_finger_collision_public(finger_point_far_away, collision_object_ptr));
+      collision_object_ptr,
+      object,
+      "gripper_finger1_finger_tip_link",
+      false,
+      &rejection_reason,
+      &collision_pair));
+  EXPECT_FALSE(gripper->check_finger_collision_public(
+      finger_point_far_away, collision_object_ptr, object, "gripper_finger1_finger_tip_link",
+      false, &rejection_reason, &collision_pair));
+}
+
+TEST_F(MultiFingerTest, FingerTipTargetContactAllowedWhenEnabled)
+{
+  GraspObject object = GenerateObjectVertical();
+  reset_variables();
+  ASSERT_NO_THROW(LoadGripper());
+  GenerateObjectCollision(0.01, 0.05, 0.02);
+  Eigen::Vector3f finger_point_sample_center(0.005, 0.025, 0.01);
+  std::string rejection_reason;
+  std::string collision_pair;
+  EXPECT_FALSE(gripper->check_finger_collision_public(
+      finger_point_sample_center, collision_object_ptr, object,
+      "gripper_finger1_finger_tip_link", true, &rejection_reason, &collision_pair));
+}
+
+TEST_F(MultiFingerTest, FingerTipTargetContactRejectedWhenDisabled)
+{
+  GraspObject object = GenerateObjectVertical();
+  reset_variables();
+  ASSERT_NO_THROW(LoadGripper());
+  GenerateObjectCollision(0.01, 0.05, 0.02);
+  Eigen::Vector3f finger_point_sample_center(0.005, 0.025, 0.01);
+  std::string rejection_reason;
+  std::string collision_pair;
+  EXPECT_TRUE(gripper->check_finger_collision_public(
+      finger_point_sample_center, collision_object_ptr, object,
+      "gripper_finger1_finger_tip_link", false, &rejection_reason, &collision_pair));
+  EXPECT_EQ("object_fingertip_expected_contact", rejection_reason);
+}
+
+TEST_F(MultiFingerTest, NonAllowedLinkContactAlwaysRejected)
+{
+  GraspObject object = GenerateObjectVertical();
+  reset_variables();
+  ASSERT_NO_THROW(LoadGripper());
+  GenerateObjectCollision(0.01, 0.05, 0.02);
+  Eigen::Vector3f finger_point_sample_center(0.005, 0.025, 0.01);
+  std::string rejection_reason;
+  std::string collision_pair;
+  EXPECT_TRUE(gripper->check_finger_collision_public(
+      finger_point_sample_center, collision_object_ptr, object,
+      "gripper_base_link", true, &rejection_reason, &collision_pair));
+  EXPECT_NE("object_fingertip_expected_contact", rejection_reason);
 }
 
 TEST_F(MultiFingerTest, getNearestPlaneIndexTest)
@@ -1853,7 +1906,7 @@ TEST_F(MultiFingerTest, generateGripperOpenConfigTest)
 
   GenerateObjectCollision(0.01, 0.05, 0.02);
   std::shared_ptr<MultiFingerGripper> gripper_sample = gripper->generate_gripper_open_config_public(
-    collision_object_ptr, finger_1, finger_2,
+    collision_object_ptr, object, finger_1, finger_2,
     open_coords[0], open_coords[1], perpendicular_grasp_direction,
     grasp_direction, "camera_frame");
 
@@ -1929,7 +1982,7 @@ TEST_F(MultiFingerTest, generateGripperOpenConfigTestInvalidNearestPointIndex)
   GenerateObjectCollision(0.01, 0.05, 0.02);
   ASSERT_NO_THROW({
     std::shared_ptr<MultiFingerGripper> gripper_sample = gripper->generate_gripper_open_config_public(
-      collision_object_ptr, closed_finger_1, closed_finger_2,
+      collision_object_ptr, object, closed_finger_1, closed_finger_2,
       open_coords[0], open_coords[1], perpendicular_grasp_direction,
       grasp_direction, "camera_frame");
 
@@ -2003,7 +2056,7 @@ TEST_F(MultiFingerTest, generateGripperOpenConfigTestCollision)
 
   GenerateObjectCollision(0.01, 0.05, 0.02);
   std::shared_ptr<MultiFingerGripper> gripper_sample = gripper->generate_gripper_open_config_public(
-    collision_object_ptr, finger_1, finger_2,
+    collision_object_ptr, object, finger_1, finger_2,
     open_coords[0], open_coords[1], perpendicular_grasp_direction,
     grasp_direction, "camera_frame");
 

--- a/easy_manipulation_deployment/emd_grasp_planner/test/multifinger_test.hpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/test/multifinger_test.hpp
@@ -62,7 +62,10 @@ public:
     const float & worldZAngleThreshold_,
     std::string grasp_stroke_direction_,
     std::string grasp_stroke_normal_direction_,
-    std::string grasp_approach_direction_
+    std::string grasp_approach_direction_,
+    bool allow_target_fingertip_contact_ = true,
+    const std::vector<std::string> & allowed_target_touch_links_ = {},
+    const std::vector<std::string> & allowed_target_touch_link_patterns_ = {}
 
   )
   : FingerGripper(
@@ -88,7 +91,10 @@ public:
       worldZAngleThreshold_,
       grasp_stroke_direction_,
       grasp_stroke_normal_direction_,
-      grasp_approach_direction_
+      grasp_approach_direction_,
+      allow_target_fingertip_contact_,
+      allowed_target_touch_links_,
+      allowed_target_touch_link_patterns_
   ) {}
 
   Eigen::Vector4f center_cutting_plane_public;
@@ -238,34 +244,53 @@ public:
 
   std::shared_ptr<MultiFingerGripper> generate_gripper_open_config_public(
     const std::shared_ptr<CollisionObject> & world_collision_object,
+    const GraspObject & object,
     const std::shared_ptr<SingleFinger> & closed_center_finger_1,
     const std::shared_ptr<SingleFinger> & closed_center_finger_2,
     const Eigen::Vector3f & open_center_finger_1,
     const Eigen::Vector3f & open_center_finger_2,
     const Eigen::Vector3f & plane_normal_normalized,
     const Eigen::Vector3f & grasp_direction,
-    std::string camera_frame)
+    std::string camera_frame,
+    bool allow_expected_target_contact = true)
   {
     return generate_gripper_open_config(
       world_collision_object,
+      object,
       closed_center_finger_1,
       closed_center_finger_2,
       open_center_finger_1,
       open_center_finger_2,
       plane_normal_normalized,
       grasp_direction,
-      camera_frame
+      camera_frame,
+      allow_expected_target_contact
     );
   }
 
   bool check_finger_collision_public(
     const Eigen::Vector3f & finger_point,
-    const std::shared_ptr<CollisionObject> & world_collision_object)
+    const std::shared_ptr<CollisionObject> & world_collision_object,
+    const GraspObject & object,
+    const std::string & touch_link_name,
+    const bool allow_expected_target_contact,
+    std::string * rejection_reason,
+    std::string * collision_pair)
   {
     return check_finger_collision(
       finger_point,
-      world_collision_object
+      world_collision_object,
+      object,
+      touch_link_name,
+      allow_expected_target_contact,
+      rejection_reason,
+      collision_pair
     );
+  }
+
+  CollisionSummary get_last_collision_summary_public() const
+  {
+    return last_collision_summary;
   }
 
   std::shared_ptr<GraspPlaneSample> generate_grasp_samples_public(


### PR DESCRIPTION
### Motivation
- The finger-gripper planner was rejecting all samples because fingertip contacts with the target object were treated as blocking collisions with no diagnostics, preventing any GraspTask from being generated.
- We need planner-side control to allow expected fingertip-to-target contact while still rejecting unsafe table/robot/self collisions, plus clear diagnostics when zero candidates remain.

### Description
- Added planner-side parameters and plumbing so `GraspScene` passes configurable allowances into `FingerGripper`: `grasp_planner_allow_target_fingertip_contact`, `grasp_planner_allowed_target_touch_links`, and `grasp_planner_allowed_target_touch_link_patterns`, with safe defaults added to the 2F config (`params_2f.yaml`).
- Implemented collision filtering refinements in `FingerGripper`: `check_finger_collision` now classifies collisions, accepts expected fingertip-target contact when enabled, and returns a rejection reason and pair label instead of a generic boolean.
- Added per-run collision aggregation (`CollisionSummary`) and a detailed `log_collision_summary` that prints object id, gripper id, raw/valid counts, grouped rejection counts and top collision pairs when no valid candidates remain.
- Added a targeted fallback: if all candidates are rejected and the dominant reason is expected fingertip-target contact, the planner retries filtering with target-fingertip contact explicitly allowed (without weakening table/robot safety).
- Improved point-cloud handling in `GraspScene::process_pointcloud` to convert XYZ-only clouds into RGB points with a throttled warning to remove noisy "rgb" mismatch logs.
- Extended public test fixtures and added unit tests to `multifinger_test` covering: fingertip-target contact allowed when enabled, rejected when disabled, non-allowed link collisions always rejected, and that rejection reasons are reported in diagnostics.
- Files changed (key):
  - planner logic and diagnostics: `easy_manipulation_deployment/emd_grasp_planner/src/end_effectors/finger_gripper.cpp` and header
  - scene/load params and point-cloud handling: `easy_manipulation_deployment/emd_grasp_planner/src/grasp_scene.cpp`
  - planner launch/config defaults: `easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml`
  - tests updated/added: `easy_manipulation_deployment/emd_grasp_planner/test/multifinger_test.*`

### Testing
- Added gtest cases in `multifinger_test` that exercise fingertip-contact acceptance, rejection, and non-allowed-link rejection; these tests are included in the package test sources but were not executed in this environment.
- Attempted automated build+tests with `colcon` (`BUILD_TESTING=ON`), but execution failed in this environment because `/opt/ros/humble/setup.bash` is not present and `colcon` is not installed, so no CI/test run could be completed here.
- Local unit tests should be runnable in a ROS Humble environment by running the usual workspace build and test commands (e.g. source ROS and workspace setup and run `colcon build --packages-select emd_grasp_planner -DBUILD_TESTING=ON` then `colcon test`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee30146388833196ca0cf22089daa4)