### PR TITLE
Add conservative cell readiness preflight checker and operator panel integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This package was tested with [easy_perception_deployment](https://github.com/ros
 - EMD grasp bridge payload manual: `docs/manuals/EMD_GRASP_BRIDGE_PAYLOAD.md`
 - Detected objects snapshot manual: `docs/manuals/DETECTED_OBJECTS_V1.md`
 - Real D435i + EPD pipeline manual: `docs/manuals/REAL_D435I_EPD_PIPELINE.md`
+- Cell readiness preflight manual: `docs/manuals/CELL_READINESS_PREFLIGHT.md`
 - Validation-only preflight helper:
 
 ```bash

--- a/docs/manuals/CELL_READINESS_PREFLIGHT.md
+++ b/docs/manuals/CELL_READINESS_PREFLIGHT.md
@@ -1,0 +1,48 @@
+# Cell Readiness Preflight
+
+## 1) Offline preflight
+Run:
+
+```bash
+python3 scripts/run_cell_readiness_check.py \
+  --scene-package ur5_2f_test \
+  --task-recipe tests/fixtures/task_recipes/valid_garbage_sorting.yaml \
+  --detected-objects tests/fixtures/detected_objects/valid_epd_garbage_sorting.yaml \
+  --json
+```
+
+Offline mode validates scene discovery, task recipe, detected objects (if provided), and generated-cell dry-run validation. ROS camera/EPD topics are not required.
+
+## 2) Live D435i/EPD preflight
+Run:
+
+```bash
+python3 scripts/run_cell_readiness_check.py \
+  --scene-package ur5_2f_test \
+  --task-recipe tests/fixtures/task_recipes/valid_garbage_sorting.yaml \
+  --live --check-ros-topics --json
+```
+
+Live mode requires D435i camera topics and the EPD output topic.
+
+## 3) TF camera-to-world check
+Add TF enforcement for live readiness:
+
+```bash
+--check-tf --target-frame world --camera-frame camera_depth_optical_frame
+```
+
+If TF camera → world is missing, preflight returns `FAIL` with a blocker.
+
+## 4) PASS / WARN / FAIL
+- **PASS**: ready for the next requested stage.
+- **WARN**: usable for diagnostics only; do not trust for motion.
+- **FAIL**: blocked; resolve blockers before replay/simulation/commissioning.
+
+## 5) Before enabling replay or motion
+- Keep generated-cycle checks in dry-run/no-motion mode first.
+- Resolve all preflight blockers.
+- Resolve warnings for any stage involving physical motion.
+- Do not publish robot motion commands from preflight.
+
+The operator panel includes a **Run Preflight Check** button that runs this script and prints blockers/warnings.

--- a/scripts/run_cell_cycle_panel.py
+++ b/scripts/run_cell_cycle_panel.py
@@ -84,6 +84,26 @@ def build_cycle_command(config: dict[str, Any]) -> list[str]:
     return cmd
 
 
+
+
+def build_preflight_command(config: dict[str, Any]) -> list[str]:
+    script = Path(__file__).resolve().parent / "run_cell_readiness_check.py"
+    cmd = [
+        sys.executable, str(script),
+        "--scene-package", config["scene_package"],
+        "--task-recipe", config["task_recipe"],
+        "--epd-topic", config["epd_topic"],
+        "--target-frame", config.get("target_frame", "world"),
+        "--camera-frame", config.get("camera_frame", "camera_depth_optical_frame"),
+        "--check-ros-topics",
+        "--json",
+    ]
+    if config.get("detected_objects"):
+        cmd += ["--detected-objects", config["detected_objects"]]
+    if config.get("capture_live"):
+        cmd += ["--live", "--check-tf"]
+    return cmd
+
 def parse_cycle_report(output_dir: Path) -> CycleReportSummary:
     report_path = output_dir / "cycle_report.json"
     generated = {
@@ -123,6 +143,7 @@ class CellCyclePanel:
         self.json_output = tk.BooleanVar(value=True)
         self.show_dev_fixtures = tk.BooleanVar(value=False)
         self.status = tk.StringVar(value="Status: idle")
+        self.preflight_btn: ttk.Button | None = None
 
         self.discovery_data = {"scenes": [], "task_recipes": [], "detected_objects": []}
         self._build_ui()
@@ -175,8 +196,10 @@ class CellCyclePanel:
         row += 1
 
         self.run_btn = ttk.Button(frm, text="Run live dry-run cycle", command=self.run_cycle)
+        self.preflight_btn = ttk.Button(frm, text="Run Preflight Check", command=self.run_preflight)
         ttk.Button(frm, text="Refresh discovery", command=self.refresh_discovery).grid(row=row, column=2, sticky="ew", pady=6)
         self.run_btn.grid(row=row, column=0, sticky="ew", pady=6)
+        self.preflight_btn.grid(row=row, column=1, sticky="w", padx=4)
         ttk.Button(frm, text="Capture live snapshot only", command=self.capture_only).grid(row=row, column=1, sticky="w")
         row += 1
         ttk.Button(frm, text="Open Output Folder", command=self.open_output).grid(row=row, column=1, sticky="w")
@@ -262,6 +285,26 @@ class CellCyclePanel:
 
         threading.Thread(target=worker, daemon=True).start()
 
+
+    def run_preflight(self) -> None:
+        cfg = self._config()
+        cmd = build_preflight_command(cfg)
+        self._append("\n$ " + " ".join(cmd) + "\n")
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        output = (proc.stdout or "") + (proc.stderr or "")
+        self._append(output)
+        try:
+            payload = json.loads(proc.stdout) if proc.stdout.strip().startswith("{") else {}
+            status = payload.get("status", "FAIL")
+            blockers = payload.get("blockers") or []
+            warns = payload.get("warnings") or []
+            if blockers:
+                self._append("Blockers:\n" + "\n".join(f"- {b}" for b in blockers) + "\n")
+            if warns:
+                self._append("Warnings:\n" + "\n".join(f"- {w}" for w in warns) + "\n")
+            self.status.set(f"Status: {status} (preflight)")
+        except Exception:
+            self.status.set("Status: FAIL (preflight parse)")
 
     def capture_only(self) -> None:
         out = Path(self.output_dir.get().strip()) / "detected_objects_live.yaml"

--- a/scripts/run_cell_readiness_check.py
+++ b/scripts/run_cell_readiness_check.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from run_generated_cell_acceptance import run_acceptance
+from validate_detected_objects import _load_yaml_or_json
+from workcell_discovery import discover_all
+
+
+def _check_topic_exists(topic: str) -> bool:
+    proc = subprocess.run(["ros2", "topic", "list"], capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        return False
+    topics = {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+    return topic in topics
+
+
+def _check_tf_available(target_frame: str, camera_frame: str) -> bool:
+    proc = subprocess.run(
+        ["ros2", "run", "tf2_ros", "tf2_echo", target_frame, camera_frame, "--once"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=8,
+    )
+    return proc.returncode == 0
+
+
+def _status_rank(status: str) -> int:
+    return {"PASS": 0, "WARN": 1, "FAIL": 2}.get(status, 2)
+
+
+def _set_check(checks: dict[str, dict[str, str]], name: str, status: str, message: str, blockers: list[str], warnings: list[str]) -> None:
+    checks[name] = {"status": status, "message": message}
+    if status == "FAIL":
+        blockers.append(f"{name}: {message}")
+    elif status == "WARN":
+        warnings.append(f"{name}: {message}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Conservative generated-cell readiness preflight checker")
+    p.add_argument("--scene-package", required=True)
+    p.add_argument("--task-recipe", type=Path, required=True)
+    p.add_argument("--detected-objects", type=Path)
+    p.add_argument("--live", action="store_true")
+    p.add_argument("--epd-topic", default="/easy_perception_deployment/epd_localize_output")
+    p.add_argument("--camera-rgb-topic", default="/camera/camera/color/image_raw")
+    p.add_argument("--camera-depth-topic", default="/camera/camera/aligned_depth_to_color/image_raw")
+    p.add_argument("--camera-info-topic", default="/camera/camera/color/camera_info")
+    p.add_argument("--pointcloud-topic", default="/camera/camera/depth/color/points")
+    p.add_argument("--target-frame", default="world")
+    p.add_argument("--camera-frame", default="camera_depth_optical_frame")
+    p.add_argument("--check-tf", action="store_true")
+    p.add_argument("--check-ros-topics", action="store_true")
+    p.add_argument("--check-runtime", action="store_true")
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args(argv)
+
+    checks: dict[str, dict[str, str]] = {}
+    blockers: list[str] = []
+    warnings: list[str] = []
+
+    scenes = {s["package_name"] for s in discover_all().get("scenes", [])}
+    if args.scene_package in scenes:
+        _set_check(checks, "scene_discovery", "PASS", "Scene package discovered.", blockers, warnings)
+    else:
+        _set_check(checks, "scene_discovery", "FAIL", f"Scene package '{args.scene_package}' was not discovered.", blockers, warnings)
+
+    if not args.task_recipe.exists():
+        _set_check(checks, "task_recipe", "FAIL", f"Task recipe not found: {args.task_recipe}", blockers, warnings)
+    else:
+        try:
+            acceptance, _ = run_acceptance(args.scene_package, args.task_recipe, args.detected_objects or args.task_recipe, Path("/tmp/cell_readiness_preflight"), strict=False)
+            if acceptance.get("status") == "FAIL":
+                _set_check(checks, "generated_cycle_dry_run", "FAIL", "Generated-cell dry-run validation failed.", blockers, warnings)
+            else:
+                _set_check(checks, "generated_cycle_dry_run", "PASS", "Generated-cell dry-run validation passed.", blockers, warnings)
+            _set_check(checks, "task_recipe", "PASS", "Task recipe exists and is readable.", blockers, warnings)
+        except Exception as exc:  # noqa: BLE001
+            _set_check(checks, "task_recipe", "FAIL", f"Task recipe validation failed: {exc}", blockers, warnings)
+            _set_check(checks, "generated_cycle_dry_run", "WARN", "Dry-run validation skipped due to task validation failure.", blockers, warnings)
+
+    if args.detected_objects:
+        if not args.detected_objects.exists():
+            _set_check(checks, "detected_objects", "FAIL", f"Detected objects file not found: {args.detected_objects}", blockers, warnings)
+        else:
+            try:
+                data, _, _ = _load_yaml_or_json(args.detected_objects)
+                count = len(data.get("objects", [])) if isinstance(data, dict) and isinstance(data.get("objects"), list) else 0
+                st = "PASS" if count > 0 else "WARN"
+                _set_check(checks, "detected_objects", st, f"Detected objects file is valid with {count} object(s).", blockers, warnings)
+            except Exception as exc:  # noqa: BLE001
+                _set_check(checks, "detected_objects", "FAIL", f"Detected objects validation failed: {exc}", blockers, warnings)
+    else:
+        _set_check(checks, "detected_objects", "PASS", "No detected objects file provided (optional).", blockers, warnings)
+
+    if args.live:
+        need_topic_check = args.check_ros_topics or True
+        if need_topic_check:
+            camera_topics = [args.camera_rgb_topic, args.camera_depth_topic, args.camera_info_topic, args.pointcloud_topic]
+            missing_camera = [t for t in camera_topics if not _check_topic_exists(t)]
+            if missing_camera:
+                _set_check(checks, "camera_topics", "FAIL", f"Missing required camera topics: {missing_camera}", blockers, warnings)
+            else:
+                _set_check(checks, "camera_topics", "PASS", "All required camera topics are visible.", blockers, warnings)
+
+            if _check_topic_exists(args.epd_topic):
+                _set_check(checks, "epd_topic", "PASS", "EPD topic is visible.", blockers, warnings)
+            else:
+                _set_check(checks, "epd_topic", "FAIL", f"Missing required EPD topic: {args.epd_topic}", blockers, warnings)
+
+        if args.check_tf:
+            if _check_tf_available(args.target_frame, args.camera_frame):
+                _set_check(checks, "tf_camera_to_world", "PASS", f"TF available: {args.camera_frame} -> {args.target_frame}", blockers, warnings)
+            else:
+                _set_check(checks, "tf_camera_to_world", "FAIL", f"Missing TF from {args.camera_frame} to {args.target_frame}", blockers, warnings)
+        else:
+            _set_check(checks, "tf_camera_to_world", "WARN", "TF check skipped (enable --check-tf for live execution readiness).", blockers, warnings)
+    else:
+        _set_check(checks, "camera_topics", "PASS", "Offline mode: ROS camera topics not required.", blockers, warnings)
+        _set_check(checks, "epd_topic", "PASS", "Offline mode: EPD topic not required.", blockers, warnings)
+        _set_check(checks, "tf_camera_to_world", "PASS", "Offline mode: TF check not required.", blockers, warnings)
+
+    if args.check_runtime:
+        runtime_ok = _check_topic_exists("/joint_states")
+        _set_check(checks, "runtime_topics", "PASS" if runtime_ok else "WARN", "Runtime topics found." if runtime_ok else "Runtime topics/services are not visible.", blockers, warnings)
+    else:
+        _set_check(checks, "runtime_topics", "PASS", "Runtime checks not requested.", blockers, warnings)
+
+    statuses = [v["status"] for v in checks.values()]
+    overall = "FAIL" if "FAIL" in statuses else ("WARN" if "WARN" in statuses else "PASS")
+    next_action = "Proceed with requested stage." if overall == "PASS" else ("Resolve warnings before trusting motion/replay." if overall == "WARN" else "Resolve blockers before continuing.")
+    report = {
+        "schema_version": "cell_readiness/v1",
+        "status": overall,
+        "scene_package": args.scene_package,
+        "mode": "live" if args.live else "offline",
+        "checks": checks,
+        "blockers": blockers,
+        "warnings": warnings,
+        "next_recommended_action": next_action,
+    }
+    print(json.dumps(report, indent=2, sort_keys=True) if args.json else f"{overall}: {next_action}")
+    return 1 if overall == "FAIL" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_run_cell_readiness_check.py
+++ b/tests/test_run_cell_readiness_check.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import patch
+
+from scripts.run_cell_readiness_check import main
+from scripts.run_cell_cycle_panel import build_preflight_command
+
+
+class ReadinessTests(unittest.TestCase):
+    def test_offline_valid(self):
+        rc = main([
+            "--scene-package", "ur5_2f_test",
+            "--task-recipe", "tests/fixtures/task_recipes/valid_garbage_sorting.yaml",
+            "--detected-objects", "tests/fixtures/detected_objects/valid_epd_garbage_sorting.yaml",
+            "--json",
+        ])
+        self.assertIn(rc, (0,))
+
+    def test_missing_task_recipe_fails(self):
+        rc = main(["--scene-package", "ur5_2f_test", "--task-recipe", "missing.yaml", "--json"])
+        self.assertEqual(rc, 1)
+
+    @patch("scripts.run_cell_readiness_check._check_topic_exists", return_value=False)
+    def test_live_missing_topics_fails(self, _mock):
+        rc = main(["--scene-package", "ur5_2f_test", "--task-recipe", "tests/fixtures/task_recipes/valid_garbage_sorting.yaml", "--live", "--json"])
+        self.assertEqual(rc, 1)
+
+    @patch("scripts.run_cell_readiness_check._check_topic_exists", return_value=True)
+    @patch("scripts.run_cell_readiness_check._check_tf_available", return_value=False)
+    def test_live_missing_tf_fails_when_enabled(self, _tf, _topic):
+        rc = main(["--scene-package", "ur5_2f_test", "--task-recipe", "tests/fixtures/task_recipes/valid_garbage_sorting.yaml", "--live", "--check-tf", "--json"])
+        self.assertEqual(rc, 1)
+
+    def test_preflight_command_generation(self):
+        cmd = build_preflight_command({
+            "scene_package": "ur5_2f_test",
+            "task_recipe": "tests/fixtures/task_recipes/valid_garbage_sorting.yaml",
+            "detected_objects": "tests/fixtures/detected_objects/valid_epd_garbage_sorting.yaml",
+            "capture_live": True,
+            "epd_topic": "/easy_perception_deployment/epd_localize_output",
+        })
+        joined = " ".join(cmd)
+        self.assertIn("run_cell_readiness_check.py", joined)
+        self.assertIn("--scene-package ur5_2f_test", joined)
+        self.assertIn("--live", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a conservative, non-invasive readiness preflight to prevent rushing into physical robot execution by validating generated/live cell readiness before dry-run, replay, simulation, or physical deployment. 
- Surface concise PASS/WARN/FAIL diagnostics and blockers/warnings to operators via the existing operator panel without changing existing GUI or runtime architecture.

### Description
- Add `scripts/run_cell_readiness_check.py` implementing the requested CLI options and producing the structured JSON schema `cell_readiness/v1`, with checks for `scene_discovery`, `task_recipe`, `detected_objects`, `camera_topics`, `epd_topic`, `tf_camera_to_world`, `runtime_topics`, and `generated_cycle_dry_run` plus aggregated `blockers`, `warnings`, and `next_recommended_action`.
- Use existing validations by calling `run_generated_cell_acceptance` and `validate_detected_objects` where appropriate and perform ROS checks via `ros2 topic list` and `tf2_ros tf2_echo` for live-mode validation when requested (no motion/publishing performed).
- Integrate into the operator panel by adding `build_preflight_command(...)`, a **Run Preflight Check** button, and a `run_preflight` handler in `scripts/run_cell_cycle_panel.py` that runs the script, prints JSON output, and displays status, blockers, and warnings; existing panel actions and layout are preserved.
- Add documentation `docs/manuals/CELL_READINESS_PREFLIGHT.md` and a README link, and include new unit tests in `tests/test_run_cell_readiness_check.py` covering offline success, missing task recipe, live missing topics, live missing TF with `--check-tf`, and panel command generation.

### Testing
- Compiled scripts with `python3 -m py_compile` for `scripts/run_cell_readiness_check.py`, `scripts/run_cell_cycle_panel.py`, `scripts/run_generated_cell_cycle.py`, and `scripts/capture_epd_detected_objects.py`, which succeeded.
- Ran the test suite with `PYTHONPATH=$PWD python3 -m pytest -q` including `tests/test_run_cell_readiness_check.py` and related panel/cycle tests, and all tests passed (`45 passed`).
- Manual usage instructions and example commands are provided in `docs/manuals/CELL_READINESS_PREFLIGHT.md` for offline and live checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36e55f0a8833186d05fd7f9d452fc)