### PR TITLE
Enable runtime destination-aware release reporting and replay validation

### DIFF
--- a/scripts/convert_runtime_plan_to_emd_grasp.py
+++ b/scripts/convert_runtime_plan_to_emd_grasp.py
@@ -236,8 +236,8 @@ def _build_bridge_payload(plan: dict[str, Any], args: argparse.Namespace) -> dic
             "destination_safety_warnings": destination_safety_warnings,
             "notes": [
                 "Destination pose preserved in bridge payload.",
-                "Current emd_msgs/GraspTarget has no explicit release/place pose field; runtime uses release_x_offset/release_use_grasp_z fallback.",
-                "TODO(adapter-boundary): extend runtime interface to consume destination_pose without breaking GraspRequest compatibility.",
+                "Runtime can consume destination_pose via explicit_release_pose bridge payload adapter when enabled.",
+                "Legacy release_x_offset/release_use_grasp_z fallback remains active when destination pose is unavailable or invalid.",
             ],
         }
         targets.append(target)
@@ -275,10 +275,10 @@ def _build_bridge_payload(plan: dict[str, Any], args: argparse.Namespace) -> dic
         },
         "grasp_task": {"task_id": task_id, "grasp_targets": targets},
         "runtime_release_adapter_boundary": {
-            "explicit_release_pose_supported_in_runtime": False,
-            "active_release_strategy": "release_x_offset/release_use_grasp_z",
-            "why": "emd_msgs/msg/GraspTarget and emd_msgs/srv/GraspRequest do not carry release destination pose fields.",
-            "todo": "Add non-breaking runtime interface extension to consume destination_pose when available.",
+            "explicit_release_pose_supported_in_runtime": True,
+            "active_release_strategy": "destination_pose_when_available_else_release_x_offset/release_use_grasp_z",
+            "why": "run_grasp_execution consumes destination_pose via explicit_release_pose bridge payload adapter path.",
+            "todo": "Optional future improvement: add first-class release destination pose fields to emd_msgs interfaces.",
         },
         "warnings": warnings,
         "errors": errors,

--- a/scripts/replay_emd_bridge_payload.py
+++ b/scripts/replay_emd_bridge_payload.py
@@ -66,8 +66,11 @@ def _validate(payload: dict[str, Any], scene_package: str) -> tuple[list[str], l
             errors.append("grasp_target entry must be a mapping.")
             continue
         dest = t.get("destination_pose") if isinstance(t.get("destination_pose"), dict) else {}
-        if not isinstance(dest.get("xyz"), list):
+        xyz = dest.get("xyz")
+        if not isinstance(xyz, list):
             warnings.append(f"Object '{t.get('object_id', '(unknown)')}' has no destination pose xyz; runtime will use fallback release mode.")
+        elif len(xyz) != 3 or not all(isinstance(v, (int, float)) for v in xyz):
+            errors.append(f"Object '{t.get('object_id', '(unknown)')}' destination pose xyz must be a 3-number list.")
         if not isinstance(dest.get("frame_id"), str) or not str(dest.get("frame_id")).strip():
             errors.append(f"Object '{t.get('object_id', '(unknown)')}' destination pose frame_id is missing.")
         methods = t.get("grasp_methods") if isinstance(t.get("grasp_methods"), list) else []
@@ -168,6 +171,10 @@ def main(argv: list[str] | None = None) -> int:
             if isinstance(item, dict):
                 s = _summarize_target(item)
                 print(f" - object={s['object_id']} class={s['object_class']} grasp_frame={s['grasp_frame']} dest={s['destination_id']} dest_frame={s['destination_frame']} release={s['release_mode']}")
+                if s["release_mode"] == "destination-aware":
+                    print(f"PASS: explicit destination release pose will be used for object='{s['object_id']}' destination='{s['destination_id']}'.")
+                else:
+                    print(f"WARN: No task destination release pose provided; legacy release fallback will be used for object='{s['object_id']}'.")
         for w in warnings:
             print(f"WARN: {w}")
         if errors:

--- a/scripts/run_generated_cell_acceptance.py
+++ b/scripts/run_generated_cell_acceptance.py
@@ -15,12 +15,11 @@ VALIDATE_RECIPE = SCRIPTS_DIR / "validate_task_recipe.py"
 ADAPTER = SCRIPTS_DIR / "run_task_recipe_adapter.py"
 BRIDGE = SCRIPTS_DIR / "convert_runtime_plan_to_emd_grasp.py"
 
-KNOWN_RUNTIME_BOUNDARY = (
-    "destination_resolved is present in the bridge payload; runtime release execution may still "
-    "use existing release fallback until runtime destination support is implemented."
+RUNTIME_DESTINATION_SUPPORT_ENABLED = (
+    "destination_release_supported=true (runtime explicit destination release adapter enabled)."
 )
-KNOWN_RUNTIME_BOUNDARY_OPERATOR_TEXT = (
-    "Task planner selected a destination, but runtime replay may not yet command that exact release pose."
+RUNTIME_DESTINATION_SUPPORT_OPERATOR_TEXT = (
+    "Task planner selected a destination and runtime can use explicit destination release pose when provided."
 )
 
 
@@ -131,7 +130,9 @@ def run_acceptance(scene_package: str, task_recipe: Path, detected_objects: Path
                 for warning in item.get("warnings", []):
                     if isinstance(warning, str):
                         warnings.append(warning)
-    warnings.append(KNOWN_RUNTIME_BOUNDARY)
+    runtime_boundary = bridge_json.get("runtime_release_adapter_boundary", {})
+    destination_release_supported = bool(runtime_boundary.get("explicit_release_pose_supported_in_runtime"))
+    runtime_release_strategy = runtime_boundary.get("active_release_strategy")
 
     status = "PASS"
     if blockers:
@@ -161,9 +162,12 @@ def run_acceptance(scene_package: str, task_recipe: Path, detected_objects: Path
         "warnings": warnings,
         "warning_groups": {
             "hard_blockers": blockers,
-            "operator_warnings": [w for w in warnings if w != KNOWN_RUNTIME_BOUNDARY],
-            "developer_runtime_todo": [KNOWN_RUNTIME_BOUNDARY, KNOWN_RUNTIME_BOUNDARY_OPERATOR_TEXT],
+            "operator_warnings": [w for w in warnings],
+            "developer_runtime_todo": [RUNTIME_DESTINATION_SUPPORT_ENABLED, RUNTIME_DESTINATION_SUPPORT_OPERATOR_TEXT],
         },
+        "runtime_destination_release": "enabled" if destination_release_supported else "disabled",
+        "destination_release_supported": destination_release_supported,
+        "runtime_release_strategy": runtime_release_strategy,
         "blockers": blockers,
         "step_status": {
             "detected_objects": obj_json.get("status"),

--- a/tests/test_generated_cell_acceptance.py
+++ b/tests/test_generated_cell_acceptance.py
@@ -42,6 +42,8 @@ class GeneratedCellAcceptanceTests(unittest.TestCase):
         self.assertEqual(payload["selected_object"], "red_001")
         self.assertEqual(payload["matched_rule"], "route_red")
         self.assertEqual(payload["destination_selected"], "red_bin")
+        self.assertEqual(payload["runtime_destination_release"], "enabled")
+        self.assertTrue(payload["destination_release_supported"])
 
     def test_fallback_destination_is_present_in_plan(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_replay_emd_bridge_payload.py
+++ b/tests/test_replay_emd_bridge_payload.py
@@ -45,6 +45,7 @@ class ReplayEmdBridgePayloadTests(unittest.TestCase):
             proc = self._run("--payload", str(p), "--scene-package", "ur5_2f_test", "--dry-run")
             self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
             self.assertIn("PASS: dry-run only", proc.stdout)
+            self.assertIn("explicit destination release pose will be used", proc.stdout)
 
     def test_missing_payload_file(self) -> None:
         proc = self._run("--payload", "/tmp/does-not-exist.json", "--scene-package", "ur5_2f_test", "--dry-run")
@@ -60,7 +61,18 @@ class ReplayEmdBridgePayloadTests(unittest.TestCase):
             p.write_text(json.dumps(payload), encoding="utf-8")
             proc = self._run("--payload", str(p), "--scene-package", "ur5_2f_test", "--dry-run")
             self.assertEqual(proc.returncode, 0)
-            self.assertIn("WARN:", proc.stdout)
+            self.assertIn("legacy release fallback will be used", proc.stdout)
+
+    def test_invalid_destination_pose_xyz_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = self._payload()
+            target = payload["grasp_task"]["grasp_targets"][0]
+            target["destination_pose"] = {"frame_id": "world", "xyz": [0.2, 0.0]}
+            p = Path(tmp) / "payload.json"
+            p.write_text(json.dumps(payload), encoding="utf-8")
+            proc = self._run("--payload", str(p), "--scene-package", "ur5_2f_test", "--dry-run")
+            self.assertEqual(proc.returncode, 1)
+            self.assertIn("destination pose xyz must be a 3-number list", proc.stdout)
 
     def test_missing_frame_id_failure(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
### Motivation
- Make task-planner-selected destination poses actionable and visible to runtime without altering core Workcell Builder or message schemas, using the existing explicit-release adapter path in `run_grasp_execution`.
- Replace the stale operator/runtime TODO with conservative, testable runtime destination-release support and clearer operator reporting.
- Add conservative validation and clear dry-run messaging so replay/acceptance tooling warns or fails early on malformed destination poses.

### Description
- Bridge payload now advertises runtime explicit-destination support and documents the active strategy in `runtime_release_adapter_boundary` and target `notes` in `scripts/convert_runtime_plan_to_emd_grasp.py`.
- Acceptance reporting in `scripts/run_generated_cell_acceptance.py` now exposes `destination_release_supported`, `runtime_destination_release`, and `runtime_release_strategy` and replaces the previous runtime TODO messaging.
- Replay tool `scripts/replay_emd_bridge_payload.py` tightened validation of `destination_pose.xyz` (must be a 3-number list) and prints explicit dry-run lines indicating whether a target will use an explicit destination release pose or fall back to legacy behavior.
- Tests updated/added in `tests/test_replay_emd_bridge_payload.py` and `tests/test_generated_cell_acceptance.py` to cover explicit destination messaging, invalid XYZ handling, and acceptance runtime-capability flags.

### Testing
- Ran `python3 -m pytest -q tests/test_replay_emd_bridge_payload.py tests/test_generated_cell_acceptance.py tests/test_emd_grasp_bridge.py` and all tests passed.
- Result: `24 passed` (run time ~9.5s) and the updated tests assert the new dry-run messages and acceptance payload fields indicating runtime destination-release support.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35d805464833191d0d954871a7033)