### PR TITLE
Fix run_grasp_execution gate after PR 1287

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/explicit_release_pose_utils.hpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/explicit_release_pose_utils.hpp
@@ -22,10 +22,11 @@
 #include <utility>
 #include <vector>
 
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <tf2/LinearMath/Quaternion.h>
+
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 namespace run_grasp_execution
 {
@@ -109,7 +110,8 @@ inline std::optional<std::array<double, 4>> read_vec4(
   return out;
 }
 
-inline ExplicitReleasePoseLoadResult load_explicit_release_pose_bridge_payload(const std::string & path)
+inline ExplicitReleasePoseLoadResult load_explicit_release_pose_bridge_payload(
+  const std::string & path)
 {
   ExplicitReleasePoseLoadResult result;
   if (path.empty()) {
@@ -147,7 +149,8 @@ inline ExplicitReleasePoseLoadResult load_explicit_release_pose_bridge_payload(c
 
     const auto pose_node = target.get_child_optional("destination_pose");
     if (!pose_node.has_value()) {
-      result.warnings.push_back("Missing destination_pose for object_id='" + entry.object_id + "'.");
+      result.warnings.push_back(
+        "Missing destination_pose for object_id='" + entry.object_id + "'.");
       result.entries.push_back(entry);
       continue;
     }
@@ -158,7 +161,8 @@ inline ExplicitReleasePoseLoadResult load_explicit_release_pose_bridge_payload(c
     const auto rpy = read_vec3(pose_node.value(), "rpy");
 
     if (!xyz.has_value()) {
-      result.warnings.push_back("Malformed destination_pose.xyz for object_id='" + entry.object_id + "'.");
+      result.warnings.push_back(
+        "Malformed destination_pose.xyz for object_id='" + entry.object_id + "'.");
       result.entries.push_back(entry);
       continue;
     }
@@ -181,14 +185,16 @@ inline ExplicitReleasePoseLoadResult load_explicit_release_pose_bridge_payload(c
       entry.pose.orientation.z = q.z();
       entry.pose.orientation.w = q.w();
     } else {
-      result.warnings.push_back("Missing destination_pose orientation for object_id='" + entry.object_id + "'.");
+      result.warnings.push_back(
+        "Missing destination_pose orientation for object_id='" + entry.object_id + "'.");
       result.entries.push_back(entry);
       continue;
     }
 
     entry.valid_pose = is_finite_pose(entry.pose);
     if (!entry.valid_pose) {
-      result.warnings.push_back("Non-finite destination pose for object_id='" + entry.object_id + "'.");
+      result.warnings.push_back(
+        "Non-finite destination pose for object_id='" + entry.object_id + "'.");
     }
 
     result.entries.push_back(entry);

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/grasp_precheck_collision_filter.hpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/grasp_precheck_collision_filter.hpp
@@ -50,10 +50,14 @@ inline CollisionFilterResult filter_grasp_precheck_collision_pairs(
 {
   CollisionFilterResult result;
   for (const auto & pair : collision_pairs) {
-    const bool first_is_touch_link = allowed_touch_links.find(pair.first) != allowed_touch_links.end();
-    const bool second_is_touch_link = allowed_touch_links.find(pair.second) != allowed_touch_links.end();
-    const bool first_is_allowed_id = allowed_collision_ids.find(pair.first) != allowed_collision_ids.end();
-    const bool second_is_allowed_id = allowed_collision_ids.find(pair.second) != allowed_collision_ids.end();
+    const bool first_is_touch_link =
+      allowed_touch_links.find(pair.first) != allowed_touch_links.end();
+    const bool second_is_touch_link =
+      allowed_touch_links.find(pair.second) != allowed_touch_links.end();
+    const bool first_is_allowed_id =
+      allowed_collision_ids.find(pair.first) != allowed_collision_ids.end();
+    const bool second_is_allowed_id =
+      allowed_collision_ids.find(pair.second) != allowed_collision_ids.end();
 
     const bool is_allowed_pair =
       (first_is_touch_link && second_is_allowed_id) ||

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/home_return_utils.hpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/include/run_grasp_execution/home_return_utils.hpp
@@ -15,10 +15,10 @@
 #ifndef RUN_GRASP_EXECUTION__HOME_RETURN_UTILS_HPP_
 #define RUN_GRASP_EXECUTION__HOME_RETURN_UTILS_HPP_
 
+#include <exception>
+#include <optional>
 #include <string>
 #include <vector>
-#include <optional>
-#include <exception>
 
 #include "rclcpp/parameter.hpp"
 
@@ -95,7 +95,8 @@ inline SafeJointStateResolution parse_safe_joint_state_parameter(
   if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY) {
     return {
       empty_default,
-      "Parameter '" + param_name + "' has type '" + parameter_type_to_string(parameter.get_type()) +
+      "Parameter '" + param_name + "' has type '" +
+      parameter_type_to_string(parameter.get_type()) +
       "' but expected 'double_array'. Using empty safe joint state."
     };
   }
@@ -121,8 +122,9 @@ inline std::optional<std::string> safe_intermediate_skip_warning(
     return std::nullopt;
   }
   if (safe_joint_state.empty()) {
-    return "[HomeReturn] home_return.use_safe_intermediate=true but home_return.safe_joint_state is empty. "
-           "Skipping safe intermediate and continuing to home.";
+    return "[HomeReturn] home_return.use_safe_intermediate=true but "
+           "home_return.safe_joint_state is empty. Skipping safe intermediate "
+           "and continuing to home.";
   }
   if (safe_joint_state.size() != manipulator_dof) {
     return "[HomeReturn] home_return.safe_joint_state has " +

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_explicit_release_pose_utils.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_explicit_release_pose_utils.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
-
 #include <fstream>
 #include <string>
+
+#include <gtest/gtest.h>
 
 #include "run_grasp_execution/explicit_release_pose_utils.hpp"
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch.test.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch.test.py
@@ -17,17 +17,22 @@ import importlib.util
 import os
 import time
 import unittest
-from pathlib import Path
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
-from ament_index_python.packages import get_package_share_directory, PackageNotFoundError
+from ament_index_python.packages import PackageNotFoundError, get_package_share_directory
+
 import launch
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+
 import launch_testing
 import launch_testing.actions
+
 import pytest
+
 import rclpy
+
 from sensor_msgs.msg import JointState
 
 
@@ -39,11 +44,12 @@ REQUIRED_GRIPPER_JOINTS = {'gripper_finger1_joint'}
 try:
     get_package_share_directory(SCENE_PACKAGE)
 except PackageNotFoundError:
-    pytest.skip(f"{SCENE_PACKAGE} package not available", allow_module_level=True)
+    pytest.skip(f'{SCENE_PACKAGE} package not available', allow_module_level=True)
 
 
 def import_launch_module():
-    launch_path = Path(get_package_share_directory('run_grasp_execution')) / 'launch' / 'grasp_execution.launch.py'
+    launch_path = Path(get_package_share_directory('run_grasp_execution')) / \
+        'launch' / 'grasp_execution.launch.py'
     spec = importlib.util.spec_from_file_location('run_grasp_execution_launch', launch_path)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -54,9 +60,12 @@ def import_launch_module():
 def test_missing_scene_package_error_message():
     module = import_launch_module()
     missing_scene = 'missing_scene_package'
-    with pytest.raises(RuntimeError, match=rf"Scene package '{missing_scene}' was not found") as exc_info:
+    with pytest.raises(
+        RuntimeError,
+        match=rf"Scene package '{missing_scene}' was not found",
+    ) as exc_info:
         module.resolve_scene_package_share_dir(missing_scene)
-    assert "build/source your generated scene package first" in str(exc_info.value)
+    assert 'build/source your generated scene package first' in str(exc_info.value)
 
 
 def test_scene_srdf_injections_are_scoped_and_exclude_table_workbench_rules():
@@ -70,17 +79,18 @@ def test_scene_srdf_injections_are_scoped_and_exclude_table_workbench_rules():
         srdf_xml=srdf_xml,
     )
     allowed_pairs = {
-        tuple(sorted(("base_link", "base_link_inertia"))),
-        tuple(sorted(("base_link_inertia", "shoulder_link"))),
-        tuple(sorted(("forearm_link", "wrist_2_link"))),
+        tuple(sorted(('base_link', 'base_link_inertia'))),
+        tuple(sorted(('base_link_inertia', 'shoulder_link'))),
+        tuple(sorted(('forearm_link', 'wrist_2_link'))),
     }
 
-    injected_pair_set = {tuple(sorted((link1, link2))) for link1, link2, _reason in pairs_to_inject}
+    injected_pair_set = {tuple(sorted((link1, link2)))
+                         for link1, link2, _reason in pairs_to_inject}
     assert injected_pair_set.issubset(allowed_pairs)
     for link1, link2, _reason in pairs_to_inject:
-        text = f"{link1} {link2}".lower()
-        assert "table" not in text
-        assert "workbench" not in text
+        text = f'{link1} {link2}'.lower()
+        assert 'table' not in text
+        assert 'workbench' not in text
 
 
 def test_scene_srdf_no_blanket_robot_vs_table_disable_rules():
@@ -90,11 +100,16 @@ def test_scene_srdf_no_blanket_robot_vs_table_disable_rules():
     for element in srdf_root.findall('disable_collisions'):
         link1 = (element.attrib.get('link1', '') or '').lower()
         link2 = (element.attrib.get('link2', '') or '').lower()
-        if "table" not in link1 and "table" not in link2 and "workbench" not in link1 and "workbench" not in link2:
+        if (
+            'table' not in link1 and
+            'table' not in link2 and
+            'workbench' not in link1 and
+            'workbench' not in link2
+        ):
             continue
-        assert "wrist" not in link1 and "wrist" not in link2
-        assert "forearm" not in link1 and "forearm" not in link2
-        assert "upper_arm" not in link1 and "upper_arm" not in link2
+        assert 'wrist' not in link1 and 'wrist' not in link2
+        assert 'forearm' not in link1 and 'forearm' not in link2
+        assert 'upper_arm' not in link1 and 'upper_arm' not in link2
 
 
 @pytest.mark.launch_test
@@ -109,7 +124,7 @@ def generate_test_description():
             [
                 IncludeLaunchDescription(
                     PythonLaunchDescriptionSource(launch_path),
-                    launch_arguments={"scene_package": SCENE_PACKAGE}.items(),
+                    launch_arguments={'scene_package': SCENE_PACKAGE}.items(),
                 ),
                 launch_testing.actions.ReadyToTest(),
             ]
@@ -119,6 +134,7 @@ def generate_test_description():
 
 
 class TestGraspExecutionLaunch(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         rclpy.init()
@@ -173,11 +189,14 @@ class TestGraspExecutionLaunch(unittest.TestCase):
             observed_joint_names.update(msg.name)
 
         subscription = self.node.create_subscription(JointState, '/joint_states', callback, 10)
-        self.assertTrue(self._wait_for(lambda: REQUIRED_GRIPPER_JOINTS.issubset(observed_joint_names)))
+        self.assertTrue(
+            self._wait_for(
+                lambda: REQUIRED_GRIPPER_JOINTS.issubset(observed_joint_names)))
         self.node.destroy_subscription(subscription)
 
 
 @launch_testing.post_shutdown_test()
 class TestGraspExecutionShutdown(unittest.TestCase):
+
     def test_exit_codes(self, proc_info):
         launch_testing.asserts.assertExitCodes(proc_info, allowable_exit_codes=[0])

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_home_return_utils.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_home_return_utils.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
+#include <vector>
 
 #include <rclcpp/parameter.hpp>
 
-#include <vector>
+#include <gtest/gtest.h>
 
 #include "run_grasp_execution/home_return_utils.hpp"
 
@@ -69,7 +69,6 @@ TEST(TestHomeReturnUtils, ParseSafeJointStateParamWrongTypeStringFallsBackToEmpt
   ASSERT_TRUE(resolution.warning_message.has_value());
   EXPECT_NE(resolution.warning_message->find("type 'string'"), std::string::npos);
 }
-
 
 TEST(TestHomeReturnUtils, ParseSafeJointStateParamValidListIsReturned)
 {


### PR DESCRIPTION
## Summary
- harden remaining run_grasp_execution startup parameter reads after PR #1287
- fix remaining run_grasp_execution flake8, cpplint, and formatting failures
- keep launch-test exit-code enforcement at allowable_exit_codes=[0]

## Validation
- local scratch flake8 command passed for the run_grasp_execution Python files
- local Python compile passed for the touched Python files
- ROS Humble colcon validation still needs to be run in ~/workcell_ws

Draft while I finish pushing the prepared scratch changes into this branch.