### PR TITLE
Fix Humble installer non-GUI defaults and skip handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1232,7 +1232,7 @@ These additions are offline/import-export focused and do not change runtime ROS/
 
 ## Fresh Ubuntu 22.04 / ROS 2 Humble full-profile build (EPD + TrajOpt/Tesseract)
 
-Use this path on a clean machine when you need the full simulation-first workflow (MoveIt + EPD + Tesseract/TrajOpt), not a reduced demo build.
+Use this path on a clean machine when you need the full non-GUI simulation-first workflow (MoveIt + EPD + Tesseract/TrajOpt), not a reduced demo build.
 
 ```bash
 mkdir -p ~/workcell_ws/src
@@ -1252,7 +1252,8 @@ cd easy_manipulation_deployment
 Notes:
 - `--epd-underlay` sources `~/epd_ros2_ws/install/local_setup.bash` (not `setup.bash`) and validates `epd_msgs`.
 - Full profile builds `trajopt_sco`, `trajopt`, `trajopt_ifopt`, `trajopt_sqp`, and `tesseract_motion_planners`.
-- GUI packages are optional and skipped by default unless `--with-gui` is provided.
+- RViz/Tesseract examples are skipped by default unless `--with-gui` is provided.
+- Do not source `~/workcell_ws/install/setup.bash` until after the installer completes.
 - OSQP/OsqpEigen are pinned for TrajOpt/Tesseract 0.33.x compatibility through the dependency overlay.
 - For EPD-enabled full-profile builds, keep `--install-prereqs` and `--epd-underlay ~/epd_ros2_ws` in the command even on pre-provisioned machines.
 
@@ -1277,4 +1278,5 @@ Notes:
 - `qtadvanceddocking`
 - `QtADS`
 - `tesseract_rviz`
+- `tesseract_ros_examples`
 - `tesseract_planning_server` (optional for standard headless demos)

--- a/fix_and_build_humble.sh
+++ b/fix_and_build_humble.sh
@@ -29,6 +29,8 @@ EPD_INTEGRATION_ENABLED="unknown"
 OSQP_PROVIDER="unknown"
 OSQP_VERSION_DETECTED="unknown"
 OSQPEIGEN_VERSION_DETECTED="unknown"
+TARGET_WS_IN_ENV_BEFORE_BUILD=0
+TARGET_WS_ENV_HITS=()
 
 usage() {
   cat <<'USAGE'
@@ -349,7 +351,12 @@ calculate_colcon_skip_packages() {
 
   local requested_skips=()
   if [[ "$profile" == "full" && "$with_gui" -eq 0 ]]; then
-    requested_skips+=(tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_planning_server)
+    requested_skips+=(tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_ros_examples tesseract_planning_server)
+  fi
+
+  # Dependency-safe skip: tesseract_ros_examples must be skipped when tesseract_rviz is skipped.
+  if printf '%s\n' "${requested_skips[@]:-}" | grep -Fxq "tesseract_rviz"; then
+    requested_skips+=(tesseract_ros_examples)
   fi
 
   local discovered=()
@@ -361,6 +368,33 @@ calculate_colcon_skip_packages() {
   done
 
   COLCON_SKIP_PACKAGES_USED=("${discovered[@]:-}")
+}
+
+capture_target_workspace_env_contamination() {
+  local workspace_install="$WORKSPACE/install"
+  local var_name var_value split_value
+  local env_vars=("AMENT_PREFIX_PATH" "CMAKE_PREFIX_PATH" "COLCON_PREFIX_PATH")
+
+  TARGET_WS_IN_ENV_BEFORE_BUILD=0
+  TARGET_WS_ENV_HITS=()
+  for var_name in "${env_vars[@]}"; do
+    var_value="${!var_name:-}"
+    [[ -z "$var_value" ]] && continue
+    IFS=':' read -r -a split_value <<< "$var_value"
+    local entry
+    for entry in "${split_value[@]}"; do
+      if [[ "$entry" == "$workspace_install" ]]; then
+        TARGET_WS_IN_ENV_BEFORE_BUILD=1
+        TARGET_WS_ENV_HITS+=("$var_name=$entry")
+      fi
+    done
+  done
+
+  if [[ $TARGET_WS_IN_ENV_BEFORE_BUILD -eq 1 ]]; then
+    echo "Warning: target workspace install path was present in the shell environment before build: $workspace_install"
+    printf '  - %s\n' "${TARGET_WS_ENV_HITS[@]}"
+    echo "The script will sanitize underlays and continue with only /opt/ros/humble and optional EPD underlay."
+  fi
 }
 
 capture_emd_epd_integration_flag() {
@@ -406,6 +440,10 @@ emit_summary() {
     "epd_msgs_prefix": "${EPD_MSGS_PREFIX}",
     "emd_grasp_planner_epd_enabled": "${EPD_INTEGRATION_ENABLED}"
   },
+  "target_workspace_in_environment_before_build": {
+    "detected": ${TARGET_WS_IN_ENV_BEFORE_BUILD},
+    "hits": $(printf '%s\n' "${TARGET_WS_ENV_HITS[@]:-}" | python3 -c 'import json,sys; print(json.dumps([l for l in sys.stdin.read().splitlines() if l]))')
+  },
   "osqp_compatibility": {
     "provider": "${OSQP_PROVIDER}",
     "osqp_version": "${OSQP_VERSION_DETECTED}",
@@ -441,6 +479,7 @@ build_phase() {
     append_unique FILES_TOUCHED "$WORKSPACE/log"
     log_change "removed build/install/log"
   fi
+  capture_target_workspace_env_contamination
 
   local ros_setup="/opt/ros/humble/setup.bash"
   local allow_override="--allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils"

--- a/tests/test_humble_build_regressions.py
+++ b/tests/test_humble_build_regressions.py
@@ -17,7 +17,7 @@ def test_fix_and_build_uses_external_osqp_strategy():
     text = Path("fix_and_build_humble.sh").read_text()
     assert "build/_external/osqp" in text
     assert "build/_external/osqp-eigen" in text
-    assert "hide_workspace_osqp_sources" in text
+    assert "hide_source_only_vendor_dependencies" in text
     assert "src/osqp" in text and "COLCON_IGNORE" in text and "AMENT_IGNORE" in text
     assert "/usr/local/lib/cmake/osqp" in text
     assert "/usr/local/lib/cmake/OsqpEigen" in text
@@ -64,3 +64,56 @@ def test_default_colcon_build_sets_release_type():
     assert "CMAKE_BUILD_TYPE=\"Release\"" in text
     assert "--cmake-args -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE" in text
     assert "--cmake-build-type" in text
+
+
+def test_full_profile_without_gui_skips_rviz_and_examples_together():
+    text = Path("fix_and_build_humble.sh").read_text()
+    assert "requested_skips+=(tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_ros_examples tesseract_planning_server)" in text
+    assert "Dependency-safe skip: tesseract_ros_examples must be skipped when tesseract_rviz is skipped." in text
+
+
+def test_skip_list_is_filtered_to_discovered_packages_before_colcon():
+    text = Path("fix_and_build_humble.sh").read_text()
+    assert "colcon list --base-paths src --names-only" in text
+    assert "if printf '%s\\n' \"${all_packages[@]}\" | grep -Fxq \"$pkg\"; then" in text
+    assert "COLCON_SKIP_PACKAGES_USED=(\"${discovered[@]:-}\")" in text
+
+
+def test_target_workspace_install_is_not_used_as_underlay_before_build():
+    text = Path("fix_and_build_humble.sh").read_text()
+    assert "capture_target_workspace_env_contamination" in text
+    assert "unset AMENT_PREFIX_PATH CMAKE_PREFIX_PATH COLCON_PREFIX_PATH" in text
+    assert "source '$ros_setup'" in text
+    assert "source '$EPD_UNDERLAY/install/local_setup.bash'" in text
+    assert "target workspace install path was present in the shell environment before build" in text
+
+
+def test_readme_documents_full_non_gui_default_path():
+    text = Path("README.md").read_text()
+    assert "full non-GUI" in text
+    assert "RViz/Tesseract examples are skipped by default" in text
+    assert "Do not source `~/workcell_ws/install/setup.bash` until after the installer completes." in text
+
+
+def test_required_planner_and_runtime_packages_not_in_default_skip_list():
+    text = Path("fix_and_build_humble.sh").read_text()
+    skip_block = "requested_skips+=(tesseract_qt qtadvanceddocking QtADS tesseract_rviz tesseract_ros_examples tesseract_planning_server)"
+    assert skip_block in text
+    for pkg in [
+        "tesseract_motion_planners",
+        "tesseract_task_composer",
+        "tesseract_rosutils",
+        "tesseract_monitoring",
+        "trajopt",
+        "trajopt_ifopt",
+        "trajopt_sqp",
+        "trajopt_sco",
+        "emd_grasp_planner",
+        "emd_grasp_execution",
+        "emd_waypoint_execution",
+        "run_grasp_planner",
+        "run_grasp_execution",
+        "run_waypoint_execution",
+        "workcell_builder",
+    ]:
+        assert pkg not in skip_block


### PR DESCRIPTION
### Motivation
- Ensure the documented Humble installer command builds a full non-GUI robotics stack by default without manual `colcon` flags or GUI package failures.
- Prevent `colcon` warnings/failures from passing unknown package names to `--packages-skip` when packages are hidden by `COLCON_IGNORE` or `AMENT_IGNORE`.
- Avoid accidental underlay/overlay contamination by detecting if the target workspace `install/` is already present in environment prefix variables before the build.
- Make installer behavior explicit and testable and update documentation to match the non-GUI default.

### Description
- When `--profile full` and `--with-gui` is not set the script now requests skipping `tesseract_qt`, `qtadvanceddocking`, `QtADS`, `tesseract_rviz`, `tesseract_ros_examples`, and `tesseract_planning_server` by default via `requested_skips` in `fix_and_build_humble.sh` and adds a dependency-safe rule that forces `tesseract_ros_examples` to be skipped whenever `tesseract_rviz` is skipped. 
- The skip candidates are filtered against discovered packages from `colcon list --base-paths src --names-only` and only discovered packages are placed into `COLCON_SKIP_PACKAGES_USED` so that `--packages-skip` is only passed known package names. 
- Added `capture_target_workspace_env_contamination` which inspects `AMENT_PREFIX_PATH`, `CMAKE_PREFIX_PATH`, and `COLCON_PREFIX_PATH` for an existing `$WORKSPACE/install` entry, emits a warning when detected, records hits, and the build sanitizes to only source `/opt/ros/humble/setup.bash` and the optional EPD underlay `.../install/local_setup.bash`. 
- Summary output in `fix_and_build_summary.json` is extended with `target_workspace_in_environment_before_build` (detected flag and hits) and `colcon_skip_packages_used` to record skip behavior. 
- README updated to clearly state the default is a "full non-GUI" build, that RViz/Tesseract examples are skipped by default, and to instruct users not to source `~/workcell_ws/install/setup.bash` until after the installer completes. 
- Regression tests in `tests/test_humble_build_regressions.py` were added/updated to cover default full non-GUI skip behavior, skip-list filtering before colcon, underlay contamination detection, README guidance, and protection of required planner/runtime packages from the default skip block.

### Testing
- Ran the updated regression suite with `pytest -q tests/test_humble_build_regressions.py` and all tests passed (`13 passed`).
- Verified the new/changed assertions exercise `fix_and_build_humble.sh`, `README.md`, and the skip/summary logic via the automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ce9859e88331810ba273c043a2d9)