### PR TITLE
Add MVP-1 emd_grasp_bridge payload replay script and preflight dry-run check

### DIFF
--- a/docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md
+++ b/docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md
@@ -99,5 +99,28 @@ python3 scripts/run_generated_cell_acceptance.py \
 ros2 launch run_grasp_execution grasp_execution.launch.py scene_package:=ur5_2f_test
 ```
 
-Bridge replay status:
-- TODO: document/standardize a lightweight bridge-payload replay publisher command if/when a shared tool is added.
+## Replay a generated task into runtime
+
+This replay flow is the backend equivalent of the future GUI **"Simulate Cycle"** button.
+
+1. Acceptance generates `emd_grasp_bridge_payload.json` from detected objects + task recipe.
+2. Replay sends that payload through the existing runtime communication boundary (`grasp_requests` service or `grasp_tasks` topic) used by `run_grasp_execution`.
+3. `run_grasp_execution` performs destination-aware placement when destination pose data is available, and falls back to legacy release mode when not.
+
+Replay command:
+
+```bash
+python3 scripts/replay_emd_bridge_payload.py \
+  --payload /tmp/mvp1/emd_grasp_bridge_payload.json \
+  --scene-package ur5_2f_test \
+  --once
+```
+
+Use `--dry-run` for validation-only checks (no ROS runtime send):
+
+```bash
+python3 scripts/replay_emd_bridge_payload.py \
+  --payload /tmp/mvp1/emd_grasp_bridge_payload.json \
+  --scene-package ur5_2f_test \
+  --dry-run
+```

--- a/scripts/preflight_workcell.sh
+++ b/scripts/preflight_workcell.sh
@@ -111,6 +111,22 @@ if [[ ${MVP1_EXIT} -eq 0 ]]; then
 else
   echo "Generated cell MVP-1 acceptance: FAIL"
 fi
+
+MVP1_BRIDGE_PAYLOAD="/tmp/mvp1/emd_grasp_bridge_payload.json"
+if [[ -f "${MVP1_BRIDGE_PAYLOAD}" ]]; then
+  set +e
+  REPLAY_OUTPUT="$(python3 "${SCRIPT_DIR}/replay_emd_bridge_payload.py" --payload "${MVP1_BRIDGE_PAYLOAD}" --scene-package ur5_2f_test --dry-run)"
+  REPLAY_EXIT=$?
+  set -e
+  echo "${REPLAY_OUTPUT}"
+  if [[ ${REPLAY_EXIT} -eq 0 ]]; then
+    echo "MVP-1 bridge replay dry-run: PASS/WARN"
+  else
+    echo "MVP-1 bridge replay dry-run: WARN (validation failed)"
+  fi
+else
+  echo "INFO: Skipping MVP-1 bridge replay dry-run (/tmp/mvp1/emd_grasp_bridge_payload.json not found)."
+fi
 "${SCRIPT_DIR}/generate_task_execution_plan_report.py"
 "${SCRIPT_DIR}/check_workcell_bundles.sh"
 "${SCRIPT_DIR}/check_generated_workcells.sh"

--- a/scripts/replay_emd_bridge_payload.py
+++ b/scripts/replay_emd_bridge_payload.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Replay emd_grasp_bridge_payload/v1 into run_grasp_execution runtime interface."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import validate_cell_definition as cell_yaml
+
+
+def _load_payload(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Payload file not found: {path}")
+    if path.suffix.lower() == ".json":
+        data = json.loads(path.read_text(encoding="utf-8"))
+    else:
+        data, _, _ = cell_yaml.load_yaml(path)
+    if not isinstance(data, dict):
+        raise ValueError("Payload root must be a mapping/object.")
+    return data
+
+
+def _summarize_target(target: dict[str, Any]) -> dict[str, str]:
+    obj_id = str(target.get("object_id") or "(unknown)")
+    obj_class = str(target.get("target_type") or "(unknown)")
+    grasp_pose = target.get("grasp_methods", [{}])[0] if isinstance(target.get("grasp_methods"), list) and target.get("grasp_methods") else {}
+    grasp_poses = grasp_pose.get("grasp_poses") if isinstance(grasp_pose, dict) else []
+    grasp_frame = "(missing)"
+    if isinstance(grasp_poses, list) and grasp_poses and isinstance(grasp_poses[0], dict):
+        grasp_frame = str(grasp_poses[0].get("frame_id") or "(missing)")
+    destination_id = str(target.get("destination_id") or "(unknown)")
+    dest_pose = target.get("destination_pose") if isinstance(target.get("destination_pose"), dict) else {}
+    dest_frame = str(dest_pose.get("frame_id") or "(missing)")
+    release_mode = "destination-aware" if isinstance(dest_pose.get("xyz"), list) else "legacy fallback"
+    return {
+        "object_id": obj_id,
+        "object_class": obj_class,
+        "grasp_frame": grasp_frame,
+        "destination_id": destination_id,
+        "destination_frame": dest_frame,
+        "release_mode": release_mode,
+    }
+
+
+def _validate(payload: dict[str, Any], scene_package: str) -> tuple[list[str], list[str]]:
+    warnings: list[str] = []
+    errors: list[str] = []
+    if payload.get("schema_version") != "emd_grasp_bridge_payload/v1":
+        errors.append("schema_version must be 'emd_grasp_bridge_payload/v1'.")
+    grasp_task = payload.get("grasp_task") if isinstance(payload.get("grasp_task"), dict) else {}
+    targets = grasp_task.get("grasp_targets") if isinstance(grasp_task.get("grasp_targets"), list) else []
+    if not targets:
+        errors.append("grasp_task.grasp_targets is missing or empty.")
+    payload_scene = payload.get("scene_package")
+    if isinstance(payload_scene, str) and payload_scene.strip() and payload_scene.strip() != scene_package:
+        warnings.append(f"scene_package mismatch: payload='{payload_scene}' cli='{scene_package}'.")
+    for t in targets:
+        if not isinstance(t, dict):
+            errors.append("grasp_target entry must be a mapping.")
+            continue
+        dest = t.get("destination_pose") if isinstance(t.get("destination_pose"), dict) else {}
+        if not isinstance(dest.get("xyz"), list):
+            warnings.append(f"Object '{t.get('object_id', '(unknown)')}' has no destination pose xyz; runtime will use fallback release mode.")
+        if not isinstance(dest.get("frame_id"), str) or not str(dest.get("frame_id")).strip():
+            errors.append(f"Object '{t.get('object_id', '(unknown)')}' destination pose frame_id is missing.")
+        methods = t.get("grasp_methods") if isinstance(t.get("grasp_methods"), list) else []
+        if not methods:
+            errors.append(f"Object '{t.get('object_id', '(unknown)')}' has no grasp_methods.")
+            continue
+        first = methods[0] if isinstance(methods[0], dict) else {}
+        poses = first.get("grasp_poses") if isinstance(first.get("grasp_poses"), list) else []
+        if not poses or not isinstance(poses[0], dict) or not str(poses[0].get("frame_id") or "").strip():
+            errors.append(f"Object '{t.get('object_id', '(unknown)')}' grasp pose frame_id is missing.")
+    return warnings, errors
+
+
+def _send_runtime(payload: dict[str, Any], args: argparse.Namespace) -> tuple[bool, str]:
+    try:
+        import rclpy
+        from rclpy.node import Node
+        from emd_msgs.msg import GraspTask, GraspTarget, GraspMethod
+        from emd_msgs.srv import GraspRequest
+        from geometry_msgs.msg import PoseStamped
+        from shape_msgs.msg import SolidPrimitive
+    except Exception as exc:
+        return False, f"Runtime endpoint unavailable: ROS imports failed ({exc})."
+
+    def make_pose(data: dict[str, Any]) -> Any:
+        msg = PoseStamped()
+        msg.header.frame_id = str(data.get("frame_id") or args.frame_id)
+        xyz = data.get("xyz") if isinstance(data.get("xyz"), list) and len(data["xyz"]) == 3 else [0.0, 0.0, 0.0]
+        msg.pose.position.x, msg.pose.position.y, msg.pose.position.z = map(float, xyz)
+        msg.pose.orientation.w = 1.0
+        return msg
+
+    rclpy.init(args=None)
+    node = Node("replay_emd_bridge_payload")
+    try:
+        task = GraspTask()
+        task.task_id = str(payload.get("grasp_task", {}).get("task_id", ""))
+        for td in payload.get("grasp_task", {}).get("grasp_targets", []):
+            if not isinstance(td, dict):
+                continue
+            t = GraspTarget()
+            t.target_type = str(td.get("target_type", "box"))
+            t.target_pose = make_pose(td.get("target_pose", {}))
+            p = SolidPrimitive()
+            p.type = SolidPrimitive.BOX
+            p.dimensions = [float(x) for x in td.get("target_shape", {}).get("dimensions", [0.04, 0.04, 0.08])]
+            t.target_shape = p
+            for md in td.get("grasp_methods", []):
+                if not isinstance(md, dict):
+                    continue
+                m = GraspMethod()
+                m.ee_id = str(md.get("ee_id", "robotiq_2f"))
+                m.grasp_poses = [make_pose(pose) for pose in md.get("grasp_poses", []) if isinstance(pose, dict)]
+                m.grasp_ranks = [float(x) for x in md.get("grasp_ranks", [1.0])]
+                t.grasp_methods.append(m)
+            task.grasp_targets.append(t)
+
+        if args.ros_interface == "topic":
+            pub = node.create_publisher(GraspTask, args.topic_name, 10)
+            rclpy.spin_once(node, timeout_sec=0.1)
+            pub.publish(task)
+            return True, f"Published grasp task to topic '{args.topic_name}'."
+        client = node.create_client(GraspRequest, args.service_name)
+        if not client.wait_for_service(timeout_sec=3.0):
+            return False, f"Runtime endpoint unavailable: service '{args.service_name}' not available."
+        req = GraspRequest.Request()
+        req.grasp_targets = task.grasp_targets
+        fut = client.call_async(req)
+        rclpy.spin_until_future_complete(node, fut, timeout_sec=5.0)
+        if not fut.done() or fut.result() is None:
+            return False, f"Runtime endpoint unavailable: service '{args.service_name}' timed out."
+        res = fut.result()
+        return bool(res.success), str(res.message)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--payload", type=Path, required=True)
+    parser.add_argument("--scene-package", required=True)
+    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--rate", type=float, default=0.2)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--ros-interface", choices=["service", "topic"], default="service")
+    parser.add_argument("--service-name", default="grasp_requests")
+    parser.add_argument("--topic-name", default="grasp_tasks")
+    parser.add_argument("--frame-id", default="base_link")
+    args = parser.parse_args(argv)
+
+    try:
+        payload = _load_payload(args.payload)
+        warnings, errors = _validate(payload, args.scene_package)
+        targets = payload.get("grasp_task", {}).get("grasp_targets", [])
+        print("PASS: payload loaded" if not errors else "FAIL: payload validation")
+        for item in targets:
+            if isinstance(item, dict):
+                s = _summarize_target(item)
+                print(f" - object={s['object_id']} class={s['object_class']} grasp_frame={s['grasp_frame']} dest={s['destination_id']} dest_frame={s['destination_frame']} release={s['release_mode']}")
+        for w in warnings:
+            print(f"WARN: {w}")
+        if errors:
+            for e in errors:
+                print(f"FAIL: {e}")
+            return 1
+        if args.dry_run:
+            print("PASS: dry-run only; runtime send skipped")
+            return 0
+        ok, msg = _send_runtime(payload, args)
+        print(("PASS: " if ok else "FAIL: ") + msg)
+        return 0 if ok else 1
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+        print(f"FAIL: {exc}")
+        return 1
+    except Exception as exc:
+        print(f"FAIL: unexpected error: {exc}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_replay_emd_bridge_payload.py
+++ b/tests/test_replay_emd_bridge_payload.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "replay_emd_bridge_payload.py"
+
+
+class ReplayEmdBridgePayloadTests(unittest.TestCase):
+    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run([sys.executable, str(SCRIPT), *args], capture_output=True, text=True, check=False)
+
+    def _payload(self, **overrides: object) -> dict[str, object]:
+        base: dict[str, object] = {
+            "schema_version": "emd_grasp_bridge_payload/v1",
+            "scene_package": "ur5_2f_test",
+            "grasp_task": {
+                "task_id": "demo",
+                "grasp_targets": [
+                    {
+                        "object_id": "obj_1",
+                        "target_type": "box",
+                        "target_pose": {"frame_id": "world", "xyz": [0, 0, 0], "rpy": [0, 0, 0]},
+                        "target_shape": {"type": "BOX", "dimensions": [0.1, 0.1, 0.1]},
+                        "grasp_methods": [{"ee_id": "robotiq_2f", "grasp_poses": [{"frame_id": "world", "xyz": [0, 0, 0], "rpy": [0, 0, 0]}], "grasp_ranks": [1.0]}],
+                        "destination_id": "red_bin",
+                        "destination_pose": {"frame_id": "world", "xyz": [0.2, 0.0, 0.1], "rpy": [0, 0, 0]},
+                    }
+                ],
+            },
+        }
+        base.update(overrides)
+        return base
+
+    def test_valid_payload_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "payload.json"
+            p.write_text(json.dumps(self._payload()), encoding="utf-8")
+            proc = self._run("--payload", str(p), "--scene-package", "ur5_2f_test", "--dry-run")
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            self.assertIn("PASS: dry-run only", proc.stdout)
+
+    def test_missing_payload_file(self) -> None:
+        proc = self._run("--payload", "/tmp/does-not-exist.json", "--scene-package", "ur5_2f_test", "--dry-run")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("Payload file not found", proc.stdout)
+
+    def test_missing_destination_pose_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self._payload()
+            target = payload["grasp_task"]["grasp_targets"][0]
+            target["destination_pose"] = {"frame_id": "world"}
+            p = Path(tmp) / "payload.json"
+            p.write_text(json.dumps(payload), encoding="utf-8")
+            proc = self._run("--payload", str(p), "--scene-package", "ur5_2f_test", "--dry-run")
+            self.assertEqual(proc.returncode, 0)
+            self.assertIn("WARN:", proc.stdout)
+
+    def test_missing_frame_id_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self._payload()
+            target = payload["grasp_task"]["grasp_targets"][0]
+            target["grasp_methods"][0]["grasp_poses"][0].pop("frame_id", None)
+            p = Path(tmp) / "payload.json"
+            p.write_text(json.dumps(payload), encoding="utf-8")
+            proc = self._run("--payload", str(p), "--scene-package", "ur5_2f_test", "--dry-run")
+            self.assertEqual(proc.returncode, 1)
+            self.assertIn("grasp pose frame_id is missing", proc.stdout)
+
+    def test_scene_package_mismatch_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "payload.json"
+            p.write_text(json.dumps(self._payload(scene_package="other_scene")), encoding="utf-8")
+            proc = self._run("--payload", str(p), "--scene-package", "ur5_2f_test", "--dry-run")
+            self.assertEqual(proc.returncode, 0)
+            self.assertIn("scene_package mismatch", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a small MVP-1 runtime replay tool so generated acceptance `emd_grasp_bridge_payload/v1` files can be validated and replayed into the existing runtime for repeatable simulation testing.
- Reuse the current runtime boundary used by `run_grasp_execution` rather than introducing a new topic/service or refactoring runtime architecture.
- Keep the change conservative and operator-friendly (no GUI, no scene duplication, clear PASS/WARN/FAIL output).

### Description
- Add `scripts/replay_emd_bridge_payload.py`, a lightweight tool that loads a JSON/YAML `emd_grasp_bridge_payload/v1`, validates required fields, prints a readable target summary, supports `--payload`, `--scene-package`, `--once`, `--rate`, `--dry-run`, and can send the payload via the same runtime boundary (`grasp_requests` service or `grasp_tasks` topic) used by `run_grasp_execution`.
- Implement a minimal mapping into `emd_msgs` types in `replay_emd_bridge_payload.py` and guard ROS interactions so dry-run and offline validation work without a live ROS graph.
- Add unit tests `tests/test_replay_emd_bridge_payload.py` that cover valid dry-run, missing payload file, missing destination pose warning, missing grasp pose `frame_id` failure, and scene package mismatch warning; tests are offline and do not require hardware or a running ROS graph.
- Extend `scripts/preflight_workcell.sh` to run the replay script in `--dry-run` if `/tmp/mvp1/emd_grasp_bridge_payload.json` exists and otherwise skip with INFO, avoiding any live-ROS dependency.
- Update `docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md` with a new "Replay a generated task into runtime" section documenting the CLI usage and workflow mapping to the future GUI "Simulate Cycle" button.

### Testing
- Ran Python compile checks with `python3 -m py_compile scripts/run_generated_cell_acceptance.py scripts/replay_emd_bridge_payload.py` which completed successfully.
- Ran unit tests with `python3 -m pytest -q tests/test_generated_cell_acceptance.py tests/test_replay_emd_bridge_payload.py` and all tests passed (`10 passed`).
- Linted the preflight script with `bash -n scripts/preflight_workcell.sh` which returned without syntax errors.
- Attempted the suggested `colcon build --symlink-install --packages-select run_grasp_execution run_grasp_planner` but `colcon` was not available in the environment so package build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33b65f36483319020d68e97ee410d)