### PR TITLE
Harden MVP-1 offline operator workflow for generated-cell cycle

### DIFF
--- a/docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md
+++ b/docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md
@@ -40,6 +40,39 @@ Arguments:
 - **WARN**: pipeline succeeded, but operator attention is required (example: scene package not found offline, missing destination pose).
 - **FAIL**: blockers occurred, or strict mode escalated warnings.
 
+## First offline operator test (recommended baseline)
+Use this sequence from repository root on a fresh machine:
+
+```bash
+colcon build --symlink-install --packages-skip tesseract_rviz tesseract_planning_server tesseract_ros_examples
+```
+
+```bash
+python3 -m pytest -q tests/test_workcell_discovery.py tests/test_run_cell_cycle_panel.py tests/test_run_generated_cell_cycle.py
+```
+
+```bash
+python3 scripts/run_generated_cell_cycle.py \
+  --scene-package ur5_2f_test \
+  --task-recipe tests/fixtures/task_recipes/valid_garbage_sorting.yaml \
+  --detected-objects tests/fixtures/detected_objects/valid_epd_garbage_sorting.yaml \
+  --output-dir /tmp/mvp1_valid_test \
+  --min-objects 1 \
+  --once \
+  --dry-run \
+  --no-replay \
+  --json
+```
+
+Expected result:
+- **PASS** or **WARN** is acceptable for first offline operator test when `blockers=[]`.
+- **FAIL** is not acceptable for first offline operator test.
+
+Fixture naming guidance:
+- `valid_*`: operator-ready examples.
+- `warn_*`: warning-path examples.
+- `fail_*`, `missing_*`, `low_confidence_*`, `unknown_*`: developer/test fixtures (kept for regression testing, not default operator selection).
+
 Previous runtime boundary (now addressed in `run_grasp_execution` destination-aware mode):
 
 > destination_resolved is present in the bridge payload; runtime release execution may still use existing release fallback until runtime destination support is implemented.

--- a/scripts/run_cell_cycle_panel.py
+++ b/scripts/run_cell_cycle_panel.py
@@ -27,8 +27,8 @@ from workcell_discovery import discover_all
 
 DEFAULTS = {
     "scene_package": "ur5_2f_test",
-    "task_recipe": "tests/fixtures/task_recipes/mvp1_generated_cell_colour_sorting.yaml",
-    "detected_objects": "tests/fixtures/detected_objects/mvp1_colour_sorting_with_fallback.yaml",
+    "task_recipe": "tests/fixtures/task_recipes/valid_garbage_sorting.yaml",
+    "detected_objects": "tests/fixtures/detected_objects/valid_epd_garbage_sorting.yaml",
     "epd_topic": "/easy_perception_deployment/epd_localize_output",
     "output_dir": "/tmp/mvp1",
     "capture_timeout": "10",
@@ -113,6 +113,7 @@ class CellCyclePanel:
         self.replay = tk.BooleanVar(value=False)
         self.strict = tk.BooleanVar(value=False)
         self.json_output = tk.BooleanVar(value=True)
+        self.show_dev_fixtures = tk.BooleanVar(value=False)
         self.status = tk.StringVar(value="Status: idle")
 
         self.discovery_data = {"scenes": [], "task_recipes": [], "detected_objects": []}
@@ -162,6 +163,8 @@ class CellCyclePanel:
         for txt, var in [("Dry run", self.dry_run), ("Replay to runtime", self.replay), ("Strict mode", self.strict), ("JSON output", self.json_output)]:
             ttk.Checkbutton(frm, text=txt, variable=var).grid(row=row, column=1, sticky="w")
             row += 1
+        ttk.Checkbutton(frm, text="Show developer/test fixtures", variable=self.show_dev_fixtures, command=self.refresh_discovery).grid(row=row, column=1, sticky="w")
+        row += 1
 
         self.run_btn = ttk.Button(frm, text="Run Cycle", command=self.run_cycle)
         ttk.Button(frm, text="Refresh", command=self.refresh_discovery).grid(row=row, column=2, sticky="ew", pady=6)
@@ -296,17 +299,22 @@ class CellCyclePanel:
         obj_sel = self.detected_objects.get()
         self.discovery_data = discover_all()
         scene_values = [x["package_name"] for x in self.discovery_data["scenes"]]
-        task_values = [x["path"] for x in self.discovery_data["task_recipes"]]
-        obj_values = [x["path"] for x in self.discovery_data["detected_objects"]]
+        show_dev = self.show_dev_fixtures.get()
+        task_values = [x["path"] for x in self.discovery_data["task_recipes"] if show_dev or x.get("category") != "failure_test"]
+        obj_values = [x["path"] for x in self.discovery_data["detected_objects"] if show_dev or x.get("category") != "failure_test"]
         self.scene_combo.configure(values=scene_values)
         self.task_combo.configure(values=task_values)
         self.objects_combo.configure(values=obj_values)
         if scene_sel in scene_values: self.scene_package.set(scene_sel)
         elif scene_values: self.scene_package.set(scene_values[0])
         if task_sel in task_values: self.task_recipe.set(task_sel)
-        elif task_values: self.task_recipe.set(task_values[0])
+        elif task_values:
+            valid_default = next((p for p in task_values if p.endswith("valid_garbage_sorting.yaml")), task_values[0])
+            self.task_recipe.set(valid_default)
         if obj_sel in obj_values: self.detected_objects.set(obj_sel)
-        elif obj_values: self.detected_objects.set(obj_values[0])
+        elif obj_values:
+            valid_default = next((p for p in obj_values if p.endswith("valid_epd_garbage_sorting.yaml")), obj_values[0])
+            self.detected_objects.set(valid_default)
         self._update_selection_details()
 
     def _update_selection_details(self) -> None:
@@ -317,9 +325,9 @@ class CellCyclePanel:
         lines.append(f"Scene: {self.scene_package.get().strip()}")
         if scene: lines.append(f"  source={scene.get('source_path')} installed={scene.get('installed')} generated={scene.get('generated')} warnings={scene.get('warnings')}")
         lines.append(f"Task: {self.task_recipe.get().strip()}")
-        if task: lines.append(f"  version={task.get('version')} type={task.get('task_type')} warnings={task.get('warnings')}")
+        if task: lines.append(f"  version={task.get('version')} type={task.get('task_type')} category={task.get('category')} warnings={task.get('warnings')}")
         lines.append(f"Detected objects: {self.detected_objects.get().strip()}")
-        if obj: lines.append(f"  version={obj.get('version')} object_count={obj.get('object_count')} warnings={obj.get('warnings')}")
+        if obj: lines.append(f"  version={obj.get('version')} object_count={obj.get('object_count')} category={obj.get('category')} warnings={obj.get('warnings')}")
         self.selection_details.configure(state='normal')
         self.selection_details.delete('1.0', tk.END)
         self.selection_details.insert(tk.END, "\n".join(lines) + "\n")

--- a/scripts/run_generated_cell_acceptance.py
+++ b/scripts/run_generated_cell_acceptance.py
@@ -19,6 +19,9 @@ KNOWN_RUNTIME_BOUNDARY = (
     "destination_resolved is present in the bridge payload; runtime release execution may still "
     "use existing release fallback until runtime destination support is implemented."
 )
+KNOWN_RUNTIME_BOUNDARY_OPERATOR_TEXT = (
+    "Task planner selected a destination, but runtime replay may not yet command that exact release pose."
+)
 
 
 def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
@@ -156,6 +159,11 @@ def run_acceptance(scene_package: str, task_recipe: Path, detected_objects: Path
         "runtime_plan_path": str(runtime_plan),
         "emd_bridge_payload_path": str(bridge_payload),
         "warnings": warnings,
+        "warning_groups": {
+            "hard_blockers": blockers,
+            "operator_warnings": [w for w in warnings if w != KNOWN_RUNTIME_BOUNDARY],
+            "developer_runtime_todo": [KNOWN_RUNTIME_BOUNDARY, KNOWN_RUNTIME_BOUNDARY_OPERATOR_TEXT],
+        },
         "blockers": blockers,
         "step_status": {
             "detected_objects": obj_json.get("status"),

--- a/scripts/workcell_discovery.py
+++ b/scripts/workcell_discovery.py
@@ -25,6 +25,7 @@ class RecipeRecord:
     path: str
     task_type: str | None
     version: str | None
+    category: str
     warnings: list[str] = field(default_factory=list)
 
 
@@ -34,6 +35,7 @@ class DetectedObjectsRecord:
     path: str
     object_count: int | None
     version: str | None
+    category: str
     warnings: list[str] = field(default_factory=list)
 
 
@@ -65,7 +67,9 @@ def discover_scene_packages() -> list[SceneRecord]:
             continue
         package_name = path.name
         warnings: list[str] = []
-        for requiredish in ("package.xml", "launch", "config"):
+        has_emd_layout = (path / "launch").exists() and (path / "environment.yaml").exists()
+        expected_dirs = ("package.xml", "launch") if has_emd_layout else ("package.xml", "launch", "config")
+        for requiredish in expected_dirs:
             if not (path / requiredish).exists():
                 warnings.append(f"missing {requiredish}")
         installed = "/install/" in str(path.resolve()) or str(path).startswith(str(REPO_ROOT / "install"))
@@ -91,6 +95,16 @@ def _load_structured_file(path: Path) -> tuple[dict[str, Any] | None, str | None
         return None, str(exc)
 
 
+
+
+def _fixture_category(name: str) -> str:
+    lowered = name.lower()
+    if lowered.startswith(("fail_", "missing_", "low_confidence_", "unknown_")):
+        return "failure_test"
+    if lowered.startswith("warn_"):
+        return "warning"
+    return "valid"
+
 def discover_task_recipes() -> list[RecipeRecord]:
     dirs = [
         REPO_ROOT / "tests/fixtures/task_recipes",
@@ -106,7 +120,7 @@ def discover_task_recipes() -> list[RecipeRecord]:
             data, err = _load_structured_file(path)
             warnings: list[str] = []
             if err:
-                records.append(RecipeRecord(path.stem, str(path), None, None, [f"parse error: {err}"]))
+                records.append(RecipeRecord(path.stem, str(path), None, None, _fixture_category(path.stem), [f"parse error: {err}"]))
                 continue
             if not data:
                 continue
@@ -114,7 +128,7 @@ def discover_task_recipes() -> list[RecipeRecord]:
             if version != "task_recipe/v1":
                 continue
             task = data.get("task") if isinstance(data.get("task"), dict) else {}
-            records.append(RecipeRecord(path.stem, str(path), task.get("type"), version, warnings))
+            records.append(RecipeRecord(path.stem, str(path), task.get("type"), version, _fixture_category(path.stem), warnings))
     return sorted(records, key=lambda r: r.display_name)
 
 
@@ -127,7 +141,7 @@ def discover_detected_objects() -> list[DetectedObjectsRecord]:
         for path in [*base.rglob("*.yaml"), *base.rglob("*.yml"), *base.rglob("*.json")]:
             data, err = _load_structured_file(path)
             if err:
-                records.append(DetectedObjectsRecord(path.stem, str(path), None, None, [f"parse error: {err}"]))
+                records.append(DetectedObjectsRecord(path.stem, str(path), None, None, _fixture_category(path.stem), [f"parse error: {err}"]))
                 continue
             if not data:
                 continue
@@ -135,7 +149,7 @@ def discover_detected_objects() -> list[DetectedObjectsRecord]:
             if version != "detected_objects/v1":
                 continue
             objects = data.get("objects") if isinstance(data.get("objects"), list) else None
-            records.append(DetectedObjectsRecord(path.stem, str(path), len(objects) if objects is not None else None, version, []))
+            records.append(DetectedObjectsRecord(path.stem, str(path), len(objects) if objects is not None else None, version, _fixture_category(path.stem), []))
     return sorted(records, key=lambda r: r.display_name)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_run_cell_cycle_panel.py
+++ b/tests/test_run_cell_cycle_panel.py
@@ -6,10 +6,22 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.run_cell_cycle_panel import build_cycle_command, parse_cycle_report
+from scripts.run_cell_cycle_panel import DEFAULTS, build_cycle_command, parse_cycle_report
+from scripts.workcell_discovery import discover_all
 
 
 class RunCellCyclePanelTests(unittest.TestCase):
+    def test_operator_defaults_use_valid_fixtures(self):
+        self.assertTrue(DEFAULTS["task_recipe"].endswith("valid_garbage_sorting.yaml"))
+        self.assertTrue(DEFAULTS["detected_objects"].endswith("valid_epd_garbage_sorting.yaml"))
+
+    def test_filtered_defaults_avoid_failure_test_fixtures(self):
+        payload = discover_all()
+        task_values = [x["path"] for x in payload["task_recipes"] if x.get("category") != "failure_test"]
+        obj_values = [x["path"] for x in payload["detected_objects"] if x.get("category") != "failure_test"]
+        self.assertNotIn("tests/fixtures/task_recipes/fail_missing_destination.yaml", task_values)
+        self.assertNotIn("tests/fixtures/detected_objects/low_confidence_object.yaml", obj_values)
+
     def test_defaults_encode_dry_run_enabled_replay_disabled(self):
         cfg = {
             "scene_package": "ur5_2f_test",

--- a/tests/test_run_generated_cell_cycle.py
+++ b/tests/test_run_generated_cell_cycle.py
@@ -8,6 +8,8 @@ SCRIPT = REPO_ROOT / 'scripts' / 'run_generated_cell_cycle.py'
 TASK = REPO_ROOT / 'tests/fixtures/task_recipes/mvp1_generated_cell_colour_sorting.yaml'
 TASK_WARN = REPO_ROOT / 'tests/fixtures/task_recipes/mvp1_generated_cell_colour_sorting_missing_reject_pose.yaml'
 OBJECTS = REPO_ROOT / 'tests/fixtures/detected_objects/mvp1_colour_sorting_with_fallback.yaml'
+TASK_VALID_GARBAGE = REPO_ROOT / 'tests/fixtures/task_recipes/valid_garbage_sorting.yaml'
+OBJECTS_VALID_GARBAGE = REPO_ROOT / 'tests/fixtures/detected_objects/valid_epd_garbage_sorting.yaml'
 
 class RunGeneratedCellCycleTests(unittest.TestCase):
     def _run(self, *args: str):
@@ -50,6 +52,14 @@ class RunGeneratedCellCycleTests(unittest.TestCase):
             p=self._run('--scene-package','ur5_2f_test','--task-recipe',str(TASK),'--detected-objects',str(OBJECTS),'--output-dir',td,'--dry-run','--json')
             report=json.loads(p.stdout)
             self.assertIn(report['status'],{'PASS','WARN','FAIL'})
+
+    def test_valid_garbage_offline_cycle_has_no_blockers(self):
+        with tempfile.TemporaryDirectory() as td:
+            p=self._run('--scene-package','ur5_2f_test','--task-recipe',str(TASK_VALID_GARBAGE),'--detected-objects',str(OBJECTS_VALID_GARBAGE),'--output-dir',td,'--dry-run','--no-replay','--json')
+            self.assertEqual(p.returncode,0,msg=p.stdout+p.stderr)
+            report=json.loads(p.stdout)
+            self.assertIn(report['status'],{'PASS','WARN'})
+            self.assertEqual(report['acceptance'].get('blockers',[]),[])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_workcell_discovery.py
+++ b/tests/test_workcell_discovery.py
@@ -30,6 +30,19 @@ class WorkcellDiscoveryTests(unittest.TestCase):
         p = subprocess.run([sys.executable, str(script), "--summary"], capture_output=True, text=True, check=False)
         self.assertEqual(p.returncode, 0)
 
+    def test_ur5_scene_not_flagged_missing_config(self):
+        scenes = discover_all()["scenes"]
+        ur5 = next((s for s in scenes if s["package_name"] == "ur5_2f_test"), None)
+        self.assertIsNotNone(ur5)
+        self.assertFalse(any("missing config" in w for w in ur5.get("warnings", [])))
+
+    def test_fixture_categories_separate_valid_from_failure_tests(self):
+        recipes = discover_task_recipes()
+        valid = next(r for r in recipes if r.display_name == "valid_garbage_sorting" and "tests/fixtures/task_recipes" in r.path)
+        fail_case = next(r for r in recipes if r.display_name == "fail_missing_destination")
+        self.assertEqual(valid.category, "valid")
+        self.assertEqual(fail_case.category, "failure_test")
+
     def test_invalid_yaml_becomes_warning(self):
         with tempfile.TemporaryDirectory() as td:
             p = Path(td) / "bad.yaml"


### PR DESCRIPTION
### Motivation
- Reduce operator friction for the offline MVP-1 generated-cell cycle by making discovery/tests reliable when run from the repo root and by avoiding misleading scene warnings. 
- Ensure the operator GUI defaults to operator-ready fixtures and keeps developer/test failure fixtures available but hidden by default. 
- Make WARN output clearer so operators can distinguish hard blockers from operator/runtime TODOs. 
- Keep changes small, reversible, and non-invasive to runtime, Workcell Builder, scenes, or live camera code.

### Description
- Add `tests/conftest.py` that inserts the repository root into `sys.path` so `pytest` works from the repo root without setting `PYTHONPATH` manually. 
- Update `scripts/workcell_discovery.py` to treat EMD-style scenes (presence of `launch` + `environment.yaml`) as having a valid layout instead of requiring a `config/` directory and add fixture categorisation (`valid`, `warning`, `failure_test`) for task recipes and detected-objects fixtures. 
- Update `scripts/run_cell_cycle_panel.py` to default to operator-valid garbage-sorting fixtures, add a "Show developer/test fixtures" checkbox to reveal `failure_test` fixtures, filter lists by category by default, and surface fixture `category` in selection details. 
- Enhance `scripts/run_generated_cell_acceptance.py` output by grouping warnings into `hard_blockers`, `operator_warnings`, and `developer_runtime_todo`, and add a concise operator-facing note clarifying the destination-resolved/runtime-release fallback boundary. 
- Update `docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md` with a new "First offline operator test" checklist showing the recommended build, test, and dry-run commands and guidance on acceptable PASS/WARN/FAIL semantics. 
- Add and adjust focused tests to cover import reliability, EMD-style scene discovery, fixture categorisation, operator defaults/filtering, and a valid offline cycle returning PASS/WARN with `blockers=[]`.

### Testing
- Ran the targeted pytest command from the repository root: `python3 -m pytest -q tests/test_workcell_discovery.py tests/test_run_cell_cycle_panel.py tests/test_run_generated_cell_cycle.py`, and all tests passed (20 passed). 
- Unit/functional updates include modified tests in `tests/test_workcell_discovery.py`, `tests/test_run_cell_cycle_panel.py`, `tests/test_run_generated_cell_cycle.py` and the new `tests/conftest.py`, which were exercised by the above pytest run. 
- The focused test run confirms the PYTHONPATH/import fix, that `ur5_2f_test` is not falsely warned as missing `config` when it matches EMD layout, that valid fixtures are categorised separately, and that a valid offline cycle returns PASS/WARN with no blockers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35bb7dc88833181c9938720719227)