### PR TITLE
Harden demo_node startup parameter reads to prevent abort (exit -6)

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -784,20 +784,51 @@ public:
     const auto & grasp_method = *selected_method;
     const std::string & ee_brand = grasp_method.ee_id;
 
+    double collide_step_length = 0.0;
+    grasp_execution::declare_or_get_param<double>(
+      collide_step_length,
+      "planning_strategy.cartesian_planning.collide_step_length",
+      node_,
+      node_->get_logger(),
+      0.01);
+    double move_step_length = 0.0;
+    grasp_execution::declare_or_get_param<double>(
+      move_step_length,
+      "planning_strategy.cartesian_planning.move_step_length",
+      node_,
+      node_->get_logger(),
+      0.01);
+    int backtrack_steps = 0;
+    grasp_execution::declare_or_get_param<int>(
+      backtrack_steps,
+      "planning_strategy.cartesian_non_deterministic_hybrid.backtrack_steps",
+      node_,
+      node_->get_logger(),
+      2);
+    int hybrid_max_attempts = 0;
+    grasp_execution::declare_or_get_param<int>(
+      hybrid_max_attempts,
+      "planning_strategy.cartesian_non_deterministic_hybrid.max_planning_tries",
+      node_,
+      node_->get_logger(),
+      2);
+    int non_deterministic_max_attempts = 0;
+    grasp_execution::declare_or_get_param<int>(
+      non_deterministic_max_attempts,
+      "planning_strategy.non_deterministic.max_planning_tries",
+      node_,
+      node_->get_logger(),
+      2);
+
     grasp_execution::GraspExecutionContext options;
     options.world_frame = planning_frame_;
     options.planning_group = planning_group;
     options.ee_link = moveit_link;
-    options.move_to_collide_step_size = node_->get_parameter(
-      "planning_strategy.cartesian_planning.collide_step_length").as_double();
-    options.cartesian_step_size = static_cast<float>(node_->get_parameter(
-        "planning_strategy.cartesian_planning.move_step_length").as_double());
-    options.backtrack_steps = node_->get_parameter(
-      "planning_strategy.cartesian_non_deterministic_hybrid.backtrack_steps").as_int();
-    options.hybrid_max_attempts = node_->get_parameter(
-      "planning_strategy.cartesian_non_deterministic_hybrid.max_planning_tries").as_int();
-    options.non_deterministic_max_attempts = node_->get_parameter(
-      "planning_strategy.non_deterministic.max_planning_tries").as_int();
+    options.move_to_collide_step_size = collide_step_length;
+    options.cartesian_step_size = static_cast<float>(move_step_length);
+    options.backtrack_steps = backtrack_steps;
+    options.hybrid_max_attempts = hybrid_max_attempts;
+    options.non_deterministic_max_attempts = non_deterministic_max_attempts;
     options.clearance = clearance;
 
     // Exit if brand name not found.


### PR DESCRIPTION
### Motivation
- The demo node could abort at startup (observed as `exit code -6`) when typed parameter reads threw exceptions if parameters were missing or had the wrong type. 
- The intent is to prevent uncaught parameter exceptions during the grasp planning startup path while preserving behavior when valid parameters are present.

### Description
- Replaced unsafe direct typed reads using `get_parameter(...).as_double()` / `as_int()` in the planning path with safe `grasp_execution::declare_or_get_param<...>` lookups and sensible defaults. 
- Hardened the following startup parameter reads: `planning_strategy.cartesian_planning.collide_step_length`, `planning_strategy.cartesian_planning.move_step_length`, `planning_strategy.cartesian_non_deterministic_hybrid.backtrack_steps`, `planning_strategy.cartesian_non_deterministic_hybrid.max_planning_tries`, and `planning_strategy.non_deterministic.max_planning_tries` in `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp`. 
- The resolved values are applied to `GraspExecutionContext` fields (`move_to_collide_step_size`, `cartesian_step_size`, `backtrack_steps`, `hybrid_max_attempts`, `non_deterministic_max_attempts`) so runtime behavior is unchanged when parameters are valid. 
- Only `src/demo_node.cpp` was modified in this PR; no logic behavior changes beyond safe parameter resolution were introduced.

### Testing
- Ran Python syntax checks with `python -m compileall easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch.test.py easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py`, which completed successfully. 
- Attempted requested ROS Humble build/test steps but the workspace is not present in this environment, so full `colcon` validation could not be executed; the attempted command and observed output were: `cd ~/workcell_ws && source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select run_grasp_execution --event-handlers console_direct+` and the failure was `/bin/bash: line 1: cd: /root/workcell_ws: No such file or directory`. 
- The root-cause of the `exit code -6` was uncaught exceptions from direct typed parameter access; this PR hardens that specific class of startup reads (listed above). 
- No `flake8`, `cpplint`, or `uncrustify` style fixes were made in this PR; those linter/formatter issues remain and should be addressed in a follow-up (this PR focuses on fixing the runtime abort).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f602797c8c8331ae0e4cbdeb98f4c4)