### PR TITLE
Add Cell Definition v1 offline schema, validators, generators, and workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,24 @@ Scene self-test metadata (`self_test` in each scene manifest) defines a determin
 ./scripts/check_task_recipes.sh
 ./scripts/check_task_recipe_dry_runs.sh
 ./scripts/check_task_execution_plans.sh
+./scripts/check_cell_definitions.sh
 ```
+
+### Cell Definition v1 (offline contract)
+
+Cell Definition v1 introduces a single high-level YAML for defining a robotic cell (robot, tool, camera, environment, objects, task rules, safe-home metadata) and generating offline preview artifacts for commissioning.
+
+Quick commands:
+
+```bash
+./scripts/check_cell_definitions.sh
+
+python3 scripts/validate_cell_definition.py tests/fixtures/cell_definition_sort_by_colour.yaml
+
+python3 scripts/generate_scene_from_cell_definition.py   tests/fixtures/cell_definition_sort_by_colour.yaml   --output-dir /tmp/emd_cell_preview
+```
+
+Reference: `docs/manuals/CELL_DEFINITION_V1.md`
 
 ### Task recipes
 

--- a/docs/manuals/CELL_DEFINITION_V1.md
+++ b/docs/manuals/CELL_DEFINITION_V1.md
@@ -1,0 +1,107 @@
+# Cell Definition v1
+
+## What a cell definition is
+
+A **Cell Definition** is a single high-level YAML contract (`schema_version: cell_definition/v1`) that captures robot-cell intent for commissioning and documentation workflows.
+
+It includes:
+
+- cell identity and description
+- robot and home behavior metadata
+- end-effector/tool metadata
+- camera metadata
+- environment and objects
+- task type, destinations, and rules
+- commissioning/export expectations
+
+## Why it exists
+
+The software supports delivery of the real product: the **physical robotic cell**.
+Cell Definition v1 makes cell setup more repeatable by creating one source of truth that can be validated, preview-generated, and reviewed by operators before runtime integration.
+
+## How this supports future click-driven generation
+
+Cell Definition v1 is designed as a bridge to future workcell-builder integration:
+
+1. operator/engineer defines cell metadata once
+2. tooling validates contract quality offline
+3. tooling generates scene/task previews
+4. tooling generates operator-readable commissioning summary
+5. reviewed metadata can be transformed into future click-driven builders/exporters
+
+No GUI is introduced in this phase.
+
+## Cell definition vs scene manifest vs task recipe
+
+- **Cell Definition v1**: high-level commissioning contract for a whole cell.
+- **Scene manifest**: lower-level scene/runtime-oriented metadata contract.
+- **Task recipe**: task intent and routing rules (destinations + decision rules).
+
+This PR adds preview generation from cell definition into scene-manifest/task-recipe shaped artifacts.
+
+## Validate a cell definition
+
+```bash
+python3 scripts/validate_cell_definition.py tests/fixtures/cell_definition_sort_by_colour.yaml
+```
+
+Validator behavior:
+
+- FAIL for malformed YAML and required contract violations
+- WARN for non-blocking concerns (example: unknown end-effector type)
+- PASS when checks are satisfied without warnings
+- exit non-zero only on failures
+
+## Generate preview files
+
+```bash
+python3 scripts/generate_scene_from_cell_definition.py \
+  tests/fixtures/cell_definition_sort_by_colour.yaml \
+  --output-dir /tmp/emd_cell_preview
+```
+
+Generated files:
+
+- `scene_manifest.preview.yaml`
+- `task_recipe.preview.yaml`
+- `commissioning_summary.md`
+
+## Review commissioning summary
+
+`commissioning_summary.md` is written for operators and includes:
+
+- cell name/id
+- robot, end-effector, camera
+- task type and destinations
+- object count and warnings
+- next commissioning steps
+- explicit limitation note
+
+## Supported non-simple task use cases
+
+Cell Definition v1 supports metadata for:
+
+- `pick_place`
+- `sort_by_colour`
+- `sort_by_shape`
+- `sort_by_class`
+- `garbage_sorting`
+- `inspection_then_place`
+- `custom`
+
+In this phase, task types only drive **offline preview generation** (no runtime behavior changes).
+
+## Workflow command
+
+```bash
+./scripts/check_cell_definitions.sh
+```
+
+This runs validation and preview generation for all `tests/fixtures/cell_definition_*.yaml` files.
+
+## Limitations
+
+- Not a safety certificate.
+- Not proof of robot reachability.
+- Not proof of collision-free execution.
+- Generated outputs must be engineering-reviewed before runtime use.

--- a/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
+++ b/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
@@ -141,6 +141,32 @@ Smoke preflight intent:
 
 ---
 
+## D1) Cell Definition workflow (offline-first)
+
+Use this when defining or importing a new cell contract before runtime integration.
+
+1. Create or import cell definition.
+2. Validate cell definition.
+3. Generate scene/task preview.
+4. Review commissioning summary.
+5. Generate or update workcell_builder scene.
+6. Run scene validation.
+7. Export commissioning bundle.
+8. Run simulation smoke test.
+9. Commission physical cell.
+
+Commands:
+
+```bash
+./scripts/check_cell_definitions.sh
+python3 scripts/validate_cell_definition.py tests/fixtures/cell_definition_pick_place.yaml
+python3 scripts/generate_scene_from_cell_definition.py   tests/fixtures/cell_definition_pick_place.yaml   --output-dir /tmp/emd_cell_preview
+```
+
+See `docs/manuals/CELL_DEFINITION_V1.md` for schema details and limitations.
+
+---
+
 ## E) Launch known-good scene
 
 Known-good execution launch command:

--- a/scripts/check_cell_definitions.sh
+++ b/scripts/check_cell_definitions.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VALIDATOR="${SCRIPT_DIR}/validate_cell_definition.py"
+GENERATOR="${SCRIPT_DIR}/generate_scene_from_cell_definition.py"
+
+status="PASS"
+warn_count=0
+fail_count=0
+
+if [[ ! -x "${VALIDATOR}" || ! -x "${GENERATOR}" ]]; then
+  echo "Cell definition checks: FAIL"
+  echo "FAIL: Required tools are missing or not executable." >&2
+  exit 2
+fi
+
+mapfile -t fixtures < <(find "${REPO_ROOT}/tests/fixtures" -maxdepth 1 -type f -name 'cell_definition_*.yaml' | sort)
+if [[ ${#fixtures[@]} -eq 0 ]]; then
+  echo "Cell definition checks: WARN"
+  echo "WARN: No cell definition fixtures found under tests/fixtures." >&2
+  exit 0
+fi
+
+tmp_root="$(mktemp -d /tmp/emd_cell_defs.XXXXXX)"
+trap 'rm -rf "${tmp_root}"' EXIT
+
+echo "Running cell definition checks in ${tmp_root}"
+for fixture in "${fixtures[@]}"; do
+  name="$(basename "${fixture}" .yaml)"
+  output_dir="${tmp_root}/${name}"
+
+  echo "--- ${name} ---"
+  set +e
+  validator_output="$(python3 "${VALIDATOR}" "${fixture}" 2>&1)"
+  validator_code=$?
+  set -e
+  echo "${validator_output}"
+  if [[ ${validator_code} -ne 0 ]]; then
+    status="FAIL"
+    ((fail_count+=1))
+    continue
+  fi
+  if grep -q "RESULT: WARN" <<<"${validator_output}"; then
+    [[ "${status}" == "PASS" ]] && status="WARN"
+    ((warn_count+=1))
+  fi
+
+  python3 "${GENERATOR}" "${fixture}" --output-dir "${output_dir}"
+
+  for generated in scene_manifest.preview.yaml task_recipe.preview.yaml commissioning_summary.md; do
+    if [[ ! -f "${output_dir}/${generated}" ]]; then
+      echo "FAIL: Missing generated artifact ${output_dir}/${generated}"
+      status="FAIL"
+      ((fail_count+=1))
+    fi
+  done
+
+  set +e
+  scene_check_output="$(python3 -c "import importlib.util,sys; from pathlib import Path; repo=Path(sys.argv[1]); manifest_path=Path(sys.argv[2]); spec=importlib.util.spec_from_file_location('validate_scene_contract', repo / 'scripts' / 'validate_scene_contract.py'); module=importlib.util.module_from_spec(spec); sys.modules['validate_scene_contract']=module; spec.loader.exec_module(module); manifest, parser, notes = module._read_manifest(str(manifest_path)); status, rule_notes = module.validate_task_recipe_block(manifest); print(f'Scene preview check parser={parser} status={status}'); [print(f'NOTE: {n}') for n in (notes + rule_notes)]; raise SystemExit(0 if status in {'PASS','WARN'} else 1)" "${REPO_ROOT}" "${output_dir}/scene_manifest.preview.yaml" 2>&1)"
+  scene_check_code=$?
+  set -e
+  echo "${scene_check_output}"
+  if [[ ${scene_check_code} -ne 0 ]]; then
+    status="FAIL"
+    ((fail_count+=1))
+  elif grep -q "status=WARN" <<<"${scene_check_output}"; then
+    [[ "${status}" == "PASS" ]] && status="WARN"
+    ((warn_count+=1))
+  fi
+done
+
+echo "Cell definition checks: ${status}"
+echo "Summary: WARN=${warn_count} FAIL=${fail_count}"
+
+if [[ "${status}" == "FAIL" ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/generate_scene_from_cell_definition.py
+++ b/scripts/generate_scene_from_cell_definition.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Generate scene/task/commissioning preview artifacts from Cell Definition v1."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import validate_cell_definition as cell_validator
+
+
+def _task_recipe_type(task_type: str) -> str:
+    mapping = {
+        "sort_by_colour": "sort",
+        "sort_by_shape": "sort",
+        "sort_by_class": "sort",
+        "garbage_sorting": "sort",
+        "inspection_then_place": "inspection_then_place",
+        "pick_place": "pick_place",
+        "custom": "custom",
+    }
+    return mapping.get(task_type, task_type)
+
+
+def _to_yaml_text(data: Any) -> str:
+    if cell_validator._pyyaml is not None:
+        return str(cell_validator._pyyaml.safe_dump(data, sort_keys=False))
+
+    def _scalar_text(value: Any) -> str:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if value is None:
+            return "null"
+        if isinstance(value, (int, float)):
+            return str(value)
+        if isinstance(value, list) and all(not isinstance(item, (dict, list)) for item in value):
+            return "[" + ", ".join(_scalar_text(item) for item in value) + "]"
+        return str(value)
+
+    def dump(value: Any, indent: int = 0) -> list[str]:
+        prefix = " " * indent
+        if isinstance(value, dict):
+            lines: list[str] = []
+            for key, child in value.items():
+                if isinstance(child, dict):
+                    lines.append(f"{prefix}{key}:")
+                    lines.extend(dump(child, indent + 2))
+                elif isinstance(child, list) and child and all(isinstance(item, dict) for item in child):
+                    lines.append(f"{prefix}{key}:")
+                    for item in child:
+                        first = True
+                        for item_key, item_value in item.items():
+                            if first and not isinstance(item_value, (dict, list)):
+                                lines.append(f"{' ' * (indent + 2)}- {item_key}: {_scalar_text(item_value)}")
+                                first = False
+                            elif first:
+                                lines.append(f"{' ' * (indent + 2)}- {item_key}:")
+                                lines.extend(dump(item_value, indent + 6))
+                                first = False
+                            elif isinstance(item_value, (dict, list)):
+                                lines.append(f"{' ' * (indent + 4)}{item_key}:")
+                                lines.extend(dump(item_value, indent + 6))
+                            else:
+                                lines.append(f"{' ' * (indent + 4)}{item_key}: {_scalar_text(item_value)}")
+                elif isinstance(child, list):
+                    lines.append(f"{prefix}{key}: {_scalar_text(child)}")
+                else:
+                    lines.append(f"{prefix}{key}: {_scalar_text(child)}")
+            return lines
+        if isinstance(value, list):
+            return [f"{prefix}- {_scalar_text(item)}" for item in value]
+        return [f"{prefix}{_scalar_text(value)}"]
+
+    return "\n".join(dump(data)) + "\n"
+
+
+def build_scene_manifest(cell_def: dict[str, Any]) -> dict[str, Any]:
+    cell = cell_def.get("cell", {})
+    robot = cell_def.get("robot", {})
+    end_effector = cell_def.get("end_effector", {})
+    environment = cell_def.get("environment", {})
+    objects = cell_def.get("objects", [])
+    task = cell_def.get("task", {})
+    commissioning = cell_def.get("commissioning", {})
+
+    self_test_object = objects[0] if objects else {}
+
+    return {
+        "schema_version": "1.0",
+        "scene": {"name": cell.get("id", "generated_cell")},
+        "robot": {
+            "model": robot.get("model", "unknown"),
+            "planning_group": robot.get("planning_group", "manipulator"),
+            "base_frame": robot.get("base_frame", "world"),
+            "ee_link": robot.get("tool_link", "tool0"),
+            "home_named_target": robot.get("home_named_target", "home"),
+        },
+        "planning": {"pipeline": "ompl", "planner_id": "RRTConnectkConfigDefault"},
+        "end_effector": {
+            "type": end_effector.get("type", "unknown"),
+            "brand": end_effector.get("brand", "unknown"),
+            "grasp_frame": end_effector.get("grasp_frame", "tool0"),
+            "allowed_touch_links": end_effector.get("allowed_touch_links", []),
+        },
+        "frames": {
+            "world": environment.get("frame", "world"),
+            "robot_base": robot.get("base_frame", "world"),
+            "grasp_frame": end_effector.get("grasp_frame", "tool0"),
+            "support_surface_frame": environment.get("frame", "world"),
+        },
+        "environment": {
+            "support_surface_link": (
+                environment.get("support_surfaces", [{}])[0].get("id", "table")
+                if isinstance(environment.get("support_surfaces"), list) and environment.get("support_surfaces")
+                else "table"
+            ),
+            "support_surfaces": environment.get("support_surfaces", []),
+            "objects": objects,
+        },
+        "self_test": {
+            "enabled": bool(commissioning.get("self_test_enabled", True)),
+            "object": {
+                "id": self_test_object.get("id", "commissioning_box"),
+                "shape": self_test_object.get("shape", "box"),
+                "frame_id": self_test_object.get("frame", "world"),
+                "dimensions": self_test_object.get("dimensions", [0.05, 0.05, 0.05]),
+                "pose_xyz": self_test_object.get("pose_xyz", [0.45, 0.0, 0.08]),
+                "pose_rpy": self_test_object.get("pose_rpy", [0.0, 0.0, 0.0]),
+                "attributes": {
+                    "color": self_test_object.get("color", "unknown"),
+                    "shape": self_test_object.get("shape", "unknown"),
+                    "material": self_test_object.get("material", "unknown"),
+                    "class": self_test_object.get("class", "unknown"),
+                },
+            },
+            "expected": {"min_grasp_candidates": 1, "allow_simulated_execution": True},
+        },
+        "task_recipe": build_task_recipe(cell_def),
+        "home_return": {
+            "enabled": True,
+            "strategy": "named_target_or_safe_joint_state",
+            "named_target": robot.get("home_named_target", "home"),
+            "safe_joint_state": robot.get("safe_joint_state", []),
+        },
+    }
+
+
+def _map_rule(rule: dict[str, Any]) -> dict[str, Any]:
+    mapped = {"id": rule.get("id", "rule"), "destination": rule.get("destination")}
+    when = rule.get("when") if isinstance(rule.get("when"), dict) else {}
+    if when.get("always") is True:
+        mapped["when"] = {"default": True}
+    else:
+        attr_key = None
+        attr_value = None
+        for key, value in when.items():
+            if key == "always":
+                continue
+            attr_key = key
+            attr_value = value
+            break
+        if attr_key is not None:
+            mapped["when"] = {"attribute": attr_key, "equals": attr_value}
+        else:
+            mapped["when"] = {"default": True}
+    mapped["action"] = "place"
+    return mapped
+
+
+def build_task_recipe(cell_def: dict[str, Any]) -> dict[str, Any]:
+    task = cell_def.get("task", {})
+    task_type = str(task.get("type", "custom"))
+    return {
+        "enabled": True,
+        "recipe_id": task.get("id", "generated_task"),
+        "id": task.get("id", "generated_task"),
+        "task_type": task_type,
+        "type": _task_recipe_type(task_type),
+        "name": task.get("id", "Generated Task"),
+        "description": f"Preview generated from cell definition task type '{task_type}'.",
+        "pick": {
+            "source": task.get("source_object", "detected_object"),
+            "object_source": "self_test",
+            "allowed_grasp_methods": ["finger", "suction"],
+        },
+        "decision_rules": [
+            _map_rule(rule) for rule in task.get("rules", []) if isinstance(rule, dict)
+        ],
+        "destinations": [
+            {
+                "id": item.get("id"),
+                "frame_id": item.get("frame", "world"),
+                "pose_xyz": item.get("pose_xyz", [0.0, 0.0, 0.0]),
+                "pose_rpy": item.get("pose_rpy", [0.0, 0.0, 0.0]),
+                "action": "place",
+            }
+            for item in task.get("destinations", [])
+            if isinstance(item, dict)
+        ],
+        "expected": {"allow_fallback_rule": True, "require_destination_pose": True},
+    }
+
+
+def build_commissioning_summary(cell_def: dict[str, Any], warnings: list[str]) -> str:
+    cell = cell_def.get("cell", {})
+    robot = cell_def.get("robot", {})
+    end_effector = cell_def.get("end_effector", {})
+    camera = cell_def.get("camera", {})
+    task = cell_def.get("task", {})
+    objects = cell_def.get("objects", [])
+    destinations = task.get("destinations", [])
+
+    lines = [
+        "# Commissioning Summary (Preview)",
+        "",
+        f"- Cell: **{cell.get('name', '(unknown)')}** (`{cell.get('id', '(unknown)')}`)",
+        f"- Robot: `{robot.get('model', '(unknown)')}` / planning group `{robot.get('planning_group', '(unknown)')}`",
+        f"- End effector: `{end_effector.get('id', '(unknown)')}` ({end_effector.get('type', '(unknown)' )})",
+        f"- Camera: `{camera.get('id', '(unknown)')}` ({camera.get('type', '(unknown)')})",
+        f"- Task type: `{task.get('type', '(unknown)')}`",
+        f"- Objects in definition: `{len(objects)}`",
+        f"- Destinations in task: `{len(destinations)}`",
+        "",
+        "## Warnings",
+    ]
+    if warnings:
+        lines.extend([f"- {warning}" for warning in warnings])
+    else:
+        lines.append("- None")
+
+    lines.extend(
+        [
+            "",
+            "## Next commissioning steps",
+            "1. Review this preview with controls/robotics engineer.",
+            "2. Generate/update workcell_builder scene package using approved metadata.",
+            "3. Run scene validation, task checks, and simulation smoke tests.",
+            "4. Validate real robot interlocks and operator safety workflow on hardware.",
+            "",
+            "> Limitation: This preview is not proof of physical reachability, collision-free motion, or safety compliance.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("yaml_path", type=Path, help="Path to cell definition YAML")
+    parser.add_argument("--output-dir", type=Path, required=True, help="Output directory for preview artifacts")
+    args = parser.parse_args()
+
+    try:
+        loaded, parser_name, parser_notes = cell_validator.load_yaml(args.yaml_path)
+    except Exception as exc:
+        print(f"FAIL: Unable to load cell definition: {exc}")
+        return 1
+
+    summary = cell_validator.validate_cell_definition(loaded, args.yaml_path, parser_name, parser_notes)
+    status = "PASS" if summary.ok and not summary.warnings else "WARN" if summary.ok else "FAIL"
+    if not summary.ok:
+        print("FAIL: Cell definition failed validation; preview generation aborted.")
+        for error in summary.errors:
+            print(f" - {error}")
+        return 1
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    scene_manifest_path = args.output_dir / "scene_manifest.preview.yaml"
+    task_recipe_path = args.output_dir / "task_recipe.preview.yaml"
+    commissioning_path = args.output_dir / "commissioning_summary.md"
+
+    scene_manifest = build_scene_manifest(loaded)
+    task_recipe = build_task_recipe(loaded)
+
+    scene_manifest_path.write_text(_to_yaml_text(scene_manifest), encoding="utf-8")
+    task_recipe_path.write_text(_to_yaml_text(task_recipe), encoding="utf-8")
+    commissioning_path.write_text(build_commissioning_summary(loaded, summary.warnings), encoding="utf-8")
+
+    print(f"RESULT: {status}")
+    print(f"Wrote: {scene_manifest_path}")
+    print(f"Wrote: {task_recipe_path}")
+    print(f"Wrote: {commissioning_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preflight_workcell.sh
+++ b/scripts/preflight_workcell.sh
@@ -62,6 +62,22 @@ echo
 "${SCRIPT_DIR}/generate_task_execution_plan_report.py"
 "${SCRIPT_DIR}/check_workcell_bundles.sh"
 set +e
+CELL_DEF_OUTPUT="$(${SCRIPT_DIR}/check_cell_definitions.sh)"
+CELL_DEF_EXIT=$?
+set -e
+echo "${CELL_DEF_OUTPUT}"
+if [[ ${CELL_DEF_EXIT} -eq 0 ]]; then
+  if grep -q "Cell definition checks: WARN" <<<"${CELL_DEF_OUTPUT}"; then
+    echo "Cell definition checks: WARN"
+  else
+    echo "Cell definition checks: PASS"
+  fi
+else
+  echo "Cell definition checks: FAIL"
+  exit ${CELL_DEF_EXIT}
+fi
+
+set +e
 WORKCELL_TEMPLATE_OUTPUT="$(${SCRIPT_DIR}/check_workcell_builder_templates.sh)"
 WORKCELL_TEMPLATE_EXIT=$?
 set -e

--- a/scripts/validate_cell_definition.py
+++ b/scripts/validate_cell_definition.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Validate Cell Definition v1 YAML files for offline commissioning workflows."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:  # Optional dependency.
+    import yaml as _pyyaml
+except Exception:  # pragma: no cover - environment dependent
+    _pyyaml = None
+
+SUPPORTED_TASK_TYPES = {
+    "pick_place",
+    "sort_by_colour",
+    "sort_by_shape",
+    "sort_by_class",
+    "garbage_sorting",
+    "inspection_then_place",
+    "custom",
+}
+SORTING_TASK_TYPES = {"sort_by_colour", "sort_by_shape", "sort_by_class", "garbage_sorting"}
+KNOWN_END_EFFECTOR_TYPES = {"finger", "suction", "magnetic", "vacuum", "custom"}
+
+
+class SimpleYamlError(ValueError):
+    """Raised when the fallback parser cannot handle the YAML structure."""
+
+
+@dataclass
+class ValidationSummary:
+    path: Path
+    parser: str
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _strip_comment(value: str) -> str:
+    quote: str | None = None
+    for idx, ch in enumerate(value):
+        if ch in {'"', "'"}:
+            if quote is None:
+                quote = ch
+            elif quote == ch:
+                quote = None
+        if ch == "#" and quote is None and idx > 0 and value[idx - 1].isspace():
+            return value[:idx].rstrip()
+    return value.rstrip()
+
+
+def _parse_scalar(value: str, line_no: int) -> Any:
+    if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
+        return value[1:-1]
+
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if lowered == "null":
+        return None
+
+    if re.fullmatch(r"[+-]?\d+", value):
+        return int(value)
+    if re.fullmatch(r"[+-]?(?:\d+\.\d*|\d*\.\d+)(?:[eE][+-]?\d+)?", value) or re.fullmatch(
+        r"[+-]?\d+[eE][+-]?\d+", value
+    ):
+        return float(value)
+
+    if value.startswith("["):
+        if not value.endswith("]"):
+            raise SimpleYamlError(f"Line {line_no}: malformed inline list")
+        inner = value[1:-1].strip()
+        if not inner:
+            return []
+        parts = [item.strip() for item in inner.split(",")]
+        if any(part == "" for part in parts):
+            raise SimpleYamlError(f"Line {line_no}: malformed inline list entries")
+        return [_parse_scalar(part, line_no) for part in parts]
+
+    if any(tok in value for tok in ("{", "}", "|", ">", "&", "*", "!!")):
+        raise SimpleYamlError(f"Line {line_no}: unsupported YAML token for fallback parser")
+
+    return value
+
+
+def _tokenize_yaml(text: str) -> list[tuple[int, int, str]]:
+    tokens: list[tuple[int, int, str]] = []
+    for idx, raw in enumerate(text.splitlines(), start=1):
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        if "\t" in raw:
+            raise SimpleYamlError(f"Line {idx}: tabs are not supported")
+        indent = len(raw) - len(raw.lstrip(" "))
+        content = _strip_comment(raw[indent:]).strip()
+        if content:
+            tokens.append((idx, indent, content))
+    return tokens
+
+
+def _parse_mapping(tokens: list[tuple[int, int, str]], start: int, indent: int) -> tuple[dict[str, Any], int]:
+    data: dict[str, Any] = {}
+    i = start
+    while i < len(tokens):
+        line_no, current_indent, content = tokens[i]
+        if current_indent < indent:
+            break
+        if current_indent > indent:
+            raise SimpleYamlError(f"Line {line_no}: unexpected indentation")
+        if content.startswith("- "):
+            raise SimpleYamlError(f"Line {line_no}: list item where mapping key expected")
+        if ":" not in content:
+            raise SimpleYamlError(f"Line {line_no}: missing ':' in mapping entry")
+
+        key, remainder = content.split(":", 1)
+        key = key.strip()
+        if not key:
+            raise SimpleYamlError(f"Line {line_no}: empty mapping key")
+        remainder = remainder.strip()
+        i += 1
+
+        if remainder:
+            data[key] = _parse_scalar(remainder, line_no)
+            continue
+
+        if i >= len(tokens) or tokens[i][1] <= current_indent:
+            data[key] = {}
+            continue
+
+        child_indent = tokens[i][1]
+        if tokens[i][2].startswith("- "):
+            parsed, i = _parse_list(tokens, i, child_indent)
+        else:
+            parsed, i = _parse_mapping(tokens, i, child_indent)
+        data[key] = parsed
+
+    return data, i
+
+
+def _parse_list(tokens: list[tuple[int, int, str]], start: int, indent: int) -> tuple[list[Any], int]:
+    out: list[Any] = []
+    i = start
+    while i < len(tokens):
+        line_no, current_indent, content = tokens[i]
+        if current_indent < indent:
+            break
+        if current_indent != indent or not content.startswith("- "):
+            break
+
+        payload = content[2:].strip()
+        i += 1
+
+        if not payload:
+            raise SimpleYamlError(f"Line {line_no}: empty list item unsupported")
+
+        if payload.endswith(":") or (":" in payload and not payload.startswith(("'", '"'))):
+            end = i
+            while end < len(tokens) and tokens[end][1] > current_indent:
+                end += 1
+            synthetic = [(line_no, indent + 2, payload)] + tokens[i:end]
+            parsed, consumed = _parse_mapping(synthetic, 0, indent + 2)
+            if consumed != len(synthetic):
+                raise SimpleYamlError(f"Line {synthetic[consumed][0]}: unsupported list mapping structure")
+            out.append(parsed)
+            i = end
+            continue
+
+        out.append(_parse_scalar(payload, line_no))
+
+    return out, i
+
+
+def parse_cell_definition_yaml(text: str) -> dict[str, Any]:
+    tokens = _tokenize_yaml(text)
+    if not tokens:
+        return {}
+    root_indent = min(item[1] for item in tokens)
+    parsed, consumed = _parse_mapping(tokens, 0, root_indent)
+    if consumed != len(tokens):
+        raise SimpleYamlError(f"Line {tokens[consumed][0]}: unsupported YAML structure")
+    return parsed
+
+
+def load_yaml(path: Path) -> tuple[dict[str, Any], str, list[str]]:
+    text = path.read_text(encoding="utf-8")
+    notes: list[str] = []
+    if _pyyaml is not None:
+        loaded = _pyyaml.safe_load(text)
+        if loaded is None:
+            loaded = {}
+        if not isinstance(loaded, dict):
+            raise ValueError("Top-level YAML must be a mapping/object.")
+        return loaded, "pyyaml", notes
+
+    notes.append("PyYAML unavailable; using fallback parser with limited YAML support.")
+    loaded = parse_cell_definition_yaml(text)
+    if not isinstance(loaded, dict):
+        raise ValueError("Top-level YAML must be a mapping/object.")
+    return loaded, "fallback", notes
+
+
+def _is_numeric_list(value: Any, expected_len: int | None = None) -> bool:
+    if not isinstance(value, list):
+        return False
+    if expected_len is not None and len(value) != expected_len:
+        return False
+    return all(isinstance(v, (int, float)) for v in value)
+
+
+def _validate_pose(summary: ValidationSummary, owner: str, block: dict[str, Any]) -> None:
+    pose_xyz = block.get("pose_xyz")
+    pose_rpy = block.get("pose_rpy")
+    if not _is_numeric_list(pose_xyz, 3):
+        summary.errors.append(f"{owner}.pose_xyz must be numeric list length 3.")
+    if not _is_numeric_list(pose_rpy, 3):
+        summary.errors.append(f"{owner}.pose_rpy must be numeric list length 3.")
+
+
+def _validate_dimensions(summary: ValidationSummary, owner: str, dims: Any) -> None:
+    if not isinstance(dims, list) or not dims:
+        summary.errors.append(f"{owner}.dimensions must be a non-empty list of positive numbers.")
+        return
+    for idx, val in enumerate(dims):
+        if not isinstance(val, (int, float)) or val <= 0:
+            summary.errors.append(f"{owner}.dimensions[{idx}] must be a positive number.")
+
+
+def validate_cell_definition(defn: dict[str, Any], path: Path, parser: str, parser_notes: list[str]) -> ValidationSummary:
+    result = ValidationSummary(path=path, parser=parser, notes=list(parser_notes))
+
+    required_keys = [
+        "schema_version",
+        "cell",
+        "robot",
+        "end_effector",
+        "camera",
+        "environment",
+        "objects",
+        "task",
+        "commissioning",
+    ]
+    for key in required_keys:
+        if key not in defn:
+            result.errors.append(f"Missing required top-level key: {key}")
+
+    if defn.get("schema_version") != "cell_definition/v1":
+        result.errors.append("schema_version must be exactly 'cell_definition/v1'.")
+
+    robot = defn.get("robot") if isinstance(defn.get("robot"), dict) else {}
+    end_effector = defn.get("end_effector") if isinstance(defn.get("end_effector"), dict) else {}
+    environment = defn.get("environment") if isinstance(defn.get("environment"), dict) else {}
+    objects = defn.get("objects") if isinstance(defn.get("objects"), list) else []
+    task = defn.get("task") if isinstance(defn.get("task"), dict) else {}
+
+    if "safe_joint_state" not in robot:
+        result.errors.append("robot.safe_joint_state key is required (empty list allowed when home_named_target exists).")
+    else:
+        safe_joint_state = robot.get("safe_joint_state")
+        if not isinstance(safe_joint_state, list):
+            result.errors.append("robot.safe_joint_state must be a list.")
+        elif not safe_joint_state and not isinstance(robot.get("home_named_target"), str):
+            result.errors.append("robot.safe_joint_state is empty and robot.home_named_target is missing.")
+        elif safe_joint_state and not all(isinstance(v, (int, float)) for v in safe_joint_state):
+            result.errors.append("robot.safe_joint_state entries must be numeric.")
+
+    ee_type = end_effector.get("type")
+    if isinstance(ee_type, str) and ee_type not in KNOWN_END_EFFECTOR_TYPES:
+        result.warnings.append(
+            f"Unknown end_effector.type '{ee_type}'. Continuing because this is metadata-only validation."
+        )
+
+    support_surfaces = environment.get("support_surfaces")
+    if isinstance(support_surfaces, list):
+        for idx, surface in enumerate(support_surfaces):
+            if not isinstance(surface, dict):
+                result.errors.append(f"environment.support_surfaces[{idx}] must be a mapping.")
+                continue
+            _validate_pose(result, f"environment.support_surfaces[{idx}]", surface)
+            _validate_dimensions(result, f"environment.support_surfaces[{idx}]", surface.get("dimensions"))
+
+    for idx, obj in enumerate(objects):
+        if not isinstance(obj, dict):
+            result.errors.append(f"objects[{idx}] must be a mapping.")
+            continue
+        _validate_pose(result, f"objects[{idx}]", obj)
+        _validate_dimensions(result, f"objects[{idx}]", obj.get("dimensions"))
+
+    task_type = task.get("type")
+    if not isinstance(task_type, str):
+        result.errors.append("task.type must be a non-empty string.")
+    elif task_type not in SUPPORTED_TASK_TYPES:
+        result.errors.append(f"task.type '{task_type}' is unsupported for cell_definition/v1.")
+    elif task_type == "custom":
+        result.warnings.append("task.type is 'custom'; ensure downstream tooling knows how to interpret it.")
+
+    destinations = task.get("destinations")
+    if not isinstance(destinations, list) or not destinations:
+        result.errors.append("task.destinations must contain at least one destination.")
+        destination_ids: set[str] = set()
+    else:
+        destination_ids = set()
+        for idx, destination in enumerate(destinations):
+            if not isinstance(destination, dict):
+                result.errors.append(f"task.destinations[{idx}] must be a mapping.")
+                continue
+            destination_id = destination.get("id")
+            if not isinstance(destination_id, str) or not destination_id.strip():
+                result.errors.append(f"task.destinations[{idx}].id must be a non-empty string.")
+            else:
+                destination_ids.add(destination_id)
+            _validate_pose(result, f"task.destinations[{idx}]", destination)
+
+    rules = task.get("rules")
+    if task_type in SORTING_TASK_TYPES and (not isinstance(rules, list) or not rules):
+        result.errors.append(f"task.rules must be a non-empty list for sorting task type '{task_type}'.")
+
+    fallback_present = False
+    if isinstance(rules, list):
+        for idx, rule in enumerate(rules):
+            if not isinstance(rule, dict):
+                result.errors.append(f"task.rules[{idx}] must be a mapping.")
+                continue
+            dest = rule.get("destination")
+            if not isinstance(dest, str) or not dest.strip():
+                result.errors.append(f"task.rules[{idx}].destination must be a non-empty string.")
+            elif dest not in destination_ids:
+                result.errors.append(f"task.rules[{idx}] destination '{dest}' does not exist in task.destinations.")
+            when = rule.get("when")
+            if isinstance(when, dict) and when.get("always") is True:
+                fallback_present = True
+
+    if task_type in SORTING_TASK_TYPES and not fallback_present:
+        result.warnings.append("Sorting task has no explicit fallback rule with when.always=true.")
+
+    return result
+
+
+def print_summary(summary: ValidationSummary) -> None:
+    print(f"Cell definition: {summary.path}")
+    print(f"Parser: {summary.parser}")
+    for note in summary.notes:
+        print(f"NOTE: {note}")
+    for warning in summary.warnings:
+        print(f"WARN: {warning}")
+    for error in summary.errors:
+        print(f"FAIL: {error}")
+
+    status = "PASS" if summary.ok and not summary.warnings else "WARN" if summary.ok else "FAIL"
+    print(f"RESULT: {status}")
+    print(
+        "SUMMARY: "
+        f"PASS={'1' if summary.ok and not summary.warnings else '0'} "
+        f"WARN={len(summary.warnings)} "
+        f"FAIL={len(summary.errors)}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("yaml_path", type=Path, help="Path to a cell_definition YAML file")
+    args = parser.parse_args()
+
+    try:
+        loaded, parser_name, notes = load_yaml(args.yaml_path)
+    except FileNotFoundError:
+        print(f"FAIL: File not found: {args.yaml_path}")
+        return 2
+    except Exception as exc:
+        print(f"FAIL: Malformed YAML: {exc}")
+        return 1
+
+    summary = validate_cell_definition(loaded, args.yaml_path, parser_name, notes)
+    print_summary(summary)
+    return 0 if summary.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/cell_definition_garbage_sorting.yaml
+++ b/tests/fixtures/cell_definition_garbage_sorting.yaml
@@ -1,0 +1,83 @@
+schema_version: cell_definition/v1
+cell:
+  id: ur5_garbage_sort_cell
+  name: UR5 garbage sorting cell
+  description: Garbage sorting preview
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: robotiq_2f
+  type: finger
+  brand: robotiq
+  grasp_frame: ee_palm
+  allowed_touch_links: [gripper_finger1_finger_tip_link, gripper_finger2_finger_tip_link]
+camera:
+  id: realsense_d435i
+  type: depth_camera
+  frame: camera_depth_optical_frame
+environment:
+  frame: world
+  support_surfaces:
+    - id: table_main
+      type: table
+      frame: world
+      pose_xyz: [0.0, 0.0, 0.0]
+      pose_rpy: [0.0, 0.0, 0.0]
+      dimensions: [1.0, 1.0, 0.05]
+objects:
+  - id: waste_item
+    class: unknown
+    shape: irregular
+    color: unknown
+    material: unknown
+    frame: world
+    dimensions: [0.05, 0.04, 0.03]
+    pose_xyz: [0.45, 0.0, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+task:
+  id: garbage_sorting_task
+  type: garbage_sorting
+  source_object: waste_item
+  destinations:
+    - id: metal_bin
+      frame: world
+      pose_xyz: [0.35, -0.30, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+    - id: plastic_bin
+      frame: world
+      pose_xyz: [0.35, -0.10, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+    - id: paper_bin
+      frame: world
+      pose_xyz: [0.35, 0.10, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+    - id: reject_bin
+      frame: world
+      pose_xyz: [0.35, 0.30, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: metal_to_metal_bin
+      when:
+        material: metal
+      destination: metal_bin
+    - id: plastic_to_plastic_bin
+      when:
+        material: plastic
+      destination: plastic_bin
+    - id: paper_to_paper_bin
+      when:
+        material: paper
+      destination: paper_bin
+    - id: fallback
+      when:
+        always: true
+      destination: reject_bin
+commissioning:
+  self_test_enabled: true
+  export_bundle: true
+  require_operator_review: true

--- a/tests/fixtures/cell_definition_pick_place.yaml
+++ b/tests/fixtures/cell_definition_pick_place.yaml
@@ -1,0 +1,64 @@
+schema_version: cell_definition/v1
+cell:
+  id: ur5_2f_demo_cell
+  name: UR5 2F demo cell
+  description: Example generated cell definition
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: robotiq_2f
+  type: finger
+  brand: robotiq
+  grasp_frame: ee_palm
+  allowed_touch_links:
+    - gripper_finger1_finger_tip_link
+    - gripper_finger2_finger_tip_link
+camera:
+  id: realsense_d435i
+  type: depth_camera
+  frame: camera_depth_optical_frame
+  pointcloud_topic: /camera/camera/depth/color/points
+  rgb_topic: /camera/camera/color/image_raw
+  depth_topic: /camera/camera/aligned_depth_to_color/image_raw
+environment:
+  frame: world
+  support_surfaces:
+    - id: table_main
+      type: table
+      frame: world
+      pose_xyz: [0.0, 0.0, 0.0]
+      pose_rpy: [0.0, 0.0, 0.0]
+      dimensions: [1.0, 1.0, 0.05]
+objects:
+  - id: commissioning_box
+    class: box
+    shape: box
+    color: unknown
+    material: unknown
+    frame: world
+    dimensions: [0.05, 0.05, 0.05]
+    pose_xyz: [0.45, 0.0, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+task:
+  id: default_task
+  type: pick_place
+  source_object: commissioning_box
+  destinations:
+    - id: default_drop_zone
+      frame: world
+      pose_xyz: [0.30, -0.30, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: default_place
+      when:
+        always: true
+      destination: default_drop_zone
+commissioning:
+  self_test_enabled: true
+  export_bundle: true
+  require_operator_review: true

--- a/tests/fixtures/cell_definition_sort_by_colour.yaml
+++ b/tests/fixtures/cell_definition_sort_by_colour.yaml
@@ -1,0 +1,75 @@
+schema_version: cell_definition/v1
+cell:
+  id: ur5_colour_sort_cell
+  name: UR5 colour sort cell
+  description: Sort by colour preview
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: robotiq_2f
+  type: finger
+  brand: robotiq
+  grasp_frame: ee_palm
+  allowed_touch_links: [gripper_finger1_finger_tip_link, gripper_finger2_finger_tip_link]
+camera:
+  id: realsense_d435i
+  type: depth_camera
+  frame: camera_depth_optical_frame
+environment:
+  frame: world
+  support_surfaces:
+    - id: table_main
+      type: table
+      frame: world
+      pose_xyz: [0.0, 0.0, 0.0]
+      pose_rpy: [0.0, 0.0, 0.0]
+      dimensions: [1.0, 1.0, 0.05]
+objects:
+  - id: detected_object
+    class: part
+    shape: box
+    color: red
+    material: plastic
+    frame: world
+    dimensions: [0.04, 0.04, 0.04]
+    pose_xyz: [0.45, 0.0, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+task:
+  id: colour_sorting_task
+  type: sort_by_colour
+  source_object: detected_object
+  destinations:
+    - id: red_bin
+      frame: world
+      pose_xyz: [0.35, -0.30, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+    - id: blue_bin
+      frame: world
+      pose_xyz: [0.35, 0.30, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+    - id: reject_bin
+      frame: world
+      pose_xyz: [0.20, 0.0, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: red_to_red_bin
+      when:
+        color: red
+      destination: red_bin
+    - id: blue_to_blue_bin
+      when:
+        color: blue
+      destination: blue_bin
+    - id: fallback
+      when:
+        always: true
+      destination: reject_bin
+commissioning:
+  self_test_enabled: true
+  export_bundle: true
+  require_operator_review: true

--- a/tests/fixtures/cell_definition_sort_by_shape.yaml
+++ b/tests/fixtures/cell_definition_sort_by_shape.yaml
@@ -1,0 +1,75 @@
+schema_version: cell_definition/v1
+cell:
+  id: ur5_shape_sort_cell
+  name: UR5 shape sort cell
+  description: Sort by shape preview
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: robotiq_2f
+  type: finger
+  brand: robotiq
+  grasp_frame: ee_palm
+  allowed_touch_links: [gripper_finger1_finger_tip_link, gripper_finger2_finger_tip_link]
+camera:
+  id: realsense_d435i
+  type: depth_camera
+  frame: camera_depth_optical_frame
+environment:
+  frame: world
+  support_surfaces:
+    - id: table_main
+      type: table
+      frame: world
+      pose_xyz: [0.0, 0.0, 0.0]
+      pose_rpy: [0.0, 0.0, 0.0]
+      dimensions: [1.0, 1.0, 0.05]
+objects:
+  - id: detected_object
+    class: part
+    shape: cylinder
+    color: yellow
+    material: plastic
+    frame: world
+    dimensions: [0.04, 0.04, 0.06]
+    pose_xyz: [0.45, 0.0, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+task:
+  id: shape_sorting_task
+  type: sort_by_shape
+  source_object: detected_object
+  destinations:
+    - id: box_bin
+      frame: world
+      pose_xyz: [0.35, -0.20, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+    - id: cylinder_bin
+      frame: world
+      pose_xyz: [0.35, 0.20, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+    - id: reject_bin
+      frame: world
+      pose_xyz: [0.20, 0.0, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: box_to_box_bin
+      when:
+        shape: box
+      destination: box_bin
+    - id: cylinder_to_cylinder_bin
+      when:
+        shape: cylinder
+      destination: cylinder_bin
+    - id: fallback
+      when:
+        always: true
+      destination: reject_bin
+commissioning:
+  self_test_enabled: true
+  export_bundle: true
+  require_operator_review: true

--- a/tests/test_cell_definition_tools.py
+++ b/tests/test_cell_definition_tools.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Tests for Cell Definition v1 validation and preview tooling."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = REPO_ROOT / "tests" / "fixtures"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+validator = _load_module("validate_cell_definition", REPO_ROOT / "scripts" / "validate_cell_definition.py")
+generator = _load_module(
+    "generate_scene_from_cell_definition", REPO_ROOT / "scripts" / "generate_scene_from_cell_definition.py"
+)
+scene_contract_validator = _load_module("validate_scene_contract", REPO_ROOT / "scripts" / "validate_scene_contract.py")
+
+
+class CellDefinitionValidationTests(unittest.TestCase):
+    def _validate_fixture(self, fixture_name: str):
+        fixture = FIXTURES / fixture_name
+        loaded, parser, notes = validator.load_yaml(fixture)
+        return validator.validate_cell_definition(loaded, fixture, parser, notes)
+
+    def test_valid_pick_place_cell_definition_passes(self) -> None:
+        summary = self._validate_fixture("cell_definition_pick_place.yaml")
+        self.assertTrue(summary.ok)
+
+    def test_valid_sort_by_colour_cell_definition_passes(self) -> None:
+        summary = self._validate_fixture("cell_definition_sort_by_colour.yaml")
+        self.assertTrue(summary.ok)
+
+    def test_valid_sort_by_shape_cell_definition_passes(self) -> None:
+        summary = self._validate_fixture("cell_definition_sort_by_shape.yaml")
+        self.assertTrue(summary.ok)
+
+    def test_valid_garbage_sorting_cell_definition_passes(self) -> None:
+        summary = self._validate_fixture("cell_definition_garbage_sorting.yaml")
+        self.assertTrue(summary.ok)
+
+    def test_missing_safe_joint_state_fails(self) -> None:
+        loaded, parser, notes = validator.load_yaml(FIXTURES / "cell_definition_pick_place.yaml")
+        del loaded["robot"]["safe_joint_state"]
+        summary = validator.validate_cell_definition(loaded, FIXTURES / "cell_definition_pick_place.yaml", parser, notes)
+        self.assertFalse(summary.ok)
+        self.assertIn("safe_joint_state", " ".join(summary.errors))
+
+    def test_empty_safe_joint_state_passes_when_home_named_target_exists(self) -> None:
+        loaded, parser, notes = validator.load_yaml(FIXTURES / "cell_definition_pick_place.yaml")
+        loaded["robot"]["safe_joint_state"] = []
+        loaded["robot"]["home_named_target"] = "home"
+        summary = validator.validate_cell_definition(loaded, FIXTURES / "cell_definition_pick_place.yaml", parser, notes)
+        self.assertTrue(summary.ok)
+
+    def test_invalid_pose_length_fails(self) -> None:
+        loaded, parser, notes = validator.load_yaml(FIXTURES / "cell_definition_pick_place.yaml")
+        loaded["objects"][0]["pose_xyz"] = [0.0, 0.0]
+        summary = validator.validate_cell_definition(loaded, FIXTURES / "cell_definition_pick_place.yaml", parser, notes)
+        self.assertFalse(summary.ok)
+        self.assertIn("pose_xyz", " ".join(summary.errors))
+
+    def test_destination_reference_to_missing_destination_fails(self) -> None:
+        loaded, parser, notes = validator.load_yaml(FIXTURES / "cell_definition_sort_by_colour.yaml")
+        loaded["task"]["rules"][0]["destination"] = "ghost_bin"
+        summary = validator.validate_cell_definition(loaded, FIXTURES / "cell_definition_sort_by_colour.yaml", parser, notes)
+        self.assertFalse(summary.ok)
+        self.assertIn("ghost_bin", " ".join(summary.errors))
+
+
+class CellDefinitionGenerationTests(unittest.TestCase):
+    def test_generated_preview_files_exist_and_scene_contract_check_is_practical(self) -> None:
+        loaded, parser, notes = validator.load_yaml(FIXTURES / "cell_definition_sort_by_colour.yaml")
+        summary = validator.validate_cell_definition(
+            loaded, FIXTURES / "cell_definition_sort_by_colour.yaml", parser, notes
+        )
+        self.assertTrue(summary.ok)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            scene_manifest = generator.build_scene_manifest(loaded)
+            task_recipe = generator.build_task_recipe(loaded)
+            (output_dir / "scene_manifest.preview.yaml").write_text(
+                generator._to_yaml_text(scene_manifest), encoding="utf-8"
+            )
+            (output_dir / "task_recipe.preview.yaml").write_text(
+                generator._to_yaml_text(task_recipe), encoding="utf-8"
+            )
+            (output_dir / "commissioning_summary.md").write_text(
+                generator.build_commissioning_summary(loaded, summary.warnings), encoding="utf-8"
+            )
+
+            self.assertTrue((output_dir / "scene_manifest.preview.yaml").is_file())
+            self.assertTrue((output_dir / "task_recipe.preview.yaml").is_file())
+            self.assertTrue((output_dir / "commissioning_summary.md").is_file())
+
+            parsed_scene, parser_name, parser_notes = scene_contract_validator._read_manifest(
+                str(output_dir / "scene_manifest.preview.yaml")
+            )
+            status, notes = scene_contract_validator.validate_task_recipe_block(parsed_scene)
+            self.assertIn(status, {"PASS", "WARN"})
+            self.assertTrue(parser_name in {"pyyaml", "fallback"})
+            self.assertTrue(isinstance(parser_notes + notes, list))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide a single high-level YAML contract (`schema_version: cell_definition/v1`) to describe a robotic cell for offline generation, validation, commissioning documentation, and future `workcell_builder` integration. 
- Enable an operator-friendly, repeatable offline workflow to validate a cell definition, preview a scene and task recipe, and produce an operator commissioning summary without changing any runtime execution components.

### Description

- Add a dependency-light validator `scripts/validate_cell_definition.py` that accepts PyYAML or a built-in fallback parser and enforces required top-level keys, numeric pose/dimension checks, `robot.safe_joint_state` rules, task/destination/rule consistency, and PASS/WARN/FAIL semantics. 
- Add a preview generator `scripts/generate_scene_from_cell_definition.py` that maps cell definitions into `scene_manifest.preview.yaml`, `task_recipe.preview.yaml`, and `commissioning_summary.md`, including rule normalization for offline task recipe previews. 
- Add `scripts/check_cell_definitions.sh` to batch-validate fixtures and generate previews, integrate these checks into `scripts/preflight_workcell.sh`, and introduce new documentation `docs/manuals/CELL_DEFINITION_V1.md` plus README/`WORKCELL_OPERATOR_MANUAL.md` updates describing the offline workflow. 
- Add fixtures and tests: four fixture YAMLs under `tests/fixtures/` (pick/place, colour/shape/garbage sorting) and `tests/test_cell_definition_tools.py` unit tests covering validation rules and preview generation contract checks. 

### Testing

- Compiled the new Python modules with `python3 -m py_compile scripts/validate_cell_definition.py scripts/generate_scene_from_cell_definition.py tests/test_cell_definition_tools.py` which succeeded. 
- Ran unit tests with `python3 -m unittest tests/test_cell_definition_tools.py` and received `OK` for all tests. 
- Checked shell script syntax with `bash -n scripts/check_cell_definitions.sh scripts/preflight_workcell.sh` which returned clean. 
- Executed `./scripts/check_cell_definitions.sh` to validate all fixtures, generate preview artifacts, and run practical scene/task contract checks, which completed reporting `Cell definition checks: PASS` and produced the expected preview files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef922247308331b4297955b56b23fb)