### PR TITLE
Add TF-based pose normalization for live generated-cell captures

### DIFF
--- a/docs/manuals/REAL_D435I_EPD_PIPELINE.md
+++ b/docs/manuals/REAL_D435I_EPD_PIPELINE.md
@@ -57,6 +57,17 @@ Check EPD topic:
 ros2 topic list | grep easy_perception
 ```
 
+## Verify TF from camera to world
+
+Before trusting any live replay/execution, verify TF is continuously available from the camera frame to the planning frame (`world` by default):
+
+```bash
+ros2 run tf2_ros tf2_echo world camera_depth_optical_frame
+ros2 run tf2_ros tf2_echo world camera_color_optical_frame
+```
+
+Expected result: transforms print continuously and do not timeout.
+
 Capture one live EPD detection (best-effort QoS, expected PASS/WARN with `objects >= 1`):
 
 ```bash
@@ -68,6 +79,8 @@ python3 scripts/capture_epd_detected_objects.py \
   --min-objects 1 \
   --once \
   --qos-reliability best_effort \
+  --target-frame world \
+  --require-transform \
   --json
 ```
 
@@ -86,8 +99,13 @@ python3 scripts/run_generated_cell_cycle.py \
   --once \
   --dry-run \
   --no-replay \
+  --target-frame world \
+  --require-transform \
   --json
 ```
+
+If transform is unavailable and `--require-transform` is active, live capture fails conservatively.
+Only use `--allow-untransformed` for debugging; this is reported as WARN and runtime replay is unsafe/not recommended.
 
 Offline fake mode is now explicit (`--offline-fake-live`) and intended only for tests/CI.
 

--- a/scripts/capture_epd_detected_objects.py
+++ b/scripts/capture_epd_detected_objects.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 SCRIPTS_DIR = Path(__file__).resolve().parent
 if str(SCRIPTS_DIR) not in sys.path:
@@ -44,6 +45,33 @@ def _message_objects(msg: Any) -> list[Any]:
     return []
 
 
+def _quaternion_from_rpy(roll: float, pitch: float, yaw: float) -> tuple[float, float, float, float]:
+    cr = math.cos(roll * 0.5)
+    sr = math.sin(roll * 0.5)
+    cp = math.cos(pitch * 0.5)
+    sp = math.sin(pitch * 0.5)
+    cy = math.cos(yaw * 0.5)
+    sy = math.sin(yaw * 0.5)
+    return (
+        sr * cp * cy - cr * sp * sy,
+        cr * sp * cy + sr * cp * sy,
+        cr * cp * sy - sr * sp * cy,
+        cr * cp * cy + sr * sp * sy,
+    )
+
+
+def _rpy_from_quaternion(x: float, y: float, z: float, w: float) -> tuple[float, float, float]:
+    sinr_cosp = 2.0 * (w * x + y * z)
+    cosr_cosp = 1.0 - 2.0 * (x * x + y * y)
+    roll = math.atan2(sinr_cosp, cosr_cosp)
+    sinp = 2.0 * (w * y - z * x)
+    pitch = math.copysign(math.pi / 2.0, sinp) if abs(sinp) >= 1.0 else math.asin(sinp)
+    siny_cosp = 2.0 * (w * z + x * y)
+    cosy_cosp = 1.0 - 2.0 * (y * y + z * z)
+    yaw = math.atan2(siny_cosp, cosy_cosp)
+    return roll, pitch, yaw
+
+
 def _object_to_detected(raw: Any, index: int, frame_id: str) -> tuple[dict[str, Any] | None, list[str]]:
     warnings: list[str] = []
     centroid = _get(raw, "centroid")
@@ -72,12 +100,15 @@ def _object_to_detected(raw: Any, index: int, frame_id: str) -> tuple[dict[str, 
         if lx and wy and hz:
             dims = {"x": lx, "y": wy, "z": hz}
 
+    raw_rpy = [0.0, 0.0, 0.0]
+    raw_pose = {"frame_id": frame_id, "xyz": [x, y, z], "rpy": raw_rpy}
     obj = {
         "object_id": f"obj_{index:03d}",
         "name": str(name),
         "class_id": str(class_id),
         "confidence": _to_float(_get(raw, "confidence")),
-        "pose": {"frame_id": frame_id, "xyz": [x, y, z], "rpy": [0.0, 0.0, 0.0]},
+        "pose": raw_pose.copy(),
+        "raw_pose": raw_pose,
         "centroid": {"x": x, "y": y, "z": z},
         "dimensions": dims,
         "shape": {"type": str(_get(raw, "shape") or "box")},
@@ -89,6 +120,25 @@ def _object_to_detected(raw: Any, index: int, frame_id: str) -> tuple[dict[str, 
         "raw": {"source_message_type": str(type(raw)).replace("<class '", "").replace("'>", "")},
     }
     return obj, warnings
+
+
+def _normalize_pose_with_tf(
+    obj: dict[str, Any],
+    target_frame: str,
+    tf_timeout_sec: float,
+    transform_pose: Callable[[str, str, list[float], list[float], float], tuple[list[float], list[float], str]],
+) -> tuple[str, str]:
+    pose = obj.get("pose") if isinstance(obj.get("pose"), dict) else {}
+    src_frame = str(pose.get("frame_id") or "").strip()
+    xyz = pose.get("xyz")
+    rpy = pose.get("rpy")
+    if not src_frame or not isinstance(xyz, list) or len(xyz) < 3:
+        return "FAIL", "Object pose missing frame_id/xyz for TF normalization"
+    if not isinstance(rpy, list) or len(rpy) < 3:
+        rpy = [0.0, 0.0, 0.0]
+    transformed_xyz, transformed_rpy, msg = transform_pose(src_frame, target_frame, xyz, rpy, tf_timeout_sec)
+    obj["pose"] = {"frame_id": target_frame, "xyz": transformed_xyz, "rpy": transformed_rpy}
+    return "PASS", msg
 
 
 def convert_epd_message_to_detected_objects(
@@ -164,6 +214,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--qos-reliability", choices=("auto", "best_effort", "reliable"), default="best_effort")
     parser.add_argument("--qos-depth", type=int, default=10)
+    parser.add_argument("--target-frame", default="world")
+    parser.add_argument("--tf-timeout", type=float, default=2.0)
+    parser.add_argument("--require-transform", action="store_true", default=True)
+    parser.add_argument("--allow-untransformed", action="store_true")
     args = parser.parse_args(argv)
 
     try:
@@ -190,7 +244,38 @@ def main(argv: list[str] | None = None) -> int:
             nonlocal latest_message
             latest_message = msg
 
+    tf_ready = False
+    tf_buffer = None
     node = CaptureNode()
+    if args.capture_live if hasattr(args, "capture_live") else True:
+        try:
+            from tf2_ros import Buffer, TransformListener  # type: ignore
+            tf_buffer = Buffer()
+            _tf_listener = TransformListener(tf_buffer, node)
+            tf_ready = True
+        except Exception:
+            tf_ready = False
+
+    def _transform_pose(src_frame: str, target_frame: str, xyz: list[float], rpy: list[float], timeout_sec: float):
+        if tf_buffer is None:
+            raise RuntimeError("TF2 listener is unavailable")
+        from geometry_msgs.msg import PoseStamped  # type: ignore
+        from rclpy.duration import Duration  # type: ignore
+        pose = PoseStamped()
+        pose.header.frame_id = src_frame
+        pose.header.stamp = node.get_clock().now().to_msg()
+        pose.pose.position.x, pose.pose.position.y, pose.pose.position.z = float(xyz[0]), float(xyz[1]), float(xyz[2])
+        qx, qy, qz, qw = _quaternion_from_rpy(float(rpy[0]), float(rpy[1]), float(rpy[2]))
+        pose.pose.orientation.x, pose.pose.orientation.y, pose.pose.orientation.z, pose.pose.orientation.w = qx, qy, qz, qw
+        transformed = tf_buffer.transform(pose, target_frame, timeout=Duration(seconds=float(timeout_sec)))
+        out_xyz = [float(transformed.pose.position.x), float(transformed.pose.position.y), float(transformed.pose.position.z)]
+        out_rpy = list(_rpy_from_quaternion(
+            float(transformed.pose.orientation.x),
+            float(transformed.pose.orientation.y),
+            float(transformed.pose.orientation.z),
+            float(transformed.pose.orientation.w),
+        ))
+        return out_xyz, out_rpy, f"Pose transformed {src_frame} -> {target_frame}"
     try:
         end_ns = node.get_clock().now().nanoseconds + int(args.timeout * 1e9)
         payload = None
@@ -211,15 +296,45 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps({"status": "FAIL", "error": f"No detections meeting min-objects={args.min_objects} on {args.topic}", "qos_reliability": node.qos_selected, "qos_depth": max(1, int(args.qos_depth))}, indent=2))
             return 1
 
+        transform_status = "PASS"
+        transform_message = "No objects required normalization"
+        source_frame = payload.get("source", {}).get("frame_id")
+        if payload.get("objects"):
+            statuses: list[str] = []
+            messages: list[str] = []
+            for obj in payload.get("objects", []):
+                try:
+                    status, message = _normalize_pose_with_tf(obj, args.target_frame, args.tf_timeout, _transform_pose)
+                except Exception as exc:
+                    status, message = "FAIL", f"TF transform failed: {exc}"
+                statuses.append(status)
+                messages.append(message)
+            transform_status = "PASS" if all(s == "PASS" for s in statuses) else "FAIL"
+            transform_message = "; ".join(messages)
+            if transform_status == "FAIL" and args.allow_untransformed:
+                transform_status = "WARN"
+                transform_message += "; continuing because --allow-untransformed"
+            if transform_status == "FAIL" and (args.require_transform and not args.allow_untransformed):
+                print(json.dumps({"status": "FAIL", "error": transform_message}, indent=2))
+                return 1
+        payload["source"]["transform"] = {
+            "requested_target_frame": args.target_frame,
+            "status": transform_status,
+            "source_frame": source_frame,
+            "target_frame": args.target_frame,
+            "message": transform_message,
+            "tf_listener_ready": tf_ready,
+        }
+
         validation = validate_detected_objects(payload, strict=False, allow_generate_ids=True)
         warnings.extend(validation.warnings)
 
         if args.dry_run:
-            print(json.dumps({"status": "WARN" if warnings else "PASS", "dry_run": True, "output": str(args.output), "payload": payload, "warnings": warnings, "qos_reliability": node.qos_selected, "qos_depth": max(1, int(args.qos_depth))}, indent=2))
+            print(json.dumps({"status": "FAIL" if transform_status == "FAIL" else ("WARN" if (warnings or transform_status == "WARN") else "PASS"), "dry_run": True, "output": str(args.output), "payload": payload, "warnings": warnings, "qos_reliability": node.qos_selected, "qos_depth": max(1, int(args.qos_depth))}, indent=2))
             return 0
 
         _write_output(payload, args.output, args.json)
-        print(json.dumps({"status": "WARN" if warnings else "PASS", "output": str(args.output), "objects": len(payload.get("objects", [])), "warnings": warnings, "qos_reliability": node.qos_selected, "qos_depth": max(1, int(args.qos_depth))}, indent=2))
+        print(json.dumps({"status": "FAIL" if transform_status == "FAIL" else ("WARN" if (warnings or transform_status == "WARN") else "PASS"), "output": str(args.output), "objects": len(payload.get("objects", [])), "warnings": warnings, "qos_reliability": node.qos_selected, "qos_depth": max(1, int(args.qos_depth))}, indent=2))
         return 0
     finally:
         node.destroy_node()

--- a/scripts/run_generated_cell_cycle.py
+++ b/scripts/run_generated_cell_cycle.py
@@ -47,6 +47,10 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument('--min-objects', type=int, default=1)
     p.add_argument('--capture-timeout', type=float, default=10)
     p.add_argument('--frame-fallback', default='camera_depth_optical_frame')
+    p.add_argument('--target-frame', default='world')
+    p.add_argument('--tf-timeout', type=float, default=2.0)
+    p.add_argument('--require-transform', action='store_true', default=True)
+    p.add_argument('--allow-untransformed', action='store_true')
     p.add_argument('--replay', action='store_true')
     p.add_argument('--no-replay', action='store_true')
     p.add_argument('--dry-run', action='store_true')
@@ -83,8 +87,11 @@ def main(argv: list[str] | None = None) -> int:
             cap_cmd = [
                 sys.executable, str(capture_script), '--topic', args.epd_topic, '--output', str(live_out),
                 '--scene-package', args.scene_package, '--timeout', str(args.capture_timeout), '--min-objects', str(args.min_objects),
-                '--frame-fallback', args.frame_fallback, '--qos-reliability', args.epd_qos_reliability, '--qos-depth', str(args.epd_qos_depth), '--once', '--json'
+                '--frame-fallback', args.frame_fallback, '--qos-reliability', args.epd_qos_reliability, '--qos-depth', str(args.epd_qos_depth), '--once', '--json',
+                '--target-frame', args.target_frame, '--tf-timeout', str(args.tf_timeout), '--require-transform'
             ]
+            if args.allow_untransformed:
+                cap_cmd.append('--allow-untransformed')
             cap = subprocess.run(cap_cmd, capture_output=True, text=True, check=False)
             if cap.returncode != 0:
                 err = cap.stdout.strip() or cap.stderr.strip() or 'unknown error'
@@ -138,6 +145,11 @@ def main(argv: list[str] | None = None) -> int:
     selected_obj = _pick_selected_object(detected_data, acceptance)
     selected_pose = (selected_obj or {}).get("pose") if isinstance(selected_obj, dict) else {}
     pose_frame = selected_pose.get("frame_id") if isinstance(selected_pose, dict) else None
+    raw_pose = (selected_obj or {}).get("raw_pose") if isinstance(selected_obj, dict) else {}
+    raw_pose_frame = raw_pose.get("frame_id") if isinstance(raw_pose, dict) else None
+    transform_meta = (((detected_data.get("source") or {}).get("transform")) if isinstance(detected_data.get("source"), dict) else {}) or {}
+    transform_status = transform_meta.get("status")
+    transform_message = transform_meta.get("message")
     xyz = selected_pose.get("xyz") if isinstance(selected_pose, dict) else None
     conf = (selected_obj or {}).get("confidence") if isinstance(selected_obj, dict) else None
     dims = (selected_obj or {}).get("dimensions") if isinstance(selected_obj, dict) else None
@@ -147,8 +159,10 @@ def main(argv: list[str] | None = None) -> int:
         warnings.append("Selected object missing confidence")
     elif isinstance(conf, (int, float)) and conf < 0.5:
         warnings.append(f"Selected object has low confidence ({conf:.3f} < 0.500)")
-    if pose_frame and pose_frame != "world":
-        warnings.append(f"Selected object pose frame is '{pose_frame}', not 'world'; transform validation not available")
+    if pose_frame and pose_frame != args.target_frame:
+        warnings.append(f"Selected object pose frame is '{pose_frame}', not target planning frame; transform validation not available")
+    if transform_status == "WARN":
+        warnings.append("Object pose transform is WARN; runtime replay is unsafe/not recommended")
     if isinstance(xyz, list) and len(xyz) >= 3 and isinstance(xyz[2], (int, float)) and xyz[2] < 0.0:
         warnings.append(f"Selected object z ({xyz[2]:.4f}) is below conservative table threshold (0.0)")
 
@@ -167,6 +181,10 @@ def main(argv: list[str] | None = None) -> int:
         'selected_object_label': (selected_obj or {}).get('name') if isinstance(selected_obj, dict) else None,
         'selected_object_confidence': conf,
         'object_pose_frame': pose_frame,
+        'object_pose_frame_raw': raw_pose_frame,
+        'object_pose_frame_normalized': pose_frame,
+        'transform_status': transform_status,
+        'transform_message': transform_message,
         'object_xyz': xyz,
         'chosen_destination': acceptance.get('destination_selected'),
         'destination_release_pose': acceptance.get('destination_release_pose'),

--- a/tests/test_capture_epd_detected_objects.py
+++ b/tests/test_capture_epd_detected_objects.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 import unittest
 from unittest.mock import patch
 
-from scripts.capture_epd_detected_objects import convert_epd_message_to_detected_objects, create_qos_profile
+from scripts.capture_epd_detected_objects import (
+    _normalize_pose_with_tf,
+    convert_epd_message_to_detected_objects,
+    create_qos_profile,
+)
 from scripts.validate_detected_objects import validate_detected_objects
 
 
@@ -82,6 +86,20 @@ class CaptureEPDDetectedObjectsTests(unittest.TestCase):
         self.assertEqual(be.kwargs["reliability"], "be")
         self.assertEqual(rel.kwargs["reliability"], "rel")
         self.assertEqual(auto.kwargs["reliability"], "be")
+
+    def test_normalize_pose_helper_pass(self) -> None:
+        obj = {"pose": {"frame_id": "camera_depth_optical_frame", "xyz": [0.1, 0.2, 0.3], "rpy": [0.0, 0.0, 0.0]}}
+
+        def fake_tf(src: str, target: str, xyz: list[float], rpy: list[float], timeout: float):
+            self.assertEqual(src, "camera_depth_optical_frame")
+            self.assertEqual(target, "world")
+            self.assertEqual(timeout, 2.0)
+            return [1.0, 2.0, 3.0], [0.1, 0.2, 0.3], "ok"
+
+        status, message = _normalize_pose_with_tf(obj, "world", 2.0, fake_tf)
+        self.assertEqual(status, "PASS")
+        self.assertEqual(message, "ok")
+        self.assertEqual(obj["pose"]["frame_id"], "world")
 
 
 if __name__ == "__main__":

--- a/tests/test_run_generated_cell_cycle.py
+++ b/tests/test_run_generated_cell_cycle.py
@@ -61,6 +61,9 @@ class RunGeneratedCellCycleTests(unittest.TestCase):
             p=self._run('--scene-package','ur5_2f_test','--task-recipe',str(TASK),'--detected-objects',str(OBJECTS),'--output-dir',td,'--dry-run','--json')
             report=json.loads(p.stdout)
             self.assertIn(report['status'],{'PASS','WARN','FAIL'})
+            self.assertIn('object_pose_frame_raw', report)
+            self.assertIn('object_pose_frame_normalized', report)
+            self.assertIn('transform_status', report)
 
     def test_valid_garbage_offline_cycle_has_no_blockers(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
### Motivation

- Live EPD/D435i captures can produce object poses in camera frames (e.g. `camera_depth_optical_frame`) while downstream planning expects a planning/world frame, so detected poses must be normalized to the planning frame before any replay/execution is trusted.
- The live capture path must fail clearly when TF is missing unless the operator explicitly allows untransformed poses, while offline fixture-based flows must remain unaffected.

### Description

- Added TF normalization to `scripts/capture_epd_detected_objects.py` with new CLI flags `--target-frame`, `--tf-timeout`, `--require-transform`, and `--allow-untransformed` and conservative defaults (`--target-frame world`, `--require-transform`).
- Implemented pose helpers (`_quaternion_from_rpy`, `_rpy_from_quaternion`) and a transform wrapper/helper `_normalize_pose_with_tf` that uses `tf2_ros.Buffer`/`TransformListener` to transform `pose.xyz` and `pose.rpy` into the target frame and writes `raw_pose` (original frame) alongside the normalized `pose`.
- Emit transform metadata under `payload['source']['transform']` including `requested_target_frame`, `status` (PASS/WARN/FAIL), `source_frame`, `target_frame`, `message`, and `tf_listener_ready`.
- Plumbed TF CLI options through `scripts/run_generated_cell_cycle.py` so live-capture subprocess calls pass TF options and implemented conservative failure behavior (FAIL when transform required but unavailable; `--allow-untransformed` yields WARN and explicit unsafe notice).
- Augmented the generated-cell cycle report with `object_pose_frame_raw`, `object_pose_frame_normalized`, `transform_status`, and `transform_message`, and added a WARN message when transforms are WARN/unsafe.
- Kept offline fixtures unchanged and only require TF for the live capture path.
- Updated documentation `docs/manuals/REAL_D435I_EPD_PIPELINE.md` with a "Verify TF from camera to world" section and example `tf2_echo` commands and guidance on `--require-transform`/`--allow-untransformed` usage.

### Testing

- Ran static compile checks with `python3 -m py_compile scripts/capture_epd_detected_objects.py scripts/run_generated_cell_cycle.py` and it succeeded.
- Ran the test suite targeted for the live/workflow smoke path with `PYTHONPATH=$PWD python3 -m pytest -q tests/test_workcell_discovery.py tests/test_run_cell_cycle_panel.py tests/test_run_generated_cell_cycle.py tests/test_capture_epd_detected_objects.py tests/test_generated_cell_acceptance.py tests/test_replay_emd_bridge_payload.py` and all tests passed (`40 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36d3391248331b5c5aade54a7a0c0)