### PR TITLE
Fix run_grasp_execution safe_joint_state crash on unset launch override

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -387,8 +387,17 @@ std::vector<double> resolve_safe_joint_state_param(
   const std::string & param_name)
 {
   const std::vector<double> empty_default;
-  if (!node->has_parameter(param_name)) {
-    return node->declare_parameter<std::vector<double>>(param_name, empty_default);
+  try {
+    if (!node->has_parameter(param_name)) {
+      return node->declare_parameter<std::vector<double>>(param_name, empty_default);
+    }
+  } catch (const rclcpp::exceptions::InvalidParameterValueException & e) {
+    RCLCPP_WARN(
+      logger,
+      "Parameter '%s' is present but has no usable value (%s). Using empty safe joint state.",
+      param_name.c_str(),
+      e.what());
+    return empty_default;
   }
 
   rclcpp::Parameter parameter;
@@ -403,10 +412,7 @@ std::vector<double> resolve_safe_joint_state_param(
   const auto resolution =
     run_grasp_execution::parse_safe_joint_state_parameter(parameter, param_name);
   if (resolution.warning_message.has_value()) {
-    RCLCPP_WARN(
-      logger,
-      "%s",
-      resolution.warning_message->c_str());
+    RCLCPP_WARN(logger, "%s", resolution.warning_message->c_str());
   }
   return resolution.value;
 }

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_home_return_utils.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_home_return_utils.cpp
@@ -70,6 +70,23 @@ TEST(TestHomeReturnUtils, ParseSafeJointStateParamWrongTypeStringFallsBackToEmpt
   EXPECT_NE(resolution.warning_message->find("type 'string'"), std::string::npos);
 }
 
+
+TEST(TestHomeReturnUtils, ParseSafeJointStateParamValidListIsReturned)
+{
+  const rclcpp::Parameter param(
+    "home_return.safe_joint_state",
+    std::vector<double>{0.1, -0.2, 1.5});
+  const auto resolution = run_grasp_execution::parse_safe_joint_state_parameter(
+    param,
+    "home_return.safe_joint_state");
+
+  ASSERT_EQ(resolution.value.size(), 3u);
+  EXPECT_DOUBLE_EQ(resolution.value[0], 0.1);
+  EXPECT_DOUBLE_EQ(resolution.value[1], -0.2);
+  EXPECT_DOUBLE_EQ(resolution.value[2], 1.5);
+  EXPECT_FALSE(resolution.warning_message.has_value());
+}
+
 TEST(TestHomeReturnUtils, ParseSafeJointStateParamWrongTypeIntegerFallsBackToEmptyWithWarning)
 {
   const rclcpp::Parameter param("home_return.safe_joint_state", 42);


### PR DESCRIPTION
### Motivation
- Launch temporary parameter files can inject a valueless/`PARAMETER_NOT_SET`/null value for `home_return.safe_joint_state`, which caused `demo_node` to throw `rclcpp::exceptions::InvalidParameterValueException` and exit with -6. This must be handled defensively so the node does not crash. 

### Description
- Guard `home_return.safe_joint_state` resolution in `resolve_safe_joint_state_param` with a `try/catch` around the `declare_parameter` path and catch `rclcpp::exceptions::InvalidParameterValueException`, logging a warning and falling back to an empty joint list; changes in `src/demo_node.cpp` implement this.  
- Preserve existing fallback behavior for unreadable parameters by keeping the `get_parameter()` warning + empty list path. 
- Add a C++ gtest `ParseSafeJointStateParamValidListIsReturned` that verifies a valid numeric `home_return.safe_joint_state` list is parsed and returned to prevent regressions in `test/test_home_return_utils.cpp`.

### Testing
- Added a unit gtest in `test/test_home_return_utils.cpp` to cover valid numeric list parsing (not executed in this environment). 
- Attempted to run `ament_flake8` in-package checks but `/opt/ros/humble/bin/ament_flake8` is not present in this container so style/lint checks were not executed here. 
- Full `colcon build`/`colcon test`/`colcon test-result` gate was not run here due to missing ROS Humble ament toolchain binaries, so runtime behaviour should be validated in the target ROS Humble workspace where the ament tools are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d2c2a5f88331bee02ebb5c896ac0)