### PR TITLE
Fix installed ROS2 import path in sorting EMD bridge payload generator

### DIFF
--- a/scenes/ur5_2f_sorting_test/scripts/generate_sorting_emd_bridge_payload.py
+++ b/scenes/ur5_2f_sorting_test/scripts/generate_sorting_emd_bridge_payload.py
@@ -4,11 +4,48 @@
 from __future__ import annotations
 
 import argparse
+import importlib.machinery
+import importlib.util
 import json
 from pathlib import Path
 import sys
 
-import generate_sorting_runtime_plan as runtime_plan
+
+def _load_runtime_plan_module():
+    script_dir = Path(__file__).resolve().parent
+    candidates = [
+        script_dir / "generate_sorting_runtime_plan.py",
+        script_dir / "generate_sorting_runtime_plan",
+    ]
+
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+
+        module_name = f"_sorting_runtime_plan_{candidate.name.replace('.', '_')}"
+        if candidate.suffix == ".py":
+            spec = importlib.util.spec_from_file_location(module_name, candidate)
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+
+        loader = importlib.machinery.SourceFileLoader(module_name, str(candidate))
+        spec = importlib.util.spec_from_loader(module_name, loader)
+        if spec is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
+        return module
+
+    raise ModuleNotFoundError(
+        "Unable to load sibling runtime plan helper from "
+        f"{candidates[0].name} or {candidates[1].name}"
+    )
+
+
+runtime_plan = _load_runtime_plan_module()
 
 SCHEMA = "emd_grasp_bridge_payload/v1"
 SOURCE_SCHEMA = "runtime_execution_plan/v1"

--- a/scenes/ur5_2f_sorting_test/test/test_generate_sorting_emd_bridge_payload.py
+++ b/scenes/ur5_2f_sorting_test/test/test_generate_sorting_emd_bridge_payload.py
@@ -3,8 +3,10 @@
 
 import json
 from pathlib import Path
+import shutil
 import subprocess
 import sys
+import tempfile
 
 
 def main() -> int:
@@ -13,6 +15,7 @@ def main() -> int:
         / "scripts"
         / "generate_sorting_emd_bridge_payload.py"
     )
+    runtime_plan_script = script_path.parent / "generate_sorting_runtime_plan.py"
 
     subprocess.run([sys.executable, str(script_path)], check=True, capture_output=True, text=True)
 
@@ -68,6 +71,40 @@ def main() -> int:
     warnings = payload.get("warnings")
     if not isinstance(warnings, list) or not any("No live EPD detections used" in w for w in warnings):
         raise AssertionError("missing dry-run warning about live EPD detections")
+
+    runtime_plan_result = subprocess.run(
+        [sys.executable, str(runtime_plan_script), "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    runtime_plan_data = json.loads(runtime_plan_result.stdout)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_scripts = Path(tmp_dir)
+        payload_script_copy = tmp_scripts / "generate_sorting_emd_bridge_payload.py"
+        runtime_plan_copy = tmp_scripts / "generate_sorting_runtime_plan"
+        runtime_plan_json = tmp_scripts / "runtime_plan.json"
+
+        shutil.copy2(script_path, payload_script_copy)
+        shutil.copy2(runtime_plan_script, runtime_plan_copy)
+        runtime_plan_json.write_text(json.dumps(runtime_plan_data), encoding="utf-8")
+
+        installed_layout_result = subprocess.run(
+            [
+                sys.executable,
+                str(payload_script_copy),
+                "--runtime-plan",
+                str(runtime_plan_json),
+                "--json",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        installed_layout_payload = json.loads(installed_layout_result.stdout)
+        if installed_layout_payload.get("schema") != "emd_grasp_bridge_payload/v1":
+            raise AssertionError("installed-layout schema mismatch")
 
     return 0
 


### PR DESCRIPTION
### Motivation
- Installed `ros2 run` scripts may be placed under `lib/<pkg>` as extensionless executables, so a plain `import generate_sorting_runtime_plan` can raise `ModuleNotFoundError` when the helper is a sibling file without a `.py` extension.
- The payload generator must be able to load its sibling runtime-plan helper both from the source tree (`generate_sorting_runtime_plan.py`) and from an installed executable layout (`generate_sorting_runtime_plan`).

### Description
- Replaced the direct `import generate_sorting_runtime_plan` with a helper `_load_runtime_plan_module()` in `scenes/ur5_2f_sorting_test/scripts/generate_sorting_emd_bridge_payload.py` that attempts to load candidates relative to `Path(__file__).resolve().parent`.
- The loader checks two candidates: `generate_sorting_runtime_plan.py` and `generate_sorting_runtime_plan`, and loads the module via `importlib.util.spec_from_file_location` for `.py` files and `importlib.machinery.SourceFileLoader` for extensionless files, then assigns the loaded module to `runtime_plan`.
- Added regression coverage to `scenes/ur5_2f_sorting_test/test/test_generate_sorting_emd_bridge_payload.py` that simulates the installed ROS2 layout by copying the payload script and an extensionless runtime-plan helper into a temporary directory and invoking the payload with `--runtime-plan` + `--json` to verify successful JSON generation.

### Testing
- Ran `python3 scenes/ur5_2f_sorting_test/test/test_generate_sorting_emd_bridge_payload.py`, which includes the new regression scenario, and it completed successfully (exit code 0).
- Ran `python3 scenes/ur5_2f_sorting_test/test/test_generate_sorting_runtime_plan.py` and it completed successfully (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d01c26788331ae9ea3f56a9bc8b8)