### PR TITLE
Add workcell commissioning bundle exporter, inspector, and checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ Generated artifacts:
 - Per-scene machine JSON: `docs/manuals/generated_execution_plans/<scene>_execution_plan.json`
 - Fleet report: `docs/manuals/latest_task_execution_plan_report.md`
 
+### Workcell commissioning bundles
+
+Workcell commissioning bundles are offline handover/export packages for one scene/workcell. They collect scene metadata, validation summaries, task recipe dry-run summaries, execution plan artifacts, and an operator checklist into one reviewable package.
+
+Use bundles for commissioning review, versioned handover, archive traceability, and future UI import/export workflows.
+
+This package is offline-only and **not** a safety certificate. It does **not** prove real robot reachability or collision-free runtime execution.
+
+```bash
+./scripts/export_workcell_bundle.py ur5_2f_test
+./scripts/export_workcell_bundle.py ur5_2f_test --zip --force
+./scripts/inspect_workcell_bundle.py dist/workcell_bundles/ur5_2f_test
+./scripts/inspect_workcell_bundle.py dist/workcell_bundles/ur5_2f_test.zip
+./scripts/check_workcell_bundles.sh
+./scripts/preflight_workcell.sh
+```
+
 ```yaml
 task_recipe:
   id: colour_sort_demo

--- a/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
+++ b/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
@@ -460,6 +460,31 @@ Commands:
 ./scripts/preflight_workcell.sh
 ```
 
+## Workcell commissioning bundles
+
+A workcell commissioning bundle is an offline handover/export package for one scene/workcell. It collects metadata, plans, checks, summaries, and an operator checklist in one per-scene folder.
+
+Use this for commissioning review, archival records, versioned handover, and future UI import/export.
+
+Safety boundary statements:
+
+- it is **not** a safety certificate,
+- it does **not** prove real robot reachability,
+- it does **not** prove collision-free runtime execution.
+
+It prepares the project for a future click-driven **Generate Cell Pack** workflow.
+
+Commands:
+
+```bash
+./scripts/export_workcell_bundle.py ur5_2f_test
+./scripts/export_workcell_bundle.py ur5_2f_test --zip --force
+./scripts/inspect_workcell_bundle.py dist/workcell_bundles/ur5_2f_test
+./scripts/inspect_workcell_bundle.py dist/workcell_bundles/ur5_2f_test.zip
+./scripts/check_workcell_bundles.sh
+./scripts/preflight_workcell.sh
+```
+
 Example plan snippet:
 
 ```text

--- a/scripts/check_workcell_bundles.sh
+++ b/scripts/check_workcell_bundles.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+EXPORTER="${SCRIPT_DIR}/export_workcell_bundle.py"
+INSPECTOR="${SCRIPT_DIR}/inspect_workcell_bundle.py"
+OUTPUT_DIR="${REPO_ROOT}/dist/workcell_bundles"
+PLAN_DIR="${REPO_ROOT}/docs/manuals/generated_execution_plans"
+
+if [[ ! -x "${EXPORTER}" ]]; then
+  echo "FAIL: missing exporter script at ${EXPORTER}" >&2
+  exit 2
+fi
+
+if [[ ! -x "${INSPECTOR}" ]]; then
+  echo "FAIL: missing inspector script at ${INSPECTOR}" >&2
+  exit 2
+fi
+
+set +e
+EXPORT_OUTPUT="$(${EXPORTER} --force "$@")"
+EXPORT_EXIT=$?
+set -e
+
+if [[ ${EXPORT_EXIT} -ne 0 ]]; then
+  echo "FAIL: bundle export failed." >&2
+  echo "${EXPORT_OUTPUT}" >&2
+  exit ${EXPORT_EXIT}
+fi
+
+echo "${EXPORT_OUTPUT}"
+
+if (( $# > 0 )); then
+  SCENES=("$@")
+else
+  mapfile -t SCENES < <(
+    find "${REPO_ROOT}/scenes" -mindepth 2 -maxdepth 2 \
+      \( -name "scene_manifest.yaml" -o -name "workcell.yaml" \) \
+      -printf '%h\n' | xargs -n1 basename | sort -u
+  )
+fi
+
+SUMMARY_FAIL=0
+SUMMARY_WARN=0
+SUMMARY_PASS=0
+SUMMARY_SKIP=0
+
+for scene in "${SCENES[@]}"; do
+  bundle_path="${OUTPUT_DIR}/${scene}"
+  if [[ ! -d "${bundle_path}" ]]; then
+    echo "FAIL ${scene}: bundle folder missing (${bundle_path})"
+    SUMMARY_FAIL=$((SUMMARY_FAIL + 1))
+    continue
+  fi
+
+  set +e
+  INSPECT_OUTPUT="$(${INSPECTOR} "${bundle_path}")"
+  INSPECT_EXIT=$?
+  set -e
+
+  echo "${INSPECT_OUTPUT}"
+
+  if [[ ${INSPECT_EXIT} -ne 0 ]]; then
+    echo "FAIL ${scene}: generated bundle cannot be inspected"
+    SUMMARY_FAIL=$((SUMMARY_FAIL + 1))
+    continue
+  fi
+
+  if grep -q '^WARN ' <<<"${INSPECT_OUTPUT}"; then
+    SUMMARY_WARN=$((SUMMARY_WARN + 1))
+  elif grep -q '^PASS ' <<<"${INSPECT_OUTPUT}"; then
+    SUMMARY_PASS=$((SUMMARY_PASS + 1))
+  else
+    SUMMARY_SKIP=$((SUMMARY_SKIP + 1))
+  fi
+
+  dry_status="$(python3 - <<'PY' "${bundle_path}/validation_summary.md"
+import re
+import sys
+from pathlib import Path
+text = Path(sys.argv[1]).read_text(encoding='utf-8')
+match = re.search(r"Dry-run status: \*\*(\w+)\*\*", text)
+print(match.group(1) if match else "UNKNOWN")
+PY
+)"
+
+  if [[ "${dry_status}" == "PASS" ]]; then
+    if [[ ! -f "${bundle_path}/execution_plan.md" || ! -f "${bundle_path}/execution_plan.json" ]]; then
+      echo "FAIL ${scene}: dry-run PASS but execution_plan files missing"
+      SUMMARY_FAIL=$((SUMMARY_FAIL + 1))
+    fi
+  fi
+
+done
+
+echo "Summary: PASS=${SUMMARY_PASS} WARN=${SUMMARY_WARN} FAIL=${SUMMARY_FAIL} SKIP=${SUMMARY_SKIP}"
+
+if [[ ${SUMMARY_FAIL} -ne 0 ]]; then
+  exit 1
+fi
+
+exit 0

--- a/scripts/export_workcell_bundle.py
+++ b/scripts/export_workcell_bundle.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Generate per-scene offline commissioning bundles for handover and archival."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import shutil
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from zipfile import ZIP_DEFLATED, ZipFile
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "dist" / "workcell_bundles"
+REPORTS_DIR = REPO_ROOT / "docs" / "manuals"
+PLAN_OUTPUT_DIR = REPORTS_DIR / "generated_execution_plans"
+DRY_RUN_PATH = REPO_ROOT / "scripts" / "dry_run_task_recipe.py"
+VALIDATOR_PATH = REPO_ROOT / "scripts" / "validate_scene_contract.py"
+SELF_TEST_REPORTER_PATH = REPO_ROOT / "scripts" / "generate_scene_self_test_report.py"
+TASK_RECIPE_REPORTER_PATH = REPO_ROOT / "scripts" / "generate_task_recipe_report.py"
+PLAN_GENERATOR_PATH = REPO_ROOT / "scripts" / "generate_task_execution_plan.py"
+
+OPTIONAL_REPORTS = (
+    "latest_scene_validation_report.md",
+    "latest_scene_self_test_report.md",
+    "latest_task_recipe_report.md",
+    "latest_task_recipe_dry_run_report.md",
+    "latest_task_execution_plan_report.md",
+)
+
+REQUIRED_FILES = (
+    "README.md",
+    "bundle_manifest.json",
+    "operator_checklist.md",
+    "scene_manifest.yaml",
+    "execution_plan.md",
+    "execution_plan.json",
+    "validation_summary.md",
+)
+
+
+@dataclass
+class SceneStatus:
+    scene: str
+    scene_validation_status: str
+    self_test_status: str
+    task_recipe_status: str
+    dry_run_status: str
+    execution_plan_status: str
+    warnings: list[str]
+
+
+def _load_module(module_name: str, module_path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if not spec or not spec.loader:
+        raise RuntimeError(f"Unable to load module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+dry_run = _load_module("bundle_dry_run_task_recipe", DRY_RUN_PATH)
+validator = _load_module("bundle_validate_scene_contract", VALIDATOR_PATH)
+self_test_reporter = _load_module("bundle_generate_scene_self_test_report", SELF_TEST_REPORTER_PATH)
+task_recipe_reporter = _load_module("bundle_generate_task_recipe_report", TASK_RECIPE_REPORTER_PATH)
+plan_generator = _load_module("bundle_generate_task_execution_plan", PLAN_GENERATOR_PATH)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(65536)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_manifest(path: Path) -> tuple[dict[str, Any], list[str]]:
+    manifest, _, parser_notes = validator._read_manifest(str(path))
+    return manifest, list(parser_notes)
+
+
+def _normalize_ee_type(end_effector: dict[str, Any]) -> str:
+    ee_type = str(end_effector.get("type", "unknown")).strip().lower()
+    if ee_type in {"finger", "suction"}:
+        return ee_type
+    return "unknown"
+
+
+def _status_from_scene(scene: str, manifest_path: Path) -> SceneStatus:
+    warnings: list[str] = []
+    manifest, parser_notes = _read_manifest(manifest_path)
+    warnings.extend(parser_notes)
+
+    scene_validation_status = "PASS"
+    _, task_recipe_notes = validator.validate_task_recipe_block(manifest)
+    task_row = task_recipe_reporter.evaluate_scene(scene, manifest_path)
+    self_test_row = self_test_reporter.evaluate_scene(scene, manifest_path)
+    dry_row = dry_run.evaluate_scene(scene, manifest_path)
+
+    if task_row.status == "FAIL" or self_test_row.status == "FAIL" or dry_row.status == "FAIL":
+        scene_validation_status = "FAIL"
+    elif task_row.status == "WARN" or self_test_row.status == "WARN" or dry_row.status in {"WARN", "SKIP"}:
+        scene_validation_status = "WARN"
+
+    plan_row = plan_generator.evaluate_scene(scene, manifest_path)
+    if plan_row.status == "PASS":
+        execution_plan_status = "PASS"
+    elif dry_row.status == "PASS":
+        execution_plan_status = "FAIL"
+        warnings.append("Dry-run is PASS but execution plan generation did not produce PASS.")
+    else:
+        execution_plan_status = plan_row.status
+
+    for note in task_recipe_notes:
+        if note not in warnings:
+            warnings.append(note)
+    for note in dry_row.notes + plan_row.notes:
+        if note not in warnings:
+            warnings.append(note)
+
+    return SceneStatus(
+        scene=scene,
+        scene_validation_status=scene_validation_status,
+        self_test_status=self_test_row.status,
+        task_recipe_status=task_row.status,
+        dry_run_status=dry_row.status,
+        execution_plan_status=execution_plan_status,
+        warnings=warnings,
+    )
+
+
+def _write_readme(bundle_dir: Path, scene: str) -> None:
+    text = f"""# Workcell Commissioning Bundle: {scene}
+
+This package is a per-scene commissioning export bundle for offline review, handover, and archival.
+
+## What this bundle is
+- A dependency-light handover artifact for scene `{scene}`.
+- A collection of manifest metadata, offline validation summaries, task recipe dry-run output, execution plan artifacts, and a practical operator checklist.
+
+## What this bundle proves
+- Required commissioning artifacts were generated for this scene.
+- Offline contract checks and metadata validation outputs are bundled in one place.
+- A deterministic task execution plan artifact is present for review.
+
+## What this bundle does not prove
+- It does **not** prove runtime collision-free behavior.
+- It does **not** prove real robot reachability in your physical cell.
+- It does **not** certify machine safety compliance.
+
+**This bundle is a commissioning aid, not a safety certificate.**
+
+## Quick operator review order
+1. Open `validation_summary.md`
+2. Open `task_recipe_dry_run_summary.md`
+3. Open `execution_plan.md`
+4. Open `operator_checklist.md`
+
+## Offline-only note
+This bundle is generated from offline scene metadata and reports. No runtime robot command is executed by this export action.
+"""
+    (bundle_dir / "README.md").write_text(text, encoding="utf-8")
+
+
+def _write_checklist(bundle_dir: Path) -> None:
+    text = """# Operator / Commissioning Checklist
+
+## Offline checks
+- [ ] Scene manifest reviewed
+- [ ] Robot base frame checked
+- [ ] End-effector link checked
+- [ ] Grasp frame checked
+- [ ] Self-test object pose reviewed
+- [ ] Task recipe decision reviewed
+- [ ] Destination pose reviewed
+- [ ] Execution plan reviewed
+
+## Simulation checks
+- [ ] Headless launch smoke test passed
+- [ ] RViz scene visually inspected
+- [ ] Object spawn pose visually inspected
+- [ ] Grasp approach visually inspected
+- [ ] Release destination visually inspected
+- [ ] Return-home path visually inspected
+
+## Physical cell checks
+- [ ] Emergency stop tested
+- [ ] Guarding/interlocks checked
+- [ ] Robot speed limits set
+- [ ] Payload/tool settings checked
+- [ ] TCP checked
+- [ ] Work object/base frame checked
+- [ ] Dry cycle completed without payload
+- [ ] Dry cycle completed with payload
+- [ ] Operator sign-off completed
+
+This checklist is a commissioning aid and does not grant any safety approval.
+"""
+    (bundle_dir / "operator_checklist.md").write_text(text, encoding="utf-8")
+
+
+def _write_dry_run_summary(bundle_dir: Path, dry_row: Any) -> None:
+    attrs = (", ".join(f"{k}={dry_row.object_attributes[k]}" for k in sorted(dry_row.object_attributes))
+             if dry_row.object_attributes else "(n/a)")
+    lines = [
+        "# Task Recipe Dry-Run Summary",
+        "",
+        f"- Scene: `{dry_row.scene}`",
+        f"- Object id: `{dry_row.object_id}`",
+        f"- Object attributes: `{attrs}`",
+        f"- Recipe id: `{dry_row.recipe_id}`",
+        f"- Task type: `{dry_row.task_type}`",
+        f"- Matched rule id: `{dry_row.matched_rule_id}`",
+        f"- Destination id: `{dry_row.selected_destination_id}`",
+        f"- Destination action: `{dry_row.selected_action}`",
+        f"- Status: **{dry_row.status}**",
+        "",
+        "## Notes",
+        "",
+    ]
+    for note in dry_row.notes:
+        lines.append(f"- {note}")
+    if dry_row.status != "PASS":
+        lines.extend(["", "No runtime action is implied by a non-PASS dry-run result."])
+    (bundle_dir / "task_recipe_dry_run_summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_validation_summary(bundle_dir: Path, status: SceneStatus, generated_files: list[str]) -> None:
+    lines = [
+        "# Validation Summary",
+        "",
+        f"- Scene contract validation status: **{status.scene_validation_status}**",
+        f"- Self-test status: **{status.self_test_status}**",
+        f"- Task recipe validation status: **{status.task_recipe_status}**",
+        f"- Dry-run status: **{status.dry_run_status}**",
+        f"- Execution plan generation status: **{status.execution_plan_status}**",
+        "",
+        "## Generated bundle files",
+        "",
+    ]
+    for item in sorted(generated_files):
+        lines.append(f"- `{item}`")
+    lines.extend(["", "## Warnings", ""])
+    if status.warnings:
+        for warning in status.warnings:
+            lines.append(f"- {warning}")
+    else:
+        lines.append("- (none)")
+
+    (bundle_dir / "validation_summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_placeholder_plan(scene: str, bundle_dir: Path, plan_row: Any) -> None:
+    md_text = (
+        f"# Offline Task Execution Plan: {scene}\n\n"
+        f"No executable plan was generated for this scene because status is `{plan_row.status}`.\n\n"
+        "This file is intentionally provided for commissioning package consistency.\n"
+    )
+    (bundle_dir / "execution_plan.md").write_text(md_text, encoding="utf-8")
+    payload = {
+        "scene": scene,
+        "status": plan_row.status,
+        "notes": list(plan_row.notes),
+        "offline_only": True,
+    }
+    (bundle_dir / "execution_plan.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _copy_or_generate_execution_plans(scene: str, manifest_path: Path, bundle_dir: Path, warnings: list[str]) -> str:
+    md_src = PLAN_OUTPUT_DIR / f"{scene}_execution_plan.md"
+    json_src = PLAN_OUTPUT_DIR / f"{scene}_execution_plan.json"
+
+    plan_row = plan_generator.evaluate_scene(scene, manifest_path)
+
+    if md_src.is_file() and json_src.is_file():
+        shutil.copy2(md_src, bundle_dir / "execution_plan.md")
+        shutil.copy2(json_src, bundle_dir / "execution_plan.json")
+        return plan_row.status
+
+    if plan_row.markdown_path and plan_row.json_path and plan_row.markdown_path.is_file() and plan_row.json_path.is_file():
+        shutil.copy2(plan_row.markdown_path, bundle_dir / "execution_plan.md")
+        shutil.copy2(plan_row.json_path, bundle_dir / "execution_plan.json")
+        return plan_row.status
+
+    if plan_row.status == "PASS":
+        warnings.append("Execution plan expected for PASS dry-run but plan files were not generated.")
+        return "FAIL"
+
+    warnings.append(f"Execution plan not generated; writing placeholder files (status={plan_row.status}).")
+    _write_placeholder_plan(scene, bundle_dir, plan_row)
+    return plan_row.status
+
+
+def _copy_reports(bundle_dir: Path, warnings: list[str]) -> None:
+    reports_dir = bundle_dir / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    for report_name in OPTIONAL_REPORTS:
+        src = REPORTS_DIR / report_name
+        if src.is_file():
+            shutil.copy2(src, reports_dir / report_name)
+        else:
+            warnings.append(f"Optional report missing: {report_name}")
+
+
+def _build_manifest(
+    bundle_dir: Path,
+    scene: str,
+    manifest: dict[str, Any],
+    dry_row: Any,
+    status: SceneStatus,
+    warnings: list[str],
+) -> dict[str, Any]:
+    robot = manifest.get("robot") if isinstance(manifest.get("robot"), dict) else {}
+    end_effector = manifest.get("end_effector") if isinstance(manifest.get("end_effector"), dict) else {}
+    task_recipe = manifest.get("task_recipe") if isinstance(manifest.get("task_recipe"), dict) else {}
+
+    files: list[dict[str, str]] = []
+    for file_path in sorted(p for p in bundle_dir.rglob("*") if p.is_file()):
+        rel = file_path.relative_to(bundle_dir).as_posix()
+        if rel == "bundle_manifest.json":
+            continue
+        files.append({"path": rel, "sha256": _sha256(file_path)})
+
+    final_warnings = list(dict.fromkeys(warnings + status.warnings))
+    return {
+        "bundle_schema_version": "1.0",
+        "scene": scene,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "repository": "Easy_Manipulator_Improved",
+        "offline_only": True,
+        "contains_runtime_code": False,
+        "scene_manifest_path": "scene_manifest.yaml",
+        "execution_plan_markdown": "execution_plan.md",
+        "execution_plan_json": "execution_plan.json",
+        "operator_checklist": "operator_checklist.md",
+        "task_recipe_status": status.task_recipe_status,
+        "execution_plan_status": status.execution_plan_status,
+        "robot": {
+            "planning_group": str(robot.get("planning_group", "unknown")),
+            "base_frame": str(robot.get("base_frame", "unknown")),
+            "ee_link": str(robot.get("ee_link", "unknown")),
+        },
+        "end_effector": {
+            "brand": str(end_effector.get("brand", "unknown")),
+            "grasp_frame": str(end_effector.get("grasp_frame", "unknown")),
+            "type": _normalize_ee_type(end_effector),
+        },
+        "task": {
+            "recipe_id": str(dry_row.recipe_id),
+            "task_type": str(dry_row.task_type),
+            "matched_rule_id": str(dry_row.matched_rule_id),
+            "destination_id": str(dry_row.selected_destination_id),
+        },
+        "files": files,
+        "warnings": final_warnings,
+    }
+
+
+def _zip_bundle(scene: str, bundle_dir: Path, output_dir: Path, force: bool) -> Path:
+    zip_path = output_dir / f"{scene}.zip"
+    if zip_path.exists() and not force:
+        raise RuntimeError(f"ZIP already exists: {zip_path}. Use --force to overwrite.")
+    if zip_path.exists():
+        zip_path.unlink()
+
+    with ZipFile(zip_path, "w", compression=ZIP_DEFLATED) as archive:
+        for file_path in sorted(path for path in bundle_dir.rglob("*") if path.is_file()):
+            archive.write(file_path, file_path.relative_to(bundle_dir).as_posix())
+    return zip_path
+
+
+def export_scene(scene: str, manifest_path: Path, output_dir: Path, zip_output: bool, force: bool) -> tuple[Path, str]:
+    bundle_dir = output_dir / scene
+    if bundle_dir.exists() and not force:
+        raise RuntimeError(f"Bundle directory already exists: {bundle_dir}. Use --force to overwrite.")
+    if bundle_dir.exists():
+        shutil.rmtree(bundle_dir)
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    warnings: list[str] = []
+    manifest, _ = _read_manifest(manifest_path)
+    status = _status_from_scene(scene, manifest_path)
+    dry_row = dry_run.evaluate_scene(scene, manifest_path)
+
+    shutil.copy2(manifest_path, bundle_dir / "scene_manifest.yaml")
+    _write_readme(bundle_dir, scene)
+    _write_checklist(bundle_dir)
+    _write_dry_run_summary(bundle_dir, dry_row)
+    status.execution_plan_status = _copy_or_generate_execution_plans(scene, manifest_path, bundle_dir, warnings)
+    _copy_reports(bundle_dir, warnings)
+
+    generated_files = [p.relative_to(bundle_dir).as_posix() for p in bundle_dir.rglob("*") if p.is_file()]
+    _write_validation_summary(bundle_dir, status, generated_files)
+
+    manifest_payload = _build_manifest(bundle_dir, scene, manifest, dry_row, status, warnings)
+    (bundle_dir / "bundle_manifest.json").write_text(
+        json.dumps(manifest_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    missing_required = [name for name in REQUIRED_FILES if not (bundle_dir / name).is_file()]
+    if missing_required:
+        raise RuntimeError(f"Bundle missing required files for scene {scene}: {', '.join(missing_required)}")
+
+    zip_path_text = ""
+    if zip_output:
+        zip_path = _zip_bundle(scene, bundle_dir, output_dir, force)
+        zip_path_text = f" zip={zip_path}"
+
+    return bundle_dir, zip_path_text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("scenes", nargs="*", help="Optional scene names to export.")
+    parser.add_argument("--zip", action="store_true", help="Also export each bundle as <scene>.zip.")
+    parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR), help="Bundle output directory.")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing bundle directory and zip.")
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    discovered = dry_run.discover_scene_manifests()
+    if args.scenes:
+        selected = set(args.scenes)
+        discovered = [entry for entry in discovered if entry[0] in selected]
+
+    if not discovered:
+        print("No scene manifests discovered for bundle export.")
+        return 2
+
+    for scene, manifest_path in discovered:
+        bundle_dir, zip_text = export_scene(scene, manifest_path, output_dir, args.zip, args.force)
+        print(f"PASS {scene:24} bundle={bundle_dir}{zip_text}")
+
+    print(f"Bundles written to: {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/inspect_workcell_bundle.py
+++ b/scripts/inspect_workcell_bundle.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Inspect exported workcell commissioning bundles (folder or zip)."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from zipfile import ZipFile
+
+REQUIRED_FILES = (
+    "README.md",
+    "bundle_manifest.json",
+    "operator_checklist.md",
+    "scene_manifest.yaml",
+    "execution_plan.md",
+    "execution_plan.json",
+    "validation_summary.md",
+)
+
+OPTIONAL_FILES = (
+    "reports",
+    "task_recipe_dry_run_summary.md",
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(65536)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_manifest(bundle_root: Path) -> dict:
+    manifest_path = bundle_root / "bundle_manifest.json"
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def inspect_bundle(bundle_path: Path) -> tuple[str, list[str]]:
+    notes: list[str] = []
+    status = "PASS"
+
+    if not bundle_path.exists():
+        return "FAIL", [f"Bundle path does not exist: {bundle_path}"]
+
+    extracted_root: Path | None = None
+    temp_dir: tempfile.TemporaryDirectory[str] | None = None
+
+    try:
+        if bundle_path.is_file() and bundle_path.suffix.lower() == ".zip":
+            temp_dir = tempfile.TemporaryDirectory()
+            extracted_root = Path(temp_dir.name)
+            with ZipFile(bundle_path, "r") as archive:
+                archive.extractall(extracted_root)
+            root = extracted_root
+        else:
+            root = bundle_path
+
+        manifest_path = root / "bundle_manifest.json"
+        if not manifest_path.is_file():
+            return "FAIL", ["Missing required file: bundle_manifest.json"]
+
+        manifest = _load_manifest(root)
+
+        for name in REQUIRED_FILES:
+            if not (root / name).exists():
+                notes.append(f"Missing required file: {name}")
+                status = "FAIL"
+
+        files_block = manifest.get("files")
+        if not isinstance(files_block, list):
+            notes.append("bundle_manifest.json missing valid files[] checksum block")
+            status = "FAIL"
+            files_block = []
+
+        for entry in files_block:
+            if not isinstance(entry, dict):
+                notes.append("Invalid file checksum entry in manifest")
+                status = "FAIL"
+                continue
+            rel_path = entry.get("path")
+            expected = entry.get("sha256")
+            if not isinstance(rel_path, str) or not isinstance(expected, str):
+                notes.append("Invalid path/sha256 in manifest file entry")
+                status = "FAIL"
+                continue
+
+            candidate = root / rel_path
+            if not candidate.is_file():
+                notes.append(f"Checksum file missing: {rel_path}")
+                status = "FAIL"
+                continue
+
+            actual = _sha256(candidate)
+            if actual != expected:
+                notes.append(f"Checksum mismatch: {rel_path}")
+                status = "FAIL"
+
+        for optional in OPTIONAL_FILES:
+            if not (root / optional).exists():
+                notes.append(f"Optional file missing: {optional}")
+
+        return status, notes
+    finally:
+        if extracted_root and extracted_root.exists():
+            shutil.rmtree(extracted_root, ignore_errors=True)
+        if temp_dir is not None:
+            temp_dir.cleanup()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle", help="Bundle directory or .zip path")
+    args = parser.parse_args()
+
+    status, notes = inspect_bundle(Path(args.bundle).resolve())
+    print(f"{status} bundle={args.bundle}")
+    for note in notes:
+        print(f"- {note}")
+
+    return 1 if status == "FAIL" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preflight_workcell.sh
+++ b/scripts/preflight_workcell.sh
@@ -8,6 +8,7 @@ SELF_TEST_REPORT_PATH="${REPO_ROOT}/docs/manuals/latest_scene_self_test_report.m
 TASK_RECIPE_REPORT_PATH="${REPO_ROOT}/docs/manuals/latest_task_recipe_report.md"
 TASK_RECIPE_DRY_RUN_REPORT_PATH="${REPO_ROOT}/docs/manuals/latest_task_recipe_dry_run_report.md"
 TASK_EXECUTION_PLAN_REPORT_PATH="${REPO_ROOT}/docs/manuals/latest_task_execution_plan_report.md"
+WORKCELL_BUNDLE_DIR="${REPO_ROOT}/dist/workcell_bundles"
 SMOKE_REPORT_PATH="${REPO_ROOT}/docs/manuals/latest_smoke_launch_report.md"
 WITH_SMOKE=false
 
@@ -59,6 +60,7 @@ echo
 "${SCRIPT_DIR}/generate_task_recipe_dry_run_report.py"
 "${SCRIPT_DIR}/check_task_execution_plans.sh"
 "${SCRIPT_DIR}/generate_task_execution_plan_report.py"
+"${SCRIPT_DIR}/check_workcell_bundles.sh"
 
 echo
 printf 'Preflight report written to: %s\n' "${REPORT_PATH}"
@@ -66,6 +68,7 @@ printf 'Self-test report written to: %s\n' "${SELF_TEST_REPORT_PATH}"
 printf 'Task recipe report written to: %s\n' "${TASK_RECIPE_REPORT_PATH}"
 printf 'Task recipe dry-run report written to: %s\n' "${TASK_RECIPE_DRY_RUN_REPORT_PATH}"
 printf 'Task execution plan report written to: %s\n' "${TASK_EXECUTION_PLAN_REPORT_PATH}"
+printf 'Workcell bundles written to: %s\n' "${WORKCELL_BUNDLE_DIR}"
 
 if [[ "${WITH_SMOKE}" == true ]]; then
   echo

--- a/tests/test_scene_validation_tools.py
+++ b/tests/test_scene_validation_tools.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 import tempfile
 import unittest
@@ -45,6 +46,12 @@ task_execution_plan = _load_module(
 )
 task_execution_plan_reporter = _load_module(
     "generate_task_execution_plan_report", REPO_ROOT / "scripts" / "generate_task_execution_plan_report.py"
+)
+workcell_bundle_exporter = _load_module(
+    "export_workcell_bundle", REPO_ROOT / "scripts" / "export_workcell_bundle.py"
+)
+workcell_bundle_inspector = _load_module(
+    "inspect_workcell_bundle", REPO_ROOT / "scripts" / "inspect_workcell_bundle.py"
 )
 
 
@@ -861,6 +868,179 @@ class TaskExecutionPlanTests(unittest.TestCase):
                 report_text = task_execution_plan_reporter.build_report(rows)
         self.assertIn("`scene_a` | **PASS**", report_text)
         self.assertIn("deterministic operator-readable job sequence", report_text)
+
+
+class WorkcellBundleTests(unittest.TestCase):
+    def _manifest_text(self) -> str:
+        return (
+            "scene:\n"
+            "  name: fake_scene\n"
+            "robot:\n"
+            "  model: ur5\n"
+            "  planning_group: manipulator\n"
+            "  base_frame: base_link\n"
+            "  ee_link: tool0\n"
+            "end_effector:\n"
+            "  type: finger\n"
+            "  brand: robotiq_2f\n"
+            "  grasp_frame: tool0\n"
+            "self_test:\n"
+            "  enabled: true\n"
+            "  object:\n"
+            "    id: commissioning_box\n"
+            "    shape: box\n"
+            "    dimensions: [0.05, 0.05, 0.05]\n"
+            "    frame_id: world\n"
+            "    pose_xyz: [0.45, 0.0, 0.08]\n"
+            "    pose_rpy: [0.0, 0.0, 0.0]\n"
+            "task_recipe:\n"
+            "  id: colour_sort_demo\n"
+            "  name: Colour Sort Demo\n"
+            "  type: sort\n"
+            "  enabled: true\n"
+            "  decision_rules:\n"
+            "    - id: red_to_bin_a\n"
+            "      when:\n"
+            "        attribute: colour\n"
+            "        equals: red\n"
+            "      destination: bin_a\n"
+            "    - id: default\n"
+            "      when:\n"
+            "        default: true\n"
+            "      destination: reject_bin\n"
+            "  destinations:\n"
+            "    - id: bin_a\n"
+            "      frame_id: world\n"
+            "      pose_xyz: [0.20, 0.0, 0.12]\n"
+            "      pose_rpy: [0.0, 0.0, 0.0]\n"
+            "      action: place\n"
+            "    - id: reject_bin\n"
+            "      frame_id: world\n"
+            "      pose_xyz: [0.15, 0.0, 0.12]\n"
+            "      pose_rpy: [0.0, 0.0, 0.0]\n"
+            "      action: reject\n"
+        )
+
+    def _write_scene(self, root: Path, name: str = "fake_scene") -> Path:
+        manifest_path = root / "scenes" / name / "scene_manifest.yaml"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(self._manifest_text().replace("fake_scene", name), encoding="utf-8")
+        return manifest_path
+
+    def _configure_bundle_modules(self, root: Path) -> None:
+        workcell_bundle_exporter.REPO_ROOT = root
+        workcell_bundle_exporter.DEFAULT_OUTPUT_DIR = root / "dist" / "workcell_bundles"
+        workcell_bundle_exporter.REPORTS_DIR = root / "docs" / "manuals"
+        workcell_bundle_exporter.PLAN_OUTPUT_DIR = root / "docs" / "manuals" / "generated_execution_plans"
+        workcell_bundle_exporter.dry_run.REPO_ROOT = root
+        workcell_bundle_exporter.plan_generator.REPO_ROOT = root
+        workcell_bundle_exporter.plan_generator.dry_run.REPO_ROOT = root
+        workcell_bundle_exporter.plan_generator.OUTPUT_DIR = root / "docs" / "manuals" / "generated_execution_plans"
+        workcell_bundle_exporter.self_test_reporter.REPO_ROOT = root
+        workcell_bundle_exporter.task_recipe_reporter.REPO_ROOT = root
+
+    def test_bundle_export_and_manifest_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = self._write_scene(root)
+            self._configure_bundle_modules(root)
+            bundle_dir, _ = workcell_bundle_exporter.export_scene(
+                "fake_scene", manifest_path, root / "dist" / "workcell_bundles", zip_output=False, force=True
+            )
+            self.assertTrue((bundle_dir / "README.md").is_file())
+            self.assertTrue((bundle_dir / "operator_checklist.md").is_file())
+            manifest = json.loads((bundle_dir / "bundle_manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["bundle_schema_version"], "1.0")
+            self.assertEqual(manifest["scene"], "fake_scene")
+            self.assertTrue(manifest["offline_only"])
+            self.assertIn("files", manifest)
+
+    def test_operator_checklist_sections_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = self._write_scene(root)
+            self._configure_bundle_modules(root)
+            bundle_dir, _ = workcell_bundle_exporter.export_scene(
+                "fake_scene", manifest_path, root / "dist" / "workcell_bundles", zip_output=False, force=True
+            )
+            checklist = (bundle_dir / "operator_checklist.md").read_text(encoding="utf-8")
+            self.assertIn("## Offline checks", checklist)
+            self.assertIn("## Simulation checks", checklist)
+            self.assertIn("## Physical cell checks", checklist)
+
+    def test_missing_optional_reports_warn_not_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = self._write_scene(root)
+            self._configure_bundle_modules(root)
+            bundle_dir, _ = workcell_bundle_exporter.export_scene(
+                "fake_scene", manifest_path, root / "dist" / "workcell_bundles", zip_output=False, force=True
+            )
+            manifest = json.loads((bundle_dir / "bundle_manifest.json").read_text(encoding="utf-8"))
+            self.assertTrue(any("Optional report missing" in warning for warning in manifest["warnings"]))
+
+    def test_inspector_pass_and_checksum_mismatch_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = self._write_scene(root)
+            self._configure_bundle_modules(root)
+            bundle_dir, _ = workcell_bundle_exporter.export_scene(
+                "fake_scene", manifest_path, root / "dist" / "workcell_bundles", zip_output=False, force=True
+            )
+            status, _ = workcell_bundle_inspector.inspect_bundle(bundle_dir)
+            self.assertEqual(status, "PASS")
+
+            readme = bundle_dir / "README.md"
+            readme.write_text(readme.read_text(encoding="utf-8") + "\nTamper\n", encoding="utf-8")
+            status_after, notes = workcell_bundle_inspector.inspect_bundle(bundle_dir)
+            self.assertEqual(status_after, "FAIL")
+            self.assertTrue(any("Checksum mismatch" in note for note in notes))
+
+    def test_zip_export_and_force_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = self._write_scene(root)
+            self._configure_bundle_modules(root)
+            out_dir = root / "dist" / "workcell_bundles"
+            bundle_dir, _ = workcell_bundle_exporter.export_scene(
+                "fake_scene", manifest_path, out_dir, zip_output=True, force=True
+            )
+            zip_path = out_dir / "fake_scene.zip"
+            self.assertTrue(zip_path.is_file())
+
+            status, _ = workcell_bundle_inspector.inspect_bundle(zip_path)
+            self.assertEqual(status, "PASS")
+
+            with self.assertRaises(RuntimeError):
+                workcell_bundle_exporter._zip_bundle("fake_scene", bundle_dir, out_dir, force=False)
+
+            zip_forced = workcell_bundle_exporter._zip_bundle("fake_scene", bundle_dir, out_dir, force=True)
+            self.assertTrue(zip_forced.is_file())
+
+    def test_missing_execution_plan_with_dry_run_pass_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = self._write_scene(root)
+            self._configure_bundle_modules(root)
+            out_dir = root / "dist" / "workcell_bundles"
+
+            with mock.patch.object(workcell_bundle_exporter.plan_generator, "evaluate_scene") as mocked_eval:
+                mocked_eval.return_value = task_execution_plan.PlanResult(
+                    scene="fake_scene",
+                    status="PASS",
+                    task_recipe_id="id",
+                    task_type="sort",
+                    matched_rule_id="rule",
+                    destination_id="bin_a",
+                    markdown_path=None,
+                    json_path=None,
+                    steps_count=0,
+                    notes=["forced failure"],
+                )
+                with self.assertRaises(RuntimeError):
+                    workcell_bundle_exporter.export_scene(
+                        "fake_scene", manifest_path, out_dir, zip_output=False, force=True
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Consolidate scattered offline reports and artifacts into a single per-scene handover package for commissioning, review, archival, and future UI import/export workflows.  
- Provide a dependency-light, offline-only exporter that does not change any runtime or hardware behaviour and is safe for CI/operator use.  

### Description
- Add `scripts/export_workcell_bundle.py` which exports `dist/workcell_bundles/<scene>/` containing `README.md`, `bundle_manifest.json`, `operator_checklist.md`, `scene_manifest.yaml`, `execution_plan.md`, `execution_plan.json`, `validation_summary.md`, a `reports/` folder with optional reports, and computed SHA256 checksums for all included files; supports `--zip`, `--output-dir`, and `--force`.  
- Add `scripts/inspect_workcell_bundle.py` to inspect a bundle folder or zip, verify required files, and validate checksums from `bundle_manifest.json` in inspect-only mode.  
- Add `scripts/check_workcell_bundles.sh` to run export + inspect across scenes and produce concise PASS/WARN/FAIL/SKIP summary with exit-code gating for missing required files or checksum failures and dry-run PASS with missing plan files.  
- Integrate bundle checks into `scripts/preflight_workcell.sh` (invoked after execution plan generation) and surface the `dist/workcell_bundles/` path without changing smoke behaviour.  
- Update documentation (`README.md` and `docs/manuals/WORKCELL_OPERATOR_MANUAL.md`) with a new “Workcell commissioning bundles” section and explicit safety boundary language.  
- Extend unit tests (`tests/test_scene_validation_tools.py`) with dependency-light tests covering bundle export, manifest content, checklist content, optional-report warnings, checksum verification (pass/fail), ZIP support and `--force` behavior, and failure when dry-run PASS lacks execution plan files.  

### Testing
- Compiled relevant scripts with `python3 -m py_compile` and found no syntax errors. (succeeded)  
- Ran the full test module with `python3 -m unittest tests/test_scene_validation_tools.py` and all tests passed. (OK)  
- Linted shell helpers with `bash -n` for `scripts/check_workcell_bundles.sh` and `scripts/preflight_workcell.sh`. (OK)  
- Exercised exporter and inspector end-to-end: `./scripts/export_workcell_bundle.py ur5_2f_test --force`, `./scripts/inspect_workcell_bundle.py dist/workcell_bundles/ur5_2f_test`, `./scripts/export_workcell_bundle.py ur5_2f_test --zip --force` and `./scripts/inspect_workcell_bundle.py dist/workcell_bundles/ur5_2f_test.zip` (all returned PASS in this environment).  
- Ran `./scripts/check_workcell_bundles.sh` and integrated `./scripts/preflight_workcell.sh` to verify the bundled flow; `preflight` completed in this environment but ROS discovery reported SKIP due to missing `ros2`/workspace sourcing (environmental, not a code failure).  

Files added/modified (high level): `scripts/export_workcell_bundle.py`, `scripts/inspect_workcell_bundle.py`, `scripts/check_workcell_bundles.sh`, `scripts/preflight_workcell.sh`, `tests/test_scene_validation_tools.py` (tests extended), `README.md`, `docs/manuals/WORKCELL_OPERATOR_MANUAL.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8c35b5e08331b605137c3d4b06cd)