### PR TITLE
Fix crash from valueless `home_return.safe_joint_state` override and enforce exit code 0

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -387,24 +387,11 @@ std::vector<double> resolve_safe_joint_state_param(
   const std::string & param_name)
 {
   const std::vector<double> empty_default;
-  try {
-    if (!node->has_parameter(param_name)) {
-      return node->declare_parameter<std::vector<double>>(param_name, empty_default);
-    }
-  } catch (const rclcpp::exceptions::InvalidParameterValueException & e) {
-    RCLCPP_WARN(
-      logger,
-      "Parameter '%s' is present but has no usable value (%s). Using empty safe joint state.",
-      param_name.c_str(),
-      e.what());
-    return empty_default;
-  }
-
   rclcpp::Parameter parameter;
   if (!node->get_parameter(param_name, parameter)) {
-    RCLCPP_WARN(
+    RCLCPP_INFO(
       logger,
-      "Could not read parameter '%s'. Using empty safe joint state.",
+      "Parameter '%s' is not set. Using empty safe joint state.",
       param_name.c_str());
     return empty_default;
   }

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch.test.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch.test.py
@@ -180,4 +180,4 @@ class TestGraspExecutionLaunch(unittest.TestCase):
 @launch_testing.post_shutdown_test()
 class TestGraspExecutionShutdown(unittest.TestCase):
     def test_exit_codes(self, proc_info):
-        launch_testing.asserts.assertExitCodes(proc_info)
+        launch_testing.asserts.assertExitCodes(proc_info, allowable_exit_codes=[0])

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_home_return_utils.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_home_return_utils.cpp
@@ -126,3 +126,16 @@ TEST(TestHomeReturnUtils, ParseSafeJointStateParamMissingFallsBackToEmptyWithout
   EXPECT_TRUE(resolution.value.empty());
   EXPECT_FALSE(resolution.warning_message.has_value());
 }
+
+TEST(TestHomeReturnUtils, ParseSafeJointStateParamValuelessOverrideFallsBackToEmptyWithoutWarning)
+{
+  const rclcpp::Parameter valueless_override(
+    "home_return.safe_joint_state",
+    rclcpp::ParameterValue());
+  const auto resolution = run_grasp_execution::parse_safe_joint_state_parameter(
+    valueless_override,
+    "home_return.safe_joint_state");
+
+  EXPECT_TRUE(resolution.value.empty());
+  EXPECT_FALSE(resolution.warning_message.has_value());
+}


### PR DESCRIPTION
### Motivation
- The demo node could crash at startup with `parameter_value_from failed` and exit `-6` when a launch-time `home_return.safe_joint_state` override existed but had no concrete value (`null`/valueless), because `declare_parameter<std::vector<double>>` can throw in that case.
- The safe-joint parameter resolution must treat missing/unset/valueless parameters as an empty vector without escaping exceptions, while keeping type-wrong cases logged and preserving valid lists.

### Description
- Reworked `resolve_safe_joint_state_param` to stop using `declare_parameter`/`has_parameter` and instead use `get_parameter` plus `parse_safe_joint_state_parameter`, returning an empty vector for unset or valueless parameters and logging an `INFO` message (changed in `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp`).
- Preserved existing parsing behavior so `PARAMETER_NOT_SET` and empty lists resolve to empty vectors, valid `double_array` values are returned intact, and wrong types produce a warning and an empty vector (via `parse_safe_joint_state_parameter`).
- Added a regression unit test `ParseSafeJointStateParamValuelessOverrideFallsBackToEmptyWithoutWarning` to cover the valueless/null override case (`easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_home_return_utils.cpp`).
- Tightened the launch post-shutdown test to explicitly allow only exit code `0` so an internal `-6` cannot be accepted (`easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch.test.py`).

### Testing
- An attempted `colcon build` and `colcon test` for the `run_grasp_execution` package could not be completed here because `/opt/ros/humble/setup.bash` and the expected workspace (`~/workcell_ws`) are not present in this environment, so the automated build/test steps did not run.
- Unit test coverage for the valueless-override case was added and is expected to run in CI; no automated test results are available locally due to the missing ROS environment.
- Linters (`cpplint`, `flake8`, `uncrustify`) were not executed in this environment and should be validated in CI as part of the merge validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d6d7dda0833181949e99771d2474)