### PR TITLE
Add scene-local sorting_manifest and validation for ur5_2f_sorting_test

### DIFF
--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
@@ -24,7 +25,16 @@ install(DIRECTORY urdf
 install(FILES
   environment.yaml
   scene_manifest.yaml
+  sorting_manifest.yaml
   README.md
   DESTINATION share/${PROJECT_NAME}
 )
+
+if(BUILD_TESTING)
+  add_test(
+    NAME ur5_2f_sorting_test_sorting_manifest_validation
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_sorting_manifest.py
+  )
+endif()
+
 ament_package()

--- a/scenes/ur5_2f_sorting_test/README.md
+++ b/scenes/ur5_2f_sorting_test/README.md
@@ -9,3 +9,33 @@ ros2 launch run_grasp_execution grasp_execution.launch.py scene_package:=ur5_2f_
 ```
 
 The scene includes a table, two destination bins (`bin_a`, `bin_b`), and three placeholder items.
+
+## Sorting manifest
+
+This scene now includes a scene-local sorting manifest at `sorting_manifest.yaml`.
+
+Object-to-destination routing:
+
+- `item_red` → `bin_a`
+- `item_blue` → `bin_b`
+- `item_green` → `reject_bin` (default/reject route)
+
+The manifest also includes:
+
+- object metadata (`label`, `class_name`, `frame_id`, `approximate_size_m`, `pick_hint`)
+- destination metadata (`name`, `frame_id`, `release_offset_xyz_m`)
+
+## Validation
+
+A lightweight test validates that the sorting manifest:
+
+- parses successfully as YAML
+- defines required object/destination frames
+- references only known objects and destinations in routing
+
+Run package-local checks:
+
+```bash
+colcon test --packages-select ur5_2f_sorting_test --event-handlers console_direct+
+colcon test-result --verbose
+```

--- a/scenes/ur5_2f_sorting_test/sorting_manifest.yaml
+++ b/scenes/ur5_2f_sorting_test/sorting_manifest.yaml
@@ -1,0 +1,54 @@
+sorting_manifest:
+  version: 1
+  scene: ur5_2f_sorting_test
+  description: >-
+    Scene-local sorting configuration for object-to-bin routing metadata.
+
+  objects:
+    - id: item_red
+      label: red_item
+      class_name: part
+      frame_id: item_red
+      approximate_size_m: [0.05, 0.05, 0.05]
+      pick_hint: top_grasp
+      destination: bin_a
+
+    - id: item_blue
+      label: blue_item
+      class_name: part
+      frame_id: item_blue
+      approximate_size_m: [0.05, 0.05, 0.05]
+      pick_hint: top_grasp
+      destination: bin_b
+
+    - id: item_green
+      label: green_item
+      class_name: part
+      frame_id: item_green
+      approximate_size_m: [0.05, 0.05, 0.05]
+      pick_hint: top_grasp
+      destination: reject_bin
+
+  destinations:
+    - id: bin_a
+      name: Bin A
+      frame_id: bin_a
+      release_offset_xyz_m: [0.0, 0.0, 0.05]
+
+    - id: bin_b
+      name: Bin B
+      frame_id: bin_b
+      release_offset_xyz_m: [0.0, 0.0, 0.05]
+
+    - id: reject_bin
+      name: Reject Bin
+      frame_id: bin_a
+      release_offset_xyz_m: [0.0, 0.0, 0.10]
+
+  routing:
+    - object: item_red
+      destination: bin_a
+    - object: item_blue
+      destination: bin_b
+    - object: item_green
+      destination: reject_bin

--- a/scenes/ur5_2f_sorting_test/test/test_sorting_manifest.py
+++ b/scenes/ur5_2f_sorting_test/test/test_sorting_manifest.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Validation checks for ur5_2f_sorting_test sorting manifest."""
+
+from pathlib import Path
+import sys
+
+import yaml
+
+
+REQUIRED_OBJECT_FIELDS = ("id", "frame_id", "destination")
+REQUIRED_DESTINATION_FIELDS = ("id", "frame_id")
+
+
+def main() -> int:
+    manifest_path = Path(__file__).resolve().parents[1] / "sorting_manifest.yaml"
+
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        root = yaml.safe_load(handle)
+
+    manifest = root.get("sorting_manifest") if isinstance(root, dict) else None
+    if not isinstance(manifest, dict):
+        raise AssertionError("sorting_manifest root mapping is missing")
+
+    objects = manifest.get("objects")
+    destinations = manifest.get("destinations")
+    routing = manifest.get("routing")
+
+    if not isinstance(objects, list) or not objects:
+        raise AssertionError("objects list is missing or empty")
+    if not isinstance(destinations, list) or not destinations:
+        raise AssertionError("destinations list is missing or empty")
+    if not isinstance(routing, list) or not routing:
+        raise AssertionError("routing list is missing or empty")
+
+    object_ids = set()
+    for obj in objects:
+        for field in REQUIRED_OBJECT_FIELDS:
+            if not obj.get(field):
+                raise AssertionError(f"object missing required field: {field}")
+        object_ids.add(obj["id"])
+
+    destination_ids = set()
+    for destination in destinations:
+        for field in REQUIRED_DESTINATION_FIELDS:
+            if not destination.get(field):
+                raise AssertionError(f"destination missing required field: {field}")
+        destination_ids.add(destination["id"])
+
+    for route in routing:
+        object_name = route.get("object")
+        destination_name = route.get("destination")
+        if not object_name or object_name not in object_ids:
+            raise AssertionError(f"routing object '{object_name}' is not defined in objects")
+        if not destination_name or destination_name not in destination_ids:
+            raise AssertionError(
+                f"routing destination '{destination_name}' is not defined in destinations"
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide a small, scene-local manifest to make the `ur5_2f_sorting_test` scene behaviour-aware for sorting without changing runtime architecture.
- Keep configuration local to the scene and express object→destination routing plus lightweight metadata for later pick-and-place integration.
- Supply a minimal validation harness so manifest correctness can be checked as part of package tests.

### Description
- Add `scenes/ur5_2f_sorting_test/sorting_manifest.yaml` containing `objects` (`item_red`, `item_blue`, `item_green`), `destinations` (`bin_a`, `bin_b`, `reject_bin`), and explicit `routing` (`item_red -> bin_a`, `item_blue -> bin_b`, `item_green -> reject_bin`) with per-item metadata (`label`, `class_name`, `frame_id`, `approximate_size_m`, `pick_hint`, `destination`) and per-destination metadata (`name`, `frame_id`, `release_offset_xyz_m`).
- Add `scenes/ur5_2f_sorting_test/test/test_sorting_manifest.py` which parses the YAML and validates that routing object and destination names exist, required fields are present, and the YAML parses successfully.
- Update `scenes/ur5_2f_sorting_test/CMakeLists.txt` to install `sorting_manifest.yaml`, discover the `Python3` interpreter, and add a test entry that runs the manifest validator when `BUILD_TESTING` is enabled.
- Update `scenes/ur5_2f_sorting_test/README.md` with the object→bin mapping and instructions for running the validation using `colcon test`.

### Testing
- Ran the manifest validator directly with `python3 scenes/ur5_2f_sorting_test/test/test_sorting_manifest.py`, which failed due to missing Python YAML dependency (`ModuleNotFoundError: No module named 'yaml'`).
- Attempted `colcon build --symlink-install --packages-select ur5_2f_sorting_test` in this environment but it failed because `colcon` is not available here (`colcon: command not found`).
- The package now wires the validator into CTest so `colcon test --packages-select ur5_2f_sorting_test` will run the validation in a properly provisioned ROS workspace where `python3-yaml` and `colcon` are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66f5d6a0483319fe6171c9795ddd1)