### PR TITLE
Handle vector-safe parameter for home_return.safe_joint_state

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -408,12 +408,28 @@ public:
       node,
       node->get_logger(),
       5);
-    grasp_execution::declare_or_get_param<std::vector<double>>(
-      home_return_safe_joint_state_,
-      "home_return.safe_joint_state",
-      node,
+    constexpr const char * kHomeReturnSafeJointStateParam = "home_return.safe_joint_state";
+    if (node->has_parameter(kHomeReturnSafeJointStateParam)) {
+      node->get_parameter_or<std::vector<double>>(
+        kHomeReturnSafeJointStateParam,
+        home_return_safe_joint_state_,
+        std::vector<double>{});
+    } else {
+      home_return_safe_joint_state_ = node->declare_parameter<std::vector<double>>(
+        kHomeReturnSafeJointStateParam,
+        std::vector<double>{});
+    }
+
+    std::vector<std::string> safe_joint_state_values;
+    safe_joint_state_values.reserve(home_return_safe_joint_state_.size());
+    for (const auto value : home_return_safe_joint_state_) {
+      safe_joint_state_values.push_back(std::to_string(value));
+    }
+    RCLCPP_INFO(
       node->get_logger(),
-      std::vector<double>{});
+      "Found parameter - %s: [%s]",
+      kHomeReturnSafeJointStateParam,
+      boost::algorithm::join(safe_joint_state_values, ", ").c_str());
     grasp_execution::declare_or_get_param<double>(
       home_return_planning_time_s_,
       "home_return.planning_time",


### PR DESCRIPTION
### Motivation
- `declare_or_get_param<std::vector<double>>` caused compile-time errors when used for `home_return.safe_joint_state` because the helper falls back to assigning an `int` and attempts to stream a `std::vector<double>`, which is invalid.
- The change isolates vector parameter handling to avoid the problematic generic helper while preserving existing scalar parameter behaviour and grasp/release logic.

### Description
- Replaced the `declare_or_get_param<std::vector<double>>` call for `home_return.safe_joint_state` with explicit handling in `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp` that checks `node->has_parameter(...)` and uses `get_parameter_or<std::vector<double>>` when pre-declared or `declare_parameter<std::vector<double>>` when not.
- Added robust logging for the vector parameter by converting each element with `std::to_string` and joining them with `boost::algorithm::join` to avoid streaming `std::vector<double>` directly.
- Left all scalar `declare_or_get_param` usages unchanged so existing parameter semantics and grasp/release behaviour are preserved.

### Testing
- An initial workspace build showed the compile failure in `run_grasp_execution` due to using `declare_or_get_param` with `std::vector<double>`, which motivated this fix (compile error observed in the rollout logs).
- After applying the change, an attempt to run `colcon build --symlink-install --packages-select run_grasp_execution` in this environment could not be completed because `colcon` is not available (`colcon: command not found`), so build verification could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3feb11d08331aa2836fbca36aff9)