### PR TITLE
Replace invalid maintainer emails with mukaram@outlook.it

### DIFF
--- a/assets/environment/workbench_description/package.xml
+++ b/assets/environment/workbench_description/package.xml
@@ -4,7 +4,7 @@
   <name>workbench_description</name>
   <version>2.0.0</version>
   <description>Workbench model and related launch assets for Easy Manipulation Deployment scenes</description>
-  <maintainer email="Mukaram01@gmail.com">Mukaram01</maintainer>
+  <maintainer email="mukaram@outlook.it">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/scenes/suction_test/package.xml
+++ b/scenes/suction_test/package.xml
@@ -4,7 +4,7 @@
   <name>suction_test</name>
   <version>2.0.0</version>
   <description>UR5 robot with single-suction gripper scene for Easy Manipulation Deployment</description>
-  <maintainer email="Mukaram01@gmail.com">Mukaram01</maintainer>
+  <maintainer email="mukaram@outlook.it">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/scenes/ur10_2f_test/package.xml
+++ b/scenes/ur10_2f_test/package.xml
@@ -4,7 +4,7 @@
   <name>ur10_2f_test</name>
   <version>2.0.0</version>
   <description>UR10 robot with Robotiq 2F gripper scene for Easy Manipulation Deployment</description>
-  <maintainer email="Mukaram01@gmail.com">Mukaram01</maintainer>
+  <maintainer email="mukaram@outlook.it">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/scenes/ur3_suction_test/package.xml
+++ b/scenes/ur3_suction_test/package.xml
@@ -4,7 +4,7 @@
   <name>ur3_suction_test</name>
   <version>2.0.0</version>
   <description>UR3 robot with single suction gripper scene for Easy Manipulation Deployment</description>
-  <maintainer email="Mukaram01@gmail.com">Mukaram01</maintainer>
+  <maintainer email="mukaram@outlook.it">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/tests/fixtures/scene_readiness/abs_path_workcell/scenes/abs_scene/package.xml
+++ b/tests/fixtures/scene_readiness/abs_path_workcell/scenes/abs_scene/package.xml
@@ -1,1 +1,1 @@
-<package format="3"><name>abs_scene</name><version>0.0.0</version><description>x</description><maintainer email="x@y">x</maintainer><license>Apache-2.0</license></package>
+<package format="3"><name>abs_scene</name><version>0.0.0</version><description>x</description><maintainer email="mukaram@outlook.it">x</maintainer><license>Apache-2.0</license></package>

--- a/tests/fixtures/scene_readiness/duplicate_mesh_workcell/scenes/dup_scene/package.xml
+++ b/tests/fixtures/scene_readiness/duplicate_mesh_workcell/scenes/dup_scene/package.xml
@@ -1,1 +1,1 @@
-<package format="3"><name>dup_scene</name><version>0.0.0</version><description>x</description><maintainer email="x@y">x</maintainer><license>Apache-2.0</license></package>
+<package format="3"><name>dup_scene</name><version>0.0.0</version><description>x</description><maintainer email="mukaram@outlook.it">x</maintainer><license>Apache-2.0</license></package>

--- a/tests/fixtures/scene_readiness/missing_mesh_workcell/scenes/missing_mesh_scene/package.xml
+++ b/tests/fixtures/scene_readiness/missing_mesh_workcell/scenes/missing_mesh_scene/package.xml
@@ -1,1 +1,1 @@
-<package format="3"><name>missing_mesh_scene</name><version>0.0.0</version><description>x</description><maintainer email="x@y">x</maintainer><license>Apache-2.0</license></package>
+<package format="3"><name>missing_mesh_scene</name><version>0.0.0</version><description>x</description><maintainer email="mukaram@outlook.it">x</maintainer><license>Apache-2.0</license></package>

--- a/tests/fixtures/scene_readiness/valid_workcell/scenes/demo_scene/package.xml
+++ b/tests/fixtures/scene_readiness/valid_workcell/scenes/demo_scene/package.xml
@@ -1,1 +1,1 @@
-<package format="3"><name>demo_scene</name><version>0.0.0</version><description>x</description><maintainer email="x@y">x</maintainer><license>Apache-2.0</license></package>
+<package format="3"><name>demo_scene</name><version>0.0.0</version><description>x</description><maintainer email="mukaram@outlook.it">x</maintainer><license>Apache-2.0</license></package>

--- a/workcell_builder/examples/ros2/package_example.xml
+++ b/workcell_builder/examples/ros2/package_example.xml
@@ -4,7 +4,7 @@
   <name>workcellexample</name>
   <version>2.0.0</version>
   <description>workcellexample description</description>
-  <maintainer email="Mukaram01@gmail.com">Mukaram01</maintainer>
+  <maintainer email="mukaram@outlook.it">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/workcell_builder/workcell_builder/templates/ros2/humble/package_example.xml
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/package_example.xml
@@ -4,7 +4,7 @@
   <name>workcellexample</name>
   <version>2.0.0</version>
   <description>workcellexample description</description>
-  <maintainer email="Mukaram01@gmail.com">Mukaram01</maintainer>
+  <maintainer email="mukaram@outlook.it">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/workcell_builder/workcell_builder/templates/ros2/package_example.xml
+++ b/workcell_builder/workcell_builder/templates/ros2/package_example.xml
@@ -4,7 +4,7 @@
   <name>workcellexample</name>
   <version>2.0.0</version>
   <description>workcellexample description</description>
-  <maintainer email="Mukaram01@gmail.com">Mukaram01</maintainer>
+  <maintainer email="mukaram@outlook.it">Mukaram01</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
### Motivation
- ROS package metadata validation (`rosdep`) failed due to an invalid maintainer email placeholder (`x@y`) in scene readiness fixtures, and several manifests used an outdated personal address (`Mukaram01@gmail.com`).
- Replace placeholders and legacy addresses with a valid, consistent maintainer address to fix validation errors and keep package metadata accurate.

### Description
- Replaced `Mukaram01@gmail.com` with `mukaram@outlook.it` in scene package manifests, workcell example/templates, and the workbench asset manifest.
- Replaced invalid placeholder maintainer emails `x@y` with `mukaram@outlook.it` in the scene readiness test fixtures under `tests/fixtures/scene_readiness/*`.
- Updated a total of 11 files and committed the changes with the message `Replace placeholder and legacy maintainer emails with mukaram@outlook.it`.

### Testing
- Ran a repository-wide search with `rg -n "Mukaram01@gmail.com|x@y"` to locate old/invalid emails before edits and confirmed matches were found.
- Ran `rg -n "Mukaram01@gmail.com|x@y|mukaram@outlook.it"` after edits to verify replacements and confirm no old/invalid values remain.
- Ran `git status --short` and created a commit; the staging and commit operations succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b8c9802c833194424ae4e6176a72)