### PR TITLE
Add dry-run runtime_execution_plan preview generator for ur5_2f_sorting_test

### DIFF
--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -42,6 +42,12 @@ install(PROGRAMS
   RENAME validate_scene_layout
 )
 
+install(PROGRAMS
+  scripts/generate_sorting_runtime_plan.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME generate_sorting_runtime_plan
+)
+
 if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_sorting_manifest_validation
@@ -56,6 +62,11 @@ if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_validate_scene_layout
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_validate_scene_layout.py
+  )
+
+  add_test(
+    NAME ur5_2f_sorting_test_generate_sorting_runtime_plan
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_generate_sorting_runtime_plan.py
   )
 endif()
 

--- a/scenes/ur5_2f_sorting_test/README.md
+++ b/scenes/ur5_2f_sorting_test/README.md
@@ -73,6 +73,28 @@ Manifest: /.../sorting_manifest.yaml
 ```
 
 
+## Dry-run runtime execution plan preview
+
+Generate a scene-local `runtime_execution_plan/v1` preview from `sorting_manifest.yaml`:
+
+```bash
+ros2 run ur5_2f_sorting_test generate_sorting_runtime_plan
+```
+
+Print full JSON to stdout:
+
+```bash
+ros2 run ur5_2f_sorting_test generate_sorting_runtime_plan --json
+```
+
+Write JSON to a file:
+
+```bash
+ros2 run ur5_2f_sorting_test generate_sorting_runtime_plan --output /tmp/runtime_plan.json
+```
+
+This tool is **dry-run only**. It does not move the robot, does not call `run_grasp_execution`, does not publish ROS grasp tasks, and does not integrate perception.
+
 ## Validate physical layout
 
 Run the deterministic scene-layout validator before RViz or execution integration:

--- a/scenes/ur5_2f_sorting_test/scripts/generate_sorting_runtime_plan.py
+++ b/scenes/ur5_2f_sorting_test/scripts/generate_sorting_runtime_plan.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Generate a dry-run runtime_execution_plan/v1 from sorting_manifest.yaml."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+import ast
+
+
+SCHEMA = "runtime_execution_plan/v1"
+SCENE_PACKAGE = "ur5_2f_sorting_test"
+PLANNING_FRAME = "world"
+MODE = "dry_run"
+
+
+def find_manifest_path() -> Path:
+    """Find sorting_manifest.yaml from install/share, with source-tree fallback."""
+    try:
+        from ament_index_python.packages import get_package_share_directory
+
+        share_dir = Path(get_package_share_directory(SCENE_PACKAGE))
+        share_manifest = share_dir / "sorting_manifest.yaml"
+        if share_manifest.exists():
+            return share_manifest
+    except Exception:
+        pass
+
+    source_manifest = Path(__file__).resolve().parents[1] / "sorting_manifest.yaml"
+    if source_manifest.exists():
+        return source_manifest
+
+    raise FileNotFoundError("Could not locate sorting_manifest.yaml in share or source tree")
+
+
+def _parse_scalar(value: str):
+    value = value.strip()
+    if value.startswith("[") and value.endswith("]"):
+        return ast.literal_eval(value)
+    if value.startswith(""") and value.endswith("""):
+        return value[1:-1]
+    return value
+
+
+def load_manifest(path: Path) -> dict:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    manifest = {"objects": [], "destinations": [], "routing": []}
+    section = None
+    current = None
+
+    for raw in lines:
+        line = raw.rstrip()
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped == "sorting_manifest:":
+            continue
+        if stripped in {"objects:", "destinations:", "routing:"}:
+            section = stripped[:-1]
+            current = None
+            continue
+        if section in {"objects", "destinations", "routing"} and stripped.startswith("- "):
+            current = {}
+            manifest[section].append(current)
+            stripped = stripped[2:].strip()
+            if stripped:
+                key, value = stripped.split(":", 1)
+                current[key.strip()] = _parse_scalar(value)
+            continue
+        if current is not None and ":" in stripped:
+            key, value = stripped.split(":", 1)
+            current[key.strip()] = _parse_scalar(value)
+
+    if not manifest["objects"] or not manifest["destinations"] or not manifest["routing"]:
+        raise AssertionError("sorting_manifest root mapping is missing or incomplete")
+    return manifest
+
+
+def build_runtime_plan(manifest: dict) -> dict:
+    objects = manifest.get("objects") or []
+    destinations = manifest.get("destinations") or []
+    routing = manifest.get("routing") or []
+
+    objects_by_id = {obj["id"]: obj for obj in objects if isinstance(obj, dict) and "id" in obj}
+    destinations_by_id = {
+        destination["id"]: destination
+        for destination in destinations
+        if isinstance(destination, dict) and "id" in destination
+    }
+
+    steps = []
+    for route in routing:
+        object_id = route.get("object")
+        destination_id = route.get("destination")
+
+        obj = objects_by_id.get(object_id)
+        destination = destinations_by_id.get(destination_id)
+        if obj is None or destination is None:
+            raise AssertionError(f"Invalid route entry: {route}")
+
+        object_frame = obj.get("frame_id", object_id)
+        destination_frame = destination.get("frame_id", destination_id)
+        pick_hint = obj.get("pick_hint", "top_grasp")
+        approximate_size = obj.get("approximate_size_m", [0.0, 0.0, 0.0])
+        release_offset = destination.get("release_offset_xyz_m", [0.0, 0.0, 0.0])
+
+        steps.append(
+            {
+                "id": f"pick_{object_id}",
+                "type": "pick",
+                "object_id": object_id,
+                "object_frame": object_frame,
+                "pick_hint": pick_hint,
+                "approximate_size_m": approximate_size,
+                "destination_id": destination_id,
+            }
+        )
+        steps.append(
+            {
+                "id": f"place_{object_id}_to_{destination_id}",
+                "type": "place",
+                "object_id": object_id,
+                "destination_id": destination_id,
+                "destination_frame": destination_frame,
+                "release_offset_xyz_m": release_offset,
+            }
+        )
+
+    return {
+        "schema": SCHEMA,
+        "scene_package": SCENE_PACKAGE,
+        "mode": MODE,
+        "planning_frame": PLANNING_FRAME,
+        "steps": steps,
+    }
+
+
+def print_summary(plan: dict, manifest_path: Path) -> None:
+    print("Dry-run sorting runtime execution plan preview")
+    print(f"Manifest: {manifest_path}")
+    print(f"Schema: {plan['schema']}")
+    print(f"Scene package: {plan['scene_package']}")
+    print(f"Mode: {plan['mode']}")
+    print(f"Planning frame: {plan['planning_frame']}")
+    print()
+
+    steps = plan.get("steps", [])
+    for index in range(0, len(steps), 2):
+        pick_step = steps[index]
+        place_step = steps[index + 1]
+        route_num = (index // 2) + 1
+        print(
+            f"{route_num}. {pick_step['object_id']} -> {place_step['destination_id']} "
+            f"({pick_step['id']}, {place_step['id']})"
+        )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Print full JSON runtime plan.")
+    parser.add_argument("--output", type=Path, help="Write JSON runtime plan to a file path.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    manifest_path = find_manifest_path()
+    manifest = load_manifest(manifest_path)
+    plan = build_runtime_plan(manifest)
+
+    plan_json = json.dumps(plan, indent=2, sort_keys=False)
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(plan_json + "\n", encoding="utf-8")
+
+    if args.json:
+        print(plan_json)
+    else:
+        print_summary(plan, manifest_path)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scenes/ur5_2f_sorting_test/test/test_generate_sorting_runtime_plan.py
+++ b/scenes/ur5_2f_sorting_test/test/test_generate_sorting_runtime_plan.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Validate dry-run runtime_execution_plan/v1 preview generation."""
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main() -> int:
+    script_path = (
+        Path(__file__).resolve().parents[1] / "scripts" / "generate_sorting_runtime_plan.py"
+    )
+
+    subprocess.run([sys.executable, str(script_path)], check=True, capture_output=True, text=True)
+
+    json_result = subprocess.run(
+        [sys.executable, str(script_path), "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    plan = json.loads(json_result.stdout)
+
+    if plan.get("schema") != "runtime_execution_plan/v1":
+        raise AssertionError("schema mismatch")
+
+    steps = plan.get("steps")
+    if not isinstance(steps, list) or len(steps) != 6:
+        raise AssertionError(f"expected 6 steps total, found: {len(steps) if isinstance(steps, list) else 'n/a'}")
+
+    place_steps = {step.get("object_id"): step for step in steps if step.get("type") == "place"}
+
+    expected_routes = {
+        "item_red": "bin_a",
+        "item_blue": "bin_b",
+        "item_green": "reject_bin",
+    }
+    for object_id, destination_id in expected_routes.items():
+        step = place_steps.get(object_id)
+        if step is None:
+            raise AssertionError(f"missing place step for {object_id}")
+        if step.get("destination_id") != destination_id:
+            raise AssertionError(f"wrong destination for {object_id}: {step.get('destination_id')}")
+
+        release_offset = step.get("release_offset_xyz_m")
+        if not isinstance(release_offset, list) or len(release_offset) != 3:
+            raise AssertionError(f"invalid release offset for {object_id}")
+        if release_offset[2] <= 0.0:
+            raise AssertionError(f"release_offset z must be positive for {object_id}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide a scene-local, offline preview of the runtime execution plan derived from `sorting_manifest.yaml` so routing and placement details can be reviewed before any robot execution. 
- Keep the tool dry-run only and not dependent on ROS runtime or perception, so it is safe to run in development environments.

### Description
- Add `scenes/ur5_2f_sorting_test/scripts/generate_sorting_runtime_plan.py` which locates `sorting_manifest.yaml` (installed share path with source-tree fallback), parses objects/destinations/routing, and builds a deterministic `runtime_execution_plan/v1` JSON preview.  
- The script prints a readable summary by default, supports `--json` to emit full JSON, and supports `--output <path>` to write JSON to a file.  
- Install the script as a ROS 2 executable via `CMakeLists.txt` so it can be run with `ros2 run ur5_2f_sorting_test generate_sorting_runtime_plan`.  
- Add `scenes/ur5_2f_sorting_test/test/test_generate_sorting_runtime_plan.py` and update `README.md` with usage and an explicit dry-run safety note; `generate_sorting_plan` is left unchanged.

### Testing
- Ran the new unit test `python3 scenes/ur5_2f_sorting_test/test/test_generate_sorting_runtime_plan.py` which executed the script and passed all assertions.  
- Verified JSON output with `python3 scenes/ur5_2f_sorting_test/scripts/generate_sorting_runtime_plan.py --json > /tmp/runtime_plan.json` and validated it with `python3 -m json.tool /tmp/runtime_plan.json`, which succeeded.  
- Tests validate that the `schema` is `runtime_execution_plan/v1`, that there are exactly six steps (pick/place for three objects), that `item_red`→`bin_a`, `item_blue`→`bin_b`, and `item_green`→`reject_bin`, and that each place `release_offset` z value is positive.  
- Attempted `colcon test --packages-select ur5_2f_sorting_test`, but `colcon` is not available in this execution environment so package-level CTest runs were not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9cc9476108331b5206011edaee49a)