### PR TITLE
Emit gripper FollowJointTrajectory controller for Humble scene templates (UR5 + Robotiq85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1115,6 +1115,12 @@ ros2 param dump /move_group | grep -A80 -B10 "moveit_simple_controller_manager"
 ros2 action list | grep -E "move|trajectory|follow"
 ```
 
+Expected output for freshly generated UR5 + Robotiq85 scenes includes:
+- Two MoveItSimpleControllerManager entries in `controller_names`: `<scene_or_robot>_arm_controller` and `<scene_or_robot>_gripper_controller`.
+- Arm joints: `shoulder_pan_joint`, `shoulder_lift_joint`, `elbow_joint`, `wrist_1_joint`, `wrist_2_joint`, `wrist_3_joint`.
+- Gripper joints: `gripper_finger1_joint`, `gripper_finger2_joint` (and not `gripper_base_joint`/inner knuckle/finger tip joints when active finger joints are available).
+- Action endpoints: `/<scene_or_robot>_arm_controller/follow_joint_trajectory` and `/<scene_or_robot>_gripper_controller/follow_joint_trajectory`.
+
 End-effector mount pose defaults in generated scenes:
 
 - The Workcell Builder end-effector `origin` fields are interpreted as the wrist mount transform (`parent` robot link -> end-effector base link).

--- a/tests/test_workcell_builder_generation.py
+++ b/tests/test_workcell_builder_generation.py
@@ -82,13 +82,18 @@ def test_humble_scene_template_emits_ur5_arm_and_gripper_controllers() -> None:
         assert joint in content
     assert "_arm_controller" in content
     assert "_gripper_controller" in content
+    assert '"controller_names": [arm_controller_name]' in content
+    assert 'controllers["controller_names"].append(gripper_controller_name)' in content
 
 
 def test_humble_scene_template_excludes_fixed_and_legacy_gripper_only_controller() -> None:
     content = (REPO_ROOT / "workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py").read_text(encoding="utf-8")
-    assert "gripper_base_joint" not in content
+    assert 'joint != "gripper_base_joint"' in content
     assert "fake_gripper_controller" not in content
     assert '"type") not in (None, "fixed")' in content
+    assert '"inner_knuckle" not in joint and "finger_tip" not in joint' in content
+    assert 'preferred = ["gripper_finger1_joint", "gripper_finger2_joint"]' in content
+    assert '"default": False' in content
 
 
 def test_humble_scene_template_preserves_fake_hardware_launch_behavior() -> None:

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -292,9 +292,14 @@ def _derive_controller_configs(scene_name, controller_group_name, controller_joi
 
     gripper_joints = [
         joint for joint in movable_joints
-        if joint.startswith("gripper_") and joint not in set(arm_joints)
+        if joint.startswith("gripper_")
+        and joint not in set(arm_joints)
+        and joint != "gripper_base_joint"
     ]
-    gripper_joints = [joint for joint in gripper_joints if "inner_knuckle" not in joint and "finger_tip" not in joint]
+    gripper_joints = [
+        joint for joint in gripper_joints
+        if "inner_knuckle" not in joint and "finger_tip" not in joint
+    ]
     preferred = ["gripper_finger1_joint", "gripper_finger2_joint"]
     preferred_gripper = [joint for joint in preferred if joint in gripper_joints]
     if preferred_gripper:
@@ -312,13 +317,17 @@ def _derive_controller_configs(scene_name, controller_group_name, controller_joi
         },
     }
 
-    if end_effector_metadata.get("spawn_gripper_controller") and gripper_joints:
+    should_emit_gripper_controller = (
+        bool(end_effector_metadata.get("spawn_gripper_controller"))
+        or end_effector_metadata.get("gripper_type") == "finger"
+    )
+    if should_emit_gripper_controller and gripper_joints:
         gripper_controller_name = (f"{robot_name}_gripper_controller" if robot_name.startswith("ur") else f"{robot_name}_gripper_controller")
         controllers["controller_names"].append(gripper_controller_name)
         controllers[gripper_controller_name] = {
             "action_ns": "follow_joint_trajectory",
             "type": "FollowJointTrajectory",
-            "default": True,
+            "default": False,
             "joints": gripper_joints,
         }
 


### PR DESCRIPTION
### Motivation
- Newly generated Humble scene launchers emitted only an arm MoveIt controller, so finger-type end-effectors (e.g. Robotiq 85) had no dedicated gripper action endpoint for `follow_joint_trajectory`.
- The intent is to generate a proper gripper controller when a movable finger gripper exists while preserving existing mount-origin sanitisation and fake-hardware/trajectory execution defaults.
- The fix must prefer active Robotiq command joints and avoid fixed/mimic/legacy joints so MoveIt exposes usable gripper action endpoints.

### Description
- Updated `_derive_controller_configs` in `workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py` to discover gripper joints that start with `gripper_` while excluding `gripper_base_joint` and filtering out `inner_knuckle`/`finger_tip` joints where possible.
- Added a preferred-joints list `[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f202068f348331b54ddf195c1aed9d)