### PR TITLE
Add offline static Workcell Project Dashboard generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This package was tested with [easy_perception_deployment](https://github.com/ros
 ## Operator manual and validation report
 
 - Operator + commissioning manual: `docs/manuals/WORKCELL_OPERATOR_MANUAL.md`
+- Workcell project dashboard manual: `docs/manuals/WORKCELL_PROJECT_DASHBOARD.md`
 - Validation-only preflight helper:
 
 ```bash
@@ -66,6 +67,8 @@ This package was tested with [easy_perception_deployment](https://github.com/ros
 Validation preflight checks manifests/files only. Smoke launch preflight verifies `run_grasp_execution` reaches readiness markers headlessly. Smoke checks do **not** validate full grasp execution quality, EPD perception, camera hardware, or physical robot behavior. See `docs/manuals/WORKCELL_OPERATOR_MANUAL.md` for operator workflow details.
 
 Scene self-test metadata (`self_test` in each scene manifest) defines a deterministic commissioning object pose for offline checks. It is metadata-only: no robot launch, no EPD/camera requirement, and no physical hardware requirement.
+
+Workcell project generation also emits a static offline dashboard at `dashboard/index.html` for read-only project review. **The dashboard is a read-only offline project summary. It does not replace the existing GUI and does not control the robot.**
 
 ```bash
 ./scripts/check_scene_self_tests.sh

--- a/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
+++ b/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
@@ -2,6 +2,8 @@
 
 This manual is written for engineers who are comfortable with Linux/ROS 2 but are new to this repository. It focuses on copy-paste operational steps for building, validating, launching, troubleshooting, and extending scenes without changing grasp runtime behavior.
 
+For generated project review dashboards, see `docs/manuals/WORKCELL_PROJECT_DASHBOARD.md`. **The dashboard is a read-only offline project summary. It does not replace the existing GUI and does not control the robot.**
+
 ---
 
 ## A) Purpose of the platform

--- a/docs/manuals/WORKCELL_PROJECT_DASHBOARD.md
+++ b/docs/manuals/WORKCELL_PROJECT_DASHBOARD.md
@@ -1,0 +1,88 @@
+# Workcell Project Dashboard
+
+## What this is
+
+The Workcell Project Dashboard is a single static HTML page generated from a workcell project's `project_manifest.json`.
+
+It gives operators, reviewers, and managers a quick offline summary of:
+
+- project identity and status,
+- cell/robot/task/environment overview,
+- validation + commissioning status,
+- generated artifacts and checksums,
+- operator next steps.
+
+**The dashboard is a read-only offline project summary. It does not replace the existing GUI and does not control the robot.**
+
+## What this is not
+
+- It does **not** launch ROS nodes.
+- It does **not** control robot motion or execution.
+- It does **not** replace MoveIt, controller, perception, EPD, or runtime tools.
+- It does **not** replace existing GUI behavior.
+
+## Generate the dashboard
+
+Dashboard generation is now included by default in project generation:
+
+```bash
+python3 scripts/create_workcell_project.py \
+  --cell-definition tests/fixtures/cell_definition_pick_place.yaml \
+  --output-dir /tmp/workcell_projects \
+  --force
+```
+
+The generated file is typically:
+
+```text
+/tmp/workcell_projects/<cell_id>/dashboard/index.html
+```
+
+Manual generation command:
+
+```bash
+python3 scripts/generate_workcell_dashboard.py \
+  --project-dir /tmp/workcell_projects/<cell_id>
+```
+
+Direct manifest mode:
+
+```bash
+python3 scripts/generate_workcell_dashboard.py \
+  --manifest /tmp/workcell_projects/<cell_id>/project_manifest.json \
+  --output /tmp/workcell_projects/<cell_id>/dashboard/index.html
+```
+
+Optional flags:
+
+- `--json`: print machine-readable summary.
+- `--strict`: convert warnings to non-zero exit.
+- `--quiet`: reduce console output.
+
+## Open the dashboard
+
+Open locally in any browser (offline):
+
+```bash
+xdg-open /tmp/workcell_projects/<cell_id>/dashboard/index.html
+```
+
+No network, CDN, external JS, or external CSS is required.
+
+## Integration with existing GUI/runtime
+
+Use this dashboard for offline review and handover checks before runtime launch.
+
+Keep normal runtime workflow unchanged:
+
+1. validate cell + scene contracts,
+2. review recipe/plan/commissioning artifacts,
+3. then run normal launch/runtime tools.
+
+The dashboard intentionally stays read-only and does not alter existing GUI/runtime behavior.
+
+## Future screenshots/pictures
+
+Future versions can embed locally generated screenshots or pictures by writing additional image files into the generated project folder and linking them from the dashboard HTML.
+
+This can be added without changing runtime logic, launch behavior, planner behavior, controller behavior, perception behavior, or grasp execution logic.

--- a/scripts/check_workcell_dashboard.sh
+++ b/scripts/check_workcell_dashboard.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+GENERATOR="${SCRIPT_DIR}/create_workcell_project.py"
+DASHBOARD_GEN="${SCRIPT_DIR}/generate_workcell_dashboard.py"
+TMP_ROOT="${REPO_ROOT}/dist/.tmp_workcell_dashboard_checks"
+OUT_ROOT="${TMP_ROOT}/projects"
+
+fixtures=(
+  "pick_place:tests/fixtures/cell_definition_pick_place.yaml:ur5_2f_demo_cell"
+  "sort_by_colour:tests/fixtures/cell_definition_sort_by_colour.yaml:ur5_colour_sort_cell"
+)
+
+pass_count=0
+warn_count=0
+fail_count=0
+
+rm -rf "${TMP_ROOT}"
+mkdir -p "${OUT_ROOT}"
+
+require_section() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -q "${needle}" "${file}"; then
+    return 1
+  fi
+  return 0
+}
+
+for entry in "${fixtures[@]}"; do
+  name="${entry%%:*}"
+  rest="${entry#*:}"
+  fixture_rel="${rest%%:*}"
+  cell_id="${entry##*:}"
+  fixture="${REPO_ROOT}/${fixture_rel}"
+
+  echo "--- dashboard fixture: ${name} ---"
+  set +e
+  gen_out="$(python3 "${GENERATOR}" --cell-definition "${fixture}" --output-dir "${OUT_ROOT}" --force 2>&1)"
+  gen_rc=$?
+  set -e
+  echo "${gen_out}"
+  if [[ ${gen_rc} -ne 0 ]]; then
+    echo "FAIL ${name}: project generation failed"
+    ((fail_count+=1))
+    continue
+  fi
+
+  project_dir="${OUT_ROOT}/${cell_id}"
+  manifest="${project_dir}/project_manifest.json"
+  dashboard="${project_dir}/dashboard/index.html"
+
+  set +e
+  dash_out="$(python3 "${DASHBOARD_GEN}" --project-dir "${project_dir}" --manifest "${manifest}" --quiet 2>&1)"
+  dash_rc=$?
+  set -e
+  if [[ ${dash_rc} -ne 0 ]]; then
+    echo "WARN ${name}: dashboard script returned non-zero"
+    echo "${dash_out}"
+    ((warn_count+=1))
+  fi
+
+  if [[ ! -f "${dashboard}" ]]; then
+    echo "FAIL ${name}: missing dashboard/index.html"
+    ((fail_count+=1))
+    continue
+  fi
+
+  sections=(
+    "Workcell Project Dashboard"
+    "Project Summary"
+    "Cell Overview"
+    "Task Overview"
+    "Generated Artifacts"
+    "Operator Next Steps"
+  )
+
+  missing=0
+  for section in "${sections[@]}"; do
+    if ! require_section "${dashboard}" "${section}"; then
+      echo "FAIL ${name}: missing section '${section}'"
+      missing=1
+    fi
+  done
+
+  if [[ ${missing} -eq 1 ]]; then
+    ((fail_count+=1))
+    continue
+  fi
+
+  echo "PASS ${name}: dashboard generated with required sections"
+  ((pass_count+=1))
+done
+
+echo
+if [[ ${fail_count} -gt 0 ]]; then
+  echo "Workcell dashboard checks: FAIL (pass=${pass_count} warn=${warn_count} fail=${fail_count})"
+  exit 1
+fi
+if [[ ${warn_count} -gt 0 ]]; then
+  echo "Workcell dashboard checks: WARN (pass=${pass_count} warn=${warn_count} fail=0)"
+  exit 0
+fi
+
+echo "Workcell dashboard checks: PASS (pass=${pass_count} warn=0 fail=0)"
+exit 0

--- a/scripts/create_workcell_project.py
+++ b/scripts/create_workcell_project.py
@@ -27,6 +27,7 @@ PLAN_PATH = SCRIPTS_DIR / "generate_task_execution_plan.py"
 BUNDLE_PATH = SCRIPTS_DIR / "export_workcell_bundle.py"
 WIZARD_PATH = SCRIPTS_DIR / "create_cell_definition_wizard.py"
 TEMPLATE_TOOL_PATH = SCRIPTS_DIR / "create_cell_from_template.py"
+DASHBOARD_PATH = SCRIPTS_DIR / "generate_workcell_dashboard.py"
 
 REQUIRED_GENERATED_FILES = (
     "package.xml",
@@ -262,6 +263,8 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--force", action="store_true")
     parser.add_argument("--skip-bundle", action="store_true")
     parser.add_argument("--skip-execution-plan", action="store_true")
+    parser.add_argument("--skip-dashboard", action="store_true", help="Skip generation of static dashboard")
+    parser.add_argument("--dashboard-output", type=Path, help="Optional output HTML path for generated dashboard")
     parser.add_argument("--json", action="store_true", help="Print final summary as JSON")
     parser.add_argument("--print-next-commands", action="store_true")
     parser.add_argument("--strict", action="store_true")
@@ -291,6 +294,7 @@ def main() -> int:
         dry_runner = _load_module("project_dry_run", DRY_RUN_PATH)
         plan_generator = _load_module("project_plan", PLAN_PATH)
         bundle_exporter = _load_module("project_bundle", BUNDLE_PATH)
+        dashboard_generator = _load_module("project_dashboard", DASHBOARD_PATH)
     except Exception as exc:
         print(f"FAIL: unable to load offline tooling: {exc}")
         return 2
@@ -373,6 +377,7 @@ def main() -> int:
         str(reports_dir / "task_execution_plan.md"),
         str(reports_dir / "task_execution_plan.json"),
         str(bundle_dir),
+        str(project_dir / "dashboard" / "index.html"),
     ]
 
     if args.dry_run:
@@ -490,17 +495,6 @@ def main() -> int:
         "commissioning_bundle": bundle_status,
     }
 
-    warnings: list[str] = []
-    errors: list[str] = []
-    for step_name, step in statuses.items():
-        for note in step.notes:
-            if step.status in {"FAIL"}:
-                errors.append(f"{step_name}: {note}")
-            elif step.status in {"WARN", "SKIP"}:
-                warnings.append(f"{step_name}: {note}")
-
-    _write_text(reports_dir / "validation_summary.md", _render_validation_summary(statuses, warnings, errors), False, planned_paths)
-
     next_commands_text = _render_next_commands(project_dir, package_name)
     _write_text(project_dir / "next_commands.md", next_commands_text, False, planned_paths)
 
@@ -522,6 +516,44 @@ def main() -> int:
         "commissioning_bundle": "commissioning_bundle",
         "next_commands": "next_commands.md",
     }
+
+    dashboard_output = args.dashboard_output.resolve() if args.dashboard_output else (project_dir / "dashboard" / "index.html")
+    if args.skip_dashboard:
+        dashboard_status = StepStatus("SKIP", ["Skipped by --skip-dashboard"])
+    else:
+        try:
+            rc = dashboard_generator.main(
+                [
+                    "--project-dir",
+                    str(project_dir),
+                    "--manifest",
+                    str(project_dir / "project_manifest.json"),
+                    "--output",
+                    str(dashboard_output),
+                    "--quiet",
+                ]
+            )
+            if rc == 0 and dashboard_output.is_file():
+                dashboard_status = StepStatus("PASS", [])
+                try:
+                    important_paths["dashboard"] = dashboard_output.relative_to(project_dir).as_posix()
+                except ValueError:
+                    important_paths["dashboard"] = dashboard_output.as_posix()
+            else:
+                dashboard_status = StepStatus("WARN", [f"Dashboard generation returned non-zero: {rc}"])
+        except Exception as exc:
+            dashboard_status = StepStatus("WARN", [f"Dashboard generation warning: {exc}"])
+
+    statuses["dashboard_generation"] = dashboard_status
+
+    warnings: list[str] = []
+    errors: list[str] = []
+    for step_name, step in statuses.items():
+        for note in step.notes:
+            if step.status in {"FAIL"}:
+                errors.append(f"{step_name}: {note}")
+            elif step.status in {"WARN", "SKIP"}:
+                warnings.append(f"{step_name}: {note}")
 
     checksums: dict[str, str] = {}
     for key, rel_path in important_paths.items():
@@ -545,6 +577,7 @@ def main() -> int:
             "generate_task_execution_plan.py",
             "export_workcell_bundle.py",
             "create_cell_definition_wizard.py",
+            "generate_workcell_dashboard.py",
         ],
         "statuses": {key: value.status for key, value in statuses.items()},
         "artifacts": important_paths,
@@ -556,6 +589,37 @@ def main() -> int:
     }
     _write_text(project_dir / "project_manifest.json", json.dumps(manifest_payload, indent=2, sort_keys=True) + "\n", False, planned_paths)
 
+    if not args.skip_dashboard and dashboard_status.status != "PASS":
+        try:
+            rc = dashboard_generator.main(
+                [
+                    "--project-dir",
+                    str(project_dir),
+                    "--manifest",
+                    str(project_dir / "project_manifest.json"),
+                    "--output",
+                    str(dashboard_output),
+                    "--quiet",
+                ]
+            )
+            if rc == 0 and dashboard_output.is_file():
+                statuses["dashboard_generation"] = StepStatus("PASS", [])
+                warnings = [w for w in warnings if not w.startswith("dashboard_generation:")]
+                try:
+                    important_paths["dashboard"] = dashboard_output.relative_to(project_dir).as_posix()
+                except ValueError:
+                    important_paths["dashboard"] = dashboard_output.as_posix()
+                checksums["dashboard"] = _sha256(dashboard_output)
+                manifest_payload["statuses"] = {key: value.status for key, value in statuses.items()}
+                manifest_payload["artifacts"] = important_paths
+                manifest_payload["warnings"] = warnings + temp_notes
+                manifest_payload["checksums"] = checksums
+                _write_text(project_dir / "project_manifest.json", json.dumps(manifest_payload, indent=2, sort_keys=True) + "\n", False, planned_paths)
+        except Exception:
+            pass
+
+    _write_text(reports_dir / "validation_summary.md", _render_validation_summary(statuses, warnings, errors), False, planned_paths)
+
     blocking_failed = any(
         statuses[key].status == "FAIL"
         for key in ("cell_definition_validation", "workcell_generation", "scene_manifest_validation")
@@ -563,6 +627,8 @@ def main() -> int:
     if not args.skip_execution_plan and statuses["task_execution_plan"].status == "FAIL":
         blocking_failed = True
     if not args.skip_bundle and statuses["commissioning_bundle"].status == "FAIL":
+        blocking_failed = True
+    if not args.skip_dashboard and statuses["dashboard_generation"].status == "FAIL":
         blocking_failed = True
 
     strict_failed = args.strict and any(step.status in {"WARN", "SKIP"} for step in statuses.values())
@@ -574,6 +640,7 @@ def main() -> int:
         "dry_run_status": statuses["task_recipe_dry_run"].status,
         "execution_plan_status": statuses["task_execution_plan"].status,
         "bundle_status": statuses["commissioning_bundle"].status,
+        "dashboard_status": statuses["dashboard_generation"].status,
         "next_command": f"cat {project_dir / 'next_commands.md'}",
         "warnings": warnings + temp_notes,
         "errors": errors,
@@ -588,6 +655,7 @@ def main() -> int:
             "dry_run_status",
             "execution_plan_status",
             "bundle_status",
+            "dashboard_status",
             "next_command",
         ):
             print(f"{key}: {summary[key]}")

--- a/scripts/generate_workcell_dashboard.py
+++ b/scripts/generate_workcell_dashboard.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Generate an offline static HTML dashboard for a workcell project manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class DashboardResult:
+    status: str
+    output_path: Path
+    warnings: list[str]
+    errors: list[str]
+    project_dir: Path
+    manifest_path: Path
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(65536)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _escape(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list)):
+        text = json.dumps(value, ensure_ascii=False)
+    else:
+        text = str(value)
+    return html.escape(text)
+
+
+def _status_rank(value: str) -> int:
+    order = {"PASS": 0, "WARN": 1, "SKIP": 1, "UNKNOWN": 1, "FAIL": 2}
+    return order.get((value or "UNKNOWN").upper(), 1)
+
+
+def _overall_status(statuses: dict[str, Any]) -> str:
+    if not isinstance(statuses, dict) or not statuses:
+        return "UNKNOWN"
+    resolved = [str(v).upper() for v in statuses.values()]
+    if any(v == "FAIL" for v in resolved):
+        return "FAIL"
+    if any(v in {"WARN", "SKIP", "UNKNOWN"} for v in resolved):
+        return "WARN"
+    if all(v == "PASS" for v in resolved):
+        return "PASS"
+    return "UNKNOWN"
+
+
+def _resolve_link(project_dir: Path, output_dir: Path, rel: str) -> tuple[str, bool]:
+    rel_path = Path(rel)
+    if rel_path.is_absolute():
+        return "#", False
+    target = (project_dir / rel_path).resolve()
+    exists = target.exists()
+    href = Path(os.path.relpath(target, output_dir.resolve()))
+    return _escape(href.as_posix()), exists
+
+
+def _rows_from_artifacts(manifest: dict[str, Any], project_dir: Path, output_dir: Path) -> list[dict[str, str]]:
+    artifacts = manifest.get("artifacts", {})
+    checksums = manifest.get("checksums", {})
+    rows: list[dict[str, str]] = []
+    if isinstance(artifacts, dict):
+        for key, rel in sorted(artifacts.items()):
+            rel_text = str(rel)
+            href, exists = _resolve_link(project_dir, output_dir, rel_text)
+            rows.append(
+                {
+                    "name": _escape(key),
+                    "path": _escape(rel_text),
+                    "href": href,
+                    "exists": "YES" if exists else "NO",
+                    "checksum": _escape(checksums.get(key, "")) if isinstance(checksums, dict) else "",
+                }
+            )
+    return rows
+
+
+def _render_status_badge(status: str) -> str:
+    text = (status or "UNKNOWN").upper()
+    css = "unknown"
+    if text == "PASS":
+        css = "pass"
+    elif text in {"WARN", "SKIP", "UNKNOWN"}:
+        css = "warn"
+    elif text == "FAIL":
+        css = "fail"
+    return f'<span class="badge {css}">{_escape(text)}</span>'
+
+
+def _load_next_steps(project_dir: Path, manifest: dict[str, Any]) -> str:
+    artifacts = manifest.get("artifacts", {})
+    candidates = []
+    if isinstance(artifacts, dict) and artifacts.get("next_commands"):
+        candidates.append(project_dir / str(artifacts["next_commands"]))
+    candidates.append(project_dir / "next_commands.md")
+    for path in candidates:
+        if path.is_file():
+            return path.read_text(encoding="utf-8")
+    return "No next command file found."
+
+
+def _render_html(manifest: dict[str, Any], project_dir: Path, manifest_path: Path, output_path: Path, warnings: list[str]) -> str:
+    output_dir = output_path.parent
+    statuses = manifest.get("statuses", {}) if isinstance(manifest.get("statuses"), dict) else {}
+    overall = _overall_status(statuses)
+
+    cell = manifest.get("cell", {}) if isinstance(manifest.get("cell"), dict) else {}
+    robot = manifest.get("robot", {}) if isinstance(manifest.get("robot"), dict) else {}
+    ee = manifest.get("end_effector", {}) if isinstance(manifest.get("end_effector"), dict) else {}
+    env = manifest.get("environment", {}) if isinstance(manifest.get("environment"), dict) else {}
+    task = manifest.get("task", {}) if isinstance(manifest.get("task"), dict) else {}
+
+    artifact_rows = _rows_from_artifacts(manifest, project_dir, output_dir)
+
+    reports: list[str] = []
+    artifacts = manifest.get("artifacts", {}) if isinstance(manifest.get("artifacts"), dict) else {}
+    for name, rel in sorted(artifacts.items()):
+        if "report" in name or "summary" in name or str(rel).startswith("reports/"):
+            href, exists = _resolve_link(project_dir, output_dir, str(rel))
+            marker = "✓" if exists else "✗"
+            reports.append(f"<li>{_escape(name)} ({marker}) - <a href=\"{href}\">{_escape(rel)}</a></li>")
+
+    next_steps = _escape(_load_next_steps(project_dir, manifest))
+
+    status_rows = "".join(
+        f"<tr><td>{_escape(name)}</td><td>{_render_status_badge(str(value))}</td></tr>" for name, value in sorted(statuses.items())
+    ) or "<tr><td colspan='2'>No status entries</td></tr>"
+
+    artifact_table = "".join(
+        "<tr>"
+        f"<td>{row['name']}</td>"
+        f"<td><a href=\"{row['href']}\">{row['path']}</a></td>"
+        f"<td>{row['exists']}</td>"
+        f"<td><code>{row['checksum']}</code></td>"
+        "</tr>"
+        for row in artifact_rows
+    ) or "<tr><td colspan='4'>No artifacts listed in manifest.</td></tr>"
+
+    warning_list = "".join(f"<li>{_escape(item)}</li>" for item in warnings) or "<li>(none)</li>"
+    report_list = "".join(reports) or "<li>No report artifacts discovered.</li>"
+
+    return f"""<!doctype html>
+<html lang=\"en\">
+<head>
+<meta charset=\"utf-8\">
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+<title>Workcell Project Dashboard</title>
+<style>
+body {{ font-family: Arial, sans-serif; margin: 1.2rem; color: #1f2937; background: #fafafa; }}
+h1, h2 {{ margin-top: 1.5rem; }}
+.card {{ background: #fff; border: 1px solid #ddd; border-radius: 8px; padding: 0.9rem; margin-bottom: 1rem; }}
+.grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 0.8rem; }}
+small {{ color: #555; }}
+.badge {{ border-radius: 999px; padding: 0.15rem 0.6rem; font-size: 0.8rem; color: white; font-weight: bold; }}
+.badge.pass {{ background: #15803d; }}
+.badge.warn {{ background: #b45309; }}
+.badge.fail {{ background: #b91c1c; }}
+.badge.unknown {{ background: #374151; }}
+table {{ width: 100%; border-collapse: collapse; }}
+th, td {{ border: 1px solid #d1d5db; padding: 0.45rem; text-align: left; vertical-align: top; }}
+code, pre {{ background: #f3f4f6; border: 1px solid #e5e7eb; border-radius: 4px; padding: 0.1rem 0.2rem; }}
+pre {{ padding: 0.6rem; overflow-x: auto; white-space: pre-wrap; }}
+ul {{ margin-top: 0.2rem; }}
+</style>
+</head>
+<body>
+<h1>Workcell Project Dashboard</h1>
+<p><small>Read-only offline project summary generated at {_escape(datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))}.</small></p>
+
+<section class=\"card\">
+<h2>Project Summary</h2>
+<div class=\"grid\">
+<div><strong>Project name:</strong> {_escape(manifest.get('cell_name') or cell.get('name') or manifest.get('cell_id') or 'UNKNOWN')}</div>
+<div><strong>Package name:</strong> {_escape(manifest.get('generated_package_name', 'UNKNOWN'))}</div>
+<div><strong>Schema version:</strong> {_escape(manifest.get('schema_version', 'UNKNOWN'))}</div>
+<div><strong>Generated timestamp:</strong> {_escape(manifest.get('generated_at_utc', 'UNKNOWN'))}</div>
+<div><strong>Overall status:</strong> {_render_status_badge(overall)}</div>
+<div><strong>Source cell definition:</strong> {_escape(manifest.get('source_path', 'UNKNOWN'))}</div>
+</div>
+<p><small>Manifest: {_escape(str(manifest_path))}</small></p>
+</section>
+
+<section class=\"card\">
+<h2>Cell Overview</h2>
+<ul>
+<li>Robot model: {_escape(robot.get('model', manifest.get('robot_model', 'UNKNOWN')))}</li>
+<li>End effector / gripper: {_escape(ee.get('id', manifest.get('end_effector_id', 'UNKNOWN')))}</li>
+<li>Planning group: {_escape(robot.get('planning_group', manifest.get('planning_group', 'UNKNOWN')))}</li>
+<li>Frames: base={_escape(robot.get('base_frame', manifest.get('base_frame', 'UNKNOWN')))}, tool={_escape(robot.get('ee_link', manifest.get('tool_frame', 'UNKNOWN')))}, grasp={_escape(ee.get('grasp_frame', manifest.get('grasp_frame', 'UNKNOWN')))}</li>
+</ul>
+</section>
+
+<section class=\"card\">
+<h2>Environment Overview</h2>
+<ul>
+<li>Support/table objects: {_escape(env.get('supports') or manifest.get('support_objects') or 'UNKNOWN')}</li>
+<li>Camera/sensors: {_escape(manifest.get('camera') or env.get('sensors') or 'UNKNOWN')}</li>
+<li>Scene/generated package path: {_escape(artifacts.get('generated_package', 'UNKNOWN'))}</li>
+</ul>
+</section>
+
+<section class=\"card\">
+<h2>Task Overview</h2>
+<ul>
+<li>Task type: {_escape(task.get('type', manifest.get('task_type', 'UNKNOWN')))}</li>
+<li>Destinations/rules: {_escape(task.get('destinations') or task.get('decision_rules') or manifest.get('task_rules') or 'UNKNOWN')}</li>
+<li>Task recipe preview: <a href=\"{_resolve_link(project_dir, output_dir, str(artifacts.get('task_preview', '#')))[0]}\">{_escape(artifacts.get('task_preview', 'UNKNOWN'))}</a></li>
+<li>Task execution plan: <a href=\"{_resolve_link(project_dir, output_dir, str(artifacts.get('execution_plan_md', '#')))[0]}\">{_escape(artifacts.get('execution_plan_md', 'UNKNOWN'))}</a></li>
+</ul>
+</section>
+
+<section class=\"card\">
+<h2>Validation and Commissioning Status</h2>
+<table>
+<thead><tr><th>Step</th><th>Status</th></tr></thead>
+<tbody>{status_rows}</tbody>
+</table>
+<h3>Generated reports</h3>
+<ul>{report_list}</ul>
+<h3>Warnings</h3>
+<ul>{warning_list}</ul>
+</section>
+
+<section class=\"card\">
+<h2>Generated Artifacts</h2>
+<table>
+<thead><tr><th>Artifact</th><th>Relative path</th><th>Exists</th><th>Checksum</th></tr></thead>
+<tbody>{artifact_table}</tbody>
+</table>
+</section>
+
+<section class=\"card\">
+<h2>Operator Next Steps</h2>
+<ol>
+<li>Review cell definition</li>
+<li>Review scene manifest</li>
+<li>Review task recipe</li>
+<li>Review commissioning bundle</li>
+<li>Run offline validation</li>
+<li>Only then test runtime launch</li>
+</ol>
+<pre>{next_steps}</pre>
+</section>
+
+<section class=\"card\">
+<h2>Notes / Limitations</h2>
+<ul>
+<li>The dashboard is a read-only offline project summary. It does not replace the existing GUI and does not control the robot.</li>
+<li>This page is static and offline (no external JavaScript/CSS/CDN dependencies).</li>
+<li>No runtime control, planner control, or ROS launch action is performed here.</li>
+</ul>
+</section>
+
+</body>
+</html>
+"""
+
+
+def generate_dashboard(project_dir: Path, manifest_path: Path, output_path: Path) -> DashboardResult:
+    warnings: list[str] = []
+    errors: list[str] = []
+
+    if not manifest_path.is_file():
+        errors.append(f"Missing manifest file: {manifest_path}")
+        return DashboardResult("FAIL", output_path, warnings, errors, project_dir, manifest_path)
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        errors.append(f"Invalid manifest JSON: {exc}")
+        return DashboardResult("FAIL", output_path, warnings, errors, project_dir, manifest_path)
+
+    for field in ("schema_version", "artifacts", "statuses"):
+        if field not in manifest:
+            warnings.append(f"Manifest missing optional dashboard field: {field}")
+
+    html_text = _render_html(manifest, project_dir, manifest_path, output_path, warnings + list(manifest.get("warnings", [])))
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(html_text, encoding="utf-8")
+
+    status = "FAIL" if errors else ("WARN" if warnings else "PASS")
+    return DashboardResult(status, output_path, warnings, errors, project_dir, manifest_path)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-dir", type=Path, help="Generated workcell project directory containing project_manifest.json")
+    parser.add_argument("--manifest", type=Path, help="Direct path to a project_manifest.json file")
+    parser.add_argument("--output", type=Path, help="Output HTML path (default: <project-dir>/dashboard/index.html)")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable summary")
+    parser.add_argument("--strict", action="store_true", help="Treat warnings as failures")
+    parser.add_argument("--quiet", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if not args.project_dir and not args.manifest:
+        print("FAIL: provide --project-dir or --manifest")
+        return 2
+
+    if args.project_dir:
+        project_dir = args.project_dir.resolve()
+        manifest_path = args.manifest.resolve() if args.manifest else project_dir / "project_manifest.json"
+    else:
+        manifest_path = args.manifest.resolve()
+        project_dir = manifest_path.parent
+
+    output_path = args.output.resolve() if args.output else (project_dir / "dashboard" / "index.html")
+
+    result = generate_dashboard(project_dir, manifest_path, output_path)
+    summary = {
+        "status": result.status,
+        "project_dir": str(result.project_dir),
+        "manifest_path": str(result.manifest_path),
+        "dashboard_path": str(result.output_path),
+        "dashboard_checksum": _sha256(result.output_path) if result.output_path.is_file() else "",
+        "warnings": result.warnings,
+        "errors": result.errors,
+    }
+
+    if not args.quiet:
+        print(f"Workcell dashboard: {result.status}")
+        print(f"manifest: {result.manifest_path}")
+        print(f"output: {result.output_path}")
+        if result.warnings:
+            print("warnings:")
+            for note in result.warnings:
+                print(f" - {note}")
+        if result.errors:
+            print("errors:")
+            for note in result.errors:
+                print(f" - {note}")
+
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+
+    if result.errors:
+        return 1
+    if args.strict and result.warnings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preflight_workcell.sh
+++ b/scripts/preflight_workcell.sh
@@ -63,6 +63,7 @@ echo
 "${SCRIPT_DIR}/check_workcell_bundles.sh"
 "${SCRIPT_DIR}/check_generated_workcells.sh"
 "${SCRIPT_DIR}/check_workcell_projects.sh"
+"${SCRIPT_DIR}/check_workcell_dashboard.sh"
 set +e
 CELL_WIZARD_OUTPUT="$(${SCRIPT_DIR}/check_cell_definition_wizard.sh)"
 CELL_WIZARD_EXIT=$?

--- a/tests/test_workcell_project_tools.py
+++ b/tests/test_workcell_project_tools.py
@@ -14,11 +14,15 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURES = REPO_ROOT / "tests" / "fixtures"
 GENERATOR = REPO_ROOT / "scripts" / "create_workcell_project.py"
 CHECKER = REPO_ROOT / "scripts" / "check_workcell_projects.sh"
+DASHBOARD_GENERATOR = REPO_ROOT / "scripts" / "generate_workcell_dashboard.py"
 
 
 class WorkcellProjectGeneratorTests(unittest.TestCase):
     def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run([sys.executable, str(GENERATOR), *args], capture_output=True, text=True, check=False)
+
+    def _run_dashboard(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run([sys.executable, str(DASHBOARD_GENERATOR), *args], capture_output=True, text=True, check=False)
 
     def test_dry_run_writes_nothing(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -170,6 +174,95 @@ class WorkcellProjectGeneratorTests(unittest.TestCase):
             self.assertTrue(manifest["checksums"])
             validation_summary = (project / "reports" / "validation_summary.md").read_text(encoding="utf-8")
             self.assertIn("direct file", validation_summary)
+
+    def test_dashboard_generated_by_default_and_manifest_includes_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir)
+            proc = self._run("--cell-definition", str(FIXTURES / "cell_definition_pick_place.yaml"), "--output-dir", str(out), "--force")
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            project = out / "ur5_2f_demo_cell"
+            dashboard = project / "dashboard" / "index.html"
+            self.assertTrue(dashboard.is_file())
+            html_text = dashboard.read_text(encoding="utf-8")
+            self.assertIn("Workcell Project Dashboard", html_text)
+            manifest = json.loads((project / "project_manifest.json").read_text(encoding="utf-8"))
+            self.assertIn("dashboard", manifest["artifacts"])
+            self.assertIn("dashboard", manifest["checksums"])
+
+    def test_skip_dashboard_prevents_creation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir)
+            proc = self._run(
+                "--cell-definition", str(FIXTURES / "cell_definition_sort_by_colour.yaml"),
+                "--output-dir", str(out),
+                "--skip-dashboard",
+                "--force",
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            project = out / "ur5_colour_sort_cell"
+            self.assertFalse((project / "dashboard" / "index.html").exists())
+
+    def test_generate_dashboard_from_project_and_manifest_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir)
+            create = self._run("--cell-definition", str(FIXTURES / "cell_definition_sort_by_shape.yaml"), "--output-dir", str(out), "--force")
+            self.assertEqual(create.returncode, 0, msg=create.stdout + create.stderr)
+            project = out / "ur5_shape_sort_cell"
+            manifest = project / "project_manifest.json"
+            dash_a = project / "dashboard" / "a.html"
+            dash_b = project / "dashboard" / "b.html"
+            proc_a = self._run_dashboard("--project-dir", str(project), "--output", str(dash_a))
+            self.assertEqual(proc_a.returncode, 0, msg=proc_a.stdout + proc_a.stderr)
+            proc_b = self._run_dashboard("--manifest", str(manifest), "--output", str(dash_b))
+            self.assertEqual(proc_b.returncode, 0, msg=proc_b.stdout + proc_b.stderr)
+            self.assertIn("Project Summary", dash_a.read_text(encoding="utf-8"))
+            self.assertIn("Generated Artifacts", dash_b.read_text(encoding="utf-8"))
+
+    def test_dashboard_escapes_unsafe_html(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir) / "proj"
+            project.mkdir(parents=True)
+            manifest = project / "project_manifest.json"
+            payload = {
+                "schema_version": "workcell_project/v1",
+                "cell_name": "<script>alert('x')</script>",
+                "generated_package_name": "pkg",
+                "statuses": {"scene_manifest_validation": "PASS"},
+                "artifacts": {"next_commands": "next_commands.md"},
+            }
+            manifest.write_text(json.dumps(payload), encoding="utf-8")
+            (project / "next_commands.md").write_text("<b>danger</b>", encoding="utf-8")
+            dash = project / "dashboard" / "index.html"
+            proc = self._run_dashboard("--manifest", str(manifest), "--output", str(dash))
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            text = dash.read_text(encoding="utf-8")
+            self.assertIn("&lt;script&gt;alert", text)
+            self.assertNotIn("<script>alert", text)
+            self.assertIn("&lt;b&gt;danger&lt;/b&gt;", text)
+
+    def test_dashboard_missing_optional_fields_warn_and_strict_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir) / "p"
+            project.mkdir(parents=True)
+            manifest = project / "project_manifest.json"
+            manifest.write_text(json.dumps({"cell_name": "x"}), encoding="utf-8")
+            proc_warn = self._run_dashboard("--manifest", str(manifest))
+            self.assertEqual(proc_warn.returncode, 0, msg=proc_warn.stdout + proc_warn.stderr)
+            self.assertIn("WARN", proc_warn.stdout)
+            proc_strict = self._run_dashboard("--manifest", str(manifest), "--strict")
+            self.assertNotEqual(proc_strict.returncode, 0)
+
+    def test_dashboard_json_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir)
+            create = self._run("--cell-definition", str(FIXTURES / "cell_definition_pick_place.yaml"), "--output-dir", str(out), "--force")
+            self.assertEqual(create.returncode, 0, msg=create.stdout + create.stderr)
+            project = out / "ur5_2f_demo_cell"
+            proc = self._run_dashboard("--project-dir", str(project), "--json", "--quiet")
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertIn("dashboard_path", payload)
+            self.assertIn("dashboard_checksum", payload)
 
 
 class WorkcellProjectCheckHelperTests(unittest.TestCase):


### PR DESCRIPTION
### Motivation

- Provide a simple, read-only, offline, browser-viewable dashboard for generated workcell projects so operators and reviewers can quickly inspect project contents and status without touching runtime/GUI tools.
- Keep all runtime, ROS launch, MoveIt, controller, perception, and grasp execution behavior unchanged by restricting this to offline tooling, docs, and tests.

### Description

- Add `scripts/generate_workcell_dashboard.py`, a pure-stdlib script that renders a single offline `dashboard/index.html` (embedded CSS, no CDN/JS), accepts `--project-dir` or `--manifest`, and supports `--output`, `--json`, `--strict`, and `--quiet` options, while escaping all rendered content with `html.escape` and using `pathlib` for safe relative links.
- Integrate dashboard creation into `scripts/create_workcell_project.py` as a default post-step and expose `--skip-dashboard` and `--dashboard-output` flags; dashboard generation is best-effort (produces WARN) unless `--strict` is set, in which case warnings convert to non-zero exit as appropriate.
- Wire dashboard artifact/status/checksum into `project_manifest.json` under `artifacts`, `statuses`, and `checksums` in a backward-compatible manner when the dashboard is generated.
- Add an offline checker `scripts/check_workcell_dashboard.sh` and integrate it into the preflight flow via `scripts/preflight_workcell.sh` without removing any existing checks.
- Extend unit tests in `tests/test_workcell_project_tools.py` to cover default dashboard creation, `--skip-dashboard`, project-dir vs manifest modes, required section presence, HTML escaping safety, `--json` summary, and strict/warn behavior, and add documentation `docs/manuals/WORKCELL_PROJECT_DASHBOARD.md` plus README/manual links.

### Testing

- Ran Python byte-compile: `python3 -m py_compile scripts/generate_workcell_dashboard.py scripts/create_workcell_project.py tests/test_workcell_project_tools.py` (success).
- Ran unit tests: `python3 -m unittest tests/test_workcell_project_tools.py` (18 tests; result: OK).
- Linted shell scripts: `bash -n scripts/check_workcell_dashboard.sh scripts/preflight_workcell.sh` (no syntax errors).
- Ran dashboard checker: `./scripts/check_workcell_dashboard.sh` (PASS for fixtures).
- Ran full preflight stub: `./scripts/preflight_workcell.sh` (completed; reported ROS discoverability SKIPs in this environment but preflight run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd357fda08331abbb5adfed62d005)