### PR TITLE
Add offline-first task_recipe adapter that outputs runtime_execution_plan/v1

### DIFF
--- a/scripts/run_task_recipe_adapter.py
+++ b/scripts/run_task_recipe_adapter.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Conservative task_recipe/v1 runtime adapter (offline-first)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import validate_cell_definition as cell_yaml
+import validate_task_recipe as task_validator
+
+SUPPORTED_TYPES = {
+    "pick_place",
+    "sort_by_colour",
+    "sort_by_shape",
+    "sort_by_class",
+    "garbage_sorting",
+    "inspection_then_place",
+}
+
+ROS_BOUNDARY = {
+    "run_grasp_execution": {
+        "topic": "grasp_tasks",
+        "service": "grasp_requests",
+        "source": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp",
+    },
+    "run_grasp_planner": {
+        "note": "Planner runs as scene/topic subscriber; no stable task submission service is inferred by this adapter.",
+        "source": "easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/src/demo_node.cpp",
+    },
+}
+
+
+@dataclass
+class AdapterResult:
+    payload: dict[str, Any]
+    warnings: list[str]
+    errors: list[str]
+
+
+def _load_yaml_or_json(path: Path) -> tuple[dict[str, Any], str, list[str]]:
+    if path.suffix.lower() == ".json":
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        if loaded is None:
+            loaded = {}
+        if not isinstance(loaded, dict):
+            raise ValueError("JSON root must be an object/mapping.")
+        return loaded, "json", []
+    return cell_yaml.load_yaml(path)
+
+
+def _resolve_task_recipe_path(task_recipe: Path | None, project_dir: Path | None) -> tuple[Path, list[str]]:
+    notes: list[str] = []
+    if task_recipe is not None:
+        return task_recipe, notes
+    if project_dir is None:
+        raise ValueError("Either --task-recipe or --project-dir must be provided.")
+
+    manifest_path = project_dir / "project_manifest.json"
+    if manifest_path.is_file():
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        artifacts = payload.get("artifacts") if isinstance(payload.get("artifacts"), dict) else {}
+        for key in ("task_preview", "task_recipe"):
+            rel = artifacts.get(key)
+            if isinstance(rel, str) and rel.strip():
+                candidate = (project_dir / rel).resolve()
+                if candidate.is_file():
+                    notes.append(f"Resolved task recipe from project manifest artifact '{key}'.")
+                    return candidate, notes
+
+    for pattern in (
+        "generated_workcell/*/generated/task_recipe.preview.yaml",
+        "generated_workcell/*/config/task_recipe.yaml",
+    ):
+        matches = sorted(project_dir.glob(pattern))
+        if matches:
+            notes.append(f"Resolved task recipe by pattern '{pattern}'.")
+            return matches[0], notes
+
+    raise FileNotFoundError("Unable to auto-discover task recipe from --project-dir.")
+
+
+def _normalize_objects(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    objects = doc.get("objects") if isinstance(doc.get("objects"), list) else None
+    if objects is None:
+        if isinstance(doc, list):
+            objects = doc
+        else:
+            raise ValueError("Objects input must provide an 'objects' list or be a top-level list.")
+    out: list[dict[str, Any]] = []
+    for idx, obj in enumerate(objects):
+        if not isinstance(obj, dict):
+            raise ValueError(f"objects[{idx}] must be a mapping.")
+        oid = str(obj.get("id", f"object_{idx+1:03d}"))
+        attrs = {
+            "class": obj.get("class") or obj.get("class_id"),
+            "colour": obj.get("colour") or obj.get("color"),
+            "shape": obj.get("shape"),
+            "material": obj.get("material"),
+            "inspection_result": obj.get("inspection_result"),
+        }
+        attrs = {k: v for k, v in attrs.items() if isinstance(v, str) and v.strip()}
+        out.append(
+            {
+                "id": oid,
+                "class_id": obj.get("class_id") or obj.get("class"),
+                "colour": obj.get("colour") or obj.get("color"),
+                "shape": obj.get("shape"),
+                "material": obj.get("material"),
+                "inspection_result": obj.get("inspection_result"),
+                "confidence": float(obj.get("confidence", 1.0)),
+                "frame_id": obj.get("frame_id", "unknown"),
+                "pose": obj.get("pose") if isinstance(obj.get("pose"), dict) else {},
+                "dimensions": obj.get("dimensions") if isinstance(obj.get("dimensions"), list) else [],
+                "attributes": attrs,
+            }
+        )
+    return out
+
+
+def _match_rule(rules: list[dict[str, Any]], attrs: dict[str, Any], confidence: float) -> dict[str, Any] | None:
+    default_rule: dict[str, Any] | None = None
+    for rule in rules:
+        when = rule.get("when") if isinstance(rule.get("when"), dict) else {}
+        if when.get("default") is True or when.get("always") is True or rule.get("fallback") is True:
+            if default_rule is None:
+                default_rule = rule
+            continue
+
+        matched = True
+        if isinstance(when.get("attribute"), str):
+            if attrs.get(when["attribute"]) != when.get("equals"):
+                matched = False
+        if "confidence_below" in when:
+            threshold = float(when["confidence_below"])
+            if not (confidence < threshold):
+                matched = False
+        if matched:
+            return rule
+    return default_rule
+
+
+def _destination_index(recipe_task: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for destination in recipe_task.get("destinations", []):
+        if isinstance(destination, dict) and isinstance(destination.get("id"), str):
+            out[destination["id"]] = destination
+    return out
+
+
+def build_plan(task_recipe: dict[str, Any], objects: list[dict[str, Any]], mode: str, dry_run: bool) -> AdapterResult:
+    warnings: list[str] = []
+    errors: list[str] = []
+
+    task = task_recipe.get("task") if isinstance(task_recipe.get("task"), dict) else {}
+    task_type = str(task.get("type", ""))
+    if task_type not in SUPPORTED_TYPES:
+        warnings.append(f"task.type '{task_type}' is not in adapter guaranteed set; using conservative generic routing.")
+
+    destination_by_id = _destination_index(task)
+    rules = [r for r in task.get("decision_rules", []) if isinstance(r, dict)]
+
+    steps: list[dict[str, Any]] = []
+    for idx, obj in enumerate(objects, start=1):
+        matched_rule = _match_rule(rules, obj["attributes"], float(obj["confidence"]))
+        if not matched_rule:
+            errors.append(f"No decision rule matched object '{obj['id']}'.")
+            continue
+        destination_id = matched_rule.get("destination")
+        destination = destination_by_id.get(destination_id) if isinstance(destination_id, str) else None
+        if destination is None:
+            errors.append(f"Matched destination '{destination_id}' for object '{obj['id']}' is undefined.")
+            continue
+
+        step = {
+            "step_id": f"route_{idx:03d}_{obj['id']}",
+            "task": "pick_route_place",
+            "object": {
+                "id": obj["id"],
+                "class_id": obj.get("class_id"),
+                "colour": obj.get("colour"),
+                "shape": obj.get("shape"),
+                "material": obj.get("material"),
+                "inspection_result": obj.get("inspection_result"),
+                "confidence": obj.get("confidence"),
+                "frame_id": obj.get("frame_id"),
+                "pose": obj.get("pose"),
+                "dimensions": obj.get("dimensions"),
+            },
+            "routing": {
+                "matched_rule_id": str(matched_rule.get("id", f"rule_{idx}")),
+                "destination_id": destination_id,
+                "destination": {
+                    "frame": destination.get("frame"),
+                    "pose_xyz": destination.get("pose_xyz"),
+                    "pose_rpy": destination.get("pose_rpy"),
+                    "label": destination.get("label"),
+                    "action": destination.get("action", "place"),
+                },
+            },
+            "execution": {
+                "mode": mode,
+                "dry_run": dry_run,
+                "planner_adapter": "run_grasp_planner",
+                "execution_adapter": "run_grasp_execution",
+                "runtime_status": "offline_planned" if (mode == "offline" or dry_run) else "runtime_candidate",
+            },
+        }
+        steps.append(step)
+
+    if mode == "ros":
+        warnings.append("ROS mode is a guarded placeholder; no live ROS topics/services are called by this adapter.")
+
+    payload = {
+        "schema_version": "runtime_execution_plan/v1",
+        "metadata": {
+            "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "adapter": "scripts/run_task_recipe_adapter.py",
+            "mode": mode,
+            "dry_run": dry_run,
+        },
+        "task_recipe": {
+            "id": task.get("id"),
+            "type": task_type,
+            "source": task.get("source") or task.get("source_object") or task.get("perception_source"),
+        },
+        "ros_bridge_boundary": ROS_BOUNDARY,
+        "summary": {
+            "object_count": len(objects),
+            "routed_count": len(steps),
+            "unrouted_count": max(0, len(objects) - len(steps)),
+        },
+        "steps": steps,
+        "warnings": warnings,
+        "errors": errors,
+    }
+    return AdapterResult(payload=payload, warnings=warnings, errors=errors)
+
+
+def _emit(payload: dict[str, Any], output: Path | None, as_json: bool) -> None:
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered + "\n", encoding="utf-8")
+    if as_json or output is None:
+        print(rendered)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--task-recipe", type=Path, help="Path to task_recipe/v1 YAML or JSON file.")
+    parser.add_argument("--project-dir", type=Path, help="Optional workcell project directory for recipe auto-discovery.")
+    parser.add_argument("--objects", type=Path, required=True, help="Detected/mock objects input YAML or JSON.")
+    parser.add_argument("--output", type=Path, help="Optional output plan path.")
+    parser.add_argument("--json", action="store_true", help="Print JSON output to stdout.")
+    parser.add_argument("--strict", action="store_true", help="Treat warnings as failures.")
+    parser.add_argument("--dry-run", action=argparse.BooleanOptionalAction, default=True, help="Enable/disable dry-run mode.")
+    parser.add_argument("--mode", choices=["offline", "ros"], default="offline", help="Execution mode; defaults to offline.")
+    args = parser.parse_args(argv)
+
+    notes: list[str] = []
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    try:
+        recipe_path, resolve_notes = _resolve_task_recipe_path(args.task_recipe, args.project_dir)
+        notes.extend(resolve_notes)
+        recipe_loaded, parser_name, parser_notes = _load_yaml_or_json(recipe_path)
+        notes.append(f"Task recipe parser: {parser_name}.")
+        notes.extend(parser_notes)
+
+        summary = task_validator.validate_task_recipe_doc(
+            recipe_loaded,
+            recipe_path,
+            parser_name,
+            parser_notes,
+            strict=args.strict,
+        )
+        errors.extend(summary.errors)
+        warnings.extend(summary.warnings)
+
+        obj_loaded, obj_parser, obj_notes = _load_yaml_or_json(args.objects)
+        notes.append(f"Objects parser: {obj_parser}.")
+        notes.extend(obj_notes)
+        objects = _normalize_objects(obj_loaded)
+
+        result = build_plan(recipe_loaded, objects, mode=args.mode, dry_run=bool(args.dry_run))
+        warnings.extend(result.warnings)
+        errors.extend(result.errors)
+
+        result.payload["metadata"]["task_recipe_path"] = str(recipe_path)
+        result.payload["metadata"]["objects_path"] = str(args.objects)
+        if args.project_dir:
+            result.payload["metadata"]["project_dir"] = str(args.project_dir)
+        result.payload["notes"] = notes
+
+        _emit(result.payload, args.output, args.json)
+
+    except Exception as exc:
+        failure = {
+            "schema_version": "runtime_execution_plan/v1",
+            "result": "FAIL",
+            "error": str(exc),
+        }
+        print(json.dumps(failure, indent=2, sort_keys=True))
+        return 2
+
+    blocking = bool(errors) or (args.strict and bool(warnings))
+    return 1 if blocking else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/runtime_objects/garbage_sorting.yaml
+++ b/tests/fixtures/runtime_objects/garbage_sorting.yaml
@@ -1,0 +1,34 @@
+objects:
+  - id: rec_001
+    class_id: bottle
+    material: plastic
+    colour: clear
+    shape: cylinder
+    confidence: 0.89
+    frame_id: camera_depth_optical_frame
+    pose:
+      xyz: [0.1, -0.1, 0.2]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.03, 0.03, 0.12]
+  - id: gen_001
+    class_id: can
+    material: metal
+    colour: silver
+    shape: cylinder
+    confidence: 0.87
+    frame_id: camera_depth_optical_frame
+    pose:
+      xyz: [0.2, -0.1, 0.2]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.03, 0.03, 0.09]
+  - id: reject_001
+    class_id: unknown
+    material: unknown
+    colour: mixed
+    shape: irregular
+    confidence: 0.41
+    frame_id: camera_depth_optical_frame
+    pose:
+      xyz: [0.3, -0.1, 0.2]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.06, 0.05, 0.02]

--- a/tests/fixtures/runtime_objects/inspection_low_confidence.yaml
+++ b/tests/fixtures/runtime_objects/inspection_low_confidence.yaml
@@ -1,0 +1,12 @@
+objects:
+  - id: inspect_001
+    class_id: part_a
+    inspection_result: fail
+    colour: blue
+    shape: box
+    confidence: 0.38
+    frame_id: camera_depth_optical_frame
+    pose:
+      xyz: [0.18, 0.11, 0.24]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.05, 0.04, 0.02]

--- a/tests/fixtures/runtime_objects/pick_place_single.yaml
+++ b/tests/fixtures/runtime_objects/pick_place_single.yaml
@@ -1,0 +1,11 @@
+objects:
+  - id: obj_001
+    class_id: box
+    colour: red
+    shape: box
+    confidence: 0.92
+    frame_id: camera_depth_optical_frame
+    pose:
+      xyz: [0.1, 0.2, 0.3]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.05, 0.05, 0.05]

--- a/tests/fixtures/runtime_objects/sort_by_colour.yaml
+++ b/tests/fixtures/runtime_objects/sort_by_colour.yaml
@@ -1,0 +1,31 @@
+objects:
+  - id: red_001
+    class_id: part
+    colour: red
+    shape: box
+    confidence: 0.97
+    frame_id: camera_depth_optical_frame
+    pose:
+      xyz: [0.1, 0.1, 0.2]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.04, 0.04, 0.02]
+  - id: blue_001
+    class_id: part
+    colour: blue
+    shape: cylinder
+    confidence: 0.95
+    frame_id: camera_depth_optical_frame
+    pose:
+      xyz: [0.2, 0.1, 0.2]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.03, 0.03, 0.06]
+  - id: green_001
+    class_id: part
+    colour: green
+    shape: sphere
+    confidence: 0.91
+    frame_id: camera_depth_optical_frame
+    pose:
+      xyz: [0.3, 0.1, 0.2]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.03, 0.03, 0.03]

--- a/tests/fixtures/runtime_objects/sort_by_shape.yaml
+++ b/tests/fixtures/runtime_objects/sort_by_shape.yaml
@@ -1,0 +1,31 @@
+objects:
+  - id: box_001
+    class_id: box
+    colour: red
+    shape: box
+    confidence: 0.94
+    frame_id: camera_depth_optical_frame
+    pose:
+      xyz: [0.1, 0.2, 0.25]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.05, 0.05, 0.05]
+  - id: cyl_001
+    class_id: cylinder
+    colour: blue
+    shape: cylinder
+    confidence: 0.96
+    frame_id: camera_depth_optical_frame
+    pose:
+      xyz: [0.2, 0.2, 0.25]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.03, 0.03, 0.07]
+  - id: sphere_001
+    class_id: sphere
+    colour: green
+    shape: sphere
+    confidence: 0.93
+    frame_id: camera_depth_optical_frame
+    pose:
+      xyz: [0.3, 0.2, 0.25]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.04, 0.04, 0.04]

--- a/tests/test_task_recipe_adapter.py
+++ b/tests/test_task_recipe_adapter.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TASK_FIXTURES = REPO_ROOT / "tests" / "fixtures" / "task_recipes"
+OBJECT_FIXTURES = REPO_ROOT / "tests" / "fixtures" / "runtime_objects"
+ADAPTER = REPO_ROOT / "scripts" / "run_task_recipe_adapter.py"
+
+
+class TaskRecipeAdapterTests(unittest.TestCase):
+    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(ADAPTER), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_sort_by_colour_routes_expected_bins(self) -> None:
+        proc = self._run(
+            "--task-recipe",
+            str(TASK_FIXTURES / "valid_sort_by_colour.yaml"),
+            "--objects",
+            str(OBJECT_FIXTURES / "sort_by_colour.yaml"),
+            "--json",
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        payload = json.loads(proc.stdout)
+        self.assertEqual(payload["schema_version"], "runtime_execution_plan/v1")
+        destinations = [step["routing"]["destination_id"] for step in payload["steps"]]
+        self.assertEqual(destinations, ["red_bin", "blue_bin", "green_bin"])
+
+    def test_garbage_low_confidence_routes_to_reject(self) -> None:
+        proc = self._run(
+            "--task-recipe",
+            str(TASK_FIXTURES / "valid_garbage_sorting.yaml"),
+            "--objects",
+            str(OBJECT_FIXTURES / "garbage_sorting.yaml"),
+            "--json",
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        payload = json.loads(proc.stdout)
+        reject = [step for step in payload["steps"] if step["object"]["id"] == "reject_001"][0]
+        self.assertEqual(reject["routing"]["destination_id"], "unknown_reject_bin")
+
+    def test_project_dir_auto_discovers_task_recipe(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir)
+            preview_rel = "generated_workcell/demo/generated/task_recipe.preview.yaml"
+            preview = project / preview_rel
+            preview.parent.mkdir(parents=True, exist_ok=True)
+            preview.write_text((TASK_FIXTURES / "valid_pick_place.yaml").read_text(encoding="utf-8"), encoding="utf-8")
+            manifest = {
+                "schema_version": "workcell_project/v1",
+                "artifacts": {"task_preview": preview_rel},
+            }
+            (project / "project_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+            proc = self._run(
+                "--project-dir",
+                str(project),
+                "--objects",
+                str(OBJECT_FIXTURES / "pick_place_single.yaml"),
+                "--json",
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["task_recipe"]["id"], "pick_place_demo")
+            self.assertEqual(payload["summary"]["routed_count"], 1)
+
+    def test_ros_mode_is_guarded_placeholder(self) -> None:
+        proc = self._run(
+            "--task-recipe",
+            str(TASK_FIXTURES / "valid_pick_place.yaml"),
+            "--objects",
+            str(OBJECT_FIXTURES / "pick_place_single.yaml"),
+            "--mode",
+            "ros",
+            "--json",
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        payload = json.loads(proc.stdout)
+        self.assertTrue(any("guarded placeholder" in warning for warning in payload.get("warnings", [])))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a conservative, reversible adapter that converts `task_recipe/v1` + detected/mock objects into a deterministic `runtime_execution_plan/v1` so downstream grasp planner/execution layers can be fed clear per-object routing steps. 
- Keep the change additive and safe for CI by defaulting to offline/dry-run behaviour and avoiding any live ROS or runtime changes.

### Description
- Add `scripts/run_task_recipe_adapter.py`, an offline-first CLI that accepts `--task-recipe`, `--project-dir` (auto-discover), `--objects`, `--output`, `--json`, `--strict`, `--dry-run` (default true), and `--mode` (defaults to `offline`, guarded `ros` placeholder). The adapter validates task recipes with the existing validator, normalizes object inputs (YAML/JSON), matches decision rules (attribute equals, `confidence_below`, default/fallback), and emits a `runtime_execution_plan/v1` JSON payload with per-object routing and execution metadata. 
- Implemented conservative routing and runtime metadata (including a `ros_bridge_boundary` describing known runtime interfaces such as `grasp_tasks` topic and `grasp_requests` service) while explicitly avoiding any live ROS/topic/service calls in this PR. 
- Implemented task-recipe auto-discovery from a `project_manifest.json` `artifacts` entries and a couple of generated-workcell path patterns when `--project-dir` is provided. 
- Add example/mock object fixtures under `tests/fixtures/runtime_objects/` for pick/place, colour/shape sorting, garbage sorting (including low-confidence reject), and inspection-like inputs, and add `tests/test_task_recipe_adapter.py` with unit tests for deterministic routing, reject routing, project-dir discovery, and guarded ROS-mode behaviour.

### Testing
- Ran `python3 -m unittest tests/test_task_recipe_adapter.py` and all adapter tests passed (OK). 
- Ran `python3 -m unittest tests/test_task_recipe_tools.py` and the existing task-recipe-related tests passed (OK). 
- The adapter is offline-first and does not alter any ROS/MoveIt/perception/launch assets; CI-friendly defaults guarantee no runtime ROS integration is required to run tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0896329d88331b665dbb57500b2f6)