### PR TITLE
Fix sorting scene pickup layout and table-relative validation

### DIFF
--- a/scenes/ur5_2f_sorting_test/scripts/validate_scene_layout.py
+++ b/scenes/ur5_2f_sorting_test/scripts/validate_scene_layout.py
@@ -103,12 +103,8 @@ def _resolve_scene_xacro() -> Path:
 
 
 def _load_xml_root(xacro_path: Path) -> ET.Element:
-    if shutil.which("xacro"):
-        try:
-            expanded = subprocess.check_output(["xacro", str(xacro_path)], text=True)
-            return ET.fromstring(expanded)
-        except subprocess.CalledProcessError as exc:
-            raise RuntimeError(f"xacro expansion failed for {xacro_path}: {exc}") from exc
+    # Parse the raw xacro source. The validator needs xacro:property tags;
+    # those disappear after xacro expansion.
     return ET.parse(xacro_path).getroot()
 
 
@@ -159,9 +155,9 @@ def main() -> int:
         "item_green": table_top_z,
     }
     item_joints = {
-        "item_red": "world_to_item_red",
-        "item_blue": "world_to_item_blue",
-        "item_green": "world_to_item_green",
+        "item_red": "table_to_item_red",
+        "item_blue": "table_to_item_blue",
+        "item_green": "table_to_item_green",
     }
     item_heights = {
         "item_red": properties["item_red_height"],
@@ -170,16 +166,16 @@ def main() -> int:
     }
 
     bins = {
-        "bin_a": "world_to_bin_a",
-        "bin_b": "world_to_bin_b",
-        "reject_bin": "world_to_reject_bin",
+        "bin_a": "table_to_bin_a",
+        "bin_b": "table_to_bin_b",
+        "reject_bin": "table_to_reject_bin",
     }
 
     report_lines = [f"scene: {xacro_path}", f"table_top_z: {table_top_z:.3f}"]
 
     for item, joint in item_joints.items():
         center_z = _find_joint_origin(root, joint, properties)[2]
-        bottom_z = center_z - item_heights[item] / 2.0
+        bottom_z = table_top_z + center_z - item_heights[item] / 2.0
         ok = math.isclose(bottom_z, expected_item_bottoms[item], abs_tol=EPS)
         if not ok:
             raise AssertionError(f"{item} bottom_z {bottom_z} does not equal table_top_z {table_top_z}")
@@ -191,7 +187,7 @@ def main() -> int:
     tray_wall_thickness = properties["tray_wall_thickness"]
     for bin_name, joint in bins.items():
         frame_z = _find_joint_origin(root, joint, properties)[2]
-        tray_bottom_z = frame_z - tray_wall_thickness
+        tray_bottom_z = table_top_z + frame_z - tray_height
         if not math.isclose(tray_bottom_z, table_top_z, abs_tol=EPS):
             raise AssertionError(
                 f"{bin_name} tray bottom {tray_bottom_z} does not equal table_top_z {table_top_z}"

--- a/scenes/ur5_2f_sorting_test/test/test_sorting_manifest.py
+++ b/scenes/ur5_2f_sorting_test/test/test_sorting_manifest.py
@@ -112,24 +112,30 @@ def main() -> int:
     if properties["table_top_z"] != "${floor_z + table_height}":
         raise AssertionError("table_top_z must be deterministic from floor_z + table_height")
 
-    expected_expressions = {
-        "item_red": "${table_top_z + item_red_height / 2}",
-        "item_blue": "${table_top_z + item_blue_length / 2}",
-        "item_green": "${table_top_z + item_green_radius}",
-        "bin_a": "${table_top_z + tray_height}",
-        "bin_b": "${table_top_z + tray_height}",
-        "reject_bin": "${table_top_z + tray_height}",
-    }
-    for name, expr in expected_expressions.items():
-        if expr not in scene_xacro_text:
-            raise AssertionError(f"{name} origin is not aligned from table_top_z expression")
+    table_relative_required_snippets = (
+        'table_to_item_red',
+        'table_to_item_blue',
+        'table_to_item_green',
+        'table_to_bin_a',
+        'table_to_bin_b',
+        'table_to_reject_bin',
+        'item_red_height / 2',
+        'item_blue_length / 2',
+        'item_green_radius',
+        'tray_height',
+    )
+    for snippet in table_relative_required_snippets:
+        if snippet not in scene_xacro_text:
+            raise AssertionError(f"scene.urdf.xacro missing table-relative layout snippet: {snippet}")
 
     required_layout_snippets = (
-        "<link name=\"table_\">",
-        "<joint name=\"world_to_table\" type=\"fixed\">",
-        "<origin xyz=\"0.15 0 ${table_top_z}\" rpy=\"0 0 0\"/>",
-        "<origin xyz=\"0 0 ${-tray_height / 2}\" rpy=\"0 0 0\"/>",
+        'link name="table_"',
+        'world_to_table',
+        '0.15 0 ${table_top_z}',
+        '-tray_height + tray_wall_thickness / 2',
+        '-tray_height / 2',
     )
+
     for snippet in required_layout_snippets:
         if snippet not in scene_xacro_text:
             raise AssertionError(f"scene.urdf.xacro missing deterministic layout snippet: {snippet}")

--- a/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro
@@ -22,8 +22,8 @@
  <xacro:property name="item_red_height" value="0.08"/>
  <xacro:property name="item_blue_length" value="0.06"/>
  <xacro:property name="item_green_radius" value="0.025"/>
- <xacro:property name="pickup_area_x" value="0.28"/>
- <xacro:property name="pickup_area_y" value="-0.12"/>
+ <xacro:property name="pickup_area_x" value="0.12"/>
+ <xacro:property name="pickup_area_y" value="0.00"/>
  <xacro:property name="destination_area_x" value="0.44"/>
  <xacro:property name="table_leg_size" value="0.07"/>
  <xacro:property name="robot_plate_length" value="0.28"/>
@@ -35,21 +35,21 @@
  <!-- Workbench frame: table_ is the main contact link; top surface z is table_top_z. -->
  <link name="table_">
    <visual>
-     <origin xyz="0 0 ${-(table_height - table_top_thickness) / 2}" rpy="0 0 0"/>
+     <origin xyz="0 0 ${-table_top_thickness - (table_height - table_top_thickness) / 2}" rpy="0 0 0"/>
      <geometry><box size="${table_length} ${table_width} ${table_height - table_top_thickness}"/></geometry>
      <material name="TableCabinet"><color rgba="0.46 0.33 0.24 1.0"/></material>
    </visual>
    <collision>
-     <origin xyz="0 0 ${-(table_height - table_top_thickness) / 2}" rpy="0 0 0"/>
+     <origin xyz="0 0 ${-table_top_thickness - (table_height - table_top_thickness) / 2}" rpy="0 0 0"/>
      <geometry><box size="${table_length} ${table_width} ${table_height - table_top_thickness}"/></geometry>
    </collision>
    <visual>
-     <origin xyz="0 0 ${table_top_thickness / 2}" rpy="0 0 0"/>
+     <origin xyz="0 0 ${-table_top_thickness / 2}" rpy="0 0 0"/>
      <geometry><box size="${table_length} ${table_width} ${table_top_thickness}"/></geometry>
      <material name="TableTop"><color rgba="0.55 0.40 0.28 1.0"/></material>
    </visual>
    <collision>
-     <origin xyz="0 0 ${table_top_thickness / 2}" rpy="0 0 0"/>
+     <origin xyz="0 0 ${-table_top_thickness / 2}" rpy="0 0 0"/>
      <geometry><box size="${table_length} ${table_width} ${table_top_thickness}"/></geometry>
    </collision>
  </link>
@@ -134,12 +134,12 @@
  <!-- Sorting destination row: tray frames are at opening/top-center; geometry extends downward onto tabletop. -->
  <link name="bin_a">
    <visual>
-     <origin xyz="0 0 ${-tray_wall_thickness / 2}" rpy="0 0 0"/>
+     <origin xyz="0 0 ${-tray_height + tray_wall_thickness / 2}" rpy="0 0 0"/>
      <geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry>
      <material name="Blue"><color rgba="0.2 0.2 0.8 1.0"/></material>
    </visual>
    <collision>
-     <origin xyz="0 0 ${-tray_wall_thickness / 2}" rpy="0 0 0"/>
+     <origin xyz="0 0 ${-tray_height + tray_wall_thickness / 2}" rpy="0 0 0"/>
      <geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry>
    </collision>
    <visual>
@@ -175,19 +175,19 @@
      <geometry><box size="${tray_wall_thickness} ${tray_width} ${tray_height}"/></geometry>
    </collision>
  </link>
- <joint name="world_to_bin_a" type="fixed">
-   <parent link="world"/>
+ <joint name="table_to_bin_a" type="fixed">
+   <parent link="table_"/>
    <child link="bin_a"/>
-   <origin xyz="${destination_area_x} -0.24 ${table_top_z + tray_wall_thickness}" rpy="0 0 0"/>
+   <origin xyz="${destination_area_x} -0.24 ${tray_height}" rpy="0 0 0"/>
  </joint>
 
  <link name="bin_b">
    <visual>
-     <origin xyz="0 0 ${-tray_wall_thickness / 2}" rpy="0 0 0"/>
+     <origin xyz="0 0 ${-tray_height + tray_wall_thickness / 2}" rpy="0 0 0"/>
      <geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry>
      <material name="Green"><color rgba="0.2 0.8 0.2 1.0"/></material>
    </visual>
-   <collision><origin xyz="0 0 ${-tray_wall_thickness / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry></collision>
+   <collision><origin xyz="0 0 ${-tray_height + tray_wall_thickness / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry></collision>
    <visual><origin xyz="0 ${tray_width / 2 - tray_wall_thickness / 2} ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_wall_thickness} ${tray_height}"/></geometry></visual>
    <collision><origin xyz="0 ${tray_width / 2 - tray_wall_thickness / 2} ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_wall_thickness} ${tray_height}"/></geometry></collision>
    <visual><origin xyz="0 ${-tray_width / 2 + tray_wall_thickness / 2} ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_wall_thickness} ${tray_height}"/></geometry></visual>
@@ -197,15 +197,15 @@
    <visual><origin xyz="${-tray_length / 2 + tray_wall_thickness / 2} 0 ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_wall_thickness} ${tray_width} ${tray_height}"/></geometry></visual>
    <collision><origin xyz="${-tray_length / 2 + tray_wall_thickness / 2} 0 ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_wall_thickness} ${tray_width} ${tray_height}"/></geometry></collision>
  </link>
- <joint name="world_to_bin_b" type="fixed">
-   <parent link="world"/>
+ <joint name="table_to_bin_b" type="fixed">
+   <parent link="table_"/>
    <child link="bin_b"/>
-   <origin xyz="${destination_area_x} 0.0 ${table_top_z + tray_wall_thickness}" rpy="0 0 0"/>
+   <origin xyz="${destination_area_x} 0.0 ${tray_height}" rpy="0 0 0"/>
  </joint>
 
  <link name="reject_bin">
-   <visual><origin xyz="0 0 ${-tray_wall_thickness / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry><material name="RejectBin"><color rgba="0.75 0.35 0.1 1.0"/></material></visual>
-   <collision><origin xyz="0 0 ${-tray_wall_thickness / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry></collision>
+   <visual><origin xyz="0 0 ${-tray_height + tray_wall_thickness / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry><material name="RejectBin"><color rgba="0.75 0.35 0.1 1.0"/></material></visual>
+   <collision><origin xyz="0 0 ${-tray_height + tray_wall_thickness / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_width} ${tray_wall_thickness}"/></geometry></collision>
    <visual><origin xyz="0 ${tray_width / 2 - tray_wall_thickness / 2} ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_wall_thickness} ${tray_height}"/></geometry></visual>
    <collision><origin xyz="0 ${tray_width / 2 - tray_wall_thickness / 2} ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_wall_thickness} ${tray_height}"/></geometry></collision>
    <visual><origin xyz="0 ${-tray_width / 2 + tray_wall_thickness / 2} ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_length} ${tray_wall_thickness} ${tray_height}"/></geometry></visual>
@@ -215,10 +215,10 @@
    <visual><origin xyz="${-tray_length / 2 + tray_wall_thickness / 2} 0 ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_wall_thickness} ${tray_width} ${tray_height}"/></geometry></visual>
    <collision><origin xyz="${-tray_length / 2 + tray_wall_thickness / 2} 0 ${-tray_height / 2}" rpy="0 0 0"/><geometry><box size="${tray_wall_thickness} ${tray_width} ${tray_height}"/></geometry></collision>
  </link>
- <joint name="world_to_reject_bin" type="fixed">
-   <parent link="world"/>
+ <joint name="table_to_reject_bin" type="fixed">
+   <parent link="table_"/>
    <child link="reject_bin"/>
-   <origin xyz="${destination_area_x} 0.24 ${table_top_z + tray_wall_thickness}" rpy="0 0 0"/>
+   <origin xyz="${destination_area_x} 0.24 ${tray_height}" rpy="0 0 0"/>
  </joint>
 
  <!-- Pickup area: three items arranged in a reachable row on the tabletop (bottoms at table_top_z). -->
@@ -226,30 +226,30 @@
    <visual><geometry><box size="0.04 0.04 0.08"/></geometry><material name="Red"><color rgba="0.9 0.1 0.1 1.0"/></material></visual>
    <collision><geometry><box size="0.04 0.04 0.08"/></geometry></collision>
  </link>
- <joint name="world_to_item_red" type="fixed">
-   <parent link="world"/>
+ <joint name="table_to_item_red" type="fixed">
+   <parent link="table_"/>
    <child link="item_red"/>
-   <origin xyz="${pickup_area_x} ${pickup_area_y} ${table_top_z + item_red_height / 2}" rpy="0 0 0"/>
+   <origin xyz="${pickup_area_x} ${pickup_area_y - 0.12} ${item_red_height / 2}" rpy="0 0 0"/>
  </joint>
 
  <link name="item_blue">
    <visual><geometry><cylinder length="0.06" radius="0.02"/></geometry><material name="BlueItem"><color rgba="0.1 0.3 0.9 1.0"/></material></visual>
    <collision><geometry><cylinder length="0.06" radius="0.02"/></geometry></collision>
  </link>
- <joint name="world_to_item_blue" type="fixed">
-   <parent link="world"/>
+ <joint name="table_to_item_blue" type="fixed">
+   <parent link="table_"/>
    <child link="item_blue"/>
-   <origin xyz="${pickup_area_x + 0.08} ${pickup_area_y} ${table_top_z + item_blue_length / 2}" rpy="0 0 0"/>
+   <origin xyz="${pickup_area_x} ${pickup_area_y} ${item_blue_length / 2}" rpy="0 0 0"/>
  </joint>
 
  <link name="item_green">
    <visual><geometry><sphere radius="0.025"/></geometry><material name="GreenItem"><color rgba="0.1 0.8 0.3 1.0"/></material></visual>
    <collision><geometry><sphere radius="0.025"/></geometry></collision>
  </link>
- <joint name="world_to_item_green" type="fixed">
-   <parent link="world"/>
+ <joint name="table_to_item_green" type="fixed">
+   <parent link="table_"/>
    <child link="item_green"/>
-   <origin xyz="${pickup_area_x + 0.16} ${pickup_area_y} ${table_top_z + item_green_radius}" rpy="0 0 0"/>
+   <origin xyz="${pickup_area_x} ${pickup_area_y + 0.12} ${item_green_radius}" rpy="0 0 0"/>
  </joint>
 
 </robot>


### PR DESCRIPTION
## Summary

This PR fixes the `ur5_2f_sorting_test` scene geometry and validation after manual RViz testing showed that the sorting-cell layout was still not ideal.

The main change is to make the scene properly table-relative: the `table_` frame now represents the tabletop surface, and the pickup items and destination trays are positioned relative to that surface instead of being loosely placed in world coordinates.

## Changes

- Fixed tabletop/tray frame semantics in `scene.urdf.xacro`.
- Updated item and bin/tray placement so:
  - items sit directly on the tabletop
  - bin_a, bin_b, and reject_bin sit directly on the tabletop
  - tray frames represent the top/opening centre
  - pickup items are placed in a clearer row in front of the bins
- Improved `validate_scene_layout.py` so it validates the raw xacro layout correctly.
- Updated `test_sorting_manifest.py` so the test matches the final table-relative scene layout instead of checking outdated world-relative expressions.
- Kept the sorting manifest and dry-run plan behaviour unchanged.

## Validation

Tested locally:

```bash
ros2 run ur5_2f_sorting_test validate_scene_layout