### PR TITLE
Add discovery-driven scene/recipe/object selection to MVP-1 panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1355,3 +1355,5 @@ ros2 launch new_scene demo.launch.py
 
 ## Manuals
 - [MVP-1 Generated Cell Acceptance](docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md) (includes the optional **Run from the operator panel** flow).
+
+- The MVP-1 operator panel now auto-discovers scene packages, task recipes, and detected-object fixtures, while still allowing manual overrides.

--- a/docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md
+++ b/docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md
@@ -262,3 +262,14 @@ By default, artifacts are written to `/tmp/mvp1` (or the selected output directo
 
 ### Future full GUI mapping
 This panel is the first GUI layer over the generated-cell cycle runner. It does not replace Workcell Builder.
+
+## Discover scenes and recipes from the operator panel
+
+Use **Refresh** in `scripts/run_cell_cycle_panel.py` to discover existing scene packages, task recipes, and detected-object fixtures. The panel now provides dropdowns for each, plus **Browse...** fallbacks for manual path selection.
+
+- Scene package dropdown: discovered packages from install/src/generated locations.
+- Task recipe dropdown: discovered `task_recipe/v1` YAML/JSON fixtures.
+- Detected objects dropdown: discovered `detected_objects/v1` YAML/JSON fixtures.
+- Selection details: shows source path, schema/version, object count, and warnings.
+- Live EPD mode does not require a detected_objects fixture.
+- Replay still requires `run_grasp_execution` to already be running.

--- a/scripts/run_cell_cycle_panel.py
+++ b/scripts/run_cell_cycle_panel.py
@@ -14,9 +14,16 @@ from typing import Any
 try:
     import tkinter as tk
     from tkinter import filedialog, messagebox, ttk
+
 except Exception as exc:  # pragma: no cover
     raise SystemExit(f"FAIL: tkinter is required for this optional panel: {exc}")
 
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+from workcell_discovery import discover_all
 
 DEFAULTS = {
     "scene_package": "ur5_2f_test",
@@ -108,7 +115,9 @@ class CellCyclePanel:
         self.json_output = tk.BooleanVar(value=True)
         self.status = tk.StringVar(value="Status: idle")
 
+        self.discovery_data = {"scenes": [], "task_recipes": [], "detected_objects": []}
         self._build_ui()
+        self.refresh_discovery()
         self._toggle_input_mode()
         self.root.after(100, self._poll_queue)
 
@@ -119,7 +128,27 @@ class CellCyclePanel:
         self.root.rowconfigure(0, weight=1)
 
         row = 0
-        for label, var in [("Scene package", self.scene_package), ("Task recipe", self.task_recipe), ("Detected objects", self.detected_objects), ("EPD topic", self.epd_topic), ("Output dir", self.output_dir), ("Capture timeout", self.capture_timeout), ("Min objects", self.min_objects)]:
+        ttk.Label(frm, text="Scene package").grid(row=row, column=0, sticky="w")
+        self.scene_combo = ttk.Combobox(frm, textvariable=self.scene_package, width=77)
+        self.scene_combo.grid(row=row, column=1, sticky="ew", padx=4, pady=2)
+        self.scene_combo.bind("<<ComboboxSelected>>", lambda _e: self._update_selection_details())
+        row += 1
+
+        ttk.Label(frm, text="Task recipe").grid(row=row, column=0, sticky="w")
+        self.task_combo = ttk.Combobox(frm, textvariable=self.task_recipe, width=77)
+        self.task_combo.grid(row=row, column=1, sticky="ew", padx=4, pady=2)
+        ttk.Button(frm, text="Browse...", command=self._browse_task_recipe).grid(row=row, column=2, sticky="w")
+        self.task_combo.bind("<<ComboboxSelected>>", lambda _e: self._update_selection_details())
+        row += 1
+
+        ttk.Label(frm, text="Detected objects").grid(row=row, column=0, sticky="w")
+        self.objects_combo = ttk.Combobox(frm, textvariable=self.detected_objects, width=77)
+        self.objects_combo.grid(row=row, column=1, sticky="ew", padx=4, pady=2)
+        ttk.Button(frm, text="Browse...", command=self._browse_detected_objects).grid(row=row, column=2, sticky="w")
+        self.objects_combo.bind("<<ComboboxSelected>>", lambda _e: self._update_selection_details())
+        row += 1
+
+        for label, var in [("EPD topic", self.epd_topic), ("Output dir", self.output_dir), ("Capture timeout", self.capture_timeout), ("Min objects", self.min_objects)]:
             ttk.Label(frm, text=label).grid(row=row, column=0, sticky="w")
             ttk.Entry(frm, textvariable=var, width=80).grid(row=row, column=1, sticky="ew", padx=4, pady=2)
             row += 1
@@ -135,6 +164,7 @@ class CellCyclePanel:
             row += 1
 
         self.run_btn = ttk.Button(frm, text="Run Cycle", command=self.run_cycle)
+        ttk.Button(frm, text="Refresh", command=self.refresh_discovery).grid(row=row, column=2, sticky="ew", pady=6)
         self.run_btn.grid(row=row, column=0, sticky="ew", pady=6)
         ttk.Button(frm, text="Open Output Folder", command=self.open_output).grid(row=row, column=1, sticky="w")
         row += 1
@@ -144,7 +174,12 @@ class CellCyclePanel:
 
         ttk.Label(frm, textvariable=self.status, font=("TkDefaultFont", 12, "bold")).grid(row=row, column=0, columnspan=2, sticky="w")
         row += 1
-        ttk.Label(frm, text="Live mode prerequisites: (1) EPD / RealSense node running, (2) run_grasp_execution running if replay is selected.").grid(row=row, column=0, columnspan=2, sticky="w")
+        ttk.Label(frm, text="Live mode prerequisites: (1) EPD / RealSense node running, (2) run_grasp_execution running if replay is selected.").grid(row=row, column=0, columnspan=3, sticky="w")
+        row += 1
+        self.selection_details = tk.Text(frm, height=5, wrap="word")
+        self.selection_details.grid(row=row, column=0, columnspan=3, sticky="ew")
+        self.selection_details.insert(tk.END, "Selection details will appear here.\n")
+        self.selection_details.configure(state="disabled")
         row += 1
 
         self.log = tk.Text(frm, height=20, wrap="word")
@@ -242,6 +277,53 @@ class CellCyclePanel:
         else:
             os.startfile(str(path))
 
+
+    def _browse_task_recipe(self) -> None:
+        path = filedialog.askopenfilename(filetypes=[("YAML/JSON", "*.yaml *.yml *.json"), ("All", "*")])
+        if path:
+            self.task_recipe.set(path)
+            self._update_selection_details()
+
+    def _browse_detected_objects(self) -> None:
+        path = filedialog.askopenfilename(filetypes=[("YAML/JSON", "*.yaml *.yml *.json"), ("All", "*")])
+        if path:
+            self.detected_objects.set(path)
+            self._update_selection_details()
+
+    def refresh_discovery(self) -> None:
+        scene_sel = self.scene_package.get()
+        task_sel = self.task_recipe.get()
+        obj_sel = self.detected_objects.get()
+        self.discovery_data = discover_all()
+        scene_values = [x["package_name"] for x in self.discovery_data["scenes"]]
+        task_values = [x["path"] for x in self.discovery_data["task_recipes"]]
+        obj_values = [x["path"] for x in self.discovery_data["detected_objects"]]
+        self.scene_combo.configure(values=scene_values)
+        self.task_combo.configure(values=task_values)
+        self.objects_combo.configure(values=obj_values)
+        if scene_sel in scene_values: self.scene_package.set(scene_sel)
+        elif scene_values: self.scene_package.set(scene_values[0])
+        if task_sel in task_values: self.task_recipe.set(task_sel)
+        elif task_values: self.task_recipe.set(task_values[0])
+        if obj_sel in obj_values: self.detected_objects.set(obj_sel)
+        elif obj_values: self.detected_objects.set(obj_values[0])
+        self._update_selection_details()
+
+    def _update_selection_details(self) -> None:
+        lines = []
+        scene = next((x for x in self.discovery_data.get("scenes", []) if x.get("package_name") == self.scene_package.get().strip()), None)
+        task = next((x for x in self.discovery_data.get("task_recipes", []) if x.get("path") == self.task_recipe.get().strip()), None)
+        obj = next((x for x in self.discovery_data.get("detected_objects", []) if x.get("path") == self.detected_objects.get().strip()), None)
+        lines.append(f"Scene: {self.scene_package.get().strip()}")
+        if scene: lines.append(f"  source={scene.get('source_path')} installed={scene.get('installed')} generated={scene.get('generated')} warnings={scene.get('warnings')}")
+        lines.append(f"Task: {self.task_recipe.get().strip()}")
+        if task: lines.append(f"  version={task.get('version')} type={task.get('task_type')} warnings={task.get('warnings')}")
+        lines.append(f"Detected objects: {self.detected_objects.get().strip()}")
+        if obj: lines.append(f"  version={obj.get('version')} object_count={obj.get('object_count')} warnings={obj.get('warnings')}")
+        self.selection_details.configure(state='normal')
+        self.selection_details.delete('1.0', tk.END)
+        self.selection_details.insert(tk.END, "\n".join(lines) + "\n")
+        self.selection_details.configure(state='disabled')
 
 def main() -> int:
     root = tk.Tk()

--- a/scripts/workcell_discovery.py
+++ b/scripts/workcell_discovery.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass
+class SceneRecord:
+    package_name: str
+    source_path: str
+    installed: bool
+    generated: bool
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RecipeRecord:
+    display_name: str
+    path: str
+    task_type: str | None
+    version: str | None
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DetectedObjectsRecord:
+    display_name: str
+    path: str
+    object_count: int | None
+    version: str | None
+    warnings: list[str] = field(default_factory=list)
+
+
+def _iter_scene_dirs() -> list[Path]:
+    roots = [REPO_ROOT / "install" / "share", REPO_ROOT / "scenes", REPO_ROOT / "src"]
+    extra_patterns = [
+        "generated_workcell/*",
+        "generated_workcell/*/*",
+        "**/generated_workcell/*",
+    ]
+    candidates: list[Path] = []
+    for root in roots:
+        if root.exists():
+            if root.name == "src":
+                candidates.extend([p for p in root.glob("**/scenes/*") if p.is_dir()])
+            else:
+                candidates.extend([p for p in root.glob("*") if p.is_dir()])
+    for pat in extra_patterns:
+        candidates.extend([p for p in REPO_ROOT.glob(pat) if p.is_dir()])
+    uniq = {p.resolve(): p for p in candidates}
+    return list(uniq.values())
+
+
+def discover_scene_packages() -> list[SceneRecord]:
+    records: dict[str, SceneRecord] = {}
+    for path in _iter_scene_dirs():
+        package_xml = path / "package.xml"
+        if not package_xml.exists() and not any((path / d).exists() for d in ("launch", "config", "urdf", "moveit_config")):
+            continue
+        package_name = path.name
+        warnings: list[str] = []
+        for requiredish in ("package.xml", "launch", "config"):
+            if not (path / requiredish).exists():
+                warnings.append(f"missing {requiredish}")
+        installed = "/install/" in str(path.resolve()) or str(path).startswith(str(REPO_ROOT / "install"))
+        generated = "generated_workcell" in str(path) or "generated" in str(path)
+        key = package_name
+        existing = records.get(key)
+        rec = SceneRecord(package_name, str(path), installed, generated, warnings)
+        if existing is None or (rec.installed and not existing.installed):
+            records[key] = rec
+    return sorted(records.values(), key=lambda r: r.package_name)
+
+
+def _load_structured_file(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        if path.suffix.lower() == ".json":
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            return loaded if isinstance(loaded, dict) else None, None
+        import yaml  # type: ignore
+
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return loaded if isinstance(loaded, dict) else None, None
+    except Exception as exc:  # noqa: BLE001
+        return None, str(exc)
+
+
+def discover_task_recipes() -> list[RecipeRecord]:
+    dirs = [
+        REPO_ROOT / "tests/fixtures/task_recipes",
+        REPO_ROOT / "config/task_recipes",
+        REPO_ROOT / "docs/examples",
+    ]
+    dirs.extend([REPO_ROOT / p for p in ["generated_workcell"]])
+    records: list[RecipeRecord] = []
+    for base in dirs:
+        if not base.exists():
+            continue
+        for path in [*base.rglob("*.yaml"), *base.rglob("*.yml"), *base.rglob("*.json")]:
+            data, err = _load_structured_file(path)
+            warnings: list[str] = []
+            if err:
+                records.append(RecipeRecord(path.stem, str(path), None, None, [f"parse error: {err}"]))
+                continue
+            if not data:
+                continue
+            version = data.get("schema_version")
+            if version != "task_recipe/v1":
+                continue
+            task = data.get("task") if isinstance(data.get("task"), dict) else {}
+            records.append(RecipeRecord(path.stem, str(path), task.get("type"), version, warnings))
+    return sorted(records, key=lambda r: r.display_name)
+
+
+def discover_detected_objects() -> list[DetectedObjectsRecord]:
+    dirs = [REPO_ROOT / "tests/fixtures/detected_objects", REPO_ROOT / "config/detected_objects"]
+    records: list[DetectedObjectsRecord] = []
+    for base in dirs:
+        if not base.exists():
+            continue
+        for path in [*base.rglob("*.yaml"), *base.rglob("*.yml"), *base.rglob("*.json")]:
+            data, err = _load_structured_file(path)
+            if err:
+                records.append(DetectedObjectsRecord(path.stem, str(path), None, None, [f"parse error: {err}"]))
+                continue
+            if not data:
+                continue
+            version = data.get("schema_version")
+            if version != "detected_objects/v1":
+                continue
+            objects = data.get("objects") if isinstance(data.get("objects"), list) else None
+            records.append(DetectedObjectsRecord(path.stem, str(path), len(objects) if objects is not None else None, version, []))
+    return sorted(records, key=lambda r: r.display_name)
+
+
+def discover_all() -> dict[str, list[dict[str, Any]]]:
+    return {
+        "scenes": [asdict(r) for r in discover_scene_packages()],
+        "task_recipes": [asdict(r) for r in discover_task_recipes()],
+        "detected_objects": [asdict(r) for r in discover_detected_objects()],
+    }
+
+
+def _print_summary(data: dict[str, list[dict[str, Any]]]) -> None:
+    scene_warnings = sum(len(x.get("warnings", [])) for x in data["scenes"])
+    recipe_warnings = sum(len(x.get("warnings", [])) for x in data["task_recipes"])
+    obj_warnings = sum(len(x.get("warnings", [])) for x in data["detected_objects"])
+    print(f"Scenes found: {len(data['scenes'])}")
+    print(f"Task recipes found: {len(data['task_recipes'])}")
+    print(f"Detected object fixtures found: {len(data['detected_objects'])}")
+    print(f"Warnings: {scene_warnings + recipe_warnings + obj_warnings}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Discover workcell scenes/recipes/fixtures")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args(argv)
+    payload = discover_all()
+    if args.summary:
+        _print_summary(payload)
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workcell_discovery.py
+++ b/tests/test_workcell_discovery.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.workcell_discovery import discover_all, discover_detected_objects, discover_task_recipes
+
+
+class WorkcellDiscoveryTests(unittest.TestCase):
+    def test_finds_task_recipe_fixtures(self):
+        records = discover_task_recipes()
+        self.assertTrue(any("mvp1_generated_cell_colour_sorting" in r.path for r in records))
+
+    def test_finds_detected_objects_fixtures(self):
+        records = discover_detected_objects()
+        self.assertTrue(any("mvp1_colour_sorting_with_fallback" in r.path for r in records))
+
+    def test_json_compatible_records(self):
+        payload = discover_all()
+        json.dumps(payload)
+        self.assertIn("scenes", payload)
+
+    def test_summary_mode_does_not_crash(self):
+        script = Path(__file__).resolve().parents[1] / "scripts/workcell_discovery.py"
+        p = subprocess.run([sys.executable, str(script), "--summary"], capture_output=True, text=True, check=False)
+        self.assertEqual(p.returncode, 0)
+
+    def test_invalid_yaml_becomes_warning(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "bad.yaml"
+            p.write_text("::::", encoding="utf-8")
+            from scripts import workcell_discovery as d
+
+            original = d.REPO_ROOT
+            d.REPO_ROOT = Path(td)
+            try:
+                recs = d.discover_task_recipes()
+                self.assertEqual(recs, [])
+            finally:
+                d.REPO_ROOT = original
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Improve operator panel usability by automatically discovering available scene packages, task recipes, and detected-object fixtures so users can pick from dropdowns instead of typing paths. 
- Keep the change as a thin usability layer over the existing backend and do not replace or duplicate Workcell Builder, scene formats, or runtime execution logic.

### Description
- Added `scripts/workcell_discovery.py` which discovers scene packages (installed/generated flags + warnings), `task_recipe/v1` fixtures, and `detected_objects/v1` fixtures and provides a simple CLI with `--json` and `--summary` modes. 
- Updated `scripts/run_cell_cycle_panel.py` to populate dropdowns/comboboxes for Scene package, Task recipe, and Detected objects using the discovery helper, added `Refresh` to re-run discovery while preserving selections, added `Browse...` buttons for file fallbacks, and added a compact Selection details area showing path/version/object count/warnings. 
- Added `tests/test_workcell_discovery.py` that exercises discovery and CLI summary mode, and updated documentation by adding a short note to `README.md` and a new section in `docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md` describing the Refresh/dropdowns/manual-browse behavior. 

### Testing
- Ran static checks: `python3 -m py_compile scripts/workcell_discovery.py scripts/run_cell_cycle_panel.py scripts/run_generated_cell_cycle.py` and they succeeded. 
- Ran unit tests: `python3 -m pytest -q tests/test_workcell_discovery.py tests/test_run_cell_cycle_panel.py tests/test_run_generated_cell_cycle.py` and all tests passed (15 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34705434083318522c9f1de591b6a)