### PR TITLE
Fix Humble generated scenes to emit Robotiq gripper controllers at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1111,6 +1111,8 @@ Expected behavior:
 Controller validation commands:
 
 ```bash
+ros2 pkg prefix <scene_package>
+ls $(ros2 pkg prefix <scene_package>)/share/<scene_package>/environment.yaml
 ros2 param dump /move_group | grep -A80 -B10 "moveit_simple_controller_manager"
 ros2 action list | grep -E "move|trajectory|follow"
 ```

--- a/tests/test_workcell_builder_generation.py
+++ b/tests/test_workcell_builder_generation.py
@@ -101,3 +101,17 @@ def test_humble_scene_template_preserves_fake_hardware_launch_behavior() -> None
     assert '"allow_trajectory_execution": False' in content
     assert '"moveit_manage_controllers": False' in content
     assert "use_fake_hardware" in content
+
+
+def test_humble_scene_cmakelists_installs_environment_yaml() -> None:
+    content = (REPO_ROOT / "workcell_builder/workcell_builder/templates/ros2/humble/CMakeLists_example.txt").read_text(encoding="utf-8")
+    assert "install(FILES environment.yaml" in content
+    assert "DESTINATION share/${PROJECT_NAME}" in content
+
+
+def test_humble_scene_template_gripper_controller_emits_without_environment_yaml_metadata() -> None:
+    content = (REPO_ROOT / "workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py").read_text(encoding="utf-8")
+    assert "or bool(gripper_joints)" in content
+    assert 'preferred = ["gripper_finger1_joint", "gripper_finger2_joint"]' in content
+    assert 'joint != "gripper_base_joint"' in content
+    assert '"inner_knuckle" not in joint and "finger_tip" not in joint' in content

--- a/workcell_builder/workcell_builder/templates/ros2/humble/CMakeLists_example.txt
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/CMakeLists_example.txt
@@ -20,4 +20,8 @@ install(DIRECTORY launch
 install(DIRECTORY urdf
   DESTINATION share/${PROJECT_NAME}
 )
+
+install(FILES environment.yaml
+  DESTINATION share/${PROJECT_NAME}
+)
 ament_package()

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -320,6 +320,7 @@ def _derive_controller_configs(scene_name, controller_group_name, controller_joi
     should_emit_gripper_controller = (
         bool(end_effector_metadata.get("spawn_gripper_controller"))
         or end_effector_metadata.get("gripper_type") == "finger"
+        or bool(gripper_joints)
     )
     if should_emit_gripper_controller and gripper_joints:
         gripper_controller_name = (f"{robot_name}_gripper_controller" if robot_name.startswith("ur") else f"{robot_name}_gripper_controller")


### PR DESCRIPTION
### Motivation
- Generated Humble scene packages were not installing `environment.yaml`, causing runtime `end_effector_metadata` to be empty and preventing gripper controllers from being emitted.
- When the URDF contains active Robotiq finger joints the launch should emit a gripper controller even if metadata is missing to preserve expected MoveIt controller/action outputs.
- Prefer the active Robotiq command joints and continue excluding base/inner-knuckle/finger-tip/fixed joints to avoid spurious controllers.

### Description
- Install `environment.yaml` into generated scene package share by adding `install(FILES environment.yaml DESTINATION share/${PROJECT_NAME})` to the Humble `CMakeLists_example.txt`.
- Harden `_derive_controller_configs(...)` in the Humble `demo.launch.py` so `should_emit_gripper_controller` is true when `gripper_joints` are present by adding `or bool(gripper_joints)` to the predicate.
- Preserve existing gripper joint filtering and preference logic so only `gripper_finger1_joint`/`gripper_finger2_joint` are chosen when present and exclude `gripper_base_joint`, inner knuckle, finger tip, and fixed joints.
- Add/extend generation regression tests in `tests/test_workcell_builder_generation.py` to assert `environment.yaml` is installed, to assert the metadata-independent gripper emission predicate exists, and to assert preferred/excluded joint logic remains present.
- Update README `Validate generated scene` section to include a command to verify the installed `environment.yaml` and to document the expected arm+gripper controller/action outputs.

### Testing
- Ran `python3 -m pytest -q tests/test_workcell_builder_generation.py`, which completed successfully with `14 passed`.
- Ran `bash -n fix_and_build_humble.sh scripts/fix_workspace_layout.sh` to validate shell scripts and it returned without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f204f4ac10833191dee24ac2168a4a)