### PR TITLE
Emit normalized end-effector metadata and add tests

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -168,6 +168,8 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_link_deletion_test test/link_deletion_test.cpp)
   ament_add_gtest(workcell_directory_inspection_test test/workcell_directory_inspection_test.cpp)
   ament_add_gtest(workcell_scene_select_paths_test test/scene_select_paths_test.cpp src_scene_select_paths.cpp)
+  ament_add_gtest(workcell_generate_yaml_end_effector_metadata_test
+    test/generate_yaml_end_effector_metadata_test.cpp)
   if(TARGET workcell_directory_inspection_test)
     target_link_libraries(workcell_directory_inspection_test
       ${Boost_LIBRARIES}
@@ -175,6 +177,23 @@ if(BUILD_TESTING)
     target_include_directories(workcell_directory_inspection_test
       PRIVATE
         ${Boost_INCLUDE_DIRS}
+    )
+  endif()
+
+  if(TARGET workcell_generate_yaml_end_effector_metadata_test)
+    ament_target_dependencies(workcell_generate_yaml_end_effector_metadata_test
+      rclcpp
+    )
+    target_link_libraries(workcell_generate_yaml_end_effector_metadata_test
+      yaml-cpp
+      ${Boost_LIBRARIES}
+    )
+    target_include_directories(workcell_generate_yaml_end_effector_metadata_test
+      PRIVATE
+        ${Boost_INCLUDE_DIRS}
+        include
+        include/attributes
+        include/yaml_parser
     )
   endif()
 

--- a/workcell_builder/workcell_builder/include/attributes/end_effector.h
+++ b/workcell_builder/workcell_builder/include/attributes/end_effector.h
@@ -40,6 +40,12 @@ public:
   std::string ee_type;
   int attribute_1 = -1;
   int attribute_2 = -1;
+  std::string planner_id;
+  std::string grasp_frame;
+  std::string tcp_link;
+  std::string gripper_type;
+  bool spawn_gripper_controller = false;
+  int finger_count = -1;
   std::string ee_robot_joint_type = "fixed";
   Origin origin;
   std::vector < std::string > ee_links;

--- a/workcell_builder/workcell_builder/include/scene_parser.h
+++ b/workcell_builder/workcell_builder/include/scene_parser.h
@@ -97,6 +97,12 @@ public:
       if (ee_it->first.as < std::string > ().compare("brand") == 0) {
         input_ee->brand = ee_it->second.as < std::string > ();
       }
+      if (ee_it->first.as < std::string > ().compare("planner_id") == 0) {
+        input_ee->planner_id = ee_it->second.as < std::string > ();
+        if (input_ee->brand.empty()) {
+          input_ee->brand = input_ee->planner_id;
+        }
+      }
       if (ee_it->first.as < std::string > ().compare("base_link") == 0) {
         input_ee->base_link = ee_it->second.as < std::string > ();
       }
@@ -108,6 +114,27 @@ public:
       }
       if (ee_it->first.as < std::string > ().compare("ee_type") == 0) {
         input_ee->ee_type = ee_it->second.as < std::string > ();
+      }
+      if (ee_it->first.as < std::string > ().compare("gripper_type") == 0) {
+        input_ee->gripper_type = ee_it->second.as < std::string > ();
+        if (input_ee->ee_type.empty()) {
+          input_ee->ee_type = input_ee->gripper_type;
+        }
+      }
+      if (ee_it->first.as < std::string > ().compare("grasp_frame") == 0) {
+        input_ee->grasp_frame = ee_it->second.as < std::string > ();
+      }
+      if (ee_it->first.as < std::string > ().compare("tcp_link") == 0) {
+        input_ee->tcp_link = ee_it->second.as < std::string > ();
+      }
+      if (ee_it->first.as < std::string > ().compare("spawn_gripper_controller") == 0) {
+        input_ee->spawn_gripper_controller = ee_it->second.as < bool > ();
+      }
+      if (ee_it->first.as < std::string > ().compare("finger_count") == 0) {
+        input_ee->finger_count = ee_it->second.as < int > ();
+        if (input_ee->attribute_1 < 0) {
+          input_ee->attribute_1 = input_ee->finger_count;
+        }
       }
 
       if (ee_it->first.as < std::string > ().compare("attributes") == 0) {
@@ -163,6 +190,21 @@ public:
         }
         input_ee->ee_links = temp_vec;
       }
+    }
+    if (input_ee->planner_id.empty()) {
+      input_ee->planner_id = input_ee->brand;
+    }
+    if (input_ee->gripper_type.empty()) {
+      input_ee->gripper_type = input_ee->ee_type;
+    }
+    if (input_ee->grasp_frame.empty()) {
+      input_ee->grasp_frame = input_ee->base_link;
+    }
+    if (input_ee->tcp_link.empty()) {
+      input_ee->tcp_link = input_ee->grasp_frame;
+    }
+    if (input_ee->finger_count < 0 && input_ee->gripper_type == "finger" && input_ee->attribute_1 > 0) {
+      input_ee->finger_count = input_ee->attribute_1;
     }
     return true;
   }

--- a/workcell_builder/workcell_builder/include/yaml_parser/generate_yaml.h
+++ b/workcell_builder/workcell_builder/include/yaml_parser/generate_yaml.h
@@ -68,6 +68,50 @@ std::vector<std::string> normalize_robot_links(const Robot & robot)
 
   return links;
 }
+
+std::string normalized_planner_id(const EndEffector & ee)
+{
+  return ee.planner_id.empty() ? ee.brand : ee.planner_id;
+}
+
+std::string normalized_gripper_type(const EndEffector & ee)
+{
+  return ee.gripper_type.empty() ? ee.ee_type : ee.gripper_type;
+}
+
+std::string normalized_grasp_frame(const EndEffector & ee)
+{
+  if (!ee.grasp_frame.empty()) {
+    return ee.grasp_frame;
+  }
+  if (!ee.tcp_link.empty()) {
+    return ee.tcp_link;
+  }
+  return ee.base_link;
+}
+
+std::string normalized_tcp_link(const EndEffector & ee)
+{
+  if (!ee.tcp_link.empty()) {
+    return ee.tcp_link;
+  }
+  if (!ee.grasp_frame.empty()) {
+    return ee.grasp_frame;
+  }
+  return ee.base_link;
+}
+
+bool normalized_spawn_gripper_controller(const EndEffector & ee)
+{
+  const std::string gripper_type = normalized_gripper_type(ee);
+  if (gripper_type == "finger") {
+    return true;
+  }
+  if (gripper_type == "suction" || gripper_type == "airpick") {
+    return false;
+  }
+  return ee.spawn_gripper_controller;
+}
 }  // namespace
 
 
@@ -128,6 +172,24 @@ public:
       out << YAML::Value << scene.ee_vector[0].robot_link;
       out << YAML::Key << "ee_type";
       out << YAML::Value << scene.ee_vector[0].ee_type;
+      out << YAML::Key << "planner_id";
+      out << YAML::Value << normalized_planner_id(scene.ee_vector[0]);
+      out << YAML::Key << "grasp_frame";
+      out << YAML::Value << normalized_grasp_frame(scene.ee_vector[0]);
+      out << YAML::Key << "tcp_link";
+      out << YAML::Value << normalized_tcp_link(scene.ee_vector[0]);
+      out << YAML::Key << "gripper_type";
+      out << YAML::Value << normalized_gripper_type(scene.ee_vector[0]);
+      out << YAML::Key << "spawn_gripper_controller";
+      out << YAML::Value << normalized_spawn_gripper_controller(scene.ee_vector[0]);
+      if (normalized_gripper_type(scene.ee_vector[0]) == "finger") {
+        const int normalized_finger_count = scene.ee_vector[0].finger_count > 0 ?
+          scene.ee_vector[0].finger_count : scene.ee_vector[0].attribute_1;
+        if (normalized_finger_count > 0) {
+          out << YAML::Key << "finger_count";
+          out << YAML::Value << normalized_finger_count;
+        }
+      }
       out << YAML::Key << "attributes";
       out << YAML::Value << YAML::BeginMap;
       if (scene.ee_vector[0].ee_type.compare("finger") == 0) {

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -76,6 +76,36 @@ def load_yaml(package_name, rel_path):
         return yaml.safe_load(file) or {}
 
 
+def extract_end_effector_metadata(environment_config):
+    end_effector = environment_config.get("end_effector", {}) if isinstance(environment_config, dict) else {}
+    if not isinstance(end_effector, dict):
+        end_effector = {}
+
+    gripper_type = end_effector.get("gripper_type") or end_effector.get("ee_type") or ""
+    planner_id = end_effector.get("planner_id") or end_effector.get("brand") or ""
+    grasp_frame = end_effector.get("grasp_frame") or end_effector.get("tcp_link") or end_effector.get("base_link") or ""
+    tcp_link = end_effector.get("tcp_link") or end_effector.get("grasp_frame") or end_effector.get("base_link") or ""
+
+    spawn_gripper_controller = end_effector.get("spawn_gripper_controller")
+    if spawn_gripper_controller is None:
+        spawn_gripper_controller = gripper_type == "finger"
+
+    finger_count = end_effector.get("finger_count")
+    if finger_count is None and gripper_type == "finger":
+        attributes = end_effector.get("attributes", {})
+        if isinstance(attributes, dict):
+            finger_count = attributes.get("fingers")
+
+    return {
+        "planner_id": planner_id,
+        "grasp_frame": grasp_frame,
+        "tcp_link": tcp_link,
+        "gripper_type": gripper_type,
+        "spawn_gripper_controller": bool(spawn_gripper_controller),
+        "finger_count": finger_count,
+    }
+
+
 def _normalize_ros_param_types(value):
     if isinstance(value, dict):
         return {str(key): _normalize_ros_param_types(item) for key, item in value.items()}
@@ -314,6 +344,8 @@ def _launch_setup(context):
         "publish_state_updates": True,
         "publish_transforms_updates": True,
     }
+    environment_config = load_yaml(scene_pkg, "environment.yaml")
+    end_effector_metadata = extract_end_effector_metadata(environment_config)
 
     try:
         validated_use_sim_time = _param_dict(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"}))
@@ -326,6 +358,9 @@ def _launch_setup(context):
         validated_trajectory_execution = _param_dict(_normalize_ros_param_types(trajectory_execution))
         validated_moveit_controller_manager = _param_dict(_normalize_ros_param_types(moveit_controller_manager))
         validated_moveit_simple_controller_manager = _param_dict(_normalize_ros_param_types(moveit_simple_controller_manager))
+        validated_end_effector_metadata = _param_dict(_normalize_ros_param_types({
+            "workcell_end_effector_metadata": end_effector_metadata
+        }))
 
         _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
         _validate_ros_param_types(validated_robot_description, "robot_description")
@@ -337,6 +372,7 @@ def _launch_setup(context):
         _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
         _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
         _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
+        _validate_ros_param_types(validated_end_effector_metadata, "end_effector_metadata")
     except TypeError as exc:
         raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
 
@@ -399,6 +435,7 @@ def _launch_setup(context):
             validated_trajectory_execution,
             validated_moveit_controller_manager,
             validated_moveit_simple_controller_manager,
+            validated_end_effector_metadata,
         ),
         remappings=[
             ("joint_states", joint_states_topic),

--- a/workcell_builder/workcell_builder/templates/ros2/humble/test_load_yaml.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/test_load_yaml.py
@@ -72,3 +72,41 @@ def test_load_yaml_returns_none_on_parse_error(tmp_path, monkeypatch):
     bad_yaml.write_text('list: [1, 2')
     monkeypatch.setattr(demo, 'get_package_share_directory', lambda pkg: str(pkg_dir))
     assert demo.load_yaml('pkg', bad_yaml.name) is None
+
+
+def test_extract_end_effector_metadata_supports_legacy_keys():
+    environment = {
+        "end_effector": {
+            "brand": "robotiq",
+            "ee_type": "finger",
+            "base_link": "robotiq_85_base_link",
+            "attributes": {"fingers": 2},
+        }
+    }
+    metadata = demo.extract_end_effector_metadata(environment)
+    assert metadata["planner_id"] == "robotiq"
+    assert metadata["gripper_type"] == "finger"
+    assert metadata["grasp_frame"] == "robotiq_85_base_link"
+    assert metadata["tcp_link"] == "robotiq_85_base_link"
+    assert metadata["spawn_gripper_controller"] is True
+    assert metadata["finger_count"] == 2
+
+
+def test_extract_end_effector_metadata_prefers_normalized_keys():
+    environment = {
+        "end_effector": {
+            "planner_id": "ur5e_robotiq",
+            "gripper_type": "airpick",
+            "grasp_frame": "vacuum_tip",
+            "tcp_link": "vacuum_tip",
+            "spawn_gripper_controller": False,
+            "finger_count": 0,
+        }
+    }
+    metadata = demo.extract_end_effector_metadata(environment)
+    assert metadata["planner_id"] == "ur5e_robotiq"
+    assert metadata["gripper_type"] == "airpick"
+    assert metadata["grasp_frame"] == "vacuum_tip"
+    assert metadata["tcp_link"] == "vacuum_tip"
+    assert metadata["spawn_gripper_controller"] is False
+    assert metadata["finger_count"] == 0

--- a/workcell_builder/workcell_builder/test/generate_yaml_end_effector_metadata_test.cpp
+++ b/workcell_builder/workcell_builder/test/generate_yaml_end_effector_metadata_test.cpp
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+#include <yaml-cpp/yaml.h>
+
+#include "attributes/end_effector.h"
+#include "attributes/robot.h"
+#include "attributes/scene.h"
+#include "yaml_parser/generate_yaml.h"
+
+namespace {
+
+Scene make_base_scene()
+{
+  Scene scene;
+
+  Robot robot;
+  robot.name = "ur5";
+  robot.brand = "universal_robot";
+  robot.filepath = "$(find ur_description)/urdf/ur5.urdf.xacro";
+  robot.base_link = "base_link";
+  robot.ee_link = "tool0";
+  robot.robot_links = {"base_link", "tool0"};
+  scene.robot_vector.push_back(robot);
+
+  return scene;
+}
+
+YAML::Node generate_environment_yaml(const Scene & scene)
+{
+  const boost::filesystem::path temp_dir =
+    boost::filesystem::temp_directory_path() / boost::filesystem::unique_path("workcell_yaml_test_%%%%-%%%%-%%%%");
+  boost::filesystem::create_directories(temp_dir);
+
+  const bool generated = GenerateYAML::generate_yaml(scene, temp_dir.string(), temp_dir, temp_dir);
+  EXPECT_TRUE(generated);
+
+  const boost::filesystem::path environment_yaml_path = temp_dir / "environment.yaml";
+  EXPECT_TRUE(boost::filesystem::exists(environment_yaml_path));
+
+  YAML::Node root = YAML::LoadFile(environment_yaml_path.string());
+
+  boost::filesystem::remove_all(temp_dir);
+  return root;
+}
+
+}  // namespace
+
+TEST(GenerateYAMLMetadataTest, FingerGripperIncludesNormalizedAndLegacyKeys)
+{
+  Scene scene = make_base_scene();
+
+  EndEffector ee;
+  ee.name = "robotiq_85";
+  ee.brand = "robotiq";
+  ee.filepath = "$(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro";
+  ee.base_link = "robotiq_85_base_link";
+  ee.robot_link = "tool0";
+  ee.ee_type = "finger";
+  ee.attribute_1 = 2;
+  ee.ee_links = {"robotiq_85_base_link", "left_finger", "right_finger"};
+  scene.ee_vector.push_back(ee);
+
+  const YAML::Node root = generate_environment_yaml(scene);
+  const YAML::Node end_effector = root["end_effector"];
+
+  ASSERT_TRUE(end_effector);
+  EXPECT_EQ(end_effector["name"].as<std::string>(), "robotiq_85");
+  EXPECT_EQ(end_effector["brand"].as<std::string>(), "robotiq");
+  EXPECT_EQ(end_effector["ee_type"].as<std::string>(), "finger");
+  EXPECT_EQ(end_effector["attributes"]["fingers"].as<int>(), 2);
+  ASSERT_TRUE(end_effector["links"]);
+
+  EXPECT_EQ(end_effector["planner_id"].as<std::string>(), "robotiq");
+  EXPECT_EQ(end_effector["grasp_frame"].as<std::string>(), "robotiq_85_base_link");
+  EXPECT_EQ(end_effector["tcp_link"].as<std::string>(), "robotiq_85_base_link");
+  EXPECT_EQ(end_effector["gripper_type"].as<std::string>(), "finger");
+  EXPECT_TRUE(end_effector["spawn_gripper_controller"].as<bool>());
+  EXPECT_EQ(end_effector["finger_count"].as<int>(), 2);
+}
+
+TEST(GenerateYAMLMetadataTest, SuctionGripperIncludesNormalizedKeysWithoutFingerCount)
+{
+  Scene scene = make_base_scene();
+
+  EndEffector ee;
+  ee.name = "single_suction_gripper";
+  ee.brand = "airpick_vendor";
+  ee.filepath = "$(find single_suction_description)/urdf/single_suction_gripper.urdf.xacro";
+  ee.base_link = "single_suction_gripper_base_link";
+  ee.robot_link = "tool0";
+  ee.ee_type = "suction";
+  ee.gripper_type = "airpick";
+  ee.attribute_1 = 1;
+  ee.attribute_2 = 1;
+  ee.ee_links = {"single_suction_gripper_base_link"};
+  scene.ee_vector.push_back(ee);
+
+  const YAML::Node root = generate_environment_yaml(scene);
+  const YAML::Node end_effector = root["end_effector"];
+
+  ASSERT_TRUE(end_effector);
+  EXPECT_EQ(end_effector["ee_type"].as<std::string>(), "suction");
+  EXPECT_EQ(end_effector["attributes"]["array_width"].as<int>(), 1);
+  EXPECT_EQ(end_effector["attributes"]["array_height"].as<int>(), 1);
+
+  EXPECT_EQ(end_effector["planner_id"].as<std::string>(), "airpick_vendor");
+  EXPECT_EQ(end_effector["gripper_type"].as<std::string>(), "airpick");
+  EXPECT_FALSE(end_effector["spawn_gripper_controller"].as<bool>());
+  EXPECT_FALSE(end_effector["finger_count"]);
+}


### PR DESCRIPTION
### Motivation

- Provide a consistent, normalized set of end-effector metadata keys in generated `environment.yaml` so downstream consumers (launch templates, planners, controllers) can rely on canonical fields. 
- Preserve backward compatibility with existing legacy keys (`name`, `brand`, `ee_type`, `attributes`, `links`) while supporting newer normalized keys and metadata-driven behaviour.

### Description

- Extend the `EndEffector` model with normalized fields: `planner_id`, `grasp_frame`, `tcp_link`, `gripper_type`, `spawn_gripper_controller` and `finger_count`; values default to legacy fields when not supplied via `planner_id`/`gripper_type` etc. (`workcell_builder/workcell_builder/include/attributes/end_effector.h`).
- Emit normalized end-effector metadata from the YAML generator by adding `planner_id`, `grasp_frame`, `tcp_link`, `gripper_type`, `spawn_gripper_controller`, and conditional `finger_count` alongside existing legacy fields (`workcell_builder/workcell_builder/include/yaml_parser/generate_yaml.h`).
- Update YAML parsing to accept both legacy and normalized keys and perform sensible fallbacks (`planner_id <- brand`, `gripper_type <- ee_type`, `grasp_frame/tcp_link <- base_link`, `finger_count <- attributes.fingers`) (`workcell_builder/workcell_builder/include/scene_parser.h`).
- Update the ROS 2 Humble launch template to extract normalized end-effector metadata from `environment.yaml` via a new `extract_end_effector_metadata()` helper and expose it as a parameter group named `workcell_end_effector_metadata` for nodes (notably `move_group`) (`workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py`).
- Add template-level unit tests for normalized vs legacy extraction behaviour in `test_load_yaml.py` and add a new C++ gtest that generates `environment.yaml` and validates emitted metadata for two scenarios (UR5 + Robotiq 2-finger gripper and a suction/airpick case), and register the test in `CMakeLists.txt` (`workcell_builder/workcell_builder/templates/ros2/humble/test_load_yaml.py`, `workcell_builder/workcell_builder/test/generate_yaml_end_effector_metadata_test.cpp`, and `workcell_builder/workcell_builder/CMakeLists.txt`).

### Testing

- Ran `pytest -q workcell_builder/workcell_builder/templates/ros2/humble/test_load_yaml.py`; the module was skipped in this environment because required runtime deps for importing the launch module are unavailable (pytest reported the test module as skipped). 
- Ran `python3 -m py_compile` on the updated template modules (`demo.launch.py` and `test_load_yaml.py`) and it completed successfully. 
- Added a new C++ gtest that is registered in `CMakeLists.txt`, but the C++ test suite was not executed in this environment; the test is present and will run as part of the normal build/test pipeline when `BUILD_TESTING` is enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef50c46450833192c00267e4f7fc7c)