### PR TITLE
Add minimal UR5 + Robotiq 2F sorting scene package

### DIFF
--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.5)
+project(ur5_2f_sorting_test)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(DIRECTORY urdf
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(FILES
+  environment.yaml
+  scene_manifest.yaml
+  README.md
+  DESTINATION share/${PROJECT_NAME}
+)
+ament_package()

--- a/scenes/ur5_2f_sorting_test/README.md
+++ b/scenes/ur5_2f_sorting_test/README.md
@@ -1,0 +1,11 @@
+# ur5_2f_sorting_test
+
+Minimal sorting-cell scene for UR5 + Robotiq 2F.
+
+## Launch
+
+```bash
+ros2 launch run_grasp_execution grasp_execution.launch.py scene_package:=ur5_2f_sorting_test launch_rviz:=true
+```
+
+The scene includes a table, two destination bins (`bin_a`, `bin_b`), and three placeholder items.

--- a/scenes/ur5_2f_sorting_test/environment.yaml
+++ b/scenes/ur5_2f_sorting_test/environment.yaml
@@ -1,0 +1,69 @@
+robot:
+  name: ur5
+  brand: universal_robot
+  filepath: ""
+  base_link: base_link
+  links:
+    - base_link
+    - shoulder_link
+    - upper_arm_link
+    - forearm_link
+    - wrist_1_link
+    - wrist_2_link
+    - wrist_3_link
+    - base
+    - tool0
+end_effector:
+  name: robotiq_85
+  brand: robotiq_85_gripper
+  filepath: assets/end_effectors/robotiq_85_gripper/robotiq_85_description
+  base_link: gripper_base_link
+  robot_link: tool0
+  ee_type: finger
+  attributes:
+    fingers: 2
+  origin:
+    x: 0
+    y: 0
+    z: 0
+    roll: 0
+    pitch: -1.5707
+    yaw: 0
+  links:
+    - gripper_base_link
+    - gripper_finger1_knuckle_link
+    - gripper_finger2_knuckle_link
+    - gripper_finger1_finger_link
+    - gripper_finger2_finger_link
+    - gripper_finger1_inner_knuckle_link
+    - gripper_finger2_inner_knuckle_link
+    - gripper_finger1_finger_tip_link
+    - gripper_finger2_finger_tip_link
+objects:
+  table:
+    child_link: table
+    links:
+      table:
+        visual:
+          name: table
+          geometry:
+            filepath: assets/environment/table_description/meshes/visual/table.stl
+            scale:
+              scale_x: 0.001
+              scale_y: 0.001
+              scale_z: 0.001
+        collision:
+          name: None
+          geometry:
+            filepath: assets/environment/table_description/meshes/visual/table.stl
+            scale:
+              scale_x: 0.001
+              scale_y: 0.001
+              scale_z: 0.001
+    table_base_joint:
+      ext_joint_type: fixed
+      child_link: table
+external joints:
+  table:
+    parent object: world
+    parent link: world

--- a/scenes/ur5_2f_sorting_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_sorting_test/launch/demo.launch.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+
+import os
+import tempfile
+import yaml
+import re
+import subprocess
+
+from launch import LaunchDescription
+from launch.actions import OpaqueFunction
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+
+scene_pkg = "ur5_2f_sorting_test"
+robot_base_link = "base_link"
+robot_moveit_pkg = "ur5_moveit_config"
+
+
+def load_xacro(package_name, rel_path, mappings=None):
+    pkg_share = get_package_share_directory(package_name)
+    abs_path = os.path.join(pkg_share, rel_path)
+    if not os.path.exists(abs_path):
+        raise FileNotFoundError(f"Missing file: {abs_path}")
+
+    effective_mappings = dict(mappings or {})
+    while True:
+        cmd = ["xacro", abs_path]
+        cmd.extend(f"{key}:={value}" for key, value in effective_mappings.items())
+        try:
+            completed = subprocess.run(cmd, check=True, text=True, capture_output=True, timeout=30)
+            return completed.stdout
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Timed out while expanding xacro file '{abs_path}'. "
+                "This usually means a dependency package is missing from the sourced workspace "
+                "or the xacro include graph is blocking."
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr or ""
+            match = re.search(r'Invalid parameter "([^"]+)"', stderr)
+            if not match:
+                raise RuntimeError(f"Failed to expand xacro file '{abs_path}':\n{stderr}") from exc
+
+            invalid_param = match.group(1)
+            if invalid_param not in effective_mappings:
+                raise RuntimeError(f"Failed to expand xacro file '{abs_path}':\n{stderr}") from exc
+            effective_mappings.pop(invalid_param)
+
+
+def load_yaml(package_name, rel_path):
+    pkg_share = get_package_share_directory(package_name)
+    abs_path = os.path.join(pkg_share, rel_path)
+    if not os.path.exists(abs_path):
+        return {}
+    with open(abs_path, "r") as file:
+        return yaml.safe_load(file) or {}
+
+
+
+
+
+
+def _normalize_ros_param_types(value):
+    if isinstance(value, dict):
+        return {str(key): _normalize_ros_param_types(item) for key, item in value.items()}
+
+    if isinstance(value, tuple):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    if isinstance(value, list):
+        return [_normalize_ros_param_types(item) for item in value]
+
+    return value
+
+
+_DROP_PARAM = object()
+
+
+def _sanitize_ros_param_types(value):
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, item in value.items():
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is _DROP_PARAM:
+                continue
+            sanitized[str(key)] = sanitized_item
+        return sanitized if sanitized else _DROP_PARAM
+
+    if isinstance(value, tuple):
+        value = list(value)
+
+    if isinstance(value, list):
+        sanitized_items = []
+        for item in value:
+            sanitized_item = _sanitize_ros_param_types(item)
+            if sanitized_item is not _DROP_PARAM:
+                sanitized_items.append(sanitized_item)
+        return sanitized_items if sanitized_items else _DROP_PARAM
+
+    if isinstance(value, (bool, int, float, str, bytes)):
+        return value
+
+    return value
+
+
+def _param_dict(value):
+    sanitized = _sanitize_ros_param_types(value)
+    return {} if sanitized is _DROP_PARAM else sanitized
+
+
+def _param_list(*values):
+    result = []
+    for value in values:
+        sanitized = _sanitize_ros_param_types(value)
+        if sanitized is _DROP_PARAM:
+            continue
+        if isinstance(sanitized, dict) and not sanitized:
+            continue
+        result.append(sanitized)
+    return result
+
+
+def _validate_ros_param_types(value, path="root"):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"Invalid ROS param type at {path}: {type(key).__name__} -> {key!r}")
+            _validate_ros_param_types(item, f"{path}.{key}")
+        return
+
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_ros_param_types(item, f"{path}[{index}]")
+        return
+
+    if isinstance(value, (bool, int, float, str, bytes)):
+        return
+
+    raise TypeError(f"Invalid ROS param type at {path}: {type(value).__name__} -> {value!r}")
+
+
+
+
+def _write_robot_description_file(scene_name, robot_description_config):
+    path = os.path.join(
+        tempfile.gettempdir(),
+        f"{scene_name}_robot_description.urdf",
+    )
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(robot_description_config)
+    return path
+
+
+def _launch_setup(context):
+    use_sim_time = LaunchConfiguration("use_sim_time")
+    use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    joint_states_topic = f"/{scene_pkg}/joint_states"
+
+    robot_description_config = load_xacro(
+        scene_pkg,
+        "urdf/scene.urdf.xacro",
+        mappings={
+            "ur_type": "ur5",
+            "name": "ur5",
+            "tf_prefix": "",
+            "use_fake_hardware": use_fake_hardware.perform(context),
+        },
+    )
+    robot_description = {"robot_description": robot_description_config}
+
+    robot_description_file = _write_robot_description_file(
+        scene_pkg,
+        robot_description_config,
+    )
+
+    robot_description_semantic_config = load_xacro(scene_pkg, "urdf/arm_hand.srdf.xacro")
+    robot_description_semantic = {"robot_description_semantic": robot_description_semantic_config}
+
+    kinematics_yaml = load_yaml(robot_moveit_pkg, "config/kinematics.yaml")
+    robot_description_kinematics = {"robot_description_kinematics": kinematics_yaml} if kinematics_yaml else {}
+
+    ompl_planning_yaml = load_yaml(robot_moveit_pkg, "config/ompl_planning.yaml")
+
+    planning_pipelines_config = {
+        "planning_pipelines": ["ompl"],
+        "default_planning_pipeline": "ompl",
+    }
+
+    ompl_planning_pipeline_config = {
+        "ompl": {
+            "planning_plugin": "ompl_interface/OMPLPlanner",
+            "request_adapters": " ".join([
+                "default_planner_request_adapters/AddTimeOptimalParameterization",
+                "default_planner_request_adapters/FixWorkspaceBounds",
+                "default_planner_request_adapters/FixStartStateBounds",
+                "default_planner_request_adapters/FixStartStateCollision",
+                "default_planner_request_adapters/FixStartStatePathConstraints",
+            ]),
+            "start_state_max_bounds_error": 0.1,
+        }
+    }
+    if isinstance(ompl_planning_yaml, dict):
+        ompl_planning_pipeline_config["ompl"].update(ompl_planning_yaml)
+
+    moveit_controller_manager = {
+        "moveit_controller_manager": "moveit_simple_controller_manager/MoveItSimpleControllerManager"
+    }
+
+    moveit_simple_controller_manager = {
+        "moveit_simple_controller_manager": {
+            "controller_names": ["ur5_arm_controller", "ur5_gripper_controller"],
+            "ur5_arm_controller": {
+                "action_ns": "follow_joint_trajectory",
+                "type": "FollowJointTrajectory",
+                "default": True,
+                "joints": [
+                    "shoulder_pan_joint",
+                    "shoulder_lift_joint",
+                    "elbow_joint",
+                    "wrist_1_joint",
+                    "wrist_2_joint",
+                    "wrist_3_joint",
+                ],
+            },
+            "ur5_gripper_controller": {
+                "action_ns": "follow_joint_trajectory",
+                "type": "FollowJointTrajectory",
+                "default": False,
+                "joints": ["gripper_finger1_joint"],
+            },
+        }
+    }
+
+    trajectory_execution = {
+        "allow_trajectory_execution": False,
+        "moveit_manage_controllers": False,
+    }
+
+    planning_scene_monitor_params = {
+        "publish_planning_scene": True,
+        "publish_geometry_updates": True,
+        "publish_state_updates": True,
+        "publish_transforms_updates": True,
+    }
+
+    try:
+        validated_use_sim_time = _param_dict(_normalize_ros_param_types({"use_sim_time": use_sim_time.perform(context).lower() == "true"}))
+        validated_robot_description = _param_dict(_normalize_ros_param_types(robot_description))
+        validated_robot_description_semantic = _param_dict(_normalize_ros_param_types(robot_description_semantic))
+        validated_robot_description_kinematics = _param_dict(_normalize_ros_param_types(robot_description_kinematics))
+        validated_planning_pipelines_config = _param_dict(_normalize_ros_param_types(planning_pipelines_config))
+        validated_ompl_planning_pipeline_config = _param_dict(_normalize_ros_param_types(ompl_planning_pipeline_config))
+        validated_planning_scene_monitor_params = _param_dict(_normalize_ros_param_types(planning_scene_monitor_params))
+        validated_trajectory_execution = _param_dict(_normalize_ros_param_types(trajectory_execution))
+        validated_moveit_controller_manager = _param_dict(_normalize_ros_param_types(moveit_controller_manager))
+        validated_moveit_simple_controller_manager = _param_dict(_normalize_ros_param_types(moveit_simple_controller_manager))
+
+        _validate_ros_param_types(validated_use_sim_time, "use_sim_time")
+        _validate_ros_param_types(validated_robot_description, "robot_description")
+        _validate_ros_param_types(validated_robot_description_semantic, "robot_description_semantic")
+        _validate_ros_param_types(validated_robot_description_kinematics, "robot_description_kinematics")
+        _validate_ros_param_types(validated_planning_pipelines_config, "planning_pipelines_config")
+        _validate_ros_param_types(validated_ompl_planning_pipeline_config, "ompl_planning_pipeline_config")
+        _validate_ros_param_types(validated_planning_scene_monitor_params, "planning_scene_monitor_params")
+        _validate_ros_param_types(validated_trajectory_execution, "trajectory_execution")
+        _validate_ros_param_types(validated_moveit_controller_manager, "moveit_controller_manager")
+        _validate_ros_param_types(validated_moveit_simple_controller_manager, "moveit_simple_controller_manager")
+    except TypeError as exc:
+        raise TypeError(f"{scene_pkg} demo.launch parameter validation failed: {exc}") from exc
+
+    static_tf = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="static_transform_publisher",
+        output="screen",
+        arguments=[
+            "--x",
+            "0.0",
+            "--y",
+            "0.0",
+            "--z",
+            "0.0",
+            "--roll",
+            "0.0",
+            "--pitch",
+            "0.0",
+            "--yaw",
+            "0.0",
+            "--frame-id",
+            "world",
+            "--child-frame-id",
+            robot_base_link,
+        ],
+    )
+
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name=f"{scene_pkg}_robot_state_publisher",
+        output="screen",
+        parameters=_param_list(validated_use_sim_time, validated_robot_description),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
+    )
+
+    joint_state_publisher = Node(
+        package="joint_state_publisher",
+        executable="joint_state_publisher",
+        name=f"{scene_pkg}_joint_state_publisher",
+        output="screen",
+        arguments=[robot_description_file],
+        parameters=_param_list(
+            validated_use_sim_time,
+        ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
+    )
+
+    move_group = Node(
+        package="moveit_ros_move_group",
+        executable="move_group",
+        output="screen",
+        parameters=_param_list(
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
+            validated_planning_pipelines_config,
+            validated_ompl_planning_pipeline_config,
+            validated_planning_scene_monitor_params,
+            validated_trajectory_execution,
+            validated_moveit_controller_manager,
+            validated_moveit_simple_controller_manager,
+        ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
+    )
+
+    rviz_config_file = os.path.join(get_package_share_directory(scene_pkg), "launch", "demo.rviz")
+    rviz_node = Node(
+        package="rviz2",
+        executable="rviz2",
+        name="rviz2",
+        output="screen",
+        arguments=["-d", rviz_config_file] if os.path.exists(rviz_config_file) else [],
+        parameters=_param_list(
+            validated_use_sim_time,
+            validated_robot_description,
+            validated_robot_description_semantic,
+            validated_robot_description_kinematics,
+        ),
+        remappings=[
+            ("joint_states", joint_states_topic),
+            ("/joint_states", joint_states_topic),
+        ],
+    )
+
+    return [
+        static_tf,
+        robot_state_publisher,
+        joint_state_publisher,
+        move_group,
+        rviz_node,
+    ]
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument("use_sim_time", default_value="false"),
+        DeclareLaunchArgument(
+            "use_fake_hardware",
+            default_value="true",
+            description=(
+                "Use simulated (fake) hardware instead of a real robot. "
+                "Default: true (safe for development/testing without a physical robot). "
+                "Set to false only when connected to a real robot via ur_robot_driver "
+                "and after setting the robot_ip in the driver launch."
+            ),
+        ),
+        OpaqueFunction(function=_launch_setup),
+    ])

--- a/scenes/ur5_2f_sorting_test/launch/demo.rviz
+++ b/scenes/ur5_2f_sorting_test/launch/demo.rviz
@@ -1,0 +1,292 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /PlanningScene1
+        - /Trajectory1
+      Splitter Ratio: 0.5
+    Tree Height: 583
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: moveit_rviz_plugin/PlanningScene
+      Enabled: true
+      Move Group Namespace: ""
+      Name: PlanningScene
+      Planning Scene Topic: /moveit_cpp/publish_planning_scene
+      Robot Description: robot_description
+      Scene Geometry:
+        Scene Alpha: 0.8999999761581421
+        Scene Color: 50; 230; 50
+        Scene Display Time: 0.20000000298023224
+        Show Scene Geometry: true
+        Voxel Coloring: Z-Axis
+        Voxel Rendering: Occupied Voxels
+      Scene Robot:
+        Attached Body Color: 150; 50; 150
+        Links:
+          All Links Enabled: true
+          Expand Joint Details: false
+          Expand Link Details: false
+          Expand Tree: false
+          Link Tree Style: Links in Alphabetic Order
+          panda_hand:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_leftfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link4:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link6:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link7:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link8:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          panda_rightfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+        Robot Alpha: 1
+        Show Robot Collision: false
+        Show Robot Visual: true
+      Value: true
+    - Class: moveit_rviz_plugin/Trajectory
+      Color Enabled: false
+      Enabled: true
+      Interrupt Display: false
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        panda_hand:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_leftfinger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link7:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        panda_link8:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        panda_rightfinger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+      Loop Animation: false
+      Name: Trajectory
+      Robot Alpha: 0.5
+      Robot Color: 150; 50; 150
+      Robot Description: robot_description
+      Show Robot Collision: false
+      Show Robot Visual: true
+      Show Trail: false
+      State Display Time: 0.05 s
+      Trail Step Size: 1
+      Trajectory Topic: /display_planned_path
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 3.8008623123168945
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.5753980278968811
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.4903981685638428
+    Saved: ~
+Window Geometry:
+  " - Trajectory Slider":
+    collapsed: false
+  Displays:
+    collapsed: false
+  Height: 812
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd000000040000000000000216000002d2fc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002d2000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000280020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000004100ffffff000000010000010f000002d2fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d000002d2000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000002cc000002d200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1533
+  X: 255
+  Y: 1107

--- a/scenes/ur5_2f_sorting_test/package.xml
+++ b/scenes/ur5_2f_sorting_test/package.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ur5_2f_sorting_test</name>
+  <version>2.0.0</version>
+  <description>ur5_test description</description>
+  <maintainer email="glenn_tan@artc.a-star.edu.sg">Tan Jing Peng GLenn</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>ur_description</exec_depend>
+  <exec_depend>ur5_moveit_config</exec_depend>
+  <exec_depend>robotiq_85_description</exec_depend>
+  <exec_depend>robotiq_85_moveit_config</exec_depend>
+  <exec_depend>realsense2_description</exec_depend>
+  <exec_depend>workbench_description</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/scenes/ur5_2f_sorting_test/scene_manifest.yaml
+++ b/scenes/ur5_2f_sorting_test/scene_manifest.yaml
@@ -1,0 +1,101 @@
+scene:
+  name: ur5_2f_sorting_test
+
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: base_link
+  ee_link: gripper_base_link
+  home_named_target: home
+
+end_effector:
+  type: finger
+  brand: robotiq_85_gripper
+  grasp_frame: gripper_base_link
+  allowed_touch_links:
+    - gripper_base_link
+    - gripper_finger1_knuckle_link
+    - gripper_finger2_knuckle_link
+    - gripper_finger1_finger_link
+    - gripper_finger2_finger_link
+    - gripper_finger1_inner_knuckle_link
+    - gripper_finger2_inner_knuckle_link
+    - gripper_finger1_finger_tip_link
+    - gripper_finger2_finger_tip_link
+
+environment:
+  support_surface_link: table
+
+perception:
+  input_frame_options:
+    - world
+    - base_link
+
+self_test:
+  # Commissioning defaults for deterministic offline checks.
+  # Tune these values for each physical workcell before production.
+  enabled: true
+  object:
+    id: commissioning_box
+    shape: box
+    dimensions: [0.05, 0.05, 0.05]
+    frame_id: world
+    pose_xyz: [0.45, 0.0, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+    attributes:
+      class: "part"
+      colour: "red"
+      shape: "box"
+      material: "plastic"
+  expected:
+    min_grasp_candidates: 1
+    allow_simulated_execution: true
+
+task_recipe:
+  # Future runtime/UI contract example plus commissioning defaults.
+  # Metadata-only in this release: validation/reporting only.
+  id: colour_sort_demo
+  name: Colour Sort Demo
+  type: sort
+  enabled: true
+  inputs:
+    perception_source: epd
+    required_attributes: [class, colour, shape]
+  pick:
+    object_source: perception
+    grasp_strategy: auto
+    allowed_grasp_methods: [finger]
+  decision_rules:
+    - id: red_to_bin_a
+      when:
+        attribute: colour
+        equals: red
+      destination: bin_a
+    - id: blue_to_bin_b
+      when:
+        attribute: colour
+        equals: blue
+      destination: bin_b
+    - id: default_reject
+      when:
+        default: true
+      destination: reject_bin
+  destinations:
+    - id: bin_a
+      frame_id: world
+      pose_xyz: [0.35, -0.35, 0.12]
+      pose_rpy: [0.0, 0.0, 0.0]
+      action: place
+    - id: bin_b
+      frame_id: world
+      pose_xyz: [0.35, 0.35, 0.12]
+      pose_rpy: [0.0, 0.0, 0.0]
+      action: place
+    - id: reject_bin
+      frame_id: world
+      pose_xyz: [0.20, 0.0, 0.12]
+      pose_rpy: [0.0, 0.0, 0.0]
+      action: reject
+  expected:
+    allow_offline_validation: true
+    min_valid_destinations: 1

--- a/scenes/ur5_2f_sorting_test/urdf/arm_hand.srdf.xacro
+++ b/scenes/ur5_2f_sorting_test/urdf/arm_hand.srdf.xacro
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="ur5_test">
+
+  <xacro:include filename="$(find ur5_moveit_config)/config/ur5.srdf.xacro" />
+
+  <xacro:include filename="$(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro" />
+
+  <xacro:ur5/>
+
+  <xacro:robotiq_85_gripper/>
+
+  <disable_collisions link1="gripper_base_link" link2="base_link" reason="Never" />
+  <disable_collisions link1="gripper_base_link" link2="shoulder_link" reason="Never" />
+  <disable_collisions link1="gripper_base_link" link2="upper_arm_link" reason="Never" />
+  <disable_collisions link1="gripper_base_link" link2="forearm_link" reason="Never" />
+  <disable_collisions link1="gripper_base_link" link2="wrist_1_link" reason="Never" />
+  <disable_collisions link1="gripper_base_link" link2="wrist_2_link" reason="Never" />
+  <disable_collisions link1="gripper_base_link" link2="wrist_3_link" reason="Never" />
+  <disable_collisions link1="gripper_base_link" link2="tool0" reason="Never" />
+  <disable_collisions link1="gripper_base_link" link2="base" reason="Never" />
+
+
+</robot>

--- a/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro
@@ -1,0 +1,141 @@
+<?xml version="1.0" ?> 
+
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="ur5_test">
+
+ <xacro:arg name="ur_type" default="ur5"/>
+ <xacro:arg name="name" default="$(arg ur_type)"/>
+ <xacro:arg name="tf_prefix" default=""/>
+ <xacro:arg name="use_fake_hardware" default="true"/>
+
+ <link name="world"/>
+
+<xacro:include filename="$(find ur_description)/urdf/ur_macro.xacro"/>
+
+<xacro:ur_robot
+  name="$(arg name)"
+  tf_prefix="$(arg tf_prefix)"
+  parent="world"
+  safety_limits="true"
+  joint_limits_parameters_file="$(find ur_description)/config/$(arg ur_type)/joint_limits.yaml"
+  kinematics_parameters_file="$(find ur_description)/config/$(arg ur_type)/default_kinematics.yaml"
+  physical_parameters_file="$(find ur_description)/config/$(arg ur_type)/physical_parameters.yaml"
+  visual_parameters_file="$(find ur_description)/config/$(arg ur_type)/visual_parameters.yaml"
+  use_fake_hardware="$(arg use_fake_hardware)">
+  <origin xyz="0 0 0" rpy="0 0 0"/>
+</xacro:ur_robot>
+
+ <xacro:include filename="$(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro"/>
+ <xacro:robotiq_85_gripper prefix="" parent="tool0">
+	<origin xyz="0 0 0" rpy="1.5707 -1.5707 0"/>
+ </xacro:robotiq_85_gripper>
+
+ <xacro:if value="$(arg use_fake_hardware)">
+   <ros2_control name="RobotiqGripperHardware" type="system">
+     <hardware>
+       <plugin>mock_components/GenericSystem</plugin>
+     </hardware>
+     <joint name="gripper_finger1_joint">
+       <command_interface name="position" />
+       <state_interface name="position">
+         <param name="initial_value">0.0</param>
+       </state_interface>
+       <state_interface name="velocity">
+         <param name="initial_value">0.0</param>
+       </state_interface>
+     </joint>
+   </ros2_control>
+ </xacro:if>
+
+ <xacro:include filename="$(find workbench_description)/urdf/table.urdf.xacro"/>
+ <xacro:table prefix="" parent="world">
+	<origin xyz="0 0 0" rpy="0 0 0"/>
+ </xacro:table>
+ 
+ <xacro:include filename="$(find realsense2_description)/urdf/_d435i.urdf.xacro"/>
+ <xacro:arg name="use_nominal_extrinsics" default="true" />
+ <xacro:sensor_d435i parent="table_" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
+    <origin xyz="-0.58 0.12 0.655" rpy="0 1.57079506 0"/>
+ </xacro:sensor_d435i>
+
+
+ <link name="camera_frame" />
+ <joint name="d435i_to_camera" type="fixed">
+    <parent link="camera_link"/>
+    <child link="camera_frame"/>
+    <!--origin xyz="0 0 0" rpy="0 0 3.14159"/-->
+    <origin xyz="0 0 0" rpy="1.57079506 0 1.57079506"/>
+ </joint>
+ 
+ <link name="ee_palm" />
+ <joint name="base_to_palm" type="fixed">
+    <parent link="tool0"/>
+    <child link="ee_palm"/>
+    <origin xyz="0 0 0.14" rpy="0 0 0"/>
+ </joint>
+
+
+ <link name="bin_a">
+   <visual>
+     <origin xyz="0 0 0" rpy="0 0 0"/>
+     <geometry><box size="0.22 0.18 0.12"/></geometry>
+     <material name="Blue"><color rgba="0.2 0.2 0.8 0.9"/></material>
+   </visual>
+   <collision>
+     <origin xyz="0 0 0" rpy="0 0 0"/>
+     <geometry><box size="0.22 0.18 0.12"/></geometry>
+   </collision>
+ </link>
+ <joint name="world_to_bin_a" type="fixed">
+   <parent link="world"/>
+   <child link="bin_a"/>
+   <origin xyz="0.45 -0.28 0.06" rpy="0 0 0"/>
+ </joint>
+
+ <link name="bin_b">
+   <visual>
+     <origin xyz="0 0 0" rpy="0 0 0"/>
+     <geometry><box size="0.22 0.18 0.12"/></geometry>
+     <material name="Green"><color rgba="0.2 0.8 0.2 0.9"/></material>
+   </visual>
+   <collision>
+     <origin xyz="0 0 0" rpy="0 0 0"/>
+     <geometry><box size="0.22 0.18 0.12"/></geometry>
+   </collision>
+ </link>
+ <joint name="world_to_bin_b" type="fixed">
+   <parent link="world"/>
+   <child link="bin_b"/>
+   <origin xyz="0.45 0.28 0.06" rpy="0 0 0"/>
+ </joint>
+
+ <link name="item_red">
+   <visual><geometry><box size="0.04 0.04 0.08"/></geometry><material name="Red"><color rgba="0.9 0.1 0.1 1.0"/></material></visual>
+   <collision><geometry><box size="0.04 0.04 0.08"/></geometry></collision>
+ </link>
+ <joint name="world_to_item_red" type="fixed">
+   <parent link="world"/>
+   <child link="item_red"/>
+   <origin xyz="0.30 -0.04 0.78" rpy="0 0 0"/>
+ </joint>
+
+ <link name="item_blue">
+   <visual><geometry><cylinder length="0.06" radius="0.02"/></geometry><material name="BlueItem"><color rgba="0.1 0.3 0.9 1.0"/></material></visual>
+   <collision><geometry><cylinder length="0.06" radius="0.02"/></geometry></collision>
+ </link>
+ <joint name="world_to_item_blue" type="fixed">
+   <parent link="world"/>
+   <child link="item_blue"/>
+   <origin xyz="0.38 0.07 0.77" rpy="0 0 0"/>
+ </joint>
+
+ <link name="item_green">
+   <visual><geometry><sphere radius="0.025"/></geometry><material name="GreenItem"><color rgba="0.1 0.8 0.3 1.0"/></material></visual>
+   <collision><geometry><sphere radius="0.025"/></geometry></collision>
+ </link>
+ <joint name="world_to_item_green" type="fixed">
+   <parent link="world"/>
+   <child link="item_green"/>
+   <origin xyz="0.34 0.12 0.765" rpy="0 0 0"/>
+ </joint>
+
+</robot>


### PR DESCRIPTION
### Motivation
- Provide a minimal sorting-cell scene foundation for a UR5 + Robotiq 2F demo to enable early integration and UI/runtime validation. 
- Keep scene/assets usage compatible with the workspace layout under `~/workcell_ws/src/assets/` and `~/workcell_ws/src/scenes/` and follow the existing scene_package pattern. 
- Avoid touching runtime architecture or unrelated packages and prevent duplicate package-name / asset duplication issues.

### Description
- Added a new scene package `scenes/ur5_2f_sorting_test` including `package.xml`, `CMakeLists.txt`, `launch/demo.launch.py`, `launch/demo.rviz`, `urdf/scene.urdf.xacro`, `urdf/arm_hand.srdf.xacro`, `environment.yaml`, `scene_manifest.yaml`, and `README.md` following the existing scene layout. 
- Reused existing UR5, Robotiq 2F and workbench/RealSense setup from the `ur5_2f_test` baseline to keep dependencies lightweight. 
- Introduced two fixed destination zones `bin_a` and `bin_b` plus three simple placeholder collision/visual items (`item_red`, `item_blue`, `item_green`) directly in the scene xacro. 
- Added install rules to include `README.md` and the scene manifest so the package is launchable with the existing `run_grasp_execution` launch flow and documented the exact launch command in the README. 

### Testing
- Attempted an automated build with `colcon build --symlink-install --packages-select ur5_2f_sorting_test run_grasp_execution`, but it could not be executed in this environment because `colcon` is not installed (`colcon: command not found`). 
- No automated unit tests were added for this small scene and no existing package behaviour was modified, so current repo test suites remain unchanged by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65a44900c83318efa73c02438e66a)