### PR TITLE
Add MVP-1 generated-cell acceptance workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1346,3 +1346,6 @@ ros2 launch new_scene demo.launch.py
 ```
 
 `workcell_builder` keeps generated scenes in `~/workcell_ws/src/scenes/<scene_name>` and generated assets in `~/workcell_ws/src/assets`; scene rediscovery on reopen scans that `scenes/` directory automatically.
+
+## Manuals
+- [MVP-1 Generated Cell Acceptance](docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md)

--- a/docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md
+++ b/docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md
@@ -1,0 +1,66 @@
+# MVP-1 Generated Cell Acceptance (Offline-First)
+
+## Purpose
+MVP-1 adds a conservative acceptance flow that proves a generated workcell can execute a user task recipe end-to-end with current backend components:
+
+`detected_objects/v1 -> validation -> task recipe validation -> runtime_execution_plan/v1 -> EMD grasp bridge payload`
+
+This is intentionally **no-new-GUI** and **no new scene/assets architecture**. It prepares backend hooks for a future GUI button chain.
+
+## Example acceptance scenario
+UR5 + Robotiq 2F style sorting logic:
+- if `colour == red` -> `red_bin`
+- if `colour == blue` -> `blue_bin`
+- else fallback -> `reject_bin`
+
+Fixtures:
+- `tests/fixtures/task_recipes/mvp1_generated_cell_colour_sorting.yaml`
+- `tests/fixtures/detected_objects/mvp1_colour_sorting_with_fallback.yaml`
+
+## Run the acceptance flow
+```bash
+python3 scripts/run_generated_cell_acceptance.py \
+  --scene-package ur5_robotiq_generated_cell \
+  --task-recipe tests/fixtures/task_recipes/mvp1_generated_cell_colour_sorting.yaml \
+  --detected-objects tests/fixtures/detected_objects/mvp1_colour_sorting_with_fallback.yaml \
+  --output-dir reports/generated_cell_acceptance \
+  --json
+```
+
+Arguments:
+- `--scene-package`: generated scene package name to probe in `scenes/` and `install/share` style locations.
+- `--task-recipe`: task recipe input.
+- `--detected-objects`: detected objects input.
+- `--output-dir`: artifact directory.
+- `--strict`: convert WARN to FAIL.
+- `--json`: machine-readable summary.
+
+## PASS / WARN / FAIL
+- **PASS**: all pipeline stages succeed and no warnings were produced.
+- **WARN**: pipeline succeeded, but operator attention is required (example: scene package not found offline, missing destination pose).
+- **FAIL**: blockers occurred, or strict mode escalated warnings.
+
+Known runtime boundary is always surfaced:
+
+> destination_resolved is present in the bridge payload; runtime release execution may still use existing release fallback until runtime destination support is implemented.
+
+## Generated-cell readiness checks
+The script performs tolerant checks for generated scene package files (for example `package.xml`, `environment.yaml`, plus `launch/`, `config/` directories when available). Missing local ROS workspace/install is WARN by default; strict mode promotes to FAIL.
+
+## Mapping to future GUI buttons
+Future GUI flow can call this backend sequence:
+1. Validate/import environment and generated scene package.
+2. Validate detected objects snapshot and task recipe.
+3. Generate runtime plan.
+4. Generate EMD bridge payload.
+5. Show readiness summary (PASS/WARN/FAIL).
+
+## Real D435i / EPD snapshot path (later)
+Later, replace the fixture input with captured snapshot output from `scripts/capture_epd_detected_objects.py`, then rerun this acceptance script for the same task recipe.
+
+## Moving from offline acceptance to ROS execution
+After offline acceptance reaches PASS/WARN-understood status:
+1. Build/source ROS 2 Humble workspace.
+2. Ensure generated scene package is discoverable.
+3. Launch existing `run_grasp_execution` stack.
+4. Feed generated runtime plan / bridge payload through current runtime integration path.

--- a/scripts/preflight_workcell.sh
+++ b/scripts/preflight_workcell.sh
@@ -93,6 +93,24 @@ echo
 "${SCRIPT_DIR}/check_task_execution_plans.sh"
 "${SCRIPT_DIR}/check_emd_grasp_bridge.sh"
 "${SCRIPT_DIR}/check_detected_objects_pipeline.sh"
+set +e
+MVP1_OUTPUT="$(python3 "${SCRIPT_DIR}/run_generated_cell_acceptance.py" \
+  --scene-package ur5_robotiq_generated_cell \
+  --task-recipe "${REPO_ROOT}/tests/fixtures/task_recipes/mvp1_generated_cell_colour_sorting.yaml" \
+  --detected-objects "${REPO_ROOT}/tests/fixtures/detected_objects/mvp1_colour_sorting_with_fallback.yaml" \
+  --output-dir "${REPO_ROOT}/reports/generated_cell_acceptance" --json)"
+MVP1_EXIT=$?
+set -e
+echo "${MVP1_OUTPUT}"
+if [[ ${MVP1_EXIT} -eq 0 ]]; then
+  if grep -q '"status": "WARN"' <<<"${MVP1_OUTPUT}"; then
+    echo "Generated cell MVP-1 acceptance: WARN"
+  else
+    echo "Generated cell MVP-1 acceptance: PASS"
+  fi
+else
+  echo "Generated cell MVP-1 acceptance: FAIL"
+fi
 "${SCRIPT_DIR}/generate_task_execution_plan_report.py"
 "${SCRIPT_DIR}/check_workcell_bundles.sh"
 "${SCRIPT_DIR}/check_generated_workcells.sh"

--- a/scripts/run_generated_cell_acceptance.py
+++ b/scripts/run_generated_cell_acceptance.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""MVP-1 generated-cell acceptance flow (offline-first, ROS-optional)."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+VALIDATE_OBJECTS = SCRIPTS_DIR / "validate_detected_objects.py"
+VALIDATE_RECIPE = SCRIPTS_DIR / "validate_task_recipe.py"
+ADAPTER = SCRIPTS_DIR / "run_task_recipe_adapter.py"
+BRIDGE = SCRIPTS_DIR / "convert_runtime_plan_to_emd_grasp.py"
+
+KNOWN_RUNTIME_BOUNDARY = (
+    "destination_resolved is present in the bridge payload; runtime release execution may still "
+    "use existing release fallback until runtime destination support is implemented."
+)
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def _extract_json(text: str) -> dict[str, Any]:
+    start = text.find("{")
+    return {} if start < 0 else json.loads(text[start:])
+
+
+def _scene_readiness(scene_package: str) -> tuple[list[str], list[str]]:
+    warnings: list[str] = []
+    errors: list[str] = []
+    candidates = [
+        Path.cwd() / "scenes" / scene_package,
+        Path.cwd() / "install" / scene_package / "share" / scene_package,
+        Path.cwd() / "install" / "share" / scene_package,
+    ]
+    existing = next((p for p in candidates if p.exists()), None)
+    if existing is None:
+        warnings.append(f"Scene package '{scene_package}' not found under workspace scenes/install paths.")
+        return warnings, errors
+
+    required = ["package.xml", "environment.yaml"]
+    optional = ["launch", "config"]
+    for name in required:
+        if not (existing / name).exists():
+            warnings.append(f"Scene package '{scene_package}' missing expected file: {name}")
+    for name in optional:
+        if not (existing / name).exists():
+            warnings.append(f"Scene package '{scene_package}' missing expected directory: {name}")
+    return warnings, errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scene-package", required=True)
+    parser.add_argument("--task-recipe", type=Path, required=True)
+    parser.add_argument("--detected-objects", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, default=Path("reports/generated_cell_acceptance"))
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    runtime_plan = args.output_dir / "runtime_execution_plan.json"
+    bridge_payload = args.output_dir / "emd_grasp_bridge_payload.json"
+
+    validate_objects_cmd = [sys.executable, str(VALIDATE_OBJECTS), str(args.detected_objects), "--json"]
+    validate_recipe_cmd = [sys.executable, str(VALIDATE_RECIPE), str(args.task_recipe), "--json"]
+    if args.strict:
+        validate_objects_cmd.append("--strict")
+        validate_recipe_cmd.append("--strict")
+
+    obj_proc = _run(validate_objects_cmd)
+    recipe_proc = _run(validate_recipe_cmd)
+
+    adapter_cmd = [
+        sys.executable,
+        str(ADAPTER),
+        "--task-recipe",
+        str(args.task_recipe),
+        "--objects",
+        str(args.detected_objects),
+        "--output",
+        str(runtime_plan),
+        "--json",
+        "--mode",
+        "offline",
+    ]
+    if args.strict:
+        adapter_cmd.append("--strict")
+    adapter_proc = _run(adapter_cmd)
+
+    bridge_cmd = [
+        sys.executable,
+        str(BRIDGE),
+        "--runtime-plan",
+        str(runtime_plan),
+        "--output",
+        str(bridge_payload),
+        "--json",
+        "--mode",
+        "offline",
+    ]
+    if args.strict:
+        bridge_cmd.append("--strict")
+    bridge_proc = _run(bridge_cmd)
+
+    obj_json = _extract_json(obj_proc.stdout)
+    recipe_json = _extract_json(recipe_proc.stdout)
+    plan_json = _extract_json(adapter_proc.stdout)
+    bridge_json = _extract_json(bridge_proc.stdout)
+
+    warnings: list[str] = []
+    blockers: list[str] = []
+    scene_warnings, scene_errors = _scene_readiness(args.scene_package)
+    warnings.extend(scene_warnings)
+    blockers.extend(scene_errors)
+
+    if obj_proc.returncode != 0:
+        blockers.append("Detected objects validation failed.")
+    if recipe_proc.returncode != 0:
+        blockers.append("Task recipe validation failed.")
+    if adapter_proc.returncode != 0:
+        blockers.append("Runtime plan generation failed.")
+    if bridge_proc.returncode != 0:
+        blockers.append("EMD grasp bridge conversion failed.")
+
+    warnings.extend(bridge_json.get("warnings", []))
+    files = recipe_json.get("files")
+    if isinstance(files, list):
+        for item in files:
+            if isinstance(item, dict):
+                for warning in item.get("warnings", []):
+                    if isinstance(warning, str):
+                        warnings.append(warning)
+    warnings.append(KNOWN_RUNTIME_BOUNDARY)
+
+    status = "PASS"
+    if blockers:
+        status = "FAIL"
+    elif warnings:
+        status = "WARN"
+    if args.strict and warnings:
+        status = "FAIL"
+        blockers.append("Strict mode treats warnings as blockers.")
+
+    steps = plan_json.get("steps", []) if isinstance(plan_json.get("steps"), list) else []
+    selected = steps[0] if steps else {}
+    selected_obj = selected.get("object", {}) if isinstance(selected.get("object"), dict) else {}
+    routing = selected.get("routing", {}) if isinstance(selected.get("routing"), dict) else {}
+    dest = routing.get("destination", {}) if isinstance(routing.get("destination"), dict) else {}
+
+    payload = {
+        "schema_version": "generated_cell_acceptance/v1",
+        "status": status,
+        "scene_package": args.scene_package,
+        "selected_object": selected_obj.get("id"),
+        "matched_rule": routing.get("matched_rule_id"),
+        "destination_selected": routing.get("destination_id"),
+        "destination_pose": {"frame": dest.get("frame"), "xyz": dest.get("pose_xyz")},
+        "runtime_plan_path": str(runtime_plan),
+        "emd_bridge_payload_path": str(bridge_payload),
+        "warnings": warnings,
+        "blockers": blockers,
+        "step_status": {
+            "detected_objects": obj_json.get("status"),
+            "task_recipe": recipe_json.get("result"),
+            "runtime_plan": "PASS" if adapter_proc.returncode == 0 else "FAIL",
+            "emd_bridge": bridge_json.get("status"),
+        },
+    }
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"Generated cell acceptance: {status}")
+        print(f"- selected object: {payload['selected_object']}")
+        print(f"- matched rule: {payload['matched_rule']}")
+        print(f"- destination selected: {payload['destination_selected']}")
+        print(f"- destination pose/frame: {payload['destination_pose']}")
+        print(f"- generated runtime plan path: {runtime_plan}")
+        print(f"- generated EMD bridge payload path: {bridge_payload}")
+        for w in warnings:
+            print(f"WARN: {w}")
+        for b in blockers:
+            print(f"FAIL: {b}")
+
+    return 1 if status == "FAIL" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/detected_objects/mvp1_colour_sorting_with_fallback.yaml
+++ b/tests/fixtures/detected_objects/mvp1_colour_sorting_with_fallback.yaml
@@ -1,0 +1,62 @@
+schema_version: detected_objects/v1
+source:
+  type: epd_localization
+  frame_id: camera_depth_optical_frame
+objects:
+  - object_id: red_001
+    name: part
+    class_id: part
+    confidence: 0.97
+    pose:
+      frame_id: camera_depth_optical_frame
+      xyz: [0.1, 0.1, 0.2]
+      rpy: [0, 0, 0]
+    centroid:
+      x: 0.1
+      y: 0.1
+      z: 0.2
+    dimensions:
+      x: 0.04
+      y: 0.04
+      z: 0.02
+    attributes:
+      colour: red
+      shape: box
+  - object_id: blue_001
+    name: part
+    class_id: part
+    confidence: 0.95
+    pose:
+      frame_id: camera_depth_optical_frame
+      xyz: [0.2, 0.1, 0.2]
+      rpy: [0, 0, 0]
+    centroid:
+      x: 0.2
+      y: 0.1
+      z: 0.2
+    dimensions:
+      x: 0.03
+      y: 0.03
+      z: 0.06
+    attributes:
+      colour: blue
+      shape: cylinder
+  - object_id: unknown_001
+    name: part
+    class_id: part
+    confidence: 0.88
+    pose:
+      frame_id: camera_depth_optical_frame
+      xyz: [0.25, 0.1, 0.2]
+      rpy: [0, 0, 0]
+    centroid:
+      x: 0.25
+      y: 0.1
+      z: 0.2
+    dimensions:
+      x: 0.05
+      y: 0.04
+      z: 0.02
+    attributes:
+      colour: yellow
+      shape: irregular

--- a/tests/fixtures/task_recipes/mvp1_generated_cell_colour_sorting.yaml
+++ b/tests/fixtures/task_recipes/mvp1_generated_cell_colour_sorting.yaml
@@ -1,0 +1,37 @@
+schema_version: task_recipe/v1
+task:
+  id: mvp1_generated_cell_colour_sorting
+  type: sort_by_colour
+  source: detected_object
+  perception_source: realsense_d435i
+  destinations:
+    - id: red_bin
+      frame: world
+      pose_xyz: [0.3, -0.2, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: red
+    - id: blue_bin
+      frame: world
+      pose_xyz: [0.3, 0.0, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: blue
+    - id: reject_bin
+      frame: world
+      pose_xyz: [0.2, 0.0, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: reject
+  decision_rules:
+    - id: route_red
+      when:
+        attribute: colour
+        equals: red
+      destination: red_bin
+    - id: route_blue
+      when:
+        attribute: colour
+        equals: blue
+      destination: blue_bin
+    - id: fallback
+      when:
+        default: true
+      destination: reject_bin

--- a/tests/fixtures/task_recipes/mvp1_generated_cell_colour_sorting_missing_reject_pose.yaml
+++ b/tests/fixtures/task_recipes/mvp1_generated_cell_colour_sorting_missing_reject_pose.yaml
@@ -1,0 +1,35 @@
+schema_version: task_recipe/v1
+task:
+  id: mvp1_generated_cell_colour_sorting
+  type: sort_by_colour
+  source: detected_object
+  perception_source: realsense_d435i
+  destinations:
+    - id: red_bin
+      frame: world
+      pose_xyz: [0.3, -0.2, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: red
+    - id: blue_bin
+      frame: world
+      pose_xyz: [0.3, 0.0, 0.1]
+      pose_rpy: [0, 0, 0]
+      label: blue
+    - id: reject_bin
+      frame: world
+      label: reject
+  decision_rules:
+    - id: route_red
+      when:
+        attribute: colour
+        equals: red
+      destination: red_bin
+    - id: route_blue
+      when:
+        attribute: colour
+        equals: blue
+      destination: blue_bin
+    - id: fallback
+      when:
+        default: true
+      destination: reject_bin

--- a/tests/test_generated_cell_acceptance.py
+++ b/tests/test_generated_cell_acceptance.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "run_generated_cell_acceptance.py"
+TASK = REPO_ROOT / "tests" / "fixtures" / "task_recipes" / "mvp1_generated_cell_colour_sorting.yaml"
+TASK_MISSING_POSE = REPO_ROOT / "tests" / "fixtures" / "task_recipes" / "mvp1_generated_cell_colour_sorting_missing_reject_pose.yaml"
+OBJECTS = REPO_ROOT / "tests" / "fixtures" / "detected_objects" / "mvp1_colour_sorting_with_fallback.yaml"
+
+
+class GeneratedCellAcceptanceTests(unittest.TestCase):
+    def _run(self, strict: bool = False, task: Path = TASK) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd = [
+                sys.executable,
+                str(SCRIPT),
+                "--scene-package",
+                "ur5_robotiq_generated_cell",
+                "--task-recipe",
+                str(task),
+                "--detected-objects",
+                str(OBJECTS),
+                "--output-dir",
+                tmpdir,
+                "--json",
+            ]
+            if strict:
+                cmd.append("--strict")
+            return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+    def test_valid_colour_routing_example(self) -> None:
+        proc = self._run(task=TASK)
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+        payload = json.loads(proc.stdout)
+        self.assertEqual(payload["selected_object"], "red_001")
+        self.assertEqual(payload["matched_rule"], "route_red")
+        self.assertEqual(payload["destination_selected"], "red_bin")
+
+    def test_fallback_destination_is_present_in_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--scene-package",
+                    "ur5_robotiq_generated_cell",
+                    "--task-recipe",
+                    str(TASK),
+                    "--detected-objects",
+                    str(OBJECTS),
+                    "--output-dir",
+                    tmpdir,
+                    "--json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            plan = json.loads((Path(tmpdir) / "runtime_execution_plan.json").read_text(encoding="utf-8"))
+            destinations = [step["routing"]["destination_id"] for step in plan["steps"]]
+            self.assertIn("reject_bin", destinations)
+
+    def test_missing_destination_pose_warning(self) -> None:
+        proc = self._run(task=TASK_MISSING_POSE)
+        payload = json.loads(proc.stdout)
+        self.assertTrue(any("pose_xyz is missing" in w for w in payload["warnings"]))
+
+    def test_missing_generated_scene_warning(self) -> None:
+        proc = self._run()
+        payload = json.loads(proc.stdout)
+        self.assertTrue(any("not found" in w for w in payload["warnings"]))
+
+    def test_strict_mode_fails_on_warnings(self) -> None:
+        proc = self._run(strict=True, task=TASK_MISSING_POSE)
+        self.assertEqual(proc.returncode, 1)
+        payload = json.loads(proc.stdout)
+        self.assertEqual(payload["status"], "FAIL")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_task_recipe_tools.py
+++ b/tests/test_task_recipe_tools.py
@@ -82,7 +82,7 @@ class TaskRecipeValidatorTests(unittest.TestCase):
         )
         self.assertNotEqual(proc.returncode, 0)
         payload = json.loads(proc.stdout)
-        self.assertEqual(len(payload["files"]), 10)
+        self.assertEqual(len(payload["files"]), 12)
 
 
 class TaskRecipeGeneratorTests(unittest.TestCase):


### PR DESCRIPTION
### Motivation
- Provide a conservative, offline-first backend acceptance flow that proves a generated workcell can run a user task recipe end-to-end (detected_objects -> validation -> task-recipe validation -> runtime_execution_plan -> EMD bridge) while preparing backend hooks for a future GUI. 
- Use a minimal UR5 + Robotiq 2F style colour-sorting example with fallback routing to validate routing, destination resolution and bridge payload generation without adding new scene/asset architectures. 

### Description
- Add `scripts/run_generated_cell_acceptance.py`, an offline-first acceptance runner that validates detected objects and the task recipe, generates a runtime execution plan via the existing adapter, converts to the EMD grasp bridge payload, and emits a PASS/WARN/FAIL summary with `--scene-package`, `--task-recipe`, `--detected-objects`, `--output-dir`, `--strict` and `--json` options. 
- Add fixtures for the MVP-1 flow: `tests/fixtures/detected_objects/mvp1_colour_sorting_with_fallback.yaml` and two task recipes `mvp1_generated_cell_colour_sorting.yaml` and `mvp1_generated_cell_colour_sorting_missing_reject_pose.yaml` (missing pose variant exercises warning paths). 
- Add unit tests `tests/test_generated_cell_acceptance.py` covering valid colour routing, fallback destination inclusion, missing destination pose warning, missing generated scene warning, and strict-mode failure; update `tests/test_task_recipe_tools.py` fixture count to account for added files. 
- Add lightweight generated-scene readiness checks to the runner (workspace/install/share probing and expected file checks) that are tolerant offline (WARN by default, escalated by `--strict`). 
- Integrate the acceptance invocation into `scripts/preflight_workcell.sh` with clear PASS/WARN/FAIL reporting, add `docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md`, and link it from `README.md`. 
- Preserve runtime boundaries and explicitly surface the runtime-note: "destination_resolved is present in the bridge payload; runtime release execution may still use existing release fallback until runtime destination support is implemented." 

### Testing
- Compiled the new script with `python3 -m py_compile scripts/run_generated_cell_acceptance.py` and the compile succeeded. 
- Ran targeted unit tests `tests/test_generated_cell_acceptance.py`, `tests/test_detected_objects_tools.py`, and `tests/test_task_recipe_tools.py`, and the suites covering the new runner and related fixtures passed. 
- Exercised the end-to-end offline flow manually via `python3 scripts/run_generated_cell_acceptance.py --scene-package ur5_robotiq_generated_cell --task-recipe tests/fixtures/task_recipes/mvp1_generated_cell_colour_sorting.yaml --detected-objects tests/fixtures/detected_objects/mvp1_colour_sorting_with_fallback.yaml --output-dir /tmp/mvp1 --json` and observed produced `runtime_execution_plan.json` and `emd_grasp_bridge_payload.json` along with expected WARN entries for offline scene discovery and destination/fallback behaviors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f327e3de0483319c29254f3cfa94ac)