### PR TITLE
Add offline validation for generated workcell packages and strengthen generator/checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Generate a reviewable ROS 2 scene package from a high-level cell definition:
 ```bash
 python3 scripts/generate_workcell_from_cell_definition.py   tests/fixtures/cell_definition_sort_by_colour.yaml   --output-dir /tmp/generated_workcells   --package-name generated_colour_sorting_cell   --force
 
-python3 scripts/validate_scene_contract.py generated_colour_sorting_cell
+python3 scripts/validate_scene_contract.py /tmp/generated_workcells/generated_colour_sorting_cell/scene_manifest.yaml
 ./scripts/check_generated_workcells.sh
 ```
 

--- a/docs/manuals/CELL_DEFINITION_V1.md
+++ b/docs/manuals/CELL_DEFINITION_V1.md
@@ -112,7 +112,7 @@ This runs validation and preview generation for all `tests/fixtures/cell_definit
 ```bash
 python3 scripts/generate_workcell_from_cell_definition.py   tests/fixtures/cell_definition_sort_by_colour.yaml   --output-dir /tmp/generated_workcells   --package-name generated_colour_sorting_cell   --force
 
-python3 scripts/validate_scene_contract.py generated_colour_sorting_cell
+python3 scripts/validate_scene_contract.py /tmp/generated_workcells/generated_colour_sorting_cell/scene_manifest.yaml
 ./scripts/check_generated_workcells.sh
 ```
 

--- a/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
+++ b/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
@@ -175,7 +175,7 @@ Use this offline command to turn one cell definition into a reviewable ROS 2 pac
 ```bash
 python3 scripts/generate_workcell_from_cell_definition.py   tests/fixtures/cell_definition_sort_by_colour.yaml   --output-dir /tmp/generated_workcells   --package-name generated_colour_sorting_cell   --force
 
-python3 scripts/validate_scene_contract.py generated_colour_sorting_cell
+python3 scripts/validate_scene_contract.py /tmp/generated_workcells/generated_colour_sorting_cell/scene_manifest.yaml
 ./scripts/check_generated_workcells.sh
 ```
 

--- a/scripts/check_generated_workcells.sh
+++ b/scripts/check_generated_workcells.sh
@@ -57,7 +57,7 @@ for fixture in "${fixtures[@]}"; do
   pkg_dir="${tmp_root}/${package_name}"
   manifest_path="${pkg_dir}/scene_manifest.yaml"
 
-  for required in package.xml CMakeLists.txt scene_manifest.yaml README.md generated/commissioning_summary.md generated/validation_report.md; do
+  for required in package.xml CMakeLists.txt scene_manifest.yaml README.md generated/commissioning_summary.md generated/validation_report.md generated/task_recipe.preview.yaml generated/scene_manifest.preview.yaml; do
     if [[ ! -f "${pkg_dir}/${required}" ]]; then
       echo "FAIL ${base_name}: missing generated file ${required}"
       fail_count=$((fail_count + 1))
@@ -65,35 +65,14 @@ for fixture in "${fixtures[@]}"; do
   done
 
   set +e
-  validate_output="$(python3 - <<'PY' "${REPO_ROOT}" "${manifest_path}" "${base_name}"
-import importlib.util
-import sys
-from pathlib import Path
-
-repo_root = Path(sys.argv[1])
-manifest_path = Path(sys.argv[2])
-scene_name = sys.argv[3]
-
-validator_spec = importlib.util.spec_from_file_location("validate_scene_contract", repo_root / "scripts" / "validate_scene_contract.py")
-validator = importlib.util.module_from_spec(validator_spec)
-sys.modules["validate_scene_contract"] = validator
-validator_spec.loader.exec_module(validator)
-
-manifest, parser, notes = validator._read_manifest(str(manifest_path))
-status, task_notes = validator.validate_task_recipe_block(manifest)
-print(f"validate_scene_contract(practical): scene={scene_name} parser={parser} status={status}")
-for note in notes + task_notes:
-    print(f"NOTE: {note}")
-raise SystemExit(0 if status in {"PASS", "WARN"} else 1)
-PY
-2>&1)"
+  validate_output="$(python3 "${SCRIPT_DIR}/validate_scene_contract.py" "${manifest_path}" 2>&1)"
   validate_code=$?
   set -e
   echo "${validate_output}"
   if [[ ${validate_code} -ne 0 ]]; then
     echo "FAIL ${base_name}: practical scene contract validation failed"
     fail_count=$((fail_count + 1))
-  elif grep -q 'status=WARN' <<<"${validate_output}"; then
+  elif grep -q 'RESULT: WARN' <<<"${validate_output}"; then
     warn_count=$((warn_count + 1))
   fi
 

--- a/scripts/generate_workcell_from_cell_definition.py
+++ b/scripts/generate_workcell_from_cell_definition.py
@@ -144,6 +144,16 @@ def _augment_scene_manifest(cell_def: dict[str, Any], scene_manifest: dict[str, 
             "home_return.safe_joint_state is empty and no home_named_target was provided; update before runtime use."
         )
 
+    self_test = out.get("self_test")
+    if isinstance(self_test, dict) and isinstance(self_test.get("object"), dict):
+        test_object = self_test["object"]
+        shape = str(test_object.get("shape", "box")).strip().lower()
+        if shape != "box":
+            warnings.append(
+                f"self_test.object.shape '{shape}' is not currently supported by validator; using conservative 'box'."
+            )
+            test_object["shape"] = "box"
+
     return out
 
 
@@ -179,7 +189,9 @@ ament_package()
 """
 
 
-def _build_readme(cell_def: dict[str, Any], package_name: str, source_path: Path, warnings: list[str]) -> str:
+def _build_readme(
+    cell_def: dict[str, Any], package_name: str, source_path: Path, package_dir: Path, warnings: list[str]
+) -> str:
     cell = cell_def.get("cell", {}) if isinstance(cell_def.get("cell"), dict) else {}
     robot = cell_def.get("robot", {}) if isinstance(cell_def.get("robot"), dict) else {}
     end_effector = cell_def.get("end_effector", {}) if isinstance(cell_def.get("end_effector"), dict) else {}
@@ -201,7 +213,7 @@ def _build_readme(cell_def: dict[str, Any], package_name: str, source_path: Path
         f"- Task type: `{task.get('type', '(unknown)')}`",
         "",
         "## Offline checks",
-        f"- Validate scene contract: `python3 scripts/validate_scene_contract.py {package_name}`",
+        f"- Validate scene contract: `python3 scripts/validate_scene_contract.py {package_dir / 'scene_manifest.yaml'}`",
         "- Dry-run task recipe (practical): `python3 scripts/dry_run_task_recipe.py --check`",
         "- Generate execution plan: `python3 scripts/generate_task_execution_plan.py --check`",
         "- Export commissioning bundle: `python3 scripts/export_workcell_bundle.py --force`",
@@ -337,7 +349,7 @@ def generate_package(
 
     (package_dir / "README.md").write_text(
         _header_markdown(cell_definition_path)
-        + _build_readme(loaded, package_name, cell_definition_path, warnings),
+        + _build_readme(loaded, package_name, cell_definition_path, package_dir, warnings),
         encoding="utf-8",
     )
 

--- a/scripts/validate_scene_contract.py
+++ b/scripts/validate_scene_contract.py
@@ -704,6 +704,60 @@ def _check_declared_files(manifest: dict[str, Any], share_dir: str, errors: list
                 )
 
 
+def validate_scene_manifest_path(manifest_path: str, package_label: str | None = None) -> tuple[ValidationResult, int]:
+    package = package_label or os.path.basename(os.path.dirname(os.path.abspath(manifest_path))) or "direct_manifest"
+    if not os.path.isfile(manifest_path):
+        result = ValidationResult(
+            package=package,
+            manifest_path=manifest_path,
+            parser="n/a",
+            errors=[f"Scene manifest path does not exist: {manifest_path}"],
+        )
+        return result, 1
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    notes: list[str] = ["Validated manifest directly from filesystem path."]
+    try:
+        manifest, parser_name, parser_notes = _read_manifest(manifest_path)
+        notes.extend(parser_notes)
+    except Exception as exc:
+        result = ValidationResult(
+            package=package,
+            manifest_path=manifest_path,
+            parser="fallback" if _pyyaml is None else "pyyaml",
+            errors=[f"Failed to parse manifest YAML: {exc}"],
+        )
+        return result, 1
+
+    package_for_type_check = package
+    scene_name = _dig(manifest, "scene.name")
+    if isinstance(scene_name, str) and scene_name.strip():
+        package_for_type_check = scene_name.strip()
+
+    _check_required(manifest, errors)
+    _check_types(manifest, errors, warnings, package_for_type_check)
+    _check_self_test(manifest, errors, warnings)
+    task_recipe_status, task_recipe_notes = validate_task_recipe_block(manifest)
+    if task_recipe_status == "FAIL":
+        errors.extend(task_recipe_notes)
+    elif task_recipe_status == "WARN":
+        warnings.extend(task_recipe_notes)
+    else:
+        notes.extend(task_recipe_notes)
+    _check_declared_files(manifest, os.path.dirname(os.path.abspath(manifest_path)), errors)
+
+    result = ValidationResult(
+        package=package,
+        manifest_path=manifest_path,
+        parser=parser_name,
+        errors=errors,
+        warnings=warnings,
+        notes=notes,
+    )
+    return result, 0 if result.ok else 1
+
+
 def validate_scene_contract(package: str) -> tuple[ValidationResult, int]:
     share_dir, resolver = resolve_package_share(package)
     if not share_dir:
@@ -811,11 +865,20 @@ def _print_report(result: ValidationResult, exit_code: int, resolver_hint: str =
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Validate scene contract manifest for a scene package")
-    parser.add_argument("scene_package", help="ROS package name of the scene (e.g. ur5_2f_test)")
+    parser.add_argument(
+        "scene_package",
+        help="ROS package name (e.g. ur5_2f_test) or direct path to scene_manifest.yaml/workcell.yaml",
+    )
     args = parser.parse_args()
 
-    _, resolver = resolve_package_share(args.scene_package)
-    result, exit_code = validate_scene_contract(args.scene_package)
+    candidate = args.scene_package
+    if os.path.isfile(candidate):
+        result, exit_code = validate_scene_manifest_path(candidate)
+        _print_report(result, exit_code, "direct-file")
+        return exit_code
+
+    _, resolver = resolve_package_share(candidate)
+    result, exit_code = validate_scene_contract(candidate)
     _print_report(result, exit_code, resolver)
     return exit_code
 

--- a/tests/test_scene_validation_tools.py
+++ b/tests/test_scene_validation_tools.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = REPO_ROOT / "tests" / "fixtures"
 
 
 def _load_module(name: str, path: Path):
@@ -110,6 +111,12 @@ end_effector:
         self.assertEqual(parser, "fallback")
         self.assertIn("PyYAML not available", " ".join(notes))
         self.assertEqual(loaded["robot"]["ee_link"], "tool0")
+
+    def test_validate_scene_manifest_path_accepts_direct_file(self) -> None:
+        result, exit_code = validator.validate_scene_manifest_path(str(FIXTURES / "generated_scene_manifest.yaml"))
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(result.ok)
+        self.assertEqual(result.manifest_path, str(FIXTURES / "generated_scene_manifest.yaml"))
 
 
 class ReportGenerationTests(unittest.TestCase):


### PR DESCRIPTION
### Motivation
- Generated workcell packages live in temporary paths and cannot be validated via ROS package discovery, so offline tools must be able to validate generated manifests directly. 
- Keep generated package outputs conservative and reviewable without changing any runtime/planning/perception behavior. 
- Provide an automated checker that verifies generated package artefacts and exercises existing offline tools end-to-end.

### Description
- Added `validate_scene_manifest_path(manifest_path, package_label=None)` to `scripts/validate_scene_contract.py` to allow validating a `scene_manifest.yaml`/`workcell.yaml` by direct filesystem path and to print the same `RESULT:/NOTE:` style report as package validation. 
- Kept existing `validate_scene_contract(package)` behavior and extended CLI to accept either a ROS package name or a direct manifest path. 
- Updated `scripts/generate_workcell_from_cell_definition.py` to normalize unsupported `self_test.object.shape` values to conservative `box` with a warning, include generated-file validation instructions that reference the manifest path, and ensure generated preview files are written under `generated/` with a clear generated header. 
- Hardened `scripts/check_generated_workcells.sh` to assert presence of preview artifacts (`generated/task_recipe.preview.yaml` and `generated/scene_manifest.preview.yaml`) and to call `scripts/validate_scene_contract.py` directly against the generated manifest path (so validation works offline without ROS discovery). 
- Added unit test coverage in `tests/test_scene_validation_tools.py` for direct-file manifest validation (`validate_scene_manifest_path`) and updated tests to use the existing fixtures. 
- Updated documentation/examples to show validating generated packages via the direct manifest path in `README.md`, `docs/manuals/WORKCELL_OPERATOR_MANUAL.md`, and `docs/manuals/CELL_DEFINITION_V1.md`.

### Testing
- Ran static checks and compilation: `python3 -m py_compile scripts/generate_workcell_from_cell_definition.py scripts/validate_cell_definition.py scripts/generate_scene_from_cell_definition.py tests/test_cell_definition_tools.py tests/test_scene_validation_tools.py` which completed successfully. 
- Ran unit tests: `python3 -m unittest tests/test_cell_definition_tools.py` and `python3 -m unittest tests/test_scene_validation_tools.py`, both passed. 
- Linted shell scripts: `bash -n scripts/check_generated_workcells.sh scripts/preflight_workcell.sh` passed. 
- Executed full generated-workcell end-to-end checker: `./scripts/check_generated_workcells.sh` completed successfully; results included `PASS`/`WARN` statuses for generated fixtures and no unexpected `FAIL` for the practical offline validation path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efcc8f00a48331a960c4ffdc7a0cf9)