### PR TITLE
Add Robot Studio Lite dry-run CLI dashboard for ur5_2f_sorting_test

### DIFF
--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -73,6 +73,12 @@ install(PROGRAMS
   RENAME preview_sorting_execution_handoff
 )
 
+install(PROGRAMS
+  scripts/robot_studio_lite.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME robot_studio_lite
+)
+
 if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_sorting_manifest_validation
@@ -112,6 +118,11 @@ if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_preview_sorting_execution_handoff
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_preview_sorting_execution_handoff.py
+  )
+
+  add_test(
+    NAME ur5_2f_sorting_test_robot_studio_lite
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_robot_studio_lite.py
   )
 endif()
 

--- a/scenes/ur5_2f_sorting_test/README.md
+++ b/scenes/ur5_2f_sorting_test/README.md
@@ -225,3 +225,39 @@ ros2 run ur5_2f_sorting_test preview_sorting_execution_handoff \
 ```
 
 This tool is still dry-run only and does not move the robot. It validates the bridge payload and previews the execution handoff contract for review. Live EPD integration and robot execution remain separate future steps.
+
+## Robot Studio Lite
+
+The first lightweight Robot Studio workflow wrapper is now available as a scene-local CLI dashboard:
+
+```bash
+ros2 run ur5_2f_sorting_test robot_studio_lite
+```
+
+JSON dashboard output:
+
+```bash
+ros2 run ur5_2f_sorting_test robot_studio_lite --json
+```
+
+Use a custom offline `detected_objects/v1` file:
+
+```bash
+ros2 run ur5_2f_sorting_test robot_studio_lite --detections <path>
+```
+
+Robot Studio Lite provides one dry-run view of:
+
+- scene health (`validate_scene_layout`)
+- static manifest routing
+- offline detections routing
+- bridge payload summary
+- guarded execution handoff preview
+
+Safety guardrails are explicit:
+
+- it does **not** move the robot
+- it does **not** call live EPD
+- it does **not** enable execution
+
+This launcher is intended for developer/operator readiness checks before any future live integration steps.

--- a/scenes/ur5_2f_sorting_test/scripts/robot_studio_lite.py
+++ b/scenes/ur5_2f_sorting_test/scripts/robot_studio_lite.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Robot Studio Lite CLI dashboard for ur5_2f_sorting_test dry-run workflow."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import importlib.machinery
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+SCHEMA = "robot_studio_lite_dashboard/v1"
+SCENE_PACKAGE = "ur5_2f_sorting_test"
+MODE = "dry_run"
+
+
+def _load_sibling_script_module(module_name: str):
+    """Load sibling helper script from source or installed ROS 2 executable layout."""
+    script_dir = Path(__file__).resolve().parent
+    candidates = [
+        script_dir / f"{module_name}.py",
+        script_dir / module_name,
+    ]
+
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+
+        unique_name = f"_ur5_2f_sorting_test_{module_name}"
+        if candidate.suffix == ".py":
+            spec = importlib.util.spec_from_file_location(unique_name, candidate)
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+
+        loader = importlib.machinery.SourceFileLoader(unique_name, str(candidate))
+        spec = importlib.util.spec_from_loader(unique_name, loader)
+        if spec is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
+        return module
+
+    searched = ", ".join(str(candidate) for candidate in candidates)
+    raise ModuleNotFoundError(f"Could not load sibling script module '{module_name}'. Searched: {searched}")
+
+
+validate_scene_layout = _load_sibling_script_module("validate_scene_layout")
+runtime_plan = _load_sibling_script_module("generate_sorting_runtime_plan")
+bridge_payload = _load_sibling_script_module("generate_sorting_emd_bridge_payload")
+bridge_from_detections = _load_sibling_script_module("generate_bridge_payload_from_detections")
+handoff_preview = _load_sibling_script_module("preview_sorting_execution_handoff")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quick", action="store_true", help="Only show manifest and safety status")
+    parser.add_argument("--json", action="store_true", help="Print dashboard as JSON")
+    parser.add_argument("--detections", type=Path, help="Path to detected_objects/v1 JSON fixture")
+    parser.add_argument("--skip-layout-validation", action="store_true", help="Skip validate_scene_layout")
+    parser.add_argument("--output", type=Path, help="Optional output file for JSON dashboard")
+    return parser.parse_args(argv)
+
+
+def _default_detections_path() -> Path:
+    try:
+        from ament_index_python.packages import get_package_share_directory
+
+        share_dir = Path(get_package_share_directory(SCENE_PACKAGE))
+        candidate = share_dir / "detected_objects_sample.json"
+        if candidate.exists():
+            return candidate
+    except Exception:
+        pass
+
+    return Path(__file__).resolve().parents[1] / "fixtures" / "detected_objects_sample.json"
+
+
+def _build_manifest_summary(plan: dict) -> dict:
+    place_steps = [step for step in plan.get("steps", []) if step.get("type") == "place"]
+    routes = [
+        {
+            "object_id": step.get("object_id"),
+            "destination_id": step.get("destination_id"),
+            "destination_frame": step.get("destination_frame"),
+        }
+        for step in place_steps
+    ]
+    return {"routes": routes}
+
+
+def _build_detection_summary(payload: dict, source: Path) -> dict:
+    routes = []
+    for target in payload.get("targets", []):
+        destination = target.get("destination", {})
+        metadata = target.get("metadata", {})
+        routes.append(
+            {
+                "detected_object_id": metadata.get("detected_object_id", target.get("object_id")),
+                "class_label": metadata.get("class_label"),
+                "destination_id": destination.get("id"),
+                "destination_frame": destination.get("frame_id"),
+            }
+        )
+    return {"source": str(source), "routes": routes}
+
+
+def build_dashboard(args: argparse.Namespace) -> dict:
+    dashboard = {
+        "schema": SCHEMA,
+        "scene_package": SCENE_PACKAGE,
+        "mode": MODE,
+        "safety": {
+            "robot_motion_requested": False,
+            "live_epd_called": False,
+            "execution_enabled": False,
+        },
+        "next_commands": [
+            "ros2 launch ur5_2f_sorting_test demo.launch.py",
+            "ros2 run ur5_2f_sorting_test generate_sorting_runtime_plan --json",
+            "ros2 run ur5_2f_sorting_test generate_bridge_payload_from_detections --detections <path> --json",
+            "ros2 run ur5_2f_sorting_test preview_sorting_execution_handoff --from-static-manifest --json",
+        ],
+    }
+
+    if args.quick:
+        manifest = runtime_plan.load_manifest(runtime_plan.find_manifest_path())
+        plan = runtime_plan.build_runtime_plan(manifest)
+        dashboard["layout_validation"] = {"status": "skipped_quick_mode"}
+        dashboard["static_manifest"] = _build_manifest_summary(plan)
+        dashboard["offline_detections"] = {"source": None, "routes": []}
+        dashboard["bridge_payload"] = {"schema": "emd_grasp_bridge_payload/v1", "target_count": 0}
+        dashboard["handoff_preview"] = {
+            "schema": "sorting_execution_handoff_preview/v1",
+            "execution_ready_preview": False,
+            "robot_motion_requested": False,
+            "requires_manual_execution_enable": True,
+        }
+        return dashboard
+
+    if args.skip_layout_validation:
+        layout_validation = {"status": "skipped"}
+    else:
+        with contextlib.redirect_stdout(io.StringIO()):
+            validate_scene_layout.main()
+        layout_validation = {"status": "pass"}
+
+    manifest = runtime_plan.load_manifest(runtime_plan.find_manifest_path())
+    plan = runtime_plan.build_runtime_plan(manifest)
+    static_bridge_payload = bridge_payload.build_bridge_payload(plan)
+
+    detections_path = args.detections if args.detections is not None else _default_detections_path()
+    _runtime_plan_from_detections, detections_bridge_payload = bridge_from_detections.build_payload(
+        detections_path, bridge_from_detections.runtime_plan_from_detections.DEFAULT_MIN_CONFIDENCE
+    )
+    preview = handoff_preview.build_handoff_preview(detections_bridge_payload, "detections")
+
+    dashboard["layout_validation"] = layout_validation
+    dashboard["static_manifest"] = _build_manifest_summary(plan)
+    dashboard["offline_detections"] = _build_detection_summary(detections_bridge_payload, detections_path)
+    dashboard["bridge_payload"] = {
+        "schema": static_bridge_payload.get("schema"),
+        "target_count": len(static_bridge_payload.get("targets", [])),
+    }
+    dashboard["handoff_preview"] = {
+        "schema": preview.get("schema"),
+        "execution_ready_preview": preview.get("execution_ready_preview"),
+        "robot_motion_requested": preview.get("robot_motion_requested"),
+        "requires_manual_execution_enable": preview.get("requires_manual_execution_enable"),
+    }
+    return dashboard
+
+
+def _print_text_dashboard(dashboard: dict) -> None:
+    print("=== Robot Studio Lite :: ur5_2f_sorting_test ===")
+    print(f"scene_package: {dashboard['scene_package']}")
+    print(f"mode: {dashboard['mode']}")
+    print()
+    print(f"layout_validation: {dashboard['layout_validation']['status']}")
+    print("static_manifest routes:")
+    for route in dashboard["static_manifest"].get("routes", []):
+        print(f"  - {route.get('object_id')} -> {route.get('destination_id')} ({route.get('destination_frame')})")
+
+    print("offline_detections routes:")
+    source = dashboard["offline_detections"].get("source")
+    if source:
+        print(f"  source: {source}")
+    for route in dashboard["offline_detections"].get("routes", []):
+        print(
+            f"  - {route.get('detected_object_id')} ({route.get('class_label')}) -> "
+            f"{route.get('destination_id')} ({route.get('destination_frame')})"
+        )
+
+    bridge = dashboard["bridge_payload"]
+    print(f"bridge_payload: {bridge.get('schema')} targets={bridge.get('target_count')}")
+    handoff = dashboard["handoff_preview"]
+    print(
+        "handoff_preview: "
+        f"{handoff.get('schema')} ready={handoff.get('execution_ready_preview')} "
+        f"robot_motion_requested={handoff.get('robot_motion_requested')}"
+    )
+    print("safety:")
+    for key, value in dashboard["safety"].items():
+        print(f"  {key}: {value}")
+
+    print("next_commands:")
+    for command in dashboard["next_commands"]:
+        print(f"  - {command}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    dashboard = build_dashboard(args)
+    dashboard_json = json.dumps(dashboard, indent=2)
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(dashboard_json + "\n", encoding="utf-8")
+
+    if args.json:
+        print(dashboard_json)
+    else:
+        _print_text_dashboard(dashboard)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scenes/ur5_2f_sorting_test/test/test_robot_studio_lite.py
+++ b/scenes/ur5_2f_sorting_test/test/test_robot_studio_lite.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Validate robot_studio_lite dashboard behavior."""
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+def main() -> int:
+    scene_root = Path(__file__).resolve().parents[1]
+    script_path = scene_root / "scripts" / "robot_studio_lite.py"
+
+    subprocess.run([sys.executable, str(script_path)], check=True, capture_output=True, text=True)
+
+    json_result = subprocess.run([sys.executable, str(script_path), "--json"], check=True, capture_output=True, text=True)
+    dashboard = json.loads(json_result.stdout)
+
+    if dashboard.get("schema") != "robot_studio_lite_dashboard/v1":
+        raise AssertionError("dashboard schema mismatch")
+
+    safety = dashboard.get("safety", {})
+    if safety.get("robot_motion_requested") is not False:
+        raise AssertionError("robot_motion_requested must be false")
+    if safety.get("live_epd_called") is not False:
+        raise AssertionError("live_epd_called must be false")
+    if safety.get("execution_enabled") is not False:
+        raise AssertionError("execution_enabled must be false")
+
+    if dashboard.get("bridge_payload", {}).get("target_count") != 3:
+        raise AssertionError("bridge_payload target_count must be 3")
+    if dashboard.get("handoff_preview", {}).get("execution_ready_preview") is not True:
+        raise AssertionError("handoff_preview.execution_ready_preview must be true")
+
+    quick_result = subprocess.run([sys.executable, str(script_path), "--quick", "--json"], check=True, capture_output=True, text=True)
+    quick_dashboard = json.loads(quick_result.stdout)
+    if quick_dashboard.get("layout_validation", {}).get("status") != "skipped_quick_mode":
+        raise AssertionError("quick mode did not skip layout validation")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_path = Path(tmp_dir) / "dashboard.json"
+        subprocess.run([sys.executable, str(script_path), "--json", "--output", str(output_path)], check=True, capture_output=True, text=True)
+        written = json.loads(output_path.read_text(encoding="utf-8"))
+        if written.get("schema") != "robot_studio_lite_dashboard/v1":
+            raise AssertionError("written dashboard schema mismatch")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide a first developer/operator-facing Robot Studio–style launcher for the `ur5_2f_sorting_test` scene that gives a single dry-run view of scene health, routing, bridge payload and execution handoff readiness. 
- Ensure the launcher is explicitly safe and offline: it must not request robot motion, call live EPD, enable execution, or publish runtime topics/services.

### Description
- Add `scenes/ur5_2f_sorting_test/scripts/robot_studio_lite.py` implementing a terminal dashboard with options `--quick`, `--json`, `--detections <path>`, `--skip-layout-validation`, and `--output <path>`, and using the robust sibling-loader pattern to call scene-local helper scripts. 
- Dashboard reports `schema: robot_studio_lite_dashboard/v1`, scene/package info, layout validation status, static manifest routing, offline detections routing, bridge payload summary, guarded execution handoff summary, safety flags (`robot_motion_requested`, `live_epd_called`, `execution_enabled` all `false`), and a list of useful next commands. 
- Install the launcher via `CMakeLists.txt` so it is available as `ros2 run ur5_2f_sorting_test robot_studio_lite`. 
- Add `test/test_robot_studio_lite.py` to validate default run, `--json` output/schema, safety booleans, `bridge_payload.target_count`, `handoff_preview.execution_ready_preview`, `--quick` behavior, and `--output` file writing. 
- Update the package `README.md` with a new **Robot Studio Lite** section showing usage and safety guarantees.

### Testing
- Ran the scene-local test script: `python scenes/ur5_2f_sorting_test/test/test_robot_studio_lite.py`, which exercises default invocation, `--json`, `--quick`, and `--output` behaviors, and it passed. 
- The dashboard `--json` output was validated as JSON and confirmed to use `schema: robot_studio_lite_dashboard/v1` and to report safety flags as `false`. 
- `colcon`-based integration tests were not run in this environment because `colcon` is not available here (attempting `colcon test` failed with `colcon: command not found`). 
- The new launcher is wired for installation via `CMakeLists.txt` so `ros2 run ur5_2f_sorting_test robot_studio_lite` will be available after a normal build/install step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e90115e88331b6db60fdb38d64f8)