### PR TITLE
Add Developer/Operator role separation, operator launcher, and bundle approval workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1417,3 +1417,12 @@ Studio Lite supports:
 5. Report path inspection/open helpers.
 
 This is a “Studio Lite” step only; fuller drag/drop Studio workflows come later.
+
+
+## Developer Studio vs Operator Runtime
+
+- **Developer Studio (developer/integrator role):** validate cell definitions, generate workcell bundles, preview environment/task flow, run preflight and gated dry-runs, inspect reports.
+- **Operator Runtime (operator role):** load generated bundles (including approved bundles), view summaries, preview environment/task flow, run preflight and gated dry-runs, inspect warnings/blockers/reports.
+- Operator Runtime does **not** expose editing or generation controls and never enables robot motion/replay/controller publishing.
+- Both roles use the same generated bundle format and the same backend scripts (no duplicate scene system, no second planning backend).
+- Bundle approval is an internal workflow marker only, not a safety certification. Physical robot execution remains disabled.

--- a/docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md
+++ b/docs/manuals/MVP1_GENERATED_CELL_ACCEPTANCE.md
@@ -433,3 +433,12 @@ python3 scripts/studio_lite.py
 ```
 
 This is a deliberate Lite step toward a fuller Studio UX later.
+
+
+## Developer Studio vs Operator Runtime
+
+- **Developer Studio (developer/integrator role):** validate cell definitions, generate workcell bundles, preview environment/task flow, run preflight and gated dry-runs, inspect reports.
+- **Operator Runtime (operator role):** load generated bundles (including approved bundles), view summaries, preview environment/task flow, run preflight and gated dry-runs, inspect warnings/blockers/reports.
+- Operator Runtime does **not** expose editing or generation controls and never enables robot motion/replay/controller publishing.
+- Both roles use the same generated bundle format and the same backend scripts (no duplicate scene system, no second planning backend).
+- Bundle approval is an internal workflow marker only, not a safety certification. Physical robot execution remains disabled.

--- a/docs/manuals/SCENE_CREATION_WORKFLOW.md
+++ b/docs/manuals/SCENE_CREATION_WORKFLOW.md
@@ -100,3 +100,12 @@ Studio Lite (`scripts/studio_lite.py`) is the first operator workflow window for
 - Keeps robot motion disabled (`safe_for_robot_motion: false`).
 
 Use Studio Lite for generate/preview/preflight/report inspection while backend authoring stays in Workcell Builder.
+
+
+## Developer Studio vs Operator Runtime
+
+- **Developer Studio (developer/integrator role):** validate cell definitions, generate workcell bundles, preview environment/task flow, run preflight and gated dry-runs, inspect reports.
+- **Operator Runtime (operator role):** load generated bundles (including approved bundles), view summaries, preview environment/task flow, run preflight and gated dry-runs, inspect warnings/blockers/reports.
+- Operator Runtime does **not** expose editing or generation controls and never enables robot motion/replay/controller publishing.
+- Both roles use the same generated bundle format and the same backend scripts (no duplicate scene system, no second planning backend).
+- Bundle approval is an internal workflow marker only, not a safety certification. Physical robot execution remains disabled.

--- a/scripts/generate_workcell_from_cell_definition.py
+++ b/scripts/generate_workcell_from_cell_definition.py
@@ -510,6 +510,7 @@ def generate_package(
         "warnings": warnings,
         "blockers": [],
         "recommended_commands": {"preflight": preflight_cmd, "gated_dry_run": gated_cmd},
+        "approval": {"status": "unapproved", "approved_by": None, "approved_at": None, "notes": ""},
     }
     summary_path.write_text(json.dumps(summary_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     command_script_path.write_text(

--- a/scripts/mark_workcell_bundle_approved.py
+++ b/scripts/mark_workcell_bundle_approved.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Mark generated workcell bundle approved")
+    parser.add_argument("--workcell", required=True)
+    parser.add_argument("--approved-by", required=True)
+    parser.add_argument("--notes", default="")
+    args = parser.parse_args(argv)
+
+    summary_path = Path(args.workcell) / "generated" / "generated_workcell_summary.json"
+    if not summary_path.exists():
+        print(f"FAIL: missing summary: {summary_path}")
+        return 1
+    data = json.loads(summary_path.read_text(encoding="utf-8"))
+    data["approval"] = {
+        "status": "approved",
+        "approved_by": args.approved_by,
+        "approved_at": datetime.now(timezone.utc).isoformat(),
+        "notes": args.notes,
+    }
+    summary_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    report_path = Path(args.workcell) / "generated" / "approval_report.json"
+    report_path.write_text(json.dumps({"workcell": args.workcell, "approval": data["approval"]}, indent=2, sort_keys=True)+"\n", encoding="utf-8")
+    print(f"PASS: updated {summary_path}")
+    print(f"PASS: wrote {report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/operator_runtime.py
+++ b/scripts/operator_runtime.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+try:
+    from scripts.studio_lite import StudioLiteApp
+    from scripts.workcell_roles import ROLE_OPERATOR
+except ModuleNotFoundError:
+    from studio_lite import StudioLiteApp
+    from workcell_roles import ROLE_OPERATOR
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Operator Runtime (no motion)")
+    parser.add_argument("--workcell", required=True, help="Path to generated workcell bundle")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    workcell = Path(args.workcell)
+    if not workcell.exists():
+        print(f"FAIL: workcell path not found: {workcell}")
+        return 1
+    try:
+        import tkinter as tk
+        from tkinter import filedialog, ttk
+    except Exception as exc:  # noqa: BLE001
+        print(f"FAIL: tkinter/display unavailable: {exc}")
+        return 1
+
+    try:
+        root = tk.Tk()
+    except Exception as exc:  # noqa: BLE001
+        print(f"FAIL: tkinter/display unavailable: {exc}")
+        return 1
+    root.title("Operator Runtime")
+    app = StudioLiteApp(root, tk, ttk, filedialog, role=ROLE_OPERATOR)
+    app.bundle_path.set(str(workcell))
+    app._load_bundle()
+    root.mainloop()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/studio_lite.py
+++ b/scripts/studio_lite.py
@@ -8,8 +8,14 @@ import subprocess
 import sys
 import threading
 from dataclasses import dataclass
+import argparse
 from pathlib import Path
 from typing import Any
+
+try:
+    from scripts.workcell_roles import ROLE_DEVELOPER, ROLE_OPERATOR, can_role_do
+except ModuleNotFoundError:
+    from workcell_roles import ROLE_DEVELOPER, ROLE_OPERATOR, can_role_do
 
 NO_MOTION_BANNER = "NO ROBOT MOTION - Studio Lite is offline preflight only"
 SAFE_FOR_ROBOT_MOTION_TEXT = "safe_for_robot_motion: false"
@@ -126,11 +132,12 @@ def _open_or_print_path(path: Path) -> str:
 
 
 class StudioLiteApp:
-    def __init__(self, root: Any, tk: Any, ttk: Any, filedialog: Any) -> None:
+    def __init__(self, root: Any, tk: Any, ttk: Any, filedialog: Any, role: str = ROLE_DEVELOPER) -> None:
         self.root = root
         self.tk = tk
         self.ttk = ttk
         self.filedialog = filedialog
+        self.role = role
         self.root.title("Studio Lite")
         self.queue: queue.Queue[tuple[str, str]] = queue.Queue()
 
@@ -141,6 +148,7 @@ class StudioLiteApp:
         self.status = tk.StringVar(value=STATUS_NOT_RUN)
         self.last_command = tk.StringVar(value="")
         self.last_exit = tk.StringVar(value="")
+        self.role_text = tk.StringVar(value=f"role: {self.role}")
 
         self._build_ui()
         self.root.after(100, self._poll)
@@ -156,27 +164,37 @@ class StudioLiteApp:
         self.ttk.Label(frm, text=NO_MOTION_BANNER, foreground="red").grid(row=r, column=0, columnspan=4, sticky="w")
         r += 1
         self.ttk.Label(frm, text="Status").grid(row=r, column=0, sticky="w")
+        self.ttk.Label(frm, textvariable=self.role_text).grid(row=r, column=3, sticky="e")
         self.ttk.Label(frm, textvariable=self.status).grid(row=r, column=1, sticky="w")
         self.ttk.Label(frm, text=SAFE_FOR_ROBOT_MOTION_TEXT).grid(row=r, column=2, columnspan=2, sticky="w")
         r += 1
 
         self.ttk.Label(frm, text="Cell definition").grid(row=r, column=0, sticky="w")
-        self.ttk.Entry(frm, textvariable=self.cell_definition, width=80).grid(row=r, column=1, sticky="ew")
-        self.ttk.Button(frm, text="Browse", command=self._browse_cell).grid(row=r, column=2, sticky="w")
+        cell_entry = self.ttk.Entry(frm, textvariable=self.cell_definition, width=80)
+        cell_entry.grid(row=r, column=1, sticky="ew")
+        browse_btn = self.ttk.Button(frm, text="Browse", command=self._browse_cell)
+        browse_btn.grid(row=r, column=2, sticky="w")
         r += 1
         self.ttk.Label(frm, text="Output dir").grid(row=r, column=0, sticky="w")
-        self.ttk.Entry(frm, textvariable=self.output_dir, width=80).grid(row=r, column=1, sticky="ew")
+        out_entry = self.ttk.Entry(frm, textvariable=self.output_dir, width=80)
+        out_entry.grid(row=r, column=1, sticky="ew")
         r += 1
         self.ttk.Label(frm, text="Package name").grid(row=r, column=0, sticky="w")
-        self.ttk.Entry(frm, textvariable=self.package_name, width=80).grid(row=r, column=1, sticky="ew")
+        pkg_entry = self.ttk.Entry(frm, textvariable=self.package_name, width=80)
+        pkg_entry.grid(row=r, column=1, sticky="ew")
         r += 1
-        self.ttk.Button(frm, text="Validate Cell Definition", command=lambda: self._run(build_validate_cell_definition_command(self.cell_definition.get()))).grid(row=r, column=0, sticky="w")
-        self.ttk.Button(frm, text="Generate Workcell Bundle", command=self._generate_bundle).grid(row=r, column=1, sticky="w")
+        if can_role_do(self.role, "validate_cell_definition"):
+            self.ttk.Button(frm, text="Validate Cell Definition", command=lambda: self._run(build_validate_cell_definition_command(self.cell_definition.get()))).grid(row=r, column=0, sticky="w")
+        if can_role_do(self.role, "generate_workcell"):
+            self.ttk.Button(frm, text="Generate Workcell Bundle", command=self._generate_bundle).grid(row=r, column=1, sticky="w")
         r += 1
 
         self.ttk.Label(frm, text="Bundle path").grid(row=r, column=0, sticky="w")
         self.ttk.Entry(frm, textvariable=self.bundle_path, width=80).grid(row=r, column=1, sticky="ew")
         self.ttk.Button(frm, text="Load Bundle", command=self._load_bundle).grid(row=r, column=2, sticky="w")
+        if not can_role_do(self.role, "edit_runtime_config"):
+            for widget in (cell_entry, browse_btn, out_entry, pkg_entry):
+                widget.state(["disabled"])
         self.ttk.Button(frm, text="Show Bundle Summary", command=lambda: self._report(_bundle_paths(self.bundle_path.get()).summary)).grid(row=r, column=3, sticky="w")
         r += 1
 
@@ -226,6 +244,13 @@ class StudioLiteApp:
             self.log.insert("end", "Missing required files:\n" + "\n".join(missing) + "\n")
         else:
             self.status.set(STATUS_PASS)
+        try:
+            summary = json.loads(p.summary.read_text(encoding="utf-8"))
+            approval_status = ((summary.get("approval") or {}).get("status") or "unapproved").lower()
+            if approval_status != "approved":
+                self.log.insert("end", "Bundle is not approved for production. Dry-run/preflight only.\n")
+        except Exception:
+            pass
 
     def _show_rviz_cmd(self) -> None:
         cfg = Path(__file__).resolve().parents[1] / "rviz" / "generated_workcell_preview.rviz"
@@ -268,6 +293,16 @@ class StudioLiteApp:
             pass
 
 
+def get_visible_capabilities(role: str) -> dict[str, bool]:
+    return {
+        "show_validate": can_role_do(role, "validate_cell_definition"),
+        "show_generate": can_role_do(role, "generate_workcell"),
+        "allow_runtime_edit": can_role_do(role, "edit_runtime_config"),
+        "no_motion_banner": NO_MOTION_BANNER,
+        "safe_for_robot_motion": SAFE_FOR_ROBOT_MOTION_TEXT,
+    }
+
+
 def main() -> int:
     try:
         import tkinter as tk
@@ -275,8 +310,15 @@ def main() -> int:
     except Exception as exc:
         print(f"FAIL: tkinter unavailable: {exc}")
         return 1
+    parser = argparse.ArgumentParser(description="Studio Lite")
+    parser.add_argument("--role", choices=[ROLE_DEVELOPER, ROLE_OPERATOR], default=ROLE_DEVELOPER)
+    parser.add_argument("--workcell", default="")
+    args = parser.parse_args()
     root = tk.Tk()
-    StudioLiteApp(root, tk, ttk, filedialog)
+    app = StudioLiteApp(root, tk, ttk, filedialog, role=args.role)
+    if args.workcell:
+        app.bundle_path.set(args.workcell)
+        app._load_bundle()
     root.mainloop()
     return 0
 

--- a/scripts/workcell_discovery.py
+++ b/scripts/workcell_discovery.py
@@ -209,6 +209,7 @@ def discover_generated_workcell_summaries() -> list[dict[str, Any]]:
                     "detected_objects_example_path": data.get("detected_objects_example_path"),
                     "warnings": data.get("warnings", []),
                     "blockers": data.get("blockers", []),
+                    "approval_status": ((data.get("approval") or {}).get("status") or "unapproved"),
                     "status": "FAIL" if data.get("blockers") else ("WARN" if data.get("warnings") else "PASS"),
                 }
             )

--- a/scripts/workcell_roles.py
+++ b/scripts/workcell_roles.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+ROLE_DEVELOPER = "developer"
+ROLE_OPERATOR = "operator"
+
+CAPABILITIES = (
+    "validate_cell_definition",
+    "generate_workcell",
+    "load_bundle",
+    "preview_bundle",
+    "preview_task_flow",
+    "run_preflight",
+    "run_gated_dry_run",
+    "open_reports",
+    "edit_runtime_config",
+    "execute_motion",
+)
+
+ROLE_CAPABILITIES = {
+    ROLE_DEVELOPER: {
+        "validate_cell_definition": True,
+        "generate_workcell": True,
+        "load_bundle": True,
+        "preview_bundle": True,
+        "preview_task_flow": True,
+        "run_preflight": True,
+        "run_gated_dry_run": True,
+        "open_reports": True,
+        "edit_runtime_config": True,
+        "execute_motion": False,
+    },
+    ROLE_OPERATOR: {
+        "validate_cell_definition": False,
+        "generate_workcell": False,
+        "load_bundle": True,
+        "preview_bundle": True,
+        "preview_task_flow": True,
+        "run_preflight": True,
+        "run_gated_dry_run": True,
+        "open_reports": True,
+        "edit_runtime_config": False,
+        "execute_motion": False,
+    },
+}
+
+
+def can_role_do(role: str, capability: str) -> bool:
+    return bool(ROLE_CAPABILITIES.get(role, {}).get(capability, False))
+
+
+def list_capabilities(role: str) -> dict[str, bool]:
+    defaults = {cap: False for cap in CAPABILITIES}
+    defaults.update(ROLE_CAPABILITIES.get(role, {}))
+    return defaults

--- a/tests/test_generated_workcell_bundle.py
+++ b/tests/test_generated_workcell_bundle.py
@@ -28,6 +28,8 @@ class GeneratedWorkcellBundleTests(unittest.TestCase):
             self.assertIn('--require-preflight', cmd_txt)
             self.assertIn('--dry-run', cmd_txt)
             self.assertIn('--no-replay', cmd_txt)
+            summary = json.loads((pkg / 'generated_workcell_summary.json').read_text(encoding='utf-8'))
+            self.assertEqual(summary['approval']['status'], 'unapproved')
 
     def test_run_bundle_build_command(self):
         summary = {

--- a/tests/test_operator_runtime.py
+++ b/tests/test_operator_runtime.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import operator_runtime, studio_lite
+from scripts.workcell_roles import ROLE_OPERATOR
+
+
+class OperatorRuntimeTests(unittest.TestCase):
+    def test_module_imports_headless_without_gui_start(self):
+        self.assertTrue(hasattr(operator_runtime, "main"))
+
+    def test_path_loading_helper(self):
+        args = operator_runtime.parse_args(["--workcell", "/tmp/demo"])
+        self.assertEqual(args.workcell, "/tmp/demo")
+
+    def test_operator_role_does_not_expose_generation(self):
+        caps = studio_lite.get_visible_capabilities(ROLE_OPERATOR)
+        self.assertFalse(caps["show_generate"])
+        self.assertFalse(caps["show_validate"])
+
+    def test_operator_role_keeps_no_motion_wording(self):
+        caps = studio_lite.get_visible_capabilities(ROLE_OPERATOR)
+        self.assertIn("NO ROBOT MOTION", caps["no_motion_banner"])
+        self.assertIn("safe_for_robot_motion: false", caps["safe_for_robot_motion"])
+
+    def test_unapproved_bundle_warning_text(self):
+        with tempfile.TemporaryDirectory() as td:
+            workcell = Path(td)
+            generated = workcell / "generated"
+            generated.mkdir()
+            summary = {
+                "approval": {"status": "unapproved", "approved_by": None, "approved_at": None, "notes": ""}
+            }
+            (generated / "generated_workcell_summary.json").write_text(json.dumps(summary), encoding="utf-8")
+            txt = json.loads((generated / "generated_workcell_summary.json").read_text(encoding="utf-8"))
+            self.assertEqual(((txt.get("approval") or {}).get("status")), "unapproved")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workcell_bundle_approval.py
+++ b/tests/test_workcell_bundle_approval.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.generate_workcell_from_cell_definition import generate_package
+from scripts.workcell_discovery import discover_generated_workcell_summaries
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEMO = REPO_ROOT / 'cell_definitions/demo_ur5_sorting_cell.yaml'
+
+
+class WorkcellBundleApprovalTests(unittest.TestCase):
+    def test_generated_bundle_defaults_to_unapproved(self):
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td)
+            self.assertEqual(generate_package(DEMO, out, 'demo_ur5_sorting_cell', force=True, dry_run=False), 0)
+            summary = json.loads((out / 'demo_ur5_sorting_cell/generated/generated_workcell_summary.json').read_text(encoding='utf-8'))
+            self.assertEqual(summary['approval']['status'], 'unapproved')
+
+    def test_mark_approved_and_report_created(self):
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td)
+            self.assertEqual(generate_package(DEMO, out, 'demo_ur5_sorting_cell', force=True, dry_run=False), 0)
+            script = REPO_ROOT / 'scripts/mark_workcell_bundle_approved.py'
+            workcell = out / 'demo_ur5_sorting_cell'
+            p = subprocess.run([sys.executable, str(script), '--workcell', str(workcell), '--approved-by', 'Integrator', '--notes', 'Offline dry-run reviewed'], capture_output=True, text=True)
+            self.assertEqual(p.returncode, 0)
+            summary = json.loads((workcell / 'generated/generated_workcell_summary.json').read_text(encoding='utf-8'))
+            self.assertEqual(summary['approval']['status'], 'approved')
+            self.assertTrue((workcell / 'generated/approval_report.json').exists())
+
+    def test_discovery_shows_approval_status(self):
+        items = discover_generated_workcell_summaries()
+        for item in items:
+            self.assertIn('approval_status', item)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_workcell_roles.py
+++ b/tests/test_workcell_roles.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+
+from scripts.workcell_roles import ROLE_DEVELOPER, ROLE_OPERATOR, can_role_do
+
+
+class WorkcellRolesTests(unittest.TestCase):
+    def test_developer_can_generate_workcell(self):
+        self.assertTrue(can_role_do(ROLE_DEVELOPER, "generate_workcell"))
+
+    def test_operator_cannot_generate_workcell(self):
+        self.assertFalse(can_role_do(ROLE_OPERATOR, "generate_workcell"))
+
+    def test_both_can_preview_bundle(self):
+        self.assertTrue(can_role_do(ROLE_DEVELOPER, "preview_bundle"))
+        self.assertTrue(can_role_do(ROLE_OPERATOR, "preview_bundle"))
+
+    def test_both_can_run_gated_dry_run(self):
+        self.assertTrue(can_role_do(ROLE_DEVELOPER, "run_gated_dry_run"))
+        self.assertTrue(can_role_do(ROLE_OPERATOR, "run_gated_dry_run"))
+
+    def test_execute_motion_false_for_both_roles(self):
+        self.assertFalse(can_role_do(ROLE_DEVELOPER, "execute_motion"))
+        self.assertFalse(can_role_do(ROLE_OPERATOR, "execute_motion"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent mixing developer/integrator functions with operator/runtime functions while reusing the same generated workcell bundle and backend tools and keeping robot motion/publishing disabled. 
- Provide a simple operator-facing launcher and clear approval marker for generated bundles so operators can safely run preview/preflight/dry-run workflows without editing or generation privileges. 

### Description
- Add `scripts/workcell_roles.py` with `ROLE_DEVELOPER`, `ROLE_OPERATOR`, capability map, and helpers `can_role_do` and `list_capabilities` with `execute_motion=False` for both roles and operator restrictions on generation/editing. 
- Update `scripts/studio_lite.py` to accept `--role {developer,operator}` (default `developer`), show current role and the existing no-motion banner, and conditionally hide/disable validate/generate/edit controls while keeping load/preview/gated dry-run/report functionality; it also warns on unapproved bundles. 
- Add `scripts/operator_runtime.py` as a dedicated operator launcher that loads a generated workcell bundle, runs Studio Lite internals in `operator` role, and fails cleanly when `tkinter`/display is unavailable. 
- Add `scripts/mark_workcell_bundle_approved.py` to manually mark a generated bundle as approved and emit `generated/approval_report.json`, and update generation (`generate_workcell_from_cell_definition.py`) to default generated summaries to `approval.status = "unapproved"`. 
- Extend `scripts/workcell_discovery.py` to include `approval_status` in discovered generated bundle summaries. 
- Add and update unit tests: `tests/test_workcell_roles.py`, `tests/test_operator_runtime.py`, `tests/test_workcell_bundle_approval.py`, and adjust `tests/test_generated_workcell_bundle.py` and others to validate the new approval fields and role behavior, and add `get_visible_capabilities` helper in Studio Lite for testability. 
- Update README and manuals with a "Developer Studio vs Operator Runtime" section clarifying role boundaries and safety guarantees (no duplicate scene system, no second planning backend, no physical robot execution). 

### Testing
- Verified Python compile for modified scripts with `python3 -m py_compile` which succeeded. 
- Ran the updated unit test suite with `PYTHONPATH=$PWD python3 -m pytest -q` covering role tests, studio/operator behavior, and approval workflow and observed all targeted tests passing (full run reported passing tests). 
- Performed manual generation with `scripts/generate_workcell_from_cell_definition.py` which produced a generated bundle with `approval.status = "unapproved"`. 
- Ran `scripts/mark_workcell_bundle_approved.py` to mark a bundle approved and confirmed `generated_workcell_summary.json` was updated and `generated/approval_report.json` was created. 
- Confirmed `scripts/operator_runtime.py` fails clearly in headless environments with a helpful message when `tkinter`/display is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f474f7444c8331a4da26219d629509)