### PR TITLE
Improve home-return robustness with retries and optional safe waypoint

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
@@ -72,6 +72,9 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_grasp_candidate_utils
     tf2_geometry_msgs
   )
+  ament_add_gtest(test_home_return_utils
+    test/test_home_return_utils.cpp)
+  target_include_directories(test_home_return_utils PUBLIC include)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml
@@ -47,6 +47,14 @@ grasp_execution_node:
     # z-height so the arm clears any surface on the return move.
     release_use_grasp_z: true
 
+    # --- Home return configuration ---
+    # Optional safe intermediate joint waypoint between detach and home.
+    home_return:
+      use_safe_intermediate: false
+      max_attempts: 5
+      safe_joint_state: []
+      planning_time: 2.0
+
     # Optional simple workspace filter to reject unreachable grasp candidates
     # before invoking OMPL.
     grasp_workspace_filter:

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/home_return_utils.hpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/home_return_utils.hpp
@@ -1,0 +1,36 @@
+#ifndef RUN_GRASP_EXECUTION__HOME_RETURN_UTILS_HPP_
+#define RUN_GRASP_EXECUTION__HOME_RETURN_UTILS_HPP_
+
+#include <string>
+#include <vector>
+
+namespace run_grasp_execution
+{
+
+struct HomeReturnStepResult
+{
+  bool success{false};
+  bool executed{false};
+  std::string failure_reason;
+};
+
+inline std::string default_home_return_failure_reason(
+  const std::string & step_name,
+  int attempt,
+  int max_attempts)
+{
+  return step_name + " planning failed on attempt " + std::to_string(attempt) +
+         "/" + std::to_string(max_attempts) +
+         " (no valid plan returned by MoveIt).";
+}
+
+inline bool safe_intermediate_enabled(
+  bool use_safe_intermediate,
+  const std::vector<double> & safe_joint_state)
+{
+  return use_safe_intermediate && !safe_joint_state.empty();
+}
+
+}  // namespace run_grasp_execution
+
+#endif  // RUN_GRASP_EXECUTION__HOME_RETURN_UTILS_HPP_

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -53,6 +53,7 @@
 #include "tf2_eigen/tf2_eigen.hpp"
 #include "run_grasp_execution/grasp_precheck_collision_filter.hpp"
 #include "run_grasp_execution/grasp_candidate_utils.hpp"
+#include "run_grasp_execution/home_return_utils.hpp"
 
 
 namespace grasp_execution
@@ -395,6 +396,30 @@ public:
       release_x_offset_, "release_x_offset", node, node->get_logger(), -0.3);
     grasp_execution::declare_or_get_param<bool>(
       release_use_grasp_z_, "release_use_grasp_z", node, node->get_logger(), true);
+    grasp_execution::declare_or_get_param<bool>(
+      home_return_use_safe_intermediate_,
+      "home_return.use_safe_intermediate",
+      node,
+      node->get_logger(),
+      false);
+    grasp_execution::declare_or_get_param<int>(
+      home_return_max_attempts_,
+      "home_return.max_attempts",
+      node,
+      node->get_logger(),
+      5);
+    grasp_execution::declare_or_get_param<std::vector<double>>(
+      home_return_safe_joint_state_,
+      "home_return.safe_joint_state",
+      node,
+      node->get_logger(),
+      std::vector<double>{});
+    grasp_execution::declare_or_get_param<double>(
+      home_return_planning_time_s_,
+      "home_return.planning_time",
+      node,
+      node->get_logger(),
+      2.0);
     grasp_execution::declare_or_get_param<int>(
       min_grasp_candidate_count_,
       "min_grasp_candidate_count",
@@ -864,12 +889,8 @@ public:
     prompt_job_start(
       node_->get_logger(), target_id,
       "Move back to home");
-    result = move_to(
-      options.non_deterministic_max_attempts,
-      planning_group, *home_state);
-
+    result = run_home_return_sequence(target_id, planning_group, *home_state);
     prompt_job_end(node_->get_logger(), result);
-
     if (!result) {
       return false;
     }
@@ -1114,6 +1135,97 @@ private:
     }
   }
 
+  bool move_to_joint_waypoint_with_retries(
+    const std::string & planning_group,
+    const moveit::core::RobotState & goal_state,
+    int max_attempts,
+    const std::string & step_name)
+  {
+    const int bounded_attempts = std::max(1, max_attempts);
+    for (int attempt = 1; attempt <= bounded_attempts && rclcpp::ok(); ++attempt) {
+      RCLCPP_INFO(
+        node_->get_logger(),
+        "[HomeReturn] %s attempt %d/%d (planning_time=%.2fs).",
+        step_name.c_str(),
+        attempt,
+        bounded_attempts,
+        home_return_planning_time_s_);
+      if (move_to(1, planning_group, goal_state, true)) {
+        RCLCPP_INFO(
+          node_->get_logger(),
+          "[HomeReturn] %s succeeded on attempt %d/%d.",
+          step_name.c_str(),
+          attempt,
+          bounded_attempts);
+        return true;
+      }
+      const std::string reason = run_grasp_execution::default_home_return_failure_reason(
+        step_name, attempt, bounded_attempts);
+      RCLCPP_WARN(node_->get_logger(), "[HomeReturn] %s", reason.c_str());
+    }
+    RCLCPP_ERROR(
+      node_->get_logger(),
+      "[HomeReturn] %s failed after %d attempt(s).",
+      step_name.c_str(),
+      bounded_attempts);
+    return false;
+  }
+
+  bool run_home_return_sequence(
+    const std::string & target_id,
+    const std::string & planning_group,
+    const moveit::core::RobotState & home_state)
+  {
+    (void)target_id;
+    if (run_grasp_execution::safe_intermediate_enabled(
+        home_return_use_safe_intermediate_, home_return_safe_joint_state_))
+    {
+      auto current_state = get_curr_state();
+      if (!current_state) {
+        RCLCPP_WARN(
+          node_->get_logger(),
+          "[HomeReturn] Could not read current state for safe intermediate waypoint. "
+          "Skipping safe intermediate and continuing to home.");
+      } else {
+        const auto * jmg = current_state->getJointModelGroup(planning_group);
+        if (!jmg) {
+          RCLCPP_WARN(
+            node_->get_logger(),
+            "[HomeReturn] Planning group '%s' not found for safe intermediate waypoint. "
+            "Skipping safe intermediate and continuing to home.",
+            planning_group.c_str());
+        } else {
+          const auto variable_names = jmg->getVariableNames();
+          if (home_return_safe_joint_state_.size() != variable_names.size()) {
+            RCLCPP_WARN(
+              node_->get_logger(),
+              "[HomeReturn] home_return.safe_joint_state has %zu values, expected %zu for "
+              "group '%s'. Skipping safe intermediate and continuing to home.",
+              home_return_safe_joint_state_.size(),
+              variable_names.size(),
+              planning_group.c_str());
+          } else {
+            moveit::core::RobotState safe_state(*current_state);
+            for (size_t i = 0; i < variable_names.size(); ++i) {
+              safe_state.setVariablePosition(variable_names[i], home_return_safe_joint_state_[i]);
+            }
+            if (!move_to_joint_waypoint_with_retries(
+                planning_group,
+                safe_state,
+                home_return_max_attempts_,
+                "Move to safe intermediate waypoint"))
+            {
+              return false;
+            }
+          }
+        }
+      }
+    }
+
+    return move_to_joint_waypoint_with_retries(
+      planning_group, home_state, home_return_max_attempts_, "Move back to home");
+  }
+
   rclcpp::Node::SharedPtr node_;
   std::shared_ptr<emd::EndEffectorExecutioninterface> end_effector_interface_;
   emd::EndEffectorExecutionContext ee_context_;
@@ -1122,6 +1234,10 @@ private:
   std::string planning_frame_;
   double release_x_offset_{-0.3};
   bool release_use_grasp_z_{true};
+  bool home_return_use_safe_intermediate_{false};
+  int home_return_max_attempts_{5};
+  std::vector<double> home_return_safe_joint_state_;
+  double home_return_planning_time_s_{2.0};
   int min_grasp_candidate_count_{8};
   double grasp_min_tool_z_warn_{0.18};
   bool reject_below_grasp_min_tool_z_warn_{false};

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_home_return_utils.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_home_return_utils.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "run_grasp_execution/home_return_utils.hpp"
+
+TEST(TestHomeReturnUtils, SafeIntermediateEnabledOnlyWithValues)
+{
+  EXPECT_FALSE(run_grasp_execution::safe_intermediate_enabled(false, {0.1, 0.2}));
+  EXPECT_FALSE(run_grasp_execution::safe_intermediate_enabled(true, {}));
+  EXPECT_TRUE(run_grasp_execution::safe_intermediate_enabled(true, {0.1, 0.2}));
+}
+
+TEST(TestHomeReturnUtils, FailureReasonIncludesAttemptAndStep)
+{
+  const auto reason = run_grasp_execution::default_home_return_failure_reason(
+    "Move back to home", 2, 5);
+  EXPECT_NE(reason.find("Move back to home"), std::string::npos);
+  EXPECT_NE(reason.find("2/5"), std::string::npos);
+  EXPECT_NE(reason.find("no valid plan returned by MoveIt"), std::string::npos);
+}

--- a/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
+++ b/easy_manipulation_deployment/emd_grasp_execution/src/moveit2/moveit_cpp_if.cpp
@@ -1673,14 +1673,28 @@ void MoveitCppGraspExecution::apply_release_planning_allowed_contacts(const std:
 void MoveitCppGraspExecution::remove_object(
   const std::string & target_id)
 {
+  bool world_object_exists = false;
+  {
+    planning_scene_monitor::LockedPlanningSceneRO scene(moveit_cpp_->getPlanningSceneMonitor());
+    world_object_exists = scene->getWorld()->hasObject(target_id);
+  }
+  if (!world_object_exists) {
+    RCLCPP_DEBUG(
+      LOGGER,
+      "World object '%s' is already absent before remove; skipping REMOVE operation.",
+      target_id.c_str());
+  }
+
   moveit_msgs::msg::CollisionObject object;
   object.id = target_id;
   object.operation = moveit_msgs::msg::CollisionObject::REMOVE;
 
-  // Add object to planning scene
+  // Apply scene cleanup and ACM cleanup.
   {    // Lock PlanningScene
     planning_scene_monitor::LockedPlanningSceneRW scene(moveit_cpp_->getPlanningSceneMonitor());
-    scene->processCollisionObjectMsg(object);
+    if (world_object_exists) {
+      scene->processCollisionObjectMsg(object);
+    }
 
     auto & acm = scene->getAllowedCollisionMatrixNonConst();
     const auto attached_ids = detail::get_attached_object_acm_ids(target_id);


### PR DESCRIPTION
### Motivation
- OMPL sometimes produces invalid self-collision plans when returning to home, causing noisy logs and intermittent retries; the goal is clearer retry logging and a safer, configurable flow without weakening collision safety.
- Provide an optional safe intermediate joint waypoint to reduce chance of sampling invalid paths when returning from a detach step.

### Description
- Added `home_return_utils.hpp` with small helpers and formatted failure messages used by the new home-return code.
- Replaced the single `move_to(... home_state)` call in the demo workflow with a `run_home_return_sequence` that performs an optional safe-intermediate joint-state move followed by a retried move-to-home, and added `move_to_joint_waypoint_with_retries` to log attempt counts and failure reasons.
- Exposed new parameters in `config/grasp_execution.yaml` and declared them in the demo node: `home_return.use_safe_intermediate`, `home_return.max_attempts`, `home_return.safe_joint_state`, and `home_return.planning_time`, with defaults preserving previous behaviour.
- Kept collision checking unchanged (no ACM relaxations for forearm<->wrist) and made `remove_object` quieter by checking world-object existence before issuing REMOVE and downgrading the missing-object case to a debug message while still cleaning ACM entries.
- Added unit test `test_home_return_utils` and wired it into the package CMake so the helper behaviour is covered by automated tests.

### Testing
- Added an automated unit test `test_home_return_utils` (included in `run_grasp_execution` CMake test targets); it was not executed in this environment.
- Attempted to run the package tests with: `source /opt/ros/humble/setup.bash && colcon test --packages-select run_grasp_execution --event-handlers console_cohesion+ --ctest-args -R test_home_return_utils`, but the environment lacks `/opt/ros/humble/setup.bash` so the test run failed in this container and no tests were completed here.
- Runtime behaviour targeted by the acceptance test (grasp → release → detach → optional safe retreat → home with clear retry logs; no executed invalid plan; quiet missing-world warnings) is preserved by the changes and should be validated by the provided acceptance scenario on a ROS-enabled host.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee39f436a883318c709ba870f13f72)