### PR TITLE
Add offline task_recipe/v1 schema, validator, generator, fixtures, and cell_definition integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This package was tested with [easy_perception_deployment](https://github.com/ros
 
 - Operator + commissioning manual: `docs/manuals/WORKCELL_OPERATOR_MANUAL.md`
 - Industrial capability contracts manual: `docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md`
+- Task recipe schema manual: `docs/manuals/TASK_RECIPE_V1.md`
 - Workcell project dashboard manual: `docs/manuals/WORKCELL_PROJECT_DASHBOARD.md`
 - Validation-only preflight helper:
 
@@ -97,7 +98,7 @@ Reference: `docs/manuals/CELL_DEFINITION_V1.md`
 
 ### Task recipes
 
-`task_recipe` metadata in `scene_manifest.yaml` / `workcell.yaml` describes what the workcell is trying to do (job intent), not only how to pick/place.
+`task_recipe/v1` metadata describes what the workcell is trying to do (job intent), not only how to pick/place.
 
 Examples include:
 
@@ -110,6 +111,8 @@ Examples include:
 - binning
 
 Current scope includes contract validation/reporting plus an offline dry-run resolver. Runtime execution remains backward compatible and existing launch behavior is unchanged.
+
+Future GUI direction: users should be able to pick task logic profiles like `sort_by_colour`, `sort_by_shape`, or `garbage_sorting`, then generate offline-validated artifacts before runtime integration.
 
 ### Offline task recipe dry-run
 

--- a/docs/manuals/SCENE_CREATION_WORKFLOW.md
+++ b/docs/manuals/SCENE_CREATION_WORKFLOW.md
@@ -33,6 +33,7 @@ This manual documents the **current intended flow** for creating/importing/editi
 
 - `environment_layout/v1`: placement/zones checklist metadata for operators.
 - `cell_definition/v1`: high-level cell intent (robot/tool/sensor/task).
+- `task_recipe/v1`: offline task logic intent (`pick_place`, `sort_by_colour`, `garbage_sorting`, etc.).
 - Scene package (`scenes/<name>`): concrete files used by existing workflow and validation.
 
 ## Helper commands

--- a/docs/manuals/TASK_RECIPE_V1.md
+++ b/docs/manuals/TASK_RECIPE_V1.md
@@ -1,0 +1,163 @@
+# TASK_RECIPE_V1
+
+`task_recipe/v1` is an **offline schema** describing industrial task intent and decision logic.
+
+It is:
+- not runtime ROS/MoveIt/grasp/perception/controller code,
+- not a replacement for runtime motion execution,
+- a bridge between user task selection and future generated runtime behaviour.
+
+## Supported task types
+
+- `pick_place`
+- `sort_by_colour`
+- `sort_by_shape`
+- `sort_by_class`
+- `garbage_sorting`
+- `inspection_then_place`
+- `custom`
+
+## Required concepts
+
+- source object or perception source
+- object attributes: `colour`, `shape`, `class`, `material`, `confidence`, `inspection_result`
+- destinations with:
+  - `id`
+  - `frame`
+  - `pose_xyz`
+  - `pose_rpy`
+  - `bin` / `type` / `label`
+- decision rules:
+  - attribute equals value
+  - confidence threshold routing (`confidence_below`)
+  - fallback/default rule
+  - reject/unknown destination routing
+
+## Safety boundary
+
+Task recipe metadata does **not** prove:
+- reachability,
+- collision safety,
+- real I/O safety,
+- production commissioning readiness.
+
+Commissioning validation is still required.
+
+## Schema sketch
+
+```yaml
+schema_version: task_recipe/v1
+task:
+  id: colour_sort_task
+  type: sort_by_colour
+  source: detected_object
+  perception_source: overhead_rgbd
+  object_attributes: [colour, shape, class, material, confidence, inspection_result]
+  destinations: []
+  decision_rules: []
+```
+
+## Example A: simple pick and place
+
+```yaml
+schema_version: task_recipe/v1
+task:
+  id: pick_place_demo
+  type: pick_place
+  source: source_part
+  destinations:
+    - id: place_bin
+      frame: world
+      pose_xyz: [0.35, -0.20, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+      bin: place
+  decision_rules:
+    - id: default_place
+      when: {default: true}
+      destination: place_bin
+```
+
+## Example B: sort red/blue/green by colour
+
+```yaml
+schema_version: task_recipe/v1
+task:
+  id: colour_sort_rgb
+  type: sort_by_colour
+  source: detected_object
+  perception_source: overhead_rgbd
+  destinations:
+    - {id: red_bin, frame: world, pose_xyz: [0.30, -0.30, 0.10], pose_rpy: [0, 0, 0], label: red}
+    - {id: blue_bin, frame: world, pose_xyz: [0.30, 0.00, 0.10], pose_rpy: [0, 0, 0], label: blue}
+    - {id: green_bin, frame: world, pose_xyz: [0.30, 0.30, 0.10], pose_rpy: [0, 0, 0], label: green}
+    - {id: unknown_reject_bin, frame: world, pose_xyz: [0.15, 0.00, 0.10], pose_rpy: [0, 0, 0], label: reject}
+  decision_rules:
+    - {id: to_red, when: {attribute: colour, equals: red}, destination: red_bin}
+    - {id: to_blue, when: {attribute: colour, equals: blue}, destination: blue_bin}
+    - {id: to_green, when: {attribute: colour, equals: green}, destination: green_bin}
+    - {id: fallback_reject, when: {default: true}, destination: unknown_reject_bin}
+```
+
+## Example C: sort by shape
+
+```yaml
+schema_version: task_recipe/v1
+task:
+  id: shape_sort
+  type: sort_by_shape
+  source: detected_object
+  destinations:
+    - {id: box_bin, frame: world, pose_xyz: [0.35, -0.20, 0.10], pose_rpy: [0, 0, 0], type: shape}
+    - {id: cylinder_bin, frame: world, pose_xyz: [0.35, 0.20, 0.10], pose_rpy: [0, 0, 0], type: shape}
+    - {id: reject_bin, frame: world, pose_xyz: [0.15, 0.00, 0.10], pose_rpy: [0, 0, 0], label: reject}
+  decision_rules:
+    - {id: to_box, when: {attribute: shape, equals: box}, destination: box_bin}
+    - {id: to_cylinder, when: {attribute: shape, equals: cylinder}, destination: cylinder_bin}
+    - {id: fallback_reject, when: {default: true}, destination: reject_bin}
+```
+
+## Example D: garbage sorting plastic/metal/paper/unknown
+
+```yaml
+schema_version: task_recipe/v1
+task:
+  id: garbage_sort
+  type: garbage_sorting
+  source: waste_item
+  destinations:
+    - {id: plastic_bin, frame: world, pose_xyz: [0.45, -0.30, 0.10], pose_rpy: [0, 0, 0], type: plastic}
+    - {id: metal_bin, frame: world, pose_xyz: [0.45, -0.10, 0.10], pose_rpy: [0, 0, 0], type: metal}
+    - {id: paper_bin, frame: world, pose_xyz: [0.45, 0.10, 0.10], pose_rpy: [0, 0, 0], type: paper}
+    - {id: unknown_reject_bin, frame: world, pose_xyz: [0.45, 0.30, 0.10], pose_rpy: [0, 0, 0], label: reject}
+  decision_rules:
+    - {id: to_plastic, when: {attribute: material, equals: plastic}, destination: plastic_bin}
+    - {id: to_metal, when: {attribute: material, equals: metal}, destination: metal_bin}
+    - {id: to_paper, when: {attribute: material, equals: paper}, destination: paper_bin}
+    - {id: low_confidence_reject, when: {confidence_below: 0.50}, destination: unknown_reject_bin}
+    - {id: fallback_reject, when: {default: true}, destination: unknown_reject_bin}
+```
+
+## Example E: inspection then place pass/fail
+
+```yaml
+schema_version: task_recipe/v1
+task:
+  id: inspect_then_place
+  type: inspection_then_place
+  source: inspected_part
+  destinations:
+    - {id: pass_bin, frame: world, pose_xyz: [0.30, -0.10, 0.10], pose_rpy: [0, 0, 0], label: pass}
+    - {id: fail_bin, frame: world, pose_xyz: [0.30, 0.10, 0.10], pose_rpy: [0, 0, 0], label: fail}
+  decision_rules:
+    - {id: pass_route, when: {attribute: inspection_result, equals: pass}, destination: pass_bin}
+    - {id: fail_route, when: {attribute: inspection_result, equals: fail}, destination: fail_bin}
+    - {id: fallback_fail, when: {default: true}, destination: fail_bin}
+```
+
+## Tools
+
+```bash
+python3 scripts/validate_task_recipe.py tests/fixtures/task_recipes
+python3 scripts/validate_task_recipe.py tests/fixtures/task_recipes --json
+python3 scripts/generate_task_recipe_from_cell_definition.py tests/fixtures/cell_definition_sort_by_colour.yaml --output /tmp/task_recipe.preview.yaml
+```

--- a/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
+++ b/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
@@ -4,6 +4,7 @@ This manual is written for engineers who are comfortable with Linux/ROS 2 but ar
 
 For generated project review dashboards, see `docs/manuals/WORKCELL_PROJECT_DASHBOARD.md`. **The dashboard is a read-only offline project summary. It does not replace the existing GUI and does not control the robot.**
 For offline robot/tool/sensor/task/asset capability contracts, see `docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md`.
+For offline task intent and routing logic, see `docs/manuals/TASK_RECIPE_V1.md`.
 
 ---
 
@@ -137,6 +138,12 @@ Smoke preflight intent:
 - Scene self-test metadata checks are deterministic/offline metadata validation only; they do not launch the robot.
 - Task recipe metadata checks are deterministic/offline contract validation only; they do not launch the robot.
 - Task recipe dry-run checks resolve decision rules against a simulated self-test object and still do not launch the robot.
+
+Layer reminder:
+- `task_recipe/v1` = what the cell should do (task intent/routing),
+- `environment_layout/v1` = where assets are placed,
+- capability contracts = what components can do,
+- scene readiness = whether scene files look sane before runtime.
 
 > Generated scenes from `workcell_builder` must pass this same validation contract before they are treated as runnable scenes.
 

--- a/scripts/check_task_recipes.sh
+++ b/scripts/check_task_recipes.sh
@@ -2,11 +2,77 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPORTER="${SCRIPT_DIR}/generate_task_recipe_report.py"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VALIDATOR="${SCRIPT_DIR}/validate_task_recipe.py"
 
-if [[ ! -x "${REPORTER}" ]]; then
-  echo "ERROR: Missing task recipe reporter at ${REPORTER}" >&2
+if [[ ! -x "${VALIDATOR}" ]]; then
+  echo "ERROR: Missing validator at ${VALIDATOR}" >&2
   exit 2
 fi
 
-"${REPORTER}" --check "$@"
+pass_count=0
+warn_count=0
+fail_count=0
+
+run_expect_pass() {
+  local path="$1"
+  local output
+  set +e
+  output=$(python3 "${VALIDATOR}" "$path" 2>&1)
+  local rc=$?
+  set -e
+  if [[ $rc -eq 0 ]]; then
+    if grep -q "RESULT: WARN\|\"result\": \"WARN\"" <<<"$output"; then
+      warn_count=$((warn_count + 1))
+      echo "WARN (allowed): $path"
+    else
+      pass_count=$((pass_count + 1))
+      echo "PASS: $path"
+    fi
+  else
+    fail_count=$((fail_count + 1))
+    echo "FAIL: unexpected validation failure for $path"
+    echo "$output"
+  fi
+}
+
+run_expect_fail() {
+  local path="$1"
+  local output
+  set +e
+  output=$(python3 "${VALIDATOR}" "$path" 2>&1)
+  local rc=$?
+  set -e
+  if [[ $rc -ne 0 ]]; then
+    pass_count=$((pass_count + 1))
+    echo "PASS (expected failure): $path"
+  else
+    fail_count=$((fail_count + 1))
+    echo "FAIL: expected failure but got pass for $path"
+    echo "$output"
+  fi
+}
+
+FIXTURE_DIR="${REPO_ROOT}/tests/fixtures/task_recipes"
+if [[ -d "${FIXTURE_DIR}" ]]; then
+  while IFS= read -r file; do
+    base="$(basename "$file")"
+    case "$base" in
+      fail_*) run_expect_fail "$file" ;;
+      *) run_expect_pass "$file" ;;
+    esac
+  done < <(find "${FIXTURE_DIR}" -maxdepth 1 -type f \( -name '*.yaml' -o -name '*.yml' \) | sort)
+else
+  echo "SKIP: ${FIXTURE_DIR} not found"
+fi
+
+for optional_dir in "${REPO_ROOT}/examples" "${REPO_ROOT}/docs"; do
+  if [[ -d "$optional_dir" ]]; then
+    while IFS= read -r file; do
+      run_expect_pass "$file"
+    done < <(find "$optional_dir" -type f \( -name '*task_recipe*.yaml' -o -name '*task_recipe*.yml' \) | sort)
+  fi
+done
+
+echo "Task recipe checks: PASS=${pass_count} WARN=${warn_count} FAIL=${fail_count}"
+[[ ${fail_count} -eq 0 ]]

--- a/scripts/create_workcell_project.py
+++ b/scripts/create_workcell_project.py
@@ -125,6 +125,7 @@ def _render_project_readme(
     end_effector = cell_def.get("end_effector", {}) if isinstance(cell_def.get("end_effector"), dict) else {}
     camera = cell_def.get("camera", {}) if isinstance(cell_def.get("camera"), dict) else {}
     task = cell_def.get("task", {}) if isinstance(cell_def.get("task"), dict) else {}
+    task_recipe_meta = _extract_task_recipe_metadata(cell_def)
 
     capability_refs = _extract_capability_refs(cell_def)
 
@@ -137,6 +138,7 @@ def _render_project_readme(
         f"- Source type: `{source_type}` (`{source_ref}`)\n"
         f"- Generated ROS package: `{package_name}`\n"
         f"- Task type: `{task.get('type', '(unknown)')}`\n"
+        f"- Task recipe metadata: `{task_recipe_meta if task_recipe_meta else 'none'}`\n"
         f"- Robot: `{robot.get('model', '(unknown)')}`\n"
         f"- End effector: `{end_effector.get('id', '(unknown)')}`\n"
         f"- Camera: `{camera.get('id', '(unknown)')}`\n"
@@ -219,6 +221,34 @@ def _extract_environment_layout(cell_def: dict[str, Any]) -> dict[str, Any]:
     layout = environment.get("layout")
     if isinstance(layout, str) and layout.strip():
         return {"path": layout, "metadata_only": True}
+    return {}
+
+
+def _extract_task_recipe_metadata(cell_def: dict[str, Any]) -> dict[str, Any]:
+    task = cell_def.get("task", {}) if isinstance(cell_def.get("task"), dict) else {}
+    recipe = task.get("recipe")
+    if isinstance(recipe, str) and recipe.strip():
+        return {"mode": "external", "path": recipe, "type": task.get("type")}
+    if isinstance(recipe, dict):
+        recipe_task = recipe.get("task") if isinstance(recipe.get("task"), dict) else recipe
+        destinations = recipe_task.get("destinations") if isinstance(recipe_task, dict) else []
+        rules = recipe_task.get("decision_rules") if isinstance(recipe_task, dict) else []
+        fallback = False
+        if isinstance(rules, list):
+            fallback = any(
+                isinstance(item, dict)
+                and isinstance(item.get("when"), dict)
+                and (item["when"].get("default") is True or item["when"].get("always") is True)
+                for item in rules
+            )
+        return {
+            "mode": "embedded",
+            "schema_version": recipe.get("schema_version"),
+            "type": recipe_task.get("type") if isinstance(recipe_task, dict) else task.get("type"),
+            "destinations_count": len(destinations) if isinstance(destinations, list) else 0,
+            "rules_count": len(rules) if isinstance(rules, list) else 0,
+            "fallback_present": fallback,
+        }
     return {}
 def _create_from_template(args: argparse.Namespace, cell_yaml_path: Path) -> tuple[int, list[str]]:
     notes: list[str] = []
@@ -617,6 +647,16 @@ def main() -> int:
         "capabilities": _extract_capability_refs(loaded),
         "capability_validation": getattr(summary, "capability_summary", {}),
         "environment_layout": getattr(summary, "environment_layout_summary", {}) or _extract_environment_layout(loaded),
+        "task": {
+            "type": loaded.get("task", {}).get("type") if isinstance(loaded.get("task"), dict) else None,
+            "destinations": len(loaded.get("task", {}).get("destinations", []))
+            if isinstance(loaded.get("task"), dict) and isinstance(loaded.get("task", {}).get("destinations"), list)
+            else 0,
+            "decision_rules": len(loaded.get("task", {}).get("rules", []))
+            if isinstance(loaded.get("task"), dict) and isinstance(loaded.get("task", {}).get("rules"), list)
+            else 0,
+        },
+        "task_recipe": _extract_task_recipe_metadata(loaded),
     }
     _write_text(project_dir / "project_manifest.json", json.dumps(manifest_payload, indent=2, sort_keys=True) + "\n", False, planned_paths)
 

--- a/scripts/generate_scene_from_cell_definition.py
+++ b/scripts/generate_scene_from_cell_definition.py
@@ -178,6 +178,22 @@ def build_scene_manifest(cell_def: dict[str, Any], capability_summary: dict[str,
             "path": environment.get("layout"),
             "metadata_only": True,
         }
+    if isinstance(task, dict) and task.get("recipe") is not None:
+        recipe = task.get("recipe")
+        if isinstance(recipe, str):
+            manifest["task_recipe_metadata"] = {"mode": "external", "path": recipe, "type": task.get("type")}
+        elif isinstance(recipe, dict):
+            recipe_task = recipe.get("task") if isinstance(recipe.get("task"), dict) else recipe
+            rules = recipe_task.get("decision_rules") if isinstance(recipe_task, dict) else []
+            manifest["task_recipe_metadata"] = {
+                "mode": "embedded",
+                "schema_version": recipe.get("schema_version"),
+                "type": recipe_task.get("type") if isinstance(recipe_task, dict) else task.get("type"),
+                "destinations_count": len(recipe_task.get("destinations", []))
+                if isinstance(recipe_task, dict) and isinstance(recipe_task.get("destinations"), list)
+                else 0,
+                "rules_count": len(rules) if isinstance(rules, list) else 0,
+            }
 
     return manifest
 

--- a/scripts/generate_task_recipe_from_cell_definition.py
+++ b/scripts/generate_task_recipe_from_cell_definition.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Generate task_recipe/v1 preview YAML from a cell_definition/v1 file."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import generate_scene_from_cell_definition as scene_generator
+import validate_cell_definition as cell_validator
+import validate_task_recipe as task_validator
+
+
+def _to_v1_task(cell_def: dict[str, Any]) -> dict[str, Any]:
+    task = cell_def.get("task", {}) if isinstance(cell_def.get("task"), dict) else {}
+    task_id = str(task.get("id", "generated_task_recipe"))
+
+    destinations = []
+    for destination in task.get("destinations", []) if isinstance(task.get("destinations"), list) else []:
+        if not isinstance(destination, dict):
+            continue
+        destinations.append(
+            {
+                "id": destination.get("id"),
+                "frame": destination.get("frame", "world"),
+                "pose_xyz": destination.get("pose_xyz", [0.0, 0.0, 0.0]),
+                "pose_rpy": destination.get("pose_rpy", [0.0, 0.0, 0.0]),
+                "type": destination.get("type", "bin"),
+                "label": destination.get("label", destination.get("id", "destination")),
+            }
+        )
+
+    decision_rules = []
+    for rule in task.get("rules", []) if isinstance(task.get("rules"), list) else []:
+        if not isinstance(rule, dict):
+            continue
+        mapped = scene_generator._map_rule(rule)
+        when = mapped.get("when", {}) if isinstance(mapped.get("when"), dict) else {}
+        item = {
+            "id": mapped.get("id", "rule"),
+            "when": when,
+            "destination": mapped.get("destination"),
+        }
+        decision_rules.append(item)
+
+    if not any(isinstance(r.get("when"), dict) and (r["when"].get("default") is True or r["when"].get("always") is True) for r in decision_rules):
+        fallback_dest = destinations[-1]["id"] if destinations else "unknown_reject_bin"
+        decision_rules.append(
+            {
+                "id": "auto_fallback",
+                "when": {"default": True},
+                "destination": fallback_dest,
+            }
+        )
+
+    return {
+        "schema_version": "task_recipe/v1",
+        "task": {
+            "id": task_id,
+            "type": task.get("type", "custom"),
+            "source": task.get("source_object", "detected_object"),
+            "perception_source": "cell_definition",
+            "object_attributes": ["colour", "shape", "class", "material", "confidence", "inspection_result"],
+            "destinations": destinations,
+            "decision_rules": decision_rules,
+            "notes": "Generated preview from cell_definition/v1. Offline metadata only.",
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("cell_definition", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        loaded, parser_name, parser_notes = cell_validator.load_yaml(args.cell_definition)
+    except Exception as exc:
+        print(f"FAIL: Unable to load cell definition: {exc}")
+        return 1
+
+    summary = cell_validator.validate_cell_definition(loaded, args.cell_definition, parser_name, parser_notes, strict=args.strict)
+    if not summary.ok:
+        print("FAIL: Input cell definition failed validation.")
+        return 1
+
+    recipe_doc = _to_v1_task(loaded)
+    task_summary = task_validator.validate_task_recipe_doc(recipe_doc, args.output, "generated", [], strict=args.strict)
+    result = "PASS" if task_summary.ok and not task_summary.warnings else "WARN" if task_summary.ok else "FAIL"
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(scene_generator._to_yaml_text(recipe_doc), encoding="utf-8")
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "result": result,
+                    "output": str(args.output),
+                    "warnings": task_summary.warnings,
+                    "errors": task_summary.errors,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for warning in task_summary.warnings:
+            print(f"WARN: {warning}")
+        for error in task_summary.errors:
+            print(f"FAIL: {error}")
+        print(f"RESULT: {result}")
+        print(f"Wrote: {args.output}")
+
+    return 1 if (result == "FAIL" or (args.strict and result == "WARN")) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_workcell_dashboard.py
+++ b/scripts/generate_workcell_dashboard.py
@@ -127,6 +127,7 @@ def _render_html(manifest: dict[str, Any], project_dir: Path, manifest_path: Pat
     ee = manifest.get("end_effector", {}) if isinstance(manifest.get("end_effector"), dict) else {}
     env = manifest.get("environment", {}) if isinstance(manifest.get("environment"), dict) else {}
     task = manifest.get("task", {}) if isinstance(manifest.get("task"), dict) else {}
+    task_recipe = manifest.get("task_recipe", {}) if isinstance(manifest.get("task_recipe"), dict) else {}
 
     artifact_rows = _rows_from_artifacts(manifest, project_dir, output_dir)
 
@@ -221,7 +222,10 @@ ul {{ margin-top: 0.2rem; }}
 <h2>Task Overview</h2>
 <ul>
 <li>Task type: {_escape(task.get('type', manifest.get('task_type', 'UNKNOWN')))}</li>
-<li>Destinations/rules: {_escape(task.get('destinations') or task.get('decision_rules') or manifest.get('task_rules') or 'UNKNOWN')}</li>
+<li>Destinations: {_escape(task.get('destinations', 'UNKNOWN'))}</li>
+<li>Decision rules: {_escape(task.get('decision_rules', manifest.get('task_rules', 'UNKNOWN')))}</li>
+<li>Task recipe mode/type: {_escape(task_recipe.get('mode', 'none'))} / {_escape(task_recipe.get('type', 'UNKNOWN'))}</li>
+<li>Task recipe fallback: {_escape(task_recipe.get('fallback_present', 'UNKNOWN'))}</li>
 <li>Task recipe preview: <a href=\"{_resolve_link(project_dir, output_dir, str(artifacts.get('task_preview', '#')))[0]}\">{_escape(artifacts.get('task_preview', 'UNKNOWN'))}</a></li>
 <li>Task execution plan: <a href=\"{_resolve_link(project_dir, output_dir, str(artifacts.get('execution_plan_md', '#')))[0]}\">{_escape(artifacts.get('execution_plan_md', 'UNKNOWN'))}</a></li>
 </ul>

--- a/scripts/validate_cell_definition.py
+++ b/scripts/validate_cell_definition.py
@@ -16,6 +16,7 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 from capability_registry import DEFAULT_CAPABILITIES_DIR, load_capability_registry
+import validate_task_recipe as task_recipe_validator
 
 try:  # Optional dependency.
     import yaml as _pyyaml
@@ -453,6 +454,53 @@ def validate_cell_definition(
 
     if task_type in SORTING_TASK_TYPES and not fallback_present:
         result.warnings.append("Sorting task has no explicit fallback rule with when.always=true.")
+
+    recipe_ref = task.get("recipe")
+    if recipe_ref is not None:
+        if isinstance(recipe_ref, str):
+            if not recipe_ref.strip():
+                result.errors.append("task.recipe must be a non-empty path string when provided.")
+            else:
+                recipe_path = (path.parent / recipe_ref).resolve()
+                if not recipe_path.exists():
+                    (result.errors if strict else result.warnings).append(
+                        f"task.recipe path not found: {recipe_ref}"
+                    )
+                else:
+                    try:
+                        recipe_loaded, recipe_parser, recipe_notes = load_yaml(recipe_path)
+                        recipe_summary = task_recipe_validator.validate_task_recipe_doc(
+                            recipe_loaded,
+                            recipe_path,
+                            recipe_parser,
+                            recipe_notes,
+                            strict=strict,
+                        )
+                        result.warnings.extend([f"task.recipe: {item}" for item in recipe_summary.warnings])
+                        result.errors.extend([f"task.recipe: {item}" for item in recipe_summary.errors])
+                        result.notes.append(f"task.recipe validated from path: {recipe_ref}")
+                    except Exception as exc:
+                        (result.errors if strict else result.warnings).append(
+                            f"task.recipe validation failed for '{recipe_ref}': {exc}"
+                        )
+        elif isinstance(recipe_ref, dict):
+            try:
+                recipe_summary = task_recipe_validator.validate_task_recipe_doc(
+                    recipe_ref,
+                    path,
+                    parser,
+                    [],
+                    strict=strict,
+                )
+                result.warnings.extend([f"task.recipe: {item}" for item in recipe_summary.warnings])
+                result.errors.extend([f"task.recipe: {item}" for item in recipe_summary.errors])
+                result.notes.append("task.recipe validated from embedded mapping.")
+            except Exception as exc:
+                (result.errors if strict else result.warnings).append(
+                    f"task.recipe embedded validation failed: {exc}"
+                )
+        else:
+            result.errors.append("task.recipe must be either a string path or an embedded mapping.")
 
     layout_path_value = environment.get("layout")
     if layout_path_value is not None:

--- a/scripts/validate_task_recipe.py
+++ b/scripts/validate_task_recipe.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Validate offline task_recipe/v1 YAML files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+try:
+    import yaml as _pyyaml
+except Exception:  # pragma: no cover
+    _pyyaml = None
+
+SUPPORTED_TASK_TYPES = {
+    "pick_place",
+    "sort_by_colour",
+    "sort_by_shape",
+    "sort_by_class",
+    "garbage_sorting",
+    "inspection_then_place",
+    "custom",
+}
+SORTING_TYPES = {"sort_by_colour", "sort_by_shape", "sort_by_class", "garbage_sorting"}
+
+
+@dataclass
+class RecipeSummary:
+    path: Path
+    parser: str
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _as_task_doc(raw: dict[str, Any]) -> dict[str, Any]:
+    if isinstance(raw.get("task"), dict):
+        return raw
+    if raw.get("schema_version") == "task_recipe/v1":
+        return {"schema_version": raw.get("schema_version"), "task": {k: v for k, v in raw.items() if k != "schema_version"}}
+    return raw
+
+
+def _is_num_list(value: Any, n: int | None = None) -> bool:
+    return isinstance(value, list) and (n is None or len(value) == n) and all(isinstance(v, (int, float)) for v in value)
+
+
+def _is_reject_like(destination: dict[str, Any]) -> bool:
+    text = " ".join(
+        str(destination.get(key, ""))
+        for key in ("id", "bin", "type", "label")
+    ).lower()
+    return "reject" in text or "unknown" in text
+
+
+def validate_task_recipe_doc(data: dict[str, Any], path: Path, parser: str, notes: list[str], strict: bool = False) -> RecipeSummary:
+    summary = RecipeSummary(path=path, parser=parser, notes=list(notes))
+    doc = _as_task_doc(data)
+
+    if doc.get("schema_version") != "task_recipe/v1":
+        summary.errors.append("schema_version must be exactly 'task_recipe/v1'.")
+
+    task = doc.get("task") if isinstance(doc.get("task"), dict) else {}
+    task_id = task.get("id")
+    if not isinstance(task_id, str) or not task_id.strip():
+        summary.errors.append("task.id must be a non-empty string.")
+
+    task_type = task.get("type")
+    if not isinstance(task_type, str) or not task_type.strip():
+        summary.errors.append("task.type must be a non-empty string.")
+        task_type = ""
+    elif task_type not in SUPPORTED_TASK_TYPES:
+        summary.errors.append(f"task.type '{task_type}' is unsupported for task_recipe/v1.")
+
+    if not any(isinstance(task.get(key), str) and str(task.get(key)).strip() for key in ("source", "source_object", "perception_source")):
+        summary.errors.append("task must declare a source via task.source, task.source_object, or task.perception_source.")
+
+    destinations = task.get("destinations")
+    if not isinstance(destinations, list) or not destinations:
+        summary.errors.append("task.destinations must be a non-empty list.")
+        destinations = []
+
+    destination_ids: set[str] = set()
+    duplicate_ids: set[str] = set()
+    all_zero = True
+    reject_like_present = False
+
+    for idx, dest in enumerate(destinations):
+        if not isinstance(dest, dict):
+            summary.errors.append(f"task.destinations[{idx}] must be a mapping.")
+            continue
+        dest_id = dest.get("id")
+        if not isinstance(dest_id, str) or not dest_id.strip():
+            summary.errors.append(f"task.destinations[{idx}].id must be a non-empty string.")
+        else:
+            if dest_id in destination_ids:
+                duplicate_ids.add(dest_id)
+            destination_ids.add(dest_id)
+
+        if not isinstance(dest.get("frame"), str) or not dest.get("frame", "").strip():
+            summary.errors.append(f"task.destinations[{idx}].frame must be a non-empty string.")
+        if not _is_num_list(dest.get("pose_xyz"), 3):
+            summary.errors.append(f"task.destinations[{idx}].pose_xyz must be numeric list length 3.")
+        else:
+            if any(float(v) != 0.0 for v in dest["pose_xyz"]):
+                all_zero = False
+        if "pose_rpy" in dest and not _is_num_list(dest.get("pose_rpy"), 3):
+            summary.errors.append(f"task.destinations[{idx}].pose_rpy must be numeric list length 3 when provided.")
+
+        reject_like_present = reject_like_present or _is_reject_like(dest)
+
+    for duplicate in sorted(duplicate_ids):
+        summary.errors.append(f"task.destinations contains duplicate destination id '{duplicate}'.")
+
+    rules = task.get("decision_rules")
+    if not isinstance(rules, list) or not rules:
+        summary.errors.append("task.decision_rules must be a non-empty list.")
+        rules = []
+
+    fallback_present = False
+    for idx, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            summary.errors.append(f"task.decision_rules[{idx}] must be a mapping.")
+            continue
+        rule_dest = rule.get("destination")
+        if not isinstance(rule_dest, str) or not rule_dest.strip():
+            summary.errors.append(f"task.decision_rules[{idx}].destination must be a non-empty string.")
+        elif rule_dest not in destination_ids:
+            summary.errors.append(f"task.decision_rules[{idx}] destination '{rule_dest}' does not exist in task.destinations.")
+
+        when = rule.get("when") if isinstance(rule.get("when"), dict) else {}
+        if when.get("default") is True or when.get("always") is True or rule.get("fallback") is True:
+            fallback_present = True
+
+        has_condition = False
+        if isinstance(when.get("attribute"), str):
+            has_condition = True
+            if "equals" not in when:
+                summary.errors.append(f"task.decision_rules[{idx}].when.equals is required when when.attribute is set.")
+        if "confidence_below" in when:
+            has_condition = True
+            threshold = when.get("confidence_below")
+            if not isinstance(threshold, (int, float)) or float(threshold) < 0.0 or float(threshold) > 1.0:
+                summary.errors.append(
+                    f"task.decision_rules[{idx}].when.confidence_below must be numeric and between 0.0 and 1.0."
+                )
+        if not has_condition and not (when.get("default") is True or when.get("always") is True):
+            summary.errors.append(f"task.decision_rules[{idx}].when must declare attribute/equals, confidence_below, or default.")
+
+    if not fallback_present:
+        (summary.errors if strict else summary.warnings).append("Task recipe has no explicit fallback/default decision rule.")
+
+    if task_type in SORTING_TYPES and not reject_like_present:
+        (summary.errors if strict else summary.warnings).append(
+            "Sorting/classification task has no reject/unknown destination metadata."
+        )
+
+    if destinations and all_zero:
+        summary.warnings.append("All task destination pose_xyz values are [0, 0, 0]; verify placement poses.")
+
+    if task_type == "custom":
+        if not any(isinstance(task.get(k), str) and task.get(k).strip() for k in ("notes", "handler_hint")):
+            summary.warnings.append("Custom task recipe should include task.notes or task.handler_hint for downstream tooling.")
+
+    return summary
+
+
+def validate_path(path: Path, strict: bool = False) -> RecipeSummary:
+    notes: list[str] = []
+    text = path.read_text(encoding="utf-8")
+    if _pyyaml is not None:
+        loaded = _pyyaml.safe_load(text) or {}
+        parser = "pyyaml"
+    else:
+        import validate_cell_definition as cell_yaml
+
+        notes.append("PyYAML unavailable; using fallback parser with limited YAML support.")
+        loaded = cell_yaml.parse_cell_definition_yaml(text)
+        parser = "fallback"
+    return validate_task_recipe_doc(loaded, path, parser, notes, strict=strict)
+
+
+def _discover_recipe_files(root: Path) -> list[Path]:
+    if root.is_file():
+        return [root]
+    if not root.is_dir():
+        raise FileNotFoundError(f"Path not found: {root}")
+    return sorted([p for p in root.rglob("*") if p.is_file() and p.suffix.lower() in {".yaml", ".yml"}])
+
+
+def _result(summary: RecipeSummary) -> str:
+    return "PASS" if summary.ok and not summary.warnings else "WARN" if summary.ok else "FAIL"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, help="Task recipe YAML file or directory")
+    parser.add_argument("--strict", action="store_true", help="Treat warnings as failures")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable output")
+    parser.add_argument("--quiet", action="store_true", help="Suppress detailed output")
+    args = parser.parse_args(argv)
+
+    try:
+        files = _discover_recipe_files(args.path)
+    except Exception as exc:
+        if args.json:
+            print(json.dumps({"result": "FAIL", "error": str(exc)}, indent=2))
+        else:
+            print(f"FAIL: {exc}")
+        return 2
+
+    summaries: list[RecipeSummary] = []
+    for file_path in files:
+        try:
+            summaries.append(validate_path(file_path, strict=args.strict))
+        except Exception as exc:
+            summaries.append(RecipeSummary(path=file_path, parser="unknown", errors=[f"Malformed YAML: {exc}"]))
+
+    blocking_fail = False
+    payload_rows = []
+
+    for summary in summaries:
+        result = _result(summary)
+        strict_fail = args.strict and result == "WARN"
+        if result == "FAIL" or strict_fail:
+            blocking_fail = True
+        payload_rows.append(
+            {
+                "path": str(summary.path),
+                "parser": summary.parser,
+                "result": "FAIL" if strict_fail else result,
+                "errors": summary.errors,
+                "warnings": summary.warnings,
+                "notes": summary.notes,
+            }
+        )
+        if not args.json and not args.quiet:
+            print(f"Task recipe: {summary.path}")
+            print(f"Parser: {summary.parser}")
+            for note in summary.notes:
+                print(f"NOTE: {note}")
+            for warning in summary.warnings:
+                print(f"WARN: {warning}")
+            for error in summary.errors:
+                print(f"FAIL: {error}")
+            print(f"RESULT: {'FAIL' if strict_fail else result}")
+
+    overall = "FAIL" if blocking_fail else ("WARN" if any(row["result"] == "WARN" for row in payload_rows) else "PASS")
+    if args.json:
+        print(json.dumps({"result": overall, "files": payload_rows}, indent=2, sort_keys=True))
+    elif not args.quiet:
+        print(f"SUMMARY: {overall} (files={len(payload_rows)})")
+
+    return 1 if blocking_fail else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/task_recipes/fail_bad_schema.yaml
+++ b/tests/fixtures/task_recipes/fail_bad_schema.yaml
@@ -1,0 +1,15 @@
+schema_version: task_recipe/v0
+task:
+  id: bad_schema
+  type: pick_place
+  source: source_part
+  destinations:
+    - id: place_bin
+      frame: world
+      pose_xyz: [0.3, 0.0, 0.1]
+      pose_rpy: [0, 0, 0]
+  decision_rules:
+    - id: fallback
+      when:
+        default: true
+      destination: place_bin

--- a/tests/fixtures/task_recipes/fail_missing_destination.yaml
+++ b/tests/fixtures/task_recipes/fail_missing_destination.yaml
@@ -1,0 +1,11 @@
+schema_version: task_recipe/v1
+task:
+  id: fail_missing_destination
+  type: pick_place
+  source: source_part
+  destinations: []
+  decision_rules:
+    - id: fallback
+      when:
+        default: true
+      destination: place_bin

--- a/tests/fixtures/task_recipes/fail_rule_unknown_destination.yaml
+++ b/tests/fixtures/task_recipes/fail_rule_unknown_destination.yaml
@@ -1,0 +1,25 @@
+schema_version: task_recipe/v1
+task:
+  id: fail_unknown_dest
+  type: sort_by_class
+  source: detected_object
+  destinations:
+    - id: class_a_bin
+      frame: world
+      pose_xyz: [0.3, -0.1, 0.1]
+      pose_rpy: [0, 0, 0]
+    - id: unknown_reject_bin
+      frame: world
+      pose_xyz: [0.2, 0.0, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: reject
+  decision_rules:
+    - id: class_a
+      when:
+        attribute: class
+        equals: class_a
+      destination: class_a_bin
+    - id: fallback
+      when:
+        default: true
+      destination: ghost_bin

--- a/tests/fixtures/task_recipes/valid_garbage_sorting.yaml
+++ b/tests/fixtures/task_recipes/valid_garbage_sorting.yaml
@@ -1,0 +1,50 @@
+schema_version: task_recipe/v1
+task:
+  id: garbage_sort
+  type: garbage_sorting
+  source: waste_item
+  destinations:
+    - id: plastic_bin
+      frame: world
+      pose_xyz: [0.4, -0.3, 0.1]
+      pose_rpy: [0, 0, 0]
+      type: plastic
+    - id: metal_bin
+      frame: world
+      pose_xyz: [0.4, -0.1, 0.1]
+      pose_rpy: [0, 0, 0]
+      type: metal
+    - id: paper_bin
+      frame: world
+      pose_xyz: [0.4, 0.1, 0.1]
+      pose_rpy: [0, 0, 0]
+      type: paper
+    - id: unknown_reject_bin
+      frame: world
+      pose_xyz: [0.4, 0.3, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: reject
+  decision_rules:
+    - id: plastic
+      when:
+        attribute: material
+        equals: plastic
+      destination: plastic_bin
+    - id: metal
+      when:
+        attribute: material
+        equals: metal
+      destination: metal_bin
+    - id: paper
+      when:
+        attribute: material
+        equals: paper
+      destination: paper_bin
+    - id: low_confidence
+      when:
+        confidence_below: 0.5
+      destination: unknown_reject_bin
+    - id: fallback
+      when:
+        default: true
+      destination: unknown_reject_bin

--- a/tests/fixtures/task_recipes/valid_inspection_then_place.yaml
+++ b/tests/fixtures/task_recipes/valid_inspection_then_place.yaml
@@ -1,0 +1,31 @@
+schema_version: task_recipe/v1
+task:
+  id: inspection_route
+  type: inspection_then_place
+  source: inspected_part
+  destinations:
+    - id: pass_bin
+      frame: world
+      pose_xyz: [0.3, -0.1, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: pass
+    - id: fail_bin
+      frame: world
+      pose_xyz: [0.3, 0.1, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: fail
+  decision_rules:
+    - id: pass
+      when:
+        attribute: inspection_result
+        equals: pass
+      destination: pass_bin
+    - id: fail
+      when:
+        attribute: inspection_result
+        equals: fail
+      destination: fail_bin
+    - id: fallback
+      when:
+        default: true
+      destination: fail_bin

--- a/tests/fixtures/task_recipes/valid_pick_place.yaml
+++ b/tests/fixtures/task_recipes/valid_pick_place.yaml
@@ -1,0 +1,16 @@
+schema_version: task_recipe/v1
+task:
+  id: pick_place_demo
+  type: pick_place
+  source: source_part
+  destinations:
+    - id: place_bin
+      frame: world
+      pose_xyz: [0.35, -0.2, 0.1]
+      pose_rpy: [0.0, 0.0, 0.0]
+      label: place
+  decision_rules:
+    - id: default_place
+      when:
+        default: true
+      destination: place_bin

--- a/tests/fixtures/task_recipes/valid_sort_by_colour.yaml
+++ b/tests/fixtures/task_recipes/valid_sort_by_colour.yaml
@@ -1,0 +1,47 @@
+schema_version: task_recipe/v1
+task:
+  id: colour_sort
+  type: sort_by_colour
+  source: detected_object
+  perception_source: overhead_rgbd
+  destinations:
+    - id: red_bin
+      frame: world
+      pose_xyz: [0.3, -0.2, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: red
+    - id: blue_bin
+      frame: world
+      pose_xyz: [0.3, 0.0, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: blue
+    - id: green_bin
+      frame: world
+      pose_xyz: [0.3, 0.2, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: green
+    - id: unknown_reject_bin
+      frame: world
+      pose_xyz: [0.2, 0.0, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: reject
+  decision_rules:
+    - id: red
+      when:
+        attribute: colour
+        equals: red
+      destination: red_bin
+    - id: blue
+      when:
+        attribute: colour
+        equals: blue
+      destination: blue_bin
+    - id: green
+      when:
+        attribute: colour
+        equals: green
+      destination: green_bin
+    - id: fallback
+      when:
+        default: true
+      destination: unknown_reject_bin

--- a/tests/fixtures/task_recipes/valid_sort_by_shape.yaml
+++ b/tests/fixtures/task_recipes/valid_sort_by_shape.yaml
@@ -1,0 +1,34 @@
+schema_version: task_recipe/v1
+task:
+  id: shape_sort
+  type: sort_by_shape
+  source: detected_object
+  destinations:
+    - id: box_bin
+      frame: world
+      pose_xyz: [0.35, -0.2, 0.1]
+      pose_rpy: [0, 0, 0]
+    - id: cylinder_bin
+      frame: world
+      pose_xyz: [0.35, 0.2, 0.1]
+      pose_rpy: [0, 0, 0]
+    - id: reject_bin
+      frame: world
+      pose_xyz: [0.2, 0.0, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: reject
+  decision_rules:
+    - id: box
+      when:
+        attribute: shape
+        equals: box
+      destination: box_bin
+    - id: cyl
+      when:
+        attribute: shape
+        equals: cylinder
+      destination: cylinder_bin
+    - id: fallback
+      when:
+        default: true
+      destination: reject_bin

--- a/tests/fixtures/task_recipes/warn_missing_fallback.yaml
+++ b/tests/fixtures/task_recipes/warn_missing_fallback.yaml
@@ -1,0 +1,21 @@
+schema_version: task_recipe/v1
+task:
+  id: warn_missing_fallback
+  type: sort_by_colour
+  source: detected_object
+  destinations:
+    - id: red_bin
+      frame: world
+      pose_xyz: [0.3, -0.1, 0.1]
+      pose_rpy: [0, 0, 0]
+    - id: reject_bin
+      frame: world
+      pose_xyz: [0.2, 0.0, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: reject
+  decision_rules:
+    - id: red
+      when:
+        attribute: colour
+        equals: red
+      destination: red_bin

--- a/tests/fixtures/task_recipes/warn_missing_reject_destination.yaml
+++ b/tests/fixtures/task_recipes/warn_missing_reject_destination.yaml
@@ -1,0 +1,29 @@
+schema_version: task_recipe/v1
+task:
+  id: warn_missing_reject
+  type: sort_by_shape
+  source: detected_object
+  destinations:
+    - id: box_bin
+      frame: world
+      pose_xyz: [0.35, -0.2, 0.1]
+      pose_rpy: [0, 0, 0]
+    - id: cylinder_bin
+      frame: world
+      pose_xyz: [0.35, 0.2, 0.1]
+      pose_rpy: [0, 0, 0]
+  decision_rules:
+    - id: box
+      when:
+        attribute: shape
+        equals: box
+      destination: box_bin
+    - id: cyl
+      when:
+        attribute: shape
+        equals: cylinder
+      destination: cylinder_bin
+    - id: fallback
+      when:
+        default: true
+      destination: cylinder_bin

--- a/tests/test_task_recipe_tools.py
+++ b/tests/test_task_recipe_tools.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = REPO_ROOT / "tests" / "fixtures"
+TASK_FIXTURES = FIXTURES / "task_recipes"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+task_validator = _load("validate_task_recipe_mod", REPO_ROOT / "scripts" / "validate_task_recipe.py")
+cell_validator = _load("validate_cell_definition_with_recipe", REPO_ROOT / "scripts" / "validate_cell_definition.py")
+generator = REPO_ROOT / "scripts" / "generate_task_recipe_from_cell_definition.py"
+
+
+class TaskRecipeValidatorTests(unittest.TestCase):
+    def test_valid_fixtures_pass(self) -> None:
+        for name in [
+            "valid_pick_place.yaml",
+            "valid_sort_by_colour.yaml",
+            "valid_sort_by_shape.yaml",
+            "valid_garbage_sorting.yaml",
+            "valid_inspection_then_place.yaml",
+        ]:
+            summary = task_validator.validate_path(TASK_FIXTURES / name)
+            self.assertTrue(summary.ok, msg=name)
+
+    def test_fail_fixtures_fail(self) -> None:
+        for name in ["fail_missing_destination.yaml", "fail_bad_schema.yaml", "fail_rule_unknown_destination.yaml"]:
+            summary = task_validator.validate_path(TASK_FIXTURES / name)
+            self.assertFalse(summary.ok, msg=name)
+
+    def test_warning_fixtures_warn(self) -> None:
+        for name in ["warn_missing_fallback.yaml", "warn_missing_reject_destination.yaml"]:
+            summary = task_validator.validate_path(TASK_FIXTURES / name)
+            self.assertTrue(summary.ok, msg=name)
+            self.assertTrue(summary.warnings)
+
+    def test_strict_converts_warning_to_fail(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(REPO_ROOT / "scripts" / "validate_task_recipe.py"), str(TASK_FIXTURES / "warn_missing_fallback.yaml"), "--strict"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+
+    def test_json_output_is_valid(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(REPO_ROOT / "scripts" / "validate_task_recipe.py"), str(TASK_FIXTURES / "valid_pick_place.yaml"), "--json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        payload = json.loads(proc.stdout)
+        self.assertIn("result", payload)
+        self.assertIn("files", payload)
+
+    def test_directory_validation_works(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(REPO_ROOT / "scripts" / "validate_task_recipe.py"), str(TASK_FIXTURES), "--json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        payload = json.loads(proc.stdout)
+        self.assertEqual(len(payload["files"]), 10)
+
+
+class TaskRecipeGeneratorTests(unittest.TestCase):
+    def test_generator_from_cell_definition_works(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "task_recipe.preview.yaml"
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(generator),
+                    str(FIXTURES / "cell_definition_sort_by_colour.yaml"),
+                    "--output",
+                    str(out),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            self.assertTrue(out.is_file())
+            summary = task_validator.validate_path(out)
+            self.assertTrue(summary.ok)
+
+
+class CellDefinitionRecipeIntegrationTests(unittest.TestCase):
+    def test_backward_compatibility_without_task_recipe(self) -> None:
+        loaded, parser, notes = cell_validator.load_yaml(FIXTURES / "cell_definition_pick_place.yaml")
+        summary = cell_validator.validate_cell_definition(loaded, FIXTURES / "cell_definition_pick_place.yaml", parser, notes)
+        self.assertTrue(summary.ok)
+
+    def test_cell_definition_with_embedded_task_recipe_validates(self) -> None:
+        loaded, parser, notes = cell_validator.load_yaml(FIXTURES / "cell_definition_pick_place.yaml")
+        embedded, _, _ = cell_validator.load_yaml(TASK_FIXTURES / "valid_pick_place.yaml")
+        loaded["task"]["recipe"] = embedded
+        summary = cell_validator.validate_cell_definition(loaded, FIXTURES / "cell_definition_pick_place.yaml", parser, notes)
+        self.assertTrue(summary.ok, msg="\n".join(summary.errors + summary.warnings))
+
+    def test_cell_definition_with_external_task_recipe_validates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            cell_path = tmp / "cell.yaml"
+            recipe_path = tmp / "recipe.yaml"
+            cell_path.write_text((FIXTURES / "cell_definition_sort_by_colour.yaml").read_text(encoding="utf-8"), encoding="utf-8")
+            recipe_path.write_text((TASK_FIXTURES / "valid_sort_by_colour.yaml").read_text(encoding="utf-8"), encoding="utf-8")
+            loaded, parser, notes = cell_validator.load_yaml(cell_path)
+            loaded["task"]["recipe"] = "recipe.yaml"
+            summary = cell_validator.validate_cell_definition(loaded, cell_path, parser, notes)
+            self.assertTrue(summary.ok, msg="\n".join(summary.errors + summary.warnings))
+
+    def test_unknown_destination_in_decision_rule_fails(self) -> None:
+        summary = task_validator.validate_path(TASK_FIXTURES / "fail_rule_unknown_destination.yaml")
+        self.assertFalse(summary.ok)
+        self.assertIn("ghost_bin", " ".join(summary.errors))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide an offline, versioned `task_recipe/v1` layer so generated robotic cells can express task intent and decision logic (pick/place, colour/shape/class sorting, garbage sorting, inspection routing, custom) without touching runtime stacks. 
- Inspected existing tooling and found `scripts/generate_scene_from_cell_definition.py` already emits a preview-style recipe (`build_task_recipe`), `scripts/validate_cell_definition.py` already validates task fields and supports strict warnings, and `create_workcell_project.py` / dashboard generation already produce offline manifests, so the change should extend those offline flows rather than replace them. 
- Constraints preserved: offline-only, no changes to ROS/MoveIt/grasp/perception/controller behaviour, no replacement of `workcell_builder`, and backward compatibility with existing `cell_definition/v1` and capability/environment layers. 

### Description
- Added documentation `docs/manuals/TASK_RECIPE_V1.md` describing schema intent, supported task types, required concepts, safety boundaries, and YAML examples. 
- Implemented validator `scripts/validate_task_recipe.py` with file+directory support, `--json` and `--strict` modes, PASS/WARN/FAIL semantics, validation of schema_version, `task.id`/`task.type`, destinations uniqueness/poses, decision rules (attribute equals, `confidence_below`, fallback/default), reject/unknown destination checks, and warnings-to-fail conversion in strict mode. 
- Added generator `scripts/generate_task_recipe_from_cell_definition.py` to emit a `task_recipe/v1` preview from a `cell_definition/v1`, inferring task type, copying destinations/rules, and auto-adding a fallback rule when missing. 
- Added fixtures under `tests/fixtures/task_recipes/` (valid/warning/fail cases) and tests `tests/test_task_recipe_tools.py` covering validator behavior, strict mode, JSON output, directory validation, generator output, and `cell_definition` integration (embedded and external `task.recipe`). 
- Integrated optional `task.recipe` into `scripts/validate_cell_definition.py` so a cell definition can reference either a path or embedded mapping and have it validated (WARN by default, FAIL in `--strict`), and preserved/published task recipe metadata in generated manifests and the static dashboard. 
- Added offline batch checker `scripts/check_task_recipes.sh` to validate fixtures and optional examples/docs, and updated README/manuals/dashboard text to surface `task_recipe/v1` tooling and boundaries. 

### Testing
- Ran `python3 -m py_compile scripts/validate_task_recipe.py scripts/generate_task_recipe_from_cell_definition.py tests/test_task_recipe_tools.py` with no syntax errors. (success) 
- Ran unit tests `python3 -m unittest tests/test_task_recipe_tools.py`, `tests/test_cell_definition_tools.py`, `tests/test_cell_capability_integration.py`, and `tests/test_workcell_project_tools.py`, and they passed in the final run. (success) 
- Executed batch/checker scripts: `./scripts/check_task_recipes.sh` validated fixtures (expected passes, warns, and expected failures) and returned success, and `./scripts/preflight_workcell.sh` completed offline checks (some runtime discoverability reported as SKIP/WARN because ROS was not sourced, but offline recipe checks and reports were generated). (success for offline stages)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0821c9f188331a99058e3be8d1705)