### PR TITLE
Add safety-gated manual static sorting executor for ur5_2f_sorting_test

### DIFF
--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -85,6 +85,12 @@ install(PROGRAMS
   RENAME prepare_static_sorting_execution
 )
 
+install(PROGRAMS
+  scripts/manual_static_sorting_executor.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME manual_static_sorting_executor
+)
+
 if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_sorting_manifest_validation
@@ -134,6 +140,11 @@ if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_prepare_static_sorting_execution
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_prepare_static_sorting_execution.py
+  )
+
+  add_test(
+    NAME ur5_2f_sorting_test_manual_static_sorting_executor
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_manual_static_sorting_executor.py
   )
 endif()
 

--- a/scenes/ur5_2f_sorting_test/README.md
+++ b/scenes/ur5_2f_sorting_test/README.md
@@ -295,3 +295,34 @@ ros2 launch run_grasp_execution grasp_execution.launch.py scene_package:=ur5_2f_
 ```
 
 A future PR can add an explicit/manual execution trigger only after this preparation layer is stable.
+
+## Manual static sorting executor
+
+First explicit guarded bridge from static sorting preparation to runtime execution handoff:
+
+```bash
+ros2 run ur5_2f_sorting_test manual_static_sorting_executor
+```
+
+Manual enable preview (still no robot motion):
+
+```bash
+ros2 run ur5_2f_sorting_test manual_static_sorting_executor --manual-enable-execution
+```
+
+Execution request (must be explicitly enabled first):
+
+```bash
+ros2 run ur5_2f_sorting_test manual_static_sorting_executor --manual-enable-execution --execute
+```
+
+Safety behavior:
+
+- Default mode is safe dry-run only.
+- `--manual-enable-execution` alone still does not move the robot.
+- `--execute` is blocked unless `--manual-enable-execution` is also provided.
+- The tool will not guess/invent unknown execution APIs.
+- If runtime interfaces are missing, it fails safely and instructs the user to launch:
+  `ros2 launch run_grasp_execution grasp_execution.launch.py scene_package:=ur5_2f_sorting_test launch_rviz:=true`
+
+This adapter does not auto-launch `run_grasp_execution`, does not auto-start RViz, does not require live EPD, and does not request robot motion by default.

--- a/scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py
+++ b/scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Manually gated static sorting execution adapter with safe dry-run defaults."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.machinery
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+SCHEMA = "manual_static_sorting_executor/v1"
+SCENE_PACKAGE = "ur5_2f_sorting_test"
+LAUNCH_COMMAND = [
+    "ros2",
+    "launch",
+    "run_grasp_execution",
+    "grasp_execution.launch.py",
+    "scene_package:=ur5_2f_sorting_test",
+    "launch_rviz:=true",
+]
+
+
+class ManualExecutorError(RuntimeError):
+    """Raised when safety gates intentionally block execution."""
+
+
+def _load_sibling_script_module(module_name: str):
+    script_dir = Path(__file__).resolve().parent
+    candidates = [script_dir / f"{module_name}.py", script_dir / module_name]
+
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+
+        unique_name = f"_ur5_2f_sorting_test_{module_name}"
+        if candidate.suffix == ".py":
+            spec = importlib.util.spec_from_file_location(unique_name, candidate)
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+
+        loader = importlib.machinery.SourceFileLoader(unique_name, str(candidate))
+        spec = importlib.util.spec_from_loader(unique_name, loader)
+        if spec is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
+        return module
+
+    raise ModuleNotFoundError(f"Could not load sibling script module '{module_name}'")
+
+
+runtime_plan = _load_sibling_script_module("generate_sorting_runtime_plan")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON output")
+    parser.add_argument("--output", type=Path, help="Write machine-readable JSON output to file")
+    parser.add_argument("--prepare-output", type=Path, help="Write selected static preparation targets JSON to file")
+    parser.add_argument("--require-active-runtime", action="store_true", help="Require active runtime checks to pass")
+    parser.add_argument("--manual-enable-execution", action="store_true", help="Explicitly enable execution mode")
+    parser.add_argument("--execute", action="store_true", help="Request execution attempt (still safety-gated)")
+    parser.add_argument("--target", action="append", dest="targets", help="Optional object_id filter; repeat for multiple")
+    return parser.parse_args(argv)
+
+
+def _initial_runtime_checks() -> dict:
+    return {
+        "checked": False,
+        "grasp_execution_node": "unknown",
+        "joint_states": "unknown",
+        "controller_manager": "unknown",
+        "ur5_arm_controller": "unknown",
+    }
+
+
+def _run_ros2(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(["ros2", *args], check=False, capture_output=True, text=True, timeout=4)
+
+
+def _runtime_checks() -> tuple[dict, list[str]]:
+    checks = _initial_runtime_checks()
+    warnings: list[str] = []
+    checks["checked"] = True
+
+    try:
+        node_out = _run_ros2(["node", "list"])
+        nodes = set(line.strip() for line in node_out.stdout.splitlines() if line.strip()) if node_out.returncode == 0 else set()
+        checks["grasp_execution_node"] = "present" if "/grasp_execution_node" in nodes else "missing"
+
+        topic_out = _run_ros2(["topic", "list"])
+        topics = set(line.strip() for line in topic_out.stdout.splitlines() if line.strip()) if topic_out.returncode == 0 else set()
+        checks["joint_states"] = "present" if "/joint_states" in topics else "missing"
+
+        service_out = _run_ros2(["service", "list"])
+        services = set(line.strip() for line in service_out.stdout.splitlines() if line.strip()) if service_out.returncode == 0 else set()
+        checks["controller_manager"] = "present" if any("controller_manager" in svc for svc in services) else "missing"
+
+        checks["ur5_arm_controller"] = "inactive"
+        ctrl_out = _run_ros2(["control", "list_controllers"])
+        if ctrl_out.returncode == 0:
+            seen = False
+            for line in ctrl_out.stdout.splitlines():
+                if not line.strip().startswith("ur5_arm_controller"):
+                    continue
+                seen = True
+                checks["ur5_arm_controller"] = "active" if " active" in f" {line} " else "inactive"
+                break
+            if not seen:
+                checks["ur5_arm_controller"] = "missing"
+        else:
+            checks["ur5_arm_controller"] = "missing"
+            warnings.append("ros2 control CLI unavailable; ur5_arm_controller status treated as missing.")
+
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        warnings.append(f"ROS runtime checks unavailable: {exc}")
+        checks["grasp_execution_node"] = "missing"
+        checks["joint_states"] = "missing"
+        checks["controller_manager"] = "missing"
+        checks["ur5_arm_controller"] = "missing"
+
+    return checks, warnings
+
+
+def _load_targets(selected: list[str] | None) -> list[dict]:
+    manifest = runtime_plan.load_manifest(runtime_plan.find_manifest_path())
+    plan = runtime_plan.build_runtime_plan(manifest)
+    all_targets = []
+    for step in plan.get("steps", []):
+        if step.get("type") != "pick":
+            continue
+        all_targets.append(
+            {
+                "object_id": step.get("object_id"),
+                "object_frame": step.get("object_frame"),
+                "pick_hint": step.get("pick_hint"),
+                "destination_id": step.get("destination_id"),
+            }
+        )
+    by_id = {t.get("object_id"): t for t in all_targets}
+    if not selected:
+        return all_targets
+    missing = [target for target in selected if target not in by_id]
+    if missing:
+        raise ManualExecutorError(f"Unknown target object_id(s): {', '.join(missing)}")
+    return [by_id[target] for target in selected]
+
+
+def _default_report() -> dict:
+    return {
+        "schema": SCHEMA,
+        "scene_package": SCENE_PACKAGE,
+        "mode": "dry_run",
+        "execution_enabled": False,
+        "execute_requested": False,
+        "execution_attempted": False,
+        "robot_motion_requested": False,
+        "target_count": 0,
+        "selected_targets": [],
+        "launch_command": LAUNCH_COMMAND,
+        "runtime_checks": _initial_runtime_checks(),
+        "result": {"status": "dry_run_only"},
+        "warnings": [],
+    }
+
+
+def build_report(args: argparse.Namespace) -> tuple[dict, int]:
+    report = _default_report()
+    report["execution_enabled"] = bool(args.manual_enable_execution)
+    report["execute_requested"] = bool(args.execute)
+
+    try:
+        selected_targets = _load_targets(args.targets)
+    except ManualExecutorError as exc:
+        report["result"] = {"status": "blocked"}
+        report["warnings"].append(str(exc))
+        return report, 2
+
+    report["selected_targets"] = selected_targets
+    report["target_count"] = len(selected_targets)
+
+    if args.execute and not args.manual_enable_execution:
+        report["mode"] = "execution_requested"
+        report["result"] = {"status": "blocked"}
+        report["warnings"].append("Execution blocked: --execute requires --manual-enable-execution.")
+        return report, 2
+
+    if args.manual_enable_execution and not args.execute:
+        report["mode"] = "manual_enabled"
+        report["result"] = {"status": "ready_for_manual_runtime"}
+        report["warnings"].append("Execution is enabled, but robot motion is still blocked until you also pass --execute.")
+        report["warnings"].append("Next explicit command: ros2 run ur5_2f_sorting_test manual_static_sorting_executor --manual-enable-execution --execute")
+
+    must_check_runtime = args.require_active_runtime or args.execute
+    if must_check_runtime:
+        checks, warnings = _runtime_checks()
+        report["runtime_checks"] = checks
+        report["warnings"].extend(warnings)
+        runtime_ready = (
+            checks["grasp_execution_node"] == "present"
+            and checks["joint_states"] == "present"
+            and checks["controller_manager"] == "present"
+            and checks["ur5_arm_controller"] == "active"
+        )
+        if not runtime_ready:
+            report["result"] = {"status": "runtime_missing"}
+            report["warnings"].append(
+                "Launch the scene first with: ros2 launch run_grasp_execution grasp_execution.launch.py scene_package:=ur5_2f_sorting_test launch_rviz:=true"
+            )
+            return report, 2
+
+    if args.execute and args.manual_enable_execution:
+        report["mode"] = "execution_requested"
+        report["result"] = {"status": "execution_api_missing"}
+        report["warnings"].append("Execution API call was intentionally skipped: no documented dry-run/test-safe execution API was found.")
+        report["warnings"].append("No robot motion was requested. This adapter will not guess or call unknown services/actions.")
+        return report, 2
+
+    return report, 0
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _print_text(report: dict) -> None:
+    print("Manual static sorting executor report")
+    print(f"scene_package: {report['scene_package']}")
+    print(f"schema: {report['schema']}")
+    print(f"mode: {report['mode']}")
+    print(f"execution_enabled: {report['execution_enabled']}")
+    print(f"execute_requested: {report['execute_requested']}")
+    print(f"execution_attempted: {report['execution_attempted']}")
+    print(f"robot_motion_requested: {report['robot_motion_requested']}")
+    print(f"target_count: {report['target_count']}")
+    print("selected_targets:")
+    for target in report["selected_targets"]:
+        print(f"  - {target['object_id']} -> {target['destination_id']}")
+    print("launch_command:")
+    print("  " + " ".join(report["launch_command"]))
+    print("available_ros_checks:")
+    print("  - ros2 node list")
+    print("  - ros2 topic list")
+    print("  - ros2 service list")
+    print("  - ros2 control list_controllers")
+    print("runtime_checks:")
+    for key, value in report["runtime_checks"].items():
+        print(f"  {key}: {value}")
+    print(f"result_status: {report['result']['status']}")
+    print("warnings:")
+    for warning in report["warnings"]:
+        print(f"  - {warning}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    report, exit_code = build_report(args)
+
+    if args.prepare_output is not None:
+        _write_json(
+            args.prepare_output,
+            {
+                "schema": "manual_static_sorting_prepare_output/v1",
+                "scene_package": SCENE_PACKAGE,
+                "selected_targets": report["selected_targets"],
+                "target_count": report["target_count"],
+            },
+        )
+
+    if args.output is not None:
+        _write_json(args.output, report)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_text(report)
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py
+++ b/scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Validate manual_static_sorting_executor safety-gated behavior."""
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+def _run(script: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, str(script), *args], check=check, capture_output=True, text=True)
+
+
+def main() -> int:
+    scene_root = Path(__file__).resolve().parents[1]
+    script_path = scene_root / "scripts" / "manual_static_sorting_executor.py"
+
+    default = _run(script_path, "--json")
+    report = json.loads(default.stdout)
+    if report.get("schema") != "manual_static_sorting_executor/v1":
+        raise AssertionError("schema mismatch")
+    if report.get("robot_motion_requested") is not False:
+        raise AssertionError("robot_motion_requested must be false")
+    if report.get("execution_attempted") is not False:
+        raise AssertionError("execution_attempted must be false")
+    if report.get("execution_enabled") is not False:
+        raise AssertionError("execution_enabled must be false")
+
+    launch_command = " ".join(report.get("launch_command", []))
+    expected_launch = "ros2 launch run_grasp_execution grasp_execution.launch.py scene_package:=ur5_2f_sorting_test launch_rviz:=true"
+    if launch_command != expected_launch:
+        raise AssertionError("launch command mismatch")
+
+    execute_blocked = _run(script_path, "--json", "--execute", check=False)
+    if execute_blocked.returncode == 0:
+        raise AssertionError("--execute without manual enable must fail")
+    execute_report = json.loads(execute_blocked.stdout)
+    if execute_report.get("result", {}).get("status") != "blocked":
+        raise AssertionError("--execute must be blocked")
+
+    manual_enabled = _run(script_path, "--json", "--manual-enable-execution")
+    manual_report = json.loads(manual_enabled.stdout)
+    if manual_report.get("execution_enabled") is not True:
+        raise AssertionError("manual enable should set execution_enabled true")
+    if manual_report.get("execution_attempted") is not False:
+        raise AssertionError("manual enable alone must not attempt execution")
+
+    selected = _run(script_path, "--json", "--target", "item_red")
+    selected_report = json.loads(selected.stdout)
+    selected_targets = selected_report.get("selected_targets", [])
+    if len(selected_targets) != 1 or selected_targets[0].get("object_id") != "item_red":
+        raise AssertionError("target filtering failed for item_red")
+
+    invalid = _run(script_path, "--json", "--target", "not_real", check=False)
+    if invalid.returncode == 0:
+        raise AssertionError("invalid target must fail")
+
+    runtime_required = _run(script_path, "--json", "--require-active-runtime", check=False)
+    runtime_report = json.loads(runtime_required.stdout)
+    if runtime_required.returncode == 0:
+        raise AssertionError("runtime should be missing in test environment")
+    if runtime_report.get("result", {}).get("status") != "runtime_missing":
+        raise AssertionError("require-active-runtime must safely report runtime_missing")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide the first explicit, safe bridge from the prepared static sorting plan to runtime execution intent while keeping robot motion blocked by default.
- Give operators a manual, reviewable workflow to inspect handoff artifacts and runtime readiness before any execution is attempted.

### Description
- Add `scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py` implementing a CLI adapter that loads the static runtime plan, supports target filtering, emits JSON/text reports, and exposes runtime graph checks without calling unknown services/actions.
- Implement explicit safety gates and CLI flags: `--json`, `--output`, `--prepare-output`, `--require-active-runtime`, `--manual-enable-execution`, `--execute`, and `--target`, where `--execute` is blocked unless `--manual-enable-execution` is also provided.
- Perform runtime checks (when requested) via `ros2` CLI probes for `/grasp_execution_node`, `/joint_states`, `controller_manager`, and `ur5_arm_controller` status and surface a clear launch suggestion `ros2 launch run_grasp_execution grasp_execution.launch.py scene_package:=ur5_2f_sorting_test launch_rviz:=true` if missing.
- Install the script as a ROS 2 runnable entry (`ros2 run ur5_2f_sorting_test manual_static_sorting_executor`), add a package test in `CMakeLists.txt`, and document usage and safety behavior in `README.md`.

### Testing
- Ran `python3 scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py`, which passed and validated default dry-run fields, JSON schema, `--execute` blocking, `--manual-enable-execution` non-execution behavior, target filtering for `item_red`, invalid target failure, and safe handling of `--require-active-runtime` when runtime is absent.
- Ran `python3 scenes/ur5_2f_sorting_test/test/test_prepare_static_sorting_execution.py`, which passed and validated the static preparation report behavior and outputs.
- The tests verified the exact launch guidance string and that no robot motion or live EPD integration is performed by default.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9edc8fb288331a3b913fd8ed95b6d)