### PR TITLE
Add offline industrial capability contracts, validator, fixtures, tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This package was tested with [easy_perception_deployment](https://github.com/ros
 ## Operator manual and validation report
 
 - Operator + commissioning manual: `docs/manuals/WORKCELL_OPERATOR_MANUAL.md`
+- Industrial capability contracts manual: `docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md`
 - Workcell project dashboard manual: `docs/manuals/WORKCELL_PROJECT_DASHBOARD.md`
 - Validation-only preflight helper:
 

--- a/docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md
+++ b/docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md
@@ -1,0 +1,230 @@
+# Industrial Capability Contracts (Offline)\
+
+This manual defines an offline capability layer for heterogeneous robotic cells.
+
+## Why capability contracts exist
+
+The platform is moving from scene-specific examples toward a fully customisable industrial cell builder. Capability contracts separate **what a cell component can do** from scene/runtime implementation details. This allows future tooling to compose cells for different robot families, tools, sensors, tasks, and environment assets without hard-coding around UR5 + Robotiq + table + box assumptions.
+
+These contracts are intentionally offline-first metadata. They do not alter ROS launch flow, MoveIt planning behavior, grasp execution runtime behavior, perception runtime behavior, or existing GUI/runtime tools.
+
+## Contract families
+
+All contracts include `schema_version` and use versioned identifiers:
+
+- `robot_capability/v1`
+- `end_effector_capability/v1`
+- `sensor_capability/v1`
+- `task_capability/v1`
+- `environment_asset/v1`
+
+Reference fixtures live under `tests/fixtures/capabilities/`.
+
+---
+
+## 1) robot_capability/v1
+
+Key fields:
+
+- `schema_version`
+- `robot.id`, `robot.label`, `robot.brand`
+- `robot.family` (`serial_6_axis`, `collaborative_6_axis`, `scara`, `delta`, `gantry`, `mobile_manipulator`, `custom`)
+- `robot.mounting` (`floor`, `table`, `wall`, `ceiling`, `overhead`, `custom`)
+- planning groups, base/tool frames, default tool frame
+- named targets, payload, reach/workspace description
+- controller type
+- supported interfaces (`moveit`, `ros2_control`, `joint_trajectory_controller`, `cartesian_path`, `named_targets`)
+- supported task families
+- limitations/warnings
+
+Examples:
+
+- UR5 serial 6-axis: `tests/fixtures/capabilities/robot_ur5.yaml`
+- Generic delta: `tests/fixtures/capabilities/robot_generic_delta.yaml`
+- Generic SCARA: `tests/fixtures/capabilities/robot_generic_scara.yaml`
+- Generic gantry: `tests/fixtures/capabilities/robot_generic_gantry.yaml`
+
+### Delta robot support
+
+`robot.family: delta` + overhead mounting + high-speed/conveyor task family metadata allows future generators to pick delta-oriented defaults (short cycle windows, top-down tools, conveyor targeting) without changing runtime today.
+
+---
+
+## 2) end_effector_capability/v1
+
+Key fields:
+
+- `id`, `label`
+- `family` (`finger_gripper`, `three_finger_gripper`, `suction`, `vacuum_array`, `magnetic`, `tool_changer`, `custom`)
+- compatible robot families
+- required frames, grasp frames
+- contact links, allowed touch links
+- max object mass and opening width/suction area
+- supported grasp strategies (`pinch`, `enveloping`, `top_down_suction`, `side_pick`, `magnetic_pick`, `custom`)
+- required IO signals
+- release behaviour
+- limitations/warnings
+
+Examples:
+
+- Robotiq 2F: `tests/fixtures/capabilities/ee_robotiq_2f.yaml`
+- Robotiq 3F: `tests/fixtures/capabilities/ee_robotiq_3f.yaml`
+- OnRobot Airpick style suction: `tests/fixtures/capabilities/ee_airpick_suction.yaml`
+- Generic vacuum array: `tests/fixtures/capabilities/ee_vacuum_array.yaml`
+- Generic magnetic gripper (manual example):
+
+```yaml
+schema_version: end_effector_capability/v1
+end_effector:
+  id: generic_magnetic_head
+  label: Generic Magnetic Gripper
+  family: magnetic
+  compatible_robot_families: [gantry, serial_6_axis]
+  required_frames: [tool0]
+  grasp_frames: [magnet_face]
+  contact_links: [magnet_face]
+  allowed_touch_links: [magnet_face]
+  max_object_mass_kg: 3.0
+  supported_grasp_strategies: [magnetic_pick]
+  required_io_signals: [magnet_enable]
+  release_behaviour: demagnetize_then_clear
+  limitations_warnings: [Ferromagnetic-only payloads]
+```
+
+---
+
+## 3) sensor_capability/v1
+
+Key fields:
+
+- `id`, `label`
+- `family` (`rgbd_camera`, `2d_camera`, `depth_camera`, `barcode_reader`, `force_torque`, `proximity`, `custom`)
+- frames, topics, detection outputs
+- supported object attributes (`class`, `colour`, `shape`, `pose`, `size`, `confidence`, `barcode`)
+- mounting (`fixed`, `wrist`, `overhead`, `custom`)
+- calibration requirements
+- limitations/warnings
+
+Examples:
+
+- Intel RealSense D435i: `tests/fixtures/capabilities/sensor_realsense_d435i.yaml`
+- Generic overhead RGBD: `tests/fixtures/capabilities/sensor_overhead_rgbd.yaml`
+- Generic wrist camera (manual example):
+
+```yaml
+schema_version: sensor_capability/v1
+sensor:
+  id: generic_wrist_cam
+  label: Generic Wrist Camera
+  family: 2d_camera
+  frames: [wrist_camera_link, wrist_camera_optical_frame]
+  topics: [/wrist/image_raw]
+  detection_outputs: [class, pose, confidence]
+  supported_object_attributes: [class, pose, confidence]
+  mounting: wrist
+  calibration_requirements: [hand_eye_extrinsics]
+  limitations_warnings: [Field of view changes with wrist pose]
+```
+
+- Barcode reader (manual example):
+
+```yaml
+schema_version: sensor_capability/v1
+sensor:
+  id: industrial_barcode_reader
+  label: Industrial Barcode Reader
+  family: barcode_reader
+  frames: [barcode_reader_link]
+  topics: [/barcode/readings]
+  detection_outputs: [barcode, confidence]
+  supported_object_attributes: [barcode, confidence, pose]
+  mounting: fixed
+  calibration_requirements: [target_distance_calibration]
+  limitations_warnings: [Requires clear line of sight]
+```
+
+---
+
+## 4) task_capability/v1
+
+Key fields:
+
+- `task.task_family` (`pick_place`, `sort_by_colour`, `sort_by_shape`, `garbage_sorting`, `machine_tending`, `palletising`, `inspection_routing`, `conveyor_sorting`, `custom`)
+- required robot capabilities
+- required end-effector capabilities
+- required sensor attributes
+- required destinations
+- rule model
+- expected validation checks
+- runtime requirements
+- limitations/warnings
+
+Examples:
+
+- Simple pick/place: `tests/fixtures/capabilities/task_pick_place.yaml`
+- Colour sorting: `tests/fixtures/capabilities/task_colour_sorting.yaml`
+- Shape sorting: `tests/fixtures/capabilities/task_shape_sorting.yaml`
+- Garbage sorting: `tests/fixtures/capabilities/task_garbage_sorting.yaml`
+- Conveyor sorting: `tests/fixtures/capabilities/task_conveyor_sorting.yaml`
+- Machine tending (manual sketch): same schema with `task_family: machine_tending`, destination stations, and door/chuck IO requirements.
+
+---
+
+## 5) environment_asset/v1
+
+Key fields:
+
+- `asset.id`, `asset.label`
+- `asset.family` (`table`, `workbench`, `bin`, `tray`, `conveyor`, `fixture`, `machine`, `safety_fence`, `camera_mount`, `custom`)
+- dimensions, frame, pose
+- collision behaviour
+- movable/static/attachable state
+- import source and mesh path
+- limitations/warnings
+
+Examples:
+
+- Table: `tests/fixtures/capabilities/asset_table.yaml`
+- Conveyor: `tests/fixtures/capabilities/asset_conveyor.yaml`
+- Bin: `tests/fixtures/capabilities/asset_bin.yaml`
+- CNC/machine tending fixture: `tests/fixtures/capabilities/asset_machine_fixture.yaml`
+- Tray (manual example): `family: tray`
+- Safety fence (manual example): `family: safety_fence`
+
+---
+
+## Offline validator and checker
+
+Validator:
+
+```bash
+python3 scripts/validate_capability_contracts.py tests/fixtures/capabilities
+python3 scripts/validate_capability_contracts.py tests/fixtures/capabilities --json
+python3 scripts/validate_capability_contracts.py tests/fixtures/capabilities --strict
+```
+
+Checker wrapper:
+
+```bash
+./scripts/check_capability_contracts.sh
+```
+
+Preflight integration:
+
+```bash
+./scripts/preflight_workcell.sh
+```
+
+This stage remains offline and metadata-only.
+
+## How future GUI and generators will use these contracts
+
+Planned direction:
+
+1. GUI catalogs load robot/tool/sensor/asset/task capability records.
+2. GUI constrains options using compatibility fields (e.g., tool family vs robot family).
+3. workcell_builder emits selected capability IDs into generated workcell metadata.
+4. Generated project validators ensure required capability combinations are complete before launch.
+5. Runtime adapters can then map validated capabilities to concrete planners/controllers/drivers.
+
+This keeps the **physical robotic cell** as the commercial product while software remains the configurable engineering pipeline used to define, validate, and commission that cell.

--- a/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
+++ b/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
@@ -3,6 +3,7 @@
 This manual is written for engineers who are comfortable with Linux/ROS 2 but are new to this repository. It focuses on copy-paste operational steps for building, validating, launching, troubleshooting, and extending scenes without changing grasp runtime behavior.
 
 For generated project review dashboards, see `docs/manuals/WORKCELL_PROJECT_DASHBOARD.md`. **The dashboard is a read-only offline project summary. It does not replace the existing GUI and does not control the robot.**
+For offline robot/tool/sensor/task/asset capability contracts, see `docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md`.
 
 ---
 

--- a/scripts/check_capability_contracts.sh
+++ b/scripts/check_capability_contracts.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VALIDATOR="${SCRIPT_DIR}/validate_capability_contracts.py"
+FIXTURE_DIR="${REPO_ROOT}/tests/fixtures/capabilities"
+
+if [[ ! -x "${VALIDATOR}" ]]; then
+  echo "Capability contract checks: FAIL"
+  echo "Missing validator: ${VALIDATOR}" >&2
+  exit 2
+fi
+
+if [[ ! -d "${FIXTURE_DIR}" ]]; then
+  echo "Capability contract checks: FAIL"
+  echo "Missing fixture directory: ${FIXTURE_DIR}" >&2
+  exit 2
+fi
+
+set +e
+OUTPUT="$(${VALIDATOR} "${FIXTURE_DIR}" 2>&1)"
+STATUS=$?
+set -e
+
+printf '%s\n' "${OUTPUT}"
+
+if [[ ${STATUS} -ne 0 ]]; then
+  echo "Capability contract checks: FAIL"
+  exit ${STATUS}
+fi
+
+if grep -q "\[WARN\]" <<<"${OUTPUT}"; then
+  echo "Capability contract checks: WARN"
+else
+  echo "Capability contract checks: PASS"
+fi

--- a/scripts/preflight_workcell.sh
+++ b/scripts/preflight_workcell.sh
@@ -51,6 +51,7 @@ fi
 
 echo
 "${SCRIPT_DIR}/check_all_scenes.sh"
+"${SCRIPT_DIR}/check_capability_contracts.sh"
 "${SCRIPT_DIR}/generate_scene_validation_report.py"
 "${SCRIPT_DIR}/check_scene_self_tests.sh"
 "${SCRIPT_DIR}/generate_scene_self_test_report.py"

--- a/scripts/validate_capability_contracts.py
+++ b/scripts/validate_capability_contracts.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""Validate offline capability contract files (YAML/JSON)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:  # Optional dependency.
+    import yaml as _pyyaml
+except Exception:  # pragma: no cover
+    _pyyaml = None
+
+SUPPORTED_EXTENSIONS = {".yaml", ".yml", ".json"}
+SCHEMA_TYPES = {
+    "robot_capability/v1": "robot",
+    "end_effector_capability/v1": "end_effector",
+    "sensor_capability/v1": "sensor",
+    "task_capability/v1": "task",
+    "environment_asset/v1": "asset",
+}
+
+ENUMS = {
+    "robot.family": {
+        "serial_6_axis",
+        "collaborative_6_axis",
+        "scara",
+        "delta",
+        "gantry",
+        "mobile_manipulator",
+        "custom",
+    },
+    "robot.mounting": {"floor", "table", "wall", "ceiling", "overhead", "custom"},
+    "end_effector.family": {
+        "finger_gripper",
+        "three_finger_gripper",
+        "suction",
+        "vacuum_array",
+        "magnetic",
+        "tool_changer",
+        "custom",
+    },
+    "sensor.family": {
+        "rgbd_camera",
+        "2d_camera",
+        "depth_camera",
+        "barcode_reader",
+        "force_torque",
+        "proximity",
+        "custom",
+    },
+    "sensor.mounting": {"fixed", "wrist", "overhead", "custom"},
+    "task.task_family": {
+        "pick_place",
+        "sort_by_colour",
+        "sort_by_shape",
+        "garbage_sorting",
+        "machine_tending",
+        "palletising",
+        "inspection_routing",
+        "conveyor_sorting",
+        "custom",
+    },
+    "asset.family": {
+        "table",
+        "workbench",
+        "bin",
+        "tray",
+        "conveyor",
+        "fixture",
+        "machine",
+        "safety_fence",
+        "camera_mount",
+        "custom",
+    },
+}
+
+LIST_FIELDS = {
+    "robot": [
+        "planning_groups",
+        "tool_frames",
+        "named_targets",
+        "supported_interfaces",
+        "supported_task_families",
+        "limitations_warnings",
+    ],
+    "end_effector": [
+        "compatible_robot_families",
+        "required_frames",
+        "grasp_frames",
+        "contact_links",
+        "allowed_touch_links",
+        "supported_grasp_strategies",
+        "required_io_signals",
+        "limitations_warnings",
+    ],
+    "sensor": [
+        "frames",
+        "topics",
+        "detection_outputs",
+        "supported_object_attributes",
+        "calibration_requirements",
+        "limitations_warnings",
+    ],
+    "task": [
+        "required_robot_capabilities",
+        "required_end_effector_capabilities",
+        "required_sensor_attributes",
+        "required_destinations",
+        "expected_validation_checks",
+        "runtime_requirements",
+        "limitations_warnings",
+    ],
+    "asset": ["dimensions", "limitations_warnings"],
+}
+
+
+class SimpleYamlError(ValueError):
+    """Raised when fallback parser hits unsupported syntax."""
+
+
+@dataclass
+class _Line:
+    line_no: int
+    indent: int
+    content: str
+
+
+@dataclass
+class FileValidationResult:
+    path: str
+    status: str
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+
+def _strip_comment(value: str) -> str:
+    quote: str | None = None
+    for idx, ch in enumerate(value):
+        if ch in {'"', "'"}:
+            if quote is None:
+                quote = ch
+            elif quote == ch:
+                quote = None
+        if ch == "#" and quote is None and idx > 0 and value[idx - 1].isspace():
+            return value[:idx].rstrip()
+    return value.rstrip()
+
+
+def _tokenize_simple_yaml(text: str) -> list[_Line]:
+    tokens: list[_Line] = []
+    for idx, raw_line in enumerate(text.splitlines(), start=1):
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        if "\t" in raw_line:
+            raise SimpleYamlError(f"Line {idx}: tabs are not supported")
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        content = _strip_comment(raw_line[indent:]).strip()
+        if not content:
+            continue
+        if any(marker in content for marker in ("|", ">", "&", "*", "!!")):
+            raise SimpleYamlError(f"Line {idx}: advanced YAML tokens are not supported")
+        tokens.append(_Line(line_no=idx, indent=indent, content=content))
+    return tokens
+
+
+def _parse_scalar(value: str, line_no: int) -> Any:
+    value = value.strip()
+    if not value:
+        return ""
+    if value.startswith("["):
+        if not value.endswith("]"):
+            raise SimpleYamlError(f"Line {line_no}: malformed inline list")
+        inner = value[1:-1].strip()
+        if not inner:
+            return []
+        parts = [part.strip() for part in inner.split(",")]
+        if any(not part for part in parts):
+            raise SimpleYamlError(f"Line {line_no}: malformed inline list entries")
+        return [_parse_scalar(part, line_no) for part in parts]
+    if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
+        return value[1:-1]
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if re.fullmatch(r"[+-]?\d+", value):
+        return int(value)
+    if re.fullmatch(r"[+-]?(?:\d+\.\d*|\d*\.\d+)(?:[eE][+-]?\d+)?", value) or re.fullmatch(
+        r"[+-]?\d+[eE][+-]?\d+", value
+    ):
+        return float(value)
+    if value.startswith("{"):
+        raise SimpleYamlError(f"Line {line_no}: flow mappings are not supported")
+    return value
+
+
+def _parse_mapping(lines: list[_Line], start: int, indent: int) -> tuple[dict[str, Any], int]:
+    result: dict[str, Any] = {}
+    i = start
+    while i < len(lines):
+        line = lines[i]
+        if line.indent < indent:
+            break
+        if line.indent > indent:
+            raise SimpleYamlError(f"Line {line.line_no}: unexpected indentation")
+        if line.content.startswith("- "):
+            raise SimpleYamlError(f"Line {line.line_no}: list item where mapping key expected")
+        if ":" not in line.content:
+            raise SimpleYamlError(f"Line {line.line_no}: missing ':'")
+        key, remainder = line.content.split(":", 1)
+        key = key.strip()
+        value_text = remainder.strip()
+        i += 1
+        if value_text:
+            result[key] = _parse_scalar(value_text, line.line_no)
+            continue
+        if i >= len(lines) or lines[i].indent <= indent:
+            result[key] = {}
+            continue
+        child_indent = lines[i].indent
+        if lines[i].content.startswith("- "):
+            parsed, i = _parse_list(lines, i, child_indent)
+            result[key] = parsed
+        else:
+            parsed, i = _parse_mapping(lines, i, child_indent)
+            result[key] = parsed
+    return result, i
+
+
+def _parse_list(lines: list[_Line], start: int, indent: int) -> tuple[list[Any], int]:
+    items: list[Any] = []
+    i = start
+    while i < len(lines):
+        line = lines[i]
+        if line.indent < indent:
+            break
+        if line.indent != indent or not line.content.startswith("- "):
+            break
+        item_text = line.content[2:].strip()
+        if not item_text:
+            raise SimpleYamlError(f"Line {line.line_no}: empty list item")
+        if item_text.endswith(":") or (":" in item_text and not item_text.startswith(("'", '"'))):
+            end = i + 1
+            while end < len(lines) and lines[end].indent > indent:
+                end += 1
+            synthetic = [_Line(line_no=line.line_no, indent=indent + 2, content=item_text)]
+            synthetic.extend(lines[i + 1 : end])
+            parsed_map, consumed = _parse_mapping(synthetic, 0, indent + 2)
+            if consumed != len(synthetic):
+                raise SimpleYamlError(f"Line {line.line_no}: unsupported list mapping")
+            items.append(parsed_map)
+            i = end
+            continue
+        items.append(_parse_scalar(item_text, line.line_no))
+        i += 1
+    return items, i
+
+
+def parse_simple_yaml(text: str) -> dict[str, Any]:
+    lines = _tokenize_simple_yaml(text)
+    if not lines:
+        return {}
+    root_indent = min(line.indent for line in lines)
+    parsed, idx = _parse_mapping(lines, 0, root_indent)
+    if idx != len(lines):
+        raise SimpleYamlError(f"Line {lines[idx].line_no}: unsupported YAML structure")
+    return parsed
+
+
+def _dig(mapping: dict[str, Any], dotted_path: str) -> Any:
+    current: Any = mapping
+    for part in dotted_path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _is_non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _is_numeric(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _validate_enum(value: Any, enum_key: str, warnings: list[str], errors: list[str], strict: bool) -> None:
+    if value is None:
+        return
+    if not _is_non_empty_string(value):
+        errors.append(f"Field '{enum_key}' must be a non-empty string.")
+        return
+    allowed = ENUMS[enum_key]
+    if value not in allowed:
+        msg = f"Field '{enum_key}' uses unknown value '{value}' (allowed: {sorted(allowed)})."
+        if strict:
+            errors.append(msg)
+        else:
+            warnings.append(msg)
+
+
+def _validate_common(contract: dict[str, Any], errors: list[str]) -> None:
+    if not _is_non_empty_string(contract.get("schema_version")):
+        errors.append("Missing or empty required field 'schema_version'.")
+
+
+def validate_contract(contract: dict[str, Any], strict: bool = False) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    _validate_common(contract, errors)
+    schema_version = contract.get("schema_version")
+    kind = SCHEMA_TYPES.get(schema_version)
+    if not kind:
+        errors.append(f"Unsupported schema_version '{schema_version}'.")
+        return errors, warnings
+
+    if kind == "robot":
+        robot = contract.get("robot")
+        if not isinstance(robot, dict):
+            errors.append("Field 'robot' must be a mapping/object.")
+            return errors, warnings
+        for field in ["id", "label", "brand", "family", "mounting", "base_frame", "default_tool_frame"]:
+            if not _is_non_empty_string(robot.get(field)):
+                errors.append(f"Field 'robot.{field}' is required and must be a non-empty string.")
+        for list_field in LIST_FIELDS["robot"]:
+            if list_field in robot and not isinstance(robot[list_field], list):
+                errors.append(f"Field 'robot.{list_field}' must be a list.")
+        _validate_enum(robot.get("family"), "robot.family", warnings, errors, strict)
+        _validate_enum(robot.get("mounting"), "robot.mounting", warnings, errors, strict)
+        for frame_field in ["base_frame", "default_tool_frame"]:
+            if frame_field in robot and not _is_non_empty_string(robot.get(frame_field)):
+                errors.append(f"Field 'robot.{frame_field}' must be a non-empty string.")
+        for num_field in ["payload_kg", "reach_m"]:
+            if num_field in robot and not _is_numeric(robot.get(num_field)):
+                errors.append(f"Field 'robot.{num_field}' must be numeric.")
+
+    elif kind == "end_effector":
+        ee = contract.get("end_effector")
+        if not isinstance(ee, dict):
+            errors.append("Field 'end_effector' must be a mapping/object.")
+            return errors, warnings
+        for field in ["id", "label", "family", "release_behaviour"]:
+            if not _is_non_empty_string(ee.get(field)):
+                errors.append(f"Field 'end_effector.{field}' is required and must be a non-empty string.")
+        for list_field in LIST_FIELDS["end_effector"]:
+            if list_field in ee and not isinstance(ee[list_field], list):
+                errors.append(f"Field 'end_effector.{list_field}' must be a list.")
+        _validate_enum(ee.get("family"), "end_effector.family", warnings, errors, strict)
+        if "max_object_mass_kg" in ee and not _is_numeric(ee.get("max_object_mass_kg")):
+            errors.append("Field 'end_effector.max_object_mass_kg' must be numeric.")
+
+    elif kind == "sensor":
+        sensor = contract.get("sensor")
+        if not isinstance(sensor, dict):
+            errors.append("Field 'sensor' must be a mapping/object.")
+            return errors, warnings
+        for field in ["id", "label", "family", "mounting"]:
+            if not _is_non_empty_string(sensor.get(field)):
+                errors.append(f"Field 'sensor.{field}' is required and must be a non-empty string.")
+        for list_field in LIST_FIELDS["sensor"]:
+            if list_field in sensor and not isinstance(sensor[list_field], list):
+                errors.append(f"Field 'sensor.{list_field}' must be a list.")
+        _validate_enum(sensor.get("family"), "sensor.family", warnings, errors, strict)
+        _validate_enum(sensor.get("mounting"), "sensor.mounting", warnings, errors, strict)
+
+    elif kind == "task":
+        task = contract.get("task")
+        if not isinstance(task, dict):
+            errors.append("Field 'task' must be a mapping/object.")
+            return errors, warnings
+        if not _is_non_empty_string(task.get("task_family")):
+            errors.append("Field 'task.task_family' is required and must be a non-empty string.")
+        _validate_enum(task.get("task_family"), "task.task_family", warnings, errors, strict)
+        if not _is_non_empty_string(task.get("rule_model")):
+            errors.append("Field 'task.rule_model' is required and must be a non-empty string.")
+        for list_field in LIST_FIELDS["task"]:
+            if list_field in task and not isinstance(task[list_field], list):
+                errors.append(f"Field 'task.{list_field}' must be a list.")
+
+    elif kind == "asset":
+        asset = contract.get("asset")
+        if not isinstance(asset, dict):
+            errors.append("Field 'asset' must be a mapping/object.")
+            return errors, warnings
+        for field in ["id", "label", "family", "frame"]:
+            if not _is_non_empty_string(asset.get(field)):
+                errors.append(f"Field 'asset.{field}' is required and must be a non-empty string.")
+        _validate_enum(asset.get("family"), "asset.family", warnings, errors, strict)
+        dims = asset.get("dimensions")
+        if dims is not None:
+            if not isinstance(dims, dict):
+                errors.append("Field 'asset.dimensions' must be a mapping/object when provided.")
+            else:
+                for key, value in dims.items():
+                    if not _is_numeric(value):
+                        errors.append(f"Field 'asset.dimensions.{key}' must be numeric.")
+
+    return errors, warnings
+
+
+def load_contract(path: Path) -> tuple[dict[str, Any], list[str]]:
+    notes: list[str] = []
+    content = path.read_text(encoding="utf-8")
+    if path.suffix.lower() == ".json":
+        loaded = json.loads(content)
+    elif _pyyaml is not None:
+        loaded = _pyyaml.safe_load(content) or {}
+    else:
+        notes.append("PyYAML not available: using built-in fallback parser.")
+        loaded = parse_simple_yaml(content)
+    if not isinstance(loaded, dict):
+        raise ValueError("Contract root must be a mapping/object.")
+    return loaded, notes
+
+
+def collect_files(path: Path) -> list[Path]:
+    if path.is_file():
+        return [path]
+    files: list[Path] = []
+    for candidate in sorted(path.rglob("*")):
+        if candidate.is_file() and candidate.suffix.lower() in SUPPORTED_EXTENSIONS:
+            files.append(candidate)
+    return files
+
+
+def validate_path(path: Path, strict: bool = False) -> list[FileValidationResult]:
+    results: list[FileValidationResult] = []
+    for file_path in collect_files(path):
+        try:
+            contract, notes = load_contract(file_path)
+            errors, warnings = validate_contract(contract, strict=strict)
+            status = "FAIL" if errors else ("WARN" if warnings else "PASS")
+            results.append(
+                FileValidationResult(
+                    path=str(file_path), status=status, errors=errors, warnings=warnings, notes=notes
+                )
+            )
+        except Exception as exc:
+            results.append(
+                FileValidationResult(path=str(file_path), status="FAIL", errors=[f"Load error: {exc}"])
+            )
+    if path.is_file() and not results:
+        results.append(FileValidationResult(path=str(path), status="FAIL", errors=["Unsupported file extension."]))
+    return results
+
+
+def build_json_summary(results: list[FileValidationResult]) -> str:
+    payload = {
+        "summary": {
+            "pass": sum(1 for r in results if r.status == "PASS"),
+            "warn": sum(1 for r in results if r.status == "WARN"),
+            "fail": sum(1 for r in results if r.status == "FAIL"),
+            "total": len(results),
+        },
+        "results": [r.__dict__ for r in results],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def print_human(results: list[FileValidationResult]) -> None:
+    for result in results:
+        print(f"[{result.status}] {result.path}")
+        for note in result.notes:
+            print(f"  NOTE: {note}")
+        for warning in result.warnings:
+            print(f"  WARN: {warning}")
+        for error in result.errors:
+            print(f"  FAIL: {error}")
+    pass_count = sum(1 for r in results if r.status == "PASS")
+    warn_count = sum(1 for r in results if r.status == "WARN")
+    fail_count = sum(1 for r in results if r.status == "FAIL")
+    print(f"SUMMARY: PASS={pass_count} WARN={warn_count} FAIL={fail_count} TOTAL={len(results)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate capability contracts (offline).")
+    parser.add_argument("target", help="Contract file or directory")
+    parser.add_argument("--json", action="store_true", dest="json_output", help="Emit JSON output")
+    parser.add_argument("--strict", action="store_true", help="Treat unknown enum values as FAIL")
+    args = parser.parse_args()
+
+    target = Path(args.target)
+    if not target.exists():
+        if args.json_output:
+            print(json.dumps({"summary": {"pass": 0, "warn": 0, "fail": 1, "total": 0}, "error": "Target not found"}))
+        else:
+            print(f"FAIL: Target does not exist: {target}")
+        return 2
+
+    results = validate_path(target, strict=args.strict)
+    if args.json_output:
+        print(build_json_summary(results))
+    else:
+        print_human(results)
+    return 1 if any(r.status == "FAIL" for r in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/capabilities/asset_bin.yaml
+++ b/tests/fixtures/capabilities/asset_bin.yaml
@@ -1,0 +1,17 @@
+schema_version: environment_asset/v1
+asset:
+  id: bin_blue_large
+  label: Blue Sorting Bin
+  family: bin
+  dimensions:
+    length_m: 0.5
+    width_m: 0.4
+    height_m: 0.35
+  frame: world
+  pose: [0.3, -0.6, 0.175, 0.0, 0.0, 0.0]
+  collision_behaviour: rigid_container
+  mobility: movable
+  import_source: internal_catalog
+  mesh_path: assets/environment/bin_blue_large.stl
+  limitations_warnings:
+    - Keep 50 mm clearance around rim for placement.

--- a/tests/fixtures/capabilities/asset_conveyor.yaml
+++ b/tests/fixtures/capabilities/asset_conveyor.yaml
@@ -1,0 +1,17 @@
+schema_version: environment_asset/v1
+asset:
+  id: conveyor_2m
+  label: Belt Conveyor 2m
+  family: conveyor
+  dimensions:
+    length_m: 2.0
+    width_m: 0.5
+    height_m: 0.85
+  frame: world
+  pose: [1.5, -0.4, 0.425, 0.0, 0.0, 0.0]
+  collision_behaviour: dynamic_surface
+  mobility: static
+  import_source: vendor_model
+  mesh_path: assets/environment/conveyor_2m.stl
+  limitations_warnings:
+    - Motion surface speed configured externally.

--- a/tests/fixtures/capabilities/asset_machine_fixture.yaml
+++ b/tests/fixtures/capabilities/asset_machine_fixture.yaml
@@ -1,0 +1,17 @@
+schema_version: environment_asset/v1
+asset:
+  id: cnc_tending_fixture_a
+  label: CNC Tending Fixture A
+  family: fixture
+  dimensions:
+    length_m: 0.9
+    width_m: 0.6
+    height_m: 0.2
+  frame: machine_base
+  pose: [0.2, 0.0, 0.1, 0.0, 0.0, 0.0]
+  collision_behaviour: rigid_fixture
+  mobility: attachable
+  import_source: cad_import
+  mesh_path: assets/environment/cnc_tending_fixture_a.stl
+  limitations_warnings:
+    - Validate spindle clearance before deployment.

--- a/tests/fixtures/capabilities/asset_table.yaml
+++ b/tests/fixtures/capabilities/asset_table.yaml
@@ -1,0 +1,17 @@
+schema_version: environment_asset/v1
+asset:
+  id: table_standard_1200
+  label: Standard Table 1200
+  family: table
+  dimensions:
+    length_m: 1.2
+    width_m: 0.8
+    height_m: 0.9
+  frame: world
+  pose: [0.8, 0.0, 0.45, 0.0, 0.0, 0.0]
+  collision_behaviour: static_collision
+  mobility: static
+  import_source: internal_catalog
+  mesh_path: assets/environment/table_standard.stl
+  limitations_warnings:
+    - Payload limit depends on selected table model.

--- a/tests/fixtures/capabilities/ee_airpick_suction.yaml
+++ b/tests/fixtures/capabilities/ee_airpick_suction.yaml
@@ -1,0 +1,17 @@
+schema_version: end_effector_capability/v1
+end_effector:
+  id: onrobot_airpick_style
+  label: OnRobot Airpick Style
+  family: suction
+  compatible_robot_families: [serial_6_axis, collaborative_6_axis, delta]
+  required_frames: [tool0]
+  grasp_frames: [suction_tip]
+  contact_links: [suction_cup]
+  allowed_touch_links: [suction_cup]
+  max_object_mass_kg: 0.6
+  suction_area_mm2: 900
+  supported_grasp_strategies: [top_down_suction, side_pick]
+  required_io_signals: [vacuum_on, blowoff]
+  release_behaviour: vacuum_off_with_blowoff
+  limitations_warnings:
+    - Porous surfaces reduce holding force.

--- a/tests/fixtures/capabilities/ee_robotiq_2f.yaml
+++ b/tests/fixtures/capabilities/ee_robotiq_2f.yaml
@@ -1,0 +1,17 @@
+schema_version: end_effector_capability/v1
+end_effector:
+  id: robotiq_2f_85
+  label: Robotiq 2F-85
+  family: finger_gripper
+  compatible_robot_families: [serial_6_axis, collaborative_6_axis, scara]
+  required_frames: [tool0]
+  grasp_frames: [tool0]
+  contact_links: [left_inner_finger, right_inner_finger]
+  allowed_touch_links: [left_inner_finger, right_inner_finger]
+  max_object_mass_kg: 2.0
+  opening_width_mm: 85
+  supported_grasp_strategies: [pinch, side_pick]
+  required_io_signals: [gripper_open_cmd, gripper_close_cmd]
+  release_behaviour: open_until_clear
+  limitations_warnings:
+    - Requires parallel approach for reliable pinch grasps.

--- a/tests/fixtures/capabilities/ee_robotiq_3f.yaml
+++ b/tests/fixtures/capabilities/ee_robotiq_3f.yaml
@@ -1,0 +1,17 @@
+schema_version: end_effector_capability/v1
+end_effector:
+  id: robotiq_3f
+  label: Robotiq 3F
+  family: three_finger_gripper
+  compatible_robot_families: [serial_6_axis, collaborative_6_axis]
+  required_frames: [tool0]
+  grasp_frames: [tool0, palm_link]
+  contact_links: [finger_a, finger_b, finger_c]
+  allowed_touch_links: [finger_a, finger_b, finger_c]
+  max_object_mass_kg: 1.5
+  opening_width_mm: 155
+  supported_grasp_strategies: [pinch, enveloping]
+  required_io_signals: [mode_cmd, grip_cmd]
+  release_behaviour: adaptive_release
+  limitations_warnings:
+    - Enveloping grasp speed is slower than pinch mode.

--- a/tests/fixtures/capabilities/ee_vacuum_array.yaml
+++ b/tests/fixtures/capabilities/ee_vacuum_array.yaml
@@ -1,0 +1,17 @@
+schema_version: end_effector_capability/v1
+end_effector:
+  id: generic_vacuum_array
+  label: Generic Vacuum Array
+  family: vacuum_array
+  compatible_robot_families: [gantry, delta, serial_6_axis]
+  required_frames: [tool0]
+  grasp_frames: [array_center]
+  contact_links: [cup_1, cup_2, cup_3, cup_4]
+  allowed_touch_links: [cup_1, cup_2, cup_3, cup_4]
+  max_object_mass_kg: 8.0
+  suction_area_mm2: 8500
+  supported_grasp_strategies: [top_down_suction]
+  required_io_signals: [vacuum_zone_a, vacuum_zone_b]
+  release_behaviour: staged_zone_release
+  limitations_warnings:
+    - Needs flat target contact area for all active cups.

--- a/tests/fixtures/capabilities/robot_generic_delta.yaml
+++ b/tests/fixtures/capabilities/robot_generic_delta.yaml
@@ -1,0 +1,20 @@
+schema_version: robot_capability/v1
+robot:
+  id: generic_delta_900
+  label: Generic Delta 900
+  brand: Generic
+  family: delta
+  mounting: overhead
+  planning_groups: [delta_arm]
+  base_frame: delta_base
+  tool_frames: [delta_tool]
+  default_tool_frame: delta_tool
+  named_targets: [home]
+  payload_kg: 1.2
+  reach_m: 0.9
+  workspace_description: High-speed dome envelope above conveyor
+  controller_type: high_speed_trajectory
+  supported_interfaces: [moveit, ros2_control, cartesian_path]
+  supported_task_families: [pick_place, conveyor_sorting]
+  limitations_warnings:
+    - Limited orientation control at workspace edges.

--- a/tests/fixtures/capabilities/robot_generic_gantry.yaml
+++ b/tests/fixtures/capabilities/robot_generic_gantry.yaml
@@ -1,0 +1,20 @@
+schema_version: robot_capability/v1
+robot:
+  id: generic_gantry_xyz
+  label: Generic Gantry XYZ
+  brand: Generic
+  family: gantry
+  mounting: ceiling
+  planning_groups: [gantry]
+  base_frame: world
+  tool_frames: [gantry_tool]
+  default_tool_frame: gantry_tool
+  named_targets: [home, park]
+  payload_kg: 15.0
+  reach_m: 3.5
+  workspace_description: Rectangular cartesian envelope over multi-station line
+  controller_type: cartesian_controller
+  supported_interfaces: [moveit, ros2_control, joint_trajectory_controller, cartesian_path]
+  supported_task_families: [palletising, machine_tending, conveyor_sorting]
+  limitations_warnings:
+    - Dynamic acceleration constrained by bridge mass.

--- a/tests/fixtures/capabilities/robot_generic_scara.yaml
+++ b/tests/fixtures/capabilities/robot_generic_scara.yaml
@@ -1,0 +1,20 @@
+schema_version: robot_capability/v1
+robot:
+  id: generic_scara_600
+  label: Generic SCARA 600
+  brand: Generic
+  family: scara
+  mounting: table
+  planning_groups: [scara_arm]
+  base_frame: scara_base
+  tool_frames: [scara_tool]
+  default_tool_frame: scara_tool
+  named_targets: [home, service]
+  payload_kg: 3.0
+  reach_m: 0.6
+  workspace_description: Planar annulus with vertical stroke
+  controller_type: joint_trajectory
+  supported_interfaces: [moveit, joint_trajectory_controller, named_targets]
+  supported_task_families: [pick_place, sort_by_shape, machine_tending]
+  limitations_warnings:
+    - Not suitable for high-angle side picks.

--- a/tests/fixtures/capabilities/robot_ur5.yaml
+++ b/tests/fixtures/capabilities/robot_ur5.yaml
@@ -1,0 +1,20 @@
+schema_version: robot_capability/v1
+robot:
+  id: ur5
+  label: Universal Robots UR5
+  brand: Universal Robots
+  family: serial_6_axis
+  mounting: floor
+  planning_groups: [manipulator]
+  base_frame: base_link
+  tool_frames: [tool0, ee_link]
+  default_tool_frame: tool0
+  named_targets: [home, ready, stow]
+  payload_kg: 5.0
+  reach_m: 0.85
+  workspace_description: Cylindrical workstation envelope
+  controller_type: position_trajectory
+  supported_interfaces: [moveit, ros2_control, joint_trajectory_controller, cartesian_path, named_targets]
+  supported_task_families: [pick_place, sort_by_colour, sort_by_shape, machine_tending]
+  limitations_warnings:
+    - Demonstration metadata only.

--- a/tests/fixtures/capabilities/sensor_overhead_rgbd.yaml
+++ b/tests/fixtures/capabilities/sensor_overhead_rgbd.yaml
@@ -1,0 +1,13 @@
+schema_version: sensor_capability/v1
+sensor:
+  id: generic_overhead_rgbd
+  label: Generic Overhead RGBD Camera
+  family: rgbd_camera
+  frames: [overhead_camera_link, overhead_optical_frame]
+  topics: [/overhead/rgb, /overhead/depth]
+  detection_outputs: [class, colour, shape, pose, confidence]
+  supported_object_attributes: [class, colour, shape, pose, size, confidence]
+  mounting: overhead
+  calibration_requirements: [extrinsics_to_world, lens_distortion]
+  limitations_warnings:
+    - Occlusion increases near tall fixtures.

--- a/tests/fixtures/capabilities/sensor_realsense_d435i.yaml
+++ b/tests/fixtures/capabilities/sensor_realsense_d435i.yaml
@@ -1,0 +1,13 @@
+schema_version: sensor_capability/v1
+sensor:
+  id: intel_realsense_d435i
+  label: Intel RealSense D435i
+  family: rgbd_camera
+  frames: [camera_link, camera_color_optical_frame, camera_depth_optical_frame]
+  topics: [/camera/color/image_raw, /camera/depth/image_rect_raw, /camera/aligned_depth_to_color/image_raw]
+  detection_outputs: [pose, size, confidence, class]
+  supported_object_attributes: [class, colour, shape, pose, size, confidence]
+  mounting: fixed
+  calibration_requirements: [intrinsics, hand_eye_if_robot_relative]
+  limitations_warnings:
+    - IR interference can reduce depth quality on reflective parts.

--- a/tests/fixtures/capabilities/task_colour_sorting.yaml
+++ b/tests/fixtures/capabilities/task_colour_sorting.yaml
@@ -1,0 +1,12 @@
+schema_version: task_capability/v1
+task:
+  task_family: sort_by_colour
+  required_robot_capabilities: [named_targets, supported_task_families]
+  required_end_effector_capabilities: [supported_grasp_strategies]
+  required_sensor_attributes: [colour, class, confidence, pose]
+  required_destinations: [bin_red, bin_blue, reject_bin]
+  rule_model: attribute_threshold_rules
+  expected_validation_checks: [destination_defined_for_all_rules, confidence_threshold_defined]
+  runtime_requirements: [continuous_detection_loop]
+  limitations_warnings:
+    - Lighting changes may impact colour classification.

--- a/tests/fixtures/capabilities/task_conveyor_sorting.yaml
+++ b/tests/fixtures/capabilities/task_conveyor_sorting.yaml
@@ -1,0 +1,12 @@
+schema_version: task_capability/v1
+task:
+  task_family: conveyor_sorting
+  required_robot_capabilities: [cartesian_path, supported_task_families]
+  required_end_effector_capabilities: [required_io_signals]
+  required_sensor_attributes: [pose, class, confidence]
+  required_destinations: [lane_a, lane_b, reject_lane]
+  rule_model: conveyor_tracking_rules
+  expected_validation_checks: [pick_window_defined, tracking_latency_budget]
+  runtime_requirements: [time_synchronization, conveyor_encoder]
+  limitations_warnings:
+    - High conveyor speed can reduce pick success.

--- a/tests/fixtures/capabilities/task_garbage_sorting.yaml
+++ b/tests/fixtures/capabilities/task_garbage_sorting.yaml
@@ -1,0 +1,12 @@
+schema_version: task_capability/v1
+task:
+  task_family: garbage_sorting
+  required_robot_capabilities: [supported_task_families]
+  required_end_effector_capabilities: [supported_grasp_strategies]
+  required_sensor_attributes: [class, confidence, pose, size]
+  required_destinations: [plastic_bin, metal_bin, organic_bin, reject_bin]
+  rule_model: class_then_fallback
+  expected_validation_checks: [category_bins_exist, hazardous_fallback_defined]
+  runtime_requirements: [category_mapping_table]
+  limitations_warnings:
+    - Hazardous material handling must follow site policy.

--- a/tests/fixtures/capabilities/task_pick_place.yaml
+++ b/tests/fixtures/capabilities/task_pick_place.yaml
@@ -1,0 +1,12 @@
+schema_version: task_capability/v1
+task:
+  task_family: pick_place
+  required_robot_capabilities: [planning_groups, base_frame, tool_frames]
+  required_end_effector_capabilities: [grasp_frames, release_behaviour]
+  required_sensor_attributes: [pose, confidence]
+  required_destinations: [place_target]
+  rule_model: direct_target
+  expected_validation_checks: [reachable_pick, reachable_place, payload_within_limit]
+  runtime_requirements: [trajectory_execution, gripper_command]
+  limitations_warnings:
+    - Assumes known pick and place poses.

--- a/tests/fixtures/capabilities/task_shape_sorting.yaml
+++ b/tests/fixtures/capabilities/task_shape_sorting.yaml
@@ -1,0 +1,12 @@
+schema_version: task_capability/v1
+task:
+  task_family: sort_by_shape
+  required_robot_capabilities: [planning_groups]
+  required_end_effector_capabilities: [supported_grasp_strategies]
+  required_sensor_attributes: [shape, pose, confidence]
+  required_destinations: [bin_cylinders, bin_cubes, reject_bin]
+  rule_model: shape_lookup
+  expected_validation_checks: [shape_rules_complete]
+  runtime_requirements: [shape_classifier]
+  limitations_warnings:
+    - Similar silhouettes may require multi-view sensing.

--- a/tests/test_capability_contracts.py
+++ b/tests/test_capability_contracts.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Tests for offline capability contract tooling."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "capabilities"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+validator = _load_module(
+    "validate_capability_contracts", REPO_ROOT / "scripts" / "validate_capability_contracts.py"
+)
+
+
+class CapabilityFixturesTests(unittest.TestCase):
+    def _assert_pass(self, filename: str) -> None:
+        results = validator.validate_path(FIXTURE_DIR / filename)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].status, "PASS", f"{filename}: {results[0].errors} {results[0].warnings}")
+
+    def test_valid_robot_fixtures(self) -> None:
+        for name in [
+            "robot_ur5.yaml",
+            "robot_generic_delta.yaml",
+            "robot_generic_scara.yaml",
+            "robot_generic_gantry.yaml",
+        ]:
+            self._assert_pass(name)
+
+    def test_valid_end_effector_fixtures(self) -> None:
+        for name in [
+            "ee_robotiq_2f.yaml",
+            "ee_robotiq_3f.yaml",
+            "ee_airpick_suction.yaml",
+            "ee_vacuum_array.yaml",
+        ]:
+            self._assert_pass(name)
+
+    def test_valid_sensor_fixtures(self) -> None:
+        for name in ["sensor_realsense_d435i.yaml", "sensor_overhead_rgbd.yaml"]:
+            self._assert_pass(name)
+
+    def test_valid_task_fixtures(self) -> None:
+        for name in [
+            "task_pick_place.yaml",
+            "task_colour_sorting.yaml",
+            "task_shape_sorting.yaml",
+            "task_garbage_sorting.yaml",
+            "task_conveyor_sorting.yaml",
+        ]:
+            self._assert_pass(name)
+
+    def test_valid_asset_fixtures(self) -> None:
+        for name in ["asset_table.yaml", "asset_conveyor.yaml", "asset_bin.yaml", "asset_machine_fixture.yaml"]:
+            self._assert_pass(name)
+
+    def test_invalid_missing_schema_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "bad.yaml"
+            path.write_text("robot:\n  id: bad\n", encoding="utf-8")
+            result = validator.validate_path(path)[0]
+            self.assertEqual(result.status, "FAIL")
+            self.assertTrue(any("schema_version" in err for err in result.errors))
+
+    def test_invalid_required_field(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "bad.yaml"
+            path.write_text(
+                "schema_version: robot_capability/v1\nrobot:\n  id: x\n  label: X\n  brand: X\n",
+                encoding="utf-8",
+            )
+            result = validator.validate_path(path)[0]
+            self.assertEqual(result.status, "FAIL")
+            self.assertTrue(any("robot.family" in err for err in result.errors))
+
+    def test_unknown_enum_warns_unless_strict(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "custom_enum.yaml"
+            path.write_text(
+                """schema_version: robot_capability/v1
+robot:
+  id: custom_bot
+  label: Custom Bot
+  brand: Internal
+  family: snake_arm
+  mounting: floor
+  planning_groups: [arm]
+  base_frame: base
+  default_tool_frame: tool0
+""",
+                encoding="utf-8",
+            )
+            warn_result = validator.validate_path(path, strict=False)[0]
+            strict_result = validator.validate_path(path, strict=True)[0]
+            self.assertEqual(warn_result.status, "WARN")
+            self.assertEqual(strict_result.status, "FAIL")
+
+    def test_json_output(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(REPO_ROOT / "scripts" / "validate_capability_contracts.py"), str(FIXTURE_DIR), "--json"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        payload = json.loads(completed.stdout)
+        self.assertIn("summary", payload)
+        self.assertGreaterEqual(payload["summary"]["pass"], 1)
+
+    def test_directory_validation(self) -> None:
+        results = validator.validate_path(FIXTURE_DIR)
+        self.assertGreaterEqual(len(results), 10)
+        self.assertTrue(all(r.status == "PASS" for r in results))
+
+    def test_check_scripts_have_valid_bash_syntax(self) -> None:
+        subprocess.run(
+            ["bash", "-n", str(REPO_ROOT / "scripts" / "check_capability_contracts.sh"), str(REPO_ROOT / "scripts" / "preflight_workcell.sh")],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a versioned, offline capability layer so workcell generation and GUIs can enumerate and compose heterogeneous robots, end-effectors, sensors, tasks and environment assets without hard-coding around UR5 examples.
- Keep this change strictly offline/architectural so runtime launch, MoveIt, perception, grasp execution and GUI runtime behavior remain unchanged.

### Description
- Introduced capability schema families: `robot_capability/v1`, `end_effector_capability/v1`, `sensor_capability/v1`, `task_capability/v1`, and `environment_asset/v1` and representative fixtures under `tests/fixtures/capabilities/` (robots, EEs, sensors, tasks, assets).
- Added `scripts/validate_capability_contracts.py` which validates YAML/JSON files, uses PyYAML if available with a built-in fallback parser, enforces required fields/types/enums/ numeric/frame checks, and supports `--json` and `--strict` modes.
- Added `scripts/check_capability_contracts.sh` and integrated it into the offline preflight stage (`scripts/preflight_workcell.sh`) so capability fixtures are validated as part of repository preflight.
- Added `docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md` and linked it from `README.md` and `docs/manuals/WORKCELL_OPERATOR_MANUAL.md` to document schema fields, examples, and intended offline usage.
- Added unit tests `tests/test_capability_contracts.py` covering valid fixtures, missing/invalid cases, enum `WARN` vs `--strict` `FAIL`, JSON output, directory validation, and shell syntax checks.

### Testing
- Byte-compiled and lint-style checks: `python3 -m py_compile scripts/validate_capability_contracts.py tests/test_capability_contracts.py` — success.
- Unit tests: `python3 -m unittest tests/test_capability_contracts.py` — all tests passed (11 tests, OK).
- Shell syntax check: `bash -n scripts/check_capability_contracts.sh scripts/preflight_workcell.sh` — success.
- Fixture validation run: `./scripts/check_capability_contracts.sh` — all provided fixtures passed (`PASS=19 WARN=0 FAIL=0`).
- Integrated preflight: `./scripts/preflight_workcell.sh` ran the offline validation stage including capability checks and completed (capability checks reported `PASS`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f06e3d16688331b998ce2158f39108)