### PR TITLE
Fix installed detections bridge payload imports

### DIFF
--- a/scenes/ur5_2f_sorting_test/scripts/generate_bridge_payload_from_detections.py
+++ b/scenes/ur5_2f_sorting_test/scripts/generate_bridge_payload_from_detections.py
@@ -4,12 +4,49 @@
 from __future__ import annotations
 
 import argparse
+import importlib.machinery
+import importlib.util
 import json
 from pathlib import Path
 import sys
 
-import generate_runtime_plan_from_detections as runtime_plan_from_detections
-import generate_sorting_emd_bridge_payload as bridge_payload_generator
+
+def _load_sibling_script_module(module_name: str):
+    """Load a sibling helper script from source or installed ROS 2 executable layout."""
+    script_dir = Path(__file__).resolve().parent
+    candidates = [
+        script_dir / f"{module_name}.py",
+        script_dir / module_name,
+    ]
+
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+
+        unique_name = f"_ur5_2f_sorting_test_{module_name}"
+
+        if candidate.suffix == ".py":
+            spec = importlib.util.spec_from_file_location(unique_name, candidate)
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+
+        loader = importlib.machinery.SourceFileLoader(unique_name, str(candidate))
+        spec = importlib.util.spec_from_loader(unique_name, loader)
+        if spec is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
+        return module
+
+    searched = ", ".join(str(candidate) for candidate in candidates)
+    raise ModuleNotFoundError(f"Could not load sibling script module '{module_name}'. Searched: {searched}")
+
+
+runtime_plan_from_detections = _load_sibling_script_module("generate_runtime_plan_from_detections")
+bridge_payload_generator = _load_sibling_script_module("generate_sorting_emd_bridge_payload")
 
 WARNING_TEXT = "Offline detected_objects/v1 fixture used; no live EPD call was made."
 


### PR DESCRIPTION
## Summary

Fixes the installed `ros2 run` path for the offline detections-to-EMD bridge payload tool.

The previous implementation of `generate_bridge_payload_from_detections.py` worked in source-tree tests but failed after installation because it directly imported sibling helper scripts:

- `generate_runtime_plan_from_detections`
- `generate_sorting_emd_bridge_payload`

When installed as ROS 2 executables, these sibling scripts may be extensionless files under `install/<pkg>/lib/<pkg>/`, so normal Python imports can fail with `ModuleNotFoundError`.

## Changes

- Replaced direct sibling imports in `generate_bridge_payload_from_detections.py`.
- Added a sibling script loader that searches beside the installed executable for both:
  - `<module_name>.py`
  - `<module_name>`
- Supports both source-tree execution and installed ROS 2 executable layout.
- Keeps the existing dry-run payload behaviour unchanged.
- No robot execution, ROS topic publishing, live EPD calls, or schema changes were added.

## Validation

Tested installed `ros2 run` commands successfully:

```bash
ros2 run ur5_2f_sorting_test generate_bridge_payload_from_detections \
  --detections ~/workcell_ws/src/easy_manipulation_deployment/scenes/ur5_2f_sorting_test/fixtures/detected_objects_sample.json