### PR TITLE
Fix live EPD capture QoS, invoke real ROS capture, and make fake-live explicit

### DIFF
--- a/docs/manuals/REAL_D435I_EPD_PIPELINE.md
+++ b/docs/manuals/REAL_D435I_EPD_PIPELINE.md
@@ -31,6 +31,66 @@ ros2 launch realsense2_camera rs_launch.py ...
 ros2 launch easy_perception_deployment run.launch.py ...
 ```
 
+## MVP live smoke-test commands (generated-cell)
+
+Run tests from repo root (no `PYTHONPATH` required):
+
+```bash
+python3 -m pytest -q \
+  tests/test_workcell_discovery.py \
+  tests/test_run_cell_cycle_panel.py \
+  tests/test_run_generated_cell_cycle.py \
+  tests/test_capture_epd_detected_objects.py \
+  tests/test_generated_cell_acceptance.py \
+  tests/test_replay_emd_bridge_payload.py
+```
+
+Check camera topics:
+
+```bash
+ros2 topic list | grep camera
+```
+
+Check EPD topic:
+
+```bash
+ros2 topic list | grep easy_perception
+```
+
+Capture one live EPD detection (best-effort QoS, expected PASS/WARN with `objects >= 1`):
+
+```bash
+python3 scripts/capture_epd_detected_objects.py \
+  --topic /easy_perception_deployment/epd_localize_output \
+  --output /tmp/mvp1_live_smoke_test/detected_objects_live.yaml \
+  --scene-package ur5_2f_test \
+  --timeout 15 \
+  --min-objects 1 \
+  --once \
+  --qos-reliability best_effort \
+  --json
+```
+
+Run generated-cell dry-run from live EPD capture (expected PASS/WARN; `perception_source=live_epd` only when ROS message capture succeeds):
+
+```bash
+python3 scripts/run_generated_cell_cycle.py \
+  --scene-package ur5_2f_test \
+  --task-recipe tests/fixtures/task_recipes/valid_garbage_sorting.yaml \
+  --capture-live \
+  --epd-topic /easy_perception_deployment/epd_localize_output \
+  --epd-qos-reliability best_effort \
+  --output-dir /tmp/mvp1_live_smoke_test \
+  --min-objects 1 \
+  --capture-timeout 15 \
+  --once \
+  --dry-run \
+  --no-replay \
+  --json
+```
+
+Offline fake mode is now explicit (`--offline-fake-live`) and intended only for tests/CI.
+
 ## Capture one snapshot
 
 ```bash

--- a/scripts/capture_epd_detected_objects.py
+++ b/scripts/capture_epd_detected_objects.py
@@ -138,6 +138,19 @@ def _write_output(payload: dict[str, Any], output: Path, as_json: bool) -> None:
             output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def create_qos_profile(reliability: str, depth: int):
+    from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy  # type: ignore
+
+    chosen = "best_effort" if reliability == "auto" else reliability
+    rel_policy = ReliabilityPolicy.BEST_EFFORT if chosen == "best_effort" else ReliabilityPolicy.RELIABLE
+    return QoSProfile(
+        history=HistoryPolicy.KEEP_LAST,
+        depth=max(1, int(depth)),
+        reliability=rel_policy,
+        durability=DurabilityPolicy.VOLATILE,
+    ), chosen
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--topic", default="/easy_perception_deployment/epd_localize_output")
@@ -149,6 +162,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--once", action="store_true")
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--qos-reliability", choices=("auto", "best_effort", "reliable"), default="best_effort")
+    parser.add_argument("--qos-depth", type=int, default=10)
     args = parser.parse_args(argv)
 
     try:
@@ -167,7 +182,9 @@ def main(argv: list[str] | None = None) -> int:
     class CaptureNode(Node):
         def __init__(self) -> None:
             super().__init__("capture_epd_detected_objects")
-            self.create_subscription(msg_type, args.topic, self._cb, 10)
+            qos_profile, qos_selected = create_qos_profile(args.qos_reliability, args.qos_depth)
+            self.qos_selected = qos_selected
+            self.create_subscription(msg_type, args.topic, self._cb, qos_profile)
 
         def _cb(self, msg: Any) -> None:
             nonlocal latest_message
@@ -191,18 +208,18 @@ def main(argv: list[str] | None = None) -> int:
                 break
 
         if payload is None or len(payload.get("objects", [])) < max(1, args.min_objects):
-            print(json.dumps({"status": "FAIL", "error": f"No detections meeting min-objects={args.min_objects} on {args.topic}"}, indent=2))
+            print(json.dumps({"status": "FAIL", "error": f"No detections meeting min-objects={args.min_objects} on {args.topic}", "qos_reliability": node.qos_selected, "qos_depth": max(1, int(args.qos_depth))}, indent=2))
             return 1
 
         validation = validate_detected_objects(payload, strict=False, allow_generate_ids=True)
         warnings.extend(validation.warnings)
 
         if args.dry_run:
-            print(json.dumps({"status": "WARN" if warnings else "PASS", "dry_run": True, "output": str(args.output), "payload": payload, "warnings": warnings}, indent=2))
+            print(json.dumps({"status": "WARN" if warnings else "PASS", "dry_run": True, "output": str(args.output), "payload": payload, "warnings": warnings, "qos_reliability": node.qos_selected, "qos_depth": max(1, int(args.qos_depth))}, indent=2))
             return 0
 
         _write_output(payload, args.output, args.json)
-        print(json.dumps({"status": "WARN" if warnings else "PASS", "output": str(args.output), "objects": len(payload.get("objects", [])), "warnings": warnings}, indent=2))
+        print(json.dumps({"status": "WARN" if warnings else "PASS", "output": str(args.output), "objects": len(payload.get("objects", [])), "warnings": warnings, "qos_reliability": node.qos_selected, "qos_depth": max(1, int(args.qos_depth))}, indent=2))
         return 0
     finally:
         node.destroy_node()

--- a/scripts/run_generated_cell_cycle.py
+++ b/scripts/run_generated_cell_cycle.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 import argparse, json, shutil
+import subprocess, sys
 from pathlib import Path
 from typing import Any
 
@@ -40,6 +41,9 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument('--capture-live', action='store_true')
     p.add_argument('--epd-topic', default='/easy_perception_deployment/epd_localize_output')
     p.add_argument('--output-dir', type=Path, default=Path('/tmp/mvp1'))
+    p.add_argument('--epd-qos-reliability', choices=('auto','best_effort','reliable'), default='best_effort')
+    p.add_argument('--epd-qos-depth', type=int, default=10)
+    p.add_argument('--offline-fake-live', action='store_true')
     p.add_argument('--min-objects', type=int, default=1)
     p.add_argument('--capture-timeout', type=float, default=10)
     p.add_argument('--frame-fallback', default='camera_depth_optical_frame')
@@ -55,22 +59,38 @@ def main(argv: list[str] | None = None) -> int:
     warnings: list[str] = []
 
     perception_source = "fixture"
+    capture_status = 'offline_fixture'
     if args.capture_live:
-        perception_source = "live_epd"
         live_out = args.output_dir / 'live_detected_objects.yaml'
-        fake_detected = Path('/tmp/mvp1/fake_detected_objects.yaml')
-        fake_path = Path('/tmp/mvp1/fake_epd_message.json')
-        if fake_detected.exists():
-            shutil.copyfile(fake_detected, live_out)
-        elif fake_path.exists():
-            msg = json.loads(fake_path.read_text())
-            payload, capture_warnings = convert_epd_message_to_detected_objects(msg, args.epd_topic, args.scene_package, args.frame_fallback)
-            warnings.extend(capture_warnings)
-            if len(payload.get('objects', [])) < max(1, args.min_objects):
-                raise SystemExit('FAIL: capture-live generated fewer than min-objects')
-            _write_output(payload, live_out, as_json=True)
+        if args.offline_fake_live:
+            fake_detected = Path('/tmp/mvp1/fake_detected_objects.yaml')
+            fake_path = Path('/tmp/mvp1/fake_epd_message.json')
+            if fake_detected.exists():
+                shutil.copyfile(fake_detected, live_out)
+                capture_status = 'offline_fake_file'
+            elif fake_path.exists():
+                msg = json.loads(fake_path.read_text())
+                payload, capture_warnings = convert_epd_message_to_detected_objects(msg, args.epd_topic, args.scene_package, args.frame_fallback)
+                warnings.extend(capture_warnings)
+                if len(payload.get('objects', [])) < max(1, args.min_objects):
+                    raise SystemExit('FAIL: capture-live generated fewer than min-objects in offline fake mode')
+                _write_output(payload, live_out, as_json=True)
+                capture_status = 'offline_fake_message'
+            else:
+                raise SystemExit('FAIL: --offline-fake-live requested but no fake input found in /tmp/mvp1')
         else:
-            raise SystemExit('FAIL: live capture requires ROS runtime; for offline tests use /tmp/mvp1/fake_detected_objects.yaml or /tmp/mvp1/fake_epd_message.json')
+            capture_script = Path(__file__).resolve().parent / 'capture_epd_detected_objects.py'
+            cap_cmd = [
+                sys.executable, str(capture_script), '--topic', args.epd_topic, '--output', str(live_out),
+                '--scene-package', args.scene_package, '--timeout', str(args.capture_timeout), '--min-objects', str(args.min_objects),
+                '--frame-fallback', args.frame_fallback, '--qos-reliability', args.epd_qos_reliability, '--qos-depth', str(args.epd_qos_depth), '--once', '--json'
+            ]
+            cap = subprocess.run(cap_cmd, capture_output=True, text=True, check=False)
+            if cap.returncode != 0:
+                err = cap.stdout.strip() or cap.stderr.strip() or 'unknown error'
+                raise SystemExit(f'FAIL: live EPD capture failed: {err}')
+            capture_status = 'live_capture_ok'
+            perception_source = 'live_epd'
         detected_input = live_out
     else:
         if not args.detected_objects:
@@ -137,6 +157,8 @@ def main(argv: list[str] | None = None) -> int:
         'scene_package': args.scene_package,
         'task_recipe': str(args.task_recipe),
         'perception_source': perception_source,
+        'capture_status': capture_status,
+        'epd_qos_reliability': args.epd_qos_reliability if args.capture_live else None,
         'epd_topic': args.epd_topic if args.capture_live else None,
         'detected_objects_used': str(used),
         'detected_object_count': detected_count,

--- a/tests/test_capture_epd_detected_objects.py
+++ b/tests/test_capture_epd_detected_objects.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import unittest
+from unittest.mock import patch
 
-from scripts.capture_epd_detected_objects import convert_epd_message_to_detected_objects
+from scripts.capture_epd_detected_objects import convert_epd_message_to_detected_objects, create_qos_profile
 from scripts.validate_detected_objects import validate_detected_objects
 
 
@@ -59,6 +60,28 @@ class CaptureEPDDetectedObjectsTests(unittest.TestCase):
         result = validate_detected_objects(payload, strict=False, allow_generate_ids=True)
         self.assertIn(result.status, {"PASS", "WARN"})
         self.assertFalse(result.errors)
+
+    def test_qos_profile_best_effort_and_reliable(self) -> None:
+        class Dummy:
+            BEST_EFFORT = "be"
+            RELIABLE = "rel"
+            VOLATILE = "vol"
+            KEEP_LAST = "kl"
+
+        class DummyQoS:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        with patch.dict("sys.modules", {"rclpy.qos": type("M", (), {"DurabilityPolicy": Dummy, "HistoryPolicy": Dummy, "QoSProfile": DummyQoS, "ReliabilityPolicy": Dummy})}):
+            be, choice_be = create_qos_profile("best_effort", 7)
+            rel, choice_rel = create_qos_profile("reliable", 3)
+            auto, choice_auto = create_qos_profile("auto", 4)
+        self.assertEqual(choice_be, "best_effort")
+        self.assertEqual(choice_rel, "reliable")
+        self.assertEqual(choice_auto, "best_effort")
+        self.assertEqual(be.kwargs["reliability"], "be")
+        self.assertEqual(rel.kwargs["reliability"], "rel")
+        self.assertEqual(auto.kwargs["reliability"], "be")
 
 
 if __name__ == "__main__":

--- a/tests/test_run_generated_cell_cycle.py
+++ b/tests/test_run_generated_cell_cycle.py
@@ -38,9 +38,18 @@ class RunGeneratedCellCycleTests(unittest.TestCase):
             fake=Path('/tmp/mvp1/fake_detected_objects.yaml')
             fake.parent.mkdir(parents=True,exist_ok=True)
             fake.write_text(OBJECTS.read_text(encoding='utf-8'), encoding='utf-8')
-            p=self._run('--scene-package','ur5_2f_test','--task-recipe',str(TASK),'--capture-live','--output-dir',td,'--dry-run','--json')
+            p=self._run('--scene-package','ur5_2f_test','--task-recipe',str(TASK),'--capture-live','--offline-fake-live','--output-dir',td,'--dry-run','--json')
             self.assertEqual(p.returncode,0,msg=p.stdout+p.stderr)
             self.assertTrue((Path(td)/'live_detected_objects.yaml').exists())
+
+    def test_capture_live_without_explicit_fake_mode_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            fake=Path('/tmp/mvp1/fake_detected_objects.yaml')
+            fake.parent.mkdir(parents=True,exist_ok=True)
+            fake.write_text(OBJECTS.read_text(encoding='utf-8'), encoding='utf-8')
+            p=self._run('--scene-package','ur5_2f_test','--task-recipe',str(TASK),'--capture-live','--output-dir',td,'--dry-run','--json')
+            self.assertNotEqual(p.returncode,0)
+            self.assertIn('live EPD capture failed', p.stderr + p.stdout)
 
     def test_strict_escalates_warning(self):
         with tempfile.TemporaryDirectory() as td:
@@ -67,10 +76,11 @@ class RunGeneratedCellCycleTests(unittest.TestCase):
             fake=Path('/tmp/mvp1/fake_detected_objects.yaml')
             fake.parent.mkdir(parents=True,exist_ok=True)
             fake.write_text(OBJECTS_VALID_GARBAGE.read_text(encoding='utf-8'), encoding='utf-8')
-            p=self._run('--scene-package','ur5_2f_test','--task-recipe',str(TASK_VALID_GARBAGE),'--capture-live','--epd-topic','/easy_perception_deployment/epd_localize_output','--output-dir',td,'--dry-run','--no-replay','--json')
+            p=self._run('--scene-package','ur5_2f_test','--task-recipe',str(TASK_VALID_GARBAGE),'--capture-live','--offline-fake-live','--epd-topic','/easy_perception_deployment/epd_localize_output','--output-dir',td,'--dry-run','--no-replay','--json')
             self.assertEqual(p.returncode,0,msg=p.stdout+p.stderr)
             report=json.loads(p.stdout)
-            self.assertEqual(report['perception_source'],'live_epd')
+            self.assertNotEqual(report['perception_source'],'live_epd')
+            self.assertIn(report['capture_status'], {'offline_fake_file', 'offline_fake_message'})
             self.assertTrue(report['detected_objects_used'].endswith('detected_objects_used.yaml'))
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Motivation
- Live EPD/D435i capture was silently falling back to offline fixtures and producing QoS incompatibility warnings, making live validation unreliable and dangerous for operator bringup.
- Need explicit QoS control for subscriptions so EPD (best-effort) topics can be consumed without RELIABILITY mismatch warnings.
- Tests should run from repo root without silent offline fallbacks and the code should clearly report when live capture fails.

### Description
- Added QoS CLI controls to `scripts/capture_epd_detected_objects.py`: `--qos-reliability {auto,best_effort,reliable}` (default `best_effort`) and `--qos-depth` (default `10`) and implemented `create_qos_profile()` returning a `QoSProfile` with `KEEP_LAST`, configured `depth`, mapped `reliability`, and `VOLATILE` durability; selected QoS is included in JSON outputs.
- Reworked `scripts/run_generated_cell_cycle.py` so `--capture-live` invokes `capture_epd_detected_objects.py` for real ROS capture (with forwarded QoS args) and fails explicitly if capture fails, rather than silently using files in `/tmp/mvp1`.
- Introduced explicit test/offline-only flag `--offline-fake-live` to permit consuming `/tmp/mvp1/fake_*` in controlled test scenarios only; default operator flow will not use fake files.
- Extended generated-cycle JSON report with `capture_status` and `epd_qos_reliability` and ensured `perception_source` is set to `live_epd` only when real capture succeeds; preserved `epd_topic`, `detected_objects_used`, and `detected_object_count` fields.
- Added unit tests: QoS profile mapping (`best_effort`, `reliable`, `auto`) and generated-cycle behavior tests to ensure normal `--capture-live` does not silently use fake inputs and that `--offline-fake-live` still works for tests.
- Updated `docs/manuals/REAL_D435I_EPD_PIPELINE.md` with MVP live smoke-test commands, pytest invocation from repo root, ROS topic checks, live capture example, and notes about explicit offline fake mode.

### Testing
- Compiled modified scripts with `python3 -m py_compile scripts/capture_epd_detected_objects.py scripts/run_generated_cell_cycle.py` and compilation succeeded.
- Ran targeted automated tests with `python3 -m pytest -q tests/test_workcell_discovery.py tests/test_run_cell_cycle_panel.py tests/test_run_generated_cell_cycle.py tests/test_capture_epd_detected_objects.py tests/test_generated_cell_acceptance.py tests/test_replay_emd_bridge_payload.py` and all tests passed (`39 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36434a9548331ae0c45360bb5805a)