### PR TITLE
Improve cell-definition workcell generation UX using existing flow

### DIFF
--- a/cell_definitions/demo_ur5_sorting_cell.yaml
+++ b/cell_definitions/demo_ur5_sorting_cell.yaml
@@ -1,0 +1,85 @@
+schema_version: cell_definition/v1
+cell:
+  id: demo_ur5_sorting_cell
+  name: Demo UR5 Sorting Cell
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: robotiq_2f
+  type: finger
+  brand: robotiq
+  grasp_frame: tool0
+  allowed_touch_links: [left_finger, right_finger]
+camera:
+  id: d435i_overhead
+  type: d435i
+  frame: camera_color_optical_frame
+environment:
+  frame: world
+  support_surfaces:
+    - id: work_table
+      shape: box
+      pose_xyz: [0.60, 0.00, 0.40]
+      pose_rpy: [0.0, 0.0, 0.0]
+      dimensions: [1.20, 0.80, 0.80]
+  assets:
+    - id: plastic_bin
+      shape: box
+      pose_xyz: [0.55, -0.25, 0.84]
+      pose_rpy: [0.0, 0.0, 0.0]
+      dimensions: [0.30, 0.20, 0.14]
+    - id: metal_bin
+      shape: box
+      pose_xyz: [0.55, 0.00, 0.84]
+      pose_rpy: [0.0, 0.0, 0.0]
+      dimensions: [0.30, 0.20, 0.14]
+    - id: reject_bin
+      shape: box
+      pose_xyz: [0.55, 0.25, 0.84]
+      pose_rpy: [0.0, 0.0, 0.0]
+      dimensions: [0.30, 0.20, 0.14]
+objects:
+  - id: spawn_box
+    shape: box
+    pose_xyz: [0.45, 0.00, 0.84]
+    pose_rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.20, 0.20, 0.10]
+    frame: world
+    class: mixed_part
+task:
+  id: demo_sort
+  type: sort_by_class
+  source_object: detected_object
+  destinations:
+    - id: plastic_dest
+      frame: world
+      pose_xyz: [0.55, -0.25, 0.95]
+      pose_rpy: [0.0, 0.0, 0.0]
+    - id: metal_dest
+      frame: world
+      pose_xyz: [0.55, 0.00, 0.95]
+      pose_rpy: [0.0, 0.0, 0.0]
+    - id: reject_dest
+      frame: world
+      pose_xyz: [0.55, 0.25, 0.95]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: to_plastic
+      when:
+        class: plastic
+      destination: plastic_dest
+    - id: to_metal
+      when:
+        class: metal
+      destination: metal_dest
+    - id: fallback_reject
+      when:
+        always: true
+      destination: reject_dest
+commissioning:
+  self_test_enabled: true

--- a/docs/manuals/SCENE_CREATION_WORKFLOW.md
+++ b/docs/manuals/SCENE_CREATION_WORKFLOW.md
@@ -45,6 +45,19 @@ python3 scripts/generate_scene_import_checklist.py path/to/fixture.stl
 python3 scripts/environment_layout_to_scene_checklist.py tests/fixtures/environment_layouts/ur5_table_bins_existing_assets.layout.yaml
 ```
 
+## Create your own environment using cell definitions
+
+Use the existing Workcell Builder + generation flow (no duplicate builder/system).
+
+1. Start from `cell_definitions/demo_ur5_sorting_cell.yaml`.
+2. Edit robot/base scene metadata, table/bin/box/camera frames, and task destinations/rules.
+3. Validate:
+   - `python3 scripts/validate_cell_definition.py --cell-definition cell_definitions/demo_ur5_sorting_cell.yaml --json`
+4. Generate staged workcell package:
+   - `python3 scripts/generate_workcell_from_cell_definition.py --cell-definition cell_definitions/demo_ur5_sorting_cell.yaml --output-dir /tmp/generated_workcells/demo_ur5_sorting_cell --json`
+5. Run preflight and gated dry-run with generated artifacts (no robot motion required).
+6. Only after offline checks pass, continue with simulation/replay commissioning steps.
+
 ## Do not do this
 
 - Do **not** copy the same mesh into multiple folders unnecessarily.

--- a/scripts/run_cell_cycle_panel.py
+++ b/scripts/run_cell_cycle_panel.py
@@ -115,6 +115,16 @@ def build_preflight_command(config: dict[str, Any]) -> list[str]:
         cmd += ["--live", "--check-tf"]
     return cmd
 
+
+def build_validate_cell_definition_command(cell_definition: str) -> list[str]:
+    script = Path(__file__).resolve().parent / "validate_cell_definition.py"
+    return [sys.executable, str(script), "--cell-definition", cell_definition, "--json"]
+
+
+def build_generate_workcell_command(cell_definition: str, output_dir: str) -> list[str]:
+    script = Path(__file__).resolve().parent / "generate_workcell_from_cell_definition.py"
+    return [sys.executable, str(script), "--cell-definition", cell_definition, "--output-dir", output_dir, "--json"]
+
 def parse_cycle_report(output_dir: Path) -> CycleReportSummary:
     report_path = output_dir / "cycle_report.json"
     generated = {

--- a/scripts/validate_cell_definition.py
+++ b/scripts/validate_cell_definition.py
@@ -241,6 +241,21 @@ def _validate_dimensions(summary: ValidationSummary, owner: str, dims: Any) -> N
             summary.errors.append(f"{owner}.dimensions[{idx}] must be a positive number.")
 
 
+def _check_duplicate_ids(summary: ValidationSummary, owner: str, entries: Any) -> None:
+    if not isinstance(entries, list):
+        return
+    seen: set[str] = set()
+    for idx, item in enumerate(entries):
+        if not isinstance(item, dict):
+            continue
+        item_id = item.get("id")
+        if not isinstance(item_id, str) or not item_id.strip():
+            continue
+        if item_id in seen:
+            summary.errors.append(f"Duplicate id '{item_id}' found in {owner}.")
+        seen.add(item_id)
+
+
 def _extract_refs(defn: dict[str, Any]) -> dict[str, Any]:
     robot = defn.get("robot") if isinstance(defn.get("robot"), dict) else {}
     end_effector = defn.get("end_effector") if isinstance(defn.get("end_effector"), dict) else {}
@@ -248,6 +263,8 @@ def _extract_refs(defn: dict[str, Any]) -> dict[str, Any]:
     if not sensors and isinstance(defn.get("camera"), dict) and defn["camera"].get("capability"):
         sensors = [{"capability": defn["camera"].get("capability")}]
     task = defn.get("task") if isinstance(defn.get("task"), dict) else {}
+    if not isinstance(robot.get("model"), str) or not robot.get("model", "").strip():
+        result.errors.append("robot.model must be a non-empty string.")
     environment = defn.get("environment") if isinstance(defn.get("environment"), dict) else {}
     assets = environment.get("assets") if isinstance(environment.get("assets"), list) else []
     return {
@@ -400,6 +417,16 @@ def validate_cell_definition(
                 continue
             _validate_pose(result, f"environment.support_surfaces[{idx}]", surface)
             _validate_dimensions(result, f"environment.support_surfaces[{idx}]", surface.get("dimensions"))
+            if isinstance(surface.get("mesh"), str) and surface.get("mesh").strip():
+                mesh_path = (Path(__file__).resolve().parents[1] / surface.get("mesh")).resolve()
+                if not mesh_path.exists():
+                    result.warnings.append(
+                        f"environment.support_surfaces[{idx}].mesh not found ({surface.get('mesh')}); using primitive collision dimensions only."
+                    )
+            surface_z = surface.get("pose_xyz", [0.0, 0.0, 0.0])[2] if _is_numeric_list(surface.get("pose_xyz"), 3) else None
+            if isinstance(surface_z, (int, float)):
+                max_surface_z = max(result.environment_layout_summary.get("surface_z", [surface_z] + [surface_z]))
+                result.environment_layout_summary["surface_z"] = [max_surface_z]
 
     for idx, obj in enumerate(objects):
         if not isinstance(obj, dict):
@@ -407,6 +434,8 @@ def validate_cell_definition(
             continue
         _validate_pose(result, f"objects[{idx}]", obj)
         _validate_dimensions(result, f"objects[{idx}]", obj.get("dimensions"))
+    _check_duplicate_ids(result, "objects", objects)
+    _check_duplicate_ids(result, "environment.support_surfaces", support_surfaces)
 
     task_type = task.get("type")
     if not isinstance(task_type, str):
@@ -432,6 +461,23 @@ def validate_cell_definition(
             else:
                 destination_ids.add(destination_id)
             _validate_pose(result, f"task.destinations[{idx}]", destination)
+            if _is_numeric_list(destination.get("pose_xyz"), 3):
+                dest_z = destination["pose_xyz"][2]
+                if isinstance(dest_z, (int, float)):
+                    surfaces = environment.get("support_surfaces")
+                    if isinstance(surfaces, list) and surfaces:
+                        top_z = None
+                        for surface in surfaces:
+                            if isinstance(surface, dict) and _is_numeric_list(surface.get("pose_xyz"), 3):
+                                z = surface["pose_xyz"][2]
+                                if isinstance(z, (int, float)):
+                                    top_z = z if top_z is None else max(top_z, z)
+                        if top_z is not None and dest_z < top_z:
+                            result.warnings.append(
+                                f"task.destinations[{idx}] z={dest_z} is below support surface z={top_z}."
+                            )
+        if len(destination_ids) != len([d for d in destinations if isinstance(d, dict) and isinstance(d.get('id'), str) and d.get('id', '').strip()]):
+            result.errors.append("task.destinations contains duplicate destination ids.")
 
     rules = task.get("rules")
     if task_type in SORTING_TASK_TYPES and (not isinstance(rules, list) or not rules):

--- a/scripts/workcell_discovery.py
+++ b/scripts/workcell_discovery.py
@@ -39,6 +39,14 @@ class DetectedObjectsRecord:
     warnings: list[str] = field(default_factory=list)
 
 
+@dataclass
+class CellDefinitionRecord:
+    display_name: str
+    path: str
+    schema_version: str | None
+    warnings: list[str] = field(default_factory=list)
+
+
 def _iter_scene_dirs() -> list[Path]:
     roots = [REPO_ROOT / "install" / "share", REPO_ROOT / "scenes", REPO_ROOT / "src"]
     extra_patterns = [
@@ -158,7 +166,42 @@ def discover_all() -> dict[str, list[dict[str, Any]]]:
         "scenes": [asdict(r) for r in discover_scene_packages()],
         "task_recipes": [asdict(r) for r in discover_task_recipes()],
         "detected_objects": [asdict(r) for r in discover_detected_objects()],
+        "cell_definitions": [asdict(r) for r in discover_cell_definitions()],
+        "generated_workcell_summaries": discover_generated_workcell_summaries(),
     }
+
+
+def discover_cell_definitions() -> list[CellDefinitionRecord]:
+    dirs = [REPO_ROOT / "cell_definitions", REPO_ROOT / "docs/examples"]
+    records: list[CellDefinitionRecord] = []
+    for base in dirs:
+        if not base.exists():
+            continue
+        for path in [*base.rglob("*.yaml"), *base.rglob("*.yml")]:
+            data, err = _load_structured_file(path)
+            if err:
+                records.append(CellDefinitionRecord(path.stem, str(path), None, [f"parse error: {err}"]))
+                continue
+            if not data:
+                continue
+            schema = data.get("schema_version")
+            if schema == "cell_definition/v1":
+                records.append(CellDefinitionRecord(path.stem, str(path), schema, []))
+    return sorted(records, key=lambda r: r.display_name)
+
+
+def discover_generated_workcell_summaries() -> list[dict[str, Any]]:
+    roots = [REPO_ROOT / "generated_workcell", REPO_ROOT / "tests/fixtures/generated_workcell"]
+    results: list[dict[str, Any]] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in root.rglob("summary.json"):
+            data, err = _load_structured_file(path)
+            if err or not data:
+                continue
+            results.append({"path": str(path), "cell_id": data.get("cell_id"), "package_name": data.get("package_name")})
+    return sorted(results, key=lambda x: x["path"])
 
 
 def _print_summary(data: dict[str, list[dict[str, Any]]]) -> None:
@@ -168,6 +211,8 @@ def _print_summary(data: dict[str, list[dict[str, Any]]]) -> None:
     print(f"Scenes found: {len(data['scenes'])}")
     print(f"Task recipes found: {len(data['task_recipes'])}")
     print(f"Detected object fixtures found: {len(data['detected_objects'])}")
+    print(f"Cell definition templates found: {len(data.get('cell_definitions', []))}")
+    print(f"Generated workcell summaries found: {len(data.get('generated_workcell_summaries', []))}")
     print(f"Warnings: {scene_warnings + recipe_warnings + obj_warnings}")
 
 

--- a/tests/test_cell_definition_generation_flow.py
+++ b/tests/test_cell_definition_generation_flow.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.validate_cell_definition import load_yaml, validate_cell_definition
+from scripts.workcell_discovery import discover_all
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEMO = REPO_ROOT / "cell_definitions/demo_ur5_sorting_cell.yaml"
+
+
+class CellDefinitionFlowTests(unittest.TestCase):
+    def test_demo_cell_definition_validates(self):
+        loaded, parser, notes = load_yaml(DEMO)
+        summary = validate_cell_definition(loaded, DEMO, parser, notes)
+        self.assertTrue(summary.ok, msg="\n".join(summary.errors + summary.warnings))
+
+    def test_invalid_dimensions_fail(self):
+        loaded, parser, notes = load_yaml(DEMO)
+        loaded["objects"][0]["dimensions"] = [0.2, -0.1, 0.1]
+        summary = validate_cell_definition(loaded, DEMO, parser, notes)
+        self.assertFalse(summary.ok)
+        self.assertTrue(any("positive number" in e for e in summary.errors))
+
+    def test_duplicate_object_id_fails(self):
+        loaded, parser, notes = load_yaml(DEMO)
+        loaded["objects"].append(dict(loaded["objects"][0]))
+        summary = validate_cell_definition(loaded, DEMO, parser, notes)
+        self.assertFalse(summary.ok)
+        self.assertTrue(any("Duplicate id" in e for e in summary.errors))
+
+    def test_missing_destination_fails(self):
+        loaded, parser, notes = load_yaml(DEMO)
+        loaded["task"]["destinations"] = []
+        summary = validate_cell_definition(loaded, DEMO, parser, notes)
+        self.assertFalse(summary.ok)
+        self.assertTrue(any("task.destinations" in e for e in summary.errors))
+
+    def test_discovery_finds_cell_definition_template(self):
+        payload = discover_all()
+        self.assertTrue(any("demo_ur5_sorting_cell" in c["path"] for c in payload["cell_definitions"]))
+
+    def test_no_duplicate_assets_or_scenes_dirs_created(self):
+        self.assertTrue((REPO_ROOT / "assets").is_dir())
+        self.assertTrue((REPO_ROOT / "scenes").is_dir())
+        self.assertFalse((REPO_ROOT / "assets_2").exists())
+        self.assertFalse((REPO_ROOT / "scenes_2").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_cell_cycle_panel.py
+++ b/tests/test_run_cell_cycle_panel.py
@@ -6,7 +6,14 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.run_cell_cycle_panel import DEFAULTS, build_cycle_command, build_gated_cycle_command, parse_cycle_report
+from scripts.run_cell_cycle_panel import (
+    DEFAULTS,
+    build_cycle_command,
+    build_gated_cycle_command,
+    build_generate_workcell_command,
+    build_validate_cell_definition_command,
+    parse_cycle_report,
+)
 from scripts.workcell_discovery import discover_all
 
 
@@ -103,6 +110,13 @@ class RunCellCyclePanelTests(unittest.TestCase):
         self.assertIn('--preflight-live', cmd)
         self.assertIn('--preflight-check-tf', cmd)
         self.assertIn('--preflight-check-ros-topics', cmd)
+
+    def test_panel_cell_definition_commands(self):
+        vcmd = build_validate_cell_definition_command("cell_definitions/demo_ur5_sorting_cell.yaml")
+        gcmd = build_generate_workcell_command("cell_definitions/demo_ur5_sorting_cell.yaml", "/tmp/generated_workcells/demo")
+        self.assertIn("validate_cell_definition.py", " ".join(vcmd))
+        self.assertIn("--cell-definition", vcmd)
+        self.assertIn("generate_workcell_from_cell_definition.py", " ".join(gcmd))
 
 
 if __name__ == "__main__":

--- a/tests/test_workcell_discovery.py
+++ b/tests/test_workcell_discovery.py
@@ -24,6 +24,7 @@ class WorkcellDiscoveryTests(unittest.TestCase):
         payload = discover_all()
         json.dumps(payload)
         self.assertIn("scenes", payload)
+        self.assertIn("cell_definitions", payload)
 
     def test_summary_mode_does_not_crash(self):
         script = Path(__file__).resolve().parents[1] / "scripts/workcell_discovery.py"


### PR DESCRIPTION
### Motivation
- Make it easier for beginners to author a full robotic cell using the existing Workcell Builder + generation scripts without adding a second builder/scene system. 
- Provide a simple, user-friendly cell-definition template and stronger validation so generated artifacts plug cleanly into the existing preflight/dry-run flow.

### Description
- Added a beginner-friendly cell definition template at `cell_definitions/demo_ur5_sorting_cell.yaml` describing robot/scene base, table, plastic/metal/reject bins, optional spawn box, D435i camera frame, destinations, and task defaults compatible with the existing generators.
- Extended `scripts/validate_cell_definition.py` to add guardrails: duplicate ID detection, required `robot.model`, destination-below-support-surface warnings, missing-mesh warnings (primitive-collision fallback guidance), and duplicate destination id checks.
- Extended `scripts/workcell_discovery.py` to discover `cell_definition/v1` templates and generated workcell summaries and to include these in JSON/summary outputs.
- Added thin operator-panel command builders in `scripts/run_cell_cycle_panel.py` for `Validate Cell Definition` and `Generate Workcell From Cell Definition` without replacing the GUI.
- Updated docs `docs/manuals/SCENE_CREATION_WORKFLOW.md` with a “Create your own environment using cell definitions” section that uses the existing flow and commands.
- Added automated tests exercising the augmented flow: `tests/test_cell_definition_generation_flow.py` plus small updates to discovery/panel tests to assert new behavior; no new parallel scene/asset folders are created.
- Kept existing workcell_builder, generation scripts and assets as the source of truth and ensured the example is compatible with `generate_workcell_from_cell_definition.py`.

### Testing
- Compiled the key scripts with `python3 -m py_compile` which succeeded for the modified scripts.
- Ran the automated test suite with `PYTHONPATH=$PWD python3 -m pytest -q tests/test_workcell_discovery.py tests/test_run_cell_cycle_panel.py tests/test_run_generated_cell_cycle.py tests/test_run_cell_readiness_check.py tests/test_cell_definition_generation_flow.py` and all tests passed.
- Manually generated the demo workcell using `scripts/generate_workcell_from_cell_definition.py` (with `--package-name` and `--force`) and verified a generated package and generated artifacts were written to `/tmp/generated_workcells/demo_ur5_sorting_cell`.
- Ran a gated dry-run preflight on the generated task recipe which produced a preflight FAIL/SKIPPED cycle as expected for this uncommissioned demo environment (no robot motion performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37334286c833186d3100e08f573af)