### PR TITLE
Add offline detected_objects/v1 -> runtime_execution_plan/v1 path for ur5_2f_sorting_test

### DIFF
--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -27,6 +27,7 @@ install(FILES
   scene_manifest.yaml
   sorting_manifest.yaml
   README.md
+  fixtures/detected_objects_sample.json
   DESTINATION share/${PROJECT_NAME}
 )
 
@@ -54,6 +55,12 @@ install(PROGRAMS
   RENAME generate_sorting_emd_bridge_payload
 )
 
+install(PROGRAMS
+  scripts/generate_runtime_plan_from_detections.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME generate_runtime_plan_from_detections
+)
+
 if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_sorting_manifest_validation
@@ -78,6 +85,11 @@ if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_generate_sorting_emd_bridge_payload
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_generate_sorting_emd_bridge_payload.py
+  )
+
+  add_test(
+    NAME ur5_2f_sorting_test_generate_runtime_plan_from_detections
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_generate_runtime_plan_from_detections.py
   )
 endif()
 

--- a/scenes/ur5_2f_sorting_test/README.md
+++ b/scenes/ur5_2f_sorting_test/README.md
@@ -97,6 +97,31 @@ This tool is **dry-run only**. It does not move the robot, does not call `run_gr
 
 ## Dry-run EMD bridge payload preview
 
+
+### Offline EPD-style detected_objects fixture path
+
+Generate `runtime_execution_plan/v1` from an offline `detected_objects/v1` fixture:
+
+```bash
+ros2 run ur5_2f_sorting_test generate_runtime_plan_from_detections \
+  --detections <path-to-detected_objects_v1.json>
+```
+
+JSON output:
+
+```bash
+ros2 run ur5_2f_sorting_test generate_runtime_plan_from_detections \
+  --detections <path-to-detected_objects_v1.json> \
+  --json
+```
+
+Architecture split:
+- EPD detects/classifies objects and provides pose/frame metadata.
+- EMD owns label-to-bin routing using scene configuration (`sorting_manifest.yaml`).
+- Robo Studio is expected to eventually edit/generate these routing rules and scene metadata.
+
+This path stays dry-run/offline and does not require ROS topic/service publishing or live EPD/camera inputs.
+
 Convert a `runtime_execution_plan/v1` into a scene-local `emd_grasp_bridge_payload/v1` preview:
 
 ```bash

--- a/scenes/ur5_2f_sorting_test/fixtures/detected_objects_sample.json
+++ b/scenes/ur5_2f_sorting_test/fixtures/detected_objects_sample.json
@@ -1,0 +1,32 @@
+{
+  "schema": "detected_objects/v1",
+  "source": "offline_fixture",
+  "camera_frame": "camera_color_optical_frame",
+  "planning_frame": "world",
+  "objects": [
+    {
+      "id": "det_red_001",
+      "class_label": "red_block",
+      "confidence": 0.95,
+      "frame_id": "item_red",
+      "pose_source": "scene_frame",
+      "approximate_size_m": [0.05, 0.05, 0.05]
+    },
+    {
+      "id": "det_blue_001",
+      "class_label": "blue_block",
+      "confidence": 0.94,
+      "frame_id": "item_blue",
+      "pose_source": "scene_frame",
+      "approximate_size_m": [0.05, 0.05, 0.05]
+    },
+    {
+      "id": "det_green_001",
+      "class_label": "green_block",
+      "confidence": 0.91,
+      "frame_id": "item_green",
+      "pose_source": "scene_frame",
+      "approximate_size_m": [0.05, 0.05, 0.05]
+    }
+  ]
+}

--- a/scenes/ur5_2f_sorting_test/scripts/generate_runtime_plan_from_detections.py
+++ b/scenes/ur5_2f_sorting_test/scripts/generate_runtime_plan_from_detections.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Generate runtime_execution_plan/v1 from detected_objects/v1 fixture input."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from pathlib import Path
+import sys
+
+SCHEMA = "runtime_execution_plan/v1"
+INPUT_SCHEMA = "detected_objects/v1"
+SCENE_PACKAGE = "ur5_2f_sorting_test"
+MODE = "dry_run"
+DEFAULT_MIN_CONFIDENCE = 0.5
+
+
+def find_sorting_manifest_path() -> Path:
+    try:
+        from ament_index_python.packages import get_package_share_directory
+
+        share_dir = Path(get_package_share_directory(SCENE_PACKAGE))
+        share_manifest = share_dir / "sorting_manifest.yaml"
+        if share_manifest.exists():
+            return share_manifest
+    except Exception:
+        pass
+
+    source_manifest = Path(__file__).resolve().parents[1] / "sorting_manifest.yaml"
+    if source_manifest.exists():
+        return source_manifest
+
+    raise FileNotFoundError("Could not locate sorting_manifest.yaml in share or source tree")
+
+
+def _parse_scalar(value: str):
+    value = value.strip()
+    if value.startswith("[") and value.endswith("]"):
+        return ast.literal_eval(value)
+    if value.startswith('"') and value.endswith('"'):
+        return value[1:-1]
+    if ":" not in value and value.replace("_", "").isalnum():
+        return value
+    return value
+
+
+def load_manifest(path: Path) -> dict:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    manifest = {
+        "objects": [],
+        "destinations": [],
+        "routing": [],
+        "class_routing": {},
+        "class_routing_defaults": {},
+    }
+    section = None
+    current = None
+
+    for raw in lines:
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#") or stripped == "sorting_manifest:":
+            continue
+        if stripped in {
+            "objects:",
+            "destinations:",
+            "routing:",
+            "class_routing:",
+            "class_routing_defaults:",
+        }:
+            section = stripped[:-1]
+            current = None
+            continue
+
+        if section in {"objects", "destinations", "routing"} and stripped.startswith("- "):
+            current = {}
+            manifest[section].append(current)
+            stripped = stripped[2:].strip()
+            if stripped:
+                key, value = stripped.split(":", 1)
+                current[key.strip()] = _parse_scalar(value)
+            continue
+
+        if section in {"class_routing", "class_routing_defaults"} and ":" in stripped:
+            key, value = stripped.split(":", 1)
+            manifest[section][key.strip()] = _parse_scalar(value)
+            continue
+
+        if current is not None and ":" in stripped:
+            key, value = stripped.split(":", 1)
+            current[key.strip()] = _parse_scalar(value)
+
+    return manifest
+
+
+def load_detections(path: Path) -> dict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema") != INPUT_SCHEMA:
+        raise AssertionError(f"Expected schema {INPUT_SCHEMA}, got {payload.get('schema')}")
+    objects = payload.get("objects")
+    if not isinstance(objects, list):
+        raise AssertionError("detected_objects payload must include objects list")
+    return payload
+
+
+def build_runtime_plan(detections: dict, manifest: dict, min_confidence: float) -> dict:
+    destinations = manifest.get("destinations") or []
+    class_routing = manifest.get("class_routing") or {}
+    defaults = manifest.get("class_routing_defaults") or {}
+
+    destinations_by_id = {entry.get("id"): entry for entry in destinations if isinstance(entry, dict)}
+    reject_destination = defaults.get("unknown_class_destination")
+    low_conf_destination = defaults.get("low_confidence_destination")
+
+    steps = []
+    for detected in detections.get("objects", []):
+        detected_id = detected.get("id")
+        class_label = detected.get("class_label")
+        confidence = float(detected.get("confidence", 0.0))
+        object_frame = detected.get("frame_id")
+        pose_source = detected.get("pose_source", "unknown")
+        approximate_size = detected.get("approximate_size_m", [0.0, 0.0, 0.0])
+
+        if confidence < min_confidence:
+            destination_id = low_conf_destination
+        else:
+            destination_id = class_routing.get(class_label, reject_destination)
+
+        if destination_id not in destinations_by_id:
+            raise AssertionError(
+                f"Destination '{destination_id}' for detected object '{detected_id}' is undefined"
+            )
+
+        destination = destinations_by_id[destination_id]
+        destination_frame = destination.get("frame_id", destination_id)
+        release_offset = destination.get("release_offset_xyz_m", [0.0, 0.0, 0.0])
+
+        metadata = {
+            "detected_object_id": detected_id,
+            "class_label": class_label,
+            "confidence": confidence,
+            "pose_source": pose_source,
+            "object_frame": object_frame,
+            "approximate_size_m": approximate_size,
+        }
+
+        steps.append(
+            {
+                "id": f"pick_{detected_id}",
+                "type": "pick",
+                "object_id": detected_id,
+                "object_frame": object_frame,
+                "pick_hint": "top_grasp",
+                **metadata,
+                "destination_id": destination_id,
+            }
+        )
+        steps.append(
+            {
+                "id": f"place_{detected_id}_to_{destination_id}",
+                "type": "place",
+                "object_id": detected_id,
+                "destination_id": destination_id,
+                "destination_frame": destination_frame,
+                "release_offset_xyz_m": release_offset,
+                **metadata,
+            }
+        )
+
+    return {
+        "schema": SCHEMA,
+        "scene_package": SCENE_PACKAGE,
+        "mode": MODE,
+        "planning_frame": detections.get("planning_frame", "world"),
+        "source_schema": INPUT_SCHEMA,
+        "min_confidence": min_confidence,
+        "steps": steps,
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--detections", type=Path, required=True, help="Path to detected_objects/v1 JSON")
+    parser.add_argument("--json", action="store_true", help="Print full JSON runtime plan.")
+    parser.add_argument("--output", type=Path, help="Write JSON runtime plan to file path.")
+    parser.add_argument("--min-confidence", type=float, default=DEFAULT_MIN_CONFIDENCE)
+    return parser.parse_args(argv)
+
+
+def print_summary(plan: dict, detections_path: Path) -> None:
+    print("Dry-run runtime plan from detections")
+    print(f"Detections: {detections_path}")
+    print(f"Schema: {plan['schema']}")
+    print(f"Planning frame: {plan['planning_frame']}")
+    print()
+    place_steps = [s for s in plan.get("steps", []) if s.get("type") == "place"]
+    for idx, step in enumerate(place_steps, start=1):
+        print(
+            f"{idx}. {step['detected_object_id']} ({step['class_label']}, conf={step['confidence']:.2f}) "
+            f"-> {step['destination_id']}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    manifest = load_manifest(find_sorting_manifest_path())
+    detections = load_detections(args.detections)
+    plan = build_runtime_plan(detections, manifest, args.min_confidence)
+    plan_json = json.dumps(plan, indent=2)
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(plan_json + "\n", encoding="utf-8")
+
+    if args.json:
+        print(plan_json)
+    else:
+        print_summary(plan, args.detections)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scenes/ur5_2f_sorting_test/sorting_manifest.yaml
+++ b/scenes/ur5_2f_sorting_test/sorting_manifest.yaml
@@ -52,3 +52,12 @@ sorting_manifest:
       destination: bin_b
     - object: item_green
       destination: reject_bin
+  class_routing:
+    red_block: bin_a
+    blue_block: bin_b
+    green_block: reject_bin
+
+  class_routing_defaults:
+    unknown_class_destination: reject_bin
+    low_confidence_destination: reject_bin
+

--- a/scenes/ur5_2f_sorting_test/test/test_generate_runtime_plan_from_detections.py
+++ b/scenes/ur5_2f_sorting_test/test/test_generate_runtime_plan_from_detections.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Validate offline detected_objects/v1 -> runtime_execution_plan/v1 generation."""
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main() -> int:
+    scene_root = Path(__file__).resolve().parents[1]
+    script_path = scene_root / "scripts" / "generate_runtime_plan_from_detections.py"
+    fixture_path = scene_root / "fixtures" / "detected_objects_sample.json"
+
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    if fixture.get("schema") != "detected_objects/v1":
+        raise AssertionError("fixture schema mismatch")
+
+    subprocess.run(
+        [sys.executable, str(script_path), "--detections", str(fixture_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    json_result = subprocess.run(
+        [sys.executable, str(script_path), "--detections", str(fixture_path), "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    plan = json.loads(json_result.stdout)
+    if plan.get("schema") != "runtime_execution_plan/v1":
+        raise AssertionError("schema mismatch")
+
+    place_steps = [step for step in plan.get("steps", []) if step.get("type") == "place"]
+    route_by_class = {step.get("class_label"): step.get("destination_id") for step in place_steps}
+    if route_by_class.get("red_block") != "bin_a":
+        raise AssertionError("red_block did not route to bin_a")
+    if route_by_class.get("blue_block") != "bin_b":
+        raise AssertionError("blue_block did not route to bin_b")
+    if route_by_class.get("green_block") != "reject_bin":
+        raise AssertionError("green_block did not route to reject_bin")
+
+    for step in place_steps:
+        release_offset = step.get("release_offset_xyz_m")
+        if not isinstance(release_offset, list) or len(release_offset) != 3 or release_offset[2] <= 0.0:
+            raise AssertionError("place release_offset z must be positive")
+
+    low_conf_fixture = dict(fixture)
+    low_conf_fixture["objects"] = [dict(fixture["objects"][0], confidence=0.2)]
+    unknown_fixture = dict(fixture)
+    unknown_fixture["objects"] = [dict(fixture["objects"][0], class_label="mystery_block")]
+
+    temp_dir = scene_root / "test" / "_tmp"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    low_conf_path = temp_dir / "low_conf.json"
+    unknown_path = temp_dir / "unknown.json"
+    low_conf_path.write_text(json.dumps(low_conf_fixture), encoding="utf-8")
+    unknown_path.write_text(json.dumps(unknown_fixture), encoding="utf-8")
+
+    low_conf_json = subprocess.run(
+        [sys.executable, str(script_path), "--detections", str(low_conf_path), "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    unknown_json = subprocess.run(
+        [sys.executable, str(script_path), "--detections", str(unknown_path), "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    low_place = [s for s in json.loads(low_conf_json.stdout).get("steps", []) if s.get("type") == "place"][0]
+    unknown_place = [s for s in json.loads(unknown_json.stdout).get("steps", []) if s.get("type") == "place"][0]
+
+    if low_place.get("destination_id") != "reject_bin":
+        raise AssertionError("low confidence object did not route to reject_bin")
+    if unknown_place.get("destination_id") != "reject_bin":
+        raise AssertionError("unknown class object did not route to reject_bin")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide an offline EPD-style input path so detected object fixtures can be converted into scene-local `runtime_execution_plan/v1` without running live EPD, cameras, ROS topics, or robot motion. 
- Keep object-to-bin business logic in EMD by driving routing from the scene `sorting_manifest.yaml` while preserving existing static object-id routing.

### Description
- Added an offline fixture `scenes/ur5_2f_sorting_test/fixtures/detected_objects_sample.json` containing `detected_objects/v1` sample detections for red/blue/green items. 
- Extended `scenes/ur5_2f_sorting_test/sorting_manifest.yaml` with `class_routing` and `class_routing_defaults` to map `red_block -> bin_a`, `blue_block -> bin_b`, `green_block -> reject_bin`, and to route unknown/low-confidence to `reject_bin`.
- Implemented `scenes/ur5_2f_sorting_test/scripts/generate_runtime_plan_from_detections.py` which accepts `--detections`, `--json`, `--output`, and `--min-confidence` (default `0.5`), loads `detected_objects/v1`, routes by class with low-confidence/unknown fallbacks, and emits `runtime_execution_plan/v1` while preserving detection metadata in each step and not requiring a ROS runtime.
- Updated `CMakeLists.txt` to install the fixture and register the new `ros2 run ur5_2f_sorting_test generate_runtime_plan_from_detections` entrypoint and added `test_generate_runtime_plan_from_detections.py` to the package tests, and updated the scene `README.md` with usage and architecture notes.

### Testing
- Ran `python3 scenes/ur5_2f_sorting_test/test/test_generate_runtime_plan_from_detections.py` and it completed successfully. 
- Ran `python3 scenes/ur5_2f_sorting_test/test/test_generate_sorting_runtime_plan.py` and it completed successfully. 
- Executed the script to produce JSON with `python3 scenes/ur5_2f_sorting_test/scripts/generate_runtime_plan_from_detections.py --detections scenes/ur5_2f_sorting_test/fixtures/detected_objects_sample.json --json` and validated `schema == 'runtime_execution_plan/v1'`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d177b1c48331a029f1c3b8688874)