### PR TITLE
Deterministic tabletop and robot mount for ur5_2f_sorting_test

### DIFF
--- a/scenes/ur5_2f_sorting_test/README.md
+++ b/scenes/ur5_2f_sorting_test/README.md
@@ -12,11 +12,12 @@ The scene includes a table, two destination bins (`bin_a`, `bin_b`), and three p
 
 ## Physical layout
 
-- The workbench (`table_`) is fixed to `world` and serves as the support surface.
-- The `world` frame represents the floor, and the UR5 base is floor-mounted (not floating) beside the table for a believable reach envelope.
-- `bin_a`, `bin_b`, and `reject_bin` are shallow destination trays placed on the tabletop in a reachable sorting row.
-- `item_red`, `item_blue`, and `item_green` are initialized in a dedicated pickup area with center heights computed from tabletop height, so they sit on the surface without sinking.
-- Release offsets are set so generated drop poses remain above each bin opening.
+- The `world` frame is the floor (`z = 0.0`), and `table_` is a self-contained workbench model fixed to the floor with deterministic dimensions and top height.
+- The workbench uses an explicit base/body and top slab, so the table is visibly supported and its top surface is exactly `table_top_z`.
+- The UR5 is table-mounted on a visible mounting plate; the robot base origin is set to `table_top_z + plate_thickness` to avoid any floating appearance.
+- `item_red`, `item_blue`, and `item_green` are initialized in the pickup area with center heights derived from `table_top_z` plus half-height/radius so they sit on the tabletop.
+- `bin_a`, `bin_b`, and `reject_bin` form a sorting row of shallow trays; each bin frame is at the tray opening and tray geometry is offset downward so tray bottoms rest on the tabletop.
+- This package remains dry-run only for sorting-plan generation and does not execute robot motion yet.
 
 ## Sorting manifest
 

--- a/scenes/ur5_2f_sorting_test/test/test_sorting_manifest.py
+++ b/scenes/ur5_2f_sorting_test/test/test_sorting_manifest.py
@@ -21,8 +21,7 @@ REQUIRED_SCENE_MARKERS = (
 )
 
 
-PROPERTY_PATTERN = re.compile(r'<xacro:property name="([^"]+)" value="([0-9.]+)"/>')
-ORIGIN_PATTERN = re.compile(r'<origin xyz="([^"]+)" rpy="0 0 0"/>')
+PROPERTY_PATTERN = re.compile(r'<xacro:property name="([^"]+)" value="([^"]+)"/>')
 
 
 def main() -> int:
@@ -89,7 +88,29 @@ def main() -> int:
             raise AssertionError(f"scene.urdf.xacro is missing required frame/link marker: {marker}")
 
     properties = dict(PROPERTY_PATTERN.findall(scene_xacro_text))
-    table_top_z = float(properties["table_top_z"])
+    required_properties = (
+        "floor_z",
+        "table_length",
+        "table_width",
+        "table_height",
+        "table_top_thickness",
+        "table_top_z",
+        "tray_length",
+        "tray_width",
+        "tray_height",
+        "item_red_height",
+        "item_blue_length",
+        "item_green_radius",
+    )
+    for property_name in required_properties:
+        if property_name not in properties:
+            raise AssertionError(f"missing xacro property: {property_name}")
+
+    if properties["floor_z"] != "0.0":
+        raise AssertionError("floor_z must be deterministic and equal to 0.0")
+
+    if properties["table_top_z"] != "${floor_z + table_height}":
+        raise AssertionError("table_top_z must be deterministic from floor_z + table_height")
 
     expected_expressions = {
         "item_red": "${table_top_z + item_red_height / 2}",
@@ -103,8 +124,15 @@ def main() -> int:
         if expr not in scene_xacro_text:
             raise AssertionError(f"{name} origin is not aligned from table_top_z expression")
 
-    if table_top_z <= 0.0:
-        raise AssertionError("table_top_z must be positive")
+    required_layout_snippets = (
+        "<link name=\"table_\">",
+        "<joint name=\"world_to_table\" type=\"fixed\">",
+        "<origin xyz=\"0.15 0 ${table_top_z}\" rpy=\"0 0 0\"/>",
+        "<origin xyz=\"0 0 ${-tray_height / 2}\" rpy=\"0 0 0\"/>",
+    )
+    for snippet in required_layout_snippets:
+        if snippet not in scene_xacro_text:
+            raise AssertionError(f"scene.urdf.xacro missing deterministic layout snippet: {snippet}")
 
     return 0
 

--- a/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?> 
+<?xml version="1.0" ?>
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="ur5_test">
 
@@ -9,18 +9,69 @@
 
  <link name="world"/>
 
- <xacro:property name="table_top_z" value="0.76"/>
- <xacro:property name="item_red_height" value="0.08"/>
- <xacro:property name="item_blue_length" value="0.06"/>
- <xacro:property name="item_green_radius" value="0.025"/>
+ <xacro:property name="floor_z" value="0.0"/>
+ <xacro:property name="table_length" value="1.20"/>
+ <xacro:property name="table_width" value="0.70"/>
+ <xacro:property name="table_height" value="0.74"/>
+ <xacro:property name="table_top_thickness" value="0.04"/>
+ <xacro:property name="table_top_z" value="${floor_z + table_height}"/>
  <xacro:property name="tray_length" value="0.22"/>
  <xacro:property name="tray_width" value="0.18"/>
  <xacro:property name="tray_height" value="0.07"/>
- <xacro:property name="pickup_area_x" value="0.30"/>
+ <xacro:property name="item_red_height" value="0.08"/>
+ <xacro:property name="item_blue_length" value="0.06"/>
+ <xacro:property name="item_green_radius" value="0.025"/>
+ <xacro:property name="pickup_area_x" value="0.32"/>
  <xacro:property name="pickup_area_y" value="0.0"/>
- <xacro:property name="destination_area_x" value="0.48"/>
+ <xacro:property name="destination_area_x" value="0.50"/>
+ <xacro:property name="table_leg_size" value="0.07"/>
+ <xacro:property name="robot_plate_length" value="0.28"/>
+ <xacro:property name="robot_plate_width" value="0.28"/>
+ <xacro:property name="robot_plate_thickness" value="0.03"/>
 
-<xacro:include filename="$(find ur_description)/urdf/ur_macro.xacro"/>
+ <xacro:include filename="$(find ur_description)/urdf/ur_macro.xacro"/>
+
+ <link name="table_">
+   <visual>
+     <origin xyz="0 0 ${-(table_height - table_top_thickness) / 2}" rpy="0 0 0"/>
+     <geometry><box size="${table_length} ${table_width} ${table_height - table_top_thickness}"/></geometry>
+     <material name="TableCabinet"><color rgba="0.46 0.33 0.24 1.0"/></material>
+   </visual>
+   <collision>
+     <origin xyz="0 0 ${-(table_height - table_top_thickness) / 2}" rpy="0 0 0"/>
+     <geometry><box size="${table_length} ${table_width} ${table_height - table_top_thickness}"/></geometry>
+   </collision>
+   <visual>
+     <origin xyz="0 0 ${table_top_thickness / 2}" rpy="0 0 0"/>
+     <geometry><box size="${table_length} ${table_width} ${table_top_thickness}"/></geometry>
+     <material name="TableTop"><color rgba="0.55 0.40 0.28 1.0"/></material>
+   </visual>
+   <collision>
+     <origin xyz="0 0 ${table_top_thickness / 2}" rpy="0 0 0"/>
+     <geometry><box size="${table_length} ${table_width} ${table_top_thickness}"/></geometry>
+   </collision>
+ </link>
+
+ <joint name="world_to_table" type="fixed">
+   <parent link="world"/>
+   <child link="table_"/>
+   <origin xyz="0.15 0 ${table_top_z}" rpy="0 0 0"/>
+ </joint>
+
+ <link name="robot_mount_plate">
+   <visual>
+     <geometry><box size="${robot_plate_length} ${robot_plate_width} ${robot_plate_thickness}"/></geometry>
+     <material name="RobotPlate"><color rgba="0.25 0.25 0.25 1.0"/></material>
+   </visual>
+   <collision>
+     <geometry><box size="${robot_plate_length} ${robot_plate_width} ${robot_plate_thickness}"/></geometry>
+   </collision>
+ </link>
+ <joint name="table_to_robot_mount_plate" type="fixed">
+   <parent link="table_"/>
+   <child link="robot_mount_plate"/>
+   <origin xyz="-0.44 0.0 ${robot_plate_thickness / 2}" rpy="0 0 0"/>
+ </joint>
 
  <xacro:ur_robot
   name="$(arg name)"
@@ -32,12 +83,12 @@
   physical_parameters_file="$(find ur_description)/config/$(arg ur_type)/physical_parameters.yaml"
   visual_parameters_file="$(find ur_description)/config/$(arg ur_type)/visual_parameters.yaml"
   use_fake_hardware="$(arg use_fake_hardware)">
-  <origin xyz="-0.35 0.0 0.0" rpy="0 0 0"/>
-</xacro:ur_robot>
+  <origin xyz="-0.29 0.0 ${table_top_z + robot_plate_thickness}" rpy="0 0 0"/>
+ </xacro:ur_robot>
 
  <xacro:include filename="$(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro"/>
  <xacro:robotiq_85_gripper prefix="" parent="tool0">
-	<origin xyz="0 0 0" rpy="1.5707 -1.5707 0"/>
+ 	<origin xyz="0 0 0" rpy="1.5707 -1.5707 0"/>
  </xacro:robotiq_85_gripper>
 
  <xacro:if value="$(arg use_fake_hardware)">
@@ -57,15 +108,10 @@
    </ros2_control>
  </xacro:if>
 
- <xacro:include filename="$(find workbench_description)/urdf/table.urdf.xacro"/>
- <xacro:table prefix="" parent="world">
-	<origin xyz="0 0 0" rpy="0 0 0"/>
- </xacro:table>
- 
  <xacro:include filename="$(find realsense2_description)/urdf/_d435i.urdf.xacro"/>
  <xacro:arg name="use_nominal_extrinsics" default="true" />
  <xacro:sensor_d435i parent="table_" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
-    <origin xyz="-0.58 0.12 0.655" rpy="0 1.57079506 0"/>
+    <origin xyz="-0.58 0.12 0.62" rpy="0 1.57079506 0"/>
  </xacro:sensor_d435i>
 
 
@@ -73,17 +119,15 @@
  <joint name="d435i_to_camera" type="fixed">
     <parent link="camera_link"/>
     <child link="camera_frame"/>
-    <!--origin xyz="0 0 0" rpy="0 0 3.14159"/-->
     <origin xyz="0 0 0" rpy="1.57079506 0 1.57079506"/>
  </joint>
- 
+
  <link name="ee_palm" />
  <joint name="base_to_palm" type="fixed">
     <parent link="tool0"/>
     <child link="ee_palm"/>
     <origin xyz="0 0 0.14" rpy="0 0 0"/>
  </joint>
-
 
  <link name="bin_a">
    <visual>


### PR DESCRIPTION
### Motivation
- The scene relied on an external `workbench_description` macro which made `table_top_z` ambiguous and caused the table, robot, bins, and items to appear to float in RViz. 
- The goal is to make tabletop height deterministic so items and trays visibly sit on the table without changing execution/perception logic or dry-run behavior.

### Description
- Replaced the imported workbench macro with an explicit scene-local `table_` link composed of a cabinet/body and a top slab and exposed deterministic properties including `floor_z`, `table_length`, `table_width`, `table_height`, `table_top_thickness`, and `table_top_z = ${floor_z + table_height}`. 
- Created a visible robot mounting plate and moved the UR5 base origin to `table_top_z + robot_plate_thickness` so the robot is clearly table-mounted and not floating. 
- Implemented deterministic object and tray placement: items use `table_top_z + half-height/radius` expressions, trays (`bin_a`, `bin_b`, `reject_bin`) are shallow with the bin frame at the opening and visual/collision geometry offset by `-tray_height/2`, and bin joint Z is `table_top_z + tray_height`. 
- Kept frame names compatible (`table_`, `bin_a`, `bin_b`, `reject_bin`, `item_red`, `item_blue`, `item_green`, `world`, `tool0`) and kept RealSense attached to `table_` with a stable transform; README updated to document the new physical layout. 
- Strengthened the lightweight layout validation test `test_sorting_manifest.py` to assert the presence of required xacro properties, `floor_z = 0.0`, the deterministic `table_top_z` expression, item/bin origin expressions, and specific layout snippets showing the local `table_` and tray offset usage.

### Testing
- Updated test: `scenes/ur5_2f_sorting_test/test/test_sorting_manifest.py` now validates required deterministic xacro properties and layout snippets. 
- Executed `python3 scenes/ur5_2f_sorting_test/test/test_sorting_manifest.py` in this environment but it failed due to a missing runtime dependency (`ModuleNotFoundError: No module named 'yaml'`). 
- Executed `python3 scenes/ur5_2f_sorting_test/test/test_generate_sorting_plan.py` and running the `generate_sorting_plan` script directly, both of which also failed here due to the same missing `PyYAML` dependency, so full automated validation could not complete in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f67841dd108331a5cf9816f7f227d2)