### PR TITLE
Add dry-run sorting plan generator for ur5_2f_sorting_test

### DIFF
--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -30,10 +30,21 @@ install(FILES
   DESTINATION share/${PROJECT_NAME}
 )
 
+install(PROGRAMS
+  scripts/generate_sorting_plan.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME generate_sorting_plan
+)
+
 if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_sorting_manifest_validation
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_sorting_manifest.py
+  )
+
+  add_test(
+    NAME ur5_2f_sorting_test_generate_sorting_plan_output
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_generate_sorting_plan.py
   )
 endif()
 

--- a/scenes/ur5_2f_sorting_test/README.md
+++ b/scenes/ur5_2f_sorting_test/README.md
@@ -25,6 +25,43 @@ The manifest also includes:
 - object metadata (`label`, `class_name`, `frame_id`, `approximate_size_m`, `pick_hint`)
 - destination metadata (`name`, `frame_id`, `release_offset_xyz_m`)
 
+## Dry-run sorting task generator
+
+A scene-local helper script generates a dry-run task list from the manifest:
+
+```bash
+ros2 run ur5_2f_sorting_test generate_sorting_plan
+```
+
+This helper only prints a plan and metadata for each object route.
+It does **not** execute robot motion, perception, grasp planning, or hardware control.
+
+Example output:
+
+```text
+Dry-run sorting task plan
+Manifest: /.../sorting_manifest.yaml
+
+1. item_red -> bin_a
+   source_frame: item_red
+   destination_frame: bin_a
+   approximate_size_m: [0.050, 0.050, 0.050]
+   pick_hint: top_grasp
+   release_offset_xyz_m: [0.000, 0.000, 0.050]
+2. item_blue -> bin_b
+   source_frame: item_blue
+   destination_frame: bin_b
+   approximate_size_m: [0.050, 0.050, 0.050]
+   pick_hint: top_grasp
+   release_offset_xyz_m: [0.000, 0.000, 0.050]
+3. item_green -> reject_bin
+   source_frame: item_green
+   destination_frame: bin_a
+   approximate_size_m: [0.050, 0.050, 0.050]
+   pick_hint: top_grasp
+   release_offset_xyz_m: [0.000, 0.000, 0.100]
+```
+
 ## Validation
 
 A lightweight test validates that the sorting manifest:
@@ -32,6 +69,7 @@ A lightweight test validates that the sorting manifest:
 - parses successfully as YAML
 - defines required object/destination frames
 - references only known objects and destinations in routing
+- dry-run plan output includes expected routing lines
 
 Run package-local checks:
 

--- a/scenes/ur5_2f_sorting_test/scripts/generate_sorting_plan.py
+++ b/scenes/ur5_2f_sorting_test/scripts/generate_sorting_plan.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Generate a dry-run sorting task plan from sorting_manifest.yaml."""
+
+from pathlib import Path
+import sys
+
+import yaml
+
+
+def find_manifest_path() -> Path:
+    """Find sorting_manifest.yaml from install/share, with source-tree fallback."""
+    try:
+        from ament_index_python.packages import get_package_share_directory
+
+        share_dir = Path(get_package_share_directory("ur5_2f_sorting_test"))
+        share_manifest = share_dir / "sorting_manifest.yaml"
+        if share_manifest.exists():
+            return share_manifest
+    except Exception:
+        pass
+
+    source_manifest = Path(__file__).resolve().parents[1] / "sorting_manifest.yaml"
+    if source_manifest.exists():
+        return source_manifest
+
+    raise FileNotFoundError("Could not locate sorting_manifest.yaml in share or source tree")
+
+
+def format_triplet(values):
+    return f"[{values[0]:.3f}, {values[1]:.3f}, {values[2]:.3f}]"
+
+
+def main() -> int:
+    manifest_path = find_manifest_path()
+
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        root = yaml.safe_load(handle)
+
+    manifest = root.get("sorting_manifest") if isinstance(root, dict) else None
+    if not isinstance(manifest, dict):
+        raise AssertionError("sorting_manifest root mapping is missing")
+
+    objects = manifest.get("objects") or []
+    destinations = manifest.get("destinations") or []
+    routing = manifest.get("routing") or []
+
+    objects_by_id = {obj["id"]: obj for obj in objects if isinstance(obj, dict) and "id" in obj}
+    destinations_by_id = {
+        destination["id"]: destination
+        for destination in destinations
+        if isinstance(destination, dict) and "id" in destination
+    }
+
+    print("Dry-run sorting task plan")
+    print(f"Manifest: {manifest_path}")
+    print()
+
+    for step_index, route in enumerate(routing, start=1):
+        object_id = route.get("object")
+        destination_id = route.get("destination")
+        obj = objects_by_id.get(object_id)
+        destination = destinations_by_id.get(destination_id)
+        if obj is None or destination is None:
+            raise AssertionError(f"Invalid route entry: {route}")
+
+        size = obj.get("approximate_size_m", [0.0, 0.0, 0.0])
+        release_offset = destination.get("release_offset_xyz_m", [0.0, 0.0, 0.0])
+
+        print(f"{step_index}. {object_id} -> {destination_id}")
+        print(f"   source_frame: {obj.get('frame_id')}")
+        print(f"   destination_frame: {destination.get('frame_id')}")
+        print(f"   approximate_size_m: {format_triplet(size)}")
+        print(f"   pick_hint: {obj.get('pick_hint', 'n/a')}")
+        print(f"   release_offset_xyz_m: {format_triplet(release_offset)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scenes/ur5_2f_sorting_test/test/test_generate_sorting_plan.py
+++ b/scenes/ur5_2f_sorting_test/test/test_generate_sorting_plan.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Smoke-test dry-run sorting plan generator output."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main() -> int:
+    script_path = (
+        Path(__file__).resolve().parents[1] / "scripts" / "generate_sorting_plan.py"
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(script_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    output = result.stdout
+
+    expected_mappings = (
+        "item_red -> bin_a",
+        "item_blue -> bin_b",
+        "item_green -> reject_bin",
+    )
+    for mapping in expected_mappings:
+        if mapping not in output:
+            raise AssertionError(f"expected mapping not found in output: {mapping}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation

- Provide a small, scene-local helper to produce an ordered dry-run sorting task list from the scene `sorting_manifest.yaml` so routing and metadata can be inspected without running robot motion or perception. 
- Keep changes minimal and focused on a read-only plan generator and lightweight verification, leaving execution, perception, and grasping logic untouched.

### Description

- Add `scenes/ur5_2f_sorting_test/scripts/generate_sorting_plan.py` which locates `sorting_manifest.yaml` via `ament_index_python` (installed share) with a source-tree fallback and prints an ordered plan. 
- The script parses objects, destinations, and routing and prints for each route: source frame, destination frame, `approximate_size_m`, `pick_hint`, and `release_offset_xyz_m`. 
- Add install rules in `CMakeLists.txt` to make the script available as the executable `generate_sorting_plan` via `ros2 run ur5_2f_sorting_test generate_sorting_plan`. 
- Add test `scenes/ur5_2f_sorting_test/test/test_generate_sorting_plan.py` to assert the generated output contains expected mappings, and update `README.md` with usage, example output, and an explicit note that this is a non-executing dry-run.

### Testing

- Ran the existing manifest validation test: `python3 scenes/ur5_2f_sorting_test/test/test_sorting_manifest.py`, which completed successfully. 
- Ran the new plan-output smoke test: `python3 scenes/ur5_2f_sorting_test/test/test_generate_sorting_plan.py`, which completed successfully and verified the expected mappings (`item_red -> bin_a`, `item_blue -> bin_b`, `item_green -> reject_bin`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f670c8bc3c8331959e3f3dfce3c0ec)