### PR TITLE
Add guarded explicit destination release-pose support in run_grasp_execution

### DIFF
--- a/docs/manuals/EMD_GRASP_BRIDGE_PAYLOAD.md
+++ b/docs/manuals/EMD_GRASP_BRIDGE_PAYLOAD.md
@@ -77,6 +77,10 @@ If ROS Python modules are unavailable, status is `FAIL` with an explicit error m
   - using explicit destination release pose metadata (offline bridge level),
   - destination frame mismatch with planning frame,
   - destination missing/malformed pose, causing fallback to `release_x_offset` / `release_use_grasp_z`.
-- Because of this interface boundary, `run_grasp_execution` keeps existing release behavior unless runtime interfaces are extended in a future non-breaking step.
+- `run_grasp_execution` now supports a **non-breaking runtime adapter** for explicit destination release poses:
+  - keep `release_x_offset` / `release_use_grasp_z` as default legacy behavior,
+  - opt-in with `use_explicit_release_pose:=true`,
+  - point `explicit_release_pose_bridge_payload_path` to the generated `emd_grasp_bridge_payload/v1` JSON,
+  - keep `fallback_to_legacy_release:=true` to safely recover when destination pose is missing, malformed, wrong-frame, or unreachable.
 - synthesized grasp poses are conservative first-pass placeholders.
 - this bridge is not full production sequencing or a safety certification layer.

--- a/docs/manuals/REAL_D435I_EPD_PIPELINE.md
+++ b/docs/manuals/REAL_D435I_EPD_PIPELINE.md
@@ -68,7 +68,16 @@ Destination-aware release pose metadata is now preserved end-to-end through:
 
 `detected_objects/v1 -> task recipe decision rule -> runtime_execution_plan/v1 destination_resolved -> emd_grasp_bridge_payload/v1 destination_pose`.
 
-Current runtime execution (`grasp_requests` / `grasp_tasks`) still uses legacy release behavior (`release_x_offset`, `release_use_grasp_z`) because the existing EMD messages do not include explicit place/release pose fields yet.
+Current runtime execution (`grasp_requests` / `grasp_tasks`) keeps legacy release behavior (`release_x_offset`, `release_use_grasp_z`) by default, and now adds a safe opt-in adapter for explicit destination release poses via bridge payload path.
+
+Recommended safe runtime knobs:
+
+- `use_explicit_release_pose: false` (default; set `true` only when bridge payload path is provided)
+- `explicit_release_pose_bridge_payload_path: /path/to/emd_grasp_bridge_payload.json`
+- `explicit_release_pose_frame_policy: require_planning_frame`
+- `fallback_to_legacy_release: true`
+
+This is required for physical sorting workflows (e.g., colour/shape/garbage bins) where route-selected destinations must map to real release coordinates while preserving existing scene compatibility.
 
 ## Not production-ready yet
 

--- a/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
+++ b/docs/manuals/WORKCELL_OPERATOR_MANUAL.md
@@ -155,7 +155,13 @@ Destination-aware routing chain (offline-first):
 - `task_recipe/v1` decision rules select destination ids (e.g., red bin, cylinder bin, reject tray).
 - `runtime_execution_plan/v1` stores both legacy destination metadata and resolved destination pose/quaternion in `routing.destination_resolved`.
 - `emd_grasp_bridge_payload/v1` preserves this release destination pose metadata and emits warnings when fallback is required.
-- Runtime release currently still follows `run_grasp_execution` fallback parameters (`release_x_offset`, `release_use_grasp_z`) until EMD runtime interfaces are extended.
+- Runtime release defaults to legacy fallback parameters (`release_x_offset`, `release_use_grasp_z`), but operators can now opt-in to explicit destination release poses from bridge payload JSON:
+  - `use_explicit_release_pose: true`
+  - `explicit_release_pose_source: auto` (or `bridge_payload`)
+  - `explicit_release_pose_bridge_payload_path: <path-to-emd_grasp_bridge_payload.json>`
+  - `explicit_release_pose_frame_policy: require_planning_frame` (strict default)
+  - `fallback_to_legacy_release: true`
+- When explicit pose is invalid/unavailable, runtime logs WARN with fallback reason and keeps legacy behavior without crashing (recommended for sorting lines: color/shape/garbage bins).
 
 Mock runtime objects under `tests/fixtures/runtime_objects` are test fixtures only and are not the normal operator path.
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
@@ -78,6 +78,12 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_home_return_utils
     rclcpp
   )
+  ament_add_gtest(test_explicit_release_pose_utils
+    test/test_explicit_release_pose_utils.cpp)
+  target_include_directories(test_explicit_release_pose_utils PUBLIC include)
+  ament_target_dependencies(test_explicit_release_pose_utils
+    tf2_geometry_msgs
+  )
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/config/grasp_execution.yaml
@@ -47,6 +47,18 @@ grasp_execution_node:
     # z-height so the arm clears any surface on the return move.
     release_use_grasp_z: true
 
+    # --- Explicit destination release pose adapter (safe opt-in) ---
+    # Keep disabled by default for backward compatibility.
+    use_explicit_release_pose: false
+    # auto | bridge_payload | disabled
+    explicit_release_pose_source: "auto"
+    # require_planning_frame | warn_and_use
+    explicit_release_pose_frame_policy: "require_planning_frame"
+    fallback_to_legacy_release: true
+    # Optional path to emd_grasp_bridge_payload/v1 JSON output from:
+    # scripts/convert_runtime_plan_to_emd_grasp.py
+    explicit_release_pose_bridge_payload_path: ""
+
     # --- Home return configuration ---
     # Optional safe intermediate joint waypoint between detach and home.
     home_return:

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/explicit_release_pose_utils.hpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/explicit_release_pose_utils.hpp
@@ -1,0 +1,187 @@
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <tf2/LinearMath/Quaternion.h>
+
+namespace run_grasp_execution
+{
+
+struct ExplicitReleasePoseEntry
+{
+  std::string object_id;
+  std::string normalized_object_id;
+  std::string destination_id;
+  std::string destination_name;
+  std::string frame_id;
+  geometry_msgs::msg::Pose pose;
+  bool valid_pose{false};
+};
+
+struct ExplicitReleasePoseLoadResult
+{
+  bool loaded{false};
+  std::vector<ExplicitReleasePoseEntry> entries;
+  std::vector<std::string> warnings;
+  std::string error;
+};
+
+inline std::string normalize_object_id(std::string value)
+{
+  while (!value.empty() && value.front() == '#') {
+    value.erase(value.begin());
+  }
+  return value;
+}
+
+inline bool is_finite_pose(const geometry_msgs::msg::Pose & pose)
+{
+  return std::isfinite(pose.position.x) && std::isfinite(pose.position.y) &&
+         std::isfinite(pose.position.z) && std::isfinite(pose.orientation.x) &&
+         std::isfinite(pose.orientation.y) && std::isfinite(pose.orientation.z) &&
+         std::isfinite(pose.orientation.w);
+}
+
+inline std::optional<std::array<double, 3>> read_vec3(
+  const boost::property_tree::ptree & node,
+  const std::string & key)
+{
+  const auto child = node.get_child_optional(key);
+  if (!child.has_value()) {
+    return std::nullopt;
+  }
+  std::array<double, 3> out{};
+  size_t i = 0;
+  for (const auto & item : child.value()) {
+    if (i >= out.size()) {
+      return std::nullopt;
+    }
+    out[i++] = item.second.get_value<double>();
+  }
+  if (i != out.size()) {
+    return std::nullopt;
+  }
+  return out;
+}
+
+inline std::optional<std::array<double, 4>> read_vec4(
+  const boost::property_tree::ptree & node,
+  const std::string & key)
+{
+  const auto child = node.get_child_optional(key);
+  if (!child.has_value()) {
+    return std::nullopt;
+  }
+  std::array<double, 4> out{};
+  size_t i = 0;
+  for (const auto & item : child.value()) {
+    if (i >= out.size()) {
+      return std::nullopt;
+    }
+    out[i++] = item.second.get_value<double>();
+  }
+  if (i != out.size()) {
+    return std::nullopt;
+  }
+  return out;
+}
+
+inline ExplicitReleasePoseLoadResult load_explicit_release_pose_bridge_payload(const std::string & path)
+{
+  ExplicitReleasePoseLoadResult result;
+  if (path.empty()) {
+    result.error = "Bridge payload path is empty.";
+    return result;
+  }
+
+  std::ifstream input(path);
+  if (!input.good()) {
+    result.error = "Cannot open bridge payload file: " + path;
+    return result;
+  }
+
+  boost::property_tree::ptree root;
+  try {
+    boost::property_tree::read_json(path, root);
+  } catch (const std::exception & ex) {
+    result.error = std::string("Failed to parse bridge payload JSON: ") + ex.what();
+    return result;
+  }
+
+  const auto targets = root.get_child_optional("grasp_task.grasp_targets");
+  if (!targets.has_value()) {
+    result.error = "Bridge payload missing grasp_task.grasp_targets.";
+    return result;
+  }
+
+  for (const auto & node_item : targets.value()) {
+    const auto & target = node_item.second;
+    ExplicitReleasePoseEntry entry;
+    entry.object_id = target.get<std::string>("object_id", "");
+    entry.normalized_object_id = normalize_object_id(entry.object_id);
+    entry.destination_id = target.get<std::string>("destination_id", "");
+    entry.destination_name = target.get<std::string>("destination_name", "");
+
+    const auto pose_node = target.get_child_optional("destination_pose");
+    if (!pose_node.has_value()) {
+      result.warnings.push_back("Missing destination_pose for object_id='" + entry.object_id + "'.");
+      result.entries.push_back(entry);
+      continue;
+    }
+
+    entry.frame_id = pose_node.value().get<std::string>("frame_id", "");
+    const auto xyz = read_vec3(pose_node.value(), "xyz");
+    const auto quat = read_vec4(pose_node.value(), "quaternion_xyzw");
+    const auto rpy = read_vec3(pose_node.value(), "rpy");
+
+    if (!xyz.has_value()) {
+      result.warnings.push_back("Malformed destination_pose.xyz for object_id='" + entry.object_id + "'.");
+      result.entries.push_back(entry);
+      continue;
+    }
+
+    entry.pose.position.x = (*xyz)[0];
+    entry.pose.position.y = (*xyz)[1];
+    entry.pose.position.z = (*xyz)[2];
+
+    if (quat.has_value()) {
+      entry.pose.orientation.x = (*quat)[0];
+      entry.pose.orientation.y = (*quat)[1];
+      entry.pose.orientation.z = (*quat)[2];
+      entry.pose.orientation.w = (*quat)[3];
+    } else if (rpy.has_value()) {
+      tf2::Quaternion q;
+      q.setRPY((*rpy)[0], (*rpy)[1], (*rpy)[2]);
+      q.normalize();
+      entry.pose.orientation.x = q.x();
+      entry.pose.orientation.y = q.y();
+      entry.pose.orientation.z = q.z();
+      entry.pose.orientation.w = q.w();
+    } else {
+      result.warnings.push_back("Missing destination_pose orientation for object_id='" + entry.object_id + "'.");
+      result.entries.push_back(entry);
+      continue;
+    }
+
+    entry.valid_pose = is_finite_pose(entry.pose);
+    if (!entry.valid_pose) {
+      result.warnings.push_back("Non-finite destination pose for object_id='" + entry.object_id + "'.");
+    }
+
+    result.entries.push_back(entry);
+  }
+
+  result.loaded = true;
+  return result;
+}
+
+}  // namespace run_grasp_execution

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -26,6 +26,7 @@
 #include <regex>
 #include <stdexcept>
 #include <unordered_set>
+#include <unordered_map>
 #include <cctype>
 #include <cmath>
 #include <mutex>
@@ -54,6 +55,7 @@
 #include "run_grasp_execution/grasp_precheck_collision_filter.hpp"
 #include "run_grasp_execution/grasp_candidate_utils.hpp"
 #include "run_grasp_execution/home_return_utils.hpp"
+#include "run_grasp_execution/explicit_release_pose_utils.hpp"
 
 
 namespace grasp_execution
@@ -412,6 +414,16 @@ std::vector<double> resolve_safe_joint_state_param(
 class Demo : public moveit2::MoveitCppGraspExecution
 {
 public:
+  struct ReleasePlanDecision
+  {
+    std::string strategy{"legacy_offset"};
+    geometry_msgs::msg::PoseStamped pose;
+    std::string destination_id;
+    std::string destination_name;
+    std::string source_object_id;
+    std::string fallback_reason;
+  };
+
   explicit Demo(
     const rclcpp::Node::SharedPtr & node,
     [[maybe_unused]] const std::string & package_name,
@@ -440,6 +452,29 @@ public:
       release_x_offset_, "release_x_offset", node, node->get_logger(), -0.3);
     grasp_execution::declare_or_get_param<bool>(
       release_use_grasp_z_, "release_use_grasp_z", node, node->get_logger(), true);
+    grasp_execution::declare_or_get_param<bool>(
+      use_explicit_release_pose_, "use_explicit_release_pose", node, node->get_logger(), false);
+    grasp_execution::declare_or_get_param<std::string>(
+      explicit_release_pose_source_,
+      "explicit_release_pose_source",
+      node,
+      node->get_logger(),
+      "auto");
+    grasp_execution::declare_or_get_param<std::string>(
+      explicit_release_pose_frame_policy_,
+      "explicit_release_pose_frame_policy",
+      node,
+      node->get_logger(),
+      "require_planning_frame");
+    grasp_execution::declare_or_get_param<bool>(
+      fallback_to_legacy_release_, "fallback_to_legacy_release", node, node->get_logger(), true);
+    grasp_execution::declare_or_get_param<std::string>(
+      explicit_release_pose_bridge_payload_path_,
+      "explicit_release_pose_bridge_payload_path",
+      node,
+      node->get_logger(),
+      "");
+    maybe_load_explicit_release_pose_adapter();
     grasp_execution::declare_or_get_param<bool>(
       home_return_use_safe_intermediate_,
       "home_return.use_safe_intermediate",
@@ -603,6 +638,14 @@ public:
     const emd_msgs::msg::GraspTask::SharedPtr & msg,
     bool blocking = false)
   {
+    explicit_release_pose_by_target_id_.clear();
+    std::unordered_map<size_t, run_grasp_execution::ExplicitReleasePoseEntry> explicit_by_index;
+    if (explicit_release_pose_adapter_loaded_) {
+      const size_t max_count = std::min(explicit_release_entries_.size(), msg->grasp_targets.size());
+      for (size_t i = 0; i < max_count; ++i) {
+        explicit_by_index.emplace(i, explicit_release_entries_[i]);
+      }
+    }
     bool all_targets_success = true;
     // target id will be "#<shape>-<task_id>-<target-index>"
 
@@ -621,6 +664,9 @@ public:
 
       auto target_id =
         gen_target_object_id(grasp_target->target_shape, msg->task_id, i);
+      if (explicit_by_index.count(i) > 0U) {
+        explicit_release_pose_by_target_id_[target_id] = explicit_by_index[i];
+      }
 
       // Start planning workflow using planning schedule
       auto status = planning_scheduler.add_workflow(
@@ -906,23 +952,54 @@ public:
 
     prompt_job_end(node_->get_logger(), true);
 
-    // Apply configurable release pose offsets. The x_offset is applied to the
-    // current EE position. Optionally the z-height is aligned to the grasp
-    // pose so the object clears any surface obstacle on approach.
-    release_pose.pose.position.x += release_x_offset_;
-    if (release_use_grasp_z_) {
-      release_pose.pose.position.z = selected_moveit_grasp_pose.pose.position.z;
+    const auto release_decision = resolve_release_plan_decision(
+      target_id, release_pose, selected_moveit_grasp_pose);
+    if (!release_decision.fallback_reason.empty()) {
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "Release strategy fallback for target %s: %s",
+        target_id.c_str(),
+        release_decision.fallback_reason.c_str());
     }
-    release_pose.pose.orientation = selected_moveit_grasp_pose.pose.orientation;
+    RCLCPP_INFO(
+      node_->get_logger(),
+      "Release strategy target=%s strategy=%s destination_id=%s destination_name=%s source_object_id=%s pose=%s",
+      target_id.c_str(),
+      release_decision.strategy.c_str(),
+      release_decision.destination_id.c_str(),
+      release_decision.destination_name.c_str(),
+      release_decision.source_object_id.c_str(),
+      format_pose_xyz_quat_rpy(release_decision.pose.pose).c_str());
 
-    if(!this->plan_and_execute_job(
+    bool release_result = this->plan_and_execute_job(
+      options,
+      "Grasp release",
+      target_id,
+      release_decision.pose);
+    if (!release_result && release_decision.strategy == "explicit_destination_pose" &&
+      fallback_to_legacy_release_)
+    {
+      const auto legacy_release_pose = make_legacy_release_pose(release_pose, selected_moveit_grasp_pose);
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "Explicit release planning failed for target %s. Falling back to legacy_offset strategy.",
+        target_id.c_str());
+      release_result = this->plan_and_execute_job(
         options,
-        "Grasp release",
+        "Grasp release (legacy fallback)",
         target_id,
-        release_pose)){
-          log_release_octomap_collision_diagnostic(target_id, planning_group);
-          return false;
-      }
+        legacy_release_pose);
+    }
+    if (!release_result) {
+      log_release_octomap_collision_diagnostic(target_id, planning_group);
+      return false;
+    }
+    RCLCPP_INFO(
+      node_->get_logger(),
+      "Release summary target=%s strategy=%s fallback_used=%s",
+      target_id.c_str(),
+      release_decision.strategy.c_str(),
+      (!release_decision.fallback_reason.empty()) ? "true" : "false");
 
     // ------------------- detach grasp object from robot --------------------------
     prompt_job_start(
@@ -959,6 +1036,125 @@ public:
   }
 
 private:
+  geometry_msgs::msg::PoseStamped make_legacy_release_pose(
+    const geometry_msgs::msg::PoseStamped & current_pose,
+    const geometry_msgs::msg::PoseStamped & selected_moveit_grasp_pose) const
+  {
+    auto release_pose = current_pose;
+    release_pose.pose.position.x += release_x_offset_;
+    if (release_use_grasp_z_) {
+      release_pose.pose.position.z = selected_moveit_grasp_pose.pose.position.z;
+    }
+    release_pose.pose.orientation = selected_moveit_grasp_pose.pose.orientation;
+    return release_pose;
+  }
+
+  void maybe_load_explicit_release_pose_adapter()
+  {
+    const auto source = to_lower_copy(explicit_release_pose_source_);
+    const bool source_disabled = source == "disabled";
+    if (!use_explicit_release_pose_ || source_disabled) {
+      return;
+    }
+    if (explicit_release_pose_bridge_payload_path_.empty()) {
+      if (source == "bridge_payload") {
+        RCLCPP_WARN(
+          node_->get_logger(),
+          "explicit_release_pose_source=bridge_payload requested but explicit_release_pose_bridge_payload_path is empty.");
+      }
+      return;
+    }
+    const auto load_result =
+      run_grasp_execution::load_explicit_release_pose_bridge_payload(explicit_release_pose_bridge_payload_path_);
+    if (!load_result.loaded) {
+      RCLCPP_WARN(node_->get_logger(), "Explicit release adapter disabled: %s", load_result.error.c_str());
+      return;
+    }
+    explicit_release_pose_adapter_loaded_ = true;
+    explicit_release_entries_ = load_result.entries;
+    for (const auto & warning : load_result.warnings) {
+      RCLCPP_WARN(node_->get_logger(), "Explicit release adapter: %s", warning.c_str());
+    }
+    RCLCPP_INFO(
+      node_->get_logger(),
+      "Loaded explicit release adapter entries=%zu from bridge payload '%s'.",
+      explicit_release_entries_.size(),
+      explicit_release_pose_bridge_payload_path_.c_str());
+  }
+
+  ReleasePlanDecision resolve_release_plan_decision(
+    const std::string & target_id,
+    const geometry_msgs::msg::PoseStamped & current_pose,
+    const geometry_msgs::msg::PoseStamped & selected_moveit_grasp_pose)
+  {
+    ReleasePlanDecision decision;
+    decision.pose = make_legacy_release_pose(current_pose, selected_moveit_grasp_pose);
+
+    if (!use_explicit_release_pose_) {
+      decision.fallback_reason = "explicit release poses are disabled by parameter.";
+      return decision;
+    }
+
+    const auto source = to_lower_copy(explicit_release_pose_source_);
+    if (source == "disabled") {
+      decision.fallback_reason = "explicit_release_pose_source=disabled.";
+      return decision;
+    }
+
+    const auto it = explicit_release_pose_by_target_id_.find(target_id);
+    if (it == explicit_release_pose_by_target_id_.end()) {
+      decision.fallback_reason = "no destination pose entry resolved for target.";
+      return decision;
+    }
+
+    const auto & entry = it->second;
+    decision.destination_id = entry.destination_id;
+    decision.destination_name = entry.destination_name;
+    decision.source_object_id = entry.object_id;
+    if (!entry.valid_pose) {
+      decision.fallback_reason = "destination pose is missing/malformed.";
+      return decision;
+    }
+    const auto destination_frame = grasp_execution::sanitize_frame_id(entry.frame_id);
+    if (destination_frame.empty()) {
+      decision.fallback_reason = "destination frame is empty.";
+      return decision;
+    }
+    if (destination_frame != planning_frame_) {
+      if (to_lower_copy(explicit_release_pose_frame_policy_) == "require_planning_frame") {
+        decision.fallback_reason =
+          "destination frame '" + destination_frame + "' does not match planning_frame '" +
+          planning_frame_ + "'.";
+        return decision;
+      }
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "Explicit destination pose frame mismatch target=%s frame=%s planning_frame=%s (policy=warn_and_use).",
+        target_id.c_str(),
+        destination_frame.c_str(),
+        planning_frame_.c_str());
+    }
+
+    geometry_msgs::msg::PoseStamped explicit_pose;
+    explicit_pose.header.frame_id = destination_frame;
+    explicit_pose.pose = entry.pose;
+    if (!pose_within_workspace(explicit_pose, workspace_bounds_)) {
+      decision.fallback_reason = "destination pose outside configured workspace bounds.";
+      return decision;
+    }
+
+    decision.strategy = "explicit_destination_pose";
+    decision.pose = explicit_pose;
+    decision.fallback_reason.clear();
+    RCLCPP_INFO(
+      node_->get_logger(),
+      "Using explicit destination release pose for target %s destination_id=%s frame=%s",
+      target_id.c_str(),
+      decision.destination_id.c_str(),
+      destination_frame.c_str());
+    return decision;
+  }
+
   void set_last_failure_message(const std::string & message)
   {
     std::lock_guard<std::mutex> lock(last_failure_mutex_);
@@ -1282,6 +1478,15 @@ private:
   std::string planning_frame_;
   double release_x_offset_{-0.3};
   bool release_use_grasp_z_{true};
+  bool use_explicit_release_pose_{false};
+  std::string explicit_release_pose_source_{"auto"};
+  std::string explicit_release_pose_frame_policy_{"require_planning_frame"};
+  bool fallback_to_legacy_release_{true};
+  std::string explicit_release_pose_bridge_payload_path_;
+  bool explicit_release_pose_adapter_loaded_{false};
+  std::vector<run_grasp_execution::ExplicitReleasePoseEntry> explicit_release_entries_;
+  std::unordered_map<std::string, run_grasp_execution::ExplicitReleasePoseEntry>
+    explicit_release_pose_by_target_id_;
   bool home_return_use_safe_intermediate_{false};
   int home_return_max_attempts_{5};
   std::vector<double> home_return_safe_joint_state_;
@@ -1443,3 +1648,11 @@ int main(int argc, char ** argv)
   rclcpp::shutdown();
   return 0;
 }
+    std::unordered_map<size_t, run_grasp_execution::ExplicitReleasePoseEntry> explicit_by_index;
+    if (explicit_release_pose_adapter_loaded_) {
+      const auto entries = explicit_release_entries_;
+      const size_t max_count = std::min(entries.size(), msg->grasp_targets.size());
+      for (size_t i = 0; i < max_count; ++i) {
+        explicit_by_index.emplace(i, entries[i]);
+      }
+    }

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_explicit_release_pose_utils.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_explicit_release_pose_utils.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <string>
+
+#include "run_grasp_execution/explicit_release_pose_utils.hpp"
+
+namespace
+{
+
+std::string write_temp_payload(const std::string & content)
+{
+  const std::string path = "/tmp/test_explicit_release_pose_payload.json";
+  std::ofstream out(path);
+  out << content;
+  out.close();
+  return path;
+}
+
+}  // namespace
+
+TEST(ExplicitReleasePoseUtilsTest, NormalizesObjectIdHashes)
+{
+  EXPECT_EQ(run_grasp_execution::normalize_object_id("##box_1"), "box_1");
+  EXPECT_EQ(run_grasp_execution::normalize_object_id("box_1"), "box_1");
+}
+
+TEST(ExplicitReleasePoseUtilsTest, LoadsValidDestinationPose)
+{
+  const auto path = write_temp_payload(R"JSON({
+    "grasp_task": {
+      "grasp_targets": [
+        {
+          "object_id": "#box_red",
+          "destination_id": "bin_red",
+          "destination_name": "Red Bin",
+          "destination_pose": {
+            "frame_id": "world",
+            "xyz": [0.4, 0.2, 0.3],
+            "rpy": [0.0, 0.0, 1.57]
+          }
+        }
+      ]
+    }
+  })JSON");
+
+  const auto result = run_grasp_execution::load_explicit_release_pose_bridge_payload(path);
+  ASSERT_TRUE(result.loaded);
+  ASSERT_EQ(result.entries.size(), 1U);
+  EXPECT_TRUE(result.entries.front().valid_pose);
+  EXPECT_EQ(result.entries.front().normalized_object_id, "box_red");
+  EXPECT_EQ(result.entries.front().frame_id, "world");
+}
+
+TEST(ExplicitReleasePoseUtilsTest, MalformedPoseDoesNotCrash)
+{
+  const auto path = write_temp_payload(R"JSON({
+    "grasp_task": {
+      "grasp_targets": [
+        {
+          "object_id": "box_bad",
+          "destination_pose": {
+            "frame_id": "world",
+            "xyz": [0.4, 0.2]
+          }
+        }
+      ]
+    }
+  })JSON");
+
+  const auto result = run_grasp_execution::load_explicit_release_pose_bridge_payload(path);
+  ASSERT_TRUE(result.loaded);
+  ASSERT_EQ(result.entries.size(), 1U);
+  EXPECT_FALSE(result.entries.front().valid_pose);
+  EXPECT_FALSE(result.warnings.empty());
+}


### PR DESCRIPTION
### Motivation
- Enable runtime use of explicit destination/release poses produced by the offline bridge (`emd_grasp_bridge_payload/v1`) so runtime can place objects into bins/lanes/trays when safe to do so.
- Preserve existing behavior and compatibility by keeping `release_x_offset` / `release_use_grasp_z` as the default and providing a guarded opt-in adapter with safe fallbacks.
- Avoid changing ROS message schemas or broad interfaces, preferring a small adapter that consumes bridge JSON when explicitly configured.

### Description
- Add a small JSON adapter and parser `include/run_grasp_execution/explicit_release_pose_utils.hpp` to load `emd_grasp_bridge_payload/v1` payloads and normalize object ids and poses.
- Add guarded runtime parameters and logic in `demo_node.cpp`: `use_explicit_release_pose`, `explicit_release_pose_source`, `explicit_release_pose_frame_policy`, `fallback_to_legacy_release`, and `explicit_release_pose_bridge_payload_path`, plus `maybe_load_explicit_release_pose_adapter()` and `resolve_release_plan_decision()` which choose explicit or legacy release strategies.
- Wire per-target explicit-release entries into the planning flow (map by `target_id`) and implement `make_legacy_release_pose()` to preserve the original `release_x_offset` / `release_use_grasp_z` fallback path.
- Add runtime diagnostics logging the chosen release strategy, `destination_id`/`destination_name`, release pose, and clear fallback reasons, and update `config/grasp_execution.yaml` and docs (`EMD_GRASP_BRIDGE_PAYLOAD.md`, `WORKCELL_OPERATOR_MANUAL.md`, `REAL_D435I_EPD_PIPELINE.md`) to describe opt-in usage and safe defaults.
- Add unit tests `test_explicit_release_pose_utils.cpp` (object-id normalization, valid/malformed payload parsing) and register the test in `CMakeLists.txt`.

### Testing
- `python3 -m py_compile scripts/convert_runtime_plan_to_emd_grasp.py` succeeded without error.
- `python3 -m pytest -q tests/test_emd_grasp_bridge.py` ran and passed (13 tests; all passed).
- `./scripts/preflight_workcell.sh` was executed and completed offline validation checks (ROS-dependent runtime launch checks were skipped/warned due to missing `ros2`/ROS setup in this environment).
- `colcon build` / runtime `ros2 launch` steps could not be executed in this environment because `colcon` and `ros2` are not available here, so the new C++ test target was added but not run in this CI sandbox.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09939cbf88331b3f95d483c35aa74)