### PR TITLE
Fix Humble full-build regressions for OSQP/TrajOpt and clean-machine flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ rosdep install --from-paths src --ignore-src -r -y --rosdistro humble \
   --skip-keys "qt_advanced_docking tesseract_visualization"
 eval "$(./src/easy_manipulation_deployment/scripts/ensure_taskflow_cmake_package.sh --export)"
 ./src/easy_manipulation_deployment/scripts/verify_workspace_discovery.sh
-colcon build --symlink-install --parallel-workers 2 \
+colcon build --symlink-install  \
   --allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils \
   --packages-skip tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_planning_server
 source install/setup.bash
@@ -420,7 +420,7 @@ For scripted workflows, `./scripts/fix_and_build.sh` now runs the same preflight
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
 eval "$(./src/easy_manipulation_deployment/scripts/ensure_taskflow_cmake_package.sh --export)"
 colcon list --base-paths src --names-only | grep -E '^tesseract_motion_planners($|_)'
-colcon build --symlink-install --parallel-workers 2 --allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils --packages-skip tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_planning_server
+colcon build --symlink-install  --allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils --packages-skip tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_planning_server
 source install/setup.bash
 ```
 
@@ -463,7 +463,7 @@ rosdep install --from-paths src --ignore-src -r -y --rosdistro humble \
 
 colcon list --base-paths src --names-only | grep -E '^tesseract_motion_planners($|_)'
 
-colcon build --symlink-install --parallel-workers 2 \
+colcon build --symlink-install  \
   --allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils \
   --packages-skip tesseract_qt QtADS tesseract_rviz tesseract_planning_server
 source install/setup.bash
@@ -487,7 +487,7 @@ test -e src/table_description && test -e src/workbench_description && test -e sr
   ```bash
   cd ~/workcell_ws
   source /opt/ros/humble/setup.bash
-  colcon build --symlink-install --parallel-workers 2 \
+  colcon build --symlink-install  \
     --packages-skip tesseract_qt QtADS tesseract_rviz tesseract_planning_server
   ```
 
@@ -702,7 +702,7 @@ For the default manual/headless path, keep the GUI packages disabled so a plain 
 ```bash
 cd ~/workcell_ws
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
-colcon build --symlink-install --parallel-workers 2
+colcon build --symlink-install 
 ```
 
 If you want an explicit non-GUI full-workspace example that matches the Humble helper-script defaults from the logs, skip the GUI packages by their discovered names (with the checkout folder as an extra fallback) or use the helper script without `--with-gui`:
@@ -710,7 +710,7 @@ If you want an explicit non-GUI full-workspace example that matches the Humble h
 ```bash
 cd ~/workcell_ws
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
-colcon build --symlink-install --parallel-workers 2 \
+colcon build --symlink-install  \
   --packages-skip tesseract_qt QtADS qtadvanceddocking
 ```
 
@@ -729,14 +729,14 @@ vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/de
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh --with-gui
 
 # 1) Build/install the core package set that exports tesseract_commonConfig.cmake
-colcon build --symlink-install --parallel-workers 2 \
+colcon build --symlink-install  \
   --packages-skip tesseract_qt QtADS qtadvanceddocking tesseract_rviz tesseract_planning_server
 
 # 2) Refresh the overlay environment from the staged install
 source install/setup.bash
 
 # 3) Build tesseract_qt and remaining downstream GUI packages
-colcon build --symlink-install --parallel-workers 2 \
+colcon build --symlink-install  \
   --packages-up-to tesseract_qt tesseract_rviz tesseract_planning_server
 ```
 
@@ -764,7 +764,7 @@ cd ~/workcell_ws/src/easy_manipulation_deployment
 cd ~/workcell_ws
 rm -rf build install log
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
-colcon build --parallel-workers 2
+colcon build 
 ```
 
 Helper-script equivalent:
@@ -823,7 +823,7 @@ cd /opt/workcell_ws/src/easy_manipulation_deployment
 ```bash
 cd ~/workcell_ws
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
-colcon build --packages-select emd_grasp_planner --parallel-workers 2
+colcon build --packages-select emd_grasp_planner 
 ```
 
 For dependency-first troubleshooting of the planning stack:
@@ -860,7 +860,7 @@ The main supported quick-start path uses a plain build:
 ```bash
 cd ~/workcell_ws
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
-colcon build --parallel-workers 2
+colcon build 
 ```
 
 If you are actively developing packages and want editable install behavior, use:
@@ -868,7 +868,7 @@ If you are actively developing packages and want editable install behavior, use:
 ```bash
 cd ~/workcell_ws
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
-colcon build --symlink-install --parallel-workers 2
+colcon build --symlink-install 
 ```
 
 Some helper scripts and source-overlay workflows still use `--symlink-install`, especially for full-profile development workspaces.
@@ -901,7 +901,7 @@ source /opt/ros/humble/setup.bash
 cd ~/workcell_ws
 rm -rf build install log
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
-colcon build --parallel-workers 2
+colcon build 
 ```
 
 Do **not** remove `ros-humble-ruckig` just to build this repository; that can remove unrelated MoveIt packages.
@@ -934,7 +934,7 @@ cd ~/workcell_ws
 vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
 colcon list | grep tesseract_motion_planners
-colcon build --symlink-install --parallel-workers 2 --packages-up-to tesseract_rosutils
+colcon build --symlink-install  --packages-up-to tesseract_rosutils
 ```
 
 If `colcon list` shows planner component packages (for example `tesseract_motion_planners_core`, `tesseract_motion_planners_simple`, `tesseract_motion_planners_ompl`, `tesseract_motion_planners_descartes`, `tesseract_motion_planners_trajopt`), build those first and then rebuild `tesseract_rosutils`.
@@ -943,7 +943,7 @@ Then source the rebuilt overlay and continue with a full workspace build:
 
 ```bash
 source ~/workcell_ws/install/setup.bash
-colcon build --symlink-install --parallel-workers 2
+colcon build --symlink-install 
 ```
 
 Binary-package path: install/verify `ros-${ROS_DISTRO}-tesseract-motion-planners`, open a fresh shell, source `/opt/ros/${ROS_DISTRO}/setup.bash`, and rebuild `tesseract_rosutils`.
@@ -955,10 +955,10 @@ If `tesseract_qt` fails to link because the ADS target name differs on your syst
 ```bash
 cd ~/workcell_ws
 ./src/easy_manipulation_deployment/scripts/apply_upstream_patches.sh
-colcon build --symlink-install --parallel-workers 2 \
+colcon build --symlink-install  \
   --packages-skip tesseract_qt QtADS qtadvanceddocking tesseract_rviz tesseract_planning_server
 source install/setup.bash
-colcon build --symlink-install --parallel-workers 2 \
+colcon build --symlink-install  \
   --packages-up-to tesseract_qt tesseract_rviz tesseract_planning_server
 ```
 
@@ -1001,7 +1001,7 @@ rm -rf build install log
 rosdep install --from-paths src --ignore-src -r -y --rosdistro humble \
   --skip-keys "qt_advanced_docking tesseract_visualization"
 colcon list --base-paths src --names-only | grep -E '^tesseract_motion_planners($|_)'
-colcon build --parallel-workers 2
+colcon build 
 ```
 
 ### `workbench_description` missing during `rosdep install`
@@ -1033,7 +1033,7 @@ sudo apt install -y libboost-dev libboost-graph-dev libboost-program-options-dev
   libboost-serialization-dev libboost-stacktrace-dev
 cd ~/workcell_ws
 rm -rf build install log
-colcon build --symlink-install --parallel-workers 2
+colcon build --symlink-install 
 ```
 
 Cereal not found:
@@ -1376,6 +1376,7 @@ Notes:
 - Full profile builds `trajopt_sco`, `trajopt`, `trajopt_ifopt`, `trajopt_sqp`, and `tesseract_motion_planners`.
 - GUI packages are optional and skipped by default unless `--with-gui` is provided.
 - OSQP/OsqpEigen are pinned for TrajOpt/Tesseract 0.33.x compatibility through the dependency overlay.
+- The shorter `./fix_and_build_humble.sh --workspace ~/workcell_ws --check-prereqs --build --profile full` flow is intended for already-prepared machines (or non-EPD runs).
 
 ### Package classification
 

--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -145,8 +145,13 @@ PY
   fi
 
   if need_command rosdep; then
-    run_cmd "rosdep init || true"
-    log_change "rosdep init"
+    local rosdep_sources="/etc/ros/rosdep/sources.list.d/20-default.list"
+    if [[ -f "$rosdep_sources" ]]; then
+      echo "rosdep default sources already initialized."
+    else
+      run_cmd "rosdep init || true"
+      log_change "rosdep init"
+    fi
   fi
 }
 
@@ -203,21 +208,21 @@ prepare_osqp_stack() {
 
   if [[ $need_local_osqp -eq 1 ]]; then
     echo "Installing pinned OSQP/OsqpEigen compatibility stack for TrajOpt/Tesseract (OSQP 0.6.3 + OsqpEigen 0.8.0)."
-    run_cmd "cmake -S src/osqp -B build/osqp -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_SHARED_LIBS=ON"
-    run_cmd "cmake --build build/osqp"
+    run_cmd "cmake -S src/osqp -B build/_external/osqp -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_SHARED_LIBS=ON"
+    run_cmd "cmake --build build/_external/osqp"
     if command -v sudo >/dev/null 2>&1; then
-      run_cmd "sudo cmake --install build/osqp"
+      run_cmd "sudo cmake --install build/_external/osqp"
     else
-      run_cmd "cmake --install build/osqp"
+      run_cmd "cmake --install build/_external/osqp"
     fi
     log_change "install osqp from source (0.6.3)"
 
-    run_cmd "cmake -S src/osqp-eigen -B build/osqp-eigen -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DOSQP_EIGEN_BUILD_PYTHON=OFF"
-    run_cmd "cmake --build build/osqp-eigen"
+    run_cmd "cmake -S src/osqp-eigen -B build/_external/osqp-eigen -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DOSQP_EIGEN_BUILD_PYTHON=OFF"
+    run_cmd "cmake --build build/_external/osqp-eigen"
     if command -v sudo >/dev/null 2>&1; then
-      run_cmd "sudo cmake --install build/osqp-eigen"
+      run_cmd "sudo cmake --install build/_external/osqp-eigen"
     else
-      run_cmd "cmake --install build/osqp-eigen"
+      run_cmd "cmake --install build/_external/osqp-eigen"
     fi
     log_change "install osqp-eigen from source (0.8.0)"
 
@@ -238,6 +243,26 @@ prepare_osqp_stack() {
     echo "Incompatible OSQP headers detected: auxil.h not found. TrajOpt SQP requires the OSQP 0.6 API." >&2
     exit 1
   fi
+
+  [[ -d "/usr/local/lib/cmake/osqp" ]] || {
+    echo "OSQP compatibility install incomplete: /usr/local/lib/cmake/osqp was not found." >&2
+    exit 1
+  }
+  [[ -d "/usr/local/lib/cmake/OsqpEigen" ]] || {
+    echo "OsqpEigen compatibility install incomplete: /usr/local/lib/cmake/OsqpEigen was not found." >&2
+    exit 1
+  }
+}
+
+hide_workspace_osqp_sources() {
+  local marker
+  local osqp_dirs=("src/osqp" "src/osqp-eigen")
+  for dir in "${osqp_dirs[@]}"; do
+    [[ -d "$dir" ]] || continue
+    for marker in COLCON_IGNORE AMENT_IGNORE; do
+      [[ -e "$dir/$marker" ]] || run_cmd "touch '$dir/$marker'"
+    done
+  done
 }
 
 capture_epd_state() {
@@ -371,8 +396,9 @@ build_phase() {
 
   run_cmd "./src/easy_manipulation_deployment/scripts/ensure_rosdep_overrides.sh"
   run_cmd "./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh $([[ $WITH_GUI -eq 1 ]] && echo --with-gui || true)"
+  hide_workspace_osqp_sources
 
-  local rosdep_skip_keys=(qt_advanced_docking tesseract_visualization taskflow trajopt_ifopt trajopt_sqp osqp osqp_vendor osqp-eigen)
+  local rosdep_skip_keys=(qt_advanced_docking tesseract_visualization taskflow trajopt_ifopt trajopt_sqp osqp osqp_vendor osqp-eigen osqp_eigen qpoases)
   local fallback_keys=""
   if fallback_keys=$(./src/easy_manipulation_deployment/scripts/preflight_tesseract_apt.sh --ros-distro humble --print-rosdep-skip-keys 2>/dev/null); then
     if [[ -n "$fallback_keys" ]]; then

--- a/scripts/fix_workspace_layout.sh
+++ b/scripts/fix_workspace_layout.sh
@@ -498,6 +498,66 @@ link_from_backup() {
   fi
 }
 
+find_package_dir_in_root() {
+  local pkg_name="$1"
+  local root="$2"
+  local pkg_xml pkg_dir discovered_name
+
+  [[ -d "$root" ]] || return 1
+  while IFS= read -r pkg_xml; do
+    pkg_dir="$(dirname "$pkg_xml")"
+    discovered_name="$(package_name_from_xml "$pkg_xml")"
+    if [[ "$discovered_name" == "$pkg_name" ]]; then
+      echo "$pkg_dir"
+      return 0
+    fi
+  done < <(find "$root" -name package.xml -print 2>/dev/null)
+
+  return 1
+}
+
+ensure_required_trajopt_package() {
+  local pkg_name="$1"
+  local -a search_roots=(
+    "$SRC_DIR/trajopt"
+    "$SRC_DIR/tesseract_planning"
+    "$BACKUP_DIR/original"
+    "$BACKUP_DIR"
+  )
+  local discovered_path=""
+  local root
+  local dest="$SRC_DIR/$pkg_name"
+
+  for root in "${search_roots[@]}"; do
+    if discovered_path="$(find_package_dir_in_root "$pkg_name" "$root")"; then
+      break
+    fi
+  done
+
+  if [[ -z "$discovered_path" ]]; then
+    echo "Warning: required TrajOpt package '$pkg_name' was not found in expected roots." >&2
+    return 1
+  fi
+
+  ensure_symlink_target "$dest" "$discovered_path"
+  echo "Verified TrajOpt package: ${pkg_name} -> $(readlink -f "$dest")"
+  return 0
+}
+
+expose_required_trajopt_packages() {
+  local pkg
+  local failed=0
+  local required=(trajopt trajopt_common trajopt_sco trajopt_ifopt trajopt_sqp)
+
+  for pkg in "${required[@]}"; do
+    if ! ensure_required_trajopt_package "$pkg"; then
+      failed=1
+    fi
+  done
+
+  return "$failed"
+}
+
 ensure_symlink_target() {
   local dest="$1"
   local target="$2"
@@ -575,7 +635,7 @@ PY
     present["$pkg"]=1
   done
 
-  local required=(trajopt trajopt_common trajopt_sco)
+  local required=(trajopt trajopt_common trajopt_sco trajopt_ifopt trajopt_sqp)
   _missing_ref=()
   for pkg in "${required[@]}"; do
     if [[ -z ${present[$pkg]:-} ]]; then
@@ -586,11 +646,11 @@ PY
   [[ ${#_missing_ref[@]} -eq 0 ]]
 }
 
-# Ensure symlink for trajopt_sco points to a valid package source.
-trajopt_sco_target="$(resolve_trajopt_sco_target "${SRC_DIR}/easy_manipulation_deployment/trajopt/trajopt_sco")"
-ensure_symlink_target \
-  "${SRC_DIR}/trajopt_sco" \
-  "${trajopt_sco_target}"
+# Ensure the required TrajOpt packages are directly discoverable from src/.
+if ! expose_required_trajopt_packages; then
+  echo "Error: failed to expose one or more required TrajOpt packages." >&2
+  exit 1
+fi
 
 # Ensure trajopt_common declares all dependencies it links against. Some
 # upstream snapshots omit find_package() calls for tinyxml2, Boost graph, and

--- a/scripts/validate_workspace_assets.sh
+++ b/scripts/validate_workspace_assets.sh
@@ -189,7 +189,7 @@ if [ ${#repo_missing[@]} -gt 0 ] || [ ${#repo_index_fail[@]} -gt 0 ]; then
   (including suction assets: single_suction_description, single_suction_moveit_config)
     1. cd ${WORKSPACE_ROOT}
     2. ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
-    3. colcon build --symlink-install --parallel-workers 2
+    3. colcon build --symlink-install
     4. source install/setup.bash
     5. rerun ${SCRIPT_DIR}/validate_workspace_assets.sh
 

--- a/tests/test_humble_build_regressions.py
+++ b/tests/test_humble_build_regressions.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+def test_no_hardcoded_parallel_workers_2_in_docs_or_scripts():
+    roots = [Path("README.md"), Path("fix_and_build_humble.sh"), Path("scripts")]
+    for root in roots:
+        if root.is_file():
+            text = root.read_text()
+            assert "--parallel-workers 2" not in text
+            continue
+        for path in root.rglob("*"):
+            if path.is_file() and path.suffix in {".sh", ".md", ".py", ".txt"}:
+                assert "--parallel-workers 2" not in path.read_text(), str(path)
+
+
+def test_fix_and_build_uses_external_osqp_strategy():
+    text = Path("fix_and_build_humble.sh").read_text()
+    assert "build/_external/osqp" in text
+    assert "build/_external/osqp-eigen" in text
+    assert "hide_workspace_osqp_sources" in text
+    assert "src/osqp" in text and "COLCON_IGNORE" in text and "AMENT_IGNORE" in text
+    assert "/usr/local/lib/cmake/osqp" in text
+    assert "/usr/local/lib/cmake/OsqpEigen" in text
+
+
+def test_rosdep_skip_keys_include_required_variants():
+    text = Path("fix_and_build_humble.sh").read_text()
+    for key in ["osqp", "osqp_vendor", "osqp-eigen", "osqp_eigen", "qpoases"]:
+        assert key in text
+
+
+def test_trajopt_required_packages_are_exposed_and_verified():
+    text = Path("scripts/fix_workspace_layout.sh").read_text()
+    assert "required=(trajopt trajopt_common trajopt_sco trajopt_ifopt trajopt_sqp)" in text
+    assert "Verified TrajOpt package:" in text
+    assert "$SRC_DIR/tesseract_planning" in text
+    assert "$BACKUP_DIR/original" in text
+
+
+def test_epd_underlay_validation_uses_local_setup_and_epd_msgs():
+    text = Path("fix_and_build_humble.sh").read_text()
+    assert "install/local_setup.bash" in text
+    assert "ros2 pkg prefix epd_msgs" in text


### PR DESCRIPTION
### Motivation
- Make a fresh-clone Humble full-profile build deterministic and clean by removing fragile workspace/package discovery collisions and noisy init steps. 
- Prevent colcon/packaging conflicts arising from importing `osqp`/`osqp-eigen` into `src/` while also building/installing them externally. 
- Ensure TrajOpt planner packages (`trajopt`, `trajopt_common`, `trajopt_sco`, `trajopt_ifopt`, `trajopt_sqp`) are reliably exposed and discoverable prior to `colcon build`. 
- Improve the developer/user experience by removing hardcoded `--parallel-workers 2` guidance and making `rosdep init` quiet/idempotent.

### Description
- Make `rosdep init` idempotent by checking `/etc/ros/rosdep/sources.list.d/20-default.list` and printing `rosdep default sources already initialized.` instead of reinitializing. 
- Implement an external-install strategy for OSQP/OsqpEigen by building them in isolated dirs `build/_external/osqp` and `build/_external/osqp-eigen`, installing to `/usr/local`, and validating presence of `/usr/local/lib/cmake/osqp` and `/usr/local/lib/cmake/OsqpEigen`. 
- Hide workspace `src/osqp` and `src/osqp-eigen` from colcon by creating `COLCON_IGNORE` / `AMENT_IGNORE` markers when external-install strategy is used to avoid colcon package-name collisions. 
- Extend rosdep skip keys to include compatibility naming variants (`osqp`, `osqp_vendor`, `osqp-eigen`, `osqp_eigen`, `qpoases`) and keep `--parallel-workers` optional by only appending it to the `colcon` command when the user explicitly passes `--parallel-workers <N>`. 
- Update `scripts/fix_workspace_layout.sh` to generically locate nested TrajOpt packages by scanning `package.xml` under multiple search roots (`src/trajopt`, `src/tesseract_planning`, backup/original trees), create `src/<package>` symlinks as needed, and print verification lines such as `Verified TrajOpt package: trajopt_sqp -> /path/to/package`. 
- Remove hardcoded `--parallel-workers 2` guidance from README and helper docs and add a note clarifying the short one-liner is for already-prepared or non-EPD machines; add small documentation cleanups. 
- Add regression tests in `tests/test_humble_build_regressions.py` that assert no hardcoded `--parallel-workers 2`, verify the external OSQP build dirs and hide-markers are referenced, check rosdep skip-key coverage, verify TrajOpt exposure logic presence, and confirm EPD underlay validation uses `install/local_setup.bash` + `epd_msgs` check.

### Testing
- Ran the new regression suite with `python3 -m pytest -q tests/test_humble_build_regressions.py`, which passed (5 tests). 
- Performed a shell syntax/quick static check with `bash -n fix_and_build_humble.sh scripts/fix_workspace_layout.sh`, which returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0dd0fc564833180d8882a5ecce135)