### PR TITLE
Add dry-run EMD bridge payload preview tool for ur5_2f_sorting_test

### DIFF
--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -48,6 +48,12 @@ install(PROGRAMS
   RENAME generate_sorting_runtime_plan
 )
 
+install(PROGRAMS
+  scripts/generate_sorting_emd_bridge_payload.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME generate_sorting_emd_bridge_payload
+)
+
 if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_sorting_manifest_validation
@@ -67,6 +73,11 @@ if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_generate_sorting_runtime_plan
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_generate_sorting_runtime_plan.py
+  )
+
+  add_test(
+    NAME ur5_2f_sorting_test_generate_sorting_emd_bridge_payload
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_generate_sorting_emd_bridge_payload.py
   )
 endif()
 

--- a/scenes/ur5_2f_sorting_test/README.md
+++ b/scenes/ur5_2f_sorting_test/README.md
@@ -95,6 +95,38 @@ ros2 run ur5_2f_sorting_test generate_sorting_runtime_plan --output /tmp/runtime
 
 This tool is **dry-run only**. It does not move the robot, does not call `run_grasp_execution`, does not publish ROS grasp tasks, and does not integrate perception.
 
+## Dry-run EMD bridge payload preview
+
+Convert a `runtime_execution_plan/v1` into a scene-local `emd_grasp_bridge_payload/v1` preview:
+
+```bash
+ros2 run ur5_2f_sorting_test generate_sorting_emd_bridge_payload
+```
+
+Use an existing runtime plan JSON as input:
+
+```bash
+ros2 run ur5_2f_sorting_test generate_sorting_emd_bridge_payload --runtime-plan /tmp/runtime_plan.json
+```
+
+Print full payload JSON:
+
+```bash
+ros2 run ur5_2f_sorting_test generate_sorting_emd_bridge_payload --json
+```
+
+Write payload JSON to a file:
+
+```bash
+ros2 run ur5_2f_sorting_test generate_sorting_emd_bridge_payload --output /tmp/emd_bridge_payload.json
+```
+
+This bridge payload generator is **dry-run only** and remains offline/reviewable. It does **not** execute robot motion, does **not** publish ROS grasp tasks, does **not** call `run_grasp_execution`, and does **not** use live EPD detections yet.
+
+Future integration path (guarded, not enabled yet):
+
+`EPD detected objects -> runtime_execution_plan/v1 -> emd_grasp_bridge_payload/v1 -> guarded EMD execution`
+
 ## Validate physical layout
 
 Run the deterministic scene-layout validator before RViz or execution integration:

--- a/scenes/ur5_2f_sorting_test/scripts/generate_sorting_emd_bridge_payload.py
+++ b/scenes/ur5_2f_sorting_test/scripts/generate_sorting_emd_bridge_payload.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Generate dry-run emd_grasp_bridge_payload/v1 from runtime_execution_plan/v1."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+import generate_sorting_runtime_plan as runtime_plan
+
+SCHEMA = "emd_grasp_bridge_payload/v1"
+SOURCE_SCHEMA = "runtime_execution_plan/v1"
+SCENE_PACKAGE = "ur5_2f_sorting_test"
+
+
+DEFAULT_WARNINGS = [
+    "No live EPD detections used; object frames come from static sorting manifest.",
+]
+
+
+def build_bridge_payload(plan: dict) -> dict:
+    if plan.get("schema") != SOURCE_SCHEMA:
+        raise AssertionError(f"Unsupported runtime plan schema: {plan.get('schema')}")
+
+    pick_steps = {}
+    place_steps = {}
+    for step in plan.get("steps", []):
+        object_id = step.get("object_id")
+        if not object_id:
+            continue
+        if step.get("type") == "pick":
+            pick_steps[object_id] = step
+        elif step.get("type") == "place":
+            place_steps[object_id] = step
+
+    targets = []
+    for object_id, pick_step in pick_steps.items():
+        place_step = place_steps.get(object_id)
+        if place_step is None:
+            raise AssertionError(f"Missing place step for object: {object_id}")
+
+        release_offset = place_step.get("release_offset_xyz_m", [0.0, 0.0, 0.0])
+        targets.append(
+            {
+                "id": object_id,
+                "object_id": object_id,
+                "object_frame": pick_step.get("object_frame", object_id),
+                "pick_hint": pick_step.get("pick_hint", "top_grasp"),
+                "approximate_size_m": pick_step.get("approximate_size_m", [0.0, 0.0, 0.0]),
+                "grasp_target": {
+                    "frame_id": pick_step.get("object_frame", object_id),
+                    "pose_source": "scene_frame",
+                    "preferred_method": pick_step.get("pick_hint", "top_grasp"),
+                },
+                "destination": {
+                    "id": place_step.get("destination_id"),
+                    "frame_id": place_step.get("destination_frame", place_step.get("destination_id")),
+                    "release_offset_xyz_m": release_offset,
+                },
+                "notes": ["dry-run bridge payload only; not executed"],
+            }
+        )
+
+    return {
+        "schema": SCHEMA,
+        "scene_package": plan.get("scene_package", SCENE_PACKAGE),
+        "mode": "dry_run",
+        "source_schema": SOURCE_SCHEMA,
+        "targets": targets,
+        "warnings": DEFAULT_WARNINGS,
+    }
+
+
+def print_summary(payload: dict, runtime_plan_path: Path | None) -> None:
+    print("Dry-run EMD grasp bridge payload preview")
+    print(f"Source schema: {payload['source_schema']}")
+    print(f"Schema: {payload['schema']}")
+    print(f"Scene package: {payload['scene_package']}")
+    print(f"Mode: {payload['mode']}")
+    print(f"Runtime plan: {runtime_plan_path if runtime_plan_path is not None else 'generated from sorting_manifest.yaml'}")
+    print()
+    for index, target in enumerate(payload.get("targets", []), start=1):
+        destination = target["destination"]
+        print(
+            f"{index}. {target['object_id']} -> {destination['id']} "
+            f"(pick_hint={target['pick_hint']}, release_offset={destination['release_offset_xyz_m']})"
+        )
+    print()
+    for warning in payload.get("warnings", []):
+        print(f"warning: {warning}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--runtime-plan",
+        type=Path,
+        help="Path to runtime_execution_plan/v1 JSON. If omitted, generate from sorting_manifest.yaml.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print full JSON bridge payload.")
+    parser.add_argument("--output", type=Path, help="Write bridge payload JSON to file path.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+
+    runtime_plan_path = args.runtime_plan
+    if runtime_plan_path is not None:
+        runtime_plan_data = json.loads(runtime_plan_path.read_text(encoding="utf-8"))
+    else:
+        manifest_path = runtime_plan.find_manifest_path()
+        manifest = runtime_plan.load_manifest(manifest_path)
+        runtime_plan_data = runtime_plan.build_runtime_plan(manifest)
+
+    payload = build_bridge_payload(runtime_plan_data)
+    payload_json = json.dumps(payload, indent=2, sort_keys=False)
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload_json + "\n", encoding="utf-8")
+
+    if args.json:
+        print(payload_json)
+    else:
+        print_summary(payload, runtime_plan_path)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scenes/ur5_2f_sorting_test/test/test_generate_sorting_emd_bridge_payload.py
+++ b/scenes/ur5_2f_sorting_test/test/test_generate_sorting_emd_bridge_payload.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Validate dry-run emd_grasp_bridge_payload/v1 preview generation."""
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main() -> int:
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "scripts"
+        / "generate_sorting_emd_bridge_payload.py"
+    )
+
+    subprocess.run([sys.executable, str(script_path)], check=True, capture_output=True, text=True)
+
+    json_result = subprocess.run(
+        [sys.executable, str(script_path), "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(json_result.stdout)
+
+    if payload.get("schema") != "emd_grasp_bridge_payload/v1":
+        raise AssertionError("schema mismatch")
+    if payload.get("source_schema") != "runtime_execution_plan/v1":
+        raise AssertionError("source_schema mismatch")
+
+    targets = payload.get("targets")
+    if not isinstance(targets, list) or len(targets) != 3:
+        raise AssertionError(f"expected 3 targets total, found: {len(targets) if isinstance(targets, list) else 'n/a'}")
+
+    expected_routes = {
+        "item_red": "bin_a",
+        "item_blue": "bin_b",
+        "item_green": "reject_bin",
+    }
+    expected_sizes = {
+        "item_red": [0.05, 0.05, 0.05],
+        "item_blue": [0.05, 0.05, 0.05],
+        "item_green": [0.05, 0.05, 0.05],
+    }
+
+    by_object = {target.get("object_id"): target for target in targets}
+    for object_id, destination_id in expected_routes.items():
+        target = by_object.get(object_id)
+        if target is None:
+            raise AssertionError(f"missing target for {object_id}")
+
+        if target.get("destination", {}).get("id") != destination_id:
+            raise AssertionError(f"wrong destination for {object_id}: {target.get('destination', {}).get('id')}")
+
+        if target.get("pick_hint") != "top_grasp":
+            raise AssertionError(f"pick_hint not preserved for {object_id}")
+
+        if target.get("approximate_size_m") != expected_sizes[object_id]:
+            raise AssertionError(f"approximate_size_m not preserved for {object_id}")
+
+        release_offset = target.get("destination", {}).get("release_offset_xyz_m")
+        if not isinstance(release_offset, list) or len(release_offset) != 3:
+            raise AssertionError(f"invalid release offset for {object_id}")
+        if release_offset[2] <= 0.0:
+            raise AssertionError(f"release_offset z must be positive for {object_id}")
+
+    warnings = payload.get("warnings")
+    if not isinstance(warnings, list) or not any("No live EPD detections used" in w for w in warnings):
+        raise AssertionError("missing dry-run warning about live EPD detections")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide a scene-local, reviewable preview that converts a `runtime_execution_plan/v1` into an `emd_grasp_bridge_payload/v1` payload for the `ur5_2f_sorting_test` scene. 
- Keep the flow strictly dry-run/offline (no robot motion, no ROS grasp task publication, no `run_grasp_execution`, no live EPD integration) while preserving a clear integration path for future EPD detections. 

### Description
- Add `scenes/ur5_2f_sorting_test/scripts/generate_sorting_emd_bridge_payload.py` which accepts `--runtime-plan <path>` or generates a runtime plan internally from `sorting_manifest.yaml`, and supports `--json` and `--output` options. 
- Convert pick/place steps from the `runtime_execution_plan/v1` into `emd_grasp_bridge_payload/v1` targets while preserving `pick_hint` and `approximate_size_m`, and include destination `release_offset_xyz_m` and dry-run `warnings`. 
- Install the script as a ROS2-executable via `CMakeLists.txt` so it can be run with `ros2 run ur5_2f_sorting_test generate_sorting_emd_bridge_payload` and register a package test. 
- Add `scenes/ur5_2f_sorting_test/test/test_generate_sorting_emd_bridge_payload.py` to validate schema, source schema, expected targets and destinations (`item_red`→`bin_a`, `item_blue`→`bin_b`, `item_green`→`reject_bin`), preserved metadata, positive release offset `z`, and presence of the dry-run EPD warning, and update `README.md` with usage and future EPD integration notes. 

### Testing
- Ran `python scenes/ur5_2f_sorting_test/test/test_generate_sorting_emd_bridge_payload.py` and it completed successfully. 
- Ran `python scenes/ur5_2f_sorting_test/test/test_generate_sorting_runtime_plan.py` and it completed successfully. 
- Executed the new script with `--json` and validated output JSON and schema via `python scenes/ur5_2f_sorting_test/scripts/generate_sorting_emd_bridge_payload.py --json` and a quick JSON schema check, which returned `emd_grasp_bridge_payload/v1` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ce15f6d48331b4aa6242ab0f66ef)