### PR TITLE
Add detected_objects/v1 capture, validation, and perception->task pipeline (D435i/EPD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This package was tested with [easy_perception_deployment](https://github.com/ros
 - Task recipe schema manual: `docs/manuals/TASK_RECIPE_V1.md`
 - Workcell project dashboard manual: `docs/manuals/WORKCELL_PROJECT_DASHBOARD.md`
 - EMD grasp bridge payload manual: `docs/manuals/EMD_GRASP_BRIDGE_PAYLOAD.md`
+- Detected objects snapshot manual: `docs/manuals/DETECTED_OBJECTS_V1.md`
+- Real D435i + EPD pipeline manual: `docs/manuals/REAL_D435I_EPD_PIPELINE.md`
 - Validation-only preflight helper:
 
 ```bash
@@ -165,6 +167,26 @@ python3 scripts/convert_runtime_plan_to_emd_grasp.py   --runtime-plan tests/fixt
 ```
 
 This is offline by default and does not change existing `run_grasp_execution` behavior.
+
+### Real perception bridge (D435i/EPD -> task runtime)
+
+The intended direction is now explicit:
+
+```text
+GUI / workcell definition
+    ↓
+environment + robot + gripper + sensor + task
+    ↓
+D435i/EPD detected objects
+    ↓
+task logic
+    ↓
+validated runtime plan
+    ↓
+existing EMD grasp execution
+```
+
+Operator path uses `detected_objects/v1` snapshots captured from live EPD topics. Mock object fixtures remain for tests/CI only.
 
 ### Workcell commissioning bundles
 

--- a/docs/manuals/DETECTED_OBJECTS_V1.md
+++ b/docs/manuals/DETECTED_OBJECTS_V1.md
@@ -1,0 +1,57 @@
+# DETECTED_OBJECTS_V1
+
+`detected_objects/v1` is the production-facing perception snapshot contract used between D435i/EPD perception and the task recipe adapter.
+
+## Intent
+
+- **Primary path**: live Intel RealSense D435i + EPD localization/tracking output.
+- **Secondary path**: offline replay from saved snapshots.
+- **Test-only path**: mock objects in `tests/fixtures/runtime_objects` (CI/offline tests only).
+
+## Schema (summary)
+
+```yaml
+schema_version: detected_objects/v1
+source:
+  type: epd_localization
+  topic: /easy_perception_deployment/epd_localize_output
+  camera: intel_realsense_d435i
+  frame_id: camera_depth_optical_frame
+  captured_at: 2026-04-28T00:00:00Z
+objects:
+  - object_id: obj_001
+    name: mouse
+    class_id: mouse
+    confidence: 0.92
+    pose:
+      frame_id: camera_depth_optical_frame
+      xyz: [-0.56, 0.09, 0.13]
+      rpy: [0.0, 0.0, 0.0]
+    centroid: {x: -0.56, y: 0.09, z: 0.13}
+    dimensions: {x: 0.08, y: 0.04, z: 0.03}
+    shape: {type: box}
+    attributes: {colour: unknown, shape: box, material: unknown}
+    raw: {source_message_type: epd_msgs/msg/EPDObjectLocalization}
+```
+
+## Validation
+
+```bash
+python3 scripts/validate_detected_objects.py tests/fixtures/detected_objects/valid_epd_single_box.yaml --json
+python3 scripts/validate_detected_objects.py tests/fixtures/detected_objects/missing_dimensions_warn.yaml --json
+python3 scripts/validate_detected_objects.py tests/fixtures/detected_objects/missing_dimensions_warn.yaml --json --strict
+```
+
+Status meanings:
+- `PASS`: valid and usable.
+- `WARN`: usable, but missing/unknown non-blocking fields.
+- `FAIL`: invalid for routing/bridge.
+
+## Adapter usage
+
+```bash
+python3 scripts/run_task_recipe_adapter.py \
+  --task-recipe tests/fixtures/task_recipes/valid_sort_by_colour.yaml \
+  --objects tests/fixtures/detected_objects/valid_epd_colour_sorting.yaml \
+  --json
+```

--- a/docs/manuals/EMD_GRASP_BRIDGE_PAYLOAD.md
+++ b/docs/manuals/EMD_GRASP_BRIDGE_PAYLOAD.md
@@ -5,6 +5,7 @@
 `runtime_execution_plan/v1 -> emd_grasp_bridge_payload/v1` provides a conservative adapter from offline task routing output into an EMD-shaped grasp payload that mirrors the existing `emd_msgs/msg/GraspTask` and `emd_msgs/srv/GraspRequest` interfaces.
 
 It is additive and does **not** replace `run_grasp_execution`.
+It is now paired with `detected_objects/v1` so real D435i/EPD captures can feed the same runtime bridge path.
 
 ## Why it exists
 
@@ -14,6 +15,7 @@ Recent workflow layers produce deterministic offline plans, but `run_grasp_execu
 
 - Input: `runtime_execution_plan/v1`
 - Output contract: `emd_grasp_bridge_payload/v1`
+- Upstream recommended input to runtime plan: `detected_objects/v1`
 - Runtime boundary references:
   - topic: `grasp_tasks` (`emd_msgs/msg/GraspTask`)
   - service: `grasp_requests` (`emd_msgs/srv/GraspRequest`)

--- a/docs/manuals/REAL_D435I_EPD_PIPELINE.md
+++ b/docs/manuals/REAL_D435I_EPD_PIPELINE.md
@@ -1,0 +1,68 @@
+# REAL_D435I_EPD_PIPELINE
+
+This is the intended production data flow:
+
+```text
+Intel RealSense D435i / EPD perception
+    ↓
+detected_objects/v1 snapshot
+    ↓
+task_recipe adapter
+    ↓
+runtime_execution_plan/v1
+    ↓
+EMD grasp bridge payload
+    ↓
+existing grasp_requests / grasp_tasks runtime
+```
+
+Mock objects remain only for offline tests and CI.
+
+## Bringup commands
+
+```bash
+source /opt/ros/humble/setup.bash
+source ~/workcell_ws/install/setup.bash
+
+ros2 launch realsense2_camera rs_launch.py ...
+
+ros2 launch easy_perception_deployment run.launch.py ...
+```
+
+## Capture one snapshot
+
+```bash
+python3 scripts/capture_epd_detected_objects.py \
+  --topic /easy_perception_deployment/epd_localize_output \
+  --once \
+  --timeout 10 \
+  --output reports/detected_objects/latest.yaml
+```
+
+## Run full offline conversion pipeline
+
+```bash
+python3 scripts/run_perception_task_pipeline.py \
+  --task-recipe path/to/task_recipe.yaml \
+  --detected-objects reports/detected_objects/latest.yaml \
+  --output-dir reports/runtime_pipeline \
+  --dry-run
+```
+
+## Optional guarded runtime send
+
+```bash
+python3 scripts/run_perception_task_pipeline.py \
+  --task-recipe path/to/task_recipe.yaml \
+  --detected-objects reports/detected_objects/latest.yaml \
+  --output-dir reports/runtime_pipeline \
+  --send-to-ros \
+  --ros-interface service
+```
+
+## Not production-ready yet
+
+- final destination-aware placement/release logic
+- safety validation
+- IO validation
+- physical robot commissioning

--- a/docs/manuals/TASK_RECIPE_V1.md
+++ b/docs/manuals/TASK_RECIPE_V1.md
@@ -7,6 +7,14 @@ It is:
 - not a replacement for runtime motion execution,
 - a bridge between user task selection and future generated runtime behaviour.
 
+## Perception input compatibility
+
+`scripts/run_task_recipe_adapter.py` accepts:
+- legacy runtime object fixtures (`tests/fixtures/runtime_objects`), and
+- real/recorded `detected_objects/v1` snapshots (`tests/fixtures/detected_objects`).
+
+For production direction, `detected_objects/v1` is the first-class input, while mock fixtures remain test-only.
+
 ## Supported task types
 
 - `pick_place`

--- a/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
+++ b/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
@@ -6,6 +6,7 @@ For generated project review dashboards, see `docs/manuals/WORKCELL_PROJECT_DASH
 For offline robot/tool/sensor/task/asset capability contracts, see `docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md`.
 For offline task intent and routing logic, see `docs/manuals/TASK_RECIPE_V1.md`.
 For runtime-plan to EMD bridge mapping, see `docs/manuals/EMD_GRASP_BRIDGE_PAYLOAD.md`.
+For real perception snapshot schema and capture workflow, see `docs/manuals/DETECTED_OBJECTS_V1.md` and `docs/manuals/REAL_D435I_EPD_PIPELINE.md`.
 
 ---
 
@@ -143,10 +144,13 @@ Smoke preflight intent:
 
 Layer reminder:
 - `task_recipe/v1` = what the cell should do (task intent/routing),
+- `detected_objects/v1` = production perception snapshot contract from D435i/EPD,
 - `environment_layout/v1` = where assets are placed,
 - capability contracts = what components can do,
 - scene readiness = whether scene files look sane before runtime,
 - `emd_grasp_bridge_payload/v1` = conservative translation of routed pick steps into EMD `GraspTask`-shaped payloads.
+
+Mock runtime objects under `tests/fixtures/runtime_objects` are test fixtures only and are not the normal operator path.
 
 > Generated scenes from `workcell_builder` must pass this same validation contract before they are treated as runnable scenes.
 

--- a/scripts/capture_epd_detected_objects.py
+++ b/scripts/capture_epd_detected_objects.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Capture EPD localization/tracking ROS messages into detected_objects/v1 snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import validate_cell_definition as cell_yaml
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def _derive_dimensions_from_segmented_pcl(segmented_pcl: Any) -> tuple[dict[str, float] | None, str | None]:
+    points = []
+    if isinstance(segmented_pcl, list):
+        points = segmented_pcl
+    elif hasattr(segmented_pcl, "points"):
+        points = list(getattr(segmented_pcl, "points"))
+
+    triples: list[tuple[float, float, float]] = []
+    for p in points:
+        if isinstance(p, dict):
+            xyz = (_float_or_none(p.get("x")), _float_or_none(p.get("y")), _float_or_none(p.get("z")))
+        else:
+            xyz = (_float_or_none(getattr(p, "x", None)), _float_or_none(getattr(p, "y", None)), _float_or_none(getattr(p, "z", None)))
+        if all(v is not None for v in xyz):
+            triples.append((float(xyz[0]), float(xyz[1]), float(xyz[2])))
+
+    if len(triples) < 2:
+        return None, "segmented_pcl unavailable/insufficient for dimensions"
+
+    xs = [t[0] for t in triples]
+    ys = [t[1] for t in triples]
+    zs = [t[2] for t in triples]
+    dims = {"x": max(xs) - min(xs), "y": max(ys) - min(ys), "z": max(zs) - min(zs)}
+    if any(v <= 0 for v in dims.values()):
+        return None, "derived point-cloud dimensions were non-positive"
+    return dims, None
+
+
+def _extract_object(raw: Any, index: int, frame_id: str, strict: bool) -> tuple[dict[str, Any] | None, list[str]]:
+    warnings: list[str] = []
+    name = getattr(raw, "name", None) or getattr(raw, "class_id", None) or f"object_{index:03d}"
+    class_id = getattr(raw, "class_id", None) or getattr(raw, "name", None) or "unknown"
+    confidence = _float_or_none(getattr(raw, "confidence", None))
+
+    centroid_raw = getattr(raw, "centroid", None)
+    centroid = {
+        "x": _float_or_none(getattr(centroid_raw, "x", None)),
+        "y": _float_or_none(getattr(centroid_raw, "y", None)),
+        "z": _float_or_none(getattr(centroid_raw, "z", None)),
+    }
+
+    if any(v is None for v in centroid.values()):
+        warnings.append(f"Object {index} missing centroid values")
+        return None, warnings
+
+    pose = {
+        "frame_id": str(getattr(raw, "frame_id", None) or frame_id),
+        "xyz": [centroid["x"], centroid["y"], centroid["z"]],
+        "rpy": [0.0, 0.0, 0.0],
+    }
+
+    dimensions = None
+    bbox = getattr(raw, "bounding_box", None)
+    if bbox is not None and all(hasattr(bbox, a) for a in ("x", "y", "z")):
+        dimensions = {"x": float(bbox.x), "y": float(bbox.y), "z": float(bbox.z)}
+    elif all(hasattr(raw, a) for a in ("length", "width", "height")):
+        dimensions = {"x": float(raw.length), "y": float(raw.width), "z": float(raw.height)}
+    else:
+        dimensions, dim_warn = _derive_dimensions_from_segmented_pcl(getattr(raw, "segmented_pcl", None))
+        if dim_warn:
+            warnings.append(f"Object {index} {dim_warn}")
+
+    if dimensions is None and strict:
+        warnings.append(f"Object {index} missing dimensions in strict mode")
+        return None, warnings
+
+    obj = {
+        "object_id": f"obj_{index:03d}",
+        "name": str(name),
+        "class_id": str(class_id),
+        "confidence": confidence,
+        "pose": pose,
+        "centroid": centroid,
+        "dimensions": dimensions,
+        "shape": {"type": "box"},
+        "attributes": {
+            "colour": str(getattr(raw, "colour", "unknown")),
+            "shape": str(getattr(raw, "shape", "box")),
+            "material": str(getattr(raw, "material", "unknown")),
+        },
+        "raw": {
+            "source_message_type": str(type(raw)).replace("<class '", "").replace("'>", ""),
+        },
+    }
+    return obj, warnings
+
+
+def _snapshot_from_message(msg: Any, topic: str, camera: str, default_frame_id: str, strict: bool) -> tuple[dict[str, Any], list[str]]:
+    warnings: list[str] = []
+    objects_raw = []
+    for key in ("objects", "localized_objects", "tracked_objects"):
+        val = getattr(msg, key, None)
+        if isinstance(val, list) and val:
+            objects_raw = val
+            break
+
+    if not objects_raw and all(hasattr(msg, k) for k in ("name", "centroid")):
+        objects_raw = [msg]
+
+    frame_id = default_frame_id
+    header = getattr(msg, "header", None)
+    if header is not None and hasattr(header, "frame_id") and str(header.frame_id).strip():
+        frame_id = str(header.frame_id)
+
+    objects: list[dict[str, Any]] = []
+    for idx, raw_obj in enumerate(objects_raw, start=1):
+        obj, obj_warnings = _extract_object(raw_obj, idx, frame_id, strict)
+        warnings.extend(obj_warnings)
+        if obj is not None:
+            objects.append(obj)
+
+    payload = {
+        "schema_version": "detected_objects/v1",
+        "source": {
+            "type": "epd_localization",
+            "topic": topic,
+            "camera": camera,
+            "frame_id": frame_id,
+            "captured_at": _now(),
+        },
+        "objects": objects,
+    }
+    return payload, warnings
+
+
+def _write_output(payload: dict[str, Any], output: Path, as_json: bool) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if as_json:
+        output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return
+    try:
+        import yaml  # type: ignore
+
+        output.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    except Exception:
+        output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--topic", default="/easy_perception_deployment/epd_localize_output")
+    parser.add_argument("--camera", default="intel_realsense_d435i")
+    parser.add_argument("--frame-id", default="camera_depth_optical_frame")
+    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--samples", type=int, default=1)
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--output", type=Path, default=Path("reports/detected_objects/latest_detected_objects.yaml"))
+    args = parser.parse_args(argv)
+
+    # Lazy ROS imports for offline-safe unit tests.
+    try:
+        import rclpy  # type: ignore
+        from rclpy.node import Node  # type: ignore
+
+        msg_type = None
+        try:
+            from epd_msgs.msg import EPDObjectLocalization as msg_type  # type: ignore
+        except Exception:
+            from epd_msgs.msg import EPDObjectTracking as msg_type  # type: ignore
+    except Exception as exc:
+        print(json.dumps({"status": "FAIL", "error": f"ROS import failed (expected in offline mode): {exc}"}, indent=2))
+        return 2
+
+    rclpy.init(args=None)
+    messages: list[Any] = []
+
+    class CaptureNode(Node):
+        def __init__(self) -> None:
+            super().__init__("capture_epd_detected_objects")
+            self.create_subscription(msg_type, args.topic, self._cb, 10)
+
+        def _cb(self, msg: Any) -> None:
+            messages.append(msg)
+
+    node = CaptureNode()
+    try:
+        end_time = node.get_clock().now().nanoseconds + int(args.timeout * 1e9)
+        target = 1 if args.once else max(1, int(args.samples))
+        while rclpy.ok() and len(messages) < target:
+            rclpy.spin_once(node, timeout_sec=0.1)
+            if node.get_clock().now().nanoseconds > end_time:
+                break
+
+        if not messages:
+            print(json.dumps({"status": "FAIL", "error": f"No messages received on {args.topic}"}, indent=2))
+            return 1
+
+        payload, warnings = _snapshot_from_message(messages[-1], args.topic, args.camera, args.frame_id, args.strict)
+        _write_output(payload, args.output, as_json=args.json)
+        report = {
+            "status": "WARN" if warnings else "PASS",
+            "output": str(args.output),
+            "objects": len(payload.get("objects", [])),
+            "warnings": warnings,
+        }
+        print(json.dumps(report, indent=2))
+        return 0 if not (args.strict and warnings) else 1
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_detected_objects_pipeline.sh
+++ b/scripts/check_detected_objects_pipeline.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FIXTURES="${REPO_ROOT}/tests/fixtures/detected_objects"
+TASK_FIXTURES="${REPO_ROOT}/tests/fixtures/task_recipes"
+VALIDATOR="${SCRIPT_DIR}/validate_detected_objects.py"
+ADAPTER="${SCRIPT_DIR}/run_task_recipe_adapter.py"
+PIPELINE="${SCRIPT_DIR}/run_perception_task_pipeline.py"
+
+pass=0
+warn=0
+fail=0
+
+run_expect_status() {
+  local fixture="$1"
+  local expected="$2"
+  local strict_flag="${3:-}"
+  set +e
+  local out
+  out="$(python3 "${VALIDATOR}" "${FIXTURES}/${fixture}" --json ${strict_flag} 2>&1)"
+  local rc=$?
+  set -e
+  local status
+  status="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read()).get("status",""))' <<<"${out}")"
+  if [[ "${status}" == "${expected}" ]]; then
+    echo "PASS validate ${fixture} => ${status}"
+    ((pass+=1))
+  elif [[ "${expected}" == "WARN" && "${status}" == "WARN" ]]; then
+    echo "WARN validate ${fixture} => ${status}"
+    ((warn+=1))
+  else
+    echo "FAIL validate ${fixture}: expected=${expected} got=${status} rc=${rc}" >&2
+    echo "${out}" >&2
+    ((fail+=1))
+  fi
+}
+
+run_expect_status "valid_epd_single_box.yaml" "PASS"
+run_expect_status "valid_epd_colour_sorting.yaml" "PASS"
+run_expect_status "valid_epd_garbage_sorting.yaml" "WARN"
+run_expect_status "missing_dimensions_warn.yaml" "WARN"
+run_expect_status "missing_pose_fail.yaml" "FAIL"
+run_expect_status "missing_dimensions_warn.yaml" "FAIL" "--strict"
+
+if python3 "${ADAPTER}" --task-recipe "${TASK_FIXTURES}/valid_sort_by_colour.yaml" --objects "${FIXTURES}/valid_epd_colour_sorting.yaml" --json >/dev/null; then
+  echo "PASS adapter detected_objects/v1"
+  ((pass+=1))
+else
+  echo "FAIL adapter detected_objects/v1" >&2
+  ((fail+=1))
+fi
+
+if python3 "${PIPELINE}" --task-recipe "${TASK_FIXTURES}/valid_sort_by_colour.yaml" --detected-objects "${FIXTURES}/valid_epd_colour_sorting.yaml" --output-dir "${REPO_ROOT}/reports/runtime_pipeline" >/dev/null; then
+  echo "PASS offline perception pipeline"
+  ((pass+=1))
+else
+  echo "FAIL offline perception pipeline" >&2
+  ((fail+=1))
+fi
+
+echo "Summary: PASS=${pass} WARN=${warn} FAIL=${fail}"
+[[ ${fail} -eq 0 ]]

--- a/scripts/preflight_workcell.sh
+++ b/scripts/preflight_workcell.sh
@@ -92,6 +92,7 @@ echo
 "${SCRIPT_DIR}/generate_task_recipe_dry_run_report.py"
 "${SCRIPT_DIR}/check_task_execution_plans.sh"
 "${SCRIPT_DIR}/check_emd_grasp_bridge.sh"
+"${SCRIPT_DIR}/check_detected_objects_pipeline.sh"
 "${SCRIPT_DIR}/generate_task_execution_plan_report.py"
 "${SCRIPT_DIR}/check_workcell_bundles.sh"
 "${SCRIPT_DIR}/check_generated_workcells.sh"

--- a/scripts/run_perception_task_pipeline.py
+++ b/scripts/run_perception_task_pipeline.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Offline-first orchestration of detected_objects -> runtime plan -> EMD bridge payload."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+VALIDATOR = SCRIPTS_DIR / "validate_detected_objects.py"
+ADAPTER = SCRIPTS_DIR / "run_task_recipe_adapter.py"
+BRIDGE = SCRIPTS_DIR / "convert_runtime_plan_to_emd_grasp.py"
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def _json_from_stdout(text: str) -> dict[str, Any]:
+    start = text.find("{")
+    if start < 0:
+        return {}
+    return json.loads(text[start:])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--task-recipe", type=Path, required=True)
+    parser.add_argument("--detected-objects", type=Path, required=True)
+    parser.add_argument("--project-dir", type=Path)
+    parser.add_argument("--output-dir", type=Path, default=Path("reports/runtime_pipeline"))
+    parser.add_argument("--dry-run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--send-to-ros", action="store_true", default=False)
+    parser.add_argument("--ros-interface", choices=["service", "topic"], default="service")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    validation_report = args.output_dir / "detected_objects_validation_report.json"
+    runtime_plan = args.output_dir / "runtime_execution_plan.json"
+    bridge_payload = args.output_dir / "emd_grasp_bridge_payload.json"
+    summary_md = args.output_dir / "summary.md"
+
+    validate_cmd = [sys.executable, str(VALIDATOR), str(args.detected_objects), "--json"]
+    if args.strict:
+        validate_cmd.append("--strict")
+    validate_proc = _run(validate_cmd)
+    validate_json = _json_from_stdout(validate_proc.stdout)
+    validation_report.write_text(json.dumps(validate_json, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    adapter_cmd = [
+        sys.executable,
+        str(ADAPTER),
+        "--task-recipe",
+        str(args.task_recipe),
+        "--objects",
+        str(args.detected_objects),
+        "--output",
+        str(runtime_plan),
+        "--json",
+        "--mode",
+        "offline",
+    ]
+    if args.project_dir:
+        adapter_cmd.extend(["--project-dir", str(args.project_dir)])
+    if args.strict:
+        adapter_cmd.append("--strict")
+    if not args.dry_run:
+        adapter_cmd.append("--no-dry-run")
+    adapter_proc = _run(adapter_cmd)
+    adapter_json = _json_from_stdout(adapter_proc.stdout)
+
+    bridge_cmd = [
+        sys.executable,
+        str(BRIDGE),
+        "--runtime-plan",
+        str(runtime_plan),
+        "--output",
+        str(bridge_payload),
+        "--json",
+        "--mode",
+        "offline",
+        "--ros-interface",
+        args.ros_interface,
+    ]
+    if args.strict:
+        bridge_cmd.append("--strict")
+    bridge_proc = _run(bridge_cmd)
+    bridge_json = _json_from_stdout(bridge_proc.stdout)
+
+    ros_proc = None
+    ros_note = "ROS send skipped (default)."
+    if args.send_to_ros:
+        ros_cmd = [
+            sys.executable,
+            str(BRIDGE),
+            "--runtime-plan",
+            str(runtime_plan),
+            "--output",
+            str(bridge_payload),
+            "--json",
+            "--mode",
+            "ros",
+            "--ros-interface",
+            args.ros_interface,
+            "--no-dry-run",
+        ]
+        ros_proc = _run(ros_cmd)
+        ros_note = "ROS send explicitly requested."
+
+    summary_lines = [
+        "# Perception Task Pipeline Summary",
+        "",
+        f"- detected_objects input: `{args.detected_objects}`",
+        f"- task_recipe input: `{args.task_recipe}`",
+        f"- validation status: `{validate_json.get('status', 'UNKNOWN')}`",
+        f"- runtime plan routed_count: `{adapter_json.get('summary', {}).get('routed_count', 'n/a')}`",
+        f"- bridge status: `{bridge_json.get('status', 'UNKNOWN')}`",
+        f"- ros: {ros_note}",
+        "",
+        "## Outputs",
+        f"- `{validation_report}`",
+        f"- `{runtime_plan}`",
+        f"- `{bridge_payload}`",
+    ]
+    summary_md.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+
+    payload = {
+        "schema_version": "perception_task_pipeline_report/v1",
+        "status": "PASS",
+        "steps": {
+            "validate_detected_objects": {"returncode": validate_proc.returncode, "status": validate_json.get("status")},
+            "task_recipe_adapter": {"returncode": adapter_proc.returncode},
+            "runtime_to_emd_bridge": {"returncode": bridge_proc.returncode, "status": bridge_json.get("status")},
+            "ros_send": {"requested": args.send_to_ros, "returncode": None if ros_proc is None else ros_proc.returncode},
+        },
+        "artifacts": {
+            "validation_report": str(validation_report),
+            "runtime_execution_plan": str(runtime_plan),
+            "emd_grasp_bridge_payload": str(bridge_payload),
+            "summary": str(summary_md),
+        },
+    }
+
+    if any(code != 0 for code in (validate_proc.returncode, adapter_proc.returncode, bridge_proc.returncode)):
+        payload["status"] = "FAIL"
+    elif validate_json.get("status") == "WARN" or bridge_json.get("status") == "WARN":
+        payload["status"] = "WARN"
+
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 1 if payload["status"] == "FAIL" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_task_recipe_adapter.py
+++ b/scripts/run_task_recipe_adapter.py
@@ -89,7 +89,16 @@ def _resolve_task_recipe_path(task_recipe: Path | None, project_dir: Path | None
     raise FileNotFoundError("Unable to auto-discover task recipe from --project-dir.")
 
 
+def _as_dimensions_list(raw: Any) -> list[float]:
+    if isinstance(raw, list) and raw:
+        return [float(x) for x in raw]
+    if isinstance(raw, dict) and all(k in raw for k in ("x", "y", "z")):
+        return [float(raw["x"]), float(raw["y"]), float(raw["z"])]
+    return []
+
+
 def _normalize_objects(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    schema_version = str(doc.get("schema_version", ""))
     objects = doc.get("objects") if isinstance(doc.get("objects"), list) else None
     if objects is None:
         if isinstance(doc, list):
@@ -100,29 +109,48 @@ def _normalize_objects(doc: dict[str, Any]) -> list[dict[str, Any]]:
     for idx, obj in enumerate(objects):
         if not isinstance(obj, dict):
             raise ValueError(f"objects[{idx}] must be a mapping.")
-        oid = str(obj.get("id", f"object_{idx+1:03d}"))
+        is_detected_v1 = schema_version == "detected_objects/v1" or "object_id" in obj
+        oid = str(obj.get("id") or obj.get("object_id") or f"object_{idx+1:03d}")
+        pose = obj.get("pose") if isinstance(obj.get("pose"), dict) else {}
+        pose_frame = str(
+            pose.get("frame_id")
+            or obj.get("frame_id")
+            or doc.get("source", {}).get("frame_id", "unknown")
+        )
+        colour = obj.get("colour") or obj.get("color")
+        shape = obj.get("shape")
+        if isinstance(shape, dict):
+            shape = shape.get("type")
+        attributes = obj.get("attributes") if isinstance(obj.get("attributes"), dict) else {}
+        colour = colour or attributes.get("colour")
+        shape = shape or attributes.get("shape")
+        class_id = obj.get("class_id") or obj.get("class") or obj.get("name")
+
         attrs = {
-            "class": obj.get("class") or obj.get("class_id"),
-            "colour": obj.get("colour") or obj.get("color"),
-            "shape": obj.get("shape"),
-            "material": obj.get("material"),
+            "class": class_id,
+            "colour": colour,
+            "shape": shape,
+            "material": obj.get("material") or attributes.get("material"),
             "inspection_result": obj.get("inspection_result"),
         }
         attrs = {k: v for k, v in attrs.items() if isinstance(v, str) and v.strip()}
         out.append(
             {
                 "id": oid,
-                "class_id": obj.get("class_id") or obj.get("class"),
-                "colour": obj.get("colour") or obj.get("color"),
-                "shape": obj.get("shape"),
-                "material": obj.get("material"),
+                "name": obj.get("name") or class_id,
+                "class_id": class_id,
+                "colour": colour,
+                "shape": shape,
+                "material": obj.get("material") or attributes.get("material"),
                 "inspection_result": obj.get("inspection_result"),
                 "confidence": float(obj.get("confidence", 1.0)),
-                "frame_id": obj.get("frame_id", "unknown"),
-                "pose": obj.get("pose") if isinstance(obj.get("pose"), dict) else {},
-                "dimensions": obj.get("dimensions") if isinstance(obj.get("dimensions"), list) else [],
+                "frame_id": pose_frame,
+                "pose": pose,
+                "centroid": obj.get("centroid") if isinstance(obj.get("centroid"), dict) else {},
+                "dimensions": _as_dimensions_list(obj.get("dimensions")),
                 "preferred_end_effector": obj.get("preferred_end_effector") or obj.get("ee_id"),
                 "attributes": attrs,
+                "source_type": "detected_objects/v1" if is_detected_v1 else "runtime_objects",
             }
         )
     return out
@@ -187,6 +215,7 @@ def build_plan(task_recipe: dict[str, Any], objects: list[dict[str, Any]], mode:
             "task": "pick_route_place",
             "object": {
                 "id": obj["id"],
+                "name": obj.get("name"),
                 "class_id": obj.get("class_id"),
                 "colour": obj.get("colour"),
                 "shape": obj.get("shape"),
@@ -195,8 +224,11 @@ def build_plan(task_recipe: dict[str, Any], objects: list[dict[str, Any]], mode:
                 "confidence": obj.get("confidence"),
                 "frame_id": obj.get("frame_id"),
                 "pose": obj.get("pose"),
+                "centroid": obj.get("centroid"),
                 "dimensions": obj.get("dimensions"),
                 "preferred_end_effector": obj.get("preferred_end_effector"),
+                "attributes": obj.get("attributes"),
+                "source_type": obj.get("source_type"),
             },
             "routing": {
                 "matched_rule_id": str(matched_rule.get("id", f"rule_{idx}")),

--- a/scripts/validate_detected_objects.py
+++ b/scripts/validate_detected_objects.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Validate detected_objects/v1 snapshots for offline task pipeline usage."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import validate_cell_definition as cell_yaml
+
+KNOWN_COLOURS = {"red", "green", "blue", "yellow", "black", "white", "clear", "silver", "brown", "orange"}
+KNOWN_SHAPES = {"box", "cylinder", "sphere", "irregular", "unknown"}
+KNOWN_CLASSES = {"mouse", "box", "part", "bottle", "can", "paper", "plastic", "metal", "unknown"}
+
+
+@dataclass
+class ValidationResult:
+    status: str
+    warnings: list[str]
+    errors: list[str]
+    notes: list[str]
+    payload: dict[str, Any]
+
+
+def _load_yaml_or_json(path: Path) -> tuple[dict[str, Any], str, list[str]]:
+    if path.suffix.lower() == ".json":
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        if loaded is None:
+            loaded = {}
+        if not isinstance(loaded, dict):
+            raise ValueError("JSON root must be an object/mapping.")
+        return loaded, "json", []
+    return cell_yaml.load_yaml(path)
+
+
+def _stable_object_id(obj: dict[str, Any], index: int) -> str:
+    base = {
+        "name": obj.get("name"),
+        "class_id": obj.get("class_id"),
+        "centroid": obj.get("centroid"),
+        "pose": obj.get("pose"),
+    }
+    digest = hashlib.sha1(json.dumps(base, sort_keys=True, default=str).encode("utf-8")).hexdigest()[:8]
+    return f"obj_{index:03d}_{digest}"
+
+
+def _normalize_dimensions(raw: Any) -> tuple[dict[str, float] | None, str | None]:
+    if raw is None:
+        return None, None
+    if isinstance(raw, list) and len(raw) == 3:
+        dims = {"x": float(raw[0]), "y": float(raw[1]), "z": float(raw[2])}
+        return dims, None
+    if isinstance(raw, dict) and all(k in raw for k in ("x", "y", "z")):
+        dims = {"x": float(raw["x"]), "y": float(raw["y"]), "z": float(raw["z"])}
+        return dims, None
+    return None, "dimensions must be a 3-list or mapping with x/y/z"
+
+
+def validate_detected_objects(doc: dict[str, Any], strict: bool, allow_generate_ids: bool) -> ValidationResult:
+    warnings: list[str] = []
+    errors: list[str] = []
+    notes: list[str] = []
+
+    if doc.get("schema_version") != "detected_objects/v1":
+        errors.append("schema_version must be detected_objects/v1")
+
+    source = doc.get("source") if isinstance(doc.get("source"), dict) else {}
+    if not source:
+        warnings.append("source block is missing or empty")
+
+    objects = doc.get("objects") if isinstance(doc.get("objects"), list) else None
+    if objects is None:
+        errors.append("objects must be a list")
+        objects = []
+
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for idx, raw in enumerate(objects, start=1):
+        if not isinstance(raw, dict):
+            errors.append(f"objects[{idx-1}] must be a mapping")
+            continue
+
+        obj = dict(raw)
+        object_id = obj.get("object_id")
+        if not isinstance(object_id, str) or not object_id.strip():
+            if allow_generate_ids:
+                object_id = _stable_object_id(obj, idx)
+                notes.append(f"Generated stable object_id '{object_id}' for objects[{idx-1}].")
+            else:
+                errors.append(f"objects[{idx-1}] missing required object_id")
+                continue
+        object_id = object_id.strip()
+        if object_id in seen:
+            errors.append(f"Duplicate object_id '{object_id}'")
+            continue
+        seen.add(object_id)
+
+        pose = obj.get("pose") if isinstance(obj.get("pose"), dict) else None
+        if pose is None:
+            errors.append(f"Object '{object_id}' is missing pose")
+        else:
+            xyz = pose.get("xyz")
+            if not (isinstance(xyz, list) and len(xyz) == 3 and all(isinstance(v, (int, float)) for v in xyz)):
+                errors.append(f"Object '{object_id}' pose.xyz must be numeric length-3 list")
+            rpy = pose.get("rpy")
+            if not (isinstance(rpy, list) and len(rpy) == 3 and all(isinstance(v, (int, float)) for v in rpy)):
+                errors.append(f"Object '{object_id}' pose.rpy must be numeric length-3 list")
+            if not isinstance(pose.get("frame_id"), str) or not str(pose.get("frame_id")).strip():
+                warnings.append(f"Object '{object_id}' pose.frame_id is missing/empty")
+
+        dims, dim_error = _normalize_dimensions(obj.get("dimensions"))
+        if dim_error:
+            errors.append(f"Object '{object_id}' {dim_error}")
+        if dims is None:
+            if strict:
+                errors.append(f"Object '{object_id}' is missing dimensions in strict mode")
+            else:
+                warnings.append(f"Object '{object_id}' missing dimensions")
+        else:
+            for axis, value in dims.items():
+                if value <= 0:
+                    errors.append(f"Object '{object_id}' dimensions.{axis} must be > 0")
+
+        conf = obj.get("confidence")
+        if conf is None:
+            warnings.append(f"Object '{object_id}' missing confidence")
+        elif not isinstance(conf, (int, float)):
+            errors.append(f"Object '{object_id}' confidence must be numeric")
+
+        attributes = obj.get("attributes") if isinstance(obj.get("attributes"), dict) else {}
+        colour = attributes.get("colour", obj.get("colour", "unknown"))
+        shape = attributes.get("shape", obj.get("shape", "unknown"))
+        class_id = obj.get("class_id") or obj.get("name")
+
+        if isinstance(colour, str) and colour.lower() not in KNOWN_COLOURS:
+            warnings.append(f"Object '{object_id}' has unknown colour '{colour}'")
+        if isinstance(shape, str) and shape.lower() not in KNOWN_SHAPES:
+            warnings.append(f"Object '{object_id}' has unknown shape '{shape}'")
+        if isinstance(class_id, str) and class_id.lower() not in KNOWN_CLASSES:
+            warnings.append(f"Object '{object_id}' has unknown class_id '{class_id}'")
+
+        obj["object_id"] = object_id
+        normalized.append(obj)
+
+    status = "PASS"
+    if errors:
+        status = "FAIL"
+    elif warnings:
+        status = "WARN"
+
+    return ValidationResult(
+        status=status,
+        warnings=warnings,
+        errors=errors,
+        notes=notes,
+        payload={
+            "schema_version": "detected_objects_validation/v1",
+            "status": status,
+            "summary": {
+                "objects_seen": len(objects),
+                "objects_validated": len(normalized),
+                "warnings": len(warnings),
+                "errors": len(errors),
+            },
+            "warnings": warnings,
+            "errors": errors,
+            "notes": notes,
+            "normalized": {"schema_version": "detected_objects/v1", "source": source, "objects": normalized},
+        },
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="Path to detected_objects/v1 YAML/JSON")
+    parser.add_argument("--json", action="store_true", help="Print JSON output")
+    parser.add_argument("--strict", action="store_true", help="Treat missing dimensions as failure")
+    parser.add_argument(
+        "--allow-generate-object-id",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Allow generating stable object ids when missing",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        loaded, parser_name, parser_notes = _load_yaml_or_json(args.input)
+        result = validate_detected_objects(loaded, strict=args.strict, allow_generate_ids=bool(args.allow_generate_object_id))
+        result.payload["input"] = str(args.input)
+        result.payload["parser"] = parser_name
+        result.payload.setdefault("notes", []).extend(parser_notes)
+        rendered = json.dumps(result.payload, indent=2, sort_keys=True)
+        print(rendered)
+        return 1 if result.status == "FAIL" else 0
+    except Exception as exc:
+        print(json.dumps({"schema_version": "detected_objects_validation/v1", "status": "FAIL", "error": str(exc)}, indent=2))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/detected_objects/low_confidence_object.yaml
+++ b/tests/fixtures/detected_objects/low_confidence_object.yaml
@@ -1,0 +1,25 @@
+schema_version: detected_objects/v1
+source:
+  type: epd_localization
+  frame_id: camera_depth_optical_frame
+objects:
+  - object_id: reject_001
+    name: unknown
+    class_id: unknown
+    confidence: 0.41
+    pose:
+      frame_id: camera_depth_optical_frame
+      xyz: [0.3, -0.1, 0.2]
+      rpy: [0, 0, 0]
+    centroid:
+      x: 0.3
+      y: -0.1
+      z: 0.2
+    dimensions:
+      x: 0.06
+      y: 0.05
+      z: 0.02
+    attributes:
+      colour: mixed
+      shape: irregular
+      material: unknown

--- a/tests/fixtures/detected_objects/missing_dimensions_warn.yaml
+++ b/tests/fixtures/detected_objects/missing_dimensions_warn.yaml
@@ -1,0 +1,20 @@
+schema_version: detected_objects/v1
+source:
+  type: epd_localization
+  frame_id: camera_depth_optical_frame
+objects:
+  - object_id: obj_missing_dims
+    name: part
+    class_id: part
+    confidence: 0.9
+    pose:
+      frame_id: camera_depth_optical_frame
+      xyz: [0.1, 0.2, 0.3]
+      rpy: [0, 0, 0]
+    centroid:
+      x: 0.1
+      y: 0.2
+      z: 0.3
+    attributes:
+      colour: unknown
+      shape: box

--- a/tests/fixtures/detected_objects/missing_pose_fail.yaml
+++ b/tests/fixtures/detected_objects/missing_pose_fail.yaml
@@ -1,0 +1,16 @@
+schema_version: detected_objects/v1
+source:
+  type: epd_localization
+  frame_id: camera_depth_optical_frame
+objects:
+  - object_id: obj_missing_pose
+    name: part
+    class_id: part
+    confidence: 0.9
+    dimensions:
+      x: 0.1
+      y: 0.1
+      z: 0.1
+    attributes:
+      colour: red
+      shape: box

--- a/tests/fixtures/detected_objects/unknown_class_fallback.yaml
+++ b/tests/fixtures/detected_objects/unknown_class_fallback.yaml
@@ -1,0 +1,24 @@
+schema_version: detected_objects/v1
+source:
+  type: epd_localization
+  frame_id: camera_depth_optical_frame
+objects:
+  - object_id: obj_unknown
+    name: mystery_part
+    class_id: mystery_part
+    confidence: 0.88
+    pose:
+      frame_id: camera_depth_optical_frame
+      xyz: [0.2, 0.05, 0.18]
+      rpy: [0, 0, 0]
+    centroid:
+      x: 0.2
+      y: 0.05
+      z: 0.18
+    dimensions:
+      x: 0.02
+      y: 0.03
+      z: 0.04
+    attributes:
+      colour: ultraviolet
+      shape: weird

--- a/tests/fixtures/detected_objects/valid_epd_colour_sorting.yaml
+++ b/tests/fixtures/detected_objects/valid_epd_colour_sorting.yaml
@@ -1,0 +1,43 @@
+schema_version: detected_objects/v1
+source:
+  type: epd_localization
+  frame_id: camera_depth_optical_frame
+objects:
+  - object_id: red_001
+    name: part
+    class_id: part
+    confidence: 0.97
+    pose:
+      frame_id: camera_depth_optical_frame
+      xyz: [0.1, 0.1, 0.2]
+      rpy: [0, 0, 0]
+    centroid:
+      x: 0.1
+      y: 0.1
+      z: 0.2
+    dimensions:
+      x: 0.04
+      y: 0.04
+      z: 0.02
+    attributes:
+      colour: red
+      shape: box
+  - object_id: blue_001
+    name: part
+    class_id: part
+    confidence: 0.95
+    pose:
+      frame_id: camera_depth_optical_frame
+      xyz: [0.2, 0.1, 0.2]
+      rpy: [0, 0, 0]
+    centroid:
+      x: 0.2
+      y: 0.1
+      z: 0.2
+    dimensions:
+      x: 0.03
+      y: 0.03
+      z: 0.06
+    attributes:
+      colour: blue
+      shape: cylinder

--- a/tests/fixtures/detected_objects/valid_epd_garbage_sorting.yaml
+++ b/tests/fixtures/detected_objects/valid_epd_garbage_sorting.yaml
@@ -1,0 +1,45 @@
+schema_version: detected_objects/v1
+source:
+  type: epd_localization
+  frame_id: camera_depth_optical_frame
+objects:
+  - object_id: rec_001
+    name: bottle
+    class_id: bottle
+    confidence: 0.89
+    pose:
+      frame_id: camera_depth_optical_frame
+      xyz: [0.1, -0.1, 0.2]
+      rpy: [0, 0, 0]
+    centroid:
+      x: 0.1
+      y: -0.1
+      z: 0.2
+    dimensions:
+      x: 0.03
+      y: 0.03
+      z: 0.12
+    attributes:
+      colour: clear
+      shape: cylinder
+      material: plastic
+  - object_id: reject_001
+    name: unknown
+    class_id: unknown
+    confidence: 0.40
+    pose:
+      frame_id: camera_depth_optical_frame
+      xyz: [0.3, -0.1, 0.2]
+      rpy: [0, 0, 0]
+    centroid:
+      x: 0.3
+      y: -0.1
+      z: 0.2
+    dimensions:
+      x: 0.06
+      y: 0.05
+      z: 0.02
+    attributes:
+      colour: mixed
+      shape: irregular
+      material: unknown

--- a/tests/fixtures/detected_objects/valid_epd_single_box.yaml
+++ b/tests/fixtures/detected_objects/valid_epd_single_box.yaml
@@ -1,0 +1,32 @@
+schema_version: detected_objects/v1
+source:
+  type: epd_localization
+  topic: /easy_perception_deployment/epd_localize_output
+  camera: intel_realsense_d435i
+  frame_id: camera_depth_optical_frame
+  captured_at: 2026-04-28T00:00:00Z
+objects:
+  - object_id: obj_001
+    name: mouse
+    class_id: mouse
+    confidence: 0.92
+    pose:
+      frame_id: camera_depth_optical_frame
+      xyz: [-0.56, 0.09, 0.13]
+      rpy: [0.0, 0.0, 0.0]
+    centroid:
+      x: -0.56
+      y: 0.09
+      z: 0.13
+    dimensions:
+      x: 0.08
+      y: 0.04
+      z: 0.03
+    shape:
+      type: box
+    attributes:
+      colour: red
+      shape: box
+      material: plastic
+    raw:
+      source_message_type: epd_msgs/msg/EPDObjectLocalization

--- a/tests/test_detected_objects_tools.py
+++ b/tests/test_detected_objects_tools.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "detected_objects"
+VALIDATOR = REPO_ROOT / "scripts" / "validate_detected_objects.py"
+ADAPTER = REPO_ROOT / "scripts" / "run_task_recipe_adapter.py"
+TASK_FIXTURES = REPO_ROOT / "tests" / "fixtures" / "task_recipes"
+CAPTURE = REPO_ROOT / "scripts" / "capture_epd_detected_objects.py"
+
+
+class DetectedObjectsToolsTests(unittest.TestCase):
+    def _run(self, script: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run([sys.executable, str(script), *args], capture_output=True, text=True, check=False)
+
+    def test_validator_pass_warn_fail_and_strict(self) -> None:
+        good = self._run(VALIDATOR, str(FIXTURES / "valid_epd_single_box.yaml"), "--json")
+        self.assertEqual(good.returncode, 0, msg=good.stdout + good.stderr)
+        self.assertEqual(json.loads(good.stdout)["status"], "PASS")
+
+        warn = self._run(VALIDATOR, str(FIXTURES / "missing_dimensions_warn.yaml"), "--json")
+        self.assertEqual(warn.returncode, 0, msg=warn.stdout + warn.stderr)
+        self.assertEqual(json.loads(warn.stdout)["status"], "WARN")
+
+        strict_fail = self._run(VALIDATOR, str(FIXTURES / "missing_dimensions_warn.yaml"), "--json", "--strict")
+        self.assertEqual(strict_fail.returncode, 1)
+        self.assertEqual(json.loads(strict_fail.stdout)["status"], "FAIL")
+
+        fail = self._run(VALIDATOR, str(FIXTURES / "missing_pose_fail.yaml"), "--json")
+        self.assertEqual(fail.returncode, 1)
+        self.assertEqual(json.loads(fail.stdout)["status"], "FAIL")
+
+    def test_adapter_accepts_detected_objects_and_routes(self) -> None:
+        proc = self._run(
+            ADAPTER,
+            "--task-recipe",
+            str(TASK_FIXTURES / "valid_sort_by_colour.yaml"),
+            "--objects",
+            str(FIXTURES / "valid_epd_colour_sorting.yaml"),
+            "--json",
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        payload = json.loads(proc.stdout)
+        destinations = [step["routing"]["destination_id"] for step in payload["steps"]]
+        self.assertEqual(destinations, ["red_bin", "blue_bin"])
+
+    def test_low_confidence_routes_to_reject(self) -> None:
+        proc = self._run(
+            ADAPTER,
+            "--task-recipe",
+            str(TASK_FIXTURES / "valid_garbage_sorting.yaml"),
+            "--objects",
+            str(FIXTURES / "low_confidence_object.yaml"),
+            "--json",
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        payload = json.loads(proc.stdout)
+        self.assertEqual(payload["steps"][0]["routing"]["destination_id"], "unknown_reject_bin")
+
+    def test_capture_script_ros_imports_are_lazy(self) -> None:
+        text = CAPTURE.read_text(encoding="utf-8")
+        main_idx = text.find("def main")
+        import_idx = text.find("import rclpy")
+        self.assertGreater(import_idx, main_idx)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_perception_task_pipeline.py
+++ b/tests/test_perception_task_pipeline.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "detected_objects"
+TASK_FIXTURES = REPO_ROOT / "tests" / "fixtures" / "task_recipes"
+PIPELINE = REPO_ROOT / "scripts" / "run_perception_task_pipeline.py"
+
+
+class PerceptionTaskPipelineTests(unittest.TestCase):
+    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run([sys.executable, str(PIPELINE), *args], capture_output=True, text=True, check=False)
+
+    def test_pipeline_produces_runtime_plan_and_bridge_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "reports"
+            proc = self._run(
+                "--task-recipe",
+                str(TASK_FIXTURES / "valid_sort_by_colour.yaml"),
+                "--detected-objects",
+                str(FIXTURES / "valid_epd_colour_sorting.yaml"),
+                "--output-dir",
+                str(out_dir),
+                "--dry-run",
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            payload = json.loads(proc.stdout)
+            self.assertIn(payload["status"], {"PASS", "WARN"})
+            self.assertTrue((out_dir / "runtime_execution_plan.json").is_file())
+            self.assertTrue((out_dir / "emd_grasp_bridge_payload.json").is_file())
+            self.assertTrue((out_dir / "detected_objects_validation_report.json").is_file())
+
+    def test_pipeline_fails_for_missing_pose(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            proc = self._run(
+                "--task-recipe",
+                str(TASK_FIXTURES / "valid_pick_place.yaml"),
+                "--detected-objects",
+                str(FIXTURES / "missing_pose_fail.yaml"),
+                "--output-dir",
+                str(Path(tmpdir) / "reports"),
+            )
+            self.assertEqual(proc.returncode, 1)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["status"], "FAIL")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Make real D435i + EPD perception a first-class input so live detected objects can feed the existing task_recipe -> runtime_execution_plan -> EMD grasp bridge pipeline.
- Provide an offline-safe path for capture/validation/replay so CI and unit tests keep working without ROS/camera/EPD present. 
- Keep changes additive and guarded so existing `run_grasp_planner`, `run_grasp_execution`, EPD message definitions, and workcell_builder behavior are not altered.

### Description
- Introduce a versioned perception snapshot format `detected_objects/v1` and documentation (`docs/manuals/DETECTED_OBJECTS_V1.md`, `docs/manuals/REAL_D435I_EPD_PIPELINE.md`) describing capture and operator flows. 
- Add an offline validator `scripts/validate_detected_objects.py` that validates `detected_objects/v1` (PASS/WARN/FAIL), supports `--json` and `--strict`, and can generate stable object IDs when allowed. 
- Add an optional ROS capture tool `scripts/capture_epd_detected_objects.py` that lazily imports ROS/EPD types, subscribes to an EPD topic, defensively extracts fields (pose/centroid/dimensions/attributes) and writes `detected_objects/v1` YAML/JSON snapshots. 
- Extend `scripts/run_task_recipe_adapter.py` to accept and normalize both legacy runtime fixtures and `detected_objects/v1` snapshots (preserve name/class_id/attributes/pose/frame/dimensions) and produce compatible `runtime_execution_plan/v1` steps; add an orchestration helper `scripts/run_perception_task_pipeline.py` and an offline checker `scripts/check_detected_objects_pipeline.sh` and integrate the checker into `scripts/preflight_workcell.sh`. 
- Add fixtures and unit tests (`tests/fixtures/detected_objects/*`, `tests/test_detected_objects_tools.py`, `tests/test_perception_task_pipeline.py`) and update README and manuals to clearly document that mock objects are test-only and that ROS send is explicit and guarded.

### Testing
- Compiled new scripts successfully with `python3 -m py_compile` (no syntax errors). 
- Ran unit tests: `python3 -m unittest tests/test_detected_objects_tools.py`, `python3 -m unittest tests/test_perception_task_pipeline.py`, `python3 -m unittest tests/test_task_recipe_adapter.py`, and `python3 -m unittest tests/test_emd_grasp_bridge.py`, and all tests passed. 
- Ran offline pipeline checks: `./scripts/check_detected_objects_pipeline.sh` completed and returned PASS/WARN summary as expected, and `scripts/preflight_workcell.sh` ran in offline mode producing expected SKIP/WARN messages when ROS is not available. 
- Tests confirm validator PASS/WARN/FAIL and strict behavior, adapter acceptance of `detected_objects/v1`, guarded lazy ROS imports in capture script, and that the offline pipeline produces runtime plan and EMD bridge payload artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0903c91888331bf5a8aed0e6b2940)