### PR TITLE
Add optional live D435i/EPD perception smoke-test workflow for MVP-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1357,3 +1357,6 @@ ros2 launch new_scene demo.launch.py
 - [MVP-1 Generated Cell Acceptance](docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md) (includes the optional **Run from the operator panel** flow).
 
 - The MVP-1 operator panel now auto-discovers scene packages, task recipes, and detected-object fixtures, while still allowing manual overrides.
+
+
+- For the operator live perception smoke workflow, see `docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md` section **First live D435i / EPD smoke test**.

--- a/docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md
+++ b/docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md
@@ -306,3 +306,81 @@ Use **Refresh** in `scripts/run_cell_cycle_panel.py` to discover existing scene 
 - Selection details: shows source path, schema/version, object count, and warnings.
 - Live EPD mode does not require a detected_objects fixture.
 - Replay still requires `run_grasp_execution` to already be running.
+
+
+## First live D435i / EPD smoke test
+
+A. Build:
+
+```bash
+colcon build --symlink-install --packages-skip tesseract_rviz tesseract_planning_server tesseract_ros_examples
+```
+
+B. Source:
+
+```bash
+source /opt/ros/humble/setup.bash
+source ~/workcell_ws/install/setup.bash
+```
+
+C. Launch RealSense D435i:
+
+```bash
+ros2 launch realsense2_camera rs_launch.py \
+  device_type:=d435i \
+  rgb_camera.color_profile:=424x240x15 \
+  depth_module.depth_profile:=424x240x15 \
+  pointcloud.enable:=true \
+  align_depth.enable:=true
+```
+
+D. Launch EPD in another terminal using the existing project command.
+
+E. Confirm topics:
+
+```bash
+ros2 topic list | grep camera
+ros2 topic list | grep easy_perception
+```
+
+F. Run capture-only smoke test:
+
+```bash
+cd ~/workcell_ws/src/easy_manipulation_deployment
+python3 scripts/capture_epd_detected_objects.py \
+  --topic /easy_perception_deployment/epd_localize_output \
+  --output /tmp/mvp1_live_smoke_test/detected_objects_live.yaml \
+  --scene-package ur5_2f_test \
+  --timeout 10 \
+  --min-objects 1 \
+  --once \
+  --json
+```
+
+G. Run full live dry-run generated-cell cycle:
+
+```bash
+python3 scripts/run_generated_cell_cycle.py \
+  --scene-package ur5_2f_test \
+  --task-recipe tests/fixtures/task_recipes/valid_garbage_sorting.yaml \
+  --capture-live \
+  --epd-topic /easy_perception_deployment/epd_localize_output \
+  --output-dir /tmp/mvp1_live_smoke_test \
+  --min-objects 1 \
+  --capture-timeout 10 \
+  --once \
+  --dry-run \
+  --no-replay \
+  --json
+```
+
+Expected outcome:
+- PASS or WARN is acceptable.
+- FAIL means a real blocker.
+- blockers=[] is required before any future replay/motion test.
+- detected_objects_used.yaml is saved.
+- runtime_execution_plan.json is saved.
+- emd_grasp_bridge_payload.json is saved.
+- cycle_report.json is saved.
+- replay_status remains SKIPPED unless explicitly enabled.
+- dry-run remains true.

--- a/scripts/run_cell_cycle_panel.py
+++ b/scripts/run_cell_cycle_panel.py
@@ -30,9 +30,10 @@ DEFAULTS = {
     "task_recipe": "tests/fixtures/task_recipes/valid_garbage_sorting.yaml",
     "detected_objects": "tests/fixtures/detected_objects/valid_epd_garbage_sorting.yaml",
     "epd_topic": "/easy_perception_deployment/epd_localize_output",
-    "output_dir": "/tmp/mvp1",
+    "output_dir": "/tmp/mvp1_live_smoke_test",
     "capture_timeout": "10",
     "min_objects": "1",
+    "frame_fallback": "world",
 }
 
 
@@ -43,6 +44,8 @@ class CycleReportSummary:
     error_count: int
     report_path: Path | None
     generated_files: dict[str, Path]
+    perception_source: str | None = None
+    detected_objects_used: str | None = None
 
 
 def build_cycle_command(config: dict[str, Any]) -> list[str]:
@@ -60,6 +63,8 @@ def build_cycle_command(config: dict[str, Any]) -> list[str]:
         str(config["min_objects"]),
         "--capture-timeout",
         str(config["capture_timeout"]),
+        "--frame-fallback",
+        str(config["frame_fallback"]),
         "--once",
     ]
     if config.get("capture_live"):
@@ -70,6 +75,8 @@ def build_cycle_command(config: dict[str, Any]) -> list[str]:
         cmd.append("--dry-run")
     if config.get("replay"):
         cmd.append("--replay")
+    else:
+        cmd.append("--no-replay")
     if config.get("strict"):
         cmd.append("--strict")
     if config.get("json"):
@@ -91,7 +98,7 @@ def parse_cycle_report(output_dir: Path) -> CycleReportSummary:
     warnings = data.get("warnings") or []
     acceptance = data.get("acceptance") or {}
     errors = acceptance.get("errors") or []
-    return CycleReportSummary(data.get("status", "FAIL"), len(warnings), len(errors), report_path, generated)
+    return CycleReportSummary(data.get("status", "FAIL"), len(warnings), len(errors), report_path, generated, data.get("perception_source"), data.get("detected_objects_used"))
 
 
 class CellCyclePanel:
@@ -108,6 +115,7 @@ class CellCyclePanel:
         self.output_dir = tk.StringVar(value=DEFAULTS["output_dir"])
         self.capture_timeout = tk.StringVar(value=DEFAULTS["capture_timeout"])
         self.min_objects = tk.StringVar(value=DEFAULTS["min_objects"])
+        self.frame_fallback = tk.StringVar(value=DEFAULTS["frame_fallback"])
         self.input_mode = tk.StringVar(value="offline")
         self.dry_run = tk.BooleanVar(value=True)
         self.replay = tk.BooleanVar(value=False)
@@ -149,7 +157,7 @@ class CellCyclePanel:
         self.objects_combo.bind("<<ComboboxSelected>>", lambda _e: self._update_selection_details())
         row += 1
 
-        for label, var in [("EPD topic", self.epd_topic), ("Output dir", self.output_dir), ("Capture timeout", self.capture_timeout), ("Min objects", self.min_objects)]:
+        for label, var in [("EPD topic", self.epd_topic), ("Output dir", self.output_dir), ("Capture timeout", self.capture_timeout), ("Min objects", self.min_objects), ("Frame fallback", self.frame_fallback)]:
             ttk.Label(frm, text=label).grid(row=row, column=0, sticky="w")
             ttk.Entry(frm, textvariable=var, width=80).grid(row=row, column=1, sticky="ew", padx=4, pady=2)
             row += 1
@@ -166,9 +174,11 @@ class CellCyclePanel:
         ttk.Checkbutton(frm, text="Show developer/test fixtures", variable=self.show_dev_fixtures, command=self.refresh_discovery).grid(row=row, column=1, sticky="w")
         row += 1
 
-        self.run_btn = ttk.Button(frm, text="Run Cycle", command=self.run_cycle)
-        ttk.Button(frm, text="Refresh", command=self.refresh_discovery).grid(row=row, column=2, sticky="ew", pady=6)
+        self.run_btn = ttk.Button(frm, text="Run live dry-run cycle", command=self.run_cycle)
+        ttk.Button(frm, text="Refresh discovery", command=self.refresh_discovery).grid(row=row, column=2, sticky="ew", pady=6)
         self.run_btn.grid(row=row, column=0, sticky="ew", pady=6)
+        ttk.Button(frm, text="Capture live snapshot only", command=self.capture_only).grid(row=row, column=1, sticky="w")
+        row += 1
         ttk.Button(frm, text="Open Output Folder", command=self.open_output).grid(row=row, column=1, sticky="w")
         row += 1
         ttk.Button(frm, text="Open cycle_report.json", command=self.open_report).grid(row=row, column=1, sticky="w")
@@ -221,6 +231,7 @@ class CellCyclePanel:
             "output_dir": self.output_dir.get().strip(),
             "capture_timeout": self.capture_timeout.get().strip(),
             "min_objects": self.min_objects.get().strip(),
+            "frame_fallback": self.frame_fallback.get().strip(),
             "dry_run": self.dry_run.get(),
             "replay": self.replay.get(),
             "strict": self.strict.get(),
@@ -251,12 +262,36 @@ class CellCyclePanel:
 
         threading.Thread(target=worker, daemon=True).start()
 
+
+    def capture_only(self) -> None:
+        out = Path(self.output_dir.get().strip()) / "detected_objects_live.yaml"
+        cmd = [
+            sys.executable,
+            str(Path(__file__).resolve().parent / "capture_epd_detected_objects.py"),
+            "--scene-package", self.scene_package.get().strip(),
+            "--topic", self.epd_topic.get().strip(),
+            "--output", str(out),
+            "--timeout", self.capture_timeout.get().strip(),
+            "--min-objects", self.min_objects.get().strip(),
+            "--frame-fallback", self.frame_fallback.get().strip(),
+            "--once",
+            "--json",
+        ]
+        self._append("\n$ " + " ".join(cmd) + "\n")
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        self._append((proc.stdout or "") + (proc.stderr or ""))
+        self.status.set("Status: PASS (capture-only)" if proc.returncode == 0 else "Status: FAIL (capture-only)")
+
     def _on_done(self, rc: int) -> None:
         self.proc = None
         self.run_btn.configure(state="normal")
         summary = parse_cycle_report(Path(self.output_dir.get().strip()))
         self._append(f"\nProcess exited with code {rc}\n")
         self._append(f"Summary: status={summary.status} warnings={summary.warning_count} errors={summary.error_count}\n")
+        if summary.perception_source:
+            self._append(f"Perception source: {summary.perception_source}\n")
+        if summary.detected_objects_used:
+            self._append(f"Detected objects used: {summary.detected_objects_used}\n")
         for name, path in summary.generated_files.items():
             self._append(f"- {name}: {'FOUND' if path.exists() else 'MISSING'} ({path})\n")
         self.status.set(f"Status: {summary.status} (warnings={summary.warning_count}, errors={summary.error_count})")

--- a/scripts/run_generated_cell_cycle.py
+++ b/scripts/run_generated_cell_cycle.py
@@ -20,6 +20,18 @@ def _load_detected(path: Path) -> dict[str, Any]:
     return data
 
 
+def _pick_selected_object(detected: dict[str, Any], acceptance: dict[str, Any]) -> dict[str, Any] | None:
+    selected_name = acceptance.get("selected_object")
+    objects = detected.get("objects") or []
+    if not isinstance(objects, list):
+        return None
+    if selected_name:
+        for obj in objects:
+            if isinstance(obj, dict) and obj.get("name") == selected_name:
+                return obj
+    return objects[0] if objects else None
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description='Run one generated-cell cycle.')
     p.add_argument('--scene-package', required=True)
@@ -42,7 +54,9 @@ def main(argv: list[str] | None = None) -> int:
     args.output_dir.mkdir(parents=True, exist_ok=True)
     warnings: list[str] = []
 
+    perception_source = "fixture"
     if args.capture_live:
+        perception_source = "live_epd"
         live_out = args.output_dir / 'live_detected_objects.yaml'
         fake_detected = Path('/tmp/mvp1/fake_detected_objects.yaml')
         fake_path = Path('/tmp/mvp1/fake_epd_message.json')
@@ -68,6 +82,7 @@ def main(argv: list[str] | None = None) -> int:
 
     used = args.output_dir / 'detected_objects_used.yaml'
     shutil.copyfile(detected_input, used)
+    detected_data = _load_detected(used)
 
     acceptance, rc = run_acceptance(args.scene_package, args.task_recipe, used, args.output_dir, strict=args.strict)
     payload_path = Path(acceptance['emd_bridge_payload_path'])
@@ -94,16 +109,51 @@ def main(argv: list[str] | None = None) -> int:
         replay_status = 'SKIPPED'
         replay_message = 'dry-run enabled'
 
+    detected_count = len(detected_data.get("objects", [])) if isinstance(detected_data.get("objects"), list) else 0
+    if detected_count == 0:
+        warnings.append("No objects detected in detected_objects_used payload")
+    if detected_count < max(1, args.min_objects):
+        warnings.append(f"Detected object count {detected_count} is below min-objects={max(1, args.min_objects)}")
+
+    selected_obj = _pick_selected_object(detected_data, acceptance)
+    selected_pose = (selected_obj or {}).get("pose") if isinstance(selected_obj, dict) else {}
+    pose_frame = selected_pose.get("frame_id") if isinstance(selected_pose, dict) else None
+    xyz = selected_pose.get("xyz") if isinstance(selected_pose, dict) else None
+    conf = (selected_obj or {}).get("confidence") if isinstance(selected_obj, dict) else None
+    dims = (selected_obj or {}).get("dimensions") if isinstance(selected_obj, dict) else None
+    if selected_obj and not dims:
+        warnings.append("Selected object missing dimensions")
+    if selected_obj and conf is None:
+        warnings.append("Selected object missing confidence")
+    elif isinstance(conf, (int, float)) and conf < 0.5:
+        warnings.append(f"Selected object has low confidence ({conf:.3f} < 0.500)")
+    if pose_frame and pose_frame != "world":
+        warnings.append(f"Selected object pose frame is '{pose_frame}', not 'world'; transform validation not available")
+    if isinstance(xyz, list) and len(xyz) >= 3 and isinstance(xyz[2], (int, float)) and xyz[2] < 0.0:
+        warnings.append(f"Selected object z ({xyz[2]:.4f}) is below conservative table threshold (0.0)")
+
     report = {
         'status': acceptance['status'] if rc == 0 else 'FAIL',
         'scene_package': args.scene_package,
         'task_recipe': str(args.task_recipe),
+        'perception_source': perception_source,
+        'epd_topic': args.epd_topic if args.capture_live else None,
         'detected_objects_used': str(used),
-        'detected_object_count': _load_detected(used).get('objects') and len(_load_detected(used)['objects']) or 0,
+        'detected_object_count': detected_count,
+        'selected_object': acceptance.get('selected_object'),
+        'selected_object_class': (selected_obj or {}).get('class_id') if isinstance(selected_obj, dict) else None,
+        'selected_object_label': (selected_obj or {}).get('name') if isinstance(selected_obj, dict) else None,
+        'selected_object_confidence': conf,
+        'object_pose_frame': pose_frame,
+        'object_xyz': xyz,
         'chosen_destination': acceptance.get('destination_selected'),
+        'destination_release_pose': acceptance.get('destination_release_pose'),
+        'runtime_release_strategy': acceptance.get('runtime_release_strategy'),
         'payload_path': str(payload_path),
         'replay_status': replay_status,
         'replay_message': replay_message,
+        'dry_run': bool(args.dry_run),
+        'blockers': acceptance.get('blockers', []),
         'warnings': acceptance.get('warnings', []) + warnings,
         'acceptance': acceptance,
     }

--- a/tests/test_run_cell_cycle_panel.py
+++ b/tests/test_run_cell_cycle_panel.py
@@ -14,6 +14,7 @@ class RunCellCyclePanelTests(unittest.TestCase):
     def test_operator_defaults_use_valid_fixtures(self):
         self.assertTrue(DEFAULTS["task_recipe"].endswith("valid_garbage_sorting.yaml"))
         self.assertTrue(DEFAULTS["detected_objects"].endswith("valid_epd_garbage_sorting.yaml"))
+        self.assertEqual(DEFAULTS["output_dir"], "/tmp/mvp1_live_smoke_test")
 
     def test_filtered_defaults_avoid_failure_test_fixtures(self):
         payload = discover_all()
@@ -32,6 +33,7 @@ class RunCellCyclePanelTests(unittest.TestCase):
             "output_dir": "/tmp/mvp1",
             "capture_timeout": 10,
             "min_objects": 1,
+            "frame_fallback": "world",
             "dry_run": True,
             "replay": False,
             "strict": False,
@@ -40,6 +42,7 @@ class RunCellCyclePanelTests(unittest.TestCase):
         cmd = build_cycle_command(cfg)
         self.assertIn("--dry-run", cmd)
         self.assertNotIn("--replay", cmd)
+        self.assertIn("--no-replay", cmd)
         self.assertIn("--detected-objects", cmd)
 
     def test_live_mode_command_uses_capture_live(self):
@@ -52,6 +55,7 @@ class RunCellCyclePanelTests(unittest.TestCase):
             "output_dir": "/tmp/mvp1",
             "capture_timeout": 10,
             "min_objects": 1,
+            "frame_fallback": "world",
             "dry_run": True,
             "replay": False,
             "strict": False,
@@ -60,6 +64,8 @@ class RunCellCyclePanelTests(unittest.TestCase):
         cmd = build_cycle_command(cfg)
         self.assertIn("--capture-live", cmd)
         self.assertIn("--epd-topic", cmd)
+        self.assertIn("--dry-run", cmd)
+        self.assertIn("--no-replay", cmd)
         self.assertNotIn("--detected-objects", cmd)
 
     def test_missing_cycle_report_is_graceful(self):
@@ -73,6 +79,8 @@ class RunCellCyclePanelTests(unittest.TestCase):
             report = {
                 "status": "WARN",
                 "warnings": ["w1", "w2"],
+                "perception_source": "live_epd",
+                "detected_objects_used": "/tmp/x/detected_objects_used.yaml",
                 "acceptance": {"errors": ["e1"]},
             }
             p = Path(td) / "cycle_report.json"
@@ -81,6 +89,7 @@ class RunCellCyclePanelTests(unittest.TestCase):
             self.assertEqual(summary.status, "WARN")
             self.assertEqual(summary.warning_count, 2)
             self.assertEqual(summary.error_count, 1)
+            self.assertEqual(summary.perception_source, "live_epd")
 
 
 if __name__ == "__main__":

--- a/tests/test_run_generated_cell_cycle.py
+++ b/tests/test_run_generated_cell_cycle.py
@@ -61,5 +61,17 @@ class RunGeneratedCellCycleTests(unittest.TestCase):
             self.assertIn(report['status'],{'PASS','WARN'})
             self.assertEqual(report['acceptance'].get('blockers',[]),[])
 
+
+    def test_report_includes_live_fields_and_snapshot_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            fake=Path('/tmp/mvp1/fake_detected_objects.yaml')
+            fake.parent.mkdir(parents=True,exist_ok=True)
+            fake.write_text(OBJECTS_VALID_GARBAGE.read_text(encoding='utf-8'), encoding='utf-8')
+            p=self._run('--scene-package','ur5_2f_test','--task-recipe',str(TASK_VALID_GARBAGE),'--capture-live','--epd-topic','/easy_perception_deployment/epd_localize_output','--output-dir',td,'--dry-run','--no-replay','--json')
+            self.assertEqual(p.returncode,0,msg=p.stdout+p.stderr)
+            report=json.loads(p.stdout)
+            self.assertEqual(report['perception_source'],'live_epd')
+            self.assertTrue(report['detected_objects_used'].endswith('detected_objects_used.yaml'))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Motivation

- Provide an operator-friendly, conservative live perception smoke-test path that verifies RealSense/EPD output through the existing generated-cell cycle without enabling robot motion. 
- Make live capture optional, visible, and repeatable while preserving existing offline fixture workflows and defaults (dry-run enabled, replay disabled).

### Description

- Added live-perception support and conservative quality checks to the generated-cycle runner by updating `scripts/run_generated_cell_cycle.py` to record `perception_source`, `epd_topic`, `detected_object_count`, selected-object fields, pose/frame/xyz, destination/release strategy, `dry_run`, `blockers`, and persist the snapshot path `detected_objects_used.yaml`, and emit conservative warnings for low-quality captures. 
- Extended the operator panel in `scripts/run_cell_cycle_panel.py` with live-smoke defaults (`/tmp/mvp1_live_smoke_test`), `frame_fallback`, `--frame-fallback` and `--no-replay` propagation, a `Capture live snapshot only` action, clearer live-oriented labels, and display of `perception_source` and snapshot path from the cycle report. 
- Reused existing backend scripts (`capture_epd_detected_objects.py`, `run_generated_cell_cycle.py`, `run_generated_cell_acceptance.py`, `replay_emd_bridge_payload.py`) and preserved Workcell Builder and runtime architecture. 
- Updated unit tests in `tests/test_run_cell_cycle_panel.py` and `tests/test_run_generated_cell_cycle.py` to validate command generation for live mode, no-replay-by-default behavior, report parsing for perception fields and persisted snapshot path, and live-fake-input handling. 
- Added documentation: new manual section `First live D435i / EPD smoke test` in `docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md` and a README pointer to that section.

### Testing

- Ran unit tests: `python3 -m unittest tests/test_run_cell_cycle_panel.py tests/test_run_generated_cell_cycle.py`, and the test suite completed successfully (`OK`).
- Existing fixture-based tests were left intact and continue to pass under CI-local unit test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35e93f7408331afa20b132a39f5c6)