### PR TITLE
Fix workcell_builder Humble scene generation paths/controllers and planner warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1280,3 +1280,17 @@ Notes:
 - `tesseract_rviz`
 - `tesseract_ros_examples`
 - `tesseract_planning_server` (optional for standard headless demos)
+
+
+### Validate generated scene
+
+After running `fix_and_build_humble.sh`, generate and validate a scene without manually moving assets/scenes into `src`:
+
+```bash
+workcell_builder
+colcon build --packages-select new_scene --symlink-install
+source install/setup.bash
+ros2 launch new_scene demo.launch.py
+```
+
+`workcell_builder` resolves assets from package shares and workspace links created by `scripts/fix_workspace_layout.sh`; manual asset/scenes moves are not required or supported.

--- a/easy_manipulation_deployment/emd_grasp_planner/src/end_effectors/finger_gripper.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/end_effectors/finger_gripper.cpp
@@ -449,7 +449,7 @@ bool FingerGripper::get_initial_sample_points(const GraspObject & object)
     object.centerpoint(2));
 
   for (auto & sample : this->grasp_samples) {
-    int first_point_index, second_point_index;
+    int first_point_index = -1, second_point_index = -1;
     float min_dist = std::numeric_limits<float>::max();
     // float min_linepoint_factor = std::numeric_limits<float>::max();
     float max_dist = 0;
@@ -491,6 +491,10 @@ bool FingerGripper::get_initial_sample_points(const GraspObject & object)
           max_dist = point_vector[i].projection_distance;
           second_point_index = point_vector[i].index;
         }
+      }
+      if (first_point_index < 0 || second_point_index < 0) {
+        sample->plane_intersects_object = false;
+        continue;
       }
       sample->sample_side_1->start_index = first_point_index;
       sample->sample_side_2->start_index = second_point_index;
@@ -1343,9 +1347,9 @@ std::vector<double> FingerGripper::get_planar_rpy(
   const Eigen::Vector3f & grasp_direction_normal)
 {
   std::vector<double> output_vec;
-  Eigen::Vector3f x_norm;
-  Eigen::Vector3f y_norm;
-  Eigen::Vector3f z_norm;
+  Eigen::Vector3f x_norm = Eigen::Vector3f::UnitX();
+  Eigen::Vector3f y_norm = Eigen::Vector3f::UnitY();
+  Eigen::Vector3f z_norm = Eigen::Vector3f::UnitZ();
   bool x_filled = false;
   bool y_filled = false;
   bool z_filled = false;
@@ -1604,7 +1608,7 @@ std::shared_ptr<GraspPlaneSample> FingerGripper::generate_grasp_samples(
 int FingerGripper::get_nearest_plane_index(float target_distance)
 {
   float plane_dist_diff = std::numeric_limits<float>::max();
-  int plane_index;
+  int plane_index = 0;
 
   /* We use the gap from the open configuration finger to compare with the cutting plane
       gaps to find the most identical distance between the center plane to that plane, and

--- a/easy_manipulation_deployment/emd_grasp_planner/src/end_effectors/suction_gripper.cpp
+++ b/easy_manipulation_deployment/emd_grasp_planner/src/end_effectors/suction_gripper.cpp
@@ -796,9 +796,9 @@ std::vector<double> SuctionGripper::get_planar_rpy(
   const Eigen::Vector3f & row_vector)
 {
   std::vector<double> output_vec;
-  Eigen::Vector3f x_norm;
-  Eigen::Vector3f y_norm;
-  Eigen::Vector3f z_norm;
+  Eigen::Vector3f x_norm = Eigen::Vector3f::UnitX();
+  Eigen::Vector3f y_norm = Eigen::Vector3f::UnitY();
+  Eigen::Vector3f z_norm = Eigen::Vector3f::UnitZ();
   bool x_filled = false;
   bool y_filled = false;
   bool z_filled = false;

--- a/tests/test_workcell_builder_generation.py
+++ b/tests/test_workcell_builder_generation.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_scene_template_filters_fixed_gripper_joints_from_controller_list() -> None:
+    content = (REPO_ROOT / "workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py").read_text(encoding="utf-8")
+    assert "fixed" in content
+    assert "_extract_controller_joints(robot_description_semantic_config, robot_description_config)" in content
+
+
+def test_object_package_parser_no_spurious_nonpackage_warning() -> None:
+    content = (REPO_ROOT / "workcell_builder/workcell_builder/include/object_package_parser.h").read_text(encoding="utf-8")
+    assert "No CMakeLists or package.xml available" not in content
+
+
+def test_default_assets_not_hardcoded_to_workspace_src_assets() -> None:
+    content = (REPO_ROOT / "workcell_builder/workcell_builder/gui/addrobot.cpp").read_text(encoding="utf-8")
+    assert "/home/ubuntu/workcell_ws/src/assets" not in content
+    assert "get_package_share_directory(\"ur_description\")" in content

--- a/workcell_builder/workcell_builder/include/object_package_parser.h
+++ b/workcell_builder/workcell_builder/include/object_package_parser.h
@@ -190,7 +190,6 @@ void generate_object_package(fs::path workcell_filepath, Object object, int ros_
 
 bool package_exists(Object object)
 {
-  std::cout << "Package exists: " << fs::current_path() << std::endl;
   fs::path temp_path(fs::current_path());
   std::string package_name = object.name + "_description";
   if (fs::is_directory(package_name)) {  // folder exists
@@ -203,12 +202,10 @@ bool package_exists(Object object)
       return false;
     }
     if (!fs::exists("CMakeLists.txt") || !fs::exists("package.xml")) {
-      std::cout << "No CMakeLists or package.xml available" << std::endl;
       safe_chdir(temp_path);
       return false;
     }
   } else {
-    std::cout << "No description folders" << std::endl;
     safe_chdir(temp_path);
     return false;
   }

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -185,7 +185,7 @@ def _validate_ros_param_types(value, path="root"):
     raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
 
 
-def _extract_controller_joints(robot_description_semantic_config):
+def _extract_controller_joints(robot_description_semantic_config, robot_description_config):
     try:
         srdf_root = ET.fromstring(robot_description_semantic_config)
     except ET.ParseError as exc:
@@ -206,13 +206,22 @@ def _extract_controller_joints(robot_description_semantic_config):
         if first_group_with_joints is None:
             first_group_with_joints = (group_name, joints)
 
-    if first_group_with_joints:
-        return first_group_with_joints
+    if not first_group_with_joints:
+        raise RuntimeError(
+            "No controller joints were found in robot_description_semantic. "
+            "Ensure the SRDF has a manipulator/arm group with explicit <joint> entries."
+        )
 
-    raise RuntimeError(
-        "No controller joints were found in robot_description_semantic. "
-        "Ensure the SRDF has a manipulator/arm group with explicit <joint> entries."
-    )
+    _, raw_joints = first_group_with_joints
+    urdf_root = ET.fromstring(robot_description_config)
+    movable = {
+        j.get("name") for j in urdf_root.findall(".//joint")
+        if j.get("name") and j.get("type") not in (None, "fixed", "mimic")
+    }
+    filtered = [joint for joint in raw_joints if joint in movable]
+    if not filtered:
+        raise RuntimeError("No movable controller joints remain after filtering fixed/mimic joints")
+    return first_group_with_joints[0], filtered
 
 
 def _validate_joint_state_configuration(robot_description_config, controller_joints):
@@ -307,7 +316,7 @@ def _launch_setup(context):
         ompl_planning_pipeline_config["ompl"].update(ompl_planning_yaml)
 
     controller_group_name, controller_joints = _extract_controller_joints(
-        robot_description_semantic_config
+        robot_description_semantic_config, robot_description_config
     )
     if not controller_joints:
         raise RuntimeError(


### PR DESCRIPTION
### Motivation

- Ensure scenes generated by `workcell_builder` build and launch cleanly on ROS 2 Humble by removing hardcoded/workspace-only asset assumptions and preventing invalid controller joint lists. 
- Remove noisy/misleading object-package warnings during normal generation and startup. 
- Eliminate real uninitialized-variable warning paths in the grasp-planner end-effector code. 
- Add focused regression tests and README guidance so generated scenes can be validated without manually moving assets.

### Description

- Hardened the Humble launch template to extract SRDF controller joints and then filter them against movable URDF joints so fixed/mimic/non-commandable joints are not placed into `FollowJointTrajectory` controller lists. 
- Removed spurious console messages from object package detection so normal asset discovery does not emit misleading `No CMakeLists or package.xml available` output. 
- Fixed uninitialized-variable / undefined-behaviour paths in `emd_grasp_planner` by initializing `first_point_index`, `second_point_index`, planar basis vectors and `plane_index` and adding guarding logic where needed. 
- Added `tests/test_workcell_builder_generation.py` with assertions that the template uses the new joint-extraction signature, that object-package parser warnings are not present, and that asset resolution code is not hardcoded to `~/workcell_ws/src/assets`. 
- Updated `README.md` with a "Validate generated scene" section showing the recommended validation steps and clarifying that users must not manually move assets/scenes into `src`.

### Testing

- Ran syntax check and workspace-layout helper: `bash -n fix_and_build_humble.sh scripts/fix_workspace_layout.sh` and it completed without syntax errors. 
- Executed the regression test suite: `python3 -m pytest -q tests/test_humble_build_regressions.py tests/test_workcell_builder_generation.py` and all tests passed (`16 passed`). 
- Verified the changes are scoped to scene generation, controller filtering, planner warning fixes, tests, and documentation with no GUI redesign performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1dfd4ca0883319aacdf54eab68796)