### PR TITLE
Conservative SRDF normalization and scoped collision regression tests

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -572,13 +572,99 @@ def _extract_link_names_from_urdf(robot_description_xml):
     return {link.attrib.get("name") for link in root.findall("link") if link.attrib.get("name")}
 
 
-def _normalize_srdf_for_ur_base_inertia(robot_description_xml, srdf_xml, logger):
-    required_pairs = (("base_link", "base_link_inertia"), ("base_link_inertia", "shoulder_link"))
-    link_names = _extract_link_names_from_urdf(robot_description_xml)
-    required_links = {"base_link_inertia", "shoulder_link"}
-    if not required_links.issubset(link_names):
-        return srdf_xml
+def _extract_fixed_joint_pairs_from_urdf(robot_description_xml):
+    try:
+        root = ET.fromstring(robot_description_xml)
+    except ET.ParseError:
+        return set()
 
+    fixed_pairs = set()
+    for joint in root.findall("joint"):
+        if (joint.attrib.get("type") or "").strip().lower() != "fixed":
+            continue
+        parent = joint.find("parent")
+        child = joint.find("child")
+        parent_link = (parent.attrib.get("link") if parent is not None else "") or ""
+        child_link = (child.attrib.get("link") if child is not None else "") or ""
+        parent_link = parent_link.strip()
+        child_link = child_link.strip()
+        if parent_link and child_link:
+            fixed_pairs.add(tuple(sorted((parent_link, child_link))))
+    return fixed_pairs
+
+
+def _extract_disable_collision_pairs_from_srdf_root(srdf_root):
+    existing_pairs = set()
+    for element in srdf_root.findall("disable_collisions"):
+        link1 = element.attrib.get("link1", "")
+        link2 = element.attrib.get("link2", "")
+        if link1 and link2:
+            existing_pairs.add(tuple(sorted((link1, link2))))
+    return existing_pairs
+
+
+def _is_camera_link_name(link_name):
+    normalized = _normalize_text(link_name)
+    return any(token in normalized for token in ("camera", "realsense", "d435"))
+
+
+def _is_environment_surface_link(link_name):
+    normalized = _normalize_text(link_name)
+    return any(token in normalized for token in ("table", "workbench"))
+
+
+def _compute_conservative_srdf_disable_collision_injections(robot_description_xml, srdf_xml):
+    urdf_link_names = _extract_link_names_from_urdf(robot_description_xml)
+    if not urdf_link_names:
+        return []
+
+    try:
+        srdf_root = ET.fromstring(srdf_xml)
+    except ET.ParseError:
+        return []
+    existing_pairs = _extract_disable_collision_pairs_from_srdf_root(srdf_root)
+
+    requested_pairs = []
+
+    # Keep existing UR base-link inertia adjacency compatibility rules.
+    if {"base_link_inertia", "shoulder_link"}.issubset(urdf_link_names):
+        requested_pairs.extend(
+            [
+                ("base_link", "base_link_inertia", "Adjacent"),
+                ("base_link_inertia", "shoulder_link", "Adjacent"),
+            ]
+        )
+
+    # Known UR false-positive: forearm_link vs wrist_2_link.
+    if {"forearm_link", "wrist_2_link"}.issubset(urdf_link_names):
+        requested_pairs.append(("forearm_link", "wrist_2_link", "Never"))
+
+    # Camera mount links can be fixed to the wrist in some scenes; only add when
+    # the URDF explicitly models a fixed wrist<->camera connection.
+    wrist_links = {"wrist_1_link", "wrist_2_link", "wrist_3_link"}
+    for pair in _extract_fixed_joint_pairs_from_urdf(robot_description_xml):
+        link1, link2 = pair
+        if _is_environment_surface_link(link1) or _is_environment_surface_link(link2):
+            continue
+        if (
+            ((link1 in wrist_links) and _is_camera_link_name(link2))
+            or ((link2 in wrist_links) and _is_camera_link_name(link1))
+        ):
+            requested_pairs.append((link1, link2, "Adjacent"))
+
+    injected_pairs = []
+    requested_pairs = sorted(set(requested_pairs), key=lambda item: (item[0], item[1], item[2]))
+    for link1, link2, reason in requested_pairs:
+        pair_key = tuple(sorted((link1, link2)))
+        if pair_key in existing_pairs:
+            continue
+        if _is_environment_surface_link(link1) or _is_environment_surface_link(link2):
+            continue
+        injected_pairs.append((link1, link2, reason))
+    return injected_pairs
+
+
+def _normalize_srdf_for_ur_base_inertia(robot_description_xml, srdf_xml, logger):
     try:
         root = ET.fromstring(srdf_xml)
     except ET.ParseError as exc:
@@ -587,30 +673,20 @@ def _normalize_srdf_for_ur_base_inertia(robot_description_xml, srdf_xml, logger)
         )
         return srdf_xml
 
-    existing_pairs = set()
-    for element in root.findall("disable_collisions"):
-        link1 = element.attrib.get("link1", "")
-        link2 = element.attrib.get("link2", "")
-        if link1 and link2:
-            existing_pairs.add(tuple(sorted((link1, link2))))
+    pairs_to_inject = _compute_conservative_srdf_disable_collision_injections(robot_description_xml, srdf_xml)
+    if not pairs_to_inject:
+        return srdf_xml
 
     injected_pairs = []
-    for link1, link2 in required_pairs:
-        pair_key = tuple(sorted((link1, link2)))
-        if pair_key in existing_pairs:
-            continue
-        ET.SubElement(root, "disable_collisions", link1=link1, link2=link2, reason="Adjacent")
-        existing_pairs.add(pair_key)
-        injected_pairs.append(f"{link1}<->{link2}")
+    for link1, link2, reason in pairs_to_inject:
+        ET.SubElement(root, "disable_collisions", link1=link1, link2=link2, reason=reason)
+        injected_pairs.append(f"{link1}<->{link2} ({reason})")
 
-    if injected_pairs:
-        logger.info(
-            "Injected SRDF disable_collisions pairs for UR base_link_inertia compatibility: "
-            + ", ".join(injected_pairs)
-        )
-        return ET.tostring(root, encoding="unicode")
-
-    return srdf_xml
+    logger.info(
+        "Injected conservative SRDF disable_collisions pairs for UR scene normalization: "
+        + ", ".join(injected_pairs)
+    )
+    return ET.tostring(root, encoding="unicode")
 
 
 def resolve_required_package_share_dir(package_name, remediation_hint):

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch.test.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch.test.py
@@ -17,6 +17,7 @@ import importlib.util
 import os
 import time
 import unittest
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
@@ -68,6 +69,44 @@ def test_missing_scene_package_error_message():
     with pytest.raises(RuntimeError, match=rf"Scene package '{missing_scene}' was not found") as exc_info:
         module.resolve_scene_package_share_dir(missing_scene)
     assert "build/source your generated scene package first" in str(exc_info.value)
+
+
+def test_scene_srdf_injections_are_scoped_and_exclude_table_workbench_rules():
+    module = import_launch_module()
+    scene_package = SCENE_PACKAGE
+    robot_description_xml = module.load_file(scene_package, "urdf/scene.urdf.xacro")
+    srdf_xml = module.load_file(scene_package, "urdf/arm_hand.srdf.xacro")
+
+    pairs_to_inject = module._compute_conservative_srdf_disable_collision_injections(
+        robot_description_xml=robot_description_xml,
+        srdf_xml=srdf_xml,
+    )
+    allowed_pairs = {
+        tuple(sorted(("base_link", "base_link_inertia"))),
+        tuple(sorted(("base_link_inertia", "shoulder_link"))),
+        tuple(sorted(("forearm_link", "wrist_2_link"))),
+    }
+
+    injected_pair_set = {tuple(sorted((link1, link2))) for link1, link2, _reason in pairs_to_inject}
+    assert injected_pair_set.issubset(allowed_pairs)
+    for link1, link2, _reason in pairs_to_inject:
+        text = f"{link1} {link2}".lower()
+        assert "table" not in text
+        assert "workbench" not in text
+
+
+def test_scene_srdf_no_blanket_robot_vs_table_disable_rules():
+    module = import_launch_module()
+    srdf_xml = module.load_file(SCENE_PACKAGE, "urdf/arm_hand.srdf.xacro")
+    srdf_root = ET.fromstring(srdf_xml)
+    for element in srdf_root.findall("disable_collisions"):
+        link1 = (element.attrib.get("link1", "") or "").lower()
+        link2 = (element.attrib.get("link2", "") or "").lower()
+        if "table" not in link1 and "table" not in link2 and "workbench" not in link1 and "workbench" not in link2:
+            continue
+        assert "wrist" not in link1 and "wrist" not in link2
+        assert "forearm" not in link1 and "forearm" not in link2
+        assert "upper_arm" not in link1 and "upper_arm" not in link2
 
 
 @pytest.mark.launch_test

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
@@ -578,6 +578,106 @@ def test_validate_and_normalize_workcell_end_effector_frames_falls_back_on_3f_ur
     assert any("declares Robotiq 3F" in message for message in logger.warning_messages)
 
 
+def _sorted_pair_set(triples):
+    return {tuple(sorted((link1, link2))) for link1, link2, _reason in triples}
+
+
+def test_compute_conservative_srdf_disable_collision_injections_keeps_ur_base_and_forearm_wrist2(
+    grasp_launch_module,
+):
+    robot_description_xml = """
+    <robot name="demo">
+      <link name="base_link"/>
+      <link name="base_link_inertia"/>
+      <link name="shoulder_link"/>
+      <link name="forearm_link"/>
+      <link name="wrist_2_link"/>
+    </robot>
+    """
+    srdf_xml = "<robot name='demo'></robot>"
+
+    injections = grasp_launch_module._compute_conservative_srdf_disable_collision_injections(
+        robot_description_xml,
+        srdf_xml,
+    )
+    pair_set = _sorted_pair_set(injections)
+
+    assert tuple(sorted(("base_link", "base_link_inertia"))) in pair_set
+    assert tuple(sorted(("base_link_inertia", "shoulder_link"))) in pair_set
+    assert tuple(sorted(("forearm_link", "wrist_2_link"))) in pair_set
+
+
+def test_compute_conservative_srdf_disable_collision_injections_adds_camera_wrist_pair_only_for_fixed_joints(
+    grasp_launch_module,
+):
+    robot_description_xml = """
+    <robot name="demo">
+      <link name="wrist_3_link"/>
+      <link name="camera_bottom_screw_frame"/>
+      <joint name="wrist_to_camera_mount" type="fixed">
+        <parent link="wrist_3_link"/>
+        <child link="camera_bottom_screw_frame"/>
+      </joint>
+    </robot>
+    """
+    srdf_xml = "<robot name='demo'></robot>"
+
+    injections = grasp_launch_module._compute_conservative_srdf_disable_collision_injections(
+        robot_description_xml,
+        srdf_xml,
+    )
+
+    assert tuple(sorted(("wrist_3_link", "camera_bottom_screw_frame"))) in _sorted_pair_set(injections)
+
+
+def test_compute_conservative_srdf_disable_collision_injections_rejects_non_fixed_camera_wrist_joints(
+    grasp_launch_module,
+):
+    robot_description_xml = """
+    <robot name="demo">
+      <link name="wrist_3_link"/>
+      <link name="camera_bottom_screw_frame"/>
+      <joint name="wrist_to_camera_mount" type="revolute">
+        <parent link="wrist_3_link"/>
+        <child link="camera_bottom_screw_frame"/>
+      </joint>
+    </robot>
+    """
+    srdf_xml = "<robot name='demo'></robot>"
+
+    injections = grasp_launch_module._compute_conservative_srdf_disable_collision_injections(
+        robot_description_xml,
+        srdf_xml,
+    )
+
+    assert tuple(sorted(("wrist_3_link", "camera_bottom_screw_frame"))) not in _sorted_pair_set(injections)
+
+
+def test_compute_conservative_srdf_disable_collision_injections_never_adds_table_or_workbench_pairs(
+    grasp_launch_module,
+):
+    robot_description_xml = """
+    <robot name="demo">
+      <link name="wrist_3_link"/>
+      <link name="table_top"/>
+      <joint name="table_joint" type="fixed">
+        <parent link="wrist_3_link"/>
+        <child link="table_top"/>
+      </joint>
+    </robot>
+    """
+    srdf_xml = "<robot name='demo'></robot>"
+
+    injections = grasp_launch_module._compute_conservative_srdf_disable_collision_injections(
+        robot_description_xml,
+        srdf_xml,
+    )
+
+    for link1, link2, _reason in injections:
+        pair_text = f"{link1} {link2}".lower()
+        assert "table" not in pair_text
+        assert "workbench" not in pair_text
+
 
 def test_require_yaml_mapping_reports_package_and_file(grasp_launch_module):
     with pytest.raises(


### PR DESCRIPTION
### Motivation

- Avoid injecting broad robot-vs-table/workbench collision disables while preserving necessary UR adjacency rules and addressing a few well-known false-positives. 
- Make SRDF normalization conservative and scene-aware so only harmless, verified disable-collisions pairs are introduced (e.g. UR base inertia adjacency, forearm/wrist_2 exception, fixed camera mounts). 

### Description

- Introduced utilities in `launch/grasp_execution.launch.py`: ` _extract_fixed_joint_pairs_from_urdf`, `_extract_disable_collision_pairs_from_srdf_root`, `_is_camera_link_name`, `_is_environment_surface_link`, and `_compute_conservative_srdf_disable_collision_injections` to compute a scoped list of SRDF `disable_collisions` injections. 
- Changed `_normalize_srdf_for_ur_base_inertia` to use the conservative injector and to avoid injecting any pair that references `table`/`workbench` links, while keeping UR base adjacency compatibility and the known `forearm_link`↔`wrist_2_link` suppression. 
- Added unit/regression tests in `test/test_grasp_execution_launch_helpers.py` to assert base adjacency preservation, forearm/wrist_2 injection, camera↔wrist fixed-joint-only behavior, rejection of non-fixed camera joints, and absence of injected table/workbench pairs. 
- Added scene-level checks in `test/test_grasp_execution_launch.test.py` to assert injected pairs are limited to the approved set and that the scene SRDF contains no blanket robot-vs-table/workbench disable rules. 

### Testing

- Ran `python -m py_compile` on the modified launch and test files and it succeeded. 
- Executed the helper test module with `pytest` in this environment where ROS runtime packages are not available; the module-level tests were skipped (environmental dependency) rather than failing. 
- Attempted a lightweight import smoke-test of the launch module in this sandbox but it was blocked by missing ROS runtime dependency `ament_index_python` (this is expected outside the ROS test harness).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef58b6d0d4833180ca5a9f514375b6)