### PR TITLE
Harden demo_node parameter handling for optional home_return.safe_joint_state

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/src/demo_node.cpp
@@ -52,10 +52,10 @@
 #include "moveit/collision_detection/collision_common.h"
 #include "moveit/planning_scene_monitor/planning_scene_monitor.h"
 #include "tf2_eigen/tf2_eigen.hpp"
-#include "run_grasp_execution/grasp_precheck_collision_filter.hpp"
-#include "run_grasp_execution/grasp_candidate_utils.hpp"
-#include "run_grasp_execution/home_return_utils.hpp"
 #include "run_grasp_execution/explicit_release_pose_utils.hpp"
+#include "run_grasp_execution/grasp_candidate_utils.hpp"
+#include "run_grasp_execution/grasp_precheck_collision_filter.hpp"
+#include "run_grasp_execution/home_return_utils.hpp"
 
 
 namespace grasp_execution
@@ -387,12 +387,21 @@ std::vector<double> resolve_safe_joint_state_param(
   const std::string & param_name)
 {
   const std::vector<double> empty_default;
-  rclcpp::Parameter parameter;
-  if (!node->get_parameter(param_name, parameter)) {
-    RCLCPP_INFO(
+  rclcpp::Parameter parameter(param_name);
+  try {
+    if (!node->get_parameter(param_name, parameter)) {
+      RCLCPP_INFO(
+        logger,
+        "Parameter '%s' is not set. Using empty safe joint state.",
+        param_name.c_str());
+      return empty_default;
+    }
+  } catch (const rclcpp::exceptions::InvalidParameterValueException & e) {
+    RCLCPP_WARN(
       logger,
-      "Parameter '%s' is not set. Using empty safe joint state.",
-      param_name.c_str());
+      "Parameter '%s' is declared without a value (%s). Using empty safe joint state.",
+      param_name.c_str(),
+      e.what());
     return empty_default;
   }
 
@@ -1594,8 +1603,8 @@ public:
       demo_ = std::make_shared<grasp_execution::Demo>(
         base_node_, grasp_execution::GRASP_EXECUTION_PACKAGE,
         grasp_execution::GRASP_TASK_TOPIC, grasp_execution::GRASP_REQUEST_TOPIC);
-      std::string workcell_context_filepath =
-        this->get_parameter("workcell_context").as_string();
+      std::string workcell_context_filepath;
+      this->get_parameter_or<std::string>("workcell_context", workcell_context_filepath, "");
       if (!std::filesystem::path(workcell_context_filepath).is_absolute()) {
         workcell_context_filepath =
           (std::filesystem::path(


### PR DESCRIPTION
### Motivation
- Prevent the demo node from aborting when `home_return.safe_joint_state` is declared but has no value by treating it as optional and falling back to an empty safe joint state.
- Preserve existing behavior of skipping the safe intermediate home-return with a warning when the parameter is missing, empty, or malformed.
- Eliminate unsafe direct typed parameter reads that can throw (`.as_string()`, `.as_*` usage) so launch tests no longer fail due to parameter read exceptions.

### Description
- Update `resolve_safe_joint_state_param()` in `demo_node.cpp` to construct a `rclcpp::Parameter` with a name and catch `rclcpp::exceptions::InvalidParameterValueException`, logging a warning and returning an empty safe joint state instead of letting the node abort.
- Replace the direct `get_parameter(...).as_string()` usage for `workcell_context` with a safe `get_parameter_or<std::string>` call to avoid typed-conversion exceptions for unset or empty parameters.
- Reorder a few local include lines in `demo_node.cpp` to align with cpplint include-order expectations and keep changes minimal and focused.
- Preserve existing `home_return_utils.hpp` logic: when the safe joint state is empty or the size mismatches, the node logs a warning and continues without executing the safe intermediate.

### Testing
- Attempted to run the requested ROS validation commands (`colcon build`, `colcon test`, `colcon test-result`) in this environment, but they could not be executed because `/opt/ros/humble/setup.bash` and the expected `workcell_ws` setup are not available here, so automated build/test could not be completed.
- Ran repository searches and applied the changes with automated edits and ensured the targeted unsafe parameter reads were replaced or protected by exception handling using automated text edits (no build performed).
- Linter/formatters specified (`ament_cpplint`, `ament_flake8`, `ament_uncrustify`) were not available in this execution environment, so those checks could not be executed here and should be validated in the CI environment that contains ROS Humble tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f605713f848331af20f1ba7d07f217)