### PR TITLE
Add environment_layout/v1 inventory, validator, preview, and cell-definition integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1289,3 +1289,15 @@ Why this matters:
 
 Use `python3 scripts/validate_cell_definition.py <cell.yaml> --capabilities-dir tests/fixtures/capabilities`.
 Use `--strict` to convert unresolved capability references from WARN to FAIL.
+
+### Environment layout + asset inventory (offline)
+
+The repository already uses `assets/` and related package asset paths as the physical source of truth.
+This project now adds metadata-only tooling around those existing assets:
+
+- `scripts/inspect_asset_inventory.py` -> `reports/asset_inventory.md` + `reports/asset_inventory.json`
+- `assets/asset_manifest.yaml` (optional sidecar metadata)
+- `environment_layout/v1` docs + validator + preview tooling
+- `scripts/check_environment_layouts.sh` integrated into `scripts/preflight_workcell.sh`
+
+These additions are offline/import-export focused and do not change runtime ROS/MoveIt/perception/grasp/controller behavior.

--- a/assets/asset_manifest.yaml
+++ b/assets/asset_manifest.yaml
@@ -1,0 +1,38 @@
+schema_version: asset_manifest/v1
+assets:
+  - asset_id: table_basic
+    display_name: Basic table
+    asset_type: table
+    source:
+      path: assets/environment/table_description
+      package: table_description
+    geometry:
+      preferred_mesh: package://table_description/meshes/visual/table.stl
+    capabilities:
+      - asset_table
+    notes:
+      - Existing asset reused. No files moved.
+  - asset_id: workbench_basic
+    display_name: Basic workbench
+    asset_type: workbench
+    source:
+      path: assets/environment/workbench_description
+      package: workbench_description
+    geometry:
+      preferred_mesh: package://workbench_description/meshes/visual/table.stl
+    capabilities:
+      - asset_workbench
+    notes:
+      - Existing asset reused. No files moved.
+  - asset_id: realsense_d435i_sensor
+    display_name: Intel RealSense D435i
+    asset_type: sensor
+    source:
+      path: assets/environment/realsense2_description
+      package: realsense2_description
+    geometry:
+      preferred_mesh: package://realsense2_description/meshes/d435.dae
+    capabilities:
+      - sensor_realsense_d435i
+    notes:
+      - Existing asset reused. No files moved.

--- a/docs/manuals/CELL_DEFINITION_V1.md
+++ b/docs/manuals/CELL_DEFINITION_V1.md
@@ -209,3 +209,22 @@ Validation behavior:
 - Non-strict mode: unresolved capability IDs report WARN.
 - Strict mode (`--strict`): unresolved capability IDs report FAIL.
 - Compatibility checks are best-effort and conservative to preserve backward compatibility.
+
+## Optional `environment.layout` reference
+
+`cell_definition/v1` now supports an optional layout reference under `environment`:
+
+```yaml
+environment:
+  layout: tests/fixtures/environment_layouts/ur5_table_bins_existing_assets.layout.yaml
+```
+
+`environment.layout` is a placement-layer input (`environment_layout/v1`) that references existing assets.
+It does not duplicate assets and does not replace the existing asset folder structure.
+
+Validation behavior:
+- Missing layout path: WARN by default, FAIL in strict mode.
+- Valid layout: summary included in validator JSON output.
+- Backward compatibility: cell definitions without `environment.layout` remain valid.
+
+See `docs/manuals/ENVIRONMENT_LAYOUT_V1.md`.

--- a/docs/manuals/ENVIRONMENT_LAYOUT_V1.md
+++ b/docs/manuals/ENVIRONMENT_LAYOUT_V1.md
@@ -1,0 +1,79 @@
+# ENVIRONMENT_LAYOUT_V1
+
+`environment_layout/v1` is an **offline placement schema**.
+
+It defines **where existing assets are placed** in a cell. It is not an asset storage layer.
+
+## Core rules
+
+- Existing `assets/` content remains the source of truth for physical meshes/models/descriptions.
+- No asset duplication is required.
+- Layout files reference existing assets via `package://...` URIs and/or repo-relative paths.
+- Layout files contain placement/zones/safety metadata only.
+
+## Schema
+
+```yaml
+schema_version: environment_layout/v1
+layout_id: ur5_table_bins_layout
+metadata:
+  name: UR5 table and bins layout
+  description: Uses existing repo assets.
+assets:
+  - id: main_table
+    asset_ref: table_basic
+    source:
+      package: table_description
+      uri: package://table_description/meshes/visual/table.stl
+      path: assets/environment/table_description/meshes/visual/table.stl
+    type: table
+    pose:
+      frame: world
+      xyz: [0.5, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+    collision: true
+    visual: true
+zones:
+  - id: pick_zone
+    type: pick
+    frame: world
+    bounds_xyz:
+      min: [0.2, -0.7, 0.35]
+      max: [0.8, -0.2, 0.75]
+safety:
+  zones:
+    - id: robot_reach_warning
+      type: warning
+      frame: world
+      bounds_xyz:
+        min: [-1.0, -1.0, 0.0]
+        max: [1.0, 1.0, 1.8]
+```
+
+## Tooling
+
+- Validate: `python3 scripts/validate_environment_layout.py <layout.yaml>`
+- Strict mode: `python3 scripts/validate_environment_layout.py <layout.yaml> --strict`
+- JSON output: `python3 scripts/validate_environment_layout.py <layout.yaml> --json`
+- Preview: `python3 scripts/generate_environment_preview.py <layout.yaml>`
+- Batch checks: `./scripts/check_environment_layouts.sh`
+
+## Cell Definition integration
+
+`cell_definition/v1` can optionally include:
+
+```yaml
+environment:
+  layout: tests/fixtures/environment_layouts/ur5_table_bins_existing_assets.layout.yaml
+```
+
+- Optional and backward-compatible.
+- Existing `environment.assets` behavior still works.
+- Missing layout path: WARN by default, FAIL in `--strict`.
+- Project manifests preserve `environment_layout` metadata for offline import/export workflows.
+
+## Runtime boundary
+
+This schema and tooling are metadata-only.
+
+No runtime ROS launch behavior, MoveIt planning behavior, grasp execution behavior, perception behavior, or controller behavior is changed by this layer.

--- a/docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md
+++ b/docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md
@@ -238,3 +238,12 @@ Capability contracts can now be referenced directly by `cell_definition/v1` tool
 - optional environment asset references
 
 This is intentionally metadata-only and does not alter runtime launch/planning/perception behavior.
+
+## Capability contracts + asset manifests + environment layouts
+
+- Capability contracts describe **what an asset/component can do**.
+- `assets/` folders store the physical meshes/models/descriptions.
+- `asset_manifest.yaml` provides optional sidecar metadata for existing assets.
+- `environment_layout/v1` describes where those existing assets are placed in a specific cell.
+
+This separation prepares future GUI import/export workflows while keeping runtime behavior unchanged in this phase.

--- a/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
+++ b/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
@@ -748,3 +748,22 @@ Generated scene/workcell manifests may now include a `capabilities` block and co
 Example combinations:
 - UR5 + Robotiq 2F + RealSense for colour sorting.
 - Delta + suction + overhead RGBD for conveyor sorting.
+
+## D3) Environment layout tooling (offline metadata)
+
+The environment layout layer is placement metadata only:
+
+- Asset storage remains in existing `assets/` folders.
+- Layout files state where assets are placed and where zones/safety bounds are.
+- No runtime launch/planning/controller/perception/grasp behavior changes.
+
+Commands:
+
+```bash
+python3 scripts/inspect_asset_inventory.py
+python3 scripts/validate_environment_layout.py tests/fixtures/environment_layouts/ur5_table_bins_existing_assets.layout.yaml
+python3 scripts/generate_environment_preview.py tests/fixtures/environment_layouts/ur5_table_bins_existing_assets.layout.yaml
+./scripts/check_environment_layouts.sh
+```
+
+Reference: `docs/manuals/ENVIRONMENT_LAYOUT_V1.md`.

--- a/reports/asset_inventory.json
+++ b/reports/asset_inventory.json
@@ -1,0 +1,7871 @@
+{
+  "entries": [
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "airpick4.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes",
+      "package": "onrobot_airpick4_description",
+      "package_uri": "package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+      "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+      "package": "onrobot_airpick4_description",
+      "package_uri": "package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml",
+      "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "onRobot_AIrpick_4_vacuum.urdf",
+      "file_type": "urdf",
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf",
+      "package": "onrobot_airpick4_description",
+      "package_uri": "package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onRobot_AIrpick_4_vacuum.urdf",
+      "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onRobot_AIrpick_4_vacuum.urdf"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "onrobot_airpick4_gripper.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf",
+      "package": "onrobot_airpick4_description",
+      "package_uri": "package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro",
+      "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "onrobot_airpick4_gripper_standalone.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf",
+      "package": "onrobot_airpick4_description",
+      "package_uri": "package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper_standalone.urdf.xacro",
+      "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper_standalone.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config",
+      "package": "onrobot_airpick4_moveit_config",
+      "package_uri": "package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/controllers.yaml",
+      "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "fake_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config",
+      "package": "onrobot_airpick4_moveit_config",
+      "package_uri": "package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/fake_controllers.yaml",
+      "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/fake_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "joint_limits.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config",
+      "package": "onrobot_airpick4_moveit_config",
+      "package_uri": "package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/joint_limits.yaml",
+      "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/joint_limits.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "kinematics.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config",
+      "package": "onrobot_airpick4_moveit_config",
+      "package_uri": "package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/kinematics.yaml",
+      "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/kinematics.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "ompl_planning.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config",
+      "package": "onrobot_airpick4_moveit_config",
+      "package_uri": "package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/ompl_planning.yaml",
+      "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/ompl_planning.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "onrobot_airpick4_gripper.srdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config",
+      "package": "onrobot_airpick4_moveit_config",
+      "package_uri": "package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/onrobot_airpick4_gripper.srdf.xacro",
+      "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/onrobot_airpick4_gripper.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+      "package": "onrobot_airpick4_moveit_config",
+      "package_uri": "package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml",
+      "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "GRIPPER_CLOSED.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_CLOSED.stl",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_CLOSED.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "GRIPPER_OPEN.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN.stl",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "GRIPPER_OPEN_FINGER_1.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_1.stl",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_1.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "GRIPPER_OPEN_FINGER_2.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_2.stl",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_2.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "GRIPPER_OPEN_FINGER_3.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_3.stl",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_3.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "GRIPPER_OPEN_PALM.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_PALM.stl",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_PALM.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "GRIPPER_CLOSED.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_CLOSED.stl",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_CLOSED.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "GRIPPER_OPEN.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN.stl",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "GRIPPER_OPEN_FINGER_1.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_1.stl",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_1.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "GRIPPER_OPEN_FINGER_2.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_2.stl",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_2.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "GRIPPER_OPEN_FINGER_3.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_3.stl",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_3.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "GRIPPER_OPEN_PALM.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_PALM.stl",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_PALM.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_0.STL",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_0.STL",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_0.STL"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_1.STL",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_1.STL",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_1.STL"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_2.STL",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_2.STL",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_2.STL"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_3.STL",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_3.STL",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_3.STL"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "palm.STL",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/palm.STL",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/palm.STL"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_0.dae",
+      "file_type": "dae",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_1.dae",
+      "file_type": "dae",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_2.dae",
+      "file_type": "dae",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_3.dae",
+      "file_type": "dae",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "palm.dae",
+      "file_type": "dae",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/palm.dae",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/palm.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq-3f-gripper_articulated.urdf",
+      "file_type": "urdf",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq-3f-gripper_articulated.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf.xacro",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq-3f-gripper_articulated.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.xacro",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq-3f-gripper_articulated_macro.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated_macro.xacro",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated_macro.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq-3f-gripper_finger_articulated_macro.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_finger_articulated_macro.xacro",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_finger_articulated_macro.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq-3f-gripper_mesh.urdf",
+      "file_type": "urdf",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh.urdf",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh.urdf"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq-3f-gripper_mesh.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh.xacro",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq-3f-gripper_mesh_macro.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh_macro.xacro",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh_macro.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq_3f_hand_macro.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq_3f_hand_macro.urdf.xacro",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq_3f_hand_macro.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config",
+      "package": "robotiq_3f_moveit_config",
+      "package_uri": "package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/controllers.yaml",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "fake_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config",
+      "package": "robotiq_3f_moveit_config",
+      "package_uri": "package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/fake_controllers.yaml",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/fake_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "joint_limits.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config",
+      "package": "robotiq_3f_moveit_config",
+      "package_uri": "package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/joint_limits.yaml",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/joint_limits.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "kinematics.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config",
+      "package": "robotiq_3f_moveit_config",
+      "package_uri": "package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/kinematics.yaml",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/kinematics.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "ompl_planning.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config",
+      "package": "robotiq_3f_moveit_config",
+      "package_uri": "package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/ompl_planning.yaml",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/ompl_planning.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq_3f_gripper.srdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config",
+      "package": "robotiq_3f_moveit_config",
+      "package_uri": "package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/robotiq_3f_gripper.srdf.xacro",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/robotiq_3f_gripper.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+      "package": "robotiq_3f_moveit_config",
+      "package_uri": "package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml",
+      "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "ros2_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/config",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/config/ros2_controllers.yaml",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/config/ros2_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "kinova_robotiq_coupler.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/kinova_robotiq_coupler.stl",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/kinova_robotiq_coupler.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "robotiq_85_base_link.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_base_link.stl",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_base_link.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "robotiq_85_finger_link.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "robotiq_85_finger_tip_link.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "robotiq_85_inner_knuckle_link.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "robotiq_85_knuckle_link.stl",
+      "file_type": "stl",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "kinova_robotiq_coupler.dae",
+      "file_type": "dae",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/kinova_robotiq_coupler.dae",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/kinova_robotiq_coupler.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "robotiq_85_base_link.dae",
+      "file_type": "dae",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "robotiq_85_finger_link.dae",
+      "file_type": "dae",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "robotiq_85_finger_tip_link.dae",
+      "file_type": "dae",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "robotiq_85_inner_knuckle_link.dae",
+      "file_type": "dae",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "robotiq_85_knuckle_link.dae",
+      "file_type": "dae",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "kinova_robotiq_85_gripper.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/kinova_robotiq_85_gripper.xacro",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/kinova_robotiq_85_gripper.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq_85_gripper.transmission.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.transmission.xacro",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.transmission.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq_85_gripper.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq_85_gripper.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.xacro",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq_85_gripper_sim_base.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper_sim_base.urdf.xacro",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper_sim_base.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq_85_kinova_coupler.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_kinova_coupler.urdf.xacro",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_kinova_coupler.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+      "package": "robotiq_85_moveit_config",
+      "package_uri": "package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/controllers.yaml",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "fake_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+      "package": "robotiq_85_moveit_config",
+      "package_uri": "package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/fake_controllers.yaml",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/fake_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "joint_limits.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+      "package": "robotiq_85_moveit_config",
+      "package_uri": "package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/joint_limits.yaml",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/joint_limits.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "kinematics.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+      "package": "robotiq_85_moveit_config",
+      "package_uri": "package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/kinematics.yaml",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/kinematics.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "ompl_planning.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+      "package": "robotiq_85_moveit_config",
+      "package_uri": "package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/ompl_planning.yaml",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/ompl_planning.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq_85_gripper.srdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+      "package": "robotiq_85_moveit_config",
+      "package_uri": "package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf.xacro",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+      "package": "robotiq_85_moveit_config",
+      "package_uri": "package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml",
+      "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "joint_names_double_fixture.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/config",
+      "package": "single_suction_description",
+      "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/config/joint_names_double_fixture.yaml",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/config/joint_names_double_fixture.yaml"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "scene_yaml",
+      "file_name": "ros2_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/config",
+      "package": "single_suction_description",
+      "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/config/ros2_controllers.yaml",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/config/ros2_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "mesh",
+      "file_name": "multiple_gripper_link.STL",
+      "file_type": "stl",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/meshes",
+      "package": "single_suction_description",
+      "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/multiple_gripper_link.STL",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/meshes/multiple_gripper_link.STL"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "mesh",
+      "file_name": "suction_cup_link.STL",
+      "file_type": "stl",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/meshes",
+      "package": "single_suction_description",
+      "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/suction_cup_link.STL",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/meshes/suction_cup_link.STL"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "wrist_fixture.STL",
+      "file_type": "stl",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/meshes",
+      "package": "single_suction_description",
+      "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description",
+      "package": "single_suction_description",
+      "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "double_fixture.urdf",
+      "file_type": "urdf",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf",
+      "package": "single_suction_description",
+      "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/double_fixture.urdf",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/double_fixture.urdf"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "single_suction_gripper.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf",
+      "package": "single_suction_description",
+      "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "single_suction_gripper_standalone.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf",
+      "package": "single_suction_description",
+      "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper_standalone.urdf.xacro",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper_standalone.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "ur5_double_fixture.urdf",
+      "file_type": "urdf",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf",
+      "package": "single_suction_description",
+      "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/ur5_double_fixture.urdf",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/ur5_double_fixture.urdf"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "ur5_double_fixture.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf",
+      "package": "single_suction_description",
+      "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/ur5_double_fixture.urdf.xacro",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/ur5_double_fixture.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "mounting_kit.urdf",
+      "file_type": "urdf",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/urdf_solidworks",
+      "package": "single_suction_description",
+      "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/urdf_solidworks/mounting_kit.urdf",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/urdf_solidworks/mounting_kit.urdf"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "scene_yaml",
+      "file_name": "controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+      "package": "single_suction_moveit_config",
+      "package_uri": "package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/controllers.yaml",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/controllers.yaml"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "scene_yaml",
+      "file_name": "fake_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+      "package": "single_suction_moveit_config",
+      "package_uri": "package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/fake_controllers.yaml",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/fake_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "scene_yaml",
+      "file_name": "joint_limits.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+      "package": "single_suction_moveit_config",
+      "package_uri": "package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/joint_limits.yaml",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/joint_limits.yaml"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "scene_yaml",
+      "file_name": "kinematics.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+      "package": "single_suction_moveit_config",
+      "package_uri": "package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/kinematics.yaml",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/kinematics.yaml"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "scene_yaml",
+      "file_name": "ompl_planning.yaml",
+      "file_type": "yaml",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+      "package": "single_suction_moveit_config",
+      "package_uri": "package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/ompl_planning.yaml",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/ompl_planning.yaml"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "urdf_xacro",
+      "file_name": "single_suction_gripper.srdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+      "package": "single_suction_moveit_config",
+      "package_uri": "package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/single_suction_gripper.srdf.xacro",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/single_suction_gripper.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+      "package": "single_suction_moveit_config",
+      "package_uri": "package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml",
+      "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "sensor",
+      "category": "mesh",
+      "file_name": "d415.stl",
+      "file_type": "stl",
+      "group": "assets/environment/realsense2_description/meshes",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/meshes/d415.stl",
+      "relative_path": "assets/environment/realsense2_description/meshes/d415.stl"
+    },
+    {
+      "asset_type_guess": "sensor",
+      "category": "mesh",
+      "file_name": "d435.dae",
+      "file_type": "dae",
+      "group": "assets/environment/realsense2_description/meshes",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/meshes/d435.dae",
+      "relative_path": "assets/environment/realsense2_description/meshes/d435.dae"
+    },
+    {
+      "asset_type_guess": "sensor",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/environment/realsense2_description",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/package.xml",
+      "relative_path": "assets/environment/realsense2_description/package.xml"
+    },
+    {
+      "asset_type_guess": "sensor",
+      "category": "urdf_xacro",
+      "file_name": "dual_d415.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/tests",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/tests/dual_d415.xacro",
+      "relative_path": "assets/environment/realsense2_description/tests/dual_d415.xacro"
+    },
+    {
+      "asset_type_guess": "sensor",
+      "category": "urdf_xacro",
+      "file_name": "dual_d435.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/tests",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/tests/dual_d435.xacro",
+      "relative_path": "assets/environment/realsense2_description/tests/dual_d435.xacro"
+    },
+    {
+      "asset_type_guess": "sensor",
+      "category": "urdf_xacro",
+      "file_name": "dual_r410.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/tests",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/tests/dual_r410.xacro",
+      "relative_path": "assets/environment/realsense2_description/tests/dual_r410.xacro"
+    },
+    {
+      "asset_type_guess": "sensor",
+      "category": "urdf_xacro",
+      "file_name": "dual_r430.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/tests",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/tests/dual_r430.xacro",
+      "relative_path": "assets/environment/realsense2_description/tests/dual_r430.xacro"
+    },
+    {
+      "asset_type_guess": "sensor",
+      "category": "urdf_xacro",
+      "file_name": "one_of_each.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/tests",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/tests/one_of_each.xacro",
+      "relative_path": "assets/environment/realsense2_description/tests/one_of_each.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "_d415.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/urdf",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/_d415.urdf.xacro",
+      "relative_path": "assets/environment/realsense2_description/urdf/_d415.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "_d435.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/urdf",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/_d435.urdf.xacro",
+      "relative_path": "assets/environment/realsense2_description/urdf/_d435.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "_d435i.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/urdf",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro",
+      "relative_path": "assets/environment/realsense2_description/urdf/_d435i.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "_d435i_imu_modules.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/urdf",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro",
+      "relative_path": "assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "_materials.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/urdf",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/_materials.urdf.xacro",
+      "relative_path": "assets/environment/realsense2_description/urdf/_materials.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "_r410.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/urdf",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/_r410.urdf.xacro",
+      "relative_path": "assets/environment/realsense2_description/urdf/_r410.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "_r430.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/urdf",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/_r430.urdf.xacro",
+      "relative_path": "assets/environment/realsense2_description/urdf/_r430.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "test_d415_camera.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/urdf",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/test_d415_camera.urdf.xacro",
+      "relative_path": "assets/environment/realsense2_description/urdf/test_d415_camera.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "test_d435_camera.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/urdf",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/test_d435_camera.urdf.xacro",
+      "relative_path": "assets/environment/realsense2_description/urdf/test_d435_camera.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "test_d435_multiple_cameras.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/urdf",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/test_d435_multiple_cameras.urdf.xacro",
+      "relative_path": "assets/environment/realsense2_description/urdf/test_d435_multiple_cameras.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "test_d435i_camera.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/urdf",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/test_d435i_camera.urdf.xacro",
+      "relative_path": "assets/environment/realsense2_description/urdf/test_d435i_camera.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "test_r410_camera.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/urdf",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/test_r410_camera.urdf.xacro",
+      "relative_path": "assets/environment/realsense2_description/urdf/test_r410_camera.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "test_r430_camera.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/realsense2_description/urdf",
+      "package": "realsense2_description",
+      "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/test_r430_camera.urdf.xacro",
+      "relative_path": "assets/environment/realsense2_description/urdf/test_r430_camera.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "table",
+      "category": "mesh",
+      "file_name": "table.stl",
+      "file_type": "stl",
+      "group": "assets/environment/table_description/meshes/collision",
+      "package": "table_description",
+      "package_uri": "package://table_description/assets/environment/table_description/meshes/collision/table.stl",
+      "relative_path": "assets/environment/table_description/meshes/collision/table.stl"
+    },
+    {
+      "asset_type_guess": "table",
+      "category": "mesh",
+      "file_name": "table.stl",
+      "file_type": "stl",
+      "group": "assets/environment/table_description/meshes/visual",
+      "package": "table_description",
+      "package_uri": "package://table_description/assets/environment/table_description/meshes/visual/table.stl",
+      "relative_path": "assets/environment/table_description/meshes/visual/table.stl"
+    },
+    {
+      "asset_type_guess": "table",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/environment/table_description",
+      "package": "table_description",
+      "package_uri": "package://table_description/assets/environment/table_description/package.xml",
+      "relative_path": "assets/environment/table_description/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "table.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/table_description/urdf",
+      "package": "table_description",
+      "package_uri": "package://table_description/assets/environment/table_description/urdf/table.urdf.xacro",
+      "relative_path": "assets/environment/table_description/urdf/table.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "table",
+      "category": "mesh",
+      "file_name": "table.stl",
+      "file_type": "stl",
+      "group": "assets/environment/workbench_description/meshes/collision",
+      "package": "workbench_description",
+      "package_uri": "package://workbench_description/assets/environment/workbench_description/meshes/collision/table.stl",
+      "relative_path": "assets/environment/workbench_description/meshes/collision/table.stl"
+    },
+    {
+      "asset_type_guess": "table",
+      "category": "mesh",
+      "file_name": "table.stl",
+      "file_type": "stl",
+      "group": "assets/environment/workbench_description/meshes/visual",
+      "package": "workbench_description",
+      "package_uri": "package://workbench_description/assets/environment/workbench_description/meshes/visual/table.stl",
+      "relative_path": "assets/environment/workbench_description/meshes/visual/table.stl"
+    },
+    {
+      "asset_type_guess": "workbench",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/environment/workbench_description",
+      "package": "workbench_description",
+      "package_uri": "package://workbench_description/assets/environment/workbench_description/package.xml",
+      "relative_path": "assets/environment/workbench_description/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "table.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/environment/workbench_description/urdf",
+      "package": "workbench_description",
+      "package_uri": "package://workbench_description/assets/environment/workbench_description/urdf/table.urdf.xacro",
+      "relative_path": "assets/environment/workbench_description/urdf/table.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "base_link.stl",
+      "file_type": "stl",
+      "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/base_link.stl",
+      "relative_path": "assets/robots/fanuc/fanuc_description/meshes/collision/base_link.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_1.stl",
+      "file_type": "stl",
+      "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_1.stl",
+      "relative_path": "assets/robots/fanuc/fanuc_description/meshes/collision/link_1.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_2.stl",
+      "file_type": "stl",
+      "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_2.stl",
+      "relative_path": "assets/robots/fanuc/fanuc_description/meshes/collision/link_2.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_3.stl",
+      "file_type": "stl",
+      "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_3.stl",
+      "relative_path": "assets/robots/fanuc/fanuc_description/meshes/collision/link_3.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_4.stl",
+      "file_type": "stl",
+      "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_4.stl",
+      "relative_path": "assets/robots/fanuc/fanuc_description/meshes/collision/link_4.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_5.stl",
+      "file_type": "stl",
+      "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_5.stl",
+      "relative_path": "assets/robots/fanuc/fanuc_description/meshes/collision/link_5.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_6.stl",
+      "file_type": "stl",
+      "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_6.stl",
+      "relative_path": "assets/robots/fanuc/fanuc_description/meshes/collision/link_6.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "base_link.stl",
+      "file_type": "stl",
+      "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/base_link.stl",
+      "relative_path": "assets/robots/fanuc/fanuc_description/meshes/visual/base_link.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_1.stl",
+      "file_type": "stl",
+      "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_1.stl",
+      "relative_path": "assets/robots/fanuc/fanuc_description/meshes/visual/link_1.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_2.stl",
+      "file_type": "stl",
+      "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_2.stl",
+      "relative_path": "assets/robots/fanuc/fanuc_description/meshes/visual/link_2.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_3.stl",
+      "file_type": "stl",
+      "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_3.stl",
+      "relative_path": "assets/robots/fanuc/fanuc_description/meshes/visual/link_3.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_4.stl",
+      "file_type": "stl",
+      "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_4.stl",
+      "relative_path": "assets/robots/fanuc/fanuc_description/meshes/visual/link_4.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_5.stl",
+      "file_type": "stl",
+      "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_5.stl",
+      "relative_path": "assets/robots/fanuc/fanuc_description/meshes/visual/link_5.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link_6.stl",
+      "file_type": "stl",
+      "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_6.stl",
+      "relative_path": "assets/robots/fanuc/fanuc_description/meshes/visual/link_6.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/robots/fanuc/fanuc_description",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/package.xml",
+      "relative_path": "assets/robots/fanuc/fanuc_description/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "fanuc.urdf",
+      "file_type": "urdf",
+      "group": "assets/robots/fanuc/fanuc_description/urdf",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/urdf/fanuc.urdf",
+      "relative_path": "assets/robots/fanuc/fanuc_description/urdf/fanuc.urdf"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "fanuc.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/robots/fanuc/fanuc_description/urdf",
+      "package": "fanuc_description",
+      "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/urdf/fanuc.urdf.xacro",
+      "relative_path": "assets/robots/fanuc/fanuc_description/urdf/fanuc.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "chomp_planning.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+      "package": "fanuc_moveit_config",
+      "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/chomp_planning.yaml",
+      "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/chomp_planning.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "fake_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+      "package": "fanuc_moveit_config",
+      "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/fake_controllers.yaml",
+      "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/fake_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "fanuc.srdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+      "package": "fanuc_moveit_config",
+      "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/fanuc.srdf.xacro",
+      "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/fanuc.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "joint_limits.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+      "package": "fanuc_moveit_config",
+      "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/joint_limits.yaml",
+      "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/joint_limits.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "kinematics.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+      "package": "fanuc_moveit_config",
+      "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/kinematics.yaml",
+      "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/kinematics.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "ompl_planning.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+      "package": "fanuc_moveit_config",
+      "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/ompl_planning.yaml",
+      "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/ompl_planning.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "ros_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+      "package": "fanuc_moveit_config",
+      "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/ros_controllers.yaml",
+      "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/ros_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "sensors_3d.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+      "package": "fanuc_moveit_config",
+      "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/sensors_3d.yaml",
+      "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/sensors_3d.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/robots/fanuc/fanuc_moveit_config",
+      "package": "fanuc_moveit_config",
+      "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/package.xml",
+      "relative_path": "assets/robots/fanuc/fanuc_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "finger.stl",
+      "file_type": "stl",
+      "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/finger.stl",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/finger.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "hand.stl",
+      "file_type": "stl",
+      "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/hand.stl",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/hand.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link0.stl",
+      "file_type": "stl",
+      "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link0.stl",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link0.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link1.stl",
+      "file_type": "stl",
+      "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link1.stl",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link1.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link2.stl",
+      "file_type": "stl",
+      "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link2.stl",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link2.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link3.stl",
+      "file_type": "stl",
+      "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link3.stl",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link3.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link4.stl",
+      "file_type": "stl",
+      "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link4.stl",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link4.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link5.stl",
+      "file_type": "stl",
+      "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link5.stl",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link5.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link6.stl",
+      "file_type": "stl",
+      "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link6.stl",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link6.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link7.stl",
+      "file_type": "stl",
+      "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link7.stl",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link7.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "finger.dae",
+      "file_type": "dae",
+      "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/finger.dae",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/finger.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "hand.dae",
+      "file_type": "dae",
+      "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/hand.dae",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/hand.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link0.dae",
+      "file_type": "dae",
+      "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link0.dae",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link0.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link1.dae",
+      "file_type": "dae",
+      "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link1.dae",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link1.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link2.dae",
+      "file_type": "dae",
+      "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link2.dae",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link2.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link3.dae",
+      "file_type": "dae",
+      "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link3.dae",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link3.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link4.dae",
+      "file_type": "dae",
+      "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link4.dae",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link4.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link5.dae",
+      "file_type": "dae",
+      "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link5.dae",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link5.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link6.dae",
+      "file_type": "dae",
+      "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link6.dae",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link6.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "link7.dae",
+      "file_type": "dae",
+      "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link7.dae",
+      "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link7.dae"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/robots/panda_robot/panda_description",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/package.xml",
+      "relative_path": "assets/robots/panda_robot/panda_description/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "panda.urdf",
+      "file_type": "urdf",
+      "group": "assets/robots/panda_robot/panda_description/urdf",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/urdf/panda.urdf",
+      "relative_path": "assets/robots/panda_robot/panda_description/urdf/panda.urdf"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "panda.urdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/robots/panda_robot/panda_description/urdf",
+      "package": "panda_description",
+      "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/urdf/panda.urdf.xacro",
+      "relative_path": "assets/robots/panda_robot/panda_description/urdf/panda.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "chomp_planning.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/chomp_planning.yaml",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/chomp_planning.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "fake_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/fake_controllers.yaml",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/fake_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "hand.xacro",
+      "file_type": "xacro",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/hand.xacro",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/hand.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "joint_limits.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/joint_limits.yaml",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/joint_limits.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "kinematics.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/kinematics.yaml",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/kinematics.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "lerp_planning.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/lerp_planning.yaml",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/lerp_planning.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "ompl_planning.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/ompl_planning.yaml",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/ompl_planning.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "panda.srdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda.srdf.xacro",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/panda.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "panda_arm.srdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_arm.srdf.xacro",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/panda_arm.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "panda_arm.xacro",
+      "file_type": "xacro",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_arm.xacro",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/panda_arm.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "panda_arm_hand.srdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_arm_hand.srdf.xacro",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/panda_arm_hand.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "panda_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_controllers.yaml",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/panda_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "panda_gripper_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_gripper_controllers.yaml",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/panda_gripper_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "sensors_kinect_depthmap.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/sensors_kinect_depthmap.yaml",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/sensors_kinect_depthmap.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "sensors_kinect_pointcloud.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/sensors_kinect_pointcloud.yaml",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/sensors_kinect_pointcloud.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "stomp_planning.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/stomp_planning.yaml",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/stomp_planning.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "trajopt_planning.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/trajopt_planning.yaml",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/trajopt_planning.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/robots/panda_robot/panda_moveit_config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/package.xml",
+      "relative_path": "assets/robots/panda_robot/panda_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+      "package": "ur10_moveit_config",
+      "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/controllers.yaml",
+      "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "fake_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+      "package": "ur10_moveit_config",
+      "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/fake_controllers.yaml",
+      "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/fake_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "initial_positions.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+      "package": "ur10_moveit_config",
+      "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/initial_positions.yaml",
+      "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/initial_positions.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "joint_limits.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+      "package": "ur10_moveit_config",
+      "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/joint_limits.yaml",
+      "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/joint_limits.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "kinematics.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+      "package": "ur10_moveit_config",
+      "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/kinematics.yaml",
+      "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/kinematics.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "ompl_planning.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+      "package": "ur10_moveit_config",
+      "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/ompl_planning.yaml",
+      "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/ompl_planning.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "ur10.ros2_control.xacro",
+      "file_type": "xacro",
+      "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+      "package": "ur10_moveit_config",
+      "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/ur10.ros2_control.xacro",
+      "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/ur10.ros2_control.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "ur10.srdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+      "package": "ur10_moveit_config",
+      "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/ur10.srdf.xacro",
+      "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/ur10.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "ur10_ros_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+      "package": "ur10_moveit_config",
+      "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/ur10_ros_controllers.yaml",
+      "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/ur10_ros_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/robots/universal_robot/ur10_moveit_config",
+      "package": "ur10_moveit_config",
+      "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/package.xml",
+      "relative_path": "assets/robots/universal_robot/ur10_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+      "package": "ur3_moveit_config",
+      "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/controllers.yaml",
+      "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "fake_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+      "package": "ur3_moveit_config",
+      "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/fake_controllers.yaml",
+      "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/fake_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "initial_positions.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+      "package": "ur3_moveit_config",
+      "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/initial_positions.yaml",
+      "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/initial_positions.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "joint_limits.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+      "package": "ur3_moveit_config",
+      "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/joint_limits.yaml",
+      "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/joint_limits.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "kinematics.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+      "package": "ur3_moveit_config",
+      "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/kinematics.yaml",
+      "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/kinematics.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "ompl_planning.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+      "package": "ur3_moveit_config",
+      "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/ompl_planning.yaml",
+      "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/ompl_planning.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "ur3.ros2_control.xacro",
+      "file_type": "xacro",
+      "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+      "package": "ur3_moveit_config",
+      "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/ur3.ros2_control.xacro",
+      "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/ur3.ros2_control.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "ur3.srdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+      "package": "ur3_moveit_config",
+      "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/ur3.srdf.xacro",
+      "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/ur3.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "ur3_ros_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+      "package": "ur3_moveit_config",
+      "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/ur3_ros_controllers.yaml",
+      "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/ur3_ros_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/robots/universal_robot/ur3_moveit_config",
+      "package": "ur3_moveit_config",
+      "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/package.xml",
+      "relative_path": "assets/robots/universal_robot/ur3_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+      "package": "ur5_moveit_config",
+      "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/controllers.yaml",
+      "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "fake_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+      "package": "ur5_moveit_config",
+      "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/fake_controllers.yaml",
+      "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/fake_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "initial_positions.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+      "package": "ur5_moveit_config",
+      "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/initial_positions.yaml",
+      "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/initial_positions.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "joint_limits.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+      "package": "ur5_moveit_config",
+      "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/joint_limits.yaml",
+      "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/joint_limits.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "kinematics.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+      "package": "ur5_moveit_config",
+      "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/kinematics.yaml",
+      "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/kinematics.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "ompl_planning.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+      "package": "ur5_moveit_config",
+      "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/ompl_planning.yaml",
+      "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/ompl_planning.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "ur5.ros2_control.xacro",
+      "file_type": "xacro",
+      "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+      "package": "ur5_moveit_config",
+      "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/ur5.ros2_control.xacro",
+      "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/ur5.ros2_control.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "ur5.srdf.xacro",
+      "file_type": "xacro",
+      "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+      "package": "ur5_moveit_config",
+      "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/ur5.srdf.xacro",
+      "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/ur5.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "ur5_ros_controllers.yaml",
+      "file_type": "yaml",
+      "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+      "package": "ur5_moveit_config",
+      "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/ur5_ros_controllers.yaml",
+      "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/ur5_ros_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "assets/robots/universal_robot/ur5_moveit_config",
+      "package": "ur5_moveit_config",
+      "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/package.xml",
+      "relative_path": "assets/robots/universal_robot/ur5_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/commissioning_bundle",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/commissioning_bundle/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "task_recipe.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config",
+      "package": "generated_ur5_2f_demo_cell",
+      "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config/task_recipe.yaml",
+      "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config/task_recipe.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell",
+      "package": "generated_ur5_2f_demo_cell",
+      "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell/scene_manifest.yaml",
+      "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.preview.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated",
+      "package": "generated_ur5_2f_demo_cell",
+      "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/scene_manifest.preview.yaml",
+      "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/scene_manifest.preview.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell",
+      "package": "generated_ur5_2f_demo_cell",
+      "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/package.xml",
+      "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell",
+      "package": "generated_ur5_2f_demo_cell",
+      "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/scene_manifest.yaml",
+      "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/commissioning_bundle",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/commissioning_bundle/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "task_recipe.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config",
+      "package": "generated_ur5_colour_sort_cell",
+      "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config/task_recipe.yaml",
+      "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config/task_recipe.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell",
+      "package": "generated_ur5_colour_sort_cell",
+      "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell/scene_manifest.yaml",
+      "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.preview.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated",
+      "package": "generated_ur5_colour_sort_cell",
+      "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/scene_manifest.preview.yaml",
+      "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/scene_manifest.preview.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell",
+      "package": "generated_ur5_colour_sort_cell",
+      "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/package.xml",
+      "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell",
+      "package": "generated_ur5_colour_sort_cell",
+      "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/scene_manifest.yaml",
+      "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/template_colour/commissioning_bundle",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/template_colour/commissioning_bundle/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "task_recipe.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/config",
+      "package": "generated_template_colour",
+      "package_uri": "package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/config/task_recipe.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/config/task_recipe.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/bundle/generated_template_colour",
+      "package": "generated_template_colour",
+      "package_uri": "package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/bundle/generated_template_colour/scene_manifest.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/bundle/generated_template_colour/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.preview.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated",
+      "package": "generated_template_colour",
+      "package_uri": "package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/scene_manifest.preview.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/scene_manifest.preview.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour",
+      "package": "generated_template_colour",
+      "package_uri": "package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/package.xml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour",
+      "package": "generated_template_colour",
+      "package_uri": "package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/scene_manifest.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/commissioning_bundle",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/commissioning_bundle/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "task_recipe.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config",
+      "package": "generated_ur5_2f_demo_cell",
+      "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config/task_recipe.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config/task_recipe.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell",
+      "package": "generated_ur5_2f_demo_cell",
+      "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell/scene_manifest.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.preview.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated",
+      "package": "generated_ur5_2f_demo_cell",
+      "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/scene_manifest.preview.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/scene_manifest.preview.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell",
+      "package": "generated_ur5_2f_demo_cell",
+      "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/package.xml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell",
+      "package": "generated_ur5_2f_demo_cell",
+      "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/scene_manifest.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/commissioning_bundle",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/commissioning_bundle/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "task_recipe.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config",
+      "package": "generated_ur5_colour_sort_cell",
+      "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config/task_recipe.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config/task_recipe.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell",
+      "package": "generated_ur5_colour_sort_cell",
+      "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell/scene_manifest.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.preview.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated",
+      "package": "generated_ur5_colour_sort_cell",
+      "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/scene_manifest.preview.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/scene_manifest.preview.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell",
+      "package": "generated_ur5_colour_sort_cell",
+      "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/package.xml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell",
+      "package": "generated_ur5_colour_sort_cell",
+      "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/scene_manifest.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/commissioning_bundle",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/commissioning_bundle/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "task_recipe.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/config",
+      "package": "generated_ur5_garbage_sort_cell",
+      "package_uri": "package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/config/task_recipe.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/config/task_recipe.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/bundle/generated_ur5_garbage_sort_cell",
+      "package": "generated_ur5_garbage_sort_cell",
+      "package_uri": "package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/bundle/generated_ur5_garbage_sort_cell/scene_manifest.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/bundle/generated_ur5_garbage_sort_cell/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.preview.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated",
+      "package": "generated_ur5_garbage_sort_cell",
+      "package_uri": "package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/scene_manifest.preview.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/scene_manifest.preview.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell",
+      "package": "generated_ur5_garbage_sort_cell",
+      "package_uri": "package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/package.xml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell",
+      "package": "generated_ur5_garbage_sort_cell",
+      "package_uri": "package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/scene_manifest.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/commissioning_bundle",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/commissioning_bundle/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "task_recipe.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/config",
+      "package": "generated_ur5_shape_sort_cell",
+      "package_uri": "package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/config/task_recipe.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/config/task_recipe.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/bundle/generated_ur5_shape_sort_cell",
+      "package": "generated_ur5_shape_sort_cell",
+      "package_uri": "package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/bundle/generated_ur5_shape_sort_cell/scene_manifest.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/bundle/generated_ur5_shape_sort_cell/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.preview.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated",
+      "package": "generated_ur5_shape_sort_cell",
+      "package_uri": "package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/scene_manifest.preview.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/scene_manifest.preview.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell",
+      "package": "generated_ur5_shape_sort_cell",
+      "package_uri": "package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/package.xml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell",
+      "package": "generated_ur5_shape_sort_cell",
+      "package_uri": "package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/scene_manifest.yaml",
+      "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/workcell_bundles/suction_test",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "dist/workcell_bundles/suction_test/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/workcell_bundles/ur5_2f_test",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "dist/workcell_bundles/ur5_2f_test/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/workcell_bundles/ur5_3f_test",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "dist/workcell_bundles/ur5_3f_test/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "dist/workcell_bundles/ur5_airpick4_test",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "dist/workcell_bundles/ur5_airpick4_test/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "table.urdf.copy.xacro",
+      "file_type": "xacro",
+      "group": "docs/reference/archived_duplicates/assets",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "docs/reference/archived_duplicates/assets/table.urdf.copy.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "onrobot_airpick4_robotiq_3f_gripper.srdf.copy.xacro",
+      "file_type": "xacro",
+      "group": "docs/reference/archived_duplicates/end_effectors",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "docs/reference/archived_duplicates/end_effectors/onrobot_airpick4_robotiq_3f_gripper.srdf.copy.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq_3f_gripper.srdf.copy.xacro",
+      "file_type": "xacro",
+      "group": "docs/reference/archived_duplicates/end_effectors",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "docs/reference/archived_duplicates/end_effectors/robotiq_3f_gripper.srdf.copy.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "dual_gripper.urdf.copy.xacro",
+      "file_type": "xacro",
+      "group": "docs/reference/archived_duplicates/single_suction_gripper",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "docs/reference/archived_duplicates/single_suction_gripper/dual_gripper.urdf.copy.xacro"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "fake_controllers.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config",
+      "package": "run_dynamic_safety",
+      "package_uri": "package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/fake_controllers.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/fake_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "moveit_cpp.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config",
+      "package": "run_dynamic_safety",
+      "package_uri": "package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/moveit_cpp.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/moveit_cpp.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "panda_controllers.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config",
+      "package": "run_dynamic_safety",
+      "package_uri": "package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/panda_controllers.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/panda_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "panda_ros_controllers.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config",
+      "package": "run_dynamic_safety",
+      "package_uri": "package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/panda_ros_controllers.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/panda_ros_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "start_positions.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config",
+      "package": "run_dynamic_safety",
+      "package_uri": "package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/start_positions.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/start_positions.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety",
+      "package": "run_dynamic_safety",
+      "package_uri": "package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/package.xml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/package.xml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "controllers.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+      "package": "run_grasp_execution",
+      "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/controllers.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/controllers.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "fake_grasp_pose_publisher.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+      "package": "run_grasp_execution",
+      "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/fake_grasp_pose_publisher.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/fake_grasp_pose_publisher.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "grasp_execution.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+      "package": "run_grasp_execution",
+      "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml"
+    },
+    {
+      "asset_type_guess": "sensor",
+      "category": "scene_yaml",
+      "file_name": "sensors_3d.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+      "package": "run_grasp_execution",
+      "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/sensors_3d.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/sensors_3d.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "start_positions.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+      "package": "run_grasp_execution",
+      "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/start_positions.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/start_positions.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "ur5_ros_controllers.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+      "package": "run_grasp_execution",
+      "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/ur5_ros_controllers.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/ur5_ros_controllers.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "workcell_context.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+      "package": "run_grasp_execution",
+      "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/workcell_context.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/workcell_context.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution",
+      "package": "run_grasp_execution",
+      "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "params.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config",
+      "package": "run_grasp_planner",
+      "package_uri": "package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "params_2f.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config",
+      "package": "run_grasp_planner",
+      "package_uri": "package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "params_3f.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config",
+      "package": "run_grasp_planner",
+      "package_uri": "package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "scene_yaml",
+      "file_name": "params_airpick4.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config",
+      "package": "run_grasp_planner",
+      "package_uri": "package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_airpick4.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_airpick4.yaml"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "scene_yaml",
+      "file_name": "params_suction.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config",
+      "package": "run_grasp_planner",
+      "package_uri": "package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_suction.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_suction.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner",
+      "package": "run_grasp_planner",
+      "package_uri": "package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/package.xml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/package.xml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "controllers.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config",
+      "package": "run_waypoint_execution",
+      "package_uri": "package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/controllers.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/controllers.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "fake_grasp_pose_publisher.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config",
+      "package": "run_waypoint_execution",
+      "package_uri": "package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/fake_grasp_pose_publisher.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/fake_grasp_pose_publisher.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "grasp_execution.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config",
+      "package": "run_waypoint_execution",
+      "package_uri": "package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/grasp_execution.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/grasp_execution.yaml"
+    },
+    {
+      "asset_type_guess": "sensor",
+      "category": "scene_yaml",
+      "file_name": "sensors_3d.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config",
+      "package": "run_waypoint_execution",
+      "package_uri": "package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/sensors_3d.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/sensors_3d.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "start_positions.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config",
+      "package": "run_waypoint_execution",
+      "package_uri": "package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/start_positions.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/start_positions.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "workcell_context.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config",
+      "package": "run_waypoint_execution",
+      "package_uri": "package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/workcell_context.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/workcell_context.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution",
+      "package": "run_waypoint_execution",
+      "package_uri": "package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/package.xml",
+      "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/package.xml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "mappings.yaml",
+      "file_type": "yaml",
+      "group": "easy_manipulation_deployment/emd_dynamic_safety/config",
+      "package": "emd_dynamic_safety",
+      "package_uri": "package://emd_dynamic_safety/easy_manipulation_deployment/emd_dynamic_safety/config/mappings.yaml",
+      "relative_path": "easy_manipulation_deployment/emd_dynamic_safety/config/mappings.yaml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "easy_manipulation_deployment/emd_dynamic_safety",
+      "package": "emd_dynamic_safety",
+      "package_uri": "package://emd_dynamic_safety/easy_manipulation_deployment/emd_dynamic_safety/package.xml",
+      "relative_path": "easy_manipulation_deployment/emd_dynamic_safety/package.xml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "easy_manipulation_deployment/emd_grasp_execution",
+      "package": "emd_grasp_execution",
+      "package_uri": "package://emd_grasp_execution/easy_manipulation_deployment/emd_grasp_execution/package.xml",
+      "relative_path": "easy_manipulation_deployment/emd_grasp_execution/package.xml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "easy_manipulation_deployment/emd_grasp_planner",
+      "package": "emd_grasp_planner",
+      "package_uri": "package://emd_grasp_planner/easy_manipulation_deployment/emd_grasp_planner/package.xml",
+      "relative_path": "easy_manipulation_deployment/emd_grasp_planner/package.xml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "easy_manipulation_deployment/emd_waypoint_execution",
+      "package": "emd_waypoint_execution",
+      "package_uri": "package://emd_waypoint_execution/easy_manipulation_deployment/emd_waypoint_execution/package.xml",
+      "relative_path": "easy_manipulation_deployment/emd_waypoint_execution/package.xml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "emd_msgs",
+      "package": "emd_msgs",
+      "package_uri": "package://emd_msgs/emd_msgs/package.xml",
+      "relative_path": "emd_msgs/package.xml"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "scene_yaml",
+      "file_name": "environment.yaml",
+      "file_type": "yaml",
+      "group": "scenes/suction_test",
+      "package": "suction_test",
+      "package_uri": "package://suction_test/scenes/suction_test/environment.yaml",
+      "relative_path": "scenes/suction_test/environment.yaml"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "scenes/suction_test",
+      "package": "suction_test",
+      "package_uri": "package://suction_test/scenes/suction_test/package.xml",
+      "relative_path": "scenes/suction_test/package.xml"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "scenes/suction_test",
+      "package": "suction_test",
+      "package_uri": "package://suction_test/scenes/suction_test/scene_manifest.yaml",
+      "relative_path": "scenes/suction_test/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "arm_hand.srdf.xacro",
+      "file_type": "xacro",
+      "group": "scenes/suction_test/urdf",
+      "package": "suction_test",
+      "package_uri": "package://suction_test/scenes/suction_test/urdf/arm_hand.srdf.xacro",
+      "relative_path": "scenes/suction_test/urdf/arm_hand.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "scene.urdf.xacro",
+      "file_type": "xacro",
+      "group": "scenes/suction_test/urdf",
+      "package": "suction_test",
+      "package_uri": "package://suction_test/scenes/suction_test/urdf/scene.urdf.xacro",
+      "relative_path": "scenes/suction_test/urdf/scene.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "environment.yaml",
+      "file_type": "yaml",
+      "group": "scenes/ur10_2f_test",
+      "package": "ur10_2f_test",
+      "package_uri": "package://ur10_2f_test/scenes/ur10_2f_test/environment.yaml",
+      "relative_path": "scenes/ur10_2f_test/environment.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "scenes/ur10_2f_test",
+      "package": "ur10_2f_test",
+      "package_uri": "package://ur10_2f_test/scenes/ur10_2f_test/package.xml",
+      "relative_path": "scenes/ur10_2f_test/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "arm_hand.srdf.xacro",
+      "file_type": "xacro",
+      "group": "scenes/ur10_2f_test/urdf",
+      "package": "ur10_2f_test",
+      "package_uri": "package://ur10_2f_test/scenes/ur10_2f_test/urdf/arm_hand.srdf.xacro",
+      "relative_path": "scenes/ur10_2f_test/urdf/arm_hand.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "scene.urdf.xacro",
+      "file_type": "xacro",
+      "group": "scenes/ur10_2f_test/urdf",
+      "package": "ur10_2f_test",
+      "package_uri": "package://ur10_2f_test/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
+      "relative_path": "scenes/ur10_2f_test/urdf/scene.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "environment.yaml",
+      "file_type": "yaml",
+      "group": "scenes/ur3_suction_test",
+      "package": "ur3_suction_test",
+      "package_uri": "package://ur3_suction_test/scenes/ur3_suction_test/environment.yaml",
+      "relative_path": "scenes/ur3_suction_test/environment.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "scenes/ur3_suction_test",
+      "package": "ur3_suction_test",
+      "package_uri": "package://ur3_suction_test/scenes/ur3_suction_test/package.xml",
+      "relative_path": "scenes/ur3_suction_test/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "arm_hand.srdf.xacro",
+      "file_type": "xacro",
+      "group": "scenes/ur3_suction_test/urdf",
+      "package": "ur3_suction_test",
+      "package_uri": "package://ur3_suction_test/scenes/ur3_suction_test/urdf/arm_hand.srdf.xacro",
+      "relative_path": "scenes/ur3_suction_test/urdf/arm_hand.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "scene.urdf.xacro",
+      "file_type": "xacro",
+      "group": "scenes/ur3_suction_test/urdf",
+      "package": "ur3_suction_test",
+      "package_uri": "package://ur3_suction_test/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
+      "relative_path": "scenes/ur3_suction_test/urdf/scene.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "environment.yaml",
+      "file_type": "yaml",
+      "group": "scenes/ur5_2f_test",
+      "package": "ur5_2f_test",
+      "package_uri": "package://ur5_2f_test/scenes/ur5_2f_test/environment.yaml",
+      "relative_path": "scenes/ur5_2f_test/environment.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "scenes/ur5_2f_test",
+      "package": "ur5_2f_test",
+      "package_uri": "package://ur5_2f_test/scenes/ur5_2f_test/package.xml",
+      "relative_path": "scenes/ur5_2f_test/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "scenes/ur5_2f_test",
+      "package": "ur5_2f_test",
+      "package_uri": "package://ur5_2f_test/scenes/ur5_2f_test/scene_manifest.yaml",
+      "relative_path": "scenes/ur5_2f_test/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "arm_hand.srdf.xacro",
+      "file_type": "xacro",
+      "group": "scenes/ur5_2f_test/urdf",
+      "package": "ur5_2f_test",
+      "package_uri": "package://ur5_2f_test/scenes/ur5_2f_test/urdf/arm_hand.srdf.xacro",
+      "relative_path": "scenes/ur5_2f_test/urdf/arm_hand.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "scene.urdf.xacro",
+      "file_type": "xacro",
+      "group": "scenes/ur5_2f_test/urdf",
+      "package": "ur5_2f_test",
+      "package_uri": "package://ur5_2f_test/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+      "relative_path": "scenes/ur5_2f_test/urdf/scene.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "environment.yaml",
+      "file_type": "yaml",
+      "group": "scenes/ur5_3f_test",
+      "package": "ur5_3f_test",
+      "package_uri": "package://ur5_3f_test/scenes/ur5_3f_test/environment.yaml",
+      "relative_path": "scenes/ur5_3f_test/environment.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "scenes/ur5_3f_test",
+      "package": "ur5_3f_test",
+      "package_uri": "package://ur5_3f_test/scenes/ur5_3f_test/package.xml",
+      "relative_path": "scenes/ur5_3f_test/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "scenes/ur5_3f_test",
+      "package": "ur5_3f_test",
+      "package_uri": "package://ur5_3f_test/scenes/ur5_3f_test/scene_manifest.yaml",
+      "relative_path": "scenes/ur5_3f_test/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "arm_hand.srdf.xacro",
+      "file_type": "xacro",
+      "group": "scenes/ur5_3f_test/urdf",
+      "package": "ur5_3f_test",
+      "package_uri": "package://ur5_3f_test/scenes/ur5_3f_test/urdf/arm_hand.srdf.xacro",
+      "relative_path": "scenes/ur5_3f_test/urdf/arm_hand.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "scene.urdf.xacro",
+      "file_type": "xacro",
+      "group": "scenes/ur5_3f_test/urdf",
+      "package": "ur5_3f_test",
+      "package_uri": "package://ur5_3f_test/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
+      "relative_path": "scenes/ur5_3f_test/urdf/scene.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "environment.yaml",
+      "file_type": "yaml",
+      "group": "scenes/ur5_airpick4_test",
+      "package": "ur5_airpick4_test",
+      "package_uri": "package://ur5_airpick4_test/scenes/ur5_airpick4_test/environment.yaml",
+      "relative_path": "scenes/ur5_airpick4_test/environment.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "scenes/ur5_airpick4_test",
+      "package": "ur5_airpick4_test",
+      "package_uri": "package://ur5_airpick4_test/scenes/ur5_airpick4_test/package.xml",
+      "relative_path": "scenes/ur5_airpick4_test/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "scenes/ur5_airpick4_test",
+      "package": "ur5_airpick4_test",
+      "package_uri": "package://ur5_airpick4_test/scenes/ur5_airpick4_test/scene_manifest.yaml",
+      "relative_path": "scenes/ur5_airpick4_test/scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "arm_hand.srdf.xacro",
+      "file_type": "xacro",
+      "group": "scenes/ur5_airpick4_test/urdf",
+      "package": "ur5_airpick4_test",
+      "package_uri": "package://ur5_airpick4_test/scenes/ur5_airpick4_test/urdf/arm_hand.srdf.xacro",
+      "relative_path": "scenes/ur5_airpick4_test/urdf/arm_hand.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "scene.urdf.xacro",
+      "file_type": "xacro",
+      "group": "scenes/ur5_airpick4_test/urdf",
+      "package": "ur5_airpick4_test",
+      "package_uri": "package://ur5_airpick4_test/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
+      "relative_path": "scenes/ur5_airpick4_test/urdf/scene.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "scene_yaml",
+      "file_name": "generated_scene_manifest.yaml",
+      "file_type": "yaml",
+      "group": "tests/fixtures",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "tests/fixtures/generated_scene_manifest.yaml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "mesh",
+      "file_name": "table.stl",
+      "file_type": "stl",
+      "group": "workcell_builder/examples/resources",
+      "package": null,
+      "package_uri": null,
+      "relative_path": "workcell_builder/examples/resources/table.stl"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+      "package": "onrobot_airpick4_description",
+      "package_uri": "package://onrobot_airpick4_description/workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml",
+      "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "onrobot_airpick4_gripper.urdf.xacro",
+      "file_type": "xacro",
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf",
+      "package": "onrobot_airpick4_description",
+      "package_uri": "package://onrobot_airpick4_description/workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro",
+      "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml",
+      "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq-3f-gripper_articulated.urdf.xacro",
+      "file_type": "xacro",
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+      "package": "robotiq_3f_gripper_description",
+      "package_uri": "package://robotiq_3f_gripper_description/workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf.xacro",
+      "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+      "package": "robotiq_3f_moveit_config",
+      "package_uri": "package://robotiq_3f_moveit_config/workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml",
+      "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml",
+      "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq_85_gripper.urdf.xacro",
+      "file_type": "xacro",
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+      "package": "robotiq_85_description",
+      "package_uri": "package://robotiq_85_description/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro",
+      "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "robotiq_85_gripper.srdf.xacro",
+      "file_type": "xacro",
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+      "package": "robotiq_85_moveit_config",
+      "package_uri": "package://robotiq_85_moveit_config/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf.xacro",
+      "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+      "package": "robotiq_85_moveit_config",
+      "package_uri": "package://robotiq_85_moveit_config/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml",
+      "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description",
+      "package": "single_suction_description",
+      "package_uri": "package://single_suction_description/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml",
+      "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "single_suction_gripper.urdf.xacro",
+      "file_type": "xacro",
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/urdf",
+      "package": "single_suction_description",
+      "package_uri": "package://single_suction_description/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro",
+      "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "end_effector",
+      "category": "urdf_xacro",
+      "file_name": "single_suction_gripper.srdf.xacro",
+      "file_type": "xacro",
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+      "package": "workcell_builder",
+      "package_uri": "package://workcell_builder/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/single_suction_gripper.srdf.xacro",
+      "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/single_suction_gripper.srdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "urdf_xacro",
+      "file_name": "table.urdf.xacro",
+      "file_type": "xacro",
+      "group": "workcell_builder/workcell_builder/assets/environment/table_description/urdf",
+      "package": "workcell_builder",
+      "package_uri": "package://workcell_builder/workcell_builder/workcell_builder/assets/environment/table_description/urdf/table.urdf.xacro",
+      "relative_path": "workcell_builder/workcell_builder/assets/environment/table_description/urdf/table.urdf.xacro"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "workcell_builder/workcell_builder/assets/robots/fanuc/fanuc_moveit_config",
+      "package": "fanuc_moveit_config",
+      "package_uri": "package://fanuc_moveit_config/workcell_builder/workcell_builder/assets/robots/fanuc/fanuc_moveit_config/package.xml",
+      "relative_path": "workcell_builder/workcell_builder/assets/robots/fanuc/fanuc_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "workcell_builder/workcell_builder/assets/robots/panda_robot/panda_moveit_config",
+      "package": "panda_moveit_config",
+      "package_uri": "package://panda_moveit_config/workcell_builder/workcell_builder/assets/robots/panda_robot/panda_moveit_config/package.xml",
+      "relative_path": "workcell_builder/workcell_builder/assets/robots/panda_robot/panda_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur10_moveit_config",
+      "package": "ur10_moveit_config",
+      "package_uri": "package://ur10_moveit_config/workcell_builder/workcell_builder/assets/robots/universal_robot/ur10_moveit_config/package.xml",
+      "relative_path": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur10_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur3_moveit_config",
+      "package": "ur3_moveit_config",
+      "package_uri": "package://ur3_moveit_config/workcell_builder/workcell_builder/assets/robots/universal_robot/ur3_moveit_config/package.xml",
+      "relative_path": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur3_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "robot",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur5_moveit_config",
+      "package": "ur5_moveit_config",
+      "package_uri": "package://ur5_moveit_config/workcell_builder/workcell_builder/assets/robots/universal_robot/ur5_moveit_config/package.xml",
+      "relative_path": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur5_moveit_config/package.xml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "package_xml",
+      "file_name": "package.xml",
+      "file_type": "xml",
+      "group": "workcell_builder/workcell_builder",
+      "package": "workcell_builder",
+      "package_uri": "package://workcell_builder/workcell_builder/workcell_builder/package.xml",
+      "relative_path": "workcell_builder/workcell_builder/package.xml"
+    },
+    {
+      "asset_type_guess": "unknown",
+      "category": "scene_yaml",
+      "file_name": "scene_manifest_contract_template.yaml",
+      "file_type": "yaml",
+      "group": "workcell_builder/workcell_builder/templates/ros2",
+      "package": "workcell_builder",
+      "package_uri": "package://workcell_builder/workcell_builder/workcell_builder/templates/ros2/scene_manifest_contract_template.yaml",
+      "relative_path": "workcell_builder/workcell_builder/templates/ros2/scene_manifest_contract_template.yaml"
+    }
+  ],
+  "groups": [
+    {
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+          "package": "onrobot_airpick4_description",
+          "package_uri": "package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml",
+          "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "airpick4.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes",
+          "package": "onrobot_airpick4_description",
+          "package_uri": "package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+          "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "onRobot_AIrpick_4_vacuum.urdf",
+          "file_type": "urdf",
+          "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf",
+          "package": "onrobot_airpick4_description",
+          "package_uri": "package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onRobot_AIrpick_4_vacuum.urdf",
+          "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onRobot_AIrpick_4_vacuum.urdf"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "onrobot_airpick4_gripper.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf",
+          "package": "onrobot_airpick4_description",
+          "package_uri": "package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro",
+          "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "onrobot_airpick4_gripper_standalone.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf",
+          "package": "onrobot_airpick4_description",
+          "package_uri": "package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper_standalone.urdf.xacro",
+          "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper_standalone.urdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+          "package": "onrobot_airpick4_moveit_config",
+          "package_uri": "package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml",
+          "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "onrobot_airpick4_gripper.srdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config",
+          "package": "onrobot_airpick4_moveit_config",
+          "package_uri": "package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/onrobot_airpick4_gripper.srdf.xacro",
+          "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/onrobot_airpick4_gripper.srdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config",
+          "package": "onrobot_airpick4_moveit_config",
+          "package_uri": "package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/controllers.yaml",
+          "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "kinematics.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config",
+          "package": "onrobot_airpick4_moveit_config",
+          "package_uri": "package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/kinematics.yaml",
+          "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/kinematics.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "fake_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config",
+          "package": "onrobot_airpick4_moveit_config",
+          "package_uri": "package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/fake_controllers.yaml",
+          "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/fake_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "joint_limits.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config",
+          "package": "onrobot_airpick4_moveit_config",
+          "package_uri": "package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/joint_limits.yaml",
+          "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/joint_limits.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "ompl_planning.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config",
+          "package": "onrobot_airpick4_moveit_config",
+          "package_uri": "package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/ompl_planning.yaml",
+          "relative_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/ompl_planning.yaml"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "GRIPPER_OPEN.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN.stl",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "GRIPPER_OPEN_FINGER_1.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_1.stl",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_1.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "GRIPPER_OPEN_FINGER_2.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_2.stl",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_2.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "GRIPPER_OPEN_PALM.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_PALM.stl",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_PALM.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "GRIPPER_OPEN_FINGER_3.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_3.stl",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_3.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "GRIPPER_CLOSED.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_CLOSED.stl",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_CLOSED.stl"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "GRIPPER_OPEN.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN.stl",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "GRIPPER_OPEN_FINGER_1.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_1.stl",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_1.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "GRIPPER_OPEN_FINGER_2.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_2.stl",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_2.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "GRIPPER_OPEN_PALM.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_PALM.stl",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_PALM.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "GRIPPER_OPEN_FINGER_3.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_3.stl",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_3.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "GRIPPER_CLOSED.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_CLOSED.stl",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_CLOSED.stl"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "palm.STL",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/palm.STL",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/palm.STL"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_1.STL",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_1.STL",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_1.STL"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_3.STL",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_3.STL",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_3.STL"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_0.STL",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_0.STL",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_0.STL"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_2.STL",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_2.STL",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_2.STL"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "palm.dae",
+          "file_type": "dae",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/palm.dae",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/palm.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_3.dae",
+          "file_type": "dae",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_0.dae",
+          "file_type": "dae",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_2.dae",
+          "file_type": "dae",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_1.dae",
+          "file_type": "dae",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq-3f-gripper_articulated.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.xacro",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq-3f-gripper_mesh.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh.xacro",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq-3f-gripper_mesh.urdf",
+          "file_type": "urdf",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh.urdf",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh.urdf"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq-3f-gripper_articulated.urdf",
+          "file_type": "urdf",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq_3f_hand_macro.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq_3f_hand_macro.urdf.xacro",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq_3f_hand_macro.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq-3f-gripper_articulated_macro.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated_macro.xacro",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated_macro.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq-3f-gripper_articulated.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf.xacro",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq-3f-gripper_finger_articulated_macro.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_finger_articulated_macro.xacro",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_finger_articulated_macro.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq-3f-gripper_mesh_macro.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh_macro.xacro",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh_macro.xacro"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+          "package": "robotiq_3f_moveit_config",
+          "package_uri": "package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config",
+          "package": "robotiq_3f_moveit_config",
+          "package_uri": "package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/controllers.yaml",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "kinematics.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config",
+          "package": "robotiq_3f_moveit_config",
+          "package_uri": "package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/kinematics.yaml",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/kinematics.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "fake_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config",
+          "package": "robotiq_3f_moveit_config",
+          "package_uri": "package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/fake_controllers.yaml",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/fake_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "joint_limits.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config",
+          "package": "robotiq_3f_moveit_config",
+          "package_uri": "package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/joint_limits.yaml",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/joint_limits.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "ompl_planning.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config",
+          "package": "robotiq_3f_moveit_config",
+          "package_uri": "package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/ompl_planning.yaml",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/ompl_planning.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq_3f_gripper.srdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config",
+          "package": "robotiq_3f_moveit_config",
+          "package_uri": "package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/robotiq_3f_gripper.srdf.xacro",
+          "relative_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/robotiq_3f_gripper.srdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "ros2_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/config",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/config/ros2_controllers.yaml",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/config/ros2_controllers.yaml"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "robotiq_85_finger_tip_link.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "robotiq_85_finger_link.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "robotiq_85_knuckle_link.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "kinova_robotiq_coupler.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/kinova_robotiq_coupler.stl",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/kinova_robotiq_coupler.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "robotiq_85_base_link.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_base_link.stl",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_base_link.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "robotiq_85_inner_knuckle_link.stl",
+          "file_type": "stl",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "robotiq_85_finger_link.dae",
+          "file_type": "dae",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "robotiq_85_inner_knuckle_link.dae",
+          "file_type": "dae",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "kinova_robotiq_coupler.dae",
+          "file_type": "dae",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/kinova_robotiq_coupler.dae",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/kinova_robotiq_coupler.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "robotiq_85_finger_tip_link.dae",
+          "file_type": "dae",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "robotiq_85_knuckle_link.dae",
+          "file_type": "dae",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "robotiq_85_base_link.dae",
+          "file_type": "dae",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq_85_gripper.transmission.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.transmission.xacro",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.transmission.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq_85_gripper_sim_base.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper_sim_base.urdf.xacro",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper_sim_base.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "kinova_robotiq_85_gripper.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/kinova_robotiq_85_gripper.xacro",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/kinova_robotiq_85_gripper.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq_85_kinova_coupler.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_kinova_coupler.urdf.xacro",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_kinova_coupler.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq_85_gripper.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.xacro",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq_85_gripper.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+          "package": "robotiq_85_moveit_config",
+          "package_uri": "package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+          "package": "robotiq_85_moveit_config",
+          "package_uri": "package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/controllers.yaml",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "kinematics.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+          "package": "robotiq_85_moveit_config",
+          "package_uri": "package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/kinematics.yaml",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/kinematics.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq_85_gripper.srdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+          "package": "robotiq_85_moveit_config",
+          "package_uri": "package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf.xacro",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "fake_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+          "package": "robotiq_85_moveit_config",
+          "package_uri": "package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/fake_controllers.yaml",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/fake_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "joint_limits.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+          "package": "robotiq_85_moveit_config",
+          "package_uri": "package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/joint_limits.yaml",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/joint_limits.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "ompl_planning.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+          "package": "robotiq_85_moveit_config",
+          "package_uri": "package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/ompl_planning.yaml",
+          "relative_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/ompl_planning.yaml"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description",
+      "items": [
+        {
+          "asset_type_guess": "end_effector",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_description",
+          "package": "single_suction_description",
+          "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "joint_names_double_fixture.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_description/config",
+          "package": "single_suction_description",
+          "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/config/joint_names_double_fixture.yaml",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/config/joint_names_double_fixture.yaml"
+        },
+        {
+          "asset_type_guess": "end_effector",
+          "category": "scene_yaml",
+          "file_name": "ros2_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_description/config",
+          "package": "single_suction_description",
+          "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/config/ros2_controllers.yaml",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/config/ros2_controllers.yaml"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/meshes",
+      "items": [
+        {
+          "asset_type_guess": "end_effector",
+          "category": "mesh",
+          "file_name": "suction_cup_link.STL",
+          "file_type": "stl",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_description/meshes",
+          "package": "single_suction_description",
+          "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/suction_cup_link.STL",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/meshes/suction_cup_link.STL"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "wrist_fixture.STL",
+          "file_type": "stl",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_description/meshes",
+          "package": "single_suction_description",
+          "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL"
+        },
+        {
+          "asset_type_guess": "end_effector",
+          "category": "mesh",
+          "file_name": "multiple_gripper_link.STL",
+          "file_type": "stl",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_description/meshes",
+          "package": "single_suction_description",
+          "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/multiple_gripper_link.STL",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/meshes/multiple_gripper_link.STL"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "single_suction_gripper.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf",
+          "package": "single_suction_description",
+          "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "ur5_double_fixture.urdf",
+          "file_type": "urdf",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf",
+          "package": "single_suction_description",
+          "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/ur5_double_fixture.urdf",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/ur5_double_fixture.urdf"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "single_suction_gripper_standalone.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf",
+          "package": "single_suction_description",
+          "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper_standalone.urdf.xacro",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper_standalone.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "ur5_double_fixture.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf",
+          "package": "single_suction_description",
+          "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/ur5_double_fixture.urdf.xacro",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/ur5_double_fixture.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "double_fixture.urdf",
+          "file_type": "urdf",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf",
+          "package": "single_suction_description",
+          "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/double_fixture.urdf",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/double_fixture.urdf"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/urdf_solidworks",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "mounting_kit.urdf",
+          "file_type": "urdf",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/urdf_solidworks",
+          "package": "single_suction_description",
+          "package_uri": "package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/urdf_solidworks/mounting_kit.urdf",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_description/urdf/urdf_solidworks/mounting_kit.urdf"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "end_effector",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+          "package": "single_suction_moveit_config",
+          "package_uri": "package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+      "items": [
+        {
+          "asset_type_guess": "end_effector",
+          "category": "scene_yaml",
+          "file_name": "controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+          "package": "single_suction_moveit_config",
+          "package_uri": "package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/controllers.yaml",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/controllers.yaml"
+        },
+        {
+          "asset_type_guess": "end_effector",
+          "category": "scene_yaml",
+          "file_name": "kinematics.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+          "package": "single_suction_moveit_config",
+          "package_uri": "package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/kinematics.yaml",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/kinematics.yaml"
+        },
+        {
+          "asset_type_guess": "end_effector",
+          "category": "scene_yaml",
+          "file_name": "fake_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+          "package": "single_suction_moveit_config",
+          "package_uri": "package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/fake_controllers.yaml",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/fake_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "end_effector",
+          "category": "urdf_xacro",
+          "file_name": "single_suction_gripper.srdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+          "package": "single_suction_moveit_config",
+          "package_uri": "package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/single_suction_gripper.srdf.xacro",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/single_suction_gripper.srdf.xacro"
+        },
+        {
+          "asset_type_guess": "end_effector",
+          "category": "scene_yaml",
+          "file_name": "joint_limits.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+          "package": "single_suction_moveit_config",
+          "package_uri": "package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/joint_limits.yaml",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/joint_limits.yaml"
+        },
+        {
+          "asset_type_guess": "end_effector",
+          "category": "scene_yaml",
+          "file_name": "ompl_planning.yaml",
+          "file_type": "yaml",
+          "group": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+          "package": "single_suction_moveit_config",
+          "package_uri": "package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/ompl_planning.yaml",
+          "relative_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/ompl_planning.yaml"
+        }
+      ]
+    },
+    {
+      "group": "assets/environment/realsense2_description",
+      "items": [
+        {
+          "asset_type_guess": "sensor",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/environment/realsense2_description",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/package.xml",
+          "relative_path": "assets/environment/realsense2_description/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/environment/realsense2_description/meshes",
+      "items": [
+        {
+          "asset_type_guess": "sensor",
+          "category": "mesh",
+          "file_name": "d435.dae",
+          "file_type": "dae",
+          "group": "assets/environment/realsense2_description/meshes",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/meshes/d435.dae",
+          "relative_path": "assets/environment/realsense2_description/meshes/d435.dae"
+        },
+        {
+          "asset_type_guess": "sensor",
+          "category": "mesh",
+          "file_name": "d415.stl",
+          "file_type": "stl",
+          "group": "assets/environment/realsense2_description/meshes",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/meshes/d415.stl",
+          "relative_path": "assets/environment/realsense2_description/meshes/d415.stl"
+        }
+      ]
+    },
+    {
+      "group": "assets/environment/realsense2_description/tests",
+      "items": [
+        {
+          "asset_type_guess": "sensor",
+          "category": "urdf_xacro",
+          "file_name": "dual_d435.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/tests",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/tests/dual_d435.xacro",
+          "relative_path": "assets/environment/realsense2_description/tests/dual_d435.xacro"
+        },
+        {
+          "asset_type_guess": "sensor",
+          "category": "urdf_xacro",
+          "file_name": "dual_r410.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/tests",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/tests/dual_r410.xacro",
+          "relative_path": "assets/environment/realsense2_description/tests/dual_r410.xacro"
+        },
+        {
+          "asset_type_guess": "sensor",
+          "category": "urdf_xacro",
+          "file_name": "one_of_each.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/tests",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/tests/one_of_each.xacro",
+          "relative_path": "assets/environment/realsense2_description/tests/one_of_each.xacro"
+        },
+        {
+          "asset_type_guess": "sensor",
+          "category": "urdf_xacro",
+          "file_name": "dual_r430.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/tests",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/tests/dual_r430.xacro",
+          "relative_path": "assets/environment/realsense2_description/tests/dual_r430.xacro"
+        },
+        {
+          "asset_type_guess": "sensor",
+          "category": "urdf_xacro",
+          "file_name": "dual_d415.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/tests",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/tests/dual_d415.xacro",
+          "relative_path": "assets/environment/realsense2_description/tests/dual_d415.xacro"
+        }
+      ]
+    },
+    {
+      "group": "assets/environment/realsense2_description/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "test_d415_camera.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/urdf",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/test_d415_camera.urdf.xacro",
+          "relative_path": "assets/environment/realsense2_description/urdf/test_d415_camera.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "_materials.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/urdf",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/_materials.urdf.xacro",
+          "relative_path": "assets/environment/realsense2_description/urdf/_materials.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "test_r410_camera.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/urdf",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/test_r410_camera.urdf.xacro",
+          "relative_path": "assets/environment/realsense2_description/urdf/test_r410_camera.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "_d435i.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/urdf",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro",
+          "relative_path": "assets/environment/realsense2_description/urdf/_d435i.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "_d435i_imu_modules.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/urdf",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro",
+          "relative_path": "assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "test_d435_multiple_cameras.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/urdf",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/test_d435_multiple_cameras.urdf.xacro",
+          "relative_path": "assets/environment/realsense2_description/urdf/test_d435_multiple_cameras.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "test_r430_camera.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/urdf",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/test_r430_camera.urdf.xacro",
+          "relative_path": "assets/environment/realsense2_description/urdf/test_r430_camera.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "test_d435_camera.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/urdf",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/test_d435_camera.urdf.xacro",
+          "relative_path": "assets/environment/realsense2_description/urdf/test_d435_camera.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "test_d435i_camera.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/urdf",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/test_d435i_camera.urdf.xacro",
+          "relative_path": "assets/environment/realsense2_description/urdf/test_d435i_camera.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "_d415.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/urdf",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/_d415.urdf.xacro",
+          "relative_path": "assets/environment/realsense2_description/urdf/_d415.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "_r410.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/urdf",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/_r410.urdf.xacro",
+          "relative_path": "assets/environment/realsense2_description/urdf/_r410.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "_d435.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/urdf",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/_d435.urdf.xacro",
+          "relative_path": "assets/environment/realsense2_description/urdf/_d435.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "_r430.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/realsense2_description/urdf",
+          "package": "realsense2_description",
+          "package_uri": "package://realsense2_description/assets/environment/realsense2_description/urdf/_r430.urdf.xacro",
+          "relative_path": "assets/environment/realsense2_description/urdf/_r430.urdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "assets/environment/table_description",
+      "items": [
+        {
+          "asset_type_guess": "table",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/environment/table_description",
+          "package": "table_description",
+          "package_uri": "package://table_description/assets/environment/table_description/package.xml",
+          "relative_path": "assets/environment/table_description/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/environment/table_description/meshes/collision",
+      "items": [
+        {
+          "asset_type_guess": "table",
+          "category": "mesh",
+          "file_name": "table.stl",
+          "file_type": "stl",
+          "group": "assets/environment/table_description/meshes/collision",
+          "package": "table_description",
+          "package_uri": "package://table_description/assets/environment/table_description/meshes/collision/table.stl",
+          "relative_path": "assets/environment/table_description/meshes/collision/table.stl"
+        }
+      ]
+    },
+    {
+      "group": "assets/environment/table_description/meshes/visual",
+      "items": [
+        {
+          "asset_type_guess": "table",
+          "category": "mesh",
+          "file_name": "table.stl",
+          "file_type": "stl",
+          "group": "assets/environment/table_description/meshes/visual",
+          "package": "table_description",
+          "package_uri": "package://table_description/assets/environment/table_description/meshes/visual/table.stl",
+          "relative_path": "assets/environment/table_description/meshes/visual/table.stl"
+        }
+      ]
+    },
+    {
+      "group": "assets/environment/table_description/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "table.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/table_description/urdf",
+          "package": "table_description",
+          "package_uri": "package://table_description/assets/environment/table_description/urdf/table.urdf.xacro",
+          "relative_path": "assets/environment/table_description/urdf/table.urdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "assets/environment/workbench_description",
+      "items": [
+        {
+          "asset_type_guess": "workbench",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/environment/workbench_description",
+          "package": "workbench_description",
+          "package_uri": "package://workbench_description/assets/environment/workbench_description/package.xml",
+          "relative_path": "assets/environment/workbench_description/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/environment/workbench_description/meshes/collision",
+      "items": [
+        {
+          "asset_type_guess": "table",
+          "category": "mesh",
+          "file_name": "table.stl",
+          "file_type": "stl",
+          "group": "assets/environment/workbench_description/meshes/collision",
+          "package": "workbench_description",
+          "package_uri": "package://workbench_description/assets/environment/workbench_description/meshes/collision/table.stl",
+          "relative_path": "assets/environment/workbench_description/meshes/collision/table.stl"
+        }
+      ]
+    },
+    {
+      "group": "assets/environment/workbench_description/meshes/visual",
+      "items": [
+        {
+          "asset_type_guess": "table",
+          "category": "mesh",
+          "file_name": "table.stl",
+          "file_type": "stl",
+          "group": "assets/environment/workbench_description/meshes/visual",
+          "package": "workbench_description",
+          "package_uri": "package://workbench_description/assets/environment/workbench_description/meshes/visual/table.stl",
+          "relative_path": "assets/environment/workbench_description/meshes/visual/table.stl"
+        }
+      ]
+    },
+    {
+      "group": "assets/environment/workbench_description/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "table.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/environment/workbench_description/urdf",
+          "package": "workbench_description",
+          "package_uri": "package://workbench_description/assets/environment/workbench_description/urdf/table.urdf.xacro",
+          "relative_path": "assets/environment/workbench_description/urdf/table.urdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/fanuc/fanuc_description",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/robots/fanuc/fanuc_description",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/package.xml",
+          "relative_path": "assets/robots/fanuc/fanuc_description/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "base_link.stl",
+          "file_type": "stl",
+          "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/base_link.stl",
+          "relative_path": "assets/robots/fanuc/fanuc_description/meshes/collision/base_link.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_5.stl",
+          "file_type": "stl",
+          "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_5.stl",
+          "relative_path": "assets/robots/fanuc/fanuc_description/meshes/collision/link_5.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_6.stl",
+          "file_type": "stl",
+          "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_6.stl",
+          "relative_path": "assets/robots/fanuc/fanuc_description/meshes/collision/link_6.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_1.stl",
+          "file_type": "stl",
+          "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_1.stl",
+          "relative_path": "assets/robots/fanuc/fanuc_description/meshes/collision/link_1.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_3.stl",
+          "file_type": "stl",
+          "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_3.stl",
+          "relative_path": "assets/robots/fanuc/fanuc_description/meshes/collision/link_3.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_2.stl",
+          "file_type": "stl",
+          "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_2.stl",
+          "relative_path": "assets/robots/fanuc/fanuc_description/meshes/collision/link_2.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_4.stl",
+          "file_type": "stl",
+          "group": "assets/robots/fanuc/fanuc_description/meshes/collision",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_4.stl",
+          "relative_path": "assets/robots/fanuc/fanuc_description/meshes/collision/link_4.stl"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "base_link.stl",
+          "file_type": "stl",
+          "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/base_link.stl",
+          "relative_path": "assets/robots/fanuc/fanuc_description/meshes/visual/base_link.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_5.stl",
+          "file_type": "stl",
+          "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_5.stl",
+          "relative_path": "assets/robots/fanuc/fanuc_description/meshes/visual/link_5.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_6.stl",
+          "file_type": "stl",
+          "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_6.stl",
+          "relative_path": "assets/robots/fanuc/fanuc_description/meshes/visual/link_6.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_1.stl",
+          "file_type": "stl",
+          "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_1.stl",
+          "relative_path": "assets/robots/fanuc/fanuc_description/meshes/visual/link_1.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_3.stl",
+          "file_type": "stl",
+          "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_3.stl",
+          "relative_path": "assets/robots/fanuc/fanuc_description/meshes/visual/link_3.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_2.stl",
+          "file_type": "stl",
+          "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_2.stl",
+          "relative_path": "assets/robots/fanuc/fanuc_description/meshes/visual/link_2.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link_4.stl",
+          "file_type": "stl",
+          "group": "assets/robots/fanuc/fanuc_description/meshes/visual",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_4.stl",
+          "relative_path": "assets/robots/fanuc/fanuc_description/meshes/visual/link_4.stl"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/fanuc/fanuc_description/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "fanuc.urdf",
+          "file_type": "urdf",
+          "group": "assets/robots/fanuc/fanuc_description/urdf",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/urdf/fanuc.urdf",
+          "relative_path": "assets/robots/fanuc/fanuc_description/urdf/fanuc.urdf"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "fanuc.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/robots/fanuc/fanuc_description/urdf",
+          "package": "fanuc_description",
+          "package_uri": "package://fanuc_description/assets/robots/fanuc/fanuc_description/urdf/fanuc.urdf.xacro",
+          "relative_path": "assets/robots/fanuc/fanuc_description/urdf/fanuc.urdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/fanuc/fanuc_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/robots/fanuc/fanuc_moveit_config",
+          "package": "fanuc_moveit_config",
+          "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/package.xml",
+          "relative_path": "assets/robots/fanuc/fanuc_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "ros_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+          "package": "fanuc_moveit_config",
+          "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/ros_controllers.yaml",
+          "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/ros_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "chomp_planning.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+          "package": "fanuc_moveit_config",
+          "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/chomp_planning.yaml",
+          "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/chomp_planning.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "kinematics.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+          "package": "fanuc_moveit_config",
+          "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/kinematics.yaml",
+          "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/kinematics.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "fake_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+          "package": "fanuc_moveit_config",
+          "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/fake_controllers.yaml",
+          "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/fake_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "joint_limits.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+          "package": "fanuc_moveit_config",
+          "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/joint_limits.yaml",
+          "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/joint_limits.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "ompl_planning.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+          "package": "fanuc_moveit_config",
+          "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/ompl_planning.yaml",
+          "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/ompl_planning.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "sensors_3d.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+          "package": "fanuc_moveit_config",
+          "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/sensors_3d.yaml",
+          "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/sensors_3d.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "fanuc.srdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/robots/fanuc/fanuc_moveit_config/config",
+          "package": "fanuc_moveit_config",
+          "package_uri": "package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/fanuc.srdf.xacro",
+          "relative_path": "assets/robots/fanuc/fanuc_moveit_config/config/fanuc.srdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/panda_robot/panda_description",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/robots/panda_robot/panda_description",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/package.xml",
+          "relative_path": "assets/robots/panda_robot/panda_description/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link1.stl",
+          "file_type": "stl",
+          "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link1.stl",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link1.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link6.stl",
+          "file_type": "stl",
+          "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link6.stl",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link6.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link4.stl",
+          "file_type": "stl",
+          "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link4.stl",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link4.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link3.stl",
+          "file_type": "stl",
+          "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link3.stl",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link3.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link7.stl",
+          "file_type": "stl",
+          "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link7.stl",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link7.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "hand.stl",
+          "file_type": "stl",
+          "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/hand.stl",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/hand.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link0.stl",
+          "file_type": "stl",
+          "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link0.stl",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link0.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link2.stl",
+          "file_type": "stl",
+          "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link2.stl",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link2.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "finger.stl",
+          "file_type": "stl",
+          "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/finger.stl",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/finger.stl"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link5.stl",
+          "file_type": "stl",
+          "group": "assets/robots/panda_robot/panda_description/meshes/collision",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link5.stl",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/collision/link5.stl"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link3.dae",
+          "file_type": "dae",
+          "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link3.dae",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link3.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link1.dae",
+          "file_type": "dae",
+          "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link1.dae",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link1.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link6.dae",
+          "file_type": "dae",
+          "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link6.dae",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link6.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "finger.dae",
+          "file_type": "dae",
+          "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/finger.dae",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/finger.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link5.dae",
+          "file_type": "dae",
+          "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link5.dae",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link5.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link7.dae",
+          "file_type": "dae",
+          "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link7.dae",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link7.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link0.dae",
+          "file_type": "dae",
+          "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link0.dae",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link0.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link4.dae",
+          "file_type": "dae",
+          "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link4.dae",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link4.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "link2.dae",
+          "file_type": "dae",
+          "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link2.dae",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/link2.dae"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "hand.dae",
+          "file_type": "dae",
+          "group": "assets/robots/panda_robot/panda_description/meshes/visual",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/hand.dae",
+          "relative_path": "assets/robots/panda_robot/panda_description/meshes/visual/hand.dae"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/panda_robot/panda_description/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "panda.urdf",
+          "file_type": "urdf",
+          "group": "assets/robots/panda_robot/panda_description/urdf",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/urdf/panda.urdf",
+          "relative_path": "assets/robots/panda_robot/panda_description/urdf/panda.urdf"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "panda.urdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/robots/panda_robot/panda_description/urdf",
+          "package": "panda_description",
+          "package_uri": "package://panda_description/assets/robots/panda_robot/panda_description/urdf/panda.urdf.xacro",
+          "relative_path": "assets/robots/panda_robot/panda_description/urdf/panda.urdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/panda_robot/panda_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/robots/panda_robot/panda_moveit_config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/package.xml",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/panda_robot/panda_moveit_config/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "panda_arm.xacro",
+          "file_type": "xacro",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_arm.xacro",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/panda_arm.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "trajopt_planning.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/trajopt_planning.yaml",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/trajopt_planning.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "panda_arm_hand.srdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_arm_hand.srdf.xacro",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/panda_arm_hand.srdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "chomp_planning.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/chomp_planning.yaml",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/chomp_planning.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "panda_gripper_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_gripper_controllers.yaml",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/panda_gripper_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "kinematics.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/kinematics.yaml",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/kinematics.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "sensors_kinect_pointcloud.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/sensors_kinect_pointcloud.yaml",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/sensors_kinect_pointcloud.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "panda_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_controllers.yaml",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/panda_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "fake_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/fake_controllers.yaml",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/fake_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "stomp_planning.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/stomp_planning.yaml",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/stomp_planning.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "lerp_planning.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/lerp_planning.yaml",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/lerp_planning.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "joint_limits.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/joint_limits.yaml",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/joint_limits.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "hand.xacro",
+          "file_type": "xacro",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/hand.xacro",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/hand.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "ompl_planning.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/ompl_planning.yaml",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/ompl_planning.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "sensors_kinect_depthmap.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/sensors_kinect_depthmap.yaml",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/sensors_kinect_depthmap.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "panda.srdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda.srdf.xacro",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/panda.srdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "panda_arm.srdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/robots/panda_robot/panda_moveit_config/config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_arm.srdf.xacro",
+          "relative_path": "assets/robots/panda_robot/panda_moveit_config/config/panda_arm.srdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/universal_robot/ur10_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/robots/universal_robot/ur10_moveit_config",
+          "package": "ur10_moveit_config",
+          "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/package.xml",
+          "relative_path": "assets/robots/universal_robot/ur10_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+          "package": "ur10_moveit_config",
+          "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/controllers.yaml",
+          "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "kinematics.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+          "package": "ur10_moveit_config",
+          "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/kinematics.yaml",
+          "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/kinematics.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "ur10.srdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+          "package": "ur10_moveit_config",
+          "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/ur10.srdf.xacro",
+          "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/ur10.srdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "fake_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+          "package": "ur10_moveit_config",
+          "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/fake_controllers.yaml",
+          "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/fake_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "ur10_ros_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+          "package": "ur10_moveit_config",
+          "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/ur10_ros_controllers.yaml",
+          "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/ur10_ros_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "joint_limits.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+          "package": "ur10_moveit_config",
+          "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/joint_limits.yaml",
+          "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/joint_limits.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "ompl_planning.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+          "package": "ur10_moveit_config",
+          "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/ompl_planning.yaml",
+          "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/ompl_planning.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "ur10.ros2_control.xacro",
+          "file_type": "xacro",
+          "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+          "package": "ur10_moveit_config",
+          "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/ur10.ros2_control.xacro",
+          "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/ur10.ros2_control.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "initial_positions.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur10_moveit_config/config",
+          "package": "ur10_moveit_config",
+          "package_uri": "package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/initial_positions.yaml",
+          "relative_path": "assets/robots/universal_robot/ur10_moveit_config/config/initial_positions.yaml"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/universal_robot/ur3_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/robots/universal_robot/ur3_moveit_config",
+          "package": "ur3_moveit_config",
+          "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/package.xml",
+          "relative_path": "assets/robots/universal_robot/ur3_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "ur3.srdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+          "package": "ur3_moveit_config",
+          "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/ur3.srdf.xacro",
+          "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/ur3.srdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+          "package": "ur3_moveit_config",
+          "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/controllers.yaml",
+          "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "ur3_ros_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+          "package": "ur3_moveit_config",
+          "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/ur3_ros_controllers.yaml",
+          "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/ur3_ros_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "kinematics.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+          "package": "ur3_moveit_config",
+          "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/kinematics.yaml",
+          "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/kinematics.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "fake_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+          "package": "ur3_moveit_config",
+          "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/fake_controllers.yaml",
+          "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/fake_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "joint_limits.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+          "package": "ur3_moveit_config",
+          "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/joint_limits.yaml",
+          "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/joint_limits.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "ompl_planning.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+          "package": "ur3_moveit_config",
+          "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/ompl_planning.yaml",
+          "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/ompl_planning.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "initial_positions.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+          "package": "ur3_moveit_config",
+          "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/initial_positions.yaml",
+          "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/initial_positions.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "ur3.ros2_control.xacro",
+          "file_type": "xacro",
+          "group": "assets/robots/universal_robot/ur3_moveit_config/config",
+          "package": "ur3_moveit_config",
+          "package_uri": "package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/ur3.ros2_control.xacro",
+          "relative_path": "assets/robots/universal_robot/ur3_moveit_config/config/ur3.ros2_control.xacro"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/universal_robot/ur5_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "assets/robots/universal_robot/ur5_moveit_config",
+          "package": "ur5_moveit_config",
+          "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/package.xml",
+          "relative_path": "assets/robots/universal_robot/ur5_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "ur5.ros2_control.xacro",
+          "file_type": "xacro",
+          "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+          "package": "ur5_moveit_config",
+          "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/ur5.ros2_control.xacro",
+          "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/ur5.ros2_control.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+          "package": "ur5_moveit_config",
+          "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/controllers.yaml",
+          "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "kinematics.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+          "package": "ur5_moveit_config",
+          "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/kinematics.yaml",
+          "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/kinematics.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "fake_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+          "package": "ur5_moveit_config",
+          "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/fake_controllers.yaml",
+          "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/fake_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "joint_limits.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+          "package": "ur5_moveit_config",
+          "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/joint_limits.yaml",
+          "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/joint_limits.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "ompl_planning.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+          "package": "ur5_moveit_config",
+          "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/ompl_planning.yaml",
+          "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/ompl_planning.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "ur5_ros_controllers.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+          "package": "ur5_moveit_config",
+          "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/ur5_ros_controllers.yaml",
+          "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/ur5_ros_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "initial_positions.yaml",
+          "file_type": "yaml",
+          "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+          "package": "ur5_moveit_config",
+          "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/initial_positions.yaml",
+          "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/initial_positions.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "ur5.srdf.xacro",
+          "file_type": "xacro",
+          "group": "assets/robots/universal_robot/ur5_moveit_config/config",
+          "package": "ur5_moveit_config",
+          "package_uri": "package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/ur5.srdf.xacro",
+          "relative_path": "assets/robots/universal_robot/ur5_moveit_config/config/ur5.srdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/commissioning_bundle",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/commissioning_bundle",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/commissioning_bundle/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell",
+          "package": "generated_ur5_2f_demo_cell",
+          "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/package.xml",
+          "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/package.xml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell",
+          "package": "generated_ur5_2f_demo_cell",
+          "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/scene_manifest.yaml",
+          "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "task_recipe.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config",
+          "package": "generated_ur5_2f_demo_cell",
+          "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config/task_recipe.yaml",
+          "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config/task_recipe.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.preview.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated",
+          "package": "generated_ur5_2f_demo_cell",
+          "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/scene_manifest.preview.yaml",
+          "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/scene_manifest.preview.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell",
+          "package": "generated_ur5_2f_demo_cell",
+          "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell/scene_manifest.yaml",
+          "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/commissioning_bundle",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/commissioning_bundle",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/commissioning_bundle/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell",
+          "package": "generated_ur5_colour_sort_cell",
+          "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/package.xml",
+          "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/package.xml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell",
+          "package": "generated_ur5_colour_sort_cell",
+          "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/scene_manifest.yaml",
+          "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "task_recipe.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config",
+          "package": "generated_ur5_colour_sort_cell",
+          "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config/task_recipe.yaml",
+          "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config/task_recipe.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.preview.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated",
+          "package": "generated_ur5_colour_sort_cell",
+          "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/scene_manifest.preview.yaml",
+          "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/scene_manifest.preview.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell",
+          "package": "generated_ur5_colour_sort_cell",
+          "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell/scene_manifest.yaml",
+          "relative_path": "dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/template_colour/commissioning_bundle",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/template_colour/commissioning_bundle",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/template_colour/commissioning_bundle/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour",
+          "package": "generated_template_colour",
+          "package_uri": "package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/package.xml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/package.xml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour",
+          "package": "generated_template_colour",
+          "package_uri": "package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/scene_manifest.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "task_recipe.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/config",
+          "package": "generated_template_colour",
+          "package_uri": "package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/config/task_recipe.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/config/task_recipe.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.preview.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated",
+          "package": "generated_template_colour",
+          "package_uri": "package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/scene_manifest.preview.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/scene_manifest.preview.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/bundle/generated_template_colour",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/bundle/generated_template_colour",
+          "package": "generated_template_colour",
+          "package_uri": "package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/bundle/generated_template_colour/scene_manifest.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/bundle/generated_template_colour/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/commissioning_bundle",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/commissioning_bundle",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/commissioning_bundle/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell",
+          "package": "generated_ur5_2f_demo_cell",
+          "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/package.xml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/package.xml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell",
+          "package": "generated_ur5_2f_demo_cell",
+          "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/scene_manifest.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "task_recipe.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config",
+          "package": "generated_ur5_2f_demo_cell",
+          "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config/task_recipe.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config/task_recipe.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.preview.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated",
+          "package": "generated_ur5_2f_demo_cell",
+          "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/scene_manifest.preview.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/scene_manifest.preview.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell",
+          "package": "generated_ur5_2f_demo_cell",
+          "package_uri": "package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell/scene_manifest.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/commissioning_bundle",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/commissioning_bundle",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/commissioning_bundle/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell",
+          "package": "generated_ur5_colour_sort_cell",
+          "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/package.xml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/package.xml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell",
+          "package": "generated_ur5_colour_sort_cell",
+          "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/scene_manifest.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "task_recipe.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config",
+          "package": "generated_ur5_colour_sort_cell",
+          "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config/task_recipe.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config/task_recipe.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.preview.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated",
+          "package": "generated_ur5_colour_sort_cell",
+          "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/scene_manifest.preview.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/scene_manifest.preview.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell",
+          "package": "generated_ur5_colour_sort_cell",
+          "package_uri": "package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell/scene_manifest.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/commissioning_bundle",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/commissioning_bundle",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/commissioning_bundle/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell",
+          "package": "generated_ur5_garbage_sort_cell",
+          "package_uri": "package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/package.xml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/package.xml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell",
+          "package": "generated_ur5_garbage_sort_cell",
+          "package_uri": "package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/scene_manifest.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "task_recipe.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/config",
+          "package": "generated_ur5_garbage_sort_cell",
+          "package_uri": "package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/config/task_recipe.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/config/task_recipe.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.preview.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated",
+          "package": "generated_ur5_garbage_sort_cell",
+          "package_uri": "package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/scene_manifest.preview.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/scene_manifest.preview.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/bundle/generated_ur5_garbage_sort_cell",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/bundle/generated_ur5_garbage_sort_cell",
+          "package": "generated_ur5_garbage_sort_cell",
+          "package_uri": "package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/bundle/generated_ur5_garbage_sort_cell/scene_manifest.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/bundle/generated_ur5_garbage_sort_cell/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/commissioning_bundle",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/commissioning_bundle",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/commissioning_bundle/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell",
+          "package": "generated_ur5_shape_sort_cell",
+          "package_uri": "package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/package.xml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/package.xml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell",
+          "package": "generated_ur5_shape_sort_cell",
+          "package_uri": "package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/scene_manifest.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "task_recipe.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/config",
+          "package": "generated_ur5_shape_sort_cell",
+          "package_uri": "package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/config/task_recipe.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/config/task_recipe.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.preview.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated",
+          "package": "generated_ur5_shape_sort_cell",
+          "package_uri": "package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/scene_manifest.preview.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/scene_manifest.preview.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/bundle/generated_ur5_shape_sort_cell",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/bundle/generated_ur5_shape_sort_cell",
+          "package": "generated_ur5_shape_sort_cell",
+          "package_uri": "package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/bundle/generated_ur5_shape_sort_cell/scene_manifest.yaml",
+          "relative_path": "dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/bundle/generated_ur5_shape_sort_cell/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/workcell_bundles/suction_test",
+      "items": [
+        {
+          "asset_type_guess": "end_effector",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/workcell_bundles/suction_test",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "dist/workcell_bundles/suction_test/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/workcell_bundles/ur5_2f_test",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/workcell_bundles/ur5_2f_test",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "dist/workcell_bundles/ur5_2f_test/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/workcell_bundles/ur5_3f_test",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/workcell_bundles/ur5_3f_test",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "dist/workcell_bundles/ur5_3f_test/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "dist/workcell_bundles/ur5_airpick4_test",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "dist/workcell_bundles/ur5_airpick4_test",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "dist/workcell_bundles/ur5_airpick4_test/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "docs/reference/archived_duplicates/assets",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "table.urdf.copy.xacro",
+          "file_type": "xacro",
+          "group": "docs/reference/archived_duplicates/assets",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "docs/reference/archived_duplicates/assets/table.urdf.copy.xacro"
+        }
+      ]
+    },
+    {
+      "group": "docs/reference/archived_duplicates/end_effectors",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq_3f_gripper.srdf.copy.xacro",
+          "file_type": "xacro",
+          "group": "docs/reference/archived_duplicates/end_effectors",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "docs/reference/archived_duplicates/end_effectors/robotiq_3f_gripper.srdf.copy.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "onrobot_airpick4_robotiq_3f_gripper.srdf.copy.xacro",
+          "file_type": "xacro",
+          "group": "docs/reference/archived_duplicates/end_effectors",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "docs/reference/archived_duplicates/end_effectors/onrobot_airpick4_robotiq_3f_gripper.srdf.copy.xacro"
+        }
+      ]
+    },
+    {
+      "group": "docs/reference/archived_duplicates/single_suction_gripper",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "dual_gripper.urdf.copy.xacro",
+          "file_type": "xacro",
+          "group": "docs/reference/archived_duplicates/single_suction_gripper",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "docs/reference/archived_duplicates/single_suction_gripper/dual_gripper.urdf.copy.xacro"
+        }
+      ]
+    },
+    {
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety",
+          "package": "run_dynamic_safety",
+          "package_uri": "package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/package.xml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "start_positions.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config",
+          "package": "run_dynamic_safety",
+          "package_uri": "package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/start_positions.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/start_positions.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "panda_ros_controllers.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config",
+          "package": "run_dynamic_safety",
+          "package_uri": "package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/panda_ros_controllers.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/panda_ros_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "panda_controllers.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config",
+          "package": "run_dynamic_safety",
+          "package_uri": "package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/panda_controllers.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/panda_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "fake_controllers.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config",
+          "package": "run_dynamic_safety",
+          "package_uri": "package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/fake_controllers.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/fake_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "moveit_cpp.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config",
+          "package": "run_dynamic_safety",
+          "package_uri": "package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/moveit_cpp.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/moveit_cpp.yaml"
+        }
+      ]
+    },
+    {
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution",
+          "package": "run_grasp_execution",
+          "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "controllers.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+          "package": "run_grasp_execution",
+          "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/controllers.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/controllers.yaml"
+        },
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "fake_grasp_pose_publisher.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+          "package": "run_grasp_execution",
+          "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/fake_grasp_pose_publisher.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/fake_grasp_pose_publisher.yaml"
+        },
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "grasp_execution.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+          "package": "run_grasp_execution",
+          "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml"
+        },
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "start_positions.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+          "package": "run_grasp_execution",
+          "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/start_positions.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/start_positions.yaml"
+        },
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "workcell_context.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+          "package": "run_grasp_execution",
+          "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/workcell_context.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/workcell_context.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "ur5_ros_controllers.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+          "package": "run_grasp_execution",
+          "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/ur5_ros_controllers.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/ur5_ros_controllers.yaml"
+        },
+        {
+          "asset_type_guess": "sensor",
+          "category": "scene_yaml",
+          "file_name": "sensors_3d.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config",
+          "package": "run_grasp_execution",
+          "package_uri": "package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/sensors_3d.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/sensors_3d.yaml"
+        }
+      ]
+    },
+    {
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner",
+          "package": "run_grasp_planner",
+          "package_uri": "package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/package.xml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "params_2f.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config",
+          "package": "run_grasp_planner",
+          "package_uri": "package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml"
+        },
+        {
+          "asset_type_guess": "end_effector",
+          "category": "scene_yaml",
+          "file_name": "params_airpick4.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config",
+          "package": "run_grasp_planner",
+          "package_uri": "package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_airpick4.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_airpick4.yaml"
+        },
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "params_3f.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config",
+          "package": "run_grasp_planner",
+          "package_uri": "package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml"
+        },
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "params.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config",
+          "package": "run_grasp_planner",
+          "package_uri": "package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params.yaml"
+        },
+        {
+          "asset_type_guess": "end_effector",
+          "category": "scene_yaml",
+          "file_name": "params_suction.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config",
+          "package": "run_grasp_planner",
+          "package_uri": "package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_suction.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_suction.yaml"
+        }
+      ]
+    },
+    {
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution",
+          "package": "run_waypoint_execution",
+          "package_uri": "package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/package.xml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "controllers.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config",
+          "package": "run_waypoint_execution",
+          "package_uri": "package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/controllers.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/controllers.yaml"
+        },
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "fake_grasp_pose_publisher.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config",
+          "package": "run_waypoint_execution",
+          "package_uri": "package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/fake_grasp_pose_publisher.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/fake_grasp_pose_publisher.yaml"
+        },
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "grasp_execution.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config",
+          "package": "run_waypoint_execution",
+          "package_uri": "package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/grasp_execution.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/grasp_execution.yaml"
+        },
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "start_positions.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config",
+          "package": "run_waypoint_execution",
+          "package_uri": "package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/start_positions.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/start_positions.yaml"
+        },
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "workcell_context.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config",
+          "package": "run_waypoint_execution",
+          "package_uri": "package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/workcell_context.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/workcell_context.yaml"
+        },
+        {
+          "asset_type_guess": "sensor",
+          "category": "scene_yaml",
+          "file_name": "sensors_3d.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config",
+          "package": "run_waypoint_execution",
+          "package_uri": "package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/sensors_3d.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/sensors_3d.yaml"
+        }
+      ]
+    },
+    {
+      "group": "easy_manipulation_deployment/emd_dynamic_safety",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "easy_manipulation_deployment/emd_dynamic_safety",
+          "package": "emd_dynamic_safety",
+          "package_uri": "package://emd_dynamic_safety/easy_manipulation_deployment/emd_dynamic_safety/package.xml",
+          "relative_path": "easy_manipulation_deployment/emd_dynamic_safety/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "easy_manipulation_deployment/emd_dynamic_safety/config",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "mappings.yaml",
+          "file_type": "yaml",
+          "group": "easy_manipulation_deployment/emd_dynamic_safety/config",
+          "package": "emd_dynamic_safety",
+          "package_uri": "package://emd_dynamic_safety/easy_manipulation_deployment/emd_dynamic_safety/config/mappings.yaml",
+          "relative_path": "easy_manipulation_deployment/emd_dynamic_safety/config/mappings.yaml"
+        }
+      ]
+    },
+    {
+      "group": "easy_manipulation_deployment/emd_grasp_execution",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "easy_manipulation_deployment/emd_grasp_execution",
+          "package": "emd_grasp_execution",
+          "package_uri": "package://emd_grasp_execution/easy_manipulation_deployment/emd_grasp_execution/package.xml",
+          "relative_path": "easy_manipulation_deployment/emd_grasp_execution/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "easy_manipulation_deployment/emd_grasp_planner",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "easy_manipulation_deployment/emd_grasp_planner",
+          "package": "emd_grasp_planner",
+          "package_uri": "package://emd_grasp_planner/easy_manipulation_deployment/emd_grasp_planner/package.xml",
+          "relative_path": "easy_manipulation_deployment/emd_grasp_planner/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "easy_manipulation_deployment/emd_waypoint_execution",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "easy_manipulation_deployment/emd_waypoint_execution",
+          "package": "emd_waypoint_execution",
+          "package_uri": "package://emd_waypoint_execution/easy_manipulation_deployment/emd_waypoint_execution/package.xml",
+          "relative_path": "easy_manipulation_deployment/emd_waypoint_execution/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "emd_msgs",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "emd_msgs",
+          "package": "emd_msgs",
+          "package_uri": "package://emd_msgs/emd_msgs/package.xml",
+          "relative_path": "emd_msgs/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "scenes/suction_test",
+      "items": [
+        {
+          "asset_type_guess": "end_effector",
+          "category": "scene_yaml",
+          "file_name": "environment.yaml",
+          "file_type": "yaml",
+          "group": "scenes/suction_test",
+          "package": "suction_test",
+          "package_uri": "package://suction_test/scenes/suction_test/environment.yaml",
+          "relative_path": "scenes/suction_test/environment.yaml"
+        },
+        {
+          "asset_type_guess": "end_effector",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "scenes/suction_test",
+          "package": "suction_test",
+          "package_uri": "package://suction_test/scenes/suction_test/package.xml",
+          "relative_path": "scenes/suction_test/package.xml"
+        },
+        {
+          "asset_type_guess": "end_effector",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "scenes/suction_test",
+          "package": "suction_test",
+          "package_uri": "package://suction_test/scenes/suction_test/scene_manifest.yaml",
+          "relative_path": "scenes/suction_test/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "scenes/suction_test/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "scene.urdf.xacro",
+          "file_type": "xacro",
+          "group": "scenes/suction_test/urdf",
+          "package": "suction_test",
+          "package_uri": "package://suction_test/scenes/suction_test/urdf/scene.urdf.xacro",
+          "relative_path": "scenes/suction_test/urdf/scene.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "arm_hand.srdf.xacro",
+          "file_type": "xacro",
+          "group": "scenes/suction_test/urdf",
+          "package": "suction_test",
+          "package_uri": "package://suction_test/scenes/suction_test/urdf/arm_hand.srdf.xacro",
+          "relative_path": "scenes/suction_test/urdf/arm_hand.srdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "scenes/ur10_2f_test",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "environment.yaml",
+          "file_type": "yaml",
+          "group": "scenes/ur10_2f_test",
+          "package": "ur10_2f_test",
+          "package_uri": "package://ur10_2f_test/scenes/ur10_2f_test/environment.yaml",
+          "relative_path": "scenes/ur10_2f_test/environment.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "scenes/ur10_2f_test",
+          "package": "ur10_2f_test",
+          "package_uri": "package://ur10_2f_test/scenes/ur10_2f_test/package.xml",
+          "relative_path": "scenes/ur10_2f_test/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "scenes/ur10_2f_test/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "scene.urdf.xacro",
+          "file_type": "xacro",
+          "group": "scenes/ur10_2f_test/urdf",
+          "package": "ur10_2f_test",
+          "package_uri": "package://ur10_2f_test/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
+          "relative_path": "scenes/ur10_2f_test/urdf/scene.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "arm_hand.srdf.xacro",
+          "file_type": "xacro",
+          "group": "scenes/ur10_2f_test/urdf",
+          "package": "ur10_2f_test",
+          "package_uri": "package://ur10_2f_test/scenes/ur10_2f_test/urdf/arm_hand.srdf.xacro",
+          "relative_path": "scenes/ur10_2f_test/urdf/arm_hand.srdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "scenes/ur3_suction_test",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "environment.yaml",
+          "file_type": "yaml",
+          "group": "scenes/ur3_suction_test",
+          "package": "ur3_suction_test",
+          "package_uri": "package://ur3_suction_test/scenes/ur3_suction_test/environment.yaml",
+          "relative_path": "scenes/ur3_suction_test/environment.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "scenes/ur3_suction_test",
+          "package": "ur3_suction_test",
+          "package_uri": "package://ur3_suction_test/scenes/ur3_suction_test/package.xml",
+          "relative_path": "scenes/ur3_suction_test/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "scenes/ur3_suction_test/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "scene.urdf.xacro",
+          "file_type": "xacro",
+          "group": "scenes/ur3_suction_test/urdf",
+          "package": "ur3_suction_test",
+          "package_uri": "package://ur3_suction_test/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
+          "relative_path": "scenes/ur3_suction_test/urdf/scene.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "arm_hand.srdf.xacro",
+          "file_type": "xacro",
+          "group": "scenes/ur3_suction_test/urdf",
+          "package": "ur3_suction_test",
+          "package_uri": "package://ur3_suction_test/scenes/ur3_suction_test/urdf/arm_hand.srdf.xacro",
+          "relative_path": "scenes/ur3_suction_test/urdf/arm_hand.srdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "scenes/ur5_2f_test",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "environment.yaml",
+          "file_type": "yaml",
+          "group": "scenes/ur5_2f_test",
+          "package": "ur5_2f_test",
+          "package_uri": "package://ur5_2f_test/scenes/ur5_2f_test/environment.yaml",
+          "relative_path": "scenes/ur5_2f_test/environment.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "scenes/ur5_2f_test",
+          "package": "ur5_2f_test",
+          "package_uri": "package://ur5_2f_test/scenes/ur5_2f_test/package.xml",
+          "relative_path": "scenes/ur5_2f_test/package.xml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "scenes/ur5_2f_test",
+          "package": "ur5_2f_test",
+          "package_uri": "package://ur5_2f_test/scenes/ur5_2f_test/scene_manifest.yaml",
+          "relative_path": "scenes/ur5_2f_test/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "scenes/ur5_2f_test/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "scene.urdf.xacro",
+          "file_type": "xacro",
+          "group": "scenes/ur5_2f_test/urdf",
+          "package": "ur5_2f_test",
+          "package_uri": "package://ur5_2f_test/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+          "relative_path": "scenes/ur5_2f_test/urdf/scene.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "arm_hand.srdf.xacro",
+          "file_type": "xacro",
+          "group": "scenes/ur5_2f_test/urdf",
+          "package": "ur5_2f_test",
+          "package_uri": "package://ur5_2f_test/scenes/ur5_2f_test/urdf/arm_hand.srdf.xacro",
+          "relative_path": "scenes/ur5_2f_test/urdf/arm_hand.srdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "scenes/ur5_3f_test",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "environment.yaml",
+          "file_type": "yaml",
+          "group": "scenes/ur5_3f_test",
+          "package": "ur5_3f_test",
+          "package_uri": "package://ur5_3f_test/scenes/ur5_3f_test/environment.yaml",
+          "relative_path": "scenes/ur5_3f_test/environment.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "scenes/ur5_3f_test",
+          "package": "ur5_3f_test",
+          "package_uri": "package://ur5_3f_test/scenes/ur5_3f_test/package.xml",
+          "relative_path": "scenes/ur5_3f_test/package.xml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "scenes/ur5_3f_test",
+          "package": "ur5_3f_test",
+          "package_uri": "package://ur5_3f_test/scenes/ur5_3f_test/scene_manifest.yaml",
+          "relative_path": "scenes/ur5_3f_test/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "scenes/ur5_3f_test/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "scene.urdf.xacro",
+          "file_type": "xacro",
+          "group": "scenes/ur5_3f_test/urdf",
+          "package": "ur5_3f_test",
+          "package_uri": "package://ur5_3f_test/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
+          "relative_path": "scenes/ur5_3f_test/urdf/scene.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "arm_hand.srdf.xacro",
+          "file_type": "xacro",
+          "group": "scenes/ur5_3f_test/urdf",
+          "package": "ur5_3f_test",
+          "package_uri": "package://ur5_3f_test/scenes/ur5_3f_test/urdf/arm_hand.srdf.xacro",
+          "relative_path": "scenes/ur5_3f_test/urdf/arm_hand.srdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "scenes/ur5_airpick4_test",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "environment.yaml",
+          "file_type": "yaml",
+          "group": "scenes/ur5_airpick4_test",
+          "package": "ur5_airpick4_test",
+          "package_uri": "package://ur5_airpick4_test/scenes/ur5_airpick4_test/environment.yaml",
+          "relative_path": "scenes/ur5_airpick4_test/environment.yaml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "scenes/ur5_airpick4_test",
+          "package": "ur5_airpick4_test",
+          "package_uri": "package://ur5_airpick4_test/scenes/ur5_airpick4_test/package.xml",
+          "relative_path": "scenes/ur5_airpick4_test/package.xml"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "scenes/ur5_airpick4_test",
+          "package": "ur5_airpick4_test",
+          "package_uri": "package://ur5_airpick4_test/scenes/ur5_airpick4_test/scene_manifest.yaml",
+          "relative_path": "scenes/ur5_airpick4_test/scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "scenes/ur5_airpick4_test/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "scene.urdf.xacro",
+          "file_type": "xacro",
+          "group": "scenes/ur5_airpick4_test/urdf",
+          "package": "ur5_airpick4_test",
+          "package_uri": "package://ur5_airpick4_test/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
+          "relative_path": "scenes/ur5_airpick4_test/urdf/scene.urdf.xacro"
+        },
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "arm_hand.srdf.xacro",
+          "file_type": "xacro",
+          "group": "scenes/ur5_airpick4_test/urdf",
+          "package": "ur5_airpick4_test",
+          "package_uri": "package://ur5_airpick4_test/scenes/ur5_airpick4_test/urdf/arm_hand.srdf.xacro",
+          "relative_path": "scenes/ur5_airpick4_test/urdf/arm_hand.srdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "tests/fixtures",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "scene_yaml",
+          "file_name": "generated_scene_manifest.yaml",
+          "file_type": "yaml",
+          "group": "tests/fixtures",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "tests/fixtures/generated_scene_manifest.yaml"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/examples/resources",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "mesh",
+          "file_name": "table.stl",
+          "file_type": "stl",
+          "group": "workcell_builder/examples/resources",
+          "package": null,
+          "package_uri": null,
+          "relative_path": "workcell_builder/examples/resources/table.stl"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "workcell_builder/workcell_builder",
+          "package": "workcell_builder",
+          "package_uri": "package://workcell_builder/workcell_builder/workcell_builder/package.xml",
+          "relative_path": "workcell_builder/workcell_builder/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+          "package": "onrobot_airpick4_description",
+          "package_uri": "package://onrobot_airpick4_description/workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml",
+          "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "onrobot_airpick4_gripper.urdf.xacro",
+          "file_type": "xacro",
+          "group": "workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf",
+          "package": "onrobot_airpick4_description",
+          "package_uri": "package://onrobot_airpick4_description/workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro",
+          "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml",
+          "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq-3f-gripper_articulated.urdf.xacro",
+          "file_type": "xacro",
+          "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf",
+          "package": "robotiq_3f_gripper_description",
+          "package_uri": "package://robotiq_3f_gripper_description/workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf.xacro",
+          "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+          "package": "robotiq_3f_moveit_config",
+          "package_uri": "package://robotiq_3f_moveit_config/workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml",
+          "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml",
+          "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq_85_gripper.urdf.xacro",
+          "file_type": "xacro",
+          "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf",
+          "package": "robotiq_85_description",
+          "package_uri": "package://robotiq_85_description/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro",
+          "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+          "package": "robotiq_85_moveit_config",
+          "package_uri": "package://robotiq_85_moveit_config/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml",
+          "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "robotiq_85_gripper.srdf.xacro",
+          "file_type": "xacro",
+          "group": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config",
+          "package": "robotiq_85_moveit_config",
+          "package_uri": "package://robotiq_85_moveit_config/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf.xacro",
+          "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description",
+      "items": [
+        {
+          "asset_type_guess": "end_effector",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description",
+          "package": "single_suction_description",
+          "package_uri": "package://single_suction_description/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml",
+          "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "single_suction_gripper.urdf.xacro",
+          "file_type": "xacro",
+          "group": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/urdf",
+          "package": "single_suction_description",
+          "package_uri": "package://single_suction_description/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro",
+          "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+      "items": [
+        {
+          "asset_type_guess": "end_effector",
+          "category": "urdf_xacro",
+          "file_name": "single_suction_gripper.srdf.xacro",
+          "file_type": "xacro",
+          "group": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config",
+          "package": "workcell_builder",
+          "package_uri": "package://workcell_builder/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/single_suction_gripper.srdf.xacro",
+          "relative_path": "workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/single_suction_gripper.srdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/environment/table_description/urdf",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "urdf_xacro",
+          "file_name": "table.urdf.xacro",
+          "file_type": "xacro",
+          "group": "workcell_builder/workcell_builder/assets/environment/table_description/urdf",
+          "package": "workcell_builder",
+          "package_uri": "package://workcell_builder/workcell_builder/workcell_builder/assets/environment/table_description/urdf/table.urdf.xacro",
+          "relative_path": "workcell_builder/workcell_builder/assets/environment/table_description/urdf/table.urdf.xacro"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/robots/fanuc/fanuc_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "workcell_builder/workcell_builder/assets/robots/fanuc/fanuc_moveit_config",
+          "package": "fanuc_moveit_config",
+          "package_uri": "package://fanuc_moveit_config/workcell_builder/workcell_builder/assets/robots/fanuc/fanuc_moveit_config/package.xml",
+          "relative_path": "workcell_builder/workcell_builder/assets/robots/fanuc/fanuc_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/robots/panda_robot/panda_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "workcell_builder/workcell_builder/assets/robots/panda_robot/panda_moveit_config",
+          "package": "panda_moveit_config",
+          "package_uri": "package://panda_moveit_config/workcell_builder/workcell_builder/assets/robots/panda_robot/panda_moveit_config/package.xml",
+          "relative_path": "workcell_builder/workcell_builder/assets/robots/panda_robot/panda_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur10_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur10_moveit_config",
+          "package": "ur10_moveit_config",
+          "package_uri": "package://ur10_moveit_config/workcell_builder/workcell_builder/assets/robots/universal_robot/ur10_moveit_config/package.xml",
+          "relative_path": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur10_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur3_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur3_moveit_config",
+          "package": "ur3_moveit_config",
+          "package_uri": "package://ur3_moveit_config/workcell_builder/workcell_builder/assets/robots/universal_robot/ur3_moveit_config/package.xml",
+          "relative_path": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur3_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur5_moveit_config",
+      "items": [
+        {
+          "asset_type_guess": "robot",
+          "category": "package_xml",
+          "file_name": "package.xml",
+          "file_type": "xml",
+          "group": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur5_moveit_config",
+          "package": "ur5_moveit_config",
+          "package_uri": "package://ur5_moveit_config/workcell_builder/workcell_builder/assets/robots/universal_robot/ur5_moveit_config/package.xml",
+          "relative_path": "workcell_builder/workcell_builder/assets/robots/universal_robot/ur5_moveit_config/package.xml"
+        }
+      ]
+    },
+    {
+      "group": "workcell_builder/workcell_builder/templates/ros2",
+      "items": [
+        {
+          "asset_type_guess": "unknown",
+          "category": "scene_yaml",
+          "file_name": "scene_manifest_contract_template.yaml",
+          "file_type": "yaml",
+          "group": "workcell_builder/workcell_builder/templates/ros2",
+          "package": "workcell_builder",
+          "package_uri": "package://workcell_builder/workcell_builder/workcell_builder/templates/ros2/scene_manifest_contract_template.yaml",
+          "relative_path": "workcell_builder/workcell_builder/templates/ros2/scene_manifest_contract_template.yaml"
+        }
+      ]
+    }
+  ],
+  "repo_root": "/workspace/Easy_Manipulator_Improved",
+  "schema_version": "asset_inventory/v1",
+  "totals": {
+    "files": 356,
+    "meshes": 79,
+    "package_xml": 52,
+    "packages": 52,
+    "scene_yaml": 138,
+    "urdf_xacro": 87
+  }
+}

--- a/reports/asset_inventory.md
+++ b/reports/asset_inventory.md
@@ -1,0 +1,1102 @@
+# Asset Inventory Report
+
+- Schema: `asset_inventory/v1`
+- Total tracked files: `356`
+- Meshes: `79`
+- URDF/Xacro: `87`
+- Scene YAML: `138`
+- package.xml files: `52`
+
+## Grouped inventory
+
+### assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml` | `onrobot_airpick4_description` | `package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml` |
+
+### assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | mesh | `assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl` | `onrobot_airpick4_description` | `package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl` |
+
+### assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onRobot_AIrpick_4_vacuum.urdf` | `onrobot_airpick4_description` | `package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onRobot_AIrpick_4_vacuum.urdf` |
+| robot | urdf_xacro | `assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro` | `onrobot_airpick4_description` | `package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper_standalone.urdf.xacro` | `onrobot_airpick4_description` | `package://onrobot_airpick4_description/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper_standalone.urdf.xacro` |
+
+### assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml` | `onrobot_airpick4_moveit_config` | `package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml` |
+
+### assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/onrobot_airpick4_gripper.srdf.xacro` | `onrobot_airpick4_moveit_config` | `package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/onrobot_airpick4_gripper.srdf.xacro` |
+| robot | scene_yaml | `assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/controllers.yaml` | `onrobot_airpick4_moveit_config` | `package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/controllers.yaml` |
+| robot | scene_yaml | `assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/kinematics.yaml` | `onrobot_airpick4_moveit_config` | `package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/kinematics.yaml` |
+| robot | scene_yaml | `assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/fake_controllers.yaml` | `onrobot_airpick4_moveit_config` | `package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/fake_controllers.yaml` |
+| robot | scene_yaml | `assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/joint_limits.yaml` | `onrobot_airpick4_moveit_config` | `package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/joint_limits.yaml` |
+| robot | scene_yaml | `assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/ompl_planning.yaml` | `onrobot_airpick4_moveit_config` | `package://onrobot_airpick4_moveit_config/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/config/ompl_planning.yaml` |
+
+### assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml` |
+
+### assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN.stl` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_1.stl` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_1.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_2.stl` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_2.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_PALM.stl` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_PALM.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_3.stl` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_OPEN_FINGER_3.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_CLOSED.stl` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/collision/GRIPPER_CLOSED.stl` |
+
+### assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN.stl` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_1.stl` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_1.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_2.stl` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_2.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_PALM.stl` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_PALM.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_3.stl` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_OPEN_FINGER_3.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_CLOSED.stl` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper/visual/GRIPPER_CLOSED.stl` |
+
+### assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/palm.STL` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/palm.STL` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_1.STL` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_1.STL` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_3.STL` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_3.STL` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_0.STL` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_0.STL` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_2.STL` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/collision/link_2.STL` |
+
+### assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/palm.dae` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/palm.dae` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae` |
+| robot | mesh | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae` |
+
+### assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.xacro` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh.xacro` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh.urdf` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh.urdf` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq_3f_hand_macro.urdf.xacro` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq_3f_hand_macro.urdf.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated_macro.xacro` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated_macro.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf.xacro` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_finger_articulated_macro.xacro` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_finger_articulated_macro.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh_macro.xacro` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_mesh_macro.xacro` |
+
+### assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml` | `robotiq_3f_moveit_config` | `package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml` |
+
+### assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/controllers.yaml` | `robotiq_3f_moveit_config` | `package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/controllers.yaml` |
+| robot | scene_yaml | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/kinematics.yaml` | `robotiq_3f_moveit_config` | `package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/kinematics.yaml` |
+| robot | scene_yaml | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/fake_controllers.yaml` | `robotiq_3f_moveit_config` | `package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/fake_controllers.yaml` |
+| robot | scene_yaml | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/joint_limits.yaml` | `robotiq_3f_moveit_config` | `package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/joint_limits.yaml` |
+| robot | scene_yaml | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/ompl_planning.yaml` | `robotiq_3f_moveit_config` | `package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/ompl_planning.yaml` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/robotiq_3f_gripper.srdf.xacro` | `robotiq_3f_moveit_config` | `package://robotiq_3f_moveit_config/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/config/robotiq_3f_gripper.srdf.xacro` |
+
+### assets/end_effectors/robotiq_85_gripper/robotiq_85_description
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml` |
+
+### assets/end_effectors/robotiq_85_gripper/robotiq_85_description/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/config/ros2_controllers.yaml` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/config/ros2_controllers.yaml` |
+
+### assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | mesh | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/kinova_robotiq_coupler.stl` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/kinova_robotiq_coupler.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_base_link.stl` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_base_link.stl` |
+| robot | mesh | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl` |
+
+### assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | mesh | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae` |
+| robot | mesh | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae` |
+| robot | mesh | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/kinova_robotiq_coupler.dae` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/kinova_robotiq_coupler.dae` |
+| robot | mesh | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae` |
+| robot | mesh | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae` |
+| robot | mesh | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae` |
+
+### assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.transmission.xacro` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.transmission.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper_sim_base.urdf.xacro` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper_sim_base.urdf.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/kinova_robotiq_85_gripper.xacro` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/kinova_robotiq_85_gripper.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_kinova_coupler.urdf.xacro` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_kinova_coupler.urdf.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.xacro` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro` | `robotiq_85_description` | `package://robotiq_85_description/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro` |
+
+### assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml` | `robotiq_85_moveit_config` | `package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml` |
+
+### assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/controllers.yaml` | `robotiq_85_moveit_config` | `package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/controllers.yaml` |
+| robot | scene_yaml | `assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/kinematics.yaml` | `robotiq_85_moveit_config` | `package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/kinematics.yaml` |
+| robot | urdf_xacro | `assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf.xacro` | `robotiq_85_moveit_config` | `package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf.xacro` |
+| robot | scene_yaml | `assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/fake_controllers.yaml` | `robotiq_85_moveit_config` | `package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/fake_controllers.yaml` |
+| robot | scene_yaml | `assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/joint_limits.yaml` | `robotiq_85_moveit_config` | `package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/joint_limits.yaml` |
+| robot | scene_yaml | `assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/ompl_planning.yaml` | `robotiq_85_moveit_config` | `package://robotiq_85_moveit_config/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/ompl_planning.yaml` |
+
+### assets/end_effectors/single_suction_gripper/single_suction_description
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| end_effector | package_xml | `assets/end_effectors/single_suction_gripper/single_suction_description/package.xml` | `single_suction_description` | `package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml` |
+
+### assets/end_effectors/single_suction_gripper/single_suction_description/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `assets/end_effectors/single_suction_gripper/single_suction_description/config/joint_names_double_fixture.yaml` | `single_suction_description` | `package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/config/joint_names_double_fixture.yaml` |
+| end_effector | scene_yaml | `assets/end_effectors/single_suction_gripper/single_suction_description/config/ros2_controllers.yaml` | `single_suction_description` | `package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/config/ros2_controllers.yaml` |
+
+### assets/end_effectors/single_suction_gripper/single_suction_description/meshes
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| end_effector | mesh | `assets/end_effectors/single_suction_gripper/single_suction_description/meshes/suction_cup_link.STL` | `single_suction_description` | `package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/suction_cup_link.STL` |
+| robot | mesh | `assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL` | `single_suction_description` | `package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL` |
+| end_effector | mesh | `assets/end_effectors/single_suction_gripper/single_suction_description/meshes/multiple_gripper_link.STL` | `single_suction_description` | `package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/multiple_gripper_link.STL` |
+
+### assets/end_effectors/single_suction_gripper/single_suction_description/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro` | `single_suction_description` | `package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/single_suction_gripper/single_suction_description/urdf/ur5_double_fixture.urdf` | `single_suction_description` | `package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/ur5_double_fixture.urdf` |
+| robot | urdf_xacro | `assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper_standalone.urdf.xacro` | `single_suction_description` | `package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper_standalone.urdf.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/single_suction_gripper/single_suction_description/urdf/ur5_double_fixture.urdf.xacro` | `single_suction_description` | `package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/ur5_double_fixture.urdf.xacro` |
+| robot | urdf_xacro | `assets/end_effectors/single_suction_gripper/single_suction_description/urdf/double_fixture.urdf` | `single_suction_description` | `package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/double_fixture.urdf` |
+
+### assets/end_effectors/single_suction_gripper/single_suction_description/urdf/urdf_solidworks
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `assets/end_effectors/single_suction_gripper/single_suction_description/urdf/urdf_solidworks/mounting_kit.urdf` | `single_suction_description` | `package://single_suction_description/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/urdf_solidworks/mounting_kit.urdf` |
+
+### assets/end_effectors/single_suction_gripper/single_suction_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| end_effector | package_xml | `assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml` | `single_suction_moveit_config` | `package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml` |
+
+### assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| end_effector | scene_yaml | `assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/controllers.yaml` | `single_suction_moveit_config` | `package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/controllers.yaml` |
+| end_effector | scene_yaml | `assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/kinematics.yaml` | `single_suction_moveit_config` | `package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/kinematics.yaml` |
+| end_effector | scene_yaml | `assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/fake_controllers.yaml` | `single_suction_moveit_config` | `package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/fake_controllers.yaml` |
+| end_effector | urdf_xacro | `assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/single_suction_gripper.srdf.xacro` | `single_suction_moveit_config` | `package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/single_suction_gripper.srdf.xacro` |
+| end_effector | scene_yaml | `assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/joint_limits.yaml` | `single_suction_moveit_config` | `package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/joint_limits.yaml` |
+| end_effector | scene_yaml | `assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/ompl_planning.yaml` | `single_suction_moveit_config` | `package://single_suction_moveit_config/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/ompl_planning.yaml` |
+
+### assets/environment/realsense2_description
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| sensor | package_xml | `assets/environment/realsense2_description/package.xml` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/package.xml` |
+
+### assets/environment/realsense2_description/meshes
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| sensor | mesh | `assets/environment/realsense2_description/meshes/d435.dae` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/meshes/d435.dae` |
+| sensor | mesh | `assets/environment/realsense2_description/meshes/d415.stl` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/meshes/d415.stl` |
+
+### assets/environment/realsense2_description/tests
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| sensor | urdf_xacro | `assets/environment/realsense2_description/tests/dual_d435.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/tests/dual_d435.xacro` |
+| sensor | urdf_xacro | `assets/environment/realsense2_description/tests/dual_r410.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/tests/dual_r410.xacro` |
+| sensor | urdf_xacro | `assets/environment/realsense2_description/tests/one_of_each.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/tests/one_of_each.xacro` |
+| sensor | urdf_xacro | `assets/environment/realsense2_description/tests/dual_r430.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/tests/dual_r430.xacro` |
+| sensor | urdf_xacro | `assets/environment/realsense2_description/tests/dual_d415.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/tests/dual_d415.xacro` |
+
+### assets/environment/realsense2_description/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `assets/environment/realsense2_description/urdf/test_d415_camera.urdf.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/urdf/test_d415_camera.urdf.xacro` |
+| robot | urdf_xacro | `assets/environment/realsense2_description/urdf/_materials.urdf.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/urdf/_materials.urdf.xacro` |
+| robot | urdf_xacro | `assets/environment/realsense2_description/urdf/test_r410_camera.urdf.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/urdf/test_r410_camera.urdf.xacro` |
+| robot | urdf_xacro | `assets/environment/realsense2_description/urdf/_d435i.urdf.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro` |
+| robot | urdf_xacro | `assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro` |
+| robot | urdf_xacro | `assets/environment/realsense2_description/urdf/test_d435_multiple_cameras.urdf.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/urdf/test_d435_multiple_cameras.urdf.xacro` |
+| robot | urdf_xacro | `assets/environment/realsense2_description/urdf/test_r430_camera.urdf.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/urdf/test_r430_camera.urdf.xacro` |
+| robot | urdf_xacro | `assets/environment/realsense2_description/urdf/test_d435_camera.urdf.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/urdf/test_d435_camera.urdf.xacro` |
+| robot | urdf_xacro | `assets/environment/realsense2_description/urdf/test_d435i_camera.urdf.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/urdf/test_d435i_camera.urdf.xacro` |
+| robot | urdf_xacro | `assets/environment/realsense2_description/urdf/_d415.urdf.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/urdf/_d415.urdf.xacro` |
+| robot | urdf_xacro | `assets/environment/realsense2_description/urdf/_r410.urdf.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/urdf/_r410.urdf.xacro` |
+| robot | urdf_xacro | `assets/environment/realsense2_description/urdf/_d435.urdf.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/urdf/_d435.urdf.xacro` |
+| robot | urdf_xacro | `assets/environment/realsense2_description/urdf/_r430.urdf.xacro` | `realsense2_description` | `package://realsense2_description/assets/environment/realsense2_description/urdf/_r430.urdf.xacro` |
+
+### assets/environment/table_description
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| table | package_xml | `assets/environment/table_description/package.xml` | `table_description` | `package://table_description/assets/environment/table_description/package.xml` |
+
+### assets/environment/table_description/meshes/collision
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| table | mesh | `assets/environment/table_description/meshes/collision/table.stl` | `table_description` | `package://table_description/assets/environment/table_description/meshes/collision/table.stl` |
+
+### assets/environment/table_description/meshes/visual
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| table | mesh | `assets/environment/table_description/meshes/visual/table.stl` | `table_description` | `package://table_description/assets/environment/table_description/meshes/visual/table.stl` |
+
+### assets/environment/table_description/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `assets/environment/table_description/urdf/table.urdf.xacro` | `table_description` | `package://table_description/assets/environment/table_description/urdf/table.urdf.xacro` |
+
+### assets/environment/workbench_description
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| workbench | package_xml | `assets/environment/workbench_description/package.xml` | `workbench_description` | `package://workbench_description/assets/environment/workbench_description/package.xml` |
+
+### assets/environment/workbench_description/meshes/collision
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| table | mesh | `assets/environment/workbench_description/meshes/collision/table.stl` | `workbench_description` | `package://workbench_description/assets/environment/workbench_description/meshes/collision/table.stl` |
+
+### assets/environment/workbench_description/meshes/visual
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| table | mesh | `assets/environment/workbench_description/meshes/visual/table.stl` | `workbench_description` | `package://workbench_description/assets/environment/workbench_description/meshes/visual/table.stl` |
+
+### assets/environment/workbench_description/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `assets/environment/workbench_description/urdf/table.urdf.xacro` | `workbench_description` | `package://workbench_description/assets/environment/workbench_description/urdf/table.urdf.xacro` |
+
+### assets/robots/fanuc/fanuc_description
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `assets/robots/fanuc/fanuc_description/package.xml` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/package.xml` |
+
+### assets/robots/fanuc/fanuc_description/meshes/collision
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | mesh | `assets/robots/fanuc/fanuc_description/meshes/collision/base_link.stl` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/base_link.stl` |
+| robot | mesh | `assets/robots/fanuc/fanuc_description/meshes/collision/link_5.stl` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_5.stl` |
+| robot | mesh | `assets/robots/fanuc/fanuc_description/meshes/collision/link_6.stl` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_6.stl` |
+| robot | mesh | `assets/robots/fanuc/fanuc_description/meshes/collision/link_1.stl` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_1.stl` |
+| robot | mesh | `assets/robots/fanuc/fanuc_description/meshes/collision/link_3.stl` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_3.stl` |
+| robot | mesh | `assets/robots/fanuc/fanuc_description/meshes/collision/link_2.stl` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_2.stl` |
+| robot | mesh | `assets/robots/fanuc/fanuc_description/meshes/collision/link_4.stl` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/collision/link_4.stl` |
+
+### assets/robots/fanuc/fanuc_description/meshes/visual
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | mesh | `assets/robots/fanuc/fanuc_description/meshes/visual/base_link.stl` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/base_link.stl` |
+| robot | mesh | `assets/robots/fanuc/fanuc_description/meshes/visual/link_5.stl` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_5.stl` |
+| robot | mesh | `assets/robots/fanuc/fanuc_description/meshes/visual/link_6.stl` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_6.stl` |
+| robot | mesh | `assets/robots/fanuc/fanuc_description/meshes/visual/link_1.stl` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_1.stl` |
+| robot | mesh | `assets/robots/fanuc/fanuc_description/meshes/visual/link_3.stl` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_3.stl` |
+| robot | mesh | `assets/robots/fanuc/fanuc_description/meshes/visual/link_2.stl` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_2.stl` |
+| robot | mesh | `assets/robots/fanuc/fanuc_description/meshes/visual/link_4.stl` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/meshes/visual/link_4.stl` |
+
+### assets/robots/fanuc/fanuc_description/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `assets/robots/fanuc/fanuc_description/urdf/fanuc.urdf` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/urdf/fanuc.urdf` |
+| robot | urdf_xacro | `assets/robots/fanuc/fanuc_description/urdf/fanuc.urdf.xacro` | `fanuc_description` | `package://fanuc_description/assets/robots/fanuc/fanuc_description/urdf/fanuc.urdf.xacro` |
+
+### assets/robots/fanuc/fanuc_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `assets/robots/fanuc/fanuc_moveit_config/package.xml` | `fanuc_moveit_config` | `package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/package.xml` |
+
+### assets/robots/fanuc/fanuc_moveit_config/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `assets/robots/fanuc/fanuc_moveit_config/config/ros_controllers.yaml` | `fanuc_moveit_config` | `package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/ros_controllers.yaml` |
+| robot | scene_yaml | `assets/robots/fanuc/fanuc_moveit_config/config/chomp_planning.yaml` | `fanuc_moveit_config` | `package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/chomp_planning.yaml` |
+| robot | scene_yaml | `assets/robots/fanuc/fanuc_moveit_config/config/kinematics.yaml` | `fanuc_moveit_config` | `package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/kinematics.yaml` |
+| robot | scene_yaml | `assets/robots/fanuc/fanuc_moveit_config/config/fake_controllers.yaml` | `fanuc_moveit_config` | `package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/fake_controllers.yaml` |
+| robot | scene_yaml | `assets/robots/fanuc/fanuc_moveit_config/config/joint_limits.yaml` | `fanuc_moveit_config` | `package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/joint_limits.yaml` |
+| robot | scene_yaml | `assets/robots/fanuc/fanuc_moveit_config/config/ompl_planning.yaml` | `fanuc_moveit_config` | `package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/ompl_planning.yaml` |
+| robot | scene_yaml | `assets/robots/fanuc/fanuc_moveit_config/config/sensors_3d.yaml` | `fanuc_moveit_config` | `package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/sensors_3d.yaml` |
+| robot | urdf_xacro | `assets/robots/fanuc/fanuc_moveit_config/config/fanuc.srdf.xacro` | `fanuc_moveit_config` | `package://fanuc_moveit_config/assets/robots/fanuc/fanuc_moveit_config/config/fanuc.srdf.xacro` |
+
+### assets/robots/panda_robot/panda_description
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `assets/robots/panda_robot/panda_description/package.xml` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/package.xml` |
+
+### assets/robots/panda_robot/panda_description/meshes/collision
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/collision/link1.stl` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link1.stl` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/collision/link6.stl` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link6.stl` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/collision/link4.stl` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link4.stl` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/collision/link3.stl` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link3.stl` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/collision/link7.stl` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link7.stl` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/collision/hand.stl` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/hand.stl` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/collision/link0.stl` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link0.stl` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/collision/link2.stl` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link2.stl` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/collision/finger.stl` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/finger.stl` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/collision/link5.stl` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/collision/link5.stl` |
+
+### assets/robots/panda_robot/panda_description/meshes/visual
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/visual/link3.dae` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link3.dae` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/visual/link1.dae` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link1.dae` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/visual/link6.dae` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link6.dae` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/visual/finger.dae` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/finger.dae` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/visual/link5.dae` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link5.dae` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/visual/link7.dae` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link7.dae` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/visual/link0.dae` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link0.dae` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/visual/link4.dae` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link4.dae` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/visual/link2.dae` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/link2.dae` |
+| robot | mesh | `assets/robots/panda_robot/panda_description/meshes/visual/hand.dae` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/meshes/visual/hand.dae` |
+
+### assets/robots/panda_robot/panda_description/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `assets/robots/panda_robot/panda_description/urdf/panda.urdf` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/urdf/panda.urdf` |
+| robot | urdf_xacro | `assets/robots/panda_robot/panda_description/urdf/panda.urdf.xacro` | `panda_description` | `package://panda_description/assets/robots/panda_robot/panda_description/urdf/panda.urdf.xacro` |
+
+### assets/robots/panda_robot/panda_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `assets/robots/panda_robot/panda_moveit_config/package.xml` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/package.xml` |
+
+### assets/robots/panda_robot/panda_moveit_config/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `assets/robots/panda_robot/panda_moveit_config/config/panda_arm.xacro` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_arm.xacro` |
+| robot | scene_yaml | `assets/robots/panda_robot/panda_moveit_config/config/trajopt_planning.yaml` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/trajopt_planning.yaml` |
+| robot | urdf_xacro | `assets/robots/panda_robot/panda_moveit_config/config/panda_arm_hand.srdf.xacro` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_arm_hand.srdf.xacro` |
+| robot | scene_yaml | `assets/robots/panda_robot/panda_moveit_config/config/chomp_planning.yaml` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/chomp_planning.yaml` |
+| robot | scene_yaml | `assets/robots/panda_robot/panda_moveit_config/config/panda_gripper_controllers.yaml` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_gripper_controllers.yaml` |
+| robot | scene_yaml | `assets/robots/panda_robot/panda_moveit_config/config/kinematics.yaml` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/kinematics.yaml` |
+| robot | scene_yaml | `assets/robots/panda_robot/panda_moveit_config/config/sensors_kinect_pointcloud.yaml` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/sensors_kinect_pointcloud.yaml` |
+| robot | scene_yaml | `assets/robots/panda_robot/panda_moveit_config/config/panda_controllers.yaml` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_controllers.yaml` |
+| robot | scene_yaml | `assets/robots/panda_robot/panda_moveit_config/config/fake_controllers.yaml` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/fake_controllers.yaml` |
+| robot | scene_yaml | `assets/robots/panda_robot/panda_moveit_config/config/stomp_planning.yaml` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/stomp_planning.yaml` |
+| robot | scene_yaml | `assets/robots/panda_robot/panda_moveit_config/config/lerp_planning.yaml` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/lerp_planning.yaml` |
+| robot | scene_yaml | `assets/robots/panda_robot/panda_moveit_config/config/joint_limits.yaml` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/joint_limits.yaml` |
+| robot | urdf_xacro | `assets/robots/panda_robot/panda_moveit_config/config/hand.xacro` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/hand.xacro` |
+| robot | scene_yaml | `assets/robots/panda_robot/panda_moveit_config/config/ompl_planning.yaml` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/ompl_planning.yaml` |
+| robot | scene_yaml | `assets/robots/panda_robot/panda_moveit_config/config/sensors_kinect_depthmap.yaml` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/sensors_kinect_depthmap.yaml` |
+| robot | urdf_xacro | `assets/robots/panda_robot/panda_moveit_config/config/panda.srdf.xacro` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda.srdf.xacro` |
+| robot | urdf_xacro | `assets/robots/panda_robot/panda_moveit_config/config/panda_arm.srdf.xacro` | `panda_moveit_config` | `package://panda_moveit_config/assets/robots/panda_robot/panda_moveit_config/config/panda_arm.srdf.xacro` |
+
+### assets/robots/universal_robot/ur10_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `assets/robots/universal_robot/ur10_moveit_config/package.xml` | `ur10_moveit_config` | `package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/package.xml` |
+
+### assets/robots/universal_robot/ur10_moveit_config/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `assets/robots/universal_robot/ur10_moveit_config/config/controllers.yaml` | `ur10_moveit_config` | `package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/controllers.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur10_moveit_config/config/kinematics.yaml` | `ur10_moveit_config` | `package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/kinematics.yaml` |
+| robot | urdf_xacro | `assets/robots/universal_robot/ur10_moveit_config/config/ur10.srdf.xacro` | `ur10_moveit_config` | `package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/ur10.srdf.xacro` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur10_moveit_config/config/fake_controllers.yaml` | `ur10_moveit_config` | `package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/fake_controllers.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur10_moveit_config/config/ur10_ros_controllers.yaml` | `ur10_moveit_config` | `package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/ur10_ros_controllers.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur10_moveit_config/config/joint_limits.yaml` | `ur10_moveit_config` | `package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/joint_limits.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur10_moveit_config/config/ompl_planning.yaml` | `ur10_moveit_config` | `package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/ompl_planning.yaml` |
+| robot | urdf_xacro | `assets/robots/universal_robot/ur10_moveit_config/config/ur10.ros2_control.xacro` | `ur10_moveit_config` | `package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/ur10.ros2_control.xacro` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur10_moveit_config/config/initial_positions.yaml` | `ur10_moveit_config` | `package://ur10_moveit_config/assets/robots/universal_robot/ur10_moveit_config/config/initial_positions.yaml` |
+
+### assets/robots/universal_robot/ur3_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `assets/robots/universal_robot/ur3_moveit_config/package.xml` | `ur3_moveit_config` | `package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/package.xml` |
+
+### assets/robots/universal_robot/ur3_moveit_config/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `assets/robots/universal_robot/ur3_moveit_config/config/ur3.srdf.xacro` | `ur3_moveit_config` | `package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/ur3.srdf.xacro` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur3_moveit_config/config/controllers.yaml` | `ur3_moveit_config` | `package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/controllers.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur3_moveit_config/config/ur3_ros_controllers.yaml` | `ur3_moveit_config` | `package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/ur3_ros_controllers.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur3_moveit_config/config/kinematics.yaml` | `ur3_moveit_config` | `package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/kinematics.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur3_moveit_config/config/fake_controllers.yaml` | `ur3_moveit_config` | `package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/fake_controllers.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur3_moveit_config/config/joint_limits.yaml` | `ur3_moveit_config` | `package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/joint_limits.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur3_moveit_config/config/ompl_planning.yaml` | `ur3_moveit_config` | `package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/ompl_planning.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur3_moveit_config/config/initial_positions.yaml` | `ur3_moveit_config` | `package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/initial_positions.yaml` |
+| robot | urdf_xacro | `assets/robots/universal_robot/ur3_moveit_config/config/ur3.ros2_control.xacro` | `ur3_moveit_config` | `package://ur3_moveit_config/assets/robots/universal_robot/ur3_moveit_config/config/ur3.ros2_control.xacro` |
+
+### assets/robots/universal_robot/ur5_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `assets/robots/universal_robot/ur5_moveit_config/package.xml` | `ur5_moveit_config` | `package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/package.xml` |
+
+### assets/robots/universal_robot/ur5_moveit_config/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `assets/robots/universal_robot/ur5_moveit_config/config/ur5.ros2_control.xacro` | `ur5_moveit_config` | `package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/ur5.ros2_control.xacro` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur5_moveit_config/config/controllers.yaml` | `ur5_moveit_config` | `package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/controllers.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur5_moveit_config/config/kinematics.yaml` | `ur5_moveit_config` | `package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/kinematics.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur5_moveit_config/config/fake_controllers.yaml` | `ur5_moveit_config` | `package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/fake_controllers.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur5_moveit_config/config/joint_limits.yaml` | `ur5_moveit_config` | `package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/joint_limits.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur5_moveit_config/config/ompl_planning.yaml` | `ur5_moveit_config` | `package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/ompl_planning.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur5_moveit_config/config/ur5_ros_controllers.yaml` | `ur5_moveit_config` | `package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/ur5_ros_controllers.yaml` |
+| robot | scene_yaml | `assets/robots/universal_robot/ur5_moveit_config/config/initial_positions.yaml` | `ur5_moveit_config` | `package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/initial_positions.yaml` |
+| robot | urdf_xacro | `assets/robots/universal_robot/ur5_moveit_config/config/ur5.srdf.xacro` | `ur5_moveit_config` | `package://ur5_moveit_config/assets/robots/universal_robot/ur5_moveit_config/config/ur5.srdf.xacro` |
+
+### dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/commissioning_bundle
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/commissioning_bundle/scene_manifest.yaml` | `-` | `-` |
+
+### dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/package.xml` | `generated_ur5_2f_demo_cell` | `package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/package.xml` |
+| robot | scene_yaml | `dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/scene_manifest.yaml` | `generated_ur5_2f_demo_cell` | `package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/scene_manifest.yaml` |
+
+### dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config/task_recipe.yaml` | `generated_ur5_2f_demo_cell` | `package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config/task_recipe.yaml` |
+
+### dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/scene_manifest.preview.yaml` | `generated_ur5_2f_demo_cell` | `package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/scene_manifest.preview.yaml` |
+
+### dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell/scene_manifest.yaml` | `generated_ur5_2f_demo_cell` | `package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell/scene_manifest.yaml` |
+
+### dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/commissioning_bundle
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/commissioning_bundle/scene_manifest.yaml` | `-` | `-` |
+
+### dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/package.xml` | `generated_ur5_colour_sort_cell` | `package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/package.xml` |
+| robot | scene_yaml | `dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/scene_manifest.yaml` | `generated_ur5_colour_sort_cell` | `package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/scene_manifest.yaml` |
+
+### dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config/task_recipe.yaml` | `generated_ur5_colour_sort_cell` | `package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config/task_recipe.yaml` |
+
+### dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/scene_manifest.preview.yaml` | `generated_ur5_colour_sort_cell` | `package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/scene_manifest.preview.yaml` |
+
+### dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell/scene_manifest.yaml` | `generated_ur5_colour_sort_cell` | `package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_dashboard_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell/scene_manifest.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/template_colour/commissioning_bundle
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/template_colour/commissioning_bundle/scene_manifest.yaml` | `-` | `-` |
+
+### dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/package.xml` | `generated_template_colour` | `package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/package.xml` |
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/scene_manifest.yaml` | `generated_template_colour` | `package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/scene_manifest.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/config/task_recipe.yaml` | `generated_template_colour` | `package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/config/task_recipe.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/scene_manifest.preview.yaml` | `generated_template_colour` | `package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/scene_manifest.preview.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/bundle/generated_template_colour
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/bundle/generated_template_colour/scene_manifest.yaml` | `generated_template_colour` | `package://generated_template_colour/dist/.tmp_workcell_project_checks/projects/template_colour/generated_workcell/generated_template_colour/generated/bundle/generated_template_colour/scene_manifest.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/commissioning_bundle
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/commissioning_bundle/scene_manifest.yaml` | `-` | `-` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/package.xml` | `generated_ur5_2f_demo_cell` | `package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/package.xml` |
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/scene_manifest.yaml` | `generated_ur5_2f_demo_cell` | `package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/scene_manifest.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config/task_recipe.yaml` | `generated_ur5_2f_demo_cell` | `package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/config/task_recipe.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/scene_manifest.preview.yaml` | `generated_ur5_2f_demo_cell` | `package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/scene_manifest.preview.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell/scene_manifest.yaml` | `generated_ur5_2f_demo_cell` | `package://generated_ur5_2f_demo_cell/dist/.tmp_workcell_project_checks/projects/ur5_2f_demo_cell/generated_workcell/generated_ur5_2f_demo_cell/generated/bundle/generated_ur5_2f_demo_cell/scene_manifest.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/commissioning_bundle
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/commissioning_bundle/scene_manifest.yaml` | `-` | `-` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/package.xml` | `generated_ur5_colour_sort_cell` | `package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/package.xml` |
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/scene_manifest.yaml` | `generated_ur5_colour_sort_cell` | `package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/scene_manifest.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config/task_recipe.yaml` | `generated_ur5_colour_sort_cell` | `package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/config/task_recipe.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/scene_manifest.preview.yaml` | `generated_ur5_colour_sort_cell` | `package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/scene_manifest.preview.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell/scene_manifest.yaml` | `generated_ur5_colour_sort_cell` | `package://generated_ur5_colour_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_colour_sort_cell/generated_workcell/generated_ur5_colour_sort_cell/generated/bundle/generated_ur5_colour_sort_cell/scene_manifest.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/commissioning_bundle
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/commissioning_bundle/scene_manifest.yaml` | `-` | `-` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/package.xml` | `generated_ur5_garbage_sort_cell` | `package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/package.xml` |
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/scene_manifest.yaml` | `generated_ur5_garbage_sort_cell` | `package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/scene_manifest.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/config/task_recipe.yaml` | `generated_ur5_garbage_sort_cell` | `package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/config/task_recipe.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/scene_manifest.preview.yaml` | `generated_ur5_garbage_sort_cell` | `package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/scene_manifest.preview.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/bundle/generated_ur5_garbage_sort_cell
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/bundle/generated_ur5_garbage_sort_cell/scene_manifest.yaml` | `generated_ur5_garbage_sort_cell` | `package://generated_ur5_garbage_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_garbage_sort_cell/generated_workcell/generated_ur5_garbage_sort_cell/generated/bundle/generated_ur5_garbage_sort_cell/scene_manifest.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/commissioning_bundle
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/commissioning_bundle/scene_manifest.yaml` | `-` | `-` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/package.xml` | `generated_ur5_shape_sort_cell` | `package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/package.xml` |
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/scene_manifest.yaml` | `generated_ur5_shape_sort_cell` | `package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/scene_manifest.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/config/task_recipe.yaml` | `generated_ur5_shape_sort_cell` | `package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/config/task_recipe.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/scene_manifest.preview.yaml` | `generated_ur5_shape_sort_cell` | `package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/scene_manifest.preview.yaml` |
+
+### dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/bundle/generated_ur5_shape_sort_cell
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/bundle/generated_ur5_shape_sort_cell/scene_manifest.yaml` | `generated_ur5_shape_sort_cell` | `package://generated_ur5_shape_sort_cell/dist/.tmp_workcell_project_checks/projects/ur5_shape_sort_cell/generated_workcell/generated_ur5_shape_sort_cell/generated/bundle/generated_ur5_shape_sort_cell/scene_manifest.yaml` |
+
+### dist/workcell_bundles/suction_test
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| end_effector | scene_yaml | `dist/workcell_bundles/suction_test/scene_manifest.yaml` | `-` | `-` |
+
+### dist/workcell_bundles/ur5_2f_test
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/workcell_bundles/ur5_2f_test/scene_manifest.yaml` | `-` | `-` |
+
+### dist/workcell_bundles/ur5_3f_test
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/workcell_bundles/ur5_3f_test/scene_manifest.yaml` | `-` | `-` |
+
+### dist/workcell_bundles/ur5_airpick4_test
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `dist/workcell_bundles/ur5_airpick4_test/scene_manifest.yaml` | `-` | `-` |
+
+### docs/reference/archived_duplicates/assets
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `docs/reference/archived_duplicates/assets/table.urdf.copy.xacro` | `-` | `-` |
+
+### docs/reference/archived_duplicates/end_effectors
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `docs/reference/archived_duplicates/end_effectors/robotiq_3f_gripper.srdf.copy.xacro` | `-` | `-` |
+| robot | urdf_xacro | `docs/reference/archived_duplicates/end_effectors/onrobot_airpick4_robotiq_3f_gripper.srdf.copy.xacro` | `-` | `-` |
+
+### docs/reference/archived_duplicates/single_suction_gripper
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `docs/reference/archived_duplicates/single_suction_gripper/dual_gripper.urdf.copy.xacro` | `-` | `-` |
+
+### easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | package_xml | `easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/package.xml` | `run_dynamic_safety` | `package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/package.xml` |
+
+### easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/start_positions.yaml` | `run_dynamic_safety` | `package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/start_positions.yaml` |
+| robot | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/panda_ros_controllers.yaml` | `run_dynamic_safety` | `package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/panda_ros_controllers.yaml` |
+| robot | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/panda_controllers.yaml` | `run_dynamic_safety` | `package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/panda_controllers.yaml` |
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/fake_controllers.yaml` | `run_dynamic_safety` | `package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/fake_controllers.yaml` |
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/moveit_cpp.yaml` | `run_dynamic_safety` | `package://run_dynamic_safety/easy_manipulation_deployment/emd_demo_nodes/run_dynamic_safety/config/moveit_cpp.yaml` |
+
+### easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | package_xml | `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml` | `run_grasp_execution` | `package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml` |
+
+### easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/controllers.yaml` | `run_grasp_execution` | `package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/controllers.yaml` |
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/fake_grasp_pose_publisher.yaml` | `run_grasp_execution` | `package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/fake_grasp_pose_publisher.yaml` |
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml` | `run_grasp_execution` | `package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml` |
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/start_positions.yaml` | `run_grasp_execution` | `package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/start_positions.yaml` |
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/workcell_context.yaml` | `run_grasp_execution` | `package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/workcell_context.yaml` |
+| robot | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/ur5_ros_controllers.yaml` | `run_grasp_execution` | `package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/ur5_ros_controllers.yaml` |
+| sensor | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/sensors_3d.yaml` | `run_grasp_execution` | `package://run_grasp_execution/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/sensors_3d.yaml` |
+
+### easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | package_xml | `easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/package.xml` | `run_grasp_planner` | `package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/package.xml` |
+
+### easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml` | `run_grasp_planner` | `package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_2f.yaml` |
+| end_effector | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_airpick4.yaml` | `run_grasp_planner` | `package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_airpick4.yaml` |
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml` | `run_grasp_planner` | `package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_3f.yaml` |
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params.yaml` | `run_grasp_planner` | `package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params.yaml` |
+| end_effector | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_suction.yaml` | `run_grasp_planner` | `package://run_grasp_planner/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/config/params_suction.yaml` |
+
+### easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | package_xml | `easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/package.xml` | `run_waypoint_execution` | `package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/package.xml` |
+
+### easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/controllers.yaml` | `run_waypoint_execution` | `package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/controllers.yaml` |
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/fake_grasp_pose_publisher.yaml` | `run_waypoint_execution` | `package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/fake_grasp_pose_publisher.yaml` |
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/grasp_execution.yaml` | `run_waypoint_execution` | `package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/grasp_execution.yaml` |
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/start_positions.yaml` | `run_waypoint_execution` | `package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/start_positions.yaml` |
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/workcell_context.yaml` | `run_waypoint_execution` | `package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/workcell_context.yaml` |
+| sensor | scene_yaml | `easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/sensors_3d.yaml` | `run_waypoint_execution` | `package://run_waypoint_execution/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/config/sensors_3d.yaml` |
+
+### easy_manipulation_deployment/emd_dynamic_safety
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | package_xml | `easy_manipulation_deployment/emd_dynamic_safety/package.xml` | `emd_dynamic_safety` | `package://emd_dynamic_safety/easy_manipulation_deployment/emd_dynamic_safety/package.xml` |
+
+### easy_manipulation_deployment/emd_dynamic_safety/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | scene_yaml | `easy_manipulation_deployment/emd_dynamic_safety/config/mappings.yaml` | `emd_dynamic_safety` | `package://emd_dynamic_safety/easy_manipulation_deployment/emd_dynamic_safety/config/mappings.yaml` |
+
+### easy_manipulation_deployment/emd_grasp_execution
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | package_xml | `easy_manipulation_deployment/emd_grasp_execution/package.xml` | `emd_grasp_execution` | `package://emd_grasp_execution/easy_manipulation_deployment/emd_grasp_execution/package.xml` |
+
+### easy_manipulation_deployment/emd_grasp_planner
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | package_xml | `easy_manipulation_deployment/emd_grasp_planner/package.xml` | `emd_grasp_planner` | `package://emd_grasp_planner/easy_manipulation_deployment/emd_grasp_planner/package.xml` |
+
+### easy_manipulation_deployment/emd_waypoint_execution
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | package_xml | `easy_manipulation_deployment/emd_waypoint_execution/package.xml` | `emd_waypoint_execution` | `package://emd_waypoint_execution/easy_manipulation_deployment/emd_waypoint_execution/package.xml` |
+
+### emd_msgs
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | package_xml | `emd_msgs/package.xml` | `emd_msgs` | `package://emd_msgs/emd_msgs/package.xml` |
+
+### scenes/suction_test
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| end_effector | scene_yaml | `scenes/suction_test/environment.yaml` | `suction_test` | `package://suction_test/scenes/suction_test/environment.yaml` |
+| end_effector | package_xml | `scenes/suction_test/package.xml` | `suction_test` | `package://suction_test/scenes/suction_test/package.xml` |
+| end_effector | scene_yaml | `scenes/suction_test/scene_manifest.yaml` | `suction_test` | `package://suction_test/scenes/suction_test/scene_manifest.yaml` |
+
+### scenes/suction_test/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `scenes/suction_test/urdf/scene.urdf.xacro` | `suction_test` | `package://suction_test/scenes/suction_test/urdf/scene.urdf.xacro` |
+| robot | urdf_xacro | `scenes/suction_test/urdf/arm_hand.srdf.xacro` | `suction_test` | `package://suction_test/scenes/suction_test/urdf/arm_hand.srdf.xacro` |
+
+### scenes/ur10_2f_test
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `scenes/ur10_2f_test/environment.yaml` | `ur10_2f_test` | `package://ur10_2f_test/scenes/ur10_2f_test/environment.yaml` |
+| robot | package_xml | `scenes/ur10_2f_test/package.xml` | `ur10_2f_test` | `package://ur10_2f_test/scenes/ur10_2f_test/package.xml` |
+
+### scenes/ur10_2f_test/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `scenes/ur10_2f_test/urdf/scene.urdf.xacro` | `ur10_2f_test` | `package://ur10_2f_test/scenes/ur10_2f_test/urdf/scene.urdf.xacro` |
+| robot | urdf_xacro | `scenes/ur10_2f_test/urdf/arm_hand.srdf.xacro` | `ur10_2f_test` | `package://ur10_2f_test/scenes/ur10_2f_test/urdf/arm_hand.srdf.xacro` |
+
+### scenes/ur3_suction_test
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `scenes/ur3_suction_test/environment.yaml` | `ur3_suction_test` | `package://ur3_suction_test/scenes/ur3_suction_test/environment.yaml` |
+| robot | package_xml | `scenes/ur3_suction_test/package.xml` | `ur3_suction_test` | `package://ur3_suction_test/scenes/ur3_suction_test/package.xml` |
+
+### scenes/ur3_suction_test/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `scenes/ur3_suction_test/urdf/scene.urdf.xacro` | `ur3_suction_test` | `package://ur3_suction_test/scenes/ur3_suction_test/urdf/scene.urdf.xacro` |
+| robot | urdf_xacro | `scenes/ur3_suction_test/urdf/arm_hand.srdf.xacro` | `ur3_suction_test` | `package://ur3_suction_test/scenes/ur3_suction_test/urdf/arm_hand.srdf.xacro` |
+
+### scenes/ur5_2f_test
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `scenes/ur5_2f_test/environment.yaml` | `ur5_2f_test` | `package://ur5_2f_test/scenes/ur5_2f_test/environment.yaml` |
+| robot | package_xml | `scenes/ur5_2f_test/package.xml` | `ur5_2f_test` | `package://ur5_2f_test/scenes/ur5_2f_test/package.xml` |
+| robot | scene_yaml | `scenes/ur5_2f_test/scene_manifest.yaml` | `ur5_2f_test` | `package://ur5_2f_test/scenes/ur5_2f_test/scene_manifest.yaml` |
+
+### scenes/ur5_2f_test/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `scenes/ur5_2f_test/urdf/scene.urdf.xacro` | `ur5_2f_test` | `package://ur5_2f_test/scenes/ur5_2f_test/urdf/scene.urdf.xacro` |
+| robot | urdf_xacro | `scenes/ur5_2f_test/urdf/arm_hand.srdf.xacro` | `ur5_2f_test` | `package://ur5_2f_test/scenes/ur5_2f_test/urdf/arm_hand.srdf.xacro` |
+
+### scenes/ur5_3f_test
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `scenes/ur5_3f_test/environment.yaml` | `ur5_3f_test` | `package://ur5_3f_test/scenes/ur5_3f_test/environment.yaml` |
+| robot | package_xml | `scenes/ur5_3f_test/package.xml` | `ur5_3f_test` | `package://ur5_3f_test/scenes/ur5_3f_test/package.xml` |
+| robot | scene_yaml | `scenes/ur5_3f_test/scene_manifest.yaml` | `ur5_3f_test` | `package://ur5_3f_test/scenes/ur5_3f_test/scene_manifest.yaml` |
+
+### scenes/ur5_3f_test/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `scenes/ur5_3f_test/urdf/scene.urdf.xacro` | `ur5_3f_test` | `package://ur5_3f_test/scenes/ur5_3f_test/urdf/scene.urdf.xacro` |
+| robot | urdf_xacro | `scenes/ur5_3f_test/urdf/arm_hand.srdf.xacro` | `ur5_3f_test` | `package://ur5_3f_test/scenes/ur5_3f_test/urdf/arm_hand.srdf.xacro` |
+
+### scenes/ur5_airpick4_test
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `scenes/ur5_airpick4_test/environment.yaml` | `ur5_airpick4_test` | `package://ur5_airpick4_test/scenes/ur5_airpick4_test/environment.yaml` |
+| robot | package_xml | `scenes/ur5_airpick4_test/package.xml` | `ur5_airpick4_test` | `package://ur5_airpick4_test/scenes/ur5_airpick4_test/package.xml` |
+| robot | scene_yaml | `scenes/ur5_airpick4_test/scene_manifest.yaml` | `ur5_airpick4_test` | `package://ur5_airpick4_test/scenes/ur5_airpick4_test/scene_manifest.yaml` |
+
+### scenes/ur5_airpick4_test/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `scenes/ur5_airpick4_test/urdf/scene.urdf.xacro` | `ur5_airpick4_test` | `package://ur5_airpick4_test/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro` |
+| robot | urdf_xacro | `scenes/ur5_airpick4_test/urdf/arm_hand.srdf.xacro` | `ur5_airpick4_test` | `package://ur5_airpick4_test/scenes/ur5_airpick4_test/urdf/arm_hand.srdf.xacro` |
+
+### tests/fixtures
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | scene_yaml | `tests/fixtures/generated_scene_manifest.yaml` | `-` | `-` |
+
+### workcell_builder/examples/resources
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | mesh | `workcell_builder/examples/resources/table.stl` | `-` | `-` |
+
+### workcell_builder/workcell_builder
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | package_xml | `workcell_builder/workcell_builder/package.xml` | `workcell_builder` | `package://workcell_builder/workcell_builder/workcell_builder/package.xml` |
+
+### workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml` | `onrobot_airpick4_description` | `package://onrobot_airpick4_description/workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml` |
+
+### workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro` | `onrobot_airpick4_description` | `package://onrobot_airpick4_description/workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro` |
+
+### workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml` |
+
+### workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf.xacro` | `robotiq_3f_gripper_description` | `package://robotiq_3f_gripper_description/workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/urdf/robotiq-3f-gripper_articulated.urdf.xacro` |
+
+### workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml` | `robotiq_3f_moveit_config` | `package://robotiq_3f_moveit_config/workcell_builder/workcell_builder/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml` |
+
+### workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml` | `robotiq_85_description` | `package://robotiq_85_description/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml` |
+
+### workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro` | `robotiq_85_description` | `package://robotiq_85_description/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro` |
+
+### workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml` | `robotiq_85_moveit_config` | `package://robotiq_85_moveit_config/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml` |
+
+### workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf.xacro` | `robotiq_85_moveit_config` | `package://robotiq_85_moveit_config/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/config/robotiq_85_gripper.srdf.xacro` |
+
+### workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| end_effector | package_xml | `workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml` | `single_suction_description` | `package://single_suction_description/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml` |
+
+### workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro` | `single_suction_description` | `package://single_suction_description/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro` |
+
+### workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| end_effector | urdf_xacro | `workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/single_suction_gripper.srdf.xacro` | `workcell_builder` | `package://workcell_builder/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/config/single_suction_gripper.srdf.xacro` |
+
+### workcell_builder/workcell_builder/assets/environment/table_description/urdf
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | urdf_xacro | `workcell_builder/workcell_builder/assets/environment/table_description/urdf/table.urdf.xacro` | `workcell_builder` | `package://workcell_builder/workcell_builder/workcell_builder/assets/environment/table_description/urdf/table.urdf.xacro` |
+
+### workcell_builder/workcell_builder/assets/robots/fanuc/fanuc_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `workcell_builder/workcell_builder/assets/robots/fanuc/fanuc_moveit_config/package.xml` | `fanuc_moveit_config` | `package://fanuc_moveit_config/workcell_builder/workcell_builder/assets/robots/fanuc/fanuc_moveit_config/package.xml` |
+
+### workcell_builder/workcell_builder/assets/robots/panda_robot/panda_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `workcell_builder/workcell_builder/assets/robots/panda_robot/panda_moveit_config/package.xml` | `panda_moveit_config` | `package://panda_moveit_config/workcell_builder/workcell_builder/assets/robots/panda_robot/panda_moveit_config/package.xml` |
+
+### workcell_builder/workcell_builder/assets/robots/universal_robot/ur10_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `workcell_builder/workcell_builder/assets/robots/universal_robot/ur10_moveit_config/package.xml` | `ur10_moveit_config` | `package://ur10_moveit_config/workcell_builder/workcell_builder/assets/robots/universal_robot/ur10_moveit_config/package.xml` |
+
+### workcell_builder/workcell_builder/assets/robots/universal_robot/ur3_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `workcell_builder/workcell_builder/assets/robots/universal_robot/ur3_moveit_config/package.xml` | `ur3_moveit_config` | `package://ur3_moveit_config/workcell_builder/workcell_builder/assets/robots/universal_robot/ur3_moveit_config/package.xml` |
+
+### workcell_builder/workcell_builder/assets/robots/universal_robot/ur5_moveit_config
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| robot | package_xml | `workcell_builder/workcell_builder/assets/robots/universal_robot/ur5_moveit_config/package.xml` | `ur5_moveit_config` | `package://ur5_moveit_config/workcell_builder/workcell_builder/assets/robots/universal_robot/ur5_moveit_config/package.xml` |
+
+### workcell_builder/workcell_builder/templates/ros2
+
+| Asset Type Guess | Category | File | Package | Package URI |
+|---|---|---|---|---|
+| unknown | scene_yaml | `workcell_builder/workcell_builder/templates/ros2/scene_manifest_contract_template.yaml` | `workcell_builder` | `package://workcell_builder/workcell_builder/workcell_builder/templates/ros2/scene_manifest_contract_template.yaml` |
+

--- a/reports/environment_layout_preview.md
+++ b/reports/environment_layout_preview.md
@@ -1,0 +1,26 @@
+# Environment Layout Preview
+
+- Source: `/workspace/Easy_Manipulator_Improved/tests/fixtures/environment_layouts/ur5_table_bins_existing_assets.layout.yaml`
+- Layout id: `ur5_table_bins_existing_assets`
+- Schema version: `environment_layout/v1`
+- Validation parser: `fallback`
+
+## Assets
+
+| id | type | asset_ref | source | pose xyz | pose rpy |
+|---|---|---|---|---|---|
+| main_table | table | table_basic | `package://table_description/meshes/visual/table.stl` | `[0.5, 0.0, 0.0]` | `[0.0, 0.0, 0.0]` |
+| overhead_sensor | sensor | realsense_d435i_sensor | `package://realsense2_description/meshes/d435.dae` | `[0.7, 0.0, 1.2]` | `[0.0, 0.0, 0.0]` |
+
+## Zones
+
+- `pick_zone` (pick) bounds={'min': [0.2, -0.7, 0.35], 'max': [0.8, -0.2, 0.75]}
+- `red_place_zone` (place) bounds={'min': [0.55, 0.3, 0.35], 'max': [0.85, 0.6, 0.75]}
+
+## Safety zones
+
+- `robot_reach_warning` (warning) bounds={'min': [-1.0, -1.0, 0.0], 'max': [1.0, 1.0, 1.8]}
+
+## Validation warnings
+
+- None

--- a/scripts/check_environment_layouts.sh
+++ b/scripts/check_environment_layouts.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FIX_DIR="${REPO_ROOT}/tests/fixtures/environment_layouts"
+PASS=0
+WARN=0
+FAIL=0
+
+run_ok() {
+  if "$@"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); fi
+}
+
+echo "=== Environment layout checks (offline) ==="
+run_ok "${SCRIPT_DIR}/inspect_asset_inventory.py" --quiet
+
+for fixture in \
+  ur5_table_bins_existing_assets.layout.yaml \
+  ur5_conveyor_sorting_existing_assets.layout.yaml \
+  machine_tending_existing_assets.layout.yaml \
+  delta_conveyor_sorting_existing_assets.layout.yaml; do
+  run_ok "${SCRIPT_DIR}/validate_environment_layout.py" "${FIX_DIR}/${fixture}" --quiet
+ done
+
+if "${SCRIPT_DIR}/validate_environment_layout.py" "${FIX_DIR}/invalid_missing_pose.layout.yaml" --quiet; then
+  echo "FAIL: invalid_missing_pose should fail"
+  FAIL=$((FAIL+1))
+else
+  PASS=$((PASS+1))
+fi
+
+if "${SCRIPT_DIR}/validate_environment_layout.py" "${FIX_DIR}/invalid_duplicate_asset_id.layout.yaml" --quiet; then
+  echo "FAIL: invalid_duplicate_asset_id should fail"
+  FAIL=$((FAIL+1))
+else
+  PASS=$((PASS+1))
+fi
+
+if "${SCRIPT_DIR}/validate_environment_layout.py" "${FIX_DIR}/invalid_bounds.layout.yaml" --quiet; then
+  echo "FAIL: invalid_bounds should fail"
+  FAIL=$((FAIL+1))
+else
+  PASS=$((PASS+1))
+fi
+
+if "${SCRIPT_DIR}/validate_environment_layout.py" "${FIX_DIR}/unknown_asset_ref_warn.layout.yaml" --quiet; then
+  WARN=$((WARN+1))
+else
+  FAIL=$((FAIL+1))
+fi
+
+if "${SCRIPT_DIR}/validate_environment_layout.py" "${FIX_DIR}/unknown_asset_ref_warn.layout.yaml" --strict --quiet; then
+  echo "FAIL: strict unknown_asset_ref should fail"
+  FAIL=$((FAIL+1))
+else
+  PASS=$((PASS+1))
+fi
+
+run_ok "${SCRIPT_DIR}/generate_environment_preview.py" "${FIX_DIR}/ur5_table_bins_existing_assets.layout.yaml" --output "${REPO_ROOT}/reports/environment_layout_preview.md"
+run_ok "${SCRIPT_DIR}/validate_cell_definition.py" "${REPO_ROOT}/tests/fixtures/cell_definition_pick_place_with_layout.yaml" --quiet
+
+if python3 - <<'PY'
+import json
+from pathlib import Path
+p=Path('/tmp/emd_layout_project')
+if p.exists():
+    import shutil; shutil.rmtree(p)
+PY
+then :; fi
+
+if "${SCRIPT_DIR}/create_workcell_project.py" --cell-definition "${REPO_ROOT}/tests/fixtures/cell_definition_pick_place_with_layout.yaml" --output-dir /tmp/emd_layout_project --force --quiet >/dev/null 2>&1; then
+  if python3 - <<'PY'
+import json
+from pathlib import Path
+manifest=Path('/tmp/emd_layout_project/ur5_pick_place_layout/project_manifest.json')
+payload=json.loads(manifest.read_text())
+assert 'environment_layout' in payload
+assert payload['environment_layout']
+print('ok')
+PY
+  then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+  fi
+else
+  WARN=$((WARN+1))
+fi
+
+if (( FAIL > 0 )); then
+  echo "Environment layout checks: FAIL (pass=${PASS} warn=${WARN} fail=${FAIL})"
+  exit 1
+fi
+if (( WARN > 0 )); then
+  echo "Environment layout checks: WARN (pass=${PASS} warn=${WARN} fail=${FAIL})"
+  exit 0
+fi
+
+echo "Environment layout checks: PASS (pass=${PASS} warn=${WARN} fail=${FAIL})"
+exit 0

--- a/scripts/create_workcell_project.py
+++ b/scripts/create_workcell_project.py
@@ -212,6 +212,14 @@ def _extract_capability_refs(cell_def: dict[str, Any]) -> dict[str, Any]:
         "environment_assets": [item.get("capability") for item in assets if isinstance(item, dict) and item.get("capability")],
     }
     return {k: v for k, v in refs.items() if v}
+
+
+def _extract_environment_layout(cell_def: dict[str, Any]) -> dict[str, Any]:
+    environment = cell_def.get("environment", {}) if isinstance(cell_def.get("environment"), dict) else {}
+    layout = environment.get("layout")
+    if isinstance(layout, str) and layout.strip():
+        return {"path": layout, "metadata_only": True}
+    return {}
 def _create_from_template(args: argparse.Namespace, cell_yaml_path: Path) -> tuple[int, list[str]]:
     notes: list[str] = []
     command: list[str]
@@ -608,6 +616,7 @@ def main() -> int:
         "parser_notes": parser_notes,
         "capabilities": _extract_capability_refs(loaded),
         "capability_validation": getattr(summary, "capability_summary", {}),
+        "environment_layout": getattr(summary, "environment_layout_summary", {}) or _extract_environment_layout(loaded),
     }
     _write_text(project_dir / "project_manifest.json", json.dumps(manifest_payload, indent=2, sort_keys=True) + "\n", False, planned_paths)
 

--- a/scripts/generate_environment_preview.py
+++ b/scripts/generate_environment_preview.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Generate markdown preview for environment_layout/v1."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import validate_environment_layout as layout_validator
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = REPO_ROOT / "reports" / "environment_layout_preview.md"
+
+
+def render_preview(layout: dict, validation: layout_validator.ValidationResult, source_path: Path) -> str:
+    assets = layout.get("assets") if isinstance(layout.get("assets"), list) else []
+    zones = layout.get("zones") if isinstance(layout.get("zones"), list) else []
+    safety = layout.get("safety") if isinstance(layout.get("safety"), dict) else {}
+    safety_zones = safety.get("zones") if isinstance(safety.get("zones"), list) else []
+    lines = [
+        "# Environment Layout Preview",
+        "",
+        f"- Source: `{source_path}`",
+        f"- Layout id: `{layout.get('layout_id', '(unknown)')}`",
+        f"- Schema version: `{layout.get('schema_version', '(missing)')}`",
+        f"- Validation parser: `{validation.parser}`",
+        "",
+        "## Assets",
+        "",
+        "| id | type | asset_ref | source | pose xyz | pose rpy |",
+        "|---|---|---|---|---|---|",
+    ]
+    for asset in assets:
+        if not isinstance(asset, dict):
+            continue
+        src = asset.get("source") if isinstance(asset.get("source"), dict) else {}
+        source = src.get("uri") or src.get("path") or src.get("package") or "-"
+        pose = asset.get("pose") if isinstance(asset.get("pose"), dict) else {}
+        lines.append(
+            f"| {asset.get('id', '-')} | {asset.get('type', '-')} | {asset.get('asset_ref', '-')} | "
+            f"`{source}` | `{pose.get('xyz', '-')}` | `{pose.get('rpy', '-')}` |"
+        )
+    if len(lines) == 11:
+        lines.append("| - | - | - | - | - | - |")
+
+    lines.extend(["", "## Zones", ""])
+    for zone in zones:
+        if not isinstance(zone, dict):
+            continue
+        lines.append(f"- `{zone.get('id', '-')}` ({zone.get('type', '-')}) bounds={zone.get('bounds_xyz', {})}")
+
+    lines.extend(["", "## Safety zones", ""])
+    for zone in safety_zones:
+        if not isinstance(zone, dict):
+            continue
+        lines.append(f"- `{zone.get('id', '-')}` ({zone.get('type', '-')}) bounds={zone.get('bounds_xyz', {})}")
+
+    lines.extend(["", "## Validation warnings", ""])
+    if validation.warnings:
+        lines.extend([f"- {warning}" for warning in validation.warnings])
+    else:
+        lines.append("- None")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("layout_path", type=Path)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    loaded, parser_name, notes = layout_validator.load_layout(args.layout_path)
+    summary = layout_validator.validate_layout(loaded, args.layout_path, parser_name, notes, strict=False)
+    text = render_preview(loaded, summary, args.layout_path)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(text, encoding="utf-8")
+    print(f"PASS: wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_scene_from_cell_definition.py
+++ b/scripts/generate_scene_from_cell_definition.py
@@ -172,6 +172,12 @@ def build_scene_manifest(cell_def: dict[str, Any], capability_summary: dict[str,
             manifest.setdefault("generated_defaults", {})
             if isinstance(manifest["generated_defaults"], dict):
                 manifest["generated_defaults"]["capability_checks"] = status
+    environment = cell_def.get("environment", {}) if isinstance(cell_def.get("environment"), dict) else {}
+    if isinstance(environment.get("layout"), str) and environment.get("layout").strip():
+        manifest["environment_layout"] = {
+            "path": environment.get("layout"),
+            "metadata_only": True,
+        }
 
     return manifest
 

--- a/scripts/inspect_asset_inventory.py
+++ b/scripts/inspect_asset_inventory.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Inspect existing repository assets and emit inventory reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPORT_DIR = REPO_ROOT / "reports"
+MESH_EXTS = {".stl", ".dae", ".obj"}
+ROBOT_EXTS = {".urdf", ".xacro"}
+SCENE_EXTS = {".yaml", ".yml"}
+
+
+def _looks_like_asset_dir(path: Path) -> bool:
+    text = str(path).lower()
+    hints = ("asset", "assets", "mesh", "meshes", "model", "models", "description", "urdf", "xacro", "scene", "world")
+    return any(hint in text for hint in hints)
+
+
+def _guess_type(path: Path) -> str:
+    text = str(path).lower()
+    rules = [
+        ("robot", ("robot", "ur", "fanuc", "panda")),
+        ("end_effector", ("end_effector", "gripper", "suction", "airpick", "robotiq")),
+        ("sensor", ("sensor", "camera", "realsense")),
+        ("table", ("table",)),
+        ("workbench", ("workbench", "bench")),
+        ("bin", ("bin", "tray")),
+        ("conveyor", ("conveyor",)),
+        ("fixture", ("fixture",)),
+    ]
+    for label, keys in rules:
+        if any(key in text for key in keys):
+            return label
+    return "unknown"
+
+
+def _pkg_for(path: Path, package_dirs: dict[Path, str]) -> str | None:
+    matches = [(pkg_path, name) for pkg_path, name in package_dirs.items() if pkg_path in path.parents or pkg_path == path]
+    if not matches:
+        return None
+    return max(matches, key=lambda item: len(item[0].parts))[1]
+
+
+def collect_inventory(repo_root: Path) -> dict[str, Any]:
+    package_dirs: dict[Path, str] = {}
+    for pkg_xml in repo_root.rglob("package.xml"):
+        package_dirs[pkg_xml.parent] = pkg_xml.parent.name
+
+    entries: list[dict[str, Any]] = []
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+    for path in repo_root.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(repo_root)
+        if rel.parts and rel.parts[0] == ".git":
+            continue
+        if "__pycache__" in rel.parts:
+            continue
+
+        suffix = path.suffix.lower()
+        category = None
+        if suffix in MESH_EXTS:
+            category = "mesh"
+        elif suffix in ROBOT_EXTS:
+            category = "urdf_xacro"
+        elif suffix in SCENE_EXTS and ("scene" in str(rel).lower() or "config" in str(rel).lower()):
+            category = "scene_yaml"
+        elif path.name == "package.xml":
+            category = "package_xml"
+
+        if category is None and not _looks_like_asset_dir(rel.parent):
+            continue
+        if category is None:
+            continue
+
+        pkg = _pkg_for(path, package_dirs)
+        source_group = str(rel.parent)
+        item = {
+            "relative_path": str(rel),
+            "file_name": path.name,
+            "file_type": suffix.lstrip(".") or path.name,
+            "category": category,
+            "asset_type_guess": _guess_type(rel),
+            "package": pkg,
+            "package_uri": f"package://{pkg}/{rel}" if pkg else None,
+            "group": source_group,
+        }
+        entries.append(item)
+        grouped[source_group].append(item)
+
+    counts = Counter(item["category"] for item in entries)
+    return {
+        "schema_version": "asset_inventory/v1",
+        "repo_root": str(repo_root),
+        "totals": {
+            "files": len(entries),
+            "meshes": counts.get("mesh", 0),
+            "urdf_xacro": counts.get("urdf_xacro", 0),
+            "scene_yaml": counts.get("scene_yaml", 0),
+            "package_xml": counts.get("package_xml", 0),
+            "packages": len(package_dirs),
+        },
+        "groups": [{"group": group, "items": items} for group, items in sorted(grouped.items())],
+        "entries": sorted(entries, key=lambda item: item["relative_path"]),
+    }
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Asset Inventory Report",
+        "",
+        f"- Schema: `{payload['schema_version']}`",
+        f"- Total tracked files: `{payload['totals']['files']}`",
+        f"- Meshes: `{payload['totals']['meshes']}`",
+        f"- URDF/Xacro: `{payload['totals']['urdf_xacro']}`",
+        f"- Scene YAML: `{payload['totals']['scene_yaml']}`",
+        f"- package.xml files: `{payload['totals']['package_xml']}`",
+        "",
+        "## Grouped inventory",
+        "",
+    ]
+    for block in payload["groups"]:
+        lines.append(f"### {block['group']}")
+        lines.append("")
+        lines.append("| Asset Type Guess | Category | File | Package | Package URI |")
+        lines.append("|---|---|---|---|---|")
+        for item in block["items"]:
+            lines.append(
+                f"| {item['asset_type_guess']} | {item['category']} | `{item['relative_path']}` | "
+                f"`{item['package'] or '-'}` | `{item['package_uri'] or '-'}` |"
+            )
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--markdown", type=Path, default=REPORT_DIR / "asset_inventory.md")
+    parser.add_argument("--json", dest="json_path", type=Path, default=REPORT_DIR / "asset_inventory.json")
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args()
+
+    payload = collect_inventory(args.repo_root.resolve())
+    args.markdown.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown.write_text(_render_markdown(payload), encoding="utf-8")
+    args.json_path.parent.mkdir(parents=True, exist_ok=True)
+    args.json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if not args.quiet:
+        print(f"PASS: wrote {args.markdown}")
+        print(f"PASS: wrote {args.json_path}")
+        print(f"SUMMARY: files={payload['totals']['files']} meshes={payload['totals']['meshes']} urdf_xacro={payload['totals']['urdf_xacro']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preflight_workcell.sh
+++ b/scripts/preflight_workcell.sh
@@ -53,6 +53,7 @@ echo
 "${SCRIPT_DIR}/check_all_scenes.sh"
 "${SCRIPT_DIR}/check_capability_contracts.sh"
 "${SCRIPT_DIR}/check_cell_capability_integration.sh"
+"${SCRIPT_DIR}/check_environment_layouts.sh"
 "${SCRIPT_DIR}/generate_scene_validation_report.py"
 "${SCRIPT_DIR}/check_scene_self_tests.sh"
 "${SCRIPT_DIR}/generate_scene_self_test_report.py"

--- a/scripts/validate_cell_definition.py
+++ b/scripts/validate_cell_definition.py
@@ -47,6 +47,7 @@ class ValidationSummary:
     warnings: list[str] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
     capability_summary: dict[str, Any] = field(default_factory=dict)
+    environment_layout_summary: dict[str, Any] = field(default_factory=dict)
 
     @property
     def ok(self) -> bool:
@@ -453,6 +454,43 @@ def validate_cell_definition(
     if task_type in SORTING_TASK_TYPES and not fallback_present:
         result.warnings.append("Sorting task has no explicit fallback rule with when.always=true.")
 
+    layout_path_value = environment.get("layout")
+    if layout_path_value is not None:
+        if not isinstance(layout_path_value, str) or not layout_path_value.strip():
+            result.errors.append("environment.layout must be a non-empty string path when provided.")
+        else:
+            layout_path = (Path(__file__).resolve().parents[1] / layout_path_value).resolve()
+            if not layout_path.exists():
+                msg = f"environment.layout path not found: {layout_path_value}"
+                (result.errors if strict else result.warnings).append(msg)
+            else:
+                try:
+                    import validate_environment_layout as env_layout_validator
+
+                    loaded_layout, layout_parser, layout_notes = env_layout_validator.load_layout(layout_path)
+                    layout_summary = env_layout_validator.validate_layout(
+                        loaded_layout,
+                        layout_path,
+                        layout_parser,
+                        layout_notes,
+                        strict=strict,
+                    )
+                    result.warnings.extend(layout_summary.warnings)
+                    result.errors.extend(layout_summary.errors)
+                    result.notes.extend([f"environment.layout: {note}" for note in layout_summary.notes])
+                    result.environment_layout_summary = {
+                        "path": layout_path_value,
+                        "layout_id": loaded_layout.get("layout_id"),
+                        "asset_count": layout_summary.summary.get("asset_count", 0),
+                        "zone_count": layout_summary.summary.get("zone_count", 0),
+                        "safety_zone_count": layout_summary.summary.get("safety_zone_count", 0),
+                        "result": "PASS" if layout_summary.ok and not layout_summary.warnings else "WARN" if layout_summary.ok else "FAIL",
+                    }
+                except Exception as exc:
+                    (result.errors if strict else result.warnings).append(
+                        f"environment.layout validation failed for '{layout_path_value}': {exc}"
+                    )
+
     _check_capabilities(defn, result, strict=strict, capabilities_dir=capabilities_dir)
     return result
 
@@ -477,6 +515,7 @@ def main() -> int:
     parser.add_argument("yaml_path", type=Path, help="Path to a cell_definition YAML file")
     parser.add_argument("--strict", action="store_true", help="Treat uncertain warnings as failures where supported")
     parser.add_argument("--json", action="store_true", help="Print machine-readable output")
+    parser.add_argument("--quiet", action="store_true", help="Suppress human-readable output")
     parser.add_argument("--capabilities-dir", type=Path, default=DEFAULT_CAPABILITIES_DIR)
     args = parser.parse_args()
 
@@ -499,9 +538,10 @@ def main() -> int:
             "notes": summary.notes,
             "result": "PASS" if summary.ok and not summary.warnings else "WARN" if summary.ok else "FAIL",
             "capabilities": summary.capability_summary,
+            "environment_layout": summary.environment_layout_summary,
         }
         print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
+    elif not args.quiet:
         print_summary(summary)
     return 0 if summary.ok else 1
 

--- a/scripts/validate_environment_layout.py
+++ b/scripts/validate_environment_layout.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Validate environment_layout/v1 YAML/JSON files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import validate_cell_definition as yaml_support
+
+
+@dataclass
+class ValidationResult:
+    path: Path
+    parser: str
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    summary: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _is_num3(value: Any) -> bool:
+    return isinstance(value, list) and len(value) == 3 and all(isinstance(v, (int, float)) for v in value)
+
+
+def _load_manifests(repo_root: Path) -> dict[str, dict[str, Any]]:
+    manifests: dict[str, dict[str, Any]] = {}
+    for candidate in list(repo_root.rglob("asset_manifest.yaml")) + list(repo_root.rglob("assets_manifest.yaml")):
+        try:
+            loaded, _, _ = yaml_support.load_yaml(candidate)
+        except Exception:
+            continue
+        if isinstance(loaded, dict):
+            if "asset_id" in loaded:
+                manifests[str(loaded.get("asset_id"))] = loaded
+            if isinstance(loaded.get("assets"), list):
+                for item in loaded["assets"]:
+                    if isinstance(item, dict) and item.get("asset_id"):
+                        manifests[str(item["asset_id"])] = item
+    return manifests
+
+
+def load_layout(path: Path) -> tuple[dict[str, Any], str, list[str]]:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() == ".json":
+        data = json.loads(text)
+        if not isinstance(data, dict):
+            raise ValueError("Top-level layout must be an object")
+        return data, "json", []
+    loaded, parser, notes = yaml_support.load_yaml(path)
+    return loaded, parser, notes
+
+
+def validate_layout(defn: dict[str, Any], path: Path, parser: str, notes: list[str], strict: bool = False, repo_root: Path = REPO_ROOT) -> ValidationResult:
+    result = ValidationResult(path=path, parser=parser, notes=list(notes))
+    manifests = _load_manifests(repo_root)
+
+    if defn.get("schema_version") != "environment_layout/v1":
+        result.errors.append("schema_version must be exactly 'environment_layout/v1'.")
+
+    assets = defn.get("assets") if isinstance(defn.get("assets"), list) else []
+    zones = defn.get("zones") if isinstance(defn.get("zones"), list) else []
+    safety = defn.get("safety") if isinstance(defn.get("safety"), dict) else {}
+    safety_zones = safety.get("zones") if isinstance(safety.get("zones"), list) else []
+
+    seen_asset_ids: set[str] = set()
+    for idx, asset in enumerate(assets):
+        if not isinstance(asset, dict):
+            result.errors.append(f"assets[{idx}] must be an object.")
+            continue
+        aid = asset.get("id")
+        if not isinstance(aid, str) or not aid.strip():
+            result.errors.append(f"assets[{idx}].id must be a non-empty string.")
+        elif aid in seen_asset_ids:
+            result.errors.append(f"Duplicate asset id '{aid}'.")
+        else:
+            seen_asset_ids.add(aid)
+
+        pose = asset.get("pose") if isinstance(asset.get("pose"), dict) else None
+        if pose is None:
+            result.errors.append(f"assets[{idx}].pose is required.")
+        else:
+            if not _is_num3(pose.get("xyz")):
+                result.errors.append(f"assets[{idx}].pose.xyz must be numeric list length 3.")
+            if not _is_num3(pose.get("rpy")):
+                result.errors.append(f"assets[{idx}].pose.rpy must be numeric list length 3.")
+
+        src = asset.get("source") if isinstance(asset.get("source"), dict) else {}
+        src_path = src.get("path")
+        src_uri = src.get("uri")
+        if isinstance(src_path, str) and src_path.strip():
+            abs_path = (repo_root / src_path).resolve()
+            if not abs_path.exists():
+                message = f"assets[{idx}].source.path '{src_path}' does not exist relative to repo root."
+                (result.errors if strict else result.warnings).append(message)
+        if isinstance(src_uri, str) and src_uri.startswith("package://"):
+            pass
+
+        ref = asset.get("asset_ref")
+        if isinstance(ref, str) and ref.strip() and ref not in manifests:
+            message = f"assets[{idx}].asset_ref '{ref}' not found in optional asset manifests."
+            (result.errors if strict else result.warnings).append(message)
+
+    def _validate_zone(zone: Any, owner: str, seen: set[str]) -> None:
+        if not isinstance(zone, dict):
+            result.errors.append(f"{owner} must be an object.")
+            return
+        zid = zone.get("id")
+        if not isinstance(zid, str) or not zid.strip():
+            result.errors.append(f"{owner}.id must be a non-empty string.")
+        elif zid in seen:
+            result.errors.append(f"Duplicate zone id '{zid}'.")
+        else:
+            seen.add(zid)
+        bounds = zone.get("bounds_xyz") if isinstance(zone.get("bounds_xyz"), dict) else {}
+        if not _is_num3(bounds.get("min")):
+            result.errors.append(f"{owner}.bounds_xyz.min must be numeric list length 3.")
+        if not _is_num3(bounds.get("max")):
+            result.errors.append(f"{owner}.bounds_xyz.max must be numeric list length 3.")
+
+    seen_zone_ids: set[str] = set()
+    for idx, zone in enumerate(zones):
+        _validate_zone(zone, f"zones[{idx}]", seen_zone_ids)
+    for idx, zone in enumerate(safety_zones):
+        _validate_zone(zone, f"safety.zones[{idx}]", seen_zone_ids)
+
+    result.summary = {
+        "layout_id": defn.get("layout_id"),
+        "asset_count": len(assets),
+        "zone_count": len(zones),
+        "safety_zone_count": len(safety_zones),
+        "manifest_asset_count": len(manifests),
+    }
+    return result
+
+
+def _to_payload(summary: ValidationResult) -> dict[str, Any]:
+    result = "PASS" if summary.ok and not summary.warnings else "WARN" if summary.ok else "FAIL"
+    return {
+        "path": str(summary.path),
+        "parser": summary.parser,
+        "result": result,
+        "errors": summary.errors,
+        "warnings": summary.warnings,
+        "notes": summary.notes,
+        "summary": summary.summary,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("layout_path", type=Path)
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        loaded, parser_name, notes = load_layout(args.layout_path)
+    except FileNotFoundError:
+        print(f"FAIL: File not found: {args.layout_path}")
+        return 2
+    except Exception as exc:
+        print(f"FAIL: Could not parse layout: {exc}")
+        return 1
+
+    summary = validate_layout(loaded, args.layout_path, parser_name, notes, strict=args.strict)
+    payload = _to_payload(summary)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    elif not args.quiet:
+        print(f"Layout: {summary.path}")
+        for note in summary.notes:
+            print(f"NOTE: {note}")
+        for warning in summary.warnings:
+            print(f"WARN: {warning}")
+        for error in summary.errors:
+            print(f"FAIL: {error}")
+        print(f"RESULT: {payload['result']}")
+
+    return 0 if summary.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/cell_definition_pick_place_with_layout.yaml
+++ b/tests/fixtures/cell_definition_pick_place_with_layout.yaml
@@ -1,0 +1,58 @@
+schema_version: cell_definition/v1
+cell:
+  id: ur5_pick_place_layout
+  name: UR5 Pick Place with Layout
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: robotiq_2f
+  type: finger
+  brand: robotiq
+  grasp_frame: tool0
+  allowed_touch_links: [left_inner_finger, right_inner_finger]
+camera:
+  id: realsense_d435i
+  type: depth_camera
+  frame: camera_depth_optical_frame
+environment:
+  frame: world
+  layout: tests/fixtures/environment_layouts/ur5_table_bins_existing_assets.layout.yaml
+  support_surfaces:
+    - id: table_main
+      type: table
+      frame: world
+      pose_xyz: [0.0, 0.0, 0.0]
+      pose_rpy: [0.0, 0.0, 0.0]
+      dimensions: [1.2, 0.8, 0.05]
+objects:
+  - id: box1
+    class: part
+    shape: box
+    color: blue
+    material: plastic
+    frame: world
+    dimensions: [0.05, 0.05, 0.05]
+    pose_xyz: [0.45, 0.0, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+task:
+  id: pick_place_task
+  type: pick_place
+  source_object: box1
+  destinations:
+    - id: place_target
+      frame: world
+      pose_xyz: [0.6, -0.2, 0.1]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: default_place
+      when:
+        always: true
+      destination: place_target
+commissioning:
+  self_test_enabled: true
+  export_bundle: false

--- a/tests/fixtures/environment_layouts/delta_conveyor_sorting_existing_assets.layout.yaml
+++ b/tests/fixtures/environment_layouts/delta_conveyor_sorting_existing_assets.layout.yaml
@@ -1,0 +1,19 @@
+schema_version: environment_layout/v1
+layout_id: delta_conveyor_sorting_existing_assets
+assets:
+  - id: delta_table
+    asset_ref: table_basic
+    source:
+      path: assets/environment/table_description/meshes/visual/table.stl
+    type: conveyor
+    pose:
+      frame: world
+      xyz: [0.0, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+zones:
+  - id: delta_lane_a
+    type: place
+    frame: world
+    bounds_xyz:
+      min: [0.5, -0.4, 0.2]
+      max: [0.9, -0.1, 0.7]

--- a/tests/fixtures/environment_layouts/invalid_bounds.layout.yaml
+++ b/tests/fixtures/environment_layouts/invalid_bounds.layout.yaml
@@ -1,0 +1,18 @@
+schema_version: environment_layout/v1
+layout_id: invalid_bounds
+assets:
+  - id: ok_asset
+    source:
+      path: assets/environment/table_description/meshes/visual/table.stl
+    type: table
+    pose:
+      frame: world
+      xyz: [0.0, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+zones:
+  - id: bad_zone
+    type: pick
+    frame: world
+    bounds_xyz:
+      min: [0.0, 0.0]
+      max: [1.0, 1.0, 1.0]

--- a/tests/fixtures/environment_layouts/invalid_duplicate_asset_id.layout.yaml
+++ b/tests/fixtures/environment_layouts/invalid_duplicate_asset_id.layout.yaml
@@ -1,0 +1,20 @@
+schema_version: environment_layout/v1
+layout_id: invalid_duplicate_asset_id
+assets:
+  - id: dup_asset
+    source:
+      path: assets/environment/table_description/meshes/visual/table.stl
+    type: table
+    pose:
+      frame: world
+      xyz: [0.0, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+  - id: dup_asset
+    source:
+      path: assets/environment/workbench_description/meshes/visual/table.stl
+    type: workbench
+    pose:
+      frame: world
+      xyz: [1.0, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+zones: []

--- a/tests/fixtures/environment_layouts/invalid_missing_pose.layout.yaml
+++ b/tests/fixtures/environment_layouts/invalid_missing_pose.layout.yaml
@@ -1,0 +1,9 @@
+schema_version: environment_layout/v1
+layout_id: invalid_missing_pose
+assets:
+  - id: no_pose_asset
+    asset_ref: table_basic
+    source:
+      path: assets/environment/table_description/meshes/visual/table.stl
+    type: table
+zones: []

--- a/tests/fixtures/environment_layouts/machine_tending_existing_assets.layout.yaml
+++ b/tests/fixtures/environment_layouts/machine_tending_existing_assets.layout.yaml
@@ -1,0 +1,20 @@
+schema_version: environment_layout/v1
+layout_id: machine_tending_existing_assets
+assets:
+  - id: machine_fixture
+    asset_ref: workbench_basic
+    source:
+      uri: package://workbench_description/meshes/visual/table.stl
+      path: assets/environment/workbench_description/meshes/visual/table.stl
+    type: fixture
+    pose:
+      frame: world
+      xyz: [0.4, -0.3, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+zones:
+  - id: machine_pick
+    type: pick
+    frame: world
+    bounds_xyz:
+      min: [0.2, -0.5, 0.1]
+      max: [0.7, -0.1, 0.8]

--- a/tests/fixtures/environment_layouts/unknown_asset_ref_warn.layout.yaml
+++ b/tests/fixtures/environment_layouts/unknown_asset_ref_warn.layout.yaml
@@ -1,0 +1,13 @@
+schema_version: environment_layout/v1
+layout_id: unknown_asset_ref_warn
+assets:
+  - id: unknown_ref_asset
+    asset_ref: unknown_asset_id
+    source:
+      path: assets/environment/table_description/meshes/visual/table.stl
+    type: table
+    pose:
+      frame: world
+      xyz: [0.0, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+zones: []

--- a/tests/fixtures/environment_layouts/ur5_conveyor_sorting_existing_assets.layout.yaml
+++ b/tests/fixtures/environment_layouts/ur5_conveyor_sorting_existing_assets.layout.yaml
@@ -1,0 +1,20 @@
+schema_version: environment_layout/v1
+layout_id: ur5_conveyor_sorting_existing_assets
+assets:
+  - id: conveyor_table
+    asset_ref: table_basic
+    source:
+      uri: package://table_description/meshes/visual/table.stl
+      path: assets/environment/table_description/meshes/visual/table.stl
+    type: conveyor
+    pose:
+      frame: world
+      xyz: [0.8, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+zones:
+  - id: conveyor_pick
+    type: pick
+    frame: world
+    bounds_xyz:
+      min: [0.4, -0.2, 0.2]
+      max: [1.1, 0.2, 0.7]

--- a/tests/fixtures/environment_layouts/ur5_table_bins_existing_assets.layout.yaml
+++ b/tests/fixtures/environment_layouts/ur5_table_bins_existing_assets.layout.yaml
@@ -1,0 +1,53 @@
+schema_version: environment_layout/v1
+layout_id: ur5_table_bins_existing_assets
+metadata:
+  name: UR5 table bins existing assets layout
+  description: Uses existing table and sensor assets.
+assets:
+  - id: main_table
+    asset_ref: table_basic
+    source:
+      package: table_description
+      uri: package://table_description/meshes/visual/table.stl
+      path: assets/environment/table_description/meshes/visual/table.stl
+    type: table
+    pose:
+      frame: world
+      xyz: [0.5, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+    collision: true
+    visual: true
+  - id: overhead_sensor
+    asset_ref: realsense_d435i_sensor
+    source:
+      package: realsense2_description
+      uri: package://realsense2_description/meshes/d435.dae
+      path: assets/environment/realsense2_description/meshes/d435.dae
+    type: sensor
+    pose:
+      frame: world
+      xyz: [0.7, 0.0, 1.2]
+      rpy: [0.0, 0.0, 0.0]
+    collision: false
+    visual: true
+zones:
+  - id: pick_zone
+    type: pick
+    frame: world
+    bounds_xyz:
+      min: [0.2, -0.7, 0.35]
+      max: [0.8, -0.2, 0.75]
+  - id: red_place_zone
+    type: place
+    frame: world
+    bounds_xyz:
+      min: [0.55, 0.3, 0.35]
+      max: [0.85, 0.6, 0.75]
+safety:
+  zones:
+    - id: robot_reach_warning
+      type: warning
+      frame: world
+      bounds_xyz:
+        min: [-1.0, -1.0, 0.0]
+        max: [1.0, 1.0, 1.8]

--- a/tests/test_environment_layout_tools.py
+++ b/tests/test_environment_layout_tools.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "environment_layouts"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+inventory = _load("inspect_asset_inventory", REPO_ROOT / "scripts" / "inspect_asset_inventory.py")
+layout_validator = _load("validate_environment_layout", REPO_ROOT / "scripts" / "validate_environment_layout.py")
+cell_validator = _load("validate_cell_definition_layout", REPO_ROOT / "scripts" / "validate_cell_definition.py")
+project_gen = REPO_ROOT / "scripts" / "create_workcell_project.py"
+
+
+class EnvironmentLayoutToolTests(unittest.TestCase):
+    def test_asset_inventory_runs(self) -> None:
+        payload = inventory.collect_inventory(REPO_ROOT)
+        self.assertEqual(payload["schema_version"], "asset_inventory/v1")
+        self.assertGreater(payload["totals"]["files"], 0)
+
+    def test_valid_layout_passes(self) -> None:
+        loaded, parser, notes = layout_validator.load_layout(FIXTURES / "ur5_table_bins_existing_assets.layout.yaml")
+        summary = layout_validator.validate_layout(loaded, FIXTURES / "ur5_table_bins_existing_assets.layout.yaml", parser, notes)
+        self.assertTrue(summary.ok)
+
+    def test_duplicate_asset_id_fails(self) -> None:
+        loaded, parser, notes = layout_validator.load_layout(FIXTURES / "invalid_duplicate_asset_id.layout.yaml")
+        summary = layout_validator.validate_layout(loaded, FIXTURES / "invalid_duplicate_asset_id.layout.yaml", parser, notes)
+        self.assertFalse(summary.ok)
+
+    def test_missing_pose_fails(self) -> None:
+        loaded, parser, notes = layout_validator.load_layout(FIXTURES / "invalid_missing_pose.layout.yaml")
+        summary = layout_validator.validate_layout(loaded, FIXTURES / "invalid_missing_pose.layout.yaml", parser, notes)
+        self.assertFalse(summary.ok)
+
+    def test_invalid_bounds_fail(self) -> None:
+        loaded, parser, notes = layout_validator.load_layout(FIXTURES / "invalid_bounds.layout.yaml")
+        summary = layout_validator.validate_layout(loaded, FIXTURES / "invalid_bounds.layout.yaml", parser, notes)
+        self.assertFalse(summary.ok)
+
+    def test_package_uri_accepted(self) -> None:
+        loaded, parser, notes = layout_validator.load_layout(FIXTURES / "ur5_conveyor_sorting_existing_assets.layout.yaml")
+        summary = layout_validator.validate_layout(loaded, FIXTURES / "ur5_conveyor_sorting_existing_assets.layout.yaml", parser, notes)
+        self.assertTrue(summary.ok)
+
+    def test_repo_relative_missing_path_warn_default_and_fail_strict(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "missing_path.layout.yaml"
+            path.write_text(
+                "schema_version: environment_layout/v1\n"
+                "layout_id: missing_path\n"
+                "assets:\n"
+                "  - id: missing\n"
+                "    source:\n"
+                "      path: assets/environment/does_not_exist.stl\n"
+                "    type: table\n"
+                "    pose:\n"
+                "      frame: world\n"
+                "      xyz: [0.0, 0.0, 0.0]\n"
+                "      rpy: [0.0, 0.0, 0.0]\n"
+                "zones: []\n",
+                encoding="utf-8",
+            )
+            loaded, parser, notes = layout_validator.load_layout(path)
+            warn_summary = layout_validator.validate_layout(loaded, path, parser, notes, strict=False)
+            strict_summary = layout_validator.validate_layout(loaded, path, parser, notes, strict=True)
+            self.assertTrue(warn_summary.ok)
+            self.assertTrue(warn_summary.warnings)
+            self.assertFalse(strict_summary.ok)
+
+    def test_unknown_asset_ref_warn_default_fail_strict(self) -> None:
+        loaded, parser, notes = layout_validator.load_layout(FIXTURES / "unknown_asset_ref_warn.layout.yaml")
+        warn_summary = layout_validator.validate_layout(loaded, FIXTURES / "unknown_asset_ref_warn.layout.yaml", parser, notes, strict=False)
+        strict_summary = layout_validator.validate_layout(loaded, FIXTURES / "unknown_asset_ref_warn.layout.yaml", parser, notes, strict=True)
+        self.assertTrue(warn_summary.ok)
+        self.assertTrue(warn_summary.warnings)
+        self.assertFalse(strict_summary.ok)
+
+    def test_cell_definition_with_layout_validates(self) -> None:
+        fixture = REPO_ROOT / "tests" / "fixtures" / "cell_definition_pick_place_with_layout.yaml"
+        loaded, parser, notes = cell_validator.load_yaml(fixture)
+        summary = cell_validator.validate_cell_definition(loaded, fixture, parser, notes)
+        self.assertTrue(summary.ok)
+        self.assertIn("path", summary.environment_layout_summary)
+
+    def test_generated_manifests_preserve_environment_layout_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(project_gen),
+                    "--cell-definition",
+                    str(REPO_ROOT / "tests" / "fixtures" / "cell_definition_pick_place_with_layout.yaml"),
+                    "--output-dir",
+                    tmpdir,
+                    "--force",
+                    "--quiet",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            manifest_path = Path(tmpdir) / "ur5_pick_place_layout" / "project_manifest.json"
+            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertIn("environment_layout", payload)
+            self.assertTrue(payload["environment_layout"])
+
+    def test_existing_cell_without_layout_still_passes(self) -> None:
+        fixture = REPO_ROOT / "tests" / "fixtures" / "cell_definition_pick_place.yaml"
+        loaded, parser, notes = cell_validator.load_yaml(fixture)
+        summary = cell_validator.validate_cell_definition(loaded, fixture, parser, notes)
+        self.assertTrue(summary.ok)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide a lightweight, offline placement layer and tooling so environment layouts can reference existing repo assets without duplicating or moving meshes/models. 
- Make it easy to inventory the existing asset surface and to validate/export environment layout metadata for future GUI/import-export workflows while keeping runtime behaviour unchanged. 

### Description

- Introduce an asset inventory tool `scripts/inspect_asset_inventory.py` that scans the repo for meshes, URDF/xacro, scene YAMLs, and package roots and emits `reports/asset_inventory.md` and `reports/asset_inventory.json`.
- Add optional asset-sidecar metadata `assets/asset_manifest.yaml` containing reusable asset IDs and preferred mesh URIs (metadata only; no assets moved/renamed).
- Implement `environment_layout/v1` placement schema docs `docs/manuals/ENVIRONMENT_LAYOUT_V1.md` plus a validator `scripts/validate_environment_layout.py` and preview generator `scripts/generate_environment_preview.py` that produce `reports/environment_layout_preview.md`.
- Integrate optional `environment.layout` into `cell_definition/v1` validation and scene/project generation so layouts are validated (WARN by default, FAIL with `--strict`) and project manifests preserve `environment_layout` metadata, and add fixtures, tests, and a batch checker `scripts/check_environment_layouts.sh` integrated into `scripts/preflight_workcell.sh`.

### Testing

- Compiled the new/updated scripts with `python3 -m py_compile` (success).
- Ran unit tests: `python3 -m unittest tests/test_environment_layout_tools.py`, `tests/test_cell_definition_tools.py`, `tests/test_cell_capability_integration.py`, and `tests/test_workcell_project_tools.py`, all of which passed (OK).
- Executed `./scripts/check_environment_layouts.sh` which completed and reported a WARN summary for the expected unresolved-asset-ref fixture (PASS=12 WARN=1 FAIL=0).
- Ran full preflight (`./scripts/preflight_workcell.sh`) in this container where ROS discovery is unavailable, producing expected WARN/SKIP for runtime-discovery-dependent checks while the new environment-layout stage executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07ac365e4833195293274903916f2)