### PR TITLE
Add safe_joint_state parsing, skip-warning helpers and tests for home-return edge cases

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
@@ -75,6 +75,9 @@ if(BUILD_TESTING)
   ament_add_gtest(test_home_return_utils
     test/test_home_return_utils.cpp)
   target_include_directories(test_home_return_utils PUBLIC include)
+  ament_target_dependencies(test_home_return_utils
+    rclcpp
+  )
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/home_return_utils.hpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/home_return_utils.hpp
@@ -3,6 +3,11 @@
 
 #include <string>
 #include <vector>
+#include <optional>
+#include <exception>
+
+#include "rclcpp/parameter.hpp"
+#include "rclcpp/parameter_type.hpp"
 
 namespace run_grasp_execution
 {
@@ -29,6 +34,93 @@ inline bool safe_intermediate_enabled(
   const std::vector<double> & safe_joint_state)
 {
   return use_safe_intermediate && !safe_joint_state.empty();
+}
+
+struct SafeJointStateResolution
+{
+  std::vector<double> value;
+  std::optional<std::string> warning_message;
+};
+
+inline std::string parameter_type_to_string(const rclcpp::ParameterType type)
+{
+  switch (type) {
+    case rclcpp::ParameterType::PARAMETER_NOT_SET:
+      return "not set";
+    case rclcpp::ParameterType::PARAMETER_BOOL:
+      return "bool";
+    case rclcpp::ParameterType::PARAMETER_INTEGER:
+      return "integer";
+    case rclcpp::ParameterType::PARAMETER_DOUBLE:
+      return "double";
+    case rclcpp::ParameterType::PARAMETER_STRING:
+      return "string";
+    case rclcpp::ParameterType::PARAMETER_BYTE_ARRAY:
+      return "byte_array";
+    case rclcpp::ParameterType::PARAMETER_BOOL_ARRAY:
+      return "bool_array";
+    case rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY:
+      return "integer_array";
+    case rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY:
+      return "double_array";
+    case rclcpp::ParameterType::PARAMETER_STRING_ARRAY:
+      return "string_array";
+    default:
+      return "unknown";
+  }
+}
+
+inline SafeJointStateResolution parse_safe_joint_state_parameter(
+  const rclcpp::Parameter & parameter,
+  const std::string & param_name)
+{
+  const std::vector<double> empty_default;
+  if (parameter.get_type() == rclcpp::ParameterType::PARAMETER_NOT_SET) {
+    return {
+      empty_default,
+      "Parameter '" + param_name + "' is set but has no value (blank/null). Using empty safe joint state."
+    };
+  }
+
+  if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY) {
+    return {
+      empty_default,
+      "Parameter '" + param_name + "' has type '" + parameter_type_to_string(parameter.get_type()) +
+      "' but expected 'double_array'. Using empty safe joint state."
+    };
+  }
+
+  try {
+    return {parameter.as_double_array(), std::nullopt};
+  } catch (const std::exception & e) {
+    return {
+      empty_default,
+      "Failed to parse parameter '" + param_name + "' as double array (" +
+      std::string(e.what()) + "). Using empty safe joint state."
+    };
+  }
+}
+
+inline std::optional<std::string> safe_intermediate_skip_warning(
+  bool use_safe_intermediate,
+  const std::vector<double> & safe_joint_state,
+  size_t manipulator_dof,
+  const std::string & planning_group)
+{
+  if (!use_safe_intermediate) {
+    return std::nullopt;
+  }
+  if (safe_joint_state.empty()) {
+    return "[HomeReturn] home_return.use_safe_intermediate=true but home_return.safe_joint_state is empty. "
+           "Skipping safe intermediate and continuing to home.";
+  }
+  if (safe_joint_state.size() != manipulator_dof) {
+    return "[HomeReturn] home_return.safe_joint_state has " +
+           std::to_string(safe_joint_state.size()) + " values, expected " +
+           std::to_string(manipulator_dof) + " for group '" + planning_group +
+           "'. Skipping safe intermediate and continuing to home.";
+  }
+  return std::nullopt;
 }
 
 }  // namespace run_grasp_execution

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -365,34 +365,6 @@ std::string format_pose_xyz_quat_rpy(const geometry_msgs::msg::Pose & pose)
   return oss.str();
 }
 
-std::string parameter_type_to_string(const rclcpp::ParameterType type)
-{
-  switch (type) {
-    case rclcpp::ParameterType::PARAMETER_NOT_SET:
-      return "not set";
-    case rclcpp::ParameterType::PARAMETER_BOOL:
-      return "bool";
-    case rclcpp::ParameterType::PARAMETER_INTEGER:
-      return "integer";
-    case rclcpp::ParameterType::PARAMETER_DOUBLE:
-      return "double";
-    case rclcpp::ParameterType::PARAMETER_STRING:
-      return "string";
-    case rclcpp::ParameterType::PARAMETER_BYTE_ARRAY:
-      return "byte_array";
-    case rclcpp::ParameterType::PARAMETER_BOOL_ARRAY:
-      return "bool_array";
-    case rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY:
-      return "integer_array";
-    case rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY:
-      return "double_array";
-    case rclcpp::ParameterType::PARAMETER_STRING_ARRAY:
-      return "string_array";
-    default:
-      return "unknown";
-  }
-}
-
 std::string format_double_vector(const std::vector<double> & values)
 {
   std::ostringstream oss;
@@ -426,33 +398,15 @@ std::vector<double> resolve_safe_joint_state_param(
     return empty_default;
   }
 
-  if (parameter.get_type() == rclcpp::ParameterType::PARAMETER_NOT_SET) {
+  const auto resolution =
+    run_grasp_execution::parse_safe_joint_state_parameter(parameter, param_name);
+  if (resolution.warning_message.has_value()) {
     RCLCPP_WARN(
       logger,
-      "Parameter '%s' is set but has no value (blank/null). Using empty safe joint state.",
-      param_name.c_str());
-    return empty_default;
+      "%s",
+      resolution.warning_message->c_str());
   }
-
-  if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY) {
-    RCLCPP_WARN(
-      logger,
-      "Parameter '%s' has type '%s' but expected 'double_array'. Using empty safe joint state.",
-      param_name.c_str(),
-      parameter_type_to_string(parameter.get_type()).c_str());
-    return empty_default;
-  }
-
-  try {
-    return parameter.as_double_array();
-  } catch (const std::exception & e) {
-    RCLCPP_WARN(
-      logger,
-      "Failed to parse parameter '%s' as double array (%s). Using empty safe joint state.",
-      param_name.c_str(),
-      e.what());
-    return empty_default;
-  }
+  return resolution.value;
 }
 
 class Demo : public moveit2::MoveitCppGraspExecution
@@ -1271,12 +1225,7 @@ private:
     const moveit::core::RobotState & home_state)
   {
     (void)target_id;
-    if (home_return_use_safe_intermediate_ && home_return_safe_joint_state_.empty()) {
-      RCLCPP_WARN(
-        node_->get_logger(),
-        "[HomeReturn] home_return.use_safe_intermediate=true but home_return.safe_joint_state is empty. "
-        "Skipping safe intermediate and continuing to home.");
-    } else if (home_return_use_safe_intermediate_) {
+    if (home_return_use_safe_intermediate_) {
       auto current_state = get_curr_state();
       if (!current_state) {
         RCLCPP_WARN(
@@ -1293,14 +1242,16 @@ private:
             planning_group.c_str());
         } else {
           const auto variable_names = jmg->getVariableNames();
-          if (home_return_safe_joint_state_.size() != variable_names.size()) {
+          const auto skip_warning = run_grasp_execution::safe_intermediate_skip_warning(
+            home_return_use_safe_intermediate_,
+            home_return_safe_joint_state_,
+            variable_names.size(),
+            planning_group);
+          if (skip_warning.has_value()) {
             RCLCPP_WARN(
               node_->get_logger(),
-              "[HomeReturn] home_return.safe_joint_state has %zu values, expected %zu for "
-              "group '%s'. Skipping safe intermediate and continuing to home.",
-              home_return_safe_joint_state_.size(),
-              variable_names.size(),
-              planning_group.c_str());
+              "%s",
+              skip_warning->c_str());
           } else {
             moveit::core::RobotState safe_state(*current_state);
             for (size_t i = 0; i < variable_names.size(); ++i) {

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
@@ -22,6 +22,7 @@ Python environment.
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 import types
 from pathlib import Path
@@ -259,6 +260,15 @@ def test_validate_gripper_controller_consistency_enables_when_joints_and_interfa
     assert details["robot_description"]["missing_command_interfaces"] == {}
     assert details["robot_description"]["missing_state_interfaces"] == {}
     assert details["missing_ros2_controller_joints"] == []
+
+
+def test_home_return_safe_intermediate_default_is_disabled():
+    config_path = Path(__file__).resolve().parent.parent / "config" / "grasp_execution.yaml"
+    config_text = config_path.read_text(encoding="utf-8")
+    assert re.search(
+        r"home_return:\s*\n(?:\s+.+\n)*?\s+use_safe_intermediate:\s*false\b",
+        config_text,
+    )
 
 
 def test_validate_gripper_controller_consistency_disables_when_joints_missing(grasp_launch_module):

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_home_return_utils.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_home_return_utils.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <rclcpp/parameter.hpp>
+
 #include <vector>
 
 #include "run_grasp_execution/home_return_utils.hpp"
@@ -18,4 +20,68 @@ TEST(TestHomeReturnUtils, FailureReasonIncludesAttemptAndStep)
   EXPECT_NE(reason.find("Move back to home"), std::string::npos);
   EXPECT_NE(reason.find("2/5"), std::string::npos);
   EXPECT_NE(reason.find("no valid plan returned by MoveIt"), std::string::npos);
+}
+
+TEST(TestHomeReturnUtils, ParseSafeJointStateParamMissingFallsBackToEmptyWithoutWarning)
+{
+  const rclcpp::Parameter missing_param("home_return.safe_joint_state");
+  const auto resolution = run_grasp_execution::parse_safe_joint_state_parameter(
+    missing_param,
+    "home_return.safe_joint_state");
+
+  EXPECT_TRUE(resolution.value.empty());
+  ASSERT_TRUE(resolution.warning_message.has_value());
+  EXPECT_NE(resolution.warning_message->find("blank/null"), std::string::npos);
+}
+
+TEST(TestHomeReturnUtils, ParseSafeJointStateParamEmptyListIsAccepted)
+{
+  const rclcpp::Parameter param("home_return.safe_joint_state", std::vector<double>{});
+  const auto resolution = run_grasp_execution::parse_safe_joint_state_parameter(
+    param,
+    "home_return.safe_joint_state");
+
+  EXPECT_TRUE(resolution.value.empty());
+  EXPECT_FALSE(resolution.warning_message.has_value());
+}
+
+TEST(TestHomeReturnUtils, ParseSafeJointStateParamWrongTypeStringFallsBackToEmptyWithWarning)
+{
+  const rclcpp::Parameter param("home_return.safe_joint_state", std::string("bad_type"));
+  const auto resolution = run_grasp_execution::parse_safe_joint_state_parameter(
+    param,
+    "home_return.safe_joint_state");
+
+  EXPECT_TRUE(resolution.value.empty());
+  ASSERT_TRUE(resolution.warning_message.has_value());
+  EXPECT_NE(resolution.warning_message->find("type 'string'"), std::string::npos);
+}
+
+TEST(TestHomeReturnUtils, ParseSafeJointStateParamWrongTypeIntegerFallsBackToEmptyWithWarning)
+{
+  const rclcpp::Parameter param("home_return.safe_joint_state", 42);
+  const auto resolution = run_grasp_execution::parse_safe_joint_state_parameter(
+    param,
+    "home_return.safe_joint_state");
+
+  EXPECT_TRUE(resolution.value.empty());
+  ASSERT_TRUE(resolution.warning_message.has_value());
+  EXPECT_NE(resolution.warning_message->find("type 'integer'"), std::string::npos);
+}
+
+TEST(TestHomeReturnUtils, SafeIntermediateSkipWarningForMismatchedDof)
+{
+  const auto warning = run_grasp_execution::safe_intermediate_skip_warning(
+    true, {0.1, 0.2}, 6, "arm");
+  ASSERT_TRUE(warning.has_value());
+  EXPECT_NE(warning->find("has 2 values, expected 6"), std::string::npos);
+  EXPECT_NE(warning->find("Skipping safe intermediate"), std::string::npos);
+}
+
+TEST(TestHomeReturnUtils, SafeIntermediateSkipWarningForEmptyList)
+{
+  const auto warning = run_grasp_execution::safe_intermediate_skip_warning(
+    true, {}, 6, "arm");
+  ASSERT_TRUE(warning.has_value());
+  EXPECT_NE(warning->find("safe_joint_state is empty"), std::string::npos);
 }


### PR DESCRIPTION
### Motivation
- Make `home_return.safe_joint_state` handling robust against missing, empty, wrong-typed, or length-mismatched parameter values so the node does not crash and instead falls back to a safe behavior.
- Centralize parsing and skip-message logic so the same behavior is reused in `demo_node.cpp` and is easy to test.
- Ensure generated configs keep the default behavior `use_safe_intermediate=false` consistent with example scenes.

### Description
- Add `SafeJointStateResolution`, `parse_safe_joint_state_parameter(...)`, and `safe_intermediate_skip_warning(...)` helpers to `run_grasp_execution/home_return_utils.hpp` to parse the parameter and produce optional warning text for callers.
- Update `demo_node.cpp` to use `parse_safe_joint_state_parameter(...)` when resolving `home_return.safe_joint_state` and to use `safe_intermediate_skip_warning(...)` when deciding whether to run the safe intermediate waypoint, converting invalid inputs into an empty safe joint state and emitting a single consolidated warning message when appropriate.
- Extend `test_home_return_utils.cpp` with gtests that cover: missing parameter (no value), empty list, wrong types (`string` and `integer`), and mismatched length vs manipulator DoF, and assert expected warning messages where feasible.
- Add a small pytest in `test_grasp_execution_launch_helpers.py` to assert the config default keeps `home_return.use_safe_intermediate: false` (keeps defaults aligned with generated scenes).
- Add `rclcpp` as a test dependency for `test_home_return_utils` in the package `CMakeLists.txt` so the new parameter-based tests link.

### Testing
- `python3 -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py` succeeded.
- `python3 -m pytest easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py -q` executed but the run was skipped in this environment (test harness stubs and/or missing `xacro`), so the Python config assertion was exercised as a unit test and skipped by the test runner.
- Attempted to run the C++ gtests via `colcon test --packages-select run_grasp_execution --ctest-args -R test_home_return_utils` but could not run in this environment because `colcon` is not available, so the new C++ gtests were added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4510f378833183c64688534f65c1)