### PR TITLE
Scene rediscovery on startup and UR+Robotiq85 default mount orientation fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1083,6 +1083,9 @@ Required external robot descriptions on ROS 2 Humble:
 
 ### Validate generated scene
 
+- Generated scenes are created under `~/workcell_ws/src/scenes/<scene_name>`.
+- Generated assets are created under `~/workcell_ws/src/assets/...`.
+- Reopening `workcell_builder` re-discovers existing scene packages under the selected `<workcell_root>/scenes`.
 - Do not manually move assets/scenes into `~/workcell_ws/src/assets`.
 - Source your built workspace before running `workcell_builder`.
 - Build the generated scene package.
@@ -1092,7 +1095,7 @@ Required external robot descriptions on ROS 2 Humble:
 rm -rf src/scenes/new_scene* src/new_scene* build/new_scene* install/new_scene* log/latest_build/new_scene*
 source ~/workcell_ws/install/setup.bash
 workcell_builder
-colcon build --packages-select <generated_scene_package> --symlink-install
+colcon build --symlink-install --packages-select <generated_scene_package>
 source install/setup.bash
 ros2 launch <generated_scene_package> demo.launch.py
 ```
@@ -1307,13 +1310,13 @@ Notes:
 
 ### Validate generated scene
 
-After running `fix_and_build_humble.sh`, generate and validate a scene without manually moving assets/scenes into `src`:
+After running `fix_and_build_humble.sh`, generate and validate a scene (without moving assets/scenes manually):
 
 ```bash
 workcell_builder
-colcon build --packages-select new_scene --symlink-install
+colcon build --symlink-install --packages-select new_scene
 source install/setup.bash
 ros2 launch new_scene demo.launch.py
 ```
 
-`workcell_builder` resolves assets from package shares and workspace links created by `scripts/fix_workspace_layout.sh`; manual asset/scenes moves are not required or supported.
+`workcell_builder` keeps generated scenes in `~/workcell_ws/src/scenes/<scene_name>` and generated assets in `~/workcell_ws/src/assets`; scene rediscovery on reopen scans that `scenes/` directory automatically.

--- a/tests/test_workcell_builder_generation.py
+++ b/tests/test_workcell_builder_generation.py
@@ -50,3 +50,19 @@ def test_onrobot_airpick_standalone_wrapper_exists_and_instantiates_required_par
     assert "<xacro:onrobot_airpick4_gripper" in content
     assert "prefix=\"\"" in content
     assert "parent=\"tool0\"" in content
+
+
+def test_scene_select_startup_rediscovery_supports_scaffolded_packages() -> None:
+    content = (REPO_ROOT / "workcell_builder/workcell_builder/gui/scene_select.cpp").read_text(encoding="utf-8")
+    assert "discover_scene_packages_on_startup" in content
+    assert "missing one of [package.xml, CMakeLists.txt, urdf/]" in content
+    assert "without environment.yaml; scene can launch but cannot be fully edited until YAML exists." in content
+    assert "scene already loaded" in content
+
+
+def test_scene_xacro_uses_fallback_robotiq_85_mount_orientation_for_ur() -> None:
+    content = (REPO_ROOT / "workcell_builder/workcell_builder/include/scene_xacro_parser.h").read_text(encoding="utf-8")
+    assert "resolve_default_ee_mount_origin" in content
+    assert "Fallback defaults only apply when user did not explicitly set an EE origin." in content
+    assert "robot.brand == \"universal_robot\" && ee.brand == \"robotiq_85_gripper\"" in content
+    assert "fallback.yaw = 1.57079632679;" in content

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -399,7 +399,71 @@ void SceneSelect::load_workcell(Workcell workcell_input)
   if (assets_path.empty()) {
     assets_path = workcell_path / "assets";
   }
+  discover_scene_packages_on_startup();
   refresh_scenes(0, false);
+}
+
+void SceneSelect::discover_scene_packages_on_startup()
+{
+  if (workcell_path.empty()) {
+    configure_startup_fallback_paths();
+  }
+  append_info("Selected workcell root: " + workcell_path.string());
+  append_info("Selected scenes directory: " + scenes_path.string());
+
+  if (!fs::exists(scenes_path) || !fs::is_directory(scenes_path)) {
+    append_warning("Scenes directory not found; skipping startup rediscovery.");
+    return;
+  }
+
+  std::unordered_set<std::string> known_scenes;
+  for (const auto & known_scene : workcell.scene_vector) {
+    known_scenes.insert(known_scene.name);
+  }
+
+  int discovered_count = 0;
+  for (const auto & entry : fs::directory_iterator(scenes_path)) {
+    if (!fs::is_directory(entry.path())) {
+      continue;
+    }
+    const std::string scene_name = entry.path().filename().string();
+    const fs::path package_xml = entry.path() / "package.xml";
+    const fs::path cmake_lists = entry.path() / "CMakeLists.txt";
+    const fs::path urdf_dir = entry.path() / "urdf";
+    const fs::path environment_yaml = entry.path() / "environment.yaml";
+
+    if (!fs::exists(package_xml) || !fs::exists(cmake_lists) || !fs::is_directory(urdf_dir)) {
+      append_info(
+        "Skipped scene directory '" + scene_name +
+        "': missing one of [package.xml, CMakeLists.txt, urdf/].");
+      continue;
+    }
+    if (known_scenes.find(scene_name) != known_scenes.end()) {
+      append_info("Skipped scene directory '" + scene_name + "': scene already loaded.");
+      continue;
+    }
+
+    Scene discovered_scene;
+    discovered_scene.name = scene_name;
+    discovered_scene.loaded = false;
+
+    if (fs::exists(environment_yaml)) {
+      if (!load_scene_from_yaml(&discovered_scene)) {
+        append_warning(
+          "Discovered scene package '" + scene_name +
+          "' but environment.yaml failed to load; showing as scaffold-only.");
+        discovered_scene.loaded = false;
+      }
+    } else {
+      append_warning(
+        "Discovered scaffold scene package '" + scene_name +
+        "' without environment.yaml; scene can launch but cannot be fully edited until YAML exists.");
+    }
+    workcell.scene_vector.push_back(discovered_scene);
+    known_scenes.insert(scene_name);
+    ++discovered_count;
+  }
+  append_info("Discovered scene packages: " + std::to_string(discovered_count));
 }
 void SceneSelect::on_add_scene_clicked()
 {

--- a/workcell_builder/workcell_builder/gui/scene_select.h
+++ b/workcell_builder/workcell_builder/gui/scene_select.h
@@ -100,6 +100,7 @@ private:
   bool validate_description_xacros(const Scene & scene, const std::string & context_label);
   void configure_startup_fallback_paths();
   void show_invalid_workcell_error(const std::string & error_message);
+  void discover_scene_packages_on_startup();
 
   int scaffold_scene_index_ = -1;
 };

--- a/workcell_builder/workcell_builder/include/scene_xacro_parser.h
+++ b/workcell_builder/workcell_builder/include/scene_xacro_parser.h
@@ -123,6 +123,22 @@ std::string resolve_ee_xacro_macro(const EndEffector & ee)
   }
   return ee.name + "_gripper";
 }
+
+Origin resolve_default_ee_mount_origin(const Scene & scene, const EndEffector & ee)
+{
+  Origin fallback;
+  fallback.disableOrigin();
+  // Fallback defaults only apply when user did not explicitly set an EE origin.
+  if (scene.robot_vector.empty()) {
+    return fallback;
+  }
+  const Robot & robot = scene.robot_vector.front();
+  if (robot.brand == "universal_robot" && ee.brand == "robotiq_85_gripper") {
+    fallback.is_origin = true;
+    fallback.yaw = 1.57079632679;
+  }
+  return fallback;
+}
 }  // namespace
 
 
@@ -218,7 +234,16 @@ void generate_scene_xacro(Scene scene, const std::string & output_path)
           scene.ee_vector[i].origin.pitch) + " " + std::to_string(scene.ee_vector[i].origin.yaw) +
           "\"/>\n";
       } else {
-        MyFile << "\t<origin xyz=\"0 0 0\" rpy=\"0 0 0\"/>\n";
+        const Origin fallback_origin = resolve_default_ee_mount_origin(scene, scene.ee_vector[i]);
+        if (fallback_origin.is_origin) {
+          MyFile << "\t<origin xyz=\"" + std::to_string(fallback_origin.x) + " " +
+            std::to_string(fallback_origin.y) + " " + std::to_string(fallback_origin.z) +
+            "\" rpy=\"" + std::to_string(fallback_origin.roll) + " " +
+            std::to_string(fallback_origin.pitch) + " " + std::to_string(fallback_origin.yaw) +
+            "\"/>\n";
+        } else {
+          MyFile << "\t<origin xyz=\"0 0 0\" rpy=\"0 0 0\"/>\n";
+        }
       }
       MyFile << " </xacro:" + ee_macro + ">\n\n";
 


### PR DESCRIPTION
### Motivation

- Ensure previously generated scene packages under `<workcell_root>/scenes` are discovered when `workcell_builder` reopens so the scene dropdown is populated even across GUI restarts.
- Provide a robust default end-effector mount for known robot/EE combos (notably `universal_robot` + `robotiq_85_gripper`) to fix the 90° mis-mounted gripper seen in generated URDFs while preserving any user-specified origins.

### Description

- Add `discover_scene_packages_on_startup()` and call it from `SceneSelect::load_workcell()` to scan the selected `<root>/scenes` directory and populate `workcell.scene_vector` for valid generated scene packages detected by the presence of `package.xml`, `CMakeLists.txt`, and `urdf/` (scaffolds without `environment.yaml` are shown with a clear scaffold warning).
- Avoid duplicate entries by checking existing `workcell.scene_vector` names, and log GUI/status messages that show the selected workcell root, selected scenes directory, number of discovered scene packages, and directories skipped with reasons.
- Implement `resolve_default_ee_mount_origin()` in `scene_xacro_parser.h` to return a fallback `Origin` (yaw = `1.57079632679`) for `universal_robot` + `robotiq_85_gripper` only when the user has not explicitly set an EE origin, and apply that fallback when generating the scene xacro; preserve any explicit user origin.
- Update README guidance to clarify generated scene and asset locations (`~/workcell_ws/src/scenes/<scene_name>` and `~/workcell_ws/src/assets/...`) and document that reopening `workcell_builder` rediscovers scenes automatically; add small unit test assertions to cover the new behaviors.

### Testing

- Ran `python3 -m pytest -q tests/test_humble_build_regressions.py tests/test_workcell_builder_generation.py` and all tests passed (`24 passed`).
- Performed quick shell syntax checks with `bash -n fix_and_build_humble.sh scripts/fix_workspace_layout.sh` which succeeded.
- New/updated files exercising the changes include `workcell_builder/workcell_builder/gui/scene_select.cpp`, `workcell_builder/workcell_builder/gui/scene_select.h`, `workcell_builder/workcell_builder/include/scene_xacro_parser.h`, `README.md`, and `tests/test_workcell_builder_generation.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1eb501864833196d97bfd2b000a7d)