### PR TITLE
Fix run_grasp_execution launch sanitizer for empty home_return.safe_joint_state

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -544,8 +544,8 @@ def sanitize_grasp_execution_params(grasp_execution_params):
         return grasp_execution_params
 
     safe_joint_state = home_return.get('safe_joint_state')
-    if safe_joint_state in (None, ''):
-        home_return['safe_joint_state'] = []
+    if safe_joint_state in (None, '') or safe_joint_state == []:
+        home_return.pop('safe_joint_state', None)
     return grasp_execution_params
 
 

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
@@ -853,3 +853,42 @@ def test_launch_setup_wraps_scene_metadata_parse_errors_with_argument_context(
     assert 'scene_package=\x27scene_pkg\x27' in message
     assert 'moveit_config_package=\x27moveit_pkg\x27' in message
     assert 'planning_frame=\x27world\x27' in message
+
+
+@pytest.mark.parametrize(
+    'safe_joint_state',
+    [None, '', []],
+)
+def test_sanitize_grasp_execution_params_removes_empty_safe_joint_state(
+    grasp_launch_module,
+    safe_joint_state,
+):
+    params = {
+        'grasp_execution_node': {
+            'ros__parameters': {
+                'home_return': {'safe_joint_state': safe_joint_state},
+            }
+        }
+    }
+
+    sanitized = grasp_launch_module.sanitize_grasp_execution_params(params)
+
+    assert 'safe_joint_state' not in sanitized['grasp_execution_node']['ros__parameters']['home_return']
+
+
+def test_sanitize_grasp_execution_params_preserves_non_empty_safe_joint_state(grasp_launch_module):
+    params = {
+        'grasp_execution_node': {
+            'ros__parameters': {
+                'home_return': {'safe_joint_state': [0.0, -1.57, 1.57]},
+            }
+        }
+    }
+
+    sanitized = grasp_launch_module.sanitize_grasp_execution_params(params)
+
+    assert sanitized['grasp_execution_node']['ros__parameters']['home_return']['safe_joint_state'] == [
+        0.0,
+        -1.57,
+        1.57,
+    ]


### PR DESCRIPTION
### Motivation
- A valueless/empty YAML list for `home_return.safe_joint_state` can become an untyped parameter in ROS 2 Humble and triggers `parameter_value_from failed` when the node declares/reads it.
- The existing sanitizer wrote `[]` back into the launch params for empty values, reintroducing the problematic parameter instead of removing it.

### Description
- Update `sanitize_grasp_execution_params()` so that when `home_return.safe_joint_state` is `None`, `''`, or `[]` it is removed from the `home_return` mapping via `pop(...)` instead of being set to `[]`.
- Preserve valid non-empty numeric lists unchanged.
- Add focused unit tests in `test_grasp_execution_launch_helpers.py` that verify removal for `None`, `''`, and `[]`, and preservation for `[0.0, -1.57, 1.57]`.

### Testing
- Executed the new helper unit tests with `pytest -k sanitize_grasp_execution_params`, but the test module was skipped due to `pytest.importorskip('xacro')` in this environment so no failures were reported.
- Attempted the requested `colcon build` workflow for `run_grasp_execution`, but the container did not contain the requested `~/workcell_ws` workspace so the build could not be run here.
- The added tests are lightweight unit tests and are expected to pass in CI and on a local machine with `xacro` available and the workspace present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62b45c4388331b35f5198ff90305e)