### PR TITLE
Add prepare_static_sorting_execution CLI and correct Robot Studio Lite launch command

### DIFF
--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -79,6 +79,12 @@ install(PROGRAMS
   RENAME robot_studio_lite
 )
 
+install(PROGRAMS
+  scripts/prepare_static_sorting_execution.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME prepare_static_sorting_execution
+)
+
 if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_sorting_manifest_validation
@@ -123,6 +129,11 @@ if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_robot_studio_lite
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_robot_studio_lite.py
+  )
+
+  add_test(
+    NAME ur5_2f_sorting_test_prepare_static_sorting_execution
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_prepare_static_sorting_execution.py
   )
 endif()
 

--- a/scenes/ur5_2f_sorting_test/README.md
+++ b/scenes/ur5_2f_sorting_test/README.md
@@ -261,3 +261,37 @@ Safety guardrails are explicit:
 - it does **not** enable execution
 
 This launcher is intended for developer/operator readiness checks before any future live integration steps.
+
+
+## Static sorting execution preparation
+
+Prepare static sorting execution artifacts and validation outputs without requesting robot motion:
+
+```bash
+ros2 run ur5_2f_sorting_test prepare_static_sorting_execution
+```
+
+JSON report output:
+
+```bash
+ros2 run ur5_2f_sorting_test prepare_static_sorting_execution --json
+```
+
+Manual execution-enabled preparation (still no robot motion) and print launch command:
+
+```bash
+ros2 run ur5_2f_sorting_test prepare_static_sorting_execution --manual-enable-execution --print-launch-command
+```
+
+This command remains safe by default and in manual-enable mode:
+
+- it does **not** move the robot
+- it does **not** call `ros2 launch` automatically
+- it prepares and validates handoff artifacts for manual review
+- user must manually run and verify RViz using:
+
+```bash
+ros2 launch run_grasp_execution grasp_execution.launch.py scene_package:=ur5_2f_sorting_test launch_rviz:=true
+```
+
+A future PR can add an explicit/manual execution trigger only after this preparation layer is stable.

--- a/scenes/ur5_2f_sorting_test/scripts/prepare_static_sorting_execution.py
+++ b/scenes/ur5_2f_sorting_test/scripts/prepare_static_sorting_execution.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Prepare static sorting execution artifacts without requesting robot motion."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.machinery
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+SCHEMA = "static_sorting_execution_preparation/v1"
+SCENE_PACKAGE = "ur5_2f_sorting_test"
+LAUNCH_COMMAND = [
+    "ros2",
+    "launch",
+    "run_grasp_execution",
+    "grasp_execution.launch.py",
+    "scene_package:=ur5_2f_sorting_test",
+    "launch_rviz:=true",
+]
+
+
+def _load_sibling_script_module(module_name: str):
+    """Load sibling helper script from source or installed ROS 2 executable layout."""
+    script_dir = Path(__file__).resolve().parent
+    candidates = [
+        script_dir / f"{module_name}.py",
+        script_dir / module_name,
+    ]
+
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+
+        unique_name = f"_ur5_2f_sorting_test_{module_name}"
+        if candidate.suffix == ".py":
+            spec = importlib.util.spec_from_file_location(unique_name, candidate)
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+
+        loader = importlib.machinery.SourceFileLoader(unique_name, str(candidate))
+        spec = importlib.util.spec_from_loader(unique_name, loader)
+        if spec is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
+        return module
+
+    searched = ", ".join(str(candidate) for candidate in candidates)
+    raise ModuleNotFoundError(f"Could not load sibling script module '{module_name}'. Searched: {searched}")
+
+
+runtime_plan = _load_sibling_script_module("generate_sorting_runtime_plan")
+bridge_payload = _load_sibling_script_module("generate_sorting_emd_bridge_payload")
+handoff_preview = _load_sibling_script_module("preview_sorting_execution_handoff")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Print preparation report as JSON")
+    parser.add_argument("--output", type=Path, help="Write preparation report JSON to path")
+    parser.add_argument("--payload-output", type=Path, help="Write emd_grasp_bridge_payload/v1 JSON to path")
+    parser.add_argument("--handoff-output", type=Path, help="Write sorting_execution_handoff_preview/v1 JSON to path")
+    parser.add_argument("--print-launch-command", action="store_true", help="Print exact manual launch command")
+    parser.add_argument("--manual-enable-execution", action="store_true", help="Manually mark execution enabled")
+    return parser.parse_args(argv)
+
+
+def build_report(manual_enable_execution: bool) -> tuple[dict, dict, dict]:
+    manifest = runtime_plan.load_manifest(runtime_plan.find_manifest_path())
+    plan = runtime_plan.build_runtime_plan(manifest)
+    payload = bridge_payload.build_bridge_payload(plan)
+    preview = handoff_preview.build_handoff_preview(payload, "static_manifest")
+
+    targets = []
+    for entry in preview.get("targets", []):
+        targets.append(
+            {
+                "object_id": entry.get("object_id"),
+                "object_frame": entry.get("object_frame"),
+                "destination_id": entry.get("destination_id"),
+                "destination_frame": entry.get("destination_frame"),
+                "pick_hint": entry.get("pick_hint"),
+                "release_offset_xyz_m": entry.get("release_offset_xyz_m"),
+            }
+        )
+
+    execution_enabled = bool(manual_enable_execution)
+    report = {
+        "schema": SCHEMA,
+        "scene_package": SCENE_PACKAGE,
+        "mode": "dry_run",
+        "execution_enabled": execution_enabled,
+        "robot_motion_requested": False,
+        "manual_execution_required": True,
+        "target_count": len(targets),
+        "targets": targets,
+        "launch_command": LAUNCH_COMMAND,
+        "payload_output_path": None,
+        "handoff_output_path": None,
+        "warnings": [
+            "Preparation only; robot motion was not requested.",
+            "Run the launch command manually and verify RViz before any execution.",
+        ],
+    }
+
+    if execution_enabled:
+        report["warnings"].append("Execution was manually enabled for planning metadata only; this script did not move the robot.")
+
+    return report, payload, preview
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _print_report_text(report: dict) -> None:
+    print("Static sorting execution preparation report")
+    print(f"scene_package: {report['scene_package']}")
+    print(f"schema: {report['schema']}")
+    print(f"execution_enabled: {report['execution_enabled']}")
+    print(f"robot_motion_requested: {report['robot_motion_requested']}")
+    print(f"manual_execution_required: {report['manual_execution_required']}")
+    print(f"target_count: {report['target_count']}")
+    print("targets:")
+    for target in report.get("targets", []):
+        print(f"  - {target['object_id']} -> {target['destination_id']} ({target['destination_frame']})")
+
+    print("launch_command:")
+    print("  " + " ".join(report["launch_command"]))
+    print(f"payload_output_path: {report.get('payload_output_path')}")
+    print(f"handoff_output_path: {report.get('handoff_output_path')}")
+    print("warnings:")
+    for warning in report.get("warnings", []):
+        print(f"  - {warning}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    report, payload, preview = build_report(args.manual_enable_execution)
+
+    if args.payload_output is not None:
+        _write_json(args.payload_output, payload)
+        report["payload_output_path"] = str(args.payload_output)
+
+    if args.handoff_output is not None:
+        _write_json(args.handoff_output, preview)
+        report["handoff_output_path"] = str(args.handoff_output)
+
+    if args.output is not None:
+        _write_json(args.output, report)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_report_text(report)
+
+    if args.print_launch_command:
+        print("\nManual next command:")
+        print(" ".join(LAUNCH_COMMAND))
+        if args.manual_enable_execution:
+            print("WARNING: This script did not move the robot; run launch manually after RViz verification.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scenes/ur5_2f_sorting_test/scripts/robot_studio_lite.py
+++ b/scenes/ur5_2f_sorting_test/scripts/robot_studio_lite.py
@@ -121,7 +121,7 @@ def build_dashboard(args: argparse.Namespace) -> dict:
             "execution_enabled": False,
         },
         "next_commands": [
-            "ros2 launch ur5_2f_sorting_test demo.launch.py",
+            "ros2 launch run_grasp_execution grasp_execution.launch.py scene_package:=ur5_2f_sorting_test launch_rviz:=true",
             "ros2 run ur5_2f_sorting_test generate_sorting_runtime_plan --json",
             "ros2 run ur5_2f_sorting_test generate_bridge_payload_from_detections --detections <path> --json",
             "ros2 run ur5_2f_sorting_test preview_sorting_execution_handoff --from-static-manifest --json",

--- a/scenes/ur5_2f_sorting_test/test/test_prepare_static_sorting_execution.py
+++ b/scenes/ur5_2f_sorting_test/test/test_prepare_static_sorting_execution.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Validate prepare_static_sorting_execution behavior."""
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+def main() -> int:
+    scene_root = Path(__file__).resolve().parents[1]
+    script_path = scene_root / "scripts" / "prepare_static_sorting_execution.py"
+
+    subprocess.run([sys.executable, str(script_path)], check=True, capture_output=True, text=True)
+
+    json_result = subprocess.run([sys.executable, str(script_path), "--json"], check=True, capture_output=True, text=True)
+    report = json.loads(json_result.stdout)
+
+    if report.get("schema") != "static_sorting_execution_preparation/v1":
+        raise AssertionError("schema mismatch")
+    if report.get("target_count") != 3:
+        raise AssertionError("target_count must be 3")
+    if report.get("execution_enabled") is not False:
+        raise AssertionError("execution_enabled must be false by default")
+    if report.get("robot_motion_requested") is not False:
+        raise AssertionError("robot_motion_requested must be false")
+
+    launch_command = " ".join(report.get("launch_command", []))
+    for token in (
+        "run_grasp_execution",
+        "grasp_execution.launch.py",
+        "scene_package:=ur5_2f_sorting_test",
+        "launch_rviz:=true",
+    ):
+        if token not in launch_command:
+            raise AssertionError(f"launch command missing token: {token}")
+
+    manual_result = subprocess.run(
+        [sys.executable, str(script_path), "--json", "--manual-enable-execution"], check=True, capture_output=True, text=True
+    )
+    manual_report = json.loads(manual_result.stdout)
+    if manual_report.get("execution_enabled") is not True:
+        raise AssertionError("execution_enabled must be true with --manual-enable-execution")
+    if manual_report.get("robot_motion_requested") is not False:
+        raise AssertionError("robot_motion_requested must remain false")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        payload_output = tmp / "payload.json"
+        handoff_output = tmp / "handoff.json"
+        report_output = tmp / "report.json"
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(script_path),
+                "--payload-output",
+                str(payload_output),
+                "--handoff-output",
+                str(handoff_output),
+                "--output",
+                str(report_output),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        payload = json.loads(payload_output.read_text(encoding="utf-8"))
+        handoff = json.loads(handoff_output.read_text(encoding="utf-8"))
+        written_report = json.loads(report_output.read_text(encoding="utf-8"))
+
+        if payload.get("schema") != "emd_grasp_bridge_payload/v1":
+            raise AssertionError("payload schema mismatch")
+        if handoff.get("schema") != "sorting_execution_handoff_preview/v1":
+            raise AssertionError("handoff schema mismatch")
+        if written_report.get("schema") != "static_sorting_execution_preparation/v1":
+            raise AssertionError("written report schema mismatch")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scenes/ur5_2f_sorting_test/test/test_robot_studio_lite.py
+++ b/scenes/ur5_2f_sorting_test/test/test_robot_studio_lite.py
@@ -33,6 +33,18 @@ def main() -> int:
     if dashboard.get("handoff_preview", {}).get("execution_ready_preview") is not True:
         raise AssertionError("handoff_preview.execution_ready_preview must be true")
 
+
+    next_commands = dashboard.get("next_commands", [])
+    joined_commands = "\n".join(next_commands)
+    for token in (
+        "run_grasp_execution",
+        "grasp_execution.launch.py",
+        "scene_package:=ur5_2f_sorting_test",
+        "launch_rviz:=true",
+    ):
+        if token not in joined_commands:
+            raise AssertionError(f"missing next command token: {token}")
+
     quick_result = subprocess.run([sys.executable, str(script_path), "--quick", "--json"], check=True, capture_output=True, text=True)
     quick_dashboard = json.loads(quick_result.stdout)
     if quick_dashboard.get("layout_validation", {}).get("status") != "skipped_quick_mode":


### PR DESCRIPTION
### Motivation
- Provide a safe, deterministic preparation step for static sorting execution that generates EMD bridge payload and guarded handoff previews without requesting robot motion. 
- Ensure Robot Studio Lite suggests the correct RViz/execution-stack launch command for this scene so operators have the exact manual next-step. 
- Keep default behaviour dry-run and explicitly manual-gated to avoid any automatic robot motion or live EPD integration. 

### Description
- Added `scenes/ur5_2f_sorting_test/scripts/prepare_static_sorting_execution.py` which reuses sibling loader helpers to build the runtime plan, produce the `emd_grasp_bridge_payload/v1`, validate and preview the guarded handoff, and produce a `static_sorting_execution_preparation/v1` report; the tool defaults to dry-run and never requests robot motion. 
- Registered the new CLI as `ros2 run ur5_2f_sorting_test prepare_static_sorting_execution` and added a test entry in `CMakeLists.txt`. 
- Fixed Robot Studio Lite `next_commands` to the correct launch guidance: `ros2 launch run_grasp_execution grasp_execution.launch.py scene_package:=ur5_2f_sorting_test launch_rviz:=true`. 
- Added `scenes/ur5_2f_sorting_test/test/test_prepare_static_sorting_execution.py` and extended `test_robot_studio_lite.py` to assert launch-command tokens and static preparation expectations, and updated the README with a new "Static sorting execution preparation" section. 

### Testing
- Ran `python3 scenes/ur5_2f_sorting_test/test/test_robot_studio_lite.py` which succeeded and verifies corrected `next_commands` tokens and dashboard safety flags. 
- Ran `python3 scenes/ur5_2f_sorting_test/test/test_prepare_static_sorting_execution.py` which succeeded and verifies schema, `target_count`, safety flags, `--manual-enable-execution` behaviour, and file outputs for payload/handoff/report. 
- Attempted `colcon test --packages-select ur5_2f_sorting_test --event-handlers console_direct+` but it was not executed in this environment because `colcon` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9eb6e79c08331ad825f17e7818fdf)