### PR TITLE
Clean colcon build warning hygiene for developer workspace

### DIFF
--- a/colcon/quiet_third_party_warnings.meta
+++ b/colcon/quiet_third_party_warnings.meta
@@ -1,0 +1,16 @@
+{
+  "names": {
+    "osqp_eigen": {
+      "cmake-args": ["-Wno-dev"]
+    },
+    "tesseract_geometry": {
+      "cmake-args": ["-DCMAKE_CXX_FLAGS=-Wno-cpp"]
+    },
+    "tesseract_urdf": {
+      "cmake-args": ["-DCMAKE_CXX_FLAGS=-Wno-cpp"]
+    },
+    "tesseract_examples": {
+      "cmake-args": ["-DCMAKE_CXX_FLAGS=-Wno-cpp"]
+    }
+  }
+}

--- a/docs/manuals/BUILD_WARNING_HYGIENE.md
+++ b/docs/manuals/BUILD_WARNING_HYGIENE.md
@@ -1,0 +1,37 @@
+# Build warning hygiene for developer colcon workspace
+
+## Observed warnings
+- `osqp_eigen` CMake developer warning: `OSQP_EIGEN_OSQP_TARGET_TO_LINK` cannot be set in parent scope.
+- Tesseract overlays (`tesseract_geometry`, `tesseract_urdf`, `tesseract_examples`) surface Assimp's deprecated `pbrmaterial.h` warning.
+- `run_grasp_execution` showed Boost.Bind global placeholders deprecation notes.
+
+## Owned fix in this repo
+`run_grasp_execution` now applies `BOOST_BIND_GLOBAL_PLACEHOLDERS` as a target-level compile definition for local targets (including `demo_node` and `test_explicit_release_pose_utils`). This removes the local Boost.Bind deprecation note without weakening standard warning flags.
+
+## Known third-party warnings
+`osqp_eigen` and Tesseract/Assimp warnings are classified as known third-party warnings. We do not patch third-party source overlays in this repository to keep vendor boundaries clean and upgrades simpler.
+
+## Developer clean build workflow
+Run:
+
+```bash
+scripts/build_workspace_dev_clean.sh
+```
+
+The script:
+1. Runs a colcon build with `colcon/quiet_third_party_warnings.meta`.
+2. Writes a timestamped log under `logs/colcon_builds/`.
+3. Runs `scripts/check_colcon_build_warnings.py --fail-on-owned` on that log.
+
+The workflow fails on owned or unknown warnings, but not on classified known third-party warnings.
+
+## Manual log inspection
+Inspect the latest log manually with tools like:
+
+```bash
+tail -n 200 logs/colcon_builds/<logfile>.log
+rg -n "warning|note|deprecated|OSQP_EIGEN_OSQP_TARGET_TO_LINK|pbrmaterial" logs/colcon_builds/<logfile>.log
+```
+
+## Important note
+This hygiene flow helps triage and noise-reduction; it is **not** a replacement for fixing legitimate project warnings.

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
@@ -10,6 +10,12 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+function(run_grasp_execution_apply_warning_suppression target_name)
+  if(TARGET ${target_name})
+    target_compile_definitions(${target_name} PRIVATE BOOST_BIND_GLOBAL_PLACEHOLDERS)
+  endif()
+endfunction()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(emd_grasp_execution REQUIRED)
@@ -21,6 +27,8 @@ find_package(ament_index_cpp REQUIRED)
 
 add_executable(demo_node src/demo_node.cpp)
 target_include_directories(demo_node PUBLIC include)
+
+run_grasp_execution_apply_warning_suppression(demo_node)
 
 ament_target_dependencies(demo_node
   emd_grasp_execution
@@ -81,6 +89,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_explicit_release_pose_utils
     test/test_explicit_release_pose_utils.cpp)
   target_include_directories(test_explicit_release_pose_utils PUBLIC include)
+  run_grasp_execution_apply_warning_suppression(test_explicit_release_pose_utils)
   ament_target_dependencies(test_explicit_release_pose_utils
     tf2_geometry_msgs
   )

--- a/scripts/build_workspace_dev_clean.sh
+++ b/scripts/build_workspace_dev_clean.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p logs/colcon_builds
+log_file="logs/colcon_builds/colcon_build_$(date -u +%Y%m%dT%H%M%SZ).log"
+
+build_cmd=(
+  colcon build --symlink-install
+  --packages-skip tesseract_rviz
+  --allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils
+  --metas colcon/quiet_third_party_warnings.meta
+)
+
+echo "Running developer build command:"
+printf '  %q' "${build_cmd[@]}"
+echo
+
+echo "Build log: ${log_file}"
+set +e
+"${build_cmd[@]}" 2>&1 | tee "${log_file}"
+build_rc=${PIPESTATUS[0]}
+set -e
+
+if [[ ${build_rc} -ne 0 ]]; then
+  echo "Build failed with exit code ${build_rc}."
+  exit "${build_rc}"
+fi
+
+scripts/check_colcon_build_warnings.py --log "${log_file}" --fail-on-owned

--- a/scripts/check_colcon_build_warnings.py
+++ b/scripts/check_colcon_build_warnings.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Classify colcon build warnings into owned/third-party/unknown buckets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+KNOWN_THIRD_PARTY_LABEL = "known_third_party"
+OWNED_LABEL = "owned_warnings"
+UNKNOWN_LABEL = "unknown_warnings"
+
+_WARNING_LINE_RE = re.compile(r"(?i)(warning:|\bwarning\b|\bnote\b)")
+_OWNED_HINTS = (
+    "easy_manipulation_deployment/",
+    "run_grasp_execution",
+    "run_grasp_planner",
+    "run_waypoint_execution",
+    "workcell_builder",
+    "scenario",
+)
+
+
+def _is_osqp_dev_warning(window: str) -> bool:
+    return "OSQP_EIGEN_OSQP_TARGET_TO_LINK" in window and "OsqpEigenDependencies.cmake" in window
+
+
+def _is_tesseract_assimp_warning(window: str) -> bool:
+    return (
+        "pbrmaterial.h is deprecated" in window
+        and "/usr/include/assimp/pbrmaterial.h" in window
+        and any(pkg in window for pkg in ("tesseract_geometry", "tesseract_urdf", "tesseract_examples"))
+    )
+
+
+def _is_owned_warning(window: str) -> bool:
+    lower = window.lower()
+    return any(hint in lower for hint in _OWNED_HINTS)
+
+
+def classify_warnings(log_text: str) -> Dict[str, List[str]]:
+    lines = log_text.splitlines()
+    classified: Dict[str, List[str]] = {
+        KNOWN_THIRD_PARTY_LABEL: [],
+        OWNED_LABEL: [],
+        UNKNOWN_LABEL: [],
+    }
+
+    for index, line in enumerate(lines):
+        if not _WARNING_LINE_RE.search(line):
+            continue
+
+        context = "\n".join(lines[max(0, index - 2) : min(len(lines), index + 3)])
+        snippet = context.strip()
+        if _is_osqp_dev_warning(context):
+            classified[KNOWN_THIRD_PARTY_LABEL].append(snippet)
+        elif _is_tesseract_assimp_warning(context):
+            classified[KNOWN_THIRD_PARTY_LABEL].append(snippet)
+        elif _is_owned_warning(context):
+            classified[OWNED_LABEL].append(snippet)
+        else:
+            classified[UNKNOWN_LABEL].append(snippet)
+
+    return classified
+
+
+def _build_result(classified: Dict[str, List[str]]) -> Dict[str, object]:
+    return {
+        "counts": {key: len(value) for key, value in classified.items()},
+        "matches": classified,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", required=True, help="Path to colcon build log.")
+    parser.add_argument("--fail-on-owned", action="store_true", help="Fail on owned or unknown warnings.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON report.")
+    args = parser.parse_args()
+
+    log_path = Path(args.log)
+    if not log_path.exists():
+        print(f"Log file not found: {log_path}", file=sys.stderr)
+        return 2
+
+    classified = classify_warnings(log_path.read_text(encoding="utf-8", errors="replace"))
+    result = _build_result(classified)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print("Warning classification summary:")
+        for key, count in result["counts"].items():
+            print(f"  {key}: {count}")
+
+    if args.fail_on_owned:
+        if classified[OWNED_LABEL] or classified[UNKNOWN_LABEL]:
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_colcon_build_warnings.py
+++ b/tests/test_check_colcon_build_warnings.py
@@ -1,0 +1,63 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import importlib.util
+
+
+MODULE_PATH = Path("scripts/check_colcon_build_warnings.py")
+spec = importlib.util.spec_from_file_location("check_colcon_build_warnings", MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+classify_warnings = module.classify_warnings
+
+
+def test_boost_bind_warning_in_run_grasp_execution_is_owned():
+    log = """
+[5.432s] Building CXX object easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeFiles/demo_node.dir/src/demo_node.cpp.o
+In file included from /usr/include/boost/bind.hpp:30:
+#warning The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated.
+"""
+    classified = classify_warnings(log)
+    assert len(classified["owned_warnings"]) == 1
+
+
+def test_osqp_warning_is_known_third_party():
+    log = """
+CMake Warning (dev) at cmake/OsqpEigenDependencies.cmake:37 (set):
+  Cannot set \"OSQP_EIGEN_OSQP_TARGET_TO_LINK\": current scope has no parent.
+Call Stack (most recent call first):
+"""
+    classified = classify_warnings(log)
+    assert len(classified["known_third_party"]) == 1
+
+
+def test_assimp_warning_from_tesseract_is_known_third_party():
+    log = """
+[12.111s] Building CXX object tesseract_geometry/CMakeFiles/foo.dir/bar.cpp.o
+/usr/include/assimp/pbrmaterial.h: warning: pbrmaterial.h is deprecated. Please update to PBR materials in materials.h and glTF-specific items in GltfMaterial.h
+"""
+    classified = classify_warnings(log)
+    assert len(classified["known_third_party"]) == 1
+
+
+def test_unknown_warning_fails_with_fail_on_owned(tmp_path: Path):
+    log_path = tmp_path / "colcon.log"
+    log_path.write_text("/tmp/other_pkg/file.cpp:9: warning: unused variable 'x'\n", encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, "scripts/check_colcon_build_warnings.py", "--log", str(log_path), "--fail-on-owned"],
+        check=False,
+    )
+    assert result.returncode == 1
+
+
+def test_quiet_meta_only_contains_third_party_packages():
+    meta_path = Path("colcon/quiet_third_party_warnings.meta")
+    text = meta_path.read_text(encoding="utf-8")
+    assert '"osqp_eigen"' in text
+    assert '"tesseract_geometry"' in text
+    assert '"tesseract_urdf"' in text
+    assert '"tesseract_examples"' in text
+    assert "run_grasp_execution" not in text
+    assert "easy_manipulation_deployment" not in text


### PR DESCRIPTION
### Motivation
- Reduce and classify build-time noise so project-owned warnings are fixed while known third-party warnings are tracked but not patched in-place.
- Remove the Boost.Bind global-placeholder deprecation note originating from this repository without weakening project warning levels.
- Provide a repeatable, transparent developer workflow that suppresses only targeted third-party noise and fails when owned or unknown warnings remain.

### Description
- Add a small CMake helper in `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt` and apply `BOOST_BIND_GLOBAL_PLACEHOLDERS` at the target level to `demo_node` and `test_explicit_release_pose_utils` to silence the local Boost.Bind note. 
- Add `scripts/check_colcon_build_warnings.py` which classifies warnings into `known_third_party`, `owned_warnings`, and `unknown_warnings` and supports `--log`, `--fail-on-owned`, and `--json` modes. 
- Add `colcon/quiet_third_party_warnings.meta` to opt-in package-scoped suppression for known third-party noise (e.g. `osqp_eigen` `-Wno-dev` and targeted `-Wno-cpp` for Tesseract overlay packages). 
- Add `scripts/build_workspace_dev_clean.sh` to run the developer `colcon` build with the quiet meta profile, tee output to `logs/colcon_builds/` and invoke the warning checker; add documentation at `docs/manuals/BUILD_WARNING_HYGIENE.md` and unit tests under `tests/test_check_colcon_build_warnings.py`. 

### Testing
- Ran the new unit tests with `pytest -q tests/test_check_colcon_build_warnings.py` and all tests passed (`5 passed`).
- The warning classifier tests validate the owned Boost.Bind detection, `osqp_eigen` dev-warning classification, Tesseract/Assimp `pbrmaterial.h` classification, unknown-warning failure in `--fail-on-owned` mode, and that the quiet meta references only third-party packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f48d76636483319e1ce2d18daaef4b)