### PR TITLE
Hide imported cereal source from colcon in Humble installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,11 @@ cd ~/workcell_ws/src/easy_manipulation_deployment
 source ~/workcell_ws/install/setup.bash
 ```
 
+Notes:
+- `cereal` is treated as a system/header-only dependency and is supplied through `libcereal-dev` via rosdep override resolution.
+- If `src/cereal` is imported by the dependency manifest, the installer intentionally writes `COLCON_IGNORE` + `AMENT_IGNORE` so colcon does not try to build upstream cereal sandbox/tests/examples.
+- Do **not** manually build `cereal` in this workspace.
+
 ### Verify the install
 
 ```bash
@@ -340,6 +345,7 @@ ros2 pkg prefix run_grasp_planner
 ros2 pkg prefix run_grasp_execution
 ros2 pkg prefix run_waypoint_execution
 ros2 pkg prefix workcell_builder
+colcon list --base-paths ~/workcell_ws/src --names-only | grep -x cereal && echo "ERROR cereal visible" || echo "OK cereal hidden"
 ```
 
 ### First launch smoke test
@@ -399,6 +405,7 @@ source ~/epd_ros2_ws/install/local_setup.bash
 
 vcs import --recursive --skip-existing src < src/easy_manipulation_deployment/dependencies/emd_epd_ws.repos
 ./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh
+touch src/cereal/COLCON_IGNORE src/cereal/AMENT_IGNORE 2>/dev/null || true
 rosdep update
 rosdep install --from-paths src --ignore-src -r -y --rosdistro humble \
   --skip-keys "qt_advanced_docking tesseract_visualization"
@@ -904,13 +911,16 @@ rm -rf build install log
 colcon build --symlink-install 
 ```
 
-Cereal not found:
+Cereal setup (header-only system dependency):
 
 ```bash
 sudo apt install -y libcereal-dev
 sudo mkdir -p /usr/lib/x86_64-linux-gnu/cmake/
 sudo ln -sf /usr/share/cmake/cereal /usr/lib/x86_64-linux-gnu/cmake/cereal
+colcon list --base-paths ~/workcell_ws/src --names-only | grep -x cereal && echo "ERROR cereal visible" || echo "OK cereal hidden"
 ```
+
+`cereal` should come from `libcereal-dev`; do not manually build `src/cereal`. If `src/cereal` exists from `vcs import`, keep it hidden with `COLCON_IGNORE` + `AMENT_IGNORE`.
 
 Boost serialization `library_version_type` error:
 

--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -278,15 +278,52 @@ prepare_osqp_stack() {
   }
 }
 
-hide_workspace_osqp_sources() {
+hide_source_only_vendor_dependencies() {
   local marker
-  local osqp_dirs=("src/osqp" "src/osqp-eigen")
-  for dir in "${osqp_dirs[@]}"; do
+  local source_only_dirs=("src/osqp" "src/osqp-eigen" "src/cereal")
+  for dir in "${source_only_dirs[@]}"; do
     [[ -d "$dir" ]] || continue
+    echo "Keeping source-only/vendor dependency hidden from colcon: $dir"
     for marker in COLCON_IGNORE AMENT_IGNORE; do
-      [[ -e "$dir/$marker" ]] || run_cmd "touch '$dir/$marker'"
+      if [[ ! -e "$dir/$marker" ]]; then
+        run_cmd "touch '$dir/$marker'"
+        append_unique FILES_TOUCHED "$WORKSPACE/$dir/$marker"
+        log_change "hide source-only dependency $dir via $marker"
+      fi
     done
   done
+}
+
+validate_cereal_dependency_handling() {
+  local rosdep_resolution
+  rosdep_resolution="$(rosdep resolve cereal 2>/dev/null || true)"
+  if [[ "$rosdep_resolution" != *"libcereal-dev"* ]]; then
+    echo "Cereal rosdep validation failed: expected cereal -> libcereal-dev mapping." >&2
+    echo "rosdep resolve cereal output:" >&2
+    printf '%s\n' "$rosdep_resolution" >&2
+    exit 1
+  fi
+  echo "Validated rosdep override: cereal resolves to libcereal-dev."
+
+  if [[ -d "src/cereal" ]]; then
+    local missing_markers=()
+    [[ -e "src/cereal/COLCON_IGNORE" ]] || missing_markers+=("src/cereal/COLCON_IGNORE")
+    [[ -e "src/cereal/AMENT_IGNORE" ]] || missing_markers+=("src/cereal/AMENT_IGNORE")
+    if [[ ${#missing_markers[@]} -gt 0 ]]; then
+      echo "Cereal source hiding validation failed: missing ignore markers:" >&2
+      printf '  - %s\n' "${missing_markers[@]}" >&2
+      exit 1
+    fi
+    echo "Validated source checkout hiding: src/cereal contains COLCON_IGNORE and AMENT_IGNORE."
+  else
+    echo "Cereal source checkout not present under src/. Relying on libcereal-dev via rosdep."
+  fi
+
+  if colcon list --base-paths src --names-only 2>/dev/null | grep -xq "cereal"; then
+    echo "Workspace validation failed: colcon still discovers package named 'cereal'." >&2
+    exit 1
+  fi
+  echo "Validated workspace discovery: no colcon package named cereal is visible."
 }
 
 capture_epd_state() {
@@ -420,7 +457,8 @@ build_phase() {
 
   run_cmd "./src/easy_manipulation_deployment/scripts/ensure_rosdep_overrides.sh"
   run_cmd "./src/easy_manipulation_deployment/scripts/fix_workspace_layout.sh $([[ $WITH_GUI -eq 1 ]] && echo --with-gui || true)"
-  hide_workspace_osqp_sources
+  hide_source_only_vendor_dependencies
+  validate_cereal_dependency_handling
 
   local rosdep_skip_keys=(qt_advanced_docking tesseract_visualization taskflow trajopt_ifopt trajopt_sqp osqp osqp_vendor osqp-eigen osqp_eigen qpoases)
   local fallback_keys=""


### PR DESCRIPTION
### Motivation
- Prevent colcon from attempting to build upstream `cereal` source (header-only) which can fail CI/clean installs due to test/example warnings being treated as errors.
- Keep conservative bootstrap behavior by leaving `.repos` imports intact while ensuring `cereal` is consumed as a system/header-only dependency via the existing rosdep override to `libcereal-dev`.

### Description
- Added `hide_source_only_vendor_dependencies()` in `fix_and_build_humble.sh` to create both `COLCON_IGNORE` and `AMENT_IGNORE` for `src/cereal` (in addition to `src/osqp` and `src/osqp-eigen`) and log/tally the action.
- Added `validate_cereal_dependency_handling()` in `fix_and_build_humble.sh` to assert `rosdep resolve cereal` maps to `libcereal-dev`, verify presence of ignore markers when `src/cereal` is present, and confirm `colcon list` does not expose a package named `cereal`.
- Wired the new hide/validate logic to run after `vcs import` and `fix_workspace_layout.sh` and before `rosdep install`/`colcon build` so discovery/build steps never attempt to build `cereal`.
- Updated `README.md` to document that `cereal` is supplied by `libcereal-dev`, that `src/cereal` (if imported) is intentionally hidden from colcon, added the smoke validation command `colcon list --base-paths ~/workcell_ws/src --names-only | grep -x cereal && echo "ERROR cereal visible" || echo "OK cereal hidden"`, and added the manual `touch src/cereal/COLCON_IGNORE src/cereal/AMENT_IGNORE` note for advanced flows.

### Testing
- Ran shell syntax checks: `bash -n fix_and_build_humble.sh` succeeded.
- Ran shell syntax checks: `bash -n scripts/verify_workspace_discovery.sh` succeeded.
- Ran grep/rg-based validations to confirm new functions/README lines are present: `rg` checks succeeded.
- No build-time changes or broad refactors were introduced and all automated checks executed in this change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e600a8fc8331b41ee81e5c68fcd8)