### PR TITLE
Handle blank home_return.safe_joint_state without launch abort

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -365,6 +365,96 @@ std::string format_pose_xyz_quat_rpy(const geometry_msgs::msg::Pose & pose)
   return oss.str();
 }
 
+std::string parameter_type_to_string(const rclcpp::ParameterType type)
+{
+  switch (type) {
+    case rclcpp::ParameterType::PARAMETER_NOT_SET:
+      return "not set";
+    case rclcpp::ParameterType::PARAMETER_BOOL:
+      return "bool";
+    case rclcpp::ParameterType::PARAMETER_INTEGER:
+      return "integer";
+    case rclcpp::ParameterType::PARAMETER_DOUBLE:
+      return "double";
+    case rclcpp::ParameterType::PARAMETER_STRING:
+      return "string";
+    case rclcpp::ParameterType::PARAMETER_BYTE_ARRAY:
+      return "byte_array";
+    case rclcpp::ParameterType::PARAMETER_BOOL_ARRAY:
+      return "bool_array";
+    case rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY:
+      return "integer_array";
+    case rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY:
+      return "double_array";
+    case rclcpp::ParameterType::PARAMETER_STRING_ARRAY:
+      return "string_array";
+    default:
+      return "unknown";
+  }
+}
+
+std::string format_double_vector(const std::vector<double> & values)
+{
+  std::ostringstream oss;
+  oss << "[";
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0) {
+      oss << ", ";
+    }
+    oss << values[i];
+  }
+  oss << "]";
+  return oss.str();
+}
+
+std::vector<double> resolve_safe_joint_state_param(
+  const rclcpp::Node::SharedPtr & node,
+  const rclcpp::Logger & logger,
+  const std::string & param_name)
+{
+  const std::vector<double> empty_default;
+  if (!node->has_parameter(param_name)) {
+    return node->declare_parameter<std::vector<double>>(param_name, empty_default);
+  }
+
+  rclcpp::Parameter parameter;
+  if (!node->get_parameter(param_name, parameter)) {
+    RCLCPP_WARN(
+      logger,
+      "Could not read parameter '%s'. Using empty safe joint state.",
+      param_name.c_str());
+    return empty_default;
+  }
+
+  if (parameter.get_type() == rclcpp::ParameterType::PARAMETER_NOT_SET) {
+    RCLCPP_WARN(
+      logger,
+      "Parameter '%s' is set but has no value (blank/null). Using empty safe joint state.",
+      param_name.c_str());
+    return empty_default;
+  }
+
+  if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY) {
+    RCLCPP_WARN(
+      logger,
+      "Parameter '%s' has type '%s' but expected 'double_array'. Using empty safe joint state.",
+      param_name.c_str(),
+      parameter_type_to_string(parameter.get_type()).c_str());
+    return empty_default;
+  }
+
+  try {
+    return parameter.as_double_array();
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(
+      logger,
+      "Failed to parse parameter '%s' as double array (%s). Using empty safe joint state.",
+      param_name.c_str(),
+      e.what());
+    return empty_default;
+  }
+}
+
 class Demo : public moveit2::MoveitCppGraspExecution
 {
 public:
@@ -409,27 +499,15 @@ public:
       node->get_logger(),
       5);
     constexpr const char * kHomeReturnSafeJointStateParam = "home_return.safe_joint_state";
-    if (node->has_parameter(kHomeReturnSafeJointStateParam)) {
-      node->get_parameter_or<std::vector<double>>(
-        kHomeReturnSafeJointStateParam,
-        home_return_safe_joint_state_,
-        std::vector<double>{});
-    } else {
-      home_return_safe_joint_state_ = node->declare_parameter<std::vector<double>>(
-        kHomeReturnSafeJointStateParam,
-        std::vector<double>{});
-    }
-
-    std::vector<std::string> safe_joint_state_values;
-    safe_joint_state_values.reserve(home_return_safe_joint_state_.size());
-    for (const auto value : home_return_safe_joint_state_) {
-      safe_joint_state_values.push_back(std::to_string(value));
-    }
+    home_return_safe_joint_state_ = resolve_safe_joint_state_param(
+      node,
+      node->get_logger(),
+      kHomeReturnSafeJointStateParam);
     RCLCPP_INFO(
       node->get_logger(),
-      "Found parameter - %s: [%s]",
+      "Resolved parameter - %s: %s",
       kHomeReturnSafeJointStateParam,
-      boost::algorithm::join(safe_joint_state_values, ", ").c_str());
+      format_double_vector(home_return_safe_joint_state_).c_str());
     grasp_execution::declare_or_get_param<double>(
       home_return_planning_time_s_,
       "home_return.planning_time",
@@ -1193,9 +1271,12 @@ private:
     const moveit::core::RobotState & home_state)
   {
     (void)target_id;
-    if (run_grasp_execution::safe_intermediate_enabled(
-        home_return_use_safe_intermediate_, home_return_safe_joint_state_))
-    {
+    if (home_return_use_safe_intermediate_ && home_return_safe_joint_state_.empty()) {
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "[HomeReturn] home_return.use_safe_intermediate=true but home_return.safe_joint_state is empty. "
+        "Skipping safe intermediate and continuing to home.");
+    } else if (home_return_use_safe_intermediate_) {
       auto current_state = get_curr_state();
       if (!current_state) {
         RCLCPP_WARN(


### PR DESCRIPTION
### Motivation
- The node crashed at startup when `home_return.safe_joint_state` was present but blank in YAML because ROS 2 exposes blank/null as `PARAMETER_NOT_SET` and the node tried to read it directly as `std::vector<double>` which threw `InvalidParameterValueException`.
- The generic `declare_or_get_param<T>` helper was not safe for `std::vector<double>` when parameters are blank or of the wrong type, so vector parameters need dedicated handling.

### Description
- Added `resolve_safe_joint_state_param`, `parameter_type_to_string`, and `format_double_vector` helpers to robustly read `home_return.safe_joint_state` and provide clear logging. 
- Replaced the previous direct `declare`/`get_parameter_or` logic with `resolve_safe_joint_state_param` so that absent parameters are declared as an empty vector, `PARAMETER_NOT_SET` (blank) and wrong-type cases are warned about and treated as an empty vector, and valid `double_array` values are read normally. 
- Updated startup logging to show the resolved safe joint vector cleanly (e.g. `[]` or the configured list). 
- Changed `run_home_return_sequence` gating so that if `home_return.use_safe_intermediate` is true but the resolved `home_return.safe_joint_state` is empty, the node logs a warning and skips the safe intermediate rather than aborting; the existing DOF-size mismatch check remains and still skips with a warning if sizes differ. 
- File changed: `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp`.
- No other behavioural or planning logic was modified and the existing YAML in this repo already uses `safe_joint_state: []`, so no YAML edits were required here.

### Testing
- Attempted to run the requested acceptance/build steps but the environment lacks ROS/colcon so automated build/launch could not be executed: `source /opt/ros/humble/setup.bash` failed because the file was not found, and `colcon` was not available so `colcon build --packages-select run_grasp_execution` could not run. 
- No unit tests were added in this patch due to environment limitations; the change is limited to parameter parsing and runtime gating to avoid startup exceptions. 
- Manual static validation: diff reviewed to ensure the vector-specialised logic avoids the previous generic-path casting/streaming issues and preserves the DOF size checks and normal home/grasp/release behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee589f911883319f70f080fc920570)