### PR TITLE
Improve grasp-frame selection for 2F/3F/suction metadata

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -98,6 +98,10 @@ def derive_planner_end_effector_id(end_effector):
     ee_type = _normalize_text(end_effector.get("ee_type"))
     ee_fingers = end_effector.get("attributes", {}).get("fingers")
 
+    if ee_name in {"suction", "airpick"}:
+        return "suction_cup"
+    if ee_brand in {"suction", "airpick"}:
+        return "suction_cup"
     if ee_name in KNOWN_PLANNER_END_EFFECTOR_IDS:
         return ee_name
     if ee_brand in KNOWN_PLANNER_END_EFFECTOR_IDS:
@@ -123,7 +127,26 @@ def derive_workcell_end_effector_link(end_effector):
     return "tool0"
 
 
-def derive_workcell_grasp_frame(end_effector):
+def _extract_end_effector_link_candidates(end_effector):
+    links = end_effector.get("links")
+    if isinstance(links, dict):
+        values = links.values()
+    elif isinstance(links, list):
+        values = links
+    elif isinstance(links, str):
+        values = [links]
+    else:
+        values = []
+
+    candidates = []
+    for value in values:
+        normalized = _normalize_text(value)
+        if normalized and normalized not in candidates:
+            candidates.append(normalized)
+    return candidates
+
+
+def _derive_normalized_ee_family(end_effector):
     ee_name = _normalize_text(end_effector.get("name"))
     ee_brand = _normalize_text(end_effector.get("brand"))
     ee_type = _normalize_text(end_effector.get("ee_type"))
@@ -131,7 +154,61 @@ def derive_workcell_grasp_frame(end_effector):
     search_blob = " ".join((ee_name, ee_brand, ee_type))
 
     if any(marker in search_blob for marker in ("robotiq_2f", "robotiq_85")) or ee_fingers == 2:
-        return "ee_palm"
+        return "2f"
+    if "robotiq_3f" in search_blob or ee_fingers == 3:
+        return "3f"
+    if any(marker in search_blob for marker in ("suction", "single_suction", "airpick")):
+        return "suction"
+    return "generic"
+
+
+def _first_from_metadata_or_links(end_effector, metadata_keys, link_candidates):
+    for key in metadata_keys:
+        value = _normalize_text(end_effector.get(key))
+        if value:
+            return value
+    for value in link_candidates:
+        if value:
+            return value
+    return ""
+
+
+def derive_workcell_grasp_frame(end_effector):
+    ee_family = _derive_normalized_ee_family(end_effector)
+    link_candidates = _extract_end_effector_link_candidates(end_effector)
+
+    if ee_family == "2f":
+        metadata_and_links = ("grasp_frame", "ee_palm", "base_link", "link")
+        return _first_from_metadata_or_links(end_effector, metadata_and_links, link_candidates) or "tool0"
+
+    if ee_family == "3f":
+        for key in ("grasp_frame", "tcp_link", "physical_ee_link", "base_link", "link"):
+            value = _normalize_text(end_effector.get(key))
+            if value:
+                return value
+        for palm_frame in ("ee_palm", "palm"):
+            if palm_frame in link_candidates:
+                return palm_frame
+        return "tool0"
+
+    if ee_family == "suction":
+        suction_metadata_keys = ("suction_cup_link",)
+        suction_link_candidates = [
+            candidate
+            for candidate in link_candidates
+            if candidate == "suction_cup_link" or "suction_cup" in candidate
+        ]
+        suction_frame = _first_from_metadata_or_links(end_effector, suction_metadata_keys, suction_link_candidates)
+        if suction_frame:
+            return suction_frame
+
+        tcp_keys = ("grasp_frame", "tcp_link", "physical_ee_link", "base_link", "link")
+        tcp_link_candidates = [
+            candidate
+            for candidate in link_candidates
+            if "tcp" in candidate or "tool_center_point" in candidate
+        ]
+        return _first_from_metadata_or_links(end_effector, tcp_keys, tcp_link_candidates) or "tool0"
 
     for key in ("grasp_frame", "tcp_link", "physical_ee_link", "base_link", "link"):
         value = _normalize_text(end_effector.get(key))

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
@@ -346,6 +346,60 @@ def test_derive_workcell_grasp_frame_prefers_ee_palm_for_robotiq_85_two_finger_m
     assert grasp_launch_module.derive_workcell_grasp_frame(end_effector) == "ee_palm"
 
 
+@pytest.mark.parametrize(
+    ("end_effector", "expected_grasp_frame"),
+    [
+        (
+            {
+                "name": "single_suction_gripper",
+                "brand": "suction",
+                "links": ["wrist_3_link", "suction_cup_link", "airpick_tcp"],
+                "tcp_link": "airpick_tcp",
+            },
+            "suction_cup_link",
+        ),
+        (
+            {
+                "name": "onrobot_airpick4",
+                "brand": "airpick",
+                "links": ["airpick_base", "airpick_tcp"],
+                "tcp_link": "airpick_tcp",
+            },
+            "airpick_tcp",
+        ),
+        (
+            {
+                "name": "robotiq_3f",
+                "attributes": {"fingers": 3},
+                "links": ["finger_1_link_0", "palm", "finger_middle_link_0"],
+            },
+            "palm",
+        ),
+        (
+            {
+                "name": "robotiq_3f",
+                "attributes": {"fingers": 3},
+                "grasp_frame": "custom_3f_tcp",
+                "links": ["palm", "finger_1_link_0"],
+            },
+            "custom_3f_tcp",
+        ),
+    ],
+)
+def test_derive_workcell_grasp_frame_metadata_only_precedence(
+    grasp_launch_module,
+    end_effector,
+    expected_grasp_frame,
+):
+    assert grasp_launch_module.derive_workcell_grasp_frame(end_effector) == expected_grasp_frame
+
+
+def test_derive_planner_end_effector_id_maps_airpick_to_suction_cup(grasp_launch_module):
+    end_effector = {"name": "airpick", "brand": "onrobot"}
+
+    assert grasp_launch_module.derive_planner_end_effector_id(end_effector) == "suction_cup"
+
+
 def test_build_workcell_context_falls_back_to_ur_tool0_only_when_scene_has_no_end_effector(grasp_launch_module):
     workcell_context, ee_id, ee_link, ee_grasp_frame = grasp_launch_module.build_workcell_context_for_scene(
         "scene_without_ee",


### PR DESCRIPTION
### Motivation
- End-effector metadata can encode different conventions for two-finger, three-finger, and suction/airpick tools and the previous heuristic missed some preferred frame names and link lists; the goal is to make `derive_workcell_grasp_frame()` choose the most appropriate grasp frame per EE family.

### Description
- Update `derive_workcell_grasp_frame()` in `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` to branch by a normalized EE family (`2f`, `3f`, `suction`, `generic`) and apply the requested precedence/fallback behavior for each family.
- Add helpers `_extract_end_effector_link_candidates()`, `_derive_normalized_ee_family()`, and `_first_from_metadata_or_links()` to inspect and normalize `end_effector.links` and to centralize metadata/link precedence logic.
- Preserve planner-brand compatibility by normalizing explicit `airpick`/`suction` `name` or `brand` values to the planner ID `suction_cup` in `derive_planner_end_effector_id()`.
- Extend `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py` with parameterized, metadata-only tests covering suction/airpick and 3F precedence and an explicit `airpick -> suction_cup` planner-ID mapping test.

### Testing
- Ran syntax check with `python -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py`, which succeeded.
- Executed `pytest -q easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py`, which was import-skipped / reported as skipped in this environment because `xacro` is unavailable (tests are designed to skip when ROS/xacro is not present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef388cb7a08331a6ec820e8cd705d6)