### PR TITLE
Fix ur5_2f_sorting_test tabletop/tray frame semantics and layout validator

### DIFF
--- a/scenes/ur5_2f_sorting_test/README.md
+++ b/scenes/ur5_2f_sorting_test/README.md
@@ -12,11 +12,12 @@ The scene includes a workbench table, a destination tray row (`bin_a`, `bin_b`, 
 
 ## Physical layout
 
-- The `world` frame is the floor (`z = 0.0`), and `table_` is a self-contained workbench model fixed to the floor with deterministic dimensions and top height.
-- The workbench uses an explicit base/body and top slab, so the table is visibly supported and its top surface is exactly `table_top_z`.
+- The `world` frame is the floor (`z = 0.0`), and `table_` is the tabletop top-surface center frame fixed to `z = table_top_z`.
+- The workbench uses an explicit body and top slab geometry offset downward from `table_`, so objects on `table_` local `z = 0` are physically on the tabletop.
 - The UR5 is table-mounted on a visible mounting plate; the robot base origin is set to `table_top_z + plate_thickness` to avoid any floating appearance.
-- `item_red`, `item_blue`, and `item_green` are initialized in a neat pickup row on the workbench top with center heights derived from `table_top_z` plus half-height/radius so they sit directly on the tabletop.
-- `bin_a`, `bin_b`, and `reject_bin` form a sorting destination row of shallow open trays (base + four walls); each bin frame is at the tray opening/top-center and tray geometry is offset downward so tray bottoms rest on the tabletop.
+- `item_red`, `item_blue`, and `item_green` are fixed children of `table_`; each item local `z` is set from half-height/radius so bottoms are exactly on tabletop local `z = 0`.
+- `bin_a`, `bin_b`, and `reject_bin` are fixed children of `table_`; each tray frame is at opening/top-center (`local z = tray_height`) and tray geometry extends downward so tray bottoms rest at tabletop local `z = 0`.
+- The RealSense camera is mounted above the pickup/sorting area (with a visible mast support) and oriented to look down toward the work area.
 - This package remains dry-run only for sorting-plan generation and does not execute robot motion yet.
 
 ## Sorting manifest

--- a/scenes/ur5_2f_sorting_test/scripts/validate_scene_layout.py
+++ b/scenes/ur5_2f_sorting_test/scripts/validate_scene_layout.py
@@ -124,10 +124,11 @@ def _find_joint_origin(root: ET.Element, joint_name: str, variables: dict[str, f
 
 def main() -> int:
     xacro_path = _resolve_scene_xacro()
+    raw_root = ET.parse(xacro_path).getroot()
     root = _load_xml_root(xacro_path)
 
     properties: dict[str, float] = {}
-    for prop in root.findall(f"{XACRO_NS}property"):
+    for prop in raw_root.findall(f"{XACRO_NS}property"):
         name = prop.get("name")
         value = prop.get("value")
         if name and value:
@@ -159,9 +160,9 @@ def main() -> int:
         "item_green": table_top_z,
     }
     item_joints = {
-        "item_red": "world_to_item_red",
-        "item_blue": "world_to_item_blue",
-        "item_green": "world_to_item_green",
+        "item_red": "table_to_item_red",
+        "item_blue": "table_to_item_blue",
+        "item_green": "table_to_item_green",
     }
     item_heights = {
         "item_red": properties["item_red_height"],
@@ -170,34 +171,38 @@ def main() -> int:
     }
 
     bins = {
-        "bin_a": "world_to_bin_a",
-        "bin_b": "world_to_bin_b",
-        "reject_bin": "world_to_reject_bin",
+        "bin_a": "table_to_bin_a",
+        "bin_b": "table_to_bin_b",
+        "reject_bin": "table_to_reject_bin",
     }
 
     report_lines = [f"scene: {xacro_path}", f"table_top_z: {table_top_z:.3f}"]
 
     for item, joint in item_joints.items():
-        center_z = _find_joint_origin(root, joint, properties)[2]
-        bottom_z = center_z - item_heights[item] / 2.0
-        ok = math.isclose(bottom_z, expected_item_bottoms[item], abs_tol=EPS)
+        center_z_local = _find_joint_origin(root, joint, properties)[2]
+        bottom_z_local = center_z_local - item_heights[item] / 2.0
+        bottom_z = table_top_z + bottom_z_local
+        ok = math.isclose(bottom_z_local, 0.0, abs_tol=EPS)
         if not ok:
-            raise AssertionError(f"{item} bottom_z {bottom_z} does not equal table_top_z {table_top_z}")
-        report_lines.append(f"{item}: bottom_z={bottom_z:.3f} OK")
+            raise AssertionError(f"{item} bottom local z {bottom_z_local} does not equal tabletop local z 0.0")
+        report_lines.append(f"{item}: bottom_z={bottom_z:.3f} local_bottom_z={bottom_z_local:.3f} OK")
 
     tray_height = properties["tray_height"]
     tray_length = properties["tray_length"]
     tray_width = properties["tray_width"]
     tray_wall_thickness = properties["tray_wall_thickness"]
     for bin_name, joint in bins.items():
-        frame_z = _find_joint_origin(root, joint, properties)[2]
-        tray_bottom_z = frame_z - tray_wall_thickness
-        if not math.isclose(tray_bottom_z, table_top_z, abs_tol=EPS):
+        frame_z_local = _find_joint_origin(root, joint, properties)[2]
+        tray_bottom_z_local = frame_z_local - tray_height
+        tray_bottom_z = table_top_z + tray_bottom_z_local
+        if not math.isclose(frame_z_local, tray_height, abs_tol=EPS):
+            raise AssertionError(f"{bin_name} frame local z {frame_z_local} does not equal tray_height {tray_height}")
+        if not math.isclose(tray_bottom_z_local, 0.0, abs_tol=EPS):
             raise AssertionError(
-                f"{bin_name} tray bottom {tray_bottom_z} does not equal table_top_z {table_top_z}"
+                f"{bin_name} tray bottom local z {tray_bottom_z_local} does not equal tabletop local z 0.0"
             )
-        report_lines.append(f"{bin_name}: tray_bottom_z={tray_bottom_z:.3f} OK")
-        report_lines.append(f"{bin_name}: frame_at_tray_opening=YES")
+        report_lines.append(f"{bin_name}: tray_bottom_z={tray_bottom_z:.3f} local_bottom_z={tray_bottom_z_local:.3f} OK")
+        report_lines.append(f"{bin_name}: frame_at_tray_opening=YES local_frame_z={frame_z_local:.3f}")
 
 
 
@@ -246,6 +251,9 @@ def main() -> int:
 
     if root.find("link[@name='robot_mount_plate']") is None:
         raise AssertionError("robot_mount_plate missing for table-mounted robot")
+    report_lines.append("robot_mount_plate_link: OK")
+    if root.find("joint[@name='table_to_robot_mount_plate']") is None:
+        raise AssertionError("table_to_robot_mount_plate joint missing")
 
     robot_origin_z = None
     for ur_robot in root.findall(f"{XACRO_NS}ur_robot"):
@@ -259,6 +267,10 @@ def main() -> int:
     if robot_origin_z + EPS < table_top_z:
         raise AssertionError("robot base origin is below table top/floor unexpectedly")
     report_lines.append("robot_mount: OK")
+
+    if root.find("link[@name='camera_link']") is None and root.find("link[@name='camera_frame']") is None:
+        raise AssertionError("camera link/frame missing")
+    report_lines.append("camera_mount: OK")
 
     print("\n".join(report_lines))
     return 0

--- a/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro
@@ -32,7 +32,7 @@
 
  <xacro:include filename="$(find ur_description)/urdf/ur_macro.xacro"/>
 
- <!-- Workbench frame: table_ is the main contact link; top surface z is table_top_z. -->
+ <!-- Workbench frame semantics: table_ frame is tabletop top-surface center (z=0 at top). -->
  <link name="table_">
    <visual>
      <origin xyz="0 0 ${-(table_height - table_top_thickness) / 2}" rpy="0 0 0"/>
@@ -44,12 +44,12 @@
      <geometry><box size="${table_length} ${table_width} ${table_height - table_top_thickness}"/></geometry>
    </collision>
    <visual>
-     <origin xyz="0 0 ${table_top_thickness / 2}" rpy="0 0 0"/>
+     <origin xyz="0 0 ${-table_top_thickness / 2}" rpy="0 0 0"/>
      <geometry><box size="${table_length} ${table_width} ${table_top_thickness}"/></geometry>
      <material name="TableTop"><color rgba="0.55 0.40 0.28 1.0"/></material>
    </visual>
    <collision>
-     <origin xyz="0 0 ${table_top_thickness / 2}" rpy="0 0 0"/>
+     <origin xyz="0 0 ${-table_top_thickness / 2}" rpy="0 0 0"/>
      <geometry><box size="${table_length} ${table_width} ${table_top_thickness}"/></geometry>
    </collision>
  </link>
@@ -112,8 +112,24 @@
 
  <xacro:include filename="$(find realsense2_description)/urdf/_d435i.urdf.xacro"/>
  <xacro:arg name="use_nominal_extrinsics" default="true" />
+ <link name="camera_mast">
+   <visual>
+     <origin xyz="0 0 0.32" rpy="0 0 0"/>
+     <geometry><cylinder radius="0.01" length="0.64"/></geometry>
+     <material name="CameraMast"><color rgba="0.2 0.2 0.2 1.0"/></material>
+   </visual>
+   <collision>
+     <origin xyz="0 0 0.32" rpy="0 0 0"/>
+     <geometry><cylinder radius="0.01" length="0.64"/></geometry>
+   </collision>
+ </link>
+ <joint name="table_to_camera_mast" type="fixed">
+   <parent link="table_"/>
+   <child link="camera_mast"/>
+   <origin xyz="-0.18 0.28 0.0" rpy="0 0 0"/>
+ </joint>
  <xacro:sensor_d435i parent="table_" use_nominal_extrinsics="$(arg use_nominal_extrinsics)">
-    <origin xyz="-0.58 0.12 0.62" rpy="0 1.57079506 0"/>
+    <origin xyz="-0.18 0.10 0.62" rpy="0 1.57079506 0"/>
  </xacro:sensor_d435i>
 
 
@@ -134,12 +150,12 @@
  <!-- Sorting destination row: tray frames are at opening/top-center; geometry extends downward onto tabletop. -->
  <link name="bin_a">
    <visual>
-     <origin xyz="0 0 ${-tray_wall_thickness / 2}" rpy="0 0 0"/>
+     <origin xyz="0 0 ${-tray_height + tray_wall_thickness / 2}" rpy="0 0 0"/>
      <geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry>
      <material name="Blue"><color rgba="0.2 0.2 0.8 1.0"/></material>
    </visual>
    <collision>
-     <origin xyz="0 0 ${-tray_wall_thickness / 2}" rpy="0 0 0"/>
+     <origin xyz="0 0 ${-tray_height + tray_wall_thickness / 2}" rpy="0 0 0"/>
      <geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry>
    </collision>
    <visual>
@@ -175,19 +191,19 @@
      <geometry><box size="${tray_wall_thickness} ${tray_width} ${tray_height}"/></geometry>
    </collision>
  </link>
- <joint name="world_to_bin_a" type="fixed">
-   <parent link="world"/>
+ <joint name="table_to_bin_a" type="fixed">
+   <parent link="table_"/>
    <child link="bin_a"/>
-   <origin xyz="${destination_area_x} -0.24 ${table_top_z + tray_wall_thickness}" rpy="0 0 0"/>
+   <origin xyz="${destination_area_x} -0.24 ${tray_height}" rpy="0 0 0"/>
  </joint>
 
  <link name="bin_b">
    <visual>
-     <origin xyz="0 0 ${-tray_wall_thickness / 2}" rpy="0 0 0"/>
+     <origin xyz="0 0 ${-tray_height + tray_wall_thickness / 2}" rpy="0 0 0"/>
      <geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry>
      <material name="Green"><color rgba="0.2 0.8 0.2 1.0"/></material>
    </visual>
-   <collision><origin xyz="0 0 ${-tray_wall_thickness / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry></collision>
+   <collision><origin xyz="0 0 ${-tray_height + tray_wall_thickness / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry></collision>
    <visual><origin xyz="0 ${tray_width / 2 - tray_wall_thickness / 2} ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_wall_thickness} ${tray_height}"/></geometry></visual>
    <collision><origin xyz="0 ${tray_width / 2 - tray_wall_thickness / 2} ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_wall_thickness} ${tray_height}"/></geometry></collision>
    <visual><origin xyz="0 ${-tray_width / 2 + tray_wall_thickness / 2} ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_wall_thickness} ${tray_height}"/></geometry></visual>
@@ -197,15 +213,15 @@
    <visual><origin xyz="${-tray_length / 2 + tray_wall_thickness / 2} 0 ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_wall_thickness} ${tray_width} ${tray_height}"/></geometry></visual>
    <collision><origin xyz="${-tray_length / 2 + tray_wall_thickness / 2} 0 ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_wall_thickness} ${tray_width} ${tray_height}"/></geometry></collision>
  </link>
- <joint name="world_to_bin_b" type="fixed">
-   <parent link="world"/>
+ <joint name="table_to_bin_b" type="fixed">
+   <parent link="table_"/>
    <child link="bin_b"/>
-   <origin xyz="${destination_area_x} 0.0 ${table_top_z + tray_wall_thickness}" rpy="0 0 0"/>
+   <origin xyz="${destination_area_x} 0.0 ${tray_height}" rpy="0 0 0"/>
  </joint>
 
  <link name="reject_bin">
-   <visual><origin xyz="0 0 ${-tray_wall_thickness / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry><material name="RejectBin"><color rgba="0.75 0.35 0.1 1.0"/></material></visual>
-   <collision><origin xyz="0 0 ${-tray_wall_thickness / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry></collision>
+   <visual><origin xyz="0 0 ${-tray_height + tray_wall_thickness / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry><material name="RejectBin"><color rgba="0.75 0.35 0.1 1.0"/></material></visual>
+   <collision><origin xyz="0 0 ${-tray_height + tray_wall_thickness / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry></collision>
    <visual><origin xyz="0 ${tray_width / 2 - tray_wall_thickness / 2} ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_wall_thickness} ${tray_height}"/></geometry></visual>
    <collision><origin xyz="0 ${tray_width / 2 - tray_wall_thickness / 2} ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_wall_thickness} ${tray_height}"/></geometry></collision>
    <visual><origin xyz="0 ${-tray_width / 2 + tray_wall_thickness / 2} ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_wall_thickness} ${tray_height}"/></geometry></visual>
@@ -215,10 +231,10 @@
    <visual><origin xyz="${-tray_length / 2 + tray_wall_thickness / 2} 0 ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_wall_thickness} ${tray_width} ${tray_height}"/></geometry></visual>
    <collision><origin xyz="${-tray_length / 2 + tray_wall_thickness / 2} 0 ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_wall_thickness} ${tray_width} ${tray_height}"/></geometry></collision>
  </link>
- <joint name="world_to_reject_bin" type="fixed">
-   <parent link="world"/>
+ <joint name="table_to_reject_bin" type="fixed">
+   <parent link="table_"/>
    <child link="reject_bin"/>
-   <origin xyz="${destination_area_x} 0.24 ${table_top_z + tray_wall_thickness}" rpy="0 0 0"/>
+   <origin xyz="${destination_area_x} 0.24 ${tray_height}" rpy="0 0 0"/>
  </joint>
 
  <!-- Pickup area: three items arranged in a reachable row on the tabletop (bottoms at table_top_z). -->
@@ -226,30 +242,30 @@
    <visual><geometry><box size="0.04 0.04 0.08"/></geometry><material name="Red"><color rgba="0.9 0.1 0.1 1.0"/></material></visual>
    <collision><geometry><box size="0.04 0.04 0.08"/></geometry></collision>
  </link>
- <joint name="world_to_item_red" type="fixed">
-   <parent link="world"/>
+ <joint name="table_to_item_red" type="fixed">
+   <parent link="table_"/>
    <child link="item_red"/>
-   <origin xyz="${pickup_area_x} ${pickup_area_y} ${table_top_z + item_red_height / 2}" rpy="0 0 0"/>
+   <origin xyz="${pickup_area_x} ${pickup_area_y} ${item_red_height / 2}" rpy="0 0 0"/>
  </joint>
 
  <link name="item_blue">
    <visual><geometry><cylinder length="0.06" radius="0.02"/></geometry><material name="BlueItem"><color rgba="0.1 0.3 0.9 1.0"/></material></visual>
    <collision><geometry><cylinder length="0.06" radius="0.02"/></geometry></collision>
  </link>
- <joint name="world_to_item_blue" type="fixed">
-   <parent link="world"/>
+ <joint name="table_to_item_blue" type="fixed">
+   <parent link="table_"/>
    <child link="item_blue"/>
-   <origin xyz="${pickup_area_x + 0.08} ${pickup_area_y} ${table_top_z + item_blue_length / 2}" rpy="0 0 0"/>
+   <origin xyz="${pickup_area_x + 0.08} ${pickup_area_y} ${item_blue_length / 2}" rpy="0 0 0"/>
  </joint>
 
  <link name="item_green">
    <visual><geometry><sphere radius="0.025"/></geometry><material name="GreenItem"><color rgba="0.1 0.8 0.3 1.0"/></material></visual>
    <collision><geometry><sphere radius="0.025"/></geometry></collision>
  </link>
- <joint name="world_to_item_green" type="fixed">
-   <parent link="world"/>
+ <joint name="table_to_item_green" type="fixed">
+   <parent link="table_"/>
    <child link="item_green"/>
-   <origin xyz="${pickup_area_x + 0.16} ${pickup_area_y} ${table_top_z + item_green_radius}" rpy="0 0 0"/>
+   <origin xyz="${pickup_area_x + 0.16} ${pickup_area_y} ${item_green_radius}" rpy="0 0 0"/>
  </joint>
 
 </robot>


### PR DESCRIPTION
### Motivation
- The scene used inconsistent frame semantics that caused items/trays to sink into the table and made the validator falsely fail when xacro was expanded. 
- The intent is to make `table_` represent the tabletop top-surface center and ensure items, trays, robot mount and camera have deterministic, visible geometry on that tabletop without adding execution or perception code. 

### Description
- Reworked scene geometry in `scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro` so `table_` is the tabletop top-surface center and the tabletop slab and cabinet geometry extend downward relative to that frame. 
- Re-parented pickup items and destination trays from `world` to `table_` and updated their local z semantics so item bottoms and tray bottoms rest exactly on the tabletop; tray frames are placed at `local z = tray_height` (opening/top-center) and tray base/walls extend downward. 
- Added a visible `camera_mast`, moved the RealSense pose to be over the work area, and kept the robot mounting plate / UR robot placement consistent with the tabletop frame. 
- Fixed the validator `scenes/ur5_2f_sorting_test/scripts/validate_scene_layout.py` to read xacro `property` values from the raw `.xacro` source (not the expanded URDF) and updated validation logic to reflect the new table-local item/tray frames and to check for camera and mount presence. 
- Updated `scenes/ur5_2f_sorting_test/README.md` to document the new tabletop/frame conventions and camera mounting. 

### Testing
- Ran the layout validator with `python3 scenes/ur5_2f_sorting_test/scripts/validate_scene_layout.py` and it succeeded, printing the expected OK markers for table, items, trays, robot mount and camera. 
- Ran the package-local test `python3 scenes/ur5_2f_sorting_test/test/test_validate_scene_layout.py` and it executed successfully. 
- Validator output confirmed items and tray bottoms are at tabletop z and tray frames are at `tray_height` (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c12d138c8331bfb51e0e47f469a5)