### PR TITLE
Add offline detections -> emd_grasp_bridge_payload dry-run command for sorting scene

### DIFF
--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -61,6 +61,12 @@ install(PROGRAMS
   RENAME generate_runtime_plan_from_detections
 )
 
+install(PROGRAMS
+  scripts/generate_bridge_payload_from_detections.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME generate_bridge_payload_from_detections
+)
+
 if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_sorting_manifest_validation
@@ -90,6 +96,11 @@ if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_generate_runtime_plan_from_detections
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_generate_runtime_plan_from_detections.py
+  )
+
+  add_test(
+    NAME ur5_2f_sorting_test_generate_bridge_payload_from_detections
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_generate_bridge_payload_from_detections.py
   )
 endif()
 

--- a/scenes/ur5_2f_sorting_test/README.md
+++ b/scenes/ur5_2f_sorting_test/README.md
@@ -152,6 +152,27 @@ Future integration path (guarded, not enabled yet):
 
 `EPD detected objects -> runtime_execution_plan/v1 -> emd_grasp_bridge_payload/v1 -> guarded EMD execution`
 
+## Offline EPD-style detections to EMD bridge payload
+
+Generate `emd_grasp_bridge_payload/v1` directly from offline `detected_objects/v1` input:
+
+```bash
+ros2 run ur5_2f_sorting_test generate_bridge_payload_from_detections --detections <path>
+```
+
+Print final payload JSON:
+
+```bash
+ros2 run ur5_2f_sorting_test generate_bridge_payload_from_detections --detections <path> --json
+```
+
+Optional outputs:
+
+- `--runtime-plan-output <path>` writes intermediate `runtime_execution_plan/v1`
+- `--output <path>` writes final `emd_grasp_bridge_payload/v1`
+
+This is the offline/dry-run path. Future live EPD integration will replace only the input boundary (`detected_objects/v1` source), while EMD routing and bridge payload generation remain reviewable and deterministic.
+
 ## Validate physical layout
 
 Run the deterministic scene-layout validator before RViz or execution integration:

--- a/scenes/ur5_2f_sorting_test/scripts/generate_bridge_payload_from_detections.py
+++ b/scenes/ur5_2f_sorting_test/scripts/generate_bridge_payload_from_detections.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Generate offline emd_grasp_bridge_payload/v1 from detected_objects/v1."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+import generate_runtime_plan_from_detections as runtime_plan_from_detections
+import generate_sorting_emd_bridge_payload as bridge_payload_generator
+
+WARNING_TEXT = "Offline detected_objects/v1 fixture used; no live EPD call was made."
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--detections", type=Path, required=True, help="Path to detected_objects/v1 JSON")
+    parser.add_argument("--min-confidence", type=float, default=runtime_plan_from_detections.DEFAULT_MIN_CONFIDENCE)
+    parser.add_argument("--json", action="store_true", help="Print full JSON bridge payload")
+    parser.add_argument("--runtime-plan-output", type=Path, help="Optional file path for runtime_execution_plan/v1 JSON")
+    parser.add_argument("--output", type=Path, help="Optional file path for emd_grasp_bridge_payload/v1 JSON")
+    return parser.parse_args(argv)
+
+
+def build_payload(detections_path: Path, min_confidence: float) -> tuple[dict, dict]:
+    manifest = runtime_plan_from_detections.load_manifest(runtime_plan_from_detections.find_sorting_manifest_path())
+    detections = runtime_plan_from_detections.load_detections(detections_path)
+    plan = runtime_plan_from_detections.build_runtime_plan(detections, manifest, min_confidence)
+
+    payload = bridge_payload_generator.build_bridge_payload(plan)
+    payload["source_chain"] = ["detected_objects/v1", "runtime_execution_plan/v1"]
+
+    for target in payload.get("targets", []):
+        object_id = target.get("object_id")
+        place_step = next(
+            (
+                step
+                for step in plan.get("steps", [])
+                if step.get("type") == "place" and step.get("object_id") == object_id
+            ),
+            None,
+        )
+        if place_step is not None:
+            target["metadata"] = {
+                "detected_object_id": place_step.get("detected_object_id"),
+                "class_label": place_step.get("class_label"),
+                "confidence": place_step.get("confidence"),
+                "pose_source": place_step.get("pose_source"),
+            }
+
+    warnings = payload.get("warnings", [])
+    if WARNING_TEXT not in warnings:
+        warnings.append(WARNING_TEXT)
+    payload["warnings"] = warnings
+    return plan, payload
+
+
+def print_summary(payload: dict) -> None:
+    print("Dry-run bridge payload from offline detections")
+    print(f"Schema: {payload.get('schema')}")
+    print(f"Source chain: {payload.get('source_chain')}")
+    print()
+    for idx, target in enumerate(payload.get("targets", []), start=1):
+        metadata = target.get("metadata", {})
+        destination = target.get("destination", {})
+        print(
+            f"{idx}. {metadata.get('detected_object_id')} / {metadata.get('class_label')} "
+            f"/ conf={float(metadata.get('confidence', 0.0)):.2f} "
+            f"/ {destination.get('id')} / release_offset={destination.get('release_offset_xyz_m')}"
+        )
+    print()
+    for warning in payload.get("warnings", []):
+        print(f"warning: {warning}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    plan, payload = build_payload(args.detections, args.min_confidence)
+
+    if args.runtime_plan_output is not None:
+        args.runtime_plan_output.parent.mkdir(parents=True, exist_ok=True)
+        args.runtime_plan_output.write_text(json.dumps(plan, indent=2) + "\n", encoding="utf-8")
+
+    payload_json = json.dumps(payload, indent=2)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload_json + "\n", encoding="utf-8")
+
+    if args.json:
+        print(payload_json)
+    else:
+        print_summary(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scenes/ur5_2f_sorting_test/test/test_generate_bridge_payload_from_detections.py
+++ b/scenes/ur5_2f_sorting_test/test/test_generate_bridge_payload_from_detections.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Validate detected_objects/v1 -> runtime_execution_plan/v1 -> emd_grasp_bridge_payload/v1."""
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+def main() -> int:
+    scene_root = Path(__file__).resolve().parents[1]
+    script_path = scene_root / "scripts" / "generate_bridge_payload_from_detections.py"
+    fixture_path = scene_root / "fixtures" / "detected_objects_sample.json"
+
+    subprocess.run(
+        [sys.executable, str(script_path), "--detections", str(fixture_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    json_result = subprocess.run(
+        [sys.executable, str(script_path), "--detections", str(fixture_path), "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(json_result.stdout)
+
+    if payload.get("schema") != "emd_grasp_bridge_payload/v1":
+        raise AssertionError("final schema mismatch")
+
+    chain = payload.get("source_chain")
+    if chain != ["detected_objects/v1", "runtime_execution_plan/v1"]:
+        raise AssertionError(f"source_chain mismatch: {chain}")
+
+    by_class = {target.get("metadata", {}).get("class_label"): target for target in payload.get("targets", [])}
+    if by_class.get("red_block", {}).get("destination", {}).get("id") != "bin_a":
+        raise AssertionError("red_block target did not route to bin_a")
+    if by_class.get("blue_block", {}).get("destination", {}).get("id") != "bin_b":
+        raise AssertionError("blue_block target did not route to bin_b")
+    if by_class.get("green_block", {}).get("destination", {}).get("id") != "reject_bin":
+        raise AssertionError("green_block target did not route to reject_bin")
+
+    for target in payload.get("targets", []):
+        metadata = target.get("metadata", {})
+        for key in ("detected_object_id", "class_label", "confidence"):
+            if key not in metadata:
+                raise AssertionError(f"missing target metadata key: {key}")
+
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    low_conf_fixture = dict(fixture)
+    low_conf_fixture["objects"] = [dict(fixture["objects"][0], confidence=0.2)]
+    unknown_fixture = dict(fixture)
+    unknown_fixture["objects"] = [dict(fixture["objects"][0], class_label="mystery_block")]
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        temp_dir = Path(tmp_dir)
+        low_conf_path = temp_dir / "low_conf.json"
+        unknown_path = temp_dir / "unknown.json"
+        runtime_plan_output = temp_dir / "runtime_plan.json"
+        bridge_output = temp_dir / "bridge_payload.json"
+
+        low_conf_path.write_text(json.dumps(low_conf_fixture), encoding="utf-8")
+        unknown_path.write_text(json.dumps(unknown_fixture), encoding="utf-8")
+
+        low_conf_json = subprocess.run(
+            [sys.executable, str(script_path), "--detections", str(low_conf_path), "--json"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        unknown_json = subprocess.run(
+            [sys.executable, str(script_path), "--detections", str(unknown_path), "--json"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        low_target = json.loads(low_conf_json.stdout)["targets"][0]
+        unknown_target = json.loads(unknown_json.stdout)["targets"][0]
+        if low_target.get("destination", {}).get("id") != "reject_bin":
+            raise AssertionError("low confidence fixture case did not route to reject_bin")
+        if unknown_target.get("destination", {}).get("id") != "reject_bin":
+            raise AssertionError("unknown class fixture case did not route to reject_bin")
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(script_path),
+                "--detections",
+                str(fixture_path),
+                "--runtime-plan-output",
+                str(runtime_plan_output),
+                "--output",
+                str(bridge_output),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        runtime_plan = json.loads(runtime_plan_output.read_text(encoding="utf-8"))
+        bridge_payload = json.loads(bridge_output.read_text(encoding="utf-8"))
+        if runtime_plan.get("schema") != "runtime_execution_plan/v1":
+            raise AssertionError("runtime plan output schema mismatch")
+        if bridge_payload.get("schema") != "emd_grasp_bridge_payload/v1":
+            raise AssertionError("bridge output schema mismatch")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide a reviewable offline/dry-run path that converts `detected_objects/v1` fixtures all the way to `emd_grasp_bridge_payload/v1` without invoking live EPD, ROS topics, or robot execution. 
- Preserve the existing EPD/EMD architecture boundary so perception remains the input and EMD continues to own label-to-bin routing and bridge payload generation. 
- Surface detection provenance and routing decisions in the payload so downstream review and future live integration are deterministic and auditable.

### Description
- Add `scenes/ur5_2f_sorting_test/scripts/generate_bridge_payload_from_detections.py` which reuses `generate_runtime_plan_from_detections` to build a `runtime_execution_plan/v1` and `generate_sorting_emd_bridge_payload` to produce the final `emd_grasp_bridge_payload/v1`. 
- The payload includes `source_chain: ["detected_objects/v1", "runtime_execution_plan/v1"]`, preserves detection metadata on each target (`detected_object_id`, `class_label`, `confidence`, `pose_source`), and appends the explicit offline warning `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d3f21c7883318d2ad26883f7548f)