### PR TITLE
Sanitize end-effector mount origin in scene generation and persist resolved origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,6 +1107,12 @@ Expected behavior:
 - No launch parameter validation error like `finger_count: NoneType -> None`.
 - MoveIt launch should continue to the "You can start planning now!" stage.
 
+End-effector mount pose defaults in generated scenes:
+
+- The Workcell Builder end-effector `origin` fields are interpreted as the wrist mount transform (`parent` robot link -> end-effector base link).
+- If those GUI fields are left unset, invalid, or contain placeholder sentinel values (`-1` for all xyz/rpy), generation now normalizes to identity: `xyz="0 0 0"` and `rpy="0 0 0"`.
+- The resolved mount transform is persisted in `environment.yaml` so regenerated packages are reproducible.
+
 ## Running demo scenes
 
 Before launching `ur5_*` demo scenes, verify that `ur5_moveit_config` resolves from the active workspace via `ament_index`. This catches the common case where asset packages are still hidden by `COLCON_IGNORE` markers because the workspace was built before running `fix_workspace_layout.sh`.

--- a/tests/test_workcell_builder_generation.py
+++ b/tests/test_workcell_builder_generation.py
@@ -60,9 +60,9 @@ def test_scene_select_startup_rediscovery_supports_scaffolded_packages() -> None
     assert "scene already loaded" in content
 
 
-def test_scene_xacro_uses_fallback_robotiq_85_mount_orientation_for_ur() -> None:
+def test_scene_xacro_sanitizes_end_effector_mount_origin_defaults_to_identity() -> None:
     content = (REPO_ROOT / "workcell_builder/workcell_builder/include/scene_xacro_parser.h").read_text(encoding="utf-8")
-    assert "resolve_default_ee_mount_origin" in content
-    assert "Fallback defaults only apply when user did not explicitly set an EE origin." in content
-    assert "robot.brand == \"universal_robot\" && ee.brand == \"robotiq_85_gripper\"" in content
-    assert "fallback.yaw = 1.57079632679;" in content
+    assert "resolve_ee_mount_origin" in content
+    assert "unset sentinel values (-1)" in content
+    assert "invalid NaN/Inf values" in content
+    assert "defaulting to identity origin xyz/rpy (0 0 0)" in content

--- a/workcell_builder/workcell_builder/include/scene_xacro_parser.h
+++ b/workcell_builder/workcell_builder/include/scene_xacro_parser.h
@@ -19,6 +19,8 @@
 
 
 #include <fstream>
+#include <cmath>
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -124,20 +126,56 @@ std::string resolve_ee_xacro_macro(const EndEffector & ee)
   return ee.name + "_gripper";
 }
 
-Origin resolve_default_ee_mount_origin(const Scene & scene, const EndEffector & ee)
+bool is_finite_origin_component(float value)
 {
-  Origin fallback;
-  fallback.disableOrigin();
-  // Fallback defaults only apply when user did not explicitly set an EE origin.
-  if (scene.robot_vector.empty()) {
-    return fallback;
-  }
-  const Robot & robot = scene.robot_vector.front();
-  if (robot.brand == "universal_robot" && ee.brand == "robotiq_85_gripper") {
-    fallback.is_origin = true;
-    fallback.yaw = 1.57079632679;
-  }
+  return std::isfinite(static_cast<double>(value));
+}
+
+bool is_all_negative_one(const Origin & origin)
+{
+  return origin.x == -1.0F && origin.y == -1.0F && origin.z == -1.0F &&
+         origin.roll == -1.0F && origin.pitch == -1.0F && origin.yaw == -1.0F;
+}
+
+bool has_any_invalid_origin_component(const Origin & origin)
+{
+  return !is_finite_origin_component(origin.x) ||
+         !is_finite_origin_component(origin.y) ||
+         !is_finite_origin_component(origin.z) ||
+         !is_finite_origin_component(origin.roll) ||
+         !is_finite_origin_component(origin.pitch) ||
+         !is_finite_origin_component(origin.yaw);
+}
+
+Origin resolve_default_ee_mount_origin(const Scene &, const EndEffector &)
+{
+  Origin fallback{};
+  fallback.is_origin = true;
+  fallback.x = 0.0F;
+  fallback.y = 0.0F;
+  fallback.z = 0.0F;
+  fallback.roll = 0.0F;
+  fallback.pitch = 0.0F;
+  fallback.yaw = 0.0F;
   return fallback;
+}
+
+Origin resolve_ee_mount_origin(const Scene & scene, const EndEffector & ee)
+{
+  (void)scene;
+  if (!ee.origin.is_origin) {
+    std::cerr << "WARNING: End-effector mount pose not set; defaulting to identity origin xyz/rpy (0 0 0).\n";
+    return resolve_default_ee_mount_origin(scene, ee);
+  }
+  if (is_all_negative_one(ee.origin)) {
+    std::cerr << "WARNING: End-effector mount pose contains unset sentinel values (-1); defaulting to identity origin xyz/rpy (0 0 0).\n";
+    return resolve_default_ee_mount_origin(scene, ee);
+  }
+  if (has_any_invalid_origin_component(ee.origin)) {
+    std::cerr << "WARNING: End-effector mount pose contains invalid NaN/Inf values; defaulting to identity origin xyz/rpy (0 0 0).\n";
+    return resolve_default_ee_mount_origin(scene, ee);
+  }
+  return ee.origin;
 }
 }  // namespace
 
@@ -226,25 +264,12 @@ void generate_scene_xacro(Scene scene, const std::string & output_path)
       MyFile << " <xacro:include filename=\"$(find " + ee_package + ")/urdf/" + ee_xacro + "\"/>\n";
       MyFile << " <xacro:" + ee_macro + " prefix=\"\" parent=\"" +
         scene.ee_vector[i].robot_link + "\">\n";
-      if (scene.ee_vector[i].origin.is_origin) {
-        MyFile << "\t<origin xyz=\"" + std::to_string(scene.ee_vector[i].origin.x) + " " +
-          std::to_string(scene.ee_vector[i].origin.y) + " " + std::to_string(
-          scene.ee_vector[i].origin.z) + "\" rpy=\"" +
-          std::to_string(scene.ee_vector[i].origin.roll) + " " + std::to_string(
-          scene.ee_vector[i].origin.pitch) + " " + std::to_string(scene.ee_vector[i].origin.yaw) +
-          "\"/>\n";
-      } else {
-        const Origin fallback_origin = resolve_default_ee_mount_origin(scene, scene.ee_vector[i]);
-        if (fallback_origin.is_origin) {
-          MyFile << "\t<origin xyz=\"" + std::to_string(fallback_origin.x) + " " +
-            std::to_string(fallback_origin.y) + " " + std::to_string(fallback_origin.z) +
-            "\" rpy=\"" + std::to_string(fallback_origin.roll) + " " +
-            std::to_string(fallback_origin.pitch) + " " + std::to_string(fallback_origin.yaw) +
-            "\"/>\n";
-        } else {
-          MyFile << "\t<origin xyz=\"0 0 0\" rpy=\"0 0 0\"/>\n";
-        }
-      }
+      const Origin ee_mount_origin = resolve_ee_mount_origin(scene, scene.ee_vector[i]);
+      MyFile << "\t<origin xyz=\"" + std::to_string(ee_mount_origin.x) + " " +
+        std::to_string(ee_mount_origin.y) + " " + std::to_string(ee_mount_origin.z) +
+        "\" rpy=\"" + std::to_string(ee_mount_origin.roll) + " " +
+        std::to_string(ee_mount_origin.pitch) + " " + std::to_string(ee_mount_origin.yaw) +
+        "\"/>\n";
       MyFile << " </xacro:" + ee_macro + ">\n\n";
 
       if (scene.ee_vector[i].brand == "robotiq_85_gripper") {

--- a/workcell_builder/workcell_builder/include/yaml_parser/generate_yaml.h
+++ b/workcell_builder/workcell_builder/include/yaml_parser/generate_yaml.h
@@ -24,6 +24,7 @@
 
 // General
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -40,6 +41,30 @@
 #include "yaml_parser/origin_parser.h"
 
 namespace {
+Origin identity_origin()
+{
+  Origin origin{};
+  origin.is_origin = true;
+  return origin;
+}
+
+bool is_valid_origin(const Origin & origin)
+{
+  const bool finite = std::isfinite(origin.x) && std::isfinite(origin.y) && std::isfinite(origin.z) &&
+    std::isfinite(origin.roll) && std::isfinite(origin.pitch) && std::isfinite(origin.yaw);
+  const bool sentinel = origin.x == -1.0F && origin.y == -1.0F && origin.z == -1.0F &&
+    origin.roll == -1.0F && origin.pitch == -1.0F && origin.yaw == -1.0F;
+  return origin.is_origin && finite && !sentinel;
+}
+
+Origin resolve_end_effector_mount_origin(const EndEffector & ee)
+{
+  if (!is_valid_origin(ee.origin)) {
+    return identity_origin();
+  }
+  return ee.origin;
+}
+
 std::vector<std::string> normalize_robot_links(const Robot & robot)
 {
   std::vector<std::string> links = robot.robot_links;
@@ -203,9 +228,7 @@ public:
       }
       out << YAML::EndMap;
 
-      if (scene.ee_vector[0].origin.is_origin) {
-        OriginParser::generate_origin(&out, scene.ee_vector[0].origin);
-      }
+      OriginParser::generate_origin(&out, resolve_end_effector_mount_origin(scene.ee_vector[0]));
 
       out << YAML::Key << "links";
       out << YAML::Value << YAML::BeginSeq;


### PR DESCRIPTION
### Motivation
- Prevent the GUI unset sentinel (`-1`) and other invalid origin values from being emitted as real mount transforms in generated `scene.urdf.xacro` so end-effectors are not placed/rotated incorrectly at runtime.
- Ensure generated scenes are reproducible by persisting the final resolved end-effector mount transform into `environment.yaml`.
- Prefer a safe identity default (`xyz="0 0 0" rpy="0 0 0"`) unless a valid explicit mount pose is provided or a known-good transform is available.

### Description
- Add sanitisation helpers and `resolve_ee_mount_origin(...)` in `workcell_builder/workcell_builder/include/scene_xacro_parser.h` to treat missing origin, all-`-1` sentinel values, and NaN/Inf as invalid and to log clear warnings before falling back to identity origin.
- Replace the previous code path that could write raw `ee.origin` (including `-1` placeholders) with an unconditional write of the sanitized `ee_mount_origin` when generating the EE `<origin .../>` block in the scene xacro.
- Remove the prior hardcoded UR+Robotiq-85 yaw fallback behavior and use the identity default unless a valid explicit origin exists (so named defaults are not applied unless known-good data is present).
- Persist the resolved mount origin into `environment.yaml` by adding `resolve_end_effector_mount_origin(...)` in `workcell_builder/workcell_builder/include/yaml_parser/generate_yaml.h` so the generated package captures the final mount transform.
- Update tests and documentation: adjust `tests/test_workcell_builder_generation.py` to assert the new sanitisation text and add README notes explaining EE mount pose fields, defaulting rules, and persistence to `environment.yaml`.

### Testing
- Ran `pytest -q tests/test_workcell_builder_generation.py` and all tests passed (`9 passed`).
- The change is limited to scene generation and YAML emit logic; existing generation tests that validate wrapper inclusion and launch template content continue to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1fa62c5d88331a14fb30e4dc6e409)