### PR TITLE
Warn when workcell EE classification falls back to arm-only defaults

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -310,7 +310,7 @@ def derive_workcell_grasp_frame(end_effector):
     return ""
 
 
-def build_workcell_context_for_scene(scene_package, scene_metadata):
+def build_workcell_context_for_scene(scene_package, scene_metadata, logger=None):
     end_effector = scene_metadata.get("end_effector", {})
     if end_effector is None:
         end_effector = {}
@@ -320,9 +320,22 @@ def build_workcell_context_for_scene(scene_package, scene_metadata):
             f"got {type(end_effector).__name__}."
         )
 
+    normalized_ee_name = _normalize_text(end_effector.get("name"))
+    normalized_ee_brand = _normalize_text(end_effector.get("brand"))
+    normalized_ee_type = _normalize_text(end_effector.get("ee_type"))
     ee_id = derive_planner_end_effector_id(end_effector)
     ee_link = derive_workcell_end_effector_link(end_effector)
     ee_grasp_frame = derive_workcell_grasp_frame(end_effector) or ee_link
+
+    if ee_id == "ur_tool0":
+        if logger is None:
+            logger = get_logger(__name__)
+        logger.warning(
+            "Falling back to arm-only workcell end effector classification for scene "
+            f"'{scene_package}' (normalized metadata: name='{normalized_ee_name}', "
+            f"brand='{normalized_ee_brand}', ee_type='{normalized_ee_type}'); "
+            "using fallback link/frame 'tool0' and planner ee id 'ur_tool0'."
+        )
     return build_workcell_context(ee_id, ee_link, ee_grasp_frame), ee_id, ee_link, ee_grasp_frame
 
 
@@ -694,7 +707,7 @@ def launch_setup(context, *args, **kwargs):
     )
 
     scene_workcell_context, scene_ee_id, scene_ee_link, scene_ee_grasp_frame = build_workcell_context_for_scene(
-        scene_package, scene_metadata
+        scene_package, scene_metadata, logger=logger
     )
     scene_link_names = _extract_link_names_from_urdf(robot_description_config)
     scene_ee_id, scene_ee_link, scene_ee_grasp_frame = validate_and_normalize_workcell_end_effector_frames(

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
@@ -52,7 +52,11 @@ launch_substitutions_mod.PythonExpression = object
 sys.modules.setdefault("launch.substitutions", launch_substitutions_mod)
 launch_logging_mod = types.ModuleType("launch.logging")
 launch_logging_mod.get_logger = (
-    lambda _name: types.SimpleNamespace(error=lambda *_args, **_kwargs: None)
+    lambda _name: types.SimpleNamespace(
+        error=lambda *_args, **_kwargs: None,
+        warning=lambda *_args, **_kwargs: None,
+        info=lambda *_args, **_kwargs: None,
+    )
 )
 sys.modules.setdefault("launch.logging", launch_logging_mod)
 launch_ros_mod = types.ModuleType("launch_ros")
@@ -496,6 +500,35 @@ def test_build_workcell_context_falls_back_to_ur_tool0_only_when_scene_has_no_en
     assert ee_link == "tool0"
     assert ee_grasp_frame == "tool0"
     assert ros_params["groups.manipulator.end_effectors"] == ["ur_tool0"]
+
+
+def test_build_workcell_context_logs_warning_for_unknown_end_effector_metadata_fallback(grasp_launch_module):
+    logger = types.SimpleNamespace(warning_messages=[])
+    logger.warning = lambda msg: logger.warning_messages.append(msg)
+
+    unknown_scene_metadata = {
+        "robot": {"name": "ur5"},
+        "end_effector": {
+            "name": " mystery_hand ",
+            "brand": " ACME ",
+            "ee_type": " HybridParallel ",
+            "robot_link": "tool0",
+        },
+    }
+
+    _workcell_context, ee_id, ee_link, ee_grasp_frame = grasp_launch_module.build_workcell_context_for_scene(
+        "mystery_scene",
+        unknown_scene_metadata,
+        logger=logger,
+    )
+
+    assert (ee_id, ee_link, ee_grasp_frame) == ("ur_tool0", "tool0", "tool0")
+    assert len(logger.warning_messages) == 1
+    assert "mystery_scene" in logger.warning_messages[0]
+    assert "name='mystery_hand'" in logger.warning_messages[0]
+    assert "brand='acme'" in logger.warning_messages[0]
+    assert "ee_type='hybridparallel'" in logger.warning_messages[0]
+    assert "tool0" in logger.warning_messages[0]
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Motivation
- Detect and make visible when end-effector classification falls back to the arm-only default (`ur_tool0`) so operators can understand why a scene is using the arm-only workcell context.
- Ensure the fallback is non-fatal and logged with useful, normalized metadata for debugging.

### Description
- Added a `logger=None` parameter to `build_workcell_context_for_scene()` and compute normalized metadata fields via `_normalize_text` for `name`, `brand`, and `ee_type`.
- When `derive_planner_end_effector_id()` yields `ur_tool0`, emit a non-throwing warning including the `scene_package` and normalized `name`, `brand`, and `ee_type`, and state the fallback (`tool0`/`ur_tool0`).
- Updated the caller in `launch_setup()` to pass the launch `logger` into `build_workcell_context_for_scene()` so fallback warnings go through normal launch logging.
- Extended the test harness: added `warning` and `info` stubs to the test `launch.logging` mock and added a unit test `test_build_workcell_context_logs_warning_for_unknown_end_effector_metadata_fallback` that supplies unknown EE metadata and asserts the fallback output and the contents of the emitted warning.

### Testing
- Ran `pytest -q easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py`; the test module uses `pytest.importorskip("xacro")` so tests were skipped in this environment (reported as skipped).
- The added unit test asserts `(ee_id, ee_link, ee_grasp_frame) == ("ur_tool0", "tool0", "tool0")` and verifies the warning contains the scene name and normalized `name`, `brand`, `ee_type`, and `tool0`.
- The fallback logging path is exercised by the unit test and is implemented to be non-throwing when `logger` is present or absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef443d20508331b90dc6b9560c1f2a)