### PR TITLE
Add offline workcell package generation from Cell Definition YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,26 @@ This package is offline-only and **not** a safety certificate. It does **not** p
 ./scripts/preflight_workcell.sh
 ```
 
+
+### Generate a workcell package from a cell definition
+
+Generate a reviewable ROS 2 scene package from a high-level cell definition:
+
+```bash
+python3 scripts/generate_workcell_from_cell_definition.py   tests/fixtures/cell_definition_sort_by_colour.yaml   --output-dir /tmp/generated_workcells   --package-name generated_colour_sorting_cell   --force
+
+python3 scripts/validate_scene_contract.py generated_colour_sorting_cell
+./scripts/check_generated_workcells.sh
+```
+
+Generated package contents include:
+- `package.xml`, `CMakeLists.txt`
+- `scene_manifest.yaml` and `workcell.yaml`
+- `README.md`
+- generated previews/reports under `generated/`
+
+Safety note: generated package metadata is for offline review and commissioning only. It is not proof of physical reachability, collision-free runtime behavior, or machine safety certification.
+
 ### Generated scenes from workcell_builder
 
 New scenes generated from `workcell_builder` now include commissioning-oriented contract defaults in `scene_manifest.yaml` (or `workcell.yaml`): `self_test`, `task_recipe`, and `home_return` metadata blocks plus explicit `home_return.safe_joint_state` (empty list allowed when a named target is provided). These defaults are designed for offline validation/export workflows first, and are intended to be edited/tuned per cell before runtime use.

--- a/docs/manuals/CELL_DEFINITION_V1.md
+++ b/docs/manuals/CELL_DEFINITION_V1.md
@@ -105,3 +105,25 @@ This runs validation and preview generation for all `tests/fixtures/cell_definit
 - Not proof of robot reachability.
 - Not proof of collision-free execution.
 - Generated outputs must be engineering-reviewed before runtime use.
+
+
+## Generate a workcell package from a cell definition
+
+```bash
+python3 scripts/generate_workcell_from_cell_definition.py   tests/fixtures/cell_definition_sort_by_colour.yaml   --output-dir /tmp/generated_workcells   --package-name generated_colour_sorting_cell   --force
+
+python3 scripts/validate_scene_contract.py generated_colour_sorting_cell
+./scripts/check_generated_workcells.sh
+```
+
+Generated package folder (example):
+
+- `/tmp/generated_workcells/generated_colour_sorting_cell/package.xml`
+- `/tmp/generated_workcells/generated_colour_sorting_cell/CMakeLists.txt`
+- `/tmp/generated_workcells/generated_colour_sorting_cell/scene_manifest.yaml`
+- `/tmp/generated_workcells/generated_colour_sorting_cell/workcell.yaml`
+- `/tmp/generated_workcells/generated_colour_sorting_cell/README.md`
+- `/tmp/generated_workcells/generated_colour_sorting_cell/generated/commissioning_summary.md`
+- `/tmp/generated_workcells/generated_colour_sorting_cell/generated/validation_report.md`
+
+Safety note: generated package is for offline review and commissioning preparation. It is not proof of physical reachability, collision-free runtime behavior, or machine safety compliance.

--- a/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
+++ b/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
@@ -167,6 +167,24 @@ See `docs/manuals/CELL_DEFINITION_V1.md` for schema details and limitations.
 
 ---
 
+
+## D2) Generate a workcell package from a cell definition
+
+Use this offline command to turn one cell definition into a reviewable ROS 2 package skeleton:
+
+```bash
+python3 scripts/generate_workcell_from_cell_definition.py   tests/fixtures/cell_definition_sort_by_colour.yaml   --output-dir /tmp/generated_workcells   --package-name generated_colour_sorting_cell   --force
+
+python3 scripts/validate_scene_contract.py generated_colour_sorting_cell
+./scripts/check_generated_workcells.sh
+```
+
+Generated package includes `scene_manifest.yaml`, `workcell.yaml`, `README.md`, and generated commissioning artifacts.
+
+Safety note: generated package is not proof of physical reachability or machine safety.
+
+---
+
 ## E) Launch known-good scene
 
 Known-good execution launch command:

--- a/scripts/check_generated_workcells.sh
+++ b/scripts/check_generated_workcells.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+GENERATOR="${SCRIPT_DIR}/generate_workcell_from_cell_definition.py"
+FIXTURE_GLOB="${REPO_ROOT}/tests/fixtures/cell_definition_*.yaml"
+
+if [[ ! -x "${GENERATOR}" ]]; then
+  echo "FAIL: missing generator script at ${GENERATOR}" >&2
+  exit 2
+fi
+
+shopt -s nullglob
+fixtures=( ${FIXTURE_GLOB} )
+shopt -u nullglob
+
+if [[ ${#fixtures[@]} -eq 0 ]]; then
+  echo "WARN: no cell definition fixtures found under tests/fixtures"
+  echo "Generated workcell checks: WARN"
+  exit 0
+fi
+
+tmp_root="$(mktemp -d /tmp/generated_workcells_check.XXXXXX)"
+trap 'rm -rf "${tmp_root}"' EXIT
+
+echo "Generated workcell check temp dir: ${tmp_root}"
+
+pass_count=0
+warn_count=0
+fail_count=0
+
+for fixture in "${fixtures[@]}"; do
+  base_name="$(basename "${fixture}" .yaml)"
+  package_name="generated_${base_name}"
+
+  echo "--- ${base_name} ---"
+
+  set +e
+  gen_output="$(python3 "${GENERATOR}" "${fixture}" --output-dir "${tmp_root}" --package-name "${package_name}" --force 2>&1)"
+  gen_code=$?
+  set -e
+  echo "${gen_output}"
+
+  if [[ ${gen_code} -ne 0 ]]; then
+    echo "FAIL ${base_name}: generation failed"
+    fail_count=$((fail_count + 1))
+    continue
+  fi
+
+  if grep -q '^WARN:' <<<"${gen_output}"; then
+    warn_count=$((warn_count + 1))
+  else
+    pass_count=$((pass_count + 1))
+  fi
+
+  pkg_dir="${tmp_root}/${package_name}"
+  manifest_path="${pkg_dir}/scene_manifest.yaml"
+
+  for required in package.xml CMakeLists.txt scene_manifest.yaml README.md generated/commissioning_summary.md generated/validation_report.md; do
+    if [[ ! -f "${pkg_dir}/${required}" ]]; then
+      echo "FAIL ${base_name}: missing generated file ${required}"
+      fail_count=$((fail_count + 1))
+    fi
+  done
+
+  set +e
+  validate_output="$(python3 - <<'PY' "${REPO_ROOT}" "${manifest_path}" "${base_name}"
+import importlib.util
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1])
+manifest_path = Path(sys.argv[2])
+scene_name = sys.argv[3]
+
+validator_spec = importlib.util.spec_from_file_location("validate_scene_contract", repo_root / "scripts" / "validate_scene_contract.py")
+validator = importlib.util.module_from_spec(validator_spec)
+sys.modules["validate_scene_contract"] = validator
+validator_spec.loader.exec_module(validator)
+
+manifest, parser, notes = validator._read_manifest(str(manifest_path))
+status, task_notes = validator.validate_task_recipe_block(manifest)
+print(f"validate_scene_contract(practical): scene={scene_name} parser={parser} status={status}")
+for note in notes + task_notes:
+    print(f"NOTE: {note}")
+raise SystemExit(0 if status in {"PASS", "WARN"} else 1)
+PY
+2>&1)"
+  validate_code=$?
+  set -e
+  echo "${validate_output}"
+  if [[ ${validate_code} -ne 0 ]]; then
+    echo "FAIL ${base_name}: practical scene contract validation failed"
+    fail_count=$((fail_count + 1))
+  elif grep -q 'status=WARN' <<<"${validate_output}"; then
+    warn_count=$((warn_count + 1))
+  fi
+
+  set +e
+  dry_output="$(python3 - <<'PY' "${REPO_ROOT}" "${manifest_path}" "${base_name}"
+import importlib.util
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1])
+manifest_path = Path(sys.argv[2])
+scene_name = sys.argv[3]
+
+spec = importlib.util.spec_from_file_location("dry_run_task_recipe", repo_root / "scripts" / "dry_run_task_recipe.py")
+module = importlib.util.module_from_spec(spec)
+sys.modules["dry_run_task_recipe"] = module
+spec.loader.exec_module(module)
+row = module.evaluate_scene(scene_name, manifest_path)
+print(f"dry_run_task_recipe(practical): scene={scene_name} status={row.status} rule={row.matched_rule_id} destination={row.selected_destination_id}")
+for note in row.notes:
+    print(f"NOTE: {note}")
+raise SystemExit(0 if row.status in {"PASS", "WARN", "SKIP"} else 1)
+PY
+2>&1)"
+  dry_code=$?
+  set -e
+  echo "${dry_output}"
+  if [[ ${dry_code} -ne 0 ]]; then
+    echo "FAIL ${base_name}: dry-run failed"
+    fail_count=$((fail_count + 1))
+  elif grep -q 'status=WARN\|status=SKIP' <<<"${dry_output}"; then
+    warn_count=$((warn_count + 1))
+  fi
+
+  set +e
+  plan_output="$(python3 - <<'PY' "${REPO_ROOT}" "${manifest_path}" "${base_name}" "${pkg_dir}/generated"
+import importlib.util
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1])
+manifest_path = Path(sys.argv[2])
+scene_name = sys.argv[3]
+out_dir = Path(sys.argv[4])
+out_dir.mkdir(parents=True, exist_ok=True)
+
+spec = importlib.util.spec_from_file_location("generate_task_execution_plan", repo_root / "scripts" / "generate_task_execution_plan.py")
+module = importlib.util.module_from_spec(spec)
+sys.modules["generate_task_execution_plan"] = module
+spec.loader.exec_module(module)
+original = module.OUTPUT_DIR
+module.OUTPUT_DIR = out_dir
+try:
+    row = module.evaluate_scene(scene_name, manifest_path)
+finally:
+    module.OUTPUT_DIR = original
+print(f"generate_task_execution_plan(practical): scene={scene_name} status={row.status} steps={row.steps_count}")
+for note in row.notes:
+    print(f"NOTE: {note}")
+raise SystemExit(0 if row.status in {"PASS", "WARN", "SKIP"} else 1)
+PY
+2>&1)"
+  plan_code=$?
+  set -e
+  echo "${plan_output}"
+  if [[ ${plan_code} -ne 0 ]]; then
+    echo "FAIL ${base_name}: execution plan generation failed"
+    fail_count=$((fail_count + 1))
+  elif grep -q 'status=WARN\|status=SKIP' <<<"${plan_output}"; then
+    warn_count=$((warn_count + 1))
+  fi
+
+  set +e
+  bundle_output="$(python3 - <<'PY' "${REPO_ROOT}" "${manifest_path}" "${base_name}" "${pkg_dir}/generated"
+import importlib.util
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1])
+manifest_path = Path(sys.argv[2])
+scene_name = sys.argv[3]
+out_dir = Path(sys.argv[4]) / "bundle"
+out_dir.mkdir(parents=True, exist_ok=True)
+
+spec = importlib.util.spec_from_file_location("export_workcell_bundle", repo_root / "scripts" / "export_workcell_bundle.py")
+module = importlib.util.module_from_spec(spec)
+sys.modules["export_workcell_bundle"] = module
+spec.loader.exec_module(module)
+
+orig_reports = module.REPORTS_DIR
+orig_plan_dir = module.PLAN_OUTPUT_DIR
+orig_default = module.DEFAULT_OUTPUT_DIR
+orig_plan_generator_out = module.plan_generator.OUTPUT_DIR
+module.REPORTS_DIR = out_dir
+module.PLAN_OUTPUT_DIR = out_dir
+module.DEFAULT_OUTPUT_DIR = out_dir
+module.plan_generator.OUTPUT_DIR = out_dir
+try:
+    bundle_dir, _ = module.export_scene(scene_name, manifest_path, out_dir, zip_output=False, force=True)
+finally:
+    module.REPORTS_DIR = orig_reports
+    module.PLAN_OUTPUT_DIR = orig_plan_dir
+    module.DEFAULT_OUTPUT_DIR = orig_default
+    module.plan_generator.OUTPUT_DIR = orig_plan_generator_out
+print(f"export_workcell_bundle(practical): scene={scene_name} bundle={bundle_dir}")
+raise SystemExit(0)
+PY
+2>&1)"
+  bundle_code=$?
+  set -e
+  echo "${bundle_output}"
+  if [[ ${bundle_code} -ne 0 ]]; then
+    echo "WARN ${base_name}: bundle export skipped or failed practically"
+    warn_count=$((warn_count + 1))
+  fi
+
+done
+
+status="PASS"
+if [[ ${fail_count} -ne 0 ]]; then
+  status="FAIL"
+elif [[ ${warn_count} -ne 0 ]]; then
+  status="WARN"
+fi
+
+echo "Generated workcell checks: ${status}"
+echo "Summary: PASS=${pass_count} WARN=${warn_count} FAIL=${fail_count}"
+
+if [[ ${fail_count} -ne 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/generate_workcell_from_cell_definition.py
+++ b/scripts/generate_workcell_from_cell_definition.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Generate an offline-reviewable ROS 2 scene package from Cell Definition v1 YAML."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import importlib.util
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+VALIDATOR_PATH = SCRIPTS_DIR / "validate_cell_definition.py"
+SCENE_GENERATOR_PATH = SCRIPTS_DIR / "generate_scene_from_cell_definition.py"
+SCENE_CONTRACT_PATH = SCRIPTS_DIR / "validate_scene_contract.py"
+DRY_RUN_PATH = SCRIPTS_DIR / "dry_run_task_recipe.py"
+PLAN_PATH = SCRIPTS_DIR / "generate_task_execution_plan.py"
+BUNDLE_EXPORT_PATH = SCRIPTS_DIR / "export_workcell_bundle.py"
+TEMPLATE_DIR = REPO_ROOT / "workcell_builder" / "workcell_builder" / "templates" / "ros2" / "humble"
+
+SUPPORTED_TASK_TYPES = {
+    "pick_place",
+    "sort_by_colour",
+    "sort_by_shape",
+    "sort_by_class",
+    "garbage_sorting",
+    "inspection_then_place",
+    "custom",
+}
+
+
+def _load_module(module_name: str, module_path: Path):
+    if not module_path.is_file():
+        raise FileNotFoundError(f"Required helper script not found: {module_path}")
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if not spec or not spec.loader:
+        raise RuntimeError(f"Unable to load module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _yaml_text_from(scene_generator: Any, data: Any) -> str:
+    return str(scene_generator._to_yaml_text(data))
+
+
+def _header_yaml(cell_definition_path: Path) -> str:
+    return (
+        "# GENERATED FILE - DO NOT EDIT DIRECTLY\n"
+        f"# Generated from cell_definition YAML: {cell_definition_path}\n"
+    )
+
+
+def _header_markdown(cell_definition_path: Path) -> str:
+    return (
+        "<!-- GENERATED FILE - DO NOT EDIT DIRECTLY -->\n"
+        f"<!-- Generated from cell_definition YAML: {cell_definition_path} -->\n\n"
+    )
+
+
+def _normalize_task_recipe(task_recipe: dict[str, Any], warnings: list[str]) -> dict[str, Any]:
+    normalized = copy.deepcopy(task_recipe)
+    task_type = str(normalized.get("task_type", normalized.get("type", "custom")))
+    if task_type not in SUPPORTED_TASK_TYPES:
+        warnings.append(
+            f"Unknown task type '{task_type}' in cell definition; using conservative custom task metadata."
+        )
+        task_type = "custom"
+    normalized["task_type"] = task_type
+
+    rule_has_default = False
+    for rule in normalized.get("decision_rules", []):
+        if not isinstance(rule, dict):
+            continue
+        when = rule.get("when") if isinstance(rule.get("when"), dict) else {}
+        if when.get("default") is True or when.get("always") is True:
+            rule_has_default = True
+
+    destination_ids = [item.get("id") for item in normalized.get("destinations", []) if isinstance(item, dict)]
+    has_reject_destination = any(
+        isinstance(dest_id, str) and ("reject" in dest_id.lower() or "fallback" in dest_id.lower())
+        for dest_id in destination_ids
+    )
+
+    if not rule_has_default:
+        warnings.append("task_recipe has no explicit default/fallback decision rule.")
+    if not has_reject_destination:
+        warnings.append("task_recipe has no reject/fallback destination id; add one for robust routing.")
+
+    return normalized
+
+
+def _augment_scene_manifest(cell_def: dict[str, Any], scene_manifest: dict[str, Any], warnings: list[str]) -> dict[str, Any]:
+    out = copy.deepcopy(scene_manifest)
+    robot = cell_def.get("robot", {}) if isinstance(cell_def.get("robot"), dict) else {}
+    end_effector = cell_def.get("end_effector", {}) if isinstance(cell_def.get("end_effector"), dict) else {}
+    camera = cell_def.get("camera", {}) if isinstance(cell_def.get("camera"), dict) else {}
+
+    out.setdefault("schema_version", "1.0")
+    out.setdefault("generated_defaults", {})
+    if isinstance(out["generated_defaults"], dict):
+        out["generated_defaults"]["review_required"] = True
+        out["generated_defaults"]["notes"] = [
+            "Generated from Cell Definition v1 for offline review.",
+            "Review robot/EE/camera geometry and safety before runtime use.",
+        ]
+
+    if str(robot.get("model", "unknown")).strip().lower() in {"", "unknown"}:
+        warnings.append("Robot model is unknown; generated manifest uses conservative placeholder values.")
+    if str(end_effector.get("type", "unknown")).strip().lower() in {"", "unknown"}:
+        warnings.append("End-effector type is unknown; generated manifest uses conservative placeholder values.")
+
+    out["perception"] = {
+        "camera_id": camera.get("id", "unknown_camera"),
+        "camera_type": camera.get("type", "unknown"),
+        "camera_frame": camera.get("frame", "world"),
+        "input_frame_options": [
+            out.get("frames", {}).get("world", "world"),
+            out.get("robot", {}).get("base_frame", "world"),
+        ],
+    }
+
+    home_return = out.get("home_return")
+    if not isinstance(home_return, dict):
+        home_return = {}
+        out["home_return"] = home_return
+    home_return.setdefault("enabled", True)
+    home_return.setdefault("strategy", "named_target_or_safe_joint_state")
+    home_return.setdefault("named_target", robot.get("home_named_target", "home"))
+    if "safe_joint_state" not in home_return:
+        home_return["safe_joint_state"] = robot.get("safe_joint_state", [])
+
+    if not isinstance(home_return.get("safe_joint_state"), list):
+        warnings.append("home_return.safe_joint_state was not a list; replacing with empty list.")
+        home_return["safe_joint_state"] = []
+
+    if not home_return.get("safe_joint_state") and not str(home_return.get("named_target", "")).strip():
+        warnings.append(
+            "home_return.safe_joint_state is empty and no home_named_target was provided; update before runtime use."
+        )
+
+    return out
+
+
+def _render_package_xml(package_name: str) -> str:
+    template_path = TEMPLATE_DIR / "package_example.xml"
+    if template_path.is_file():
+        text = template_path.read_text(encoding="utf-8")
+        return text.replace("workcellexample", package_name)
+    return f"""<?xml version=\"1.0\"?>
+<package format=\"3\">
+  <name>{package_name}</name>
+  <version>0.1.0</version>
+  <description>Generated workcell package from Cell Definition.</description>
+  <maintainer email=\"noreply@example.com\">generated</maintainer>
+  <license>Apache-2.0</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <exec_depend>python3-yaml</exec_depend>
+  <export><build_type>ament_cmake</build_type></export>
+</package>
+"""
+
+
+def _render_cmakelists(package_name: str) -> str:
+    template_path = TEMPLATE_DIR / "CMakeLists_example.txt"
+    if template_path.is_file():
+        text = template_path.read_text(encoding="utf-8")
+        return text.replace("project(workcellexample)", f"project({package_name})")
+    return f"""cmake_minimum_required(VERSION 3.5)
+project({package_name})
+find_package(ament_cmake REQUIRED)
+install(DIRECTORY launch config urdf generated DESTINATION share/${{PROJECT_NAME}})
+ament_package()
+"""
+
+
+def _build_readme(cell_def: dict[str, Any], package_name: str, source_path: Path, warnings: list[str]) -> str:
+    cell = cell_def.get("cell", {}) if isinstance(cell_def.get("cell"), dict) else {}
+    robot = cell_def.get("robot", {}) if isinstance(cell_def.get("robot"), dict) else {}
+    end_effector = cell_def.get("end_effector", {}) if isinstance(cell_def.get("end_effector"), dict) else {}
+    camera = cell_def.get("camera", {}) if isinstance(cell_def.get("camera"), dict) else {}
+    task = cell_def.get("task", {}) if isinstance(cell_def.get("task"), dict) else {}
+
+    lines = [
+        f"# Generated Workcell Package: {package_name}",
+        "",
+        "This package was generated offline from a high-level cell definition YAML.",
+        "",
+        "## Metadata",
+        f"- Cell name/id: `{cell.get('name', '(unknown)')}` / `{cell.get('id', '(unknown)')}`",
+        f"- Generated package: `{package_name}`",
+        f"- Source cell definition: `{source_path}`",
+        f"- Robot: `{robot.get('model', '(unknown)')}`",
+        f"- End-effector: `{end_effector.get('id', '(unknown)')} ({end_effector.get('type', '(unknown)')})`",
+        f"- Camera: `{camera.get('id', '(unknown)')} ({camera.get('type', '(unknown)')})`",
+        f"- Task type: `{task.get('type', '(unknown)')}`",
+        "",
+        "## Offline checks",
+        f"- Validate scene contract: `python3 scripts/validate_scene_contract.py {package_name}`",
+        "- Dry-run task recipe (practical): `python3 scripts/dry_run_task_recipe.py --check`",
+        "- Generate execution plan: `python3 scripts/generate_task_execution_plan.py --check`",
+        "- Export commissioning bundle: `python3 scripts/export_workcell_bundle.py --force`",
+        "",
+        "## Generation warnings",
+    ]
+    if warnings:
+        lines.extend(f"- {warning}" for warning in warnings)
+    else:
+        lines.append("- None")
+
+    lines.extend(
+        [
+            "",
+            "## Safety note",
+            "Generated package content is not proof of physical reachability, collision-free motion,",
+            "or machine safety compliance. Review and commissioning sign-off are required.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _write_validation_report(report_path: Path, manifest: dict[str, Any], scene_contract: Any, dry_result: Any) -> None:
+    task_status, task_notes = scene_contract.validate_task_recipe_block(manifest)
+    lines = [
+        "# Generated Scene Validation Report",
+        "",
+        f"- Task recipe contract status: **{task_status}**",
+        f"- Dry-run status: **{dry_result.status}**",
+        f"- Dry-run matched rule: `{dry_result.matched_rule_id}`",
+        f"- Dry-run selected destination: `{dry_result.selected_destination_id}`",
+        "",
+        "## Notes",
+    ]
+    for note in list(task_notes) + list(dry_result.notes):
+        lines.append(f"- {note}")
+    if len(lines) == 8:
+        lines.append("- None")
+    lines.append("")
+    report_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _run_optional_bundle_export(
+    bundle_exporter: Any,
+    package_name: str,
+    manifest_path: Path,
+    generated_dir: Path,
+    warnings: list[str],
+) -> None:
+    try:
+        bundle_root = generated_dir / "bundle"
+        bundle_exporter.export_scene(package_name, manifest_path, bundle_root, zip_output=False, force=True)
+    except Exception as exc:  # pragma: no cover - environment dependent
+        warnings.append(f"Optional commissioning bundle export skipped: {exc}")
+
+
+def generate_package(
+    cell_definition_path: Path,
+    output_dir: Path,
+    package_name: str,
+    force: bool,
+    dry_run: bool,
+) -> int:
+    if not VALIDATOR_PATH.is_file():
+        print(f"FAIL: Missing required validation tool: {VALIDATOR_PATH}")
+        return 2
+
+    try:
+        cell_validator = _load_module("generated_cell_definition_validator", VALIDATOR_PATH)
+        scene_generator = _load_module("generated_scene_preview_builder", SCENE_GENERATOR_PATH)
+        scene_contract = _load_module("generated_scene_contract_validator", SCENE_CONTRACT_PATH)
+        dry_runner = _load_module("generated_task_recipe_dry_run", DRY_RUN_PATH)
+        plan_generator = _load_module("generated_task_plan_generator", PLAN_PATH)
+        bundle_exporter = _load_module("generated_bundle_exporter", BUNDLE_EXPORT_PATH)
+    except Exception as exc:
+        print(f"FAIL: Unable to load helper tooling: {exc}")
+        return 2
+
+    try:
+        loaded, parser_name, parser_notes = cell_validator.load_yaml(cell_definition_path)
+    except Exception as exc:
+        print(f"FAIL: Unable to load cell definition: {exc}")
+        return 1
+
+    summary = cell_validator.validate_cell_definition(loaded, cell_definition_path, parser_name, parser_notes)
+    warnings = list(summary.warnings)
+    if not summary.ok:
+        print("FAIL: Cell definition failed validation.")
+        for error in summary.errors:
+            print(f" - {error}")
+        return 1
+
+    scene_manifest = _augment_scene_manifest(loaded, scene_generator.build_scene_manifest(loaded), warnings)
+    task_recipe = _normalize_task_recipe(scene_generator.build_task_recipe(loaded), warnings)
+    scene_manifest["task_recipe"] = task_recipe
+
+    package_dir = output_dir / package_name
+    if package_dir.exists() and not force:
+        print(f"FAIL: Output package already exists: {package_dir} (use --force to overwrite)")
+        return 1
+
+    if dry_run:
+        print(f"PASS: dry-run successful for package '{package_name}'")
+        print(f"WARN count: {len(warnings)}")
+        for warning in warnings:
+            print(f"WARN: {warning}")
+        print(f"Would write package to: {package_dir}")
+        return 0
+
+    if package_dir.exists():
+        shutil.rmtree(package_dir)
+
+    (package_dir / "config").mkdir(parents=True, exist_ok=True)
+    (package_dir / "launch").mkdir(parents=True, exist_ok=True)
+    (package_dir / "urdf").mkdir(parents=True, exist_ok=True)
+    (package_dir / "generated").mkdir(parents=True, exist_ok=True)
+
+    scene_manifest_path = package_dir / "scene_manifest.yaml"
+    workcell_yaml_path = package_dir / "workcell.yaml"
+    task_recipe_path = package_dir / "config" / "task_recipe.yaml"
+
+    scene_manifest_text = _header_yaml(cell_definition_path) + _yaml_text_from(scene_generator, scene_manifest)
+    task_recipe_text = _header_yaml(cell_definition_path) + _yaml_text_from(scene_generator, task_recipe)
+
+    (package_dir / "package.xml").write_text(_render_package_xml(package_name), encoding="utf-8")
+    (package_dir / "CMakeLists.txt").write_text(_render_cmakelists(package_name), encoding="utf-8")
+    scene_manifest_path.write_text(scene_manifest_text, encoding="utf-8")
+    workcell_yaml_path.write_text(scene_manifest_text, encoding="utf-8")
+    task_recipe_path.write_text(task_recipe_text, encoding="utf-8")
+    (package_dir / "generated" / "task_recipe.preview.yaml").write_text(task_recipe_text, encoding="utf-8")
+    (package_dir / "generated" / "scene_manifest.preview.yaml").write_text(scene_manifest_text, encoding="utf-8")
+
+    (package_dir / "README.md").write_text(
+        _header_markdown(cell_definition_path)
+        + _build_readme(loaded, package_name, cell_definition_path, warnings),
+        encoding="utf-8",
+    )
+
+    commissioning_summary = scene_generator.build_commissioning_summary(loaded, warnings)
+    (package_dir / "generated" / "commissioning_summary.md").write_text(
+        _header_markdown(cell_definition_path) + commissioning_summary,
+        encoding="utf-8",
+    )
+
+    (package_dir / "launch" / "README.md").write_text(
+        _header_markdown(cell_definition_path)
+        + "# Launch placeholders\n\nGenerated package placeholder. Reuse validated scene launch assets after review.\n",
+        encoding="utf-8",
+    )
+    (package_dir / "urdf" / "README.md").write_text(
+        _header_markdown(cell_definition_path)
+        + "# URDF placeholders\n\nReview and connect approved robot/environment geometry assets manually.\n",
+        encoding="utf-8",
+    )
+
+    dry_result = dry_runner.evaluate_scene(package_name, scene_manifest_path)
+
+    with tempfile.TemporaryDirectory(prefix="generated_workcell_plan_") as tmp_plan_dir:
+        original_plan_dir = plan_generator.OUTPUT_DIR
+        plan_generator.OUTPUT_DIR = Path(tmp_plan_dir)
+        try:
+            plan_result = plan_generator.evaluate_scene(package_name, scene_manifest_path)
+            if plan_result.status == "PASS" and plan_result.markdown_path and plan_result.json_path:
+                shutil.copy2(plan_result.markdown_path, package_dir / "generated" / "execution_plan.md")
+                shutil.copy2(plan_result.json_path, package_dir / "generated" / "execution_plan.json")
+            else:
+                warnings.append(f"Execution plan generation status: {plan_result.status}")
+        finally:
+            plan_generator.OUTPUT_DIR = original_plan_dir
+
+    _write_validation_report(package_dir / "generated" / "validation_report.md", scene_manifest, scene_contract, dry_result)
+
+    commissioning = loaded.get("commissioning", {}) if isinstance(loaded.get("commissioning"), dict) else {}
+    if bool(commissioning.get("export_bundle", False)):
+        _run_optional_bundle_export(bundle_exporter, package_name, scene_manifest_path, package_dir / "generated", warnings)
+
+    status = "PASS" if not warnings else "WARN"
+    print(f"{status}: generated package at {package_dir}")
+    print(f"PASS: package.xml -> {package_dir / 'package.xml'}")
+    print(f"PASS: scene_manifest.yaml -> {scene_manifest_path}")
+    print(f"PASS: README.md -> {package_dir / 'README.md'}")
+    print(f"PASS: commissioning_summary -> {package_dir / 'generated' / 'commissioning_summary.md'}")
+    print(f"PASS: validation_report -> {package_dir / 'generated' / 'validation_report.md'}")
+    for warning in warnings:
+        print(f"WARN: {warning}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("cell_definition", type=Path, help="Path to Cell Definition v1 YAML")
+    parser.add_argument("--output-dir", type=Path, required=True, help="Directory where package folder is generated")
+    parser.add_argument("--package-name", type=str, required=True, help="Output ROS package name")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing generated package directory")
+    parser.add_argument("--dry-run", action="store_true", help="Validate and preview actions without writing files")
+    args = parser.parse_args()
+
+    return generate_package(
+        cell_definition_path=args.cell_definition.resolve(),
+        output_dir=args.output_dir.resolve(),
+        package_name=args.package_name.strip(),
+        force=args.force,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preflight_workcell.sh
+++ b/scripts/preflight_workcell.sh
@@ -61,6 +61,7 @@ echo
 "${SCRIPT_DIR}/check_task_execution_plans.sh"
 "${SCRIPT_DIR}/generate_task_execution_plan_report.py"
 "${SCRIPT_DIR}/check_workcell_bundles.sh"
+"${SCRIPT_DIR}/check_generated_workcells.sh"
 set +e
 CELL_DEF_OUTPUT="$(${SCRIPT_DIR}/check_cell_definitions.sh)"
 CELL_DEF_EXIT=$?

--- a/tests/test_cell_definition_tools.py
+++ b/tests/test_cell_definition_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for Cell Definition v1 validation and preview tooling."""
+"""Tests for Cell Definition v1 validation and preview/tooling workflows."""
 
 from __future__ import annotations
 
@@ -27,6 +27,9 @@ generator = _load_module(
     "generate_scene_from_cell_definition", REPO_ROOT / "scripts" / "generate_scene_from_cell_definition.py"
 )
 scene_contract_validator = _load_module("validate_scene_contract", REPO_ROOT / "scripts" / "validate_scene_contract.py")
+workcell_generator = _load_module(
+    "generate_workcell_from_cell_definition", REPO_ROOT / "scripts" / "generate_workcell_from_cell_definition.py"
+)
 
 
 class CellDefinitionValidationTests(unittest.TestCase):
@@ -113,6 +116,118 @@ class CellDefinitionGenerationTests(unittest.TestCase):
             self.assertIn(status, {"PASS", "WARN"})
             self.assertTrue(parser_name in {"pyyaml", "fallback"})
             self.assertTrue(isinstance(parser_notes + notes, list))
+
+
+class WorkcellPackageGenerationTests(unittest.TestCase):
+    def _assert_generate_fixture(self, fixture_name: str, package_name: str) -> Path:
+        fixture = FIXTURES / fixture_name
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            rc = workcell_generator.generate_package(
+                cell_definition_path=fixture,
+                output_dir=tmp_path,
+                package_name=package_name,
+                force=False,
+                dry_run=False,
+            )
+            self.assertEqual(rc, 0)
+            package_dir = tmp_path / package_name
+            self.assertTrue((package_dir / "package.xml").is_file())
+            self.assertTrue((package_dir / "CMakeLists.txt").is_file())
+            self.assertTrue((package_dir / "scene_manifest.yaml").is_file())
+            self.assertTrue((package_dir / "README.md").is_file())
+
+            parsed_manifest, _, _ = scene_contract_validator._read_manifest(str(package_dir / "scene_manifest.yaml"))
+            self.assertIn("self_test", parsed_manifest)
+            self.assertIn("task_recipe", parsed_manifest)
+            self.assertIn("home_return", parsed_manifest)
+            self.assertIn("safe_joint_state", parsed_manifest["home_return"])
+            return package_dir
+
+    def test_pick_place_generates_package(self) -> None:
+        self._assert_generate_fixture("cell_definition_pick_place.yaml", "generated_pick_place")
+
+    def test_sort_by_colour_generates_package(self) -> None:
+        self._assert_generate_fixture("cell_definition_sort_by_colour.yaml", "generated_sort_colour")
+
+    def test_sort_by_shape_generates_package(self) -> None:
+        self._assert_generate_fixture("cell_definition_sort_by_shape.yaml", "generated_sort_shape")
+
+    def test_garbage_sorting_generates_package(self) -> None:
+        self._assert_generate_fixture("cell_definition_garbage_sorting.yaml", "generated_garbage_sort")
+
+    def test_dry_run_does_not_write_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            rc = workcell_generator.generate_package(
+                cell_definition_path=FIXTURES / "cell_definition_sort_by_colour.yaml",
+                output_dir=tmp_path,
+                package_name="generated_dry_run",
+                force=False,
+                dry_run=True,
+            )
+            self.assertEqual(rc, 0)
+            self.assertFalse((tmp_path / "generated_dry_run").exists())
+
+    def test_existing_output_without_force_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            pkg = tmp_path / "generated_exists"
+            pkg.mkdir(parents=True, exist_ok=True)
+            rc = workcell_generator.generate_package(
+                cell_definition_path=FIXTURES / "cell_definition_sort_by_colour.yaml",
+                output_dir=tmp_path,
+                package_name="generated_exists",
+                force=False,
+                dry_run=False,
+            )
+            self.assertNotEqual(rc, 0)
+
+    def test_force_overwrites_generated_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            pkg = tmp_path / "generated_force"
+            pkg.mkdir(parents=True, exist_ok=True)
+            (pkg / "README.md").write_text("old", encoding="utf-8")
+            rc = workcell_generator.generate_package(
+                cell_definition_path=FIXTURES / "cell_definition_sort_by_colour.yaml",
+                output_dir=tmp_path,
+                package_name="generated_force",
+                force=True,
+                dry_run=False,
+            )
+            self.assertEqual(rc, 0)
+            self.assertNotEqual((pkg / "README.md").read_text(encoding="utf-8"), "old")
+
+    def test_invalid_cell_definition_fails_clearly(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            invalid_path = tmp_path / "invalid.yaml"
+            invalid_path.write_text("schema_version: cell_definition/v1\ncell: {}\n", encoding="utf-8")
+            rc = workcell_generator.generate_package(
+                cell_definition_path=invalid_path,
+                output_dir=tmp_path,
+                package_name="generated_invalid",
+                force=False,
+                dry_run=False,
+            )
+            self.assertNotEqual(rc, 0)
+
+    def test_generated_package_offline_validation_is_practical(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            rc = workcell_generator.generate_package(
+                cell_definition_path=FIXTURES / "cell_definition_sort_by_colour.yaml",
+                output_dir=tmp_path,
+                package_name="generated_validation",
+                force=False,
+                dry_run=False,
+            )
+            self.assertEqual(rc, 0)
+            manifest_path = tmp_path / "generated_validation" / "scene_manifest.yaml"
+            manifest, _, _ = scene_contract_validator._read_manifest(str(manifest_path))
+            status, _ = scene_contract_validator.validate_task_recipe_block(manifest)
+            self.assertIn(status, {"PASS", "WARN"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Provide an offline, deterministic step that converts a high-level `cell_definition/v1` YAML into a reviewable ROS 2 scene package suitable for commissioning review and later import into `workcell_builder` flows. 
- Reuse existing validators and preview builders so generated packages follow the existing scene manifest/task_recipe contract and can be validated/exported by offline tooling. 
- Keep all changes tooling/docs/tests-only and conservative: do not change runtime execution, perception, planning, controllers, or launch behavior.

### Description

- Add `scripts/generate_workcell_from_cell_definition.py` which builds a deterministic ROS 2 package skeleton (writes `package.xml`, `CMakeLists.txt`, `scene_manifest.yaml`, `workcell.yaml`, `README.md`, plus `generated/` previews and reports) and supports `--output-dir`, `--package-name`, `--force`, and `--dry-run` options. 
- Add `scripts/check_generated_workcells.sh` to batch-generate packages for all `tests/fixtures/cell_definition_*.yaml` and run practical offline checks (scene contract validation, dry-run, execution plan generation, optional bundle export) with PASS/WARN/FAIL summary behavior. 
- Integrate the generated-workcell check into `scripts/preflight_workcell.sh` as an offline validation stage while preserving prior preflight behavior. 
- Extend `tests/test_cell_definition_tools.py` to cover generation: fixture-based generation for `pick_place`, `sort_by_colour`, `sort_by_shape`, and `garbage_sorting`, file presence checks, manifest block assertions (`self_test`, `task_recipe`, `home_return.safe_joint_state`), `--dry-run`, `--force` overwrite behavior, and invalid-input failure. 
- Update docs with a new "Generate a workcell package from a cell definition" section in `README.md`, `docs/manuals/WORKCELL_OPERATOR_MANUAL.md`, and `docs/manuals/CELL_DEFINITION_V1.md` and produce generated-file headers and conservative default/warning behavior (placeholder metadata, preserved `home_return.safe_joint_state`, and non-fatal WARNs for unknown values).

### Testing

- Run static compile checks with `python3 -m py_compile` for `scripts/generate_workcell_from_cell_definition.py`, `scripts/validate_cell_definition.py`, `scripts/generate_scene_from_cell_definition.py`, `tests/test_cell_definition_tools.py`, and `tests/test_scene_validation_tools.py`, and this succeeded. 
- Run unit tests with `python3 -m unittest tests/test_cell_definition_tools.py` (18 tests) and `python3 -m unittest tests/test_scene_validation_tools.py` (50 tests) and both test suites passed. 
- Shell checks with `bash -n` for `scripts/check_generated_workcells.sh` and `scripts/preflight_workcell.sh` succeeded, and `./scripts/check_generated_workcells.sh` was executed successfully producing practical checks; the run finished with overall summary `Generated workcell checks: WARN` and `Summary: PASS=3 WARN=1 FAIL=0` (warnings reflect conservative placeholder metadata, not generation failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc46182948331a59750a6a5717374)