### PR TITLE
Fix run_grasp_execution helper flake8 line length

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
@@ -873,7 +873,8 @@ def test_sanitize_grasp_execution_params_removes_empty_safe_joint_state(
 
     sanitized = grasp_launch_module.sanitize_grasp_execution_params(params)
 
-    assert 'safe_joint_state' not in sanitized['grasp_execution_node']['ros__parameters']['home_return']
+    home_return = sanitized['grasp_execution_node']['ros__parameters']['home_return']
+    assert 'safe_joint_state' not in home_return
 
 
 def test_sanitize_grasp_execution_params_preserves_non_empty_safe_joint_state(grasp_launch_module):
@@ -887,7 +888,8 @@ def test_sanitize_grasp_execution_params_preserves_non_empty_safe_joint_state(gr
 
     sanitized = grasp_launch_module.sanitize_grasp_execution_params(params)
 
-    assert sanitized['grasp_execution_node']['ros__parameters']['home_return']['safe_joint_state'] == [
+    home_return = sanitized['grasp_execution_node']['ros__parameters']['home_return']
+    assert home_return['safe_joint_state'] == [
         0.0,
         -1.57,
         1.57,


### PR DESCRIPTION
Fixes the remaining run_grasp_execution flake8 failure by splitting long safe_joint_state assertions in test_grasp_execution_launch_helpers.py.

Local validation:
- colcon test --packages-select run_grasp_execution passed
- 100% tests passed, 0 tests failed out of 13
- Summary: 90 tests, 0 errors, 0 failures, 10 skipped

This is a test-only lint fix and does not change runtime behaviour.