### PR TITLE
Apply uncrustify cleanups for planner and waypoint tests

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/src/demo_node.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_planner/src/demo_node.cpp
@@ -69,8 +69,8 @@ int main(int argc, char * argv[])
 
   const auto point_cloud_topic =
     get_parameter_or(
-      node, "camera_parameters.point_cloud_topic",
-      std::string("/camera/camera/depth/color/points"));
+    node, "camera_parameters.point_cloud_topic",
+    std::string("/camera/camera/depth/color/points"));
 
   rclcpp::executors::MultiThreadedExecutor executor;
   #if EPD_ENABLED == 1
@@ -101,7 +101,8 @@ int main(int argc, char * argv[])
     if (!detection_topic.empty()) {
       RCLCPP_INFO(LOGGER_DEMO, "EPD detection adapter enabled.");
       adapter_node = std::make_shared<grasp_planner::EpdDetectionAdapter>(node_options);
-      adapter_node->set_parameters({
+      adapter_node->set_parameters(
+      {
         rclcpp::Parameter("camera_parameters.fx", camera_fx),
         rclcpp::Parameter("camera_parameters.fy", camera_fy),
         rclcpp::Parameter("camera_parameters.ppx", camera_ppx),

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/include/run_waypoint_execution/target_validation.hpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/include/run_waypoint_execution/target_validation.hpp
@@ -30,8 +30,8 @@ bool validate_grasp_target_selection(
   const rclcpp::Logger & logger,
   const emd_msgs::msg::GraspTarget::SharedPtr & target,
   const std::string & target_id,
-  const emd_msgs::msg::GraspMethod *& grasp_method,
-  const geometry_msgs::msg::PoseStamped *& grasp_pose);
+  const emd_msgs::msg::GraspMethod * & grasp_method,
+  const geometry_msgs::msg::PoseStamped * & grasp_pose);
 
 bool resolve_end_effector_mapping(
   const grasp_execution::WorkcellContext & workcell_context,

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/target_validation.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/src/target_validation.cpp
@@ -23,8 +23,8 @@ bool validate_grasp_target_selection(
   const rclcpp::Logger & logger,
   const emd_msgs::msg::GraspTarget::SharedPtr & target,
   const std::string & target_id,
-  const emd_msgs::msg::GraspMethod *& grasp_method,
-  const geometry_msgs::msg::PoseStamped *& grasp_pose)
+  const emd_msgs::msg::GraspMethod * & grasp_method,
+  const geometry_msgs::msg::PoseStamped * & grasp_pose)
 {
   grasp_method = nullptr;
   grasp_pose = nullptr;

--- a/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/test/test_target_validation.cpp
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_waypoint_execution/test/test_target_validation.cpp
@@ -32,7 +32,8 @@ TEST(TargetValidation, RejectsNullTarget)
   const emd_msgs::msg::GraspMethod * grasp_method = nullptr;
   const geometry_msgs::msg::PoseStamped * grasp_pose = nullptr;
 
-  EXPECT_FALSE(run_waypoint_execution::validate_grasp_target_selection(
+  EXPECT_FALSE(
+    run_waypoint_execution::validate_grasp_target_selection(
       rclcpp::get_logger("test_target_validation"),
       nullptr,
       "target-null",
@@ -49,7 +50,8 @@ TEST(TargetValidation, RejectsEmptyGraspMethods)
   const emd_msgs::msg::GraspMethod * grasp_method = nullptr;
   const geometry_msgs::msg::PoseStamped * grasp_pose = nullptr;
 
-  EXPECT_FALSE(run_waypoint_execution::validate_grasp_target_selection(
+  EXPECT_FALSE(
+    run_waypoint_execution::validate_grasp_target_selection(
       rclcpp::get_logger("test_target_validation"),
       target,
       "target-empty-methods",
@@ -68,7 +70,8 @@ TEST(TargetValidation, RejectsEmptyGraspPoses)
   const emd_msgs::msg::GraspMethod * grasp_method = nullptr;
   const geometry_msgs::msg::PoseStamped * grasp_pose = nullptr;
 
-  EXPECT_FALSE(run_waypoint_execution::validate_grasp_target_selection(
+  EXPECT_FALSE(
+    run_waypoint_execution::validate_grasp_target_selection(
       rclcpp::get_logger("test_target_validation"),
       target,
       "target-empty-poses",
@@ -88,7 +91,8 @@ TEST(TargetValidation, AcceptsValidFirstSelection)
   const emd_msgs::msg::GraspMethod * grasp_method = nullptr;
   const geometry_msgs::msg::PoseStamped * grasp_pose = nullptr;
 
-  EXPECT_TRUE(run_waypoint_execution::validate_grasp_target_selection(
+  EXPECT_TRUE(
+    run_waypoint_execution::validate_grasp_target_selection(
       rclcpp::get_logger("test_target_validation"),
       target,
       "target-valid",
@@ -110,7 +114,8 @@ TEST(TargetValidation, RejectsUnknownEndEffectorMapping)
   std::string ee_link = "stale_link";
   double clearance = 0.42;
 
-  EXPECT_FALSE(run_waypoint_execution::resolve_end_effector_mapping(
+  EXPECT_FALSE(
+    run_waypoint_execution::resolve_end_effector_mapping(
       workcell_context, "unknown-ee-id", planning_group, ee_link, clearance));
   EXPECT_TRUE(planning_group.empty());
   EXPECT_TRUE(ee_link.empty());


### PR DESCRIPTION
Applies local ament_uncrustify formatting fixes that could not be run in the Codex environment.

Validated locally:
- run_grasp_planner uncrustify passed
- run_waypoint_execution uncrustify passed