### PR TITLE
Add generated workcell bundle outputs and gated dry-run runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1371,3 +1371,11 @@ ros2 launch new_scene demo.launch.py
 6. Do not proceed to replay/motion unless all blockers are clear
 
 This path is dry-run only and never executes robot motion.
+
+## Generate and test your own workcell bundle
+1. Edit `cell_definitions/demo_ur5_sorting_cell.yaml`.
+2. Generate package: `python3 scripts/generate_workcell_from_cell_definition.py cell_definitions/demo_ur5_sorting_cell.yaml --output-dir /tmp/generated_workcells --package-name demo_ur5_sorting_cell --force`.
+3. Run gated dry-run: `python3 scripts/run_generated_workcell_bundle.py --workcell /tmp/generated_workcells/demo_ur5_sorting_cell --gated-dry-run --json`.
+4. Read PASS/WARN/FAIL in `bundle_run_report.json` and `cell_cycle_gated_report.json`.
+5. Do not proceed to robot motion (dry-run/preflight only).
+6. Future Studio flow will generate this cell definition visually.

--- a/docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md
+++ b/docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md
@@ -394,3 +394,6 @@ Expected outcome:
 6. Do not proceed to replay/motion unless all blockers are clear
 
 This path is dry-run only and never executes robot motion.
+
+## Generate and test your own workcell bundle
+Generated packages now include `generated/generated_workcell_summary.json`, detected-object example, environment objects, destinations export, and an executable gated dry-run command script. Use `scripts/run_generated_workcell_bundle.py` for PASS/WARN/FAIL dry-run validation.

--- a/docs/manuals/SCENE_CREATION_WORKFLOW.md
+++ b/docs/manuals/SCENE_CREATION_WORKFLOW.md
@@ -71,3 +71,6 @@ Use the existing Workcell Builder + generation flow (no duplicate builder/system
 This workflow/manual improves authoring readiness only.
 
 It does not change runtime ROS 2, MoveIt, grasp, perception, or controller behavior.
+
+## Generate and test your own workcell bundle
+Use `generate_workcell_from_cell_definition.py` then run `run_generated_workcell_bundle.py --gated-dry-run --json` to execute preflight + gated dry-run with generated defaults only; robot motion remains disabled.

--- a/scripts/generate_workcell_from_cell_definition.py
+++ b/scripts/generate_workcell_from_cell_definition.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import copy
 import importlib.util
+import json
 import shutil
 import sys
 import tempfile
@@ -267,6 +268,81 @@ def _write_validation_report(report_path: Path, manifest: dict[str, Any], scene_
     report_path.write_text("\n".join(lines), encoding="utf-8")
 
 
+def _build_detected_objects_example(cell_def: dict[str, Any], task_recipe: dict[str, Any]) -> dict[str, Any]:
+    planning_frame = str((cell_def.get("cell", {}) or {}).get("planning_frame", "world"))
+    rules = task_recipe.get("decision_rules", []) if isinstance(task_recipe.get("decision_rules"), list) else []
+    matched = {}
+    for rule in rules:
+        when = rule.get("when", {}) if isinstance(rule, dict) and isinstance(rule.get("when"), dict) else {}
+        if any(when.get(k) for k in ("class", "label", "colour", "color", "material")):
+            matched = when
+            break
+    support_surfaces = cell_def.get("support_surfaces", []) if isinstance(cell_def.get("support_surfaces"), list) else []
+    first_surface = support_surfaces[0] if support_surfaces and isinstance(support_surfaces[0], dict) else {}
+    surface_pose = first_surface.get("pose", {}) if isinstance(first_surface.get("pose"), dict) else {}
+    surface_dims = first_surface.get("dimensions", [1.0, 1.0, 0.2]) if isinstance(first_surface.get("dimensions"), list) else [1.0, 1.0, 0.2]
+    sx, sy, sz = (surface_dims + [1.0, 1.0, 0.2])[:3]
+    pose_xyz = surface_pose.get("xyz", [0.5, 0.0, 0.75]) if isinstance(surface_pose.get("xyz"), list) else [0.5, 0.0, 0.75]
+    object_pose = [float(pose_xyz[0]), float(pose_xyz[1]), float(pose_xyz[2]) + max(float(sz) * 0.5, 0.05)]
+    return {
+        "schema_version": "detected_objects/v1",
+        "scene_id": str((cell_def.get("cell", {}) or {}).get("id", "generated_scene")),
+        "source": {"type": "generated_example", "note": "offline-safe example for gated dry-run"},
+        "objects": [
+            {
+                "name": "generated_example_object_1",
+                "class": matched.get("class", "box"),
+                "label": matched.get("label", matched.get("class", "demo_item")),
+                "colour": matched.get("colour", matched.get("color", "blue")),
+                "material": matched.get("material", "plastic"),
+                "confidence": 0.9,
+                "dimensions": [max(0.03, float(sx) * 0.1), max(0.03, float(sy) * 0.1), 0.05],
+                "pose": {"frame_id": planning_frame, "position": object_pose, "orientation_rpy": [0.0, 0.0, 0.0]},
+            }
+        ],
+    }
+
+
+def _build_destinations_export(task_recipe: dict[str, Any]) -> dict[str, Any]:
+    out = {"schema_version": "generated_destinations/v1", "destinations": []}
+    for dst in task_recipe.get("destinations", []):
+        if not isinstance(dst, dict):
+            continue
+        pose = dst.get("pose", {}) if isinstance(dst.get("pose"), dict) else {}
+        out["destinations"].append(
+            {
+                "id": dst.get("id"),
+                "frame": pose.get("frame", "world"),
+                "pose_xyz": pose.get("xyz", [0.0, 0.0, 0.0]),
+                "pose_rpy": pose.get("rpy", [0.0, 0.0, 0.0]),
+                "role": dst.get("role"),
+                "linked_environment_object": dst.get("environment_object"),
+            }
+        )
+    return out
+
+
+def _build_environment_objects(cell_def: dict[str, Any]) -> dict[str, Any]:
+    objects = []
+    for key, role in [("support_surfaces", "support_surface"), ("environment", "environment"), ("assets", "asset"), ("objects", "object")]:
+        entries = cell_def.get(key, []) if isinstance(cell_def.get(key), list) else []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            objects.append(
+                {
+                    "id": entry.get("id", entry.get("name")),
+                    "type": entry.get("type", key.rstrip("s")),
+                    "role": entry.get("role", role),
+                    "dimensions": entry.get("dimensions"),
+                    "pose": entry.get("pose"),
+                    "primitive_fallback": entry.get("primitive", {"shape": "box"}),
+                    "mesh": entry.get("mesh") or entry.get("mesh_path"),
+                }
+            )
+    return {"schema_version": "environment_objects/v1", "objects": objects}
+
+
 def _run_optional_bundle_export(
     bundle_exporter: Any,
     package_name: str,
@@ -396,6 +472,52 @@ def generate_package(
             plan_generator.OUTPUT_DIR = original_plan_dir
 
     _write_validation_report(package_dir / "generated" / "validation_report.md", scene_manifest, scene_contract, dry_result)
+
+    generated_dir = package_dir / "generated"
+    detected_example_path = generated_dir / "generated_detected_objects_example.yaml"
+    env_objects_path = generated_dir / "generated_environment_objects.yaml"
+    destinations_path = generated_dir / "generated_destinations.yaml"
+    summary_path = generated_dir / "generated_workcell_summary.json"
+    command_script_path = generated_dir / "generated_gated_dry_run_command.sh"
+    detected_example = _build_detected_objects_example(loaded, task_recipe)
+    env_objects = _build_environment_objects(loaded)
+    destinations = _build_destinations_export(task_recipe)
+    detected_example_path.write_text(_yaml_text_from(scene_generator, detected_example), encoding="utf-8")
+    env_objects_path.write_text(_yaml_text_from(scene_generator, env_objects), encoding="utf-8")
+    destinations_path.write_text(_yaml_text_from(scene_generator, destinations), encoding="utf-8")
+    preflight_cmd = (
+        f"python3 scripts/run_cell_readiness_check.py --scene-package {package_name} "
+        f"--task-recipe {task_recipe_path} --detected-objects {detected_example_path} --json"
+    )
+    gated_cmd = (
+        f"python3 scripts/run_generated_cell_cycle.py --scene-package {package_name} "
+        f"--task-recipe {task_recipe_path} --detected-objects {detected_example_path} "
+        f"--output-dir /tmp/{package_name}_gated_dry_run --min-objects 1 --once --dry-run --no-replay --require-preflight --json"
+    )
+    summary_payload = {
+        "schema_version": "generated_workcell_bundle/v1",
+        "package_name": package_name,
+        "source_cell_definition": str(cell_definition_path),
+        "scene_package": package_name,
+        "planning_frame": str((loaded.get("cell", {}) or {}).get("planning_frame", "world")),
+        "robot": loaded.get("robot", {}),
+        "end_effector": loaded.get("end_effector", {}),
+        "camera": loaded.get("camera", {}),
+        "task_recipe_path": str(task_recipe_path),
+        "detected_objects_example_path": str(detected_example_path),
+        "environment_objects_path": str(env_objects_path),
+        "destinations_path": str(destinations_path),
+        "warnings": warnings,
+        "blockers": [],
+        "recommended_commands": {"preflight": preflight_cmd, "gated_dry_run": gated_cmd},
+    }
+    summary_path.write_text(json.dumps(summary_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    command_script_path.write_text(
+        "#!/usr/bin/env bash\nset -euo pipefail\n\n"
+        f"cd {REPO_ROOT}\n{gated_cmd}\n",
+        encoding="utf-8",
+    )
+    command_script_path.chmod(0o755)
 
     commissioning = loaded.get("commissioning", {}) if isinstance(loaded.get("commissioning"), dict) else {}
     if bool(commissioning.get("export_bundle", False)):

--- a/scripts/run_cell_cycle_panel.py
+++ b/scripts/run_cell_cycle_panel.py
@@ -125,6 +125,14 @@ def build_generate_workcell_command(cell_definition: str, output_dir: str) -> li
     script = Path(__file__).resolve().parent / "generate_workcell_from_cell_definition.py"
     return [sys.executable, str(script), "--cell-definition", cell_definition, "--output-dir", output_dir, "--json"]
 
+
+def build_run_generated_workcell_bundle_command(workcell_path: str, output_dir: str | None = None) -> list[str]:
+    script = Path(__file__).resolve().parent / "run_generated_workcell_bundle.py"
+    cmd = [sys.executable, str(script), "--workcell", workcell_path, "--gated-dry-run", "--dry-run", "--no-replay", "--json"]
+    if output_dir:
+        cmd += ["--output-dir", output_dir]
+    return cmd
+
 def parse_cycle_report(output_dir: Path) -> CycleReportSummary:
     report_path = output_dir / "cycle_report.json"
     generated = {

--- a/scripts/run_generated_workcell_bundle.py
+++ b/scripts/run_generated_workcell_bundle.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, subprocess, sys
+from pathlib import Path
+
+
+def _load_summary(workcell: Path) -> dict:
+    path = workcell / "generated" / "generated_workcell_summary.json"
+    if not path.exists():
+        raise SystemExit(f"FAIL: missing generated summary: {path}")
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def build_command(summary: dict, output_dir: Path, dry_run: bool, no_replay: bool, gated: bool, as_json: bool) -> list[str]:
+    cmd = [sys.executable, str(Path(__file__).resolve().parent / 'run_generated_cell_cycle.py'), '--scene-package', summary['scene_package'], '--task-recipe', summary['task_recipe_path'], '--detected-objects', summary['detected_objects_example_path'], '--output-dir', str(output_dir), '--min-objects', '1', '--once']
+    if dry_run:
+        cmd.append('--dry-run')
+    if no_replay:
+        cmd.append('--no-replay')
+    if gated:
+        cmd.append('--require-preflight')
+    if as_json:
+        cmd.append('--json')
+    return cmd
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description='Run generated workcell bundle gated dry-run')
+    p.add_argument('--workcell', type=Path, required=True)
+    p.add_argument('--output-dir', type=Path)
+    p.add_argument('--gated-dry-run', action='store_true')
+    p.add_argument('--dry-run', action='store_true', default=True)
+    p.add_argument('--no-replay', action='store_true', default=True)
+    p.add_argument('--json', action='store_true')
+    args = p.parse_args(argv)
+    summary = _load_summary(args.workcell)
+    detected = Path(summary.get('detected_objects_example_path', ''))
+    if not detected.exists():
+        raise SystemExit(f"FAIL: missing detected objects example: {detected}")
+    out = args.output_dir or (args.workcell / 'generated' / 'bundle_run')
+    out.mkdir(parents=True, exist_ok=True)
+    cmd = build_command(summary, out, args.dry_run, args.no_replay, args.gated_dry_run, args.json)
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    payload = {'status': 'FAIL', 'stdout': proc.stdout, 'stderr': proc.stderr, 'command': cmd}
+    if args.json and proc.stdout.strip():
+        try:
+            payload = json.loads(proc.stdout)
+        except Exception:
+            pass
+    (out / 'bundle_run_report.json').write_text(json.dumps(payload, indent=2, sort_keys=True)+'\n', encoding='utf-8')
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(proc.stdout if proc.stdout else proc.stderr)
+    return proc.returncode
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/workcell_discovery.py
+++ b/scripts/workcell_discovery.py
@@ -196,11 +196,22 @@ def discover_generated_workcell_summaries() -> list[dict[str, Any]]:
     for root in roots:
         if not root.exists():
             continue
-        for path in root.rglob("summary.json"):
+        for path in [*root.rglob("summary.json"), *root.rglob("generated_workcell_summary.json")]:
             data, err = _load_structured_file(path)
             if err or not data:
                 continue
-            results.append({"path": str(path), "cell_id": data.get("cell_id"), "package_name": data.get("package_name")})
+            results.append(
+                {
+                    "path": str(path),
+                    "cell_id": data.get("cell_id"),
+                    "package_name": data.get("package_name"),
+                    "task_recipe_path": data.get("task_recipe_path"),
+                    "detected_objects_example_path": data.get("detected_objects_example_path"),
+                    "warnings": data.get("warnings", []),
+                    "blockers": data.get("blockers", []),
+                    "status": "FAIL" if data.get("blockers") else ("WARN" if data.get("warnings") else "PASS"),
+                }
+            )
     return sorted(results, key=lambda x: x["path"])
 
 

--- a/tests/test_generated_workcell_bundle.py
+++ b/tests/test_generated_workcell_bundle.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json, tempfile, unittest
+from pathlib import Path
+
+from scripts.generate_workcell_from_cell_definition import generate_package
+from scripts.run_generated_workcell_bundle import build_command
+from scripts.run_cell_cycle_panel import build_run_generated_workcell_bundle_command
+from scripts.validate_detected_objects import _load_yaml_or_json
+from scripts.workcell_discovery import discover_generated_workcell_summaries
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEMO = REPO_ROOT / 'cell_definitions/demo_ur5_sorting_cell.yaml'
+
+
+class GeneratedWorkcellBundleTests(unittest.TestCase):
+    def test_bundle_files_created_and_detected_valid(self):
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td)
+            rc = generate_package(DEMO, out, 'demo_ur5_sorting_cell', force=True, dry_run=False)
+            self.assertEqual(rc, 0)
+            pkg = out / 'demo_ur5_sorting_cell' / 'generated'
+            for name in ['generated_workcell_summary.json','generated_detected_objects_example.yaml','generated_environment_objects.yaml','generated_destinations.yaml','generated_gated_dry_run_command.sh']:
+                self.assertTrue((pkg / name).exists(), name)
+            data, _, _ = _load_yaml_or_json(pkg / 'generated_detected_objects_example.yaml')
+            self.assertEqual(data.get('schema_version'), 'detected_objects/v1')
+            cmd_txt = (pkg / 'generated_gated_dry_run_command.sh').read_text(encoding='utf-8')
+            self.assertIn('--require-preflight', cmd_txt)
+            self.assertIn('--dry-run', cmd_txt)
+            self.assertIn('--no-replay', cmd_txt)
+
+    def test_run_bundle_build_command(self):
+        summary = {
+            'scene_package': 'demo',
+            'task_recipe_path': '/tmp/a/task.yaml',
+            'detected_objects_example_path': '/tmp/a/detected.yaml',
+        }
+        cmd = build_command(summary, Path('/tmp/out'), True, True, True, True)
+        self.assertIn('--require-preflight', cmd)
+        self.assertIn('--dry-run', cmd)
+        self.assertIn('--no-replay', cmd)
+
+    def test_missing_summary_fails_clearly(self):
+        script = REPO_ROOT / 'scripts/run_generated_workcell_bundle.py'
+        with tempfile.TemporaryDirectory() as td:
+            import subprocess, sys
+            p = subprocess.run([sys.executable, str(script), '--workcell', td, '--gated-dry-run', '--json'], capture_output=True, text=True, check=False)
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn('missing generated summary', p.stderr + p.stdout)
+
+    def test_panel_bundle_command_builder(self):
+        cmd = build_run_generated_workcell_bundle_command('/tmp/generated/demo')
+        self.assertIn('run_generated_workcell_bundle.py', ' '.join(cmd))
+
+    def test_discovery_generated_bundle_shape(self):
+        summaries = discover_generated_workcell_summaries()
+        self.assertIsInstance(summaries, list)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Make generated workcell packages immediately usable for discovery, preflight, and gated dry-run without manual hunting for files and commands. 
- Provide a machine-readable summary and safe offline fixtures so generated packages plug into existing tooling and operator panel flows while remaining dry-run only.

### Description
- Extend `scripts/generate_workcell_from_cell_definition.py` to write `generated/` artifacts: `generated_workcell_summary.json`, `generated_detected_objects_example.yaml`, `generated_environment_objects.yaml`, `generated_destinations.yaml`, and an executable `generated_gated_dry_run_command.sh`, and populate `recommended_commands` and bundle metadata (robot/ee/camera, paths, warnings/blockers).
- Add `scripts/run_generated_workcell_bundle.py` which loads the bundle summary, validates presence of required files, constructs a safe gated dry-run command (defaults to `--dry-run` and `--no-replay`), runs the existing `run_generated_cell_cycle.py` and writes `bundle_run_report.json` with PASS/WARN/FAIL semantics.
- Update `scripts/workcell_discovery.py` to detect `generated/generated_workcell_summary.json` and surface `package_name`, `task_recipe_path`, `detected_objects_example_path`, `warnings`, `blockers`, and a derived `status` while preserving existing discovery output.
- Add a thin operator-panel helper in `scripts/run_cell_cycle_panel.py` via `build_run_generated_workcell_bundle_command(...)` to enable the panel to launch generated bundles without changing the GUI.
- Add tests in `tests/test_generated_workcell_bundle.py` to cover package generation output, detected-object example validation, generated command flags, missing-summary failure behavior, panel command builder, and discovery shape checks.
- Update docs/README: `README.md`, `docs/manuals/SCENE_CREATION_WORKFLOW.md`, and `docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md` with a short “Generate and test your own workcell bundle” workflow.

### Testing
- Compiled modified scripts: `python3 -m py_compile scripts/generate_scene_from_cell_definition.py scripts/generate_workcell_from_cell_definition.py scripts/run_generated_workcell_bundle.py scripts/workcell_discovery.py scripts/run_generated_cell_cycle.py scripts/run_cell_cycle_panel.py` and compilation succeeded.
- Ran unit/integration test suite for the affected areas with: `PYTHONPATH=$PWD python3 -m pytest -q tests/test_workcell_discovery.py tests/test_run_cell_cycle_panel.py tests/test_run_generated_cell_cycle.py tests/test_run_cell_readiness_check.py tests/test_cell_definition_generation_flow.py tests/test_generated_workcell_bundle.py` and all tests passed (`44 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3765bfd348331a86b835d86744838)