### PR TITLE
Sanitize grasp_execution launch params to ensure home_return.safe_joint_state is a valid empty array

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -525,6 +525,28 @@ def write_temp_yaml_params(data, prefix="ros2_controllers_"):
     return path
 
 
+def sanitize_grasp_execution_params(grasp_execution_params):
+    node_section = grasp_execution_params.get('grasp_execution_node')
+    if not isinstance(node_section, dict):
+        return grasp_execution_params
+
+    ros_params = node_section.get('ros__parameters')
+    if not isinstance(ros_params, dict):
+        return grasp_execution_params
+
+    home_return = ros_params.get('home_return')
+    if home_return is None:
+        home_return = {}
+        ros_params['home_return'] = home_return
+    if not isinstance(home_return, dict):
+        return grasp_execution_params
+
+    safe_joint_state = home_return.get('safe_joint_state')
+    if safe_joint_state in (None, ''):
+        home_return['safe_joint_state'] = []
+    return grasp_execution_params
+
+
 def require_yaml_mapping(data, field_name, package_name, file_name):
     if not isinstance(data, dict):
         raise RuntimeError(
@@ -925,8 +947,14 @@ def launch_setup(context, *args, **kwargs):
         f"Generated sanitized sensors params file at '{sensors_yaml}' with octomap_frame='{planning_frame}'."
     )
 
-    grasp_execution_yaml = os.path.join(run_share, "config", "grasp_execution.yaml")
-    rviz_config_file = os.path.join(run_share, "config", "grasp_execution.rviz")
+    grasp_execution_config = sanitize_grasp_execution_params(
+        load_yaml(PACKAGE_NAME, 'config/grasp_execution.yaml')
+    )
+    grasp_execution_yaml = write_temp_yaml_params(
+        grasp_execution_config,
+        prefix='grasp_execution_',
+    )
+    rviz_config_file = os.path.join(run_share, 'config', 'grasp_execution.rviz')
 
     grasp_execution_demo_node = Node(
         name="grasp_execution_node",


### PR DESCRIPTION
### Motivation
- Prevent `demo_node` from aborting on startup when a launch-time override injects an unset/valueless `home_return.safe_joint_state` parameter. 
- Ensure the node always receives a valid double-array (explicit `[]`) for `home_return.safe_joint_state` so internal fallback logic is not bypassed.

### Description
- Added `sanitize_grasp_execution_params()` to `launch/grasp_execution.launch.py` to ensure `grasp_execution_node.ros__parameters.home_return.safe_joint_state` is present and normalized to `[]` when the override is `None` or an empty string. 
- Switched the grasp execution node parameter input from the raw packaged YAML to a sanitized temporary YAML generated at launch via `write_temp_yaml_params(load_yaml(...))` so valueless overrides are not propagated to the node. 
- Kept all other parameter handling and behavior unchanged and added defensive type checks when normalizing the `home_return` section.

### Testing
- `python3 -m py_compile easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py` passed, confirming the modified launch file is syntactically valid. 
- Attempted `colcon build --symlink-install --packages-select run_grasp_execution` and subsequent `colcon test`/`colcon test-result` commands could not be executed in this environment because the ROS 2 Humble environment (`/opt/ros/humble/setup.bash`) is not available, so package build/tests were not run here. 
- Linters/formatters (`flake8`, `cpplint`, `uncrustify`) were not executed in this environment due to missing tools, so their results are not available from this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6078bc07483318aa0d32c5524ae73)