### PR TITLE
Fix runtime readiness detection and add static runtime bridge payload generator

### DIFF
--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -91,6 +91,12 @@ install(PROGRAMS
   RENAME manual_static_sorting_executor
 )
 
+install(PROGRAMS
+  scripts/generate_static_sorting_runtime_bridge_payload.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME generate_static_sorting_runtime_bridge_payload
+)
+
 if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_sorting_manifest_validation
@@ -145,6 +151,11 @@ if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_manual_static_sorting_executor
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_manual_static_sorting_executor.py
+  )
+
+  add_test(
+    NAME ur5_2f_sorting_test_generate_static_sorting_runtime_bridge_payload
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_generate_static_sorting_runtime_bridge_payload.py
   )
 endif()
 

--- a/scenes/ur5_2f_sorting_test/README.md
+++ b/scenes/ur5_2f_sorting_test/README.md
@@ -326,3 +326,29 @@ Safety behavior:
   `ros2 launch run_grasp_execution grasp_execution.launch.py scene_package:=ur5_2f_sorting_test launch_rviz:=true`
 
 This adapter does not auto-launch `run_grasp_execution`, does not auto-start RViz, does not require live EPD, and does not request robot motion by default.
+
+## Runtime-compatible static sorting bridge payload
+
+Generate runtime-shaped payload (offline only):
+
+```bash
+ros2 run ur5_2f_sorting_test generate_static_sorting_runtime_bridge_payload --json
+```
+
+Write payload to file:
+
+```bash
+ros2 run ur5_2f_sorting_test generate_static_sorting_runtime_bridge_payload \
+  --output /tmp/ur5_2f_sorting_runtime_bridge_payload.json
+```
+
+Validate payload structure using replay dry-run (no ROS send):
+
+```bash
+python3 scripts/replay_emd_bridge_payload.py \
+  --payload /tmp/ur5_2f_sorting_runtime_bridge_payload.json \
+  --scene-package ur5_2f_sorting_test \
+  --dry-run
+```
+
+This does **not** move the robot. It only creates the runtime-shaped bridge payload expected by `replay_emd_bridge_payload.py`. A later PR can add an explicit manual send path to `/grasp_requests` after dry-run replay validation is stable.

--- a/scenes/ur5_2f_sorting_test/scripts/generate_static_sorting_runtime_bridge_payload.py
+++ b/scenes/ur5_2f_sorting_test/scripts/generate_static_sorting_runtime_bridge_payload.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Generate runtime-compatible emd_grasp_bridge_payload/v1 for static sorting."""
+from __future__ import annotations
+
+import argparse, json
+from pathlib import Path
+import sys
+
+import importlib.util
+
+SCHEMA_VERSION = "emd_grasp_bridge_payload/v1"
+SCENE_PACKAGE = "ur5_2f_sorting_test"
+
+
+def _load_runtime_plan_module():
+    p = Path(__file__).resolve().parent / "generate_sorting_runtime_plan.py"
+    spec = importlib.util.spec_from_file_location("_runtime_plan", p)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+runtime_plan = _load_runtime_plan_module()
+
+
+def _fallback_pose(frame_id: str, index: int) -> dict:
+    return {"frame_id": frame_id, "xyz": [round(0.1 * index, 3), 0.0, 0.1], "rpy": [0.0, 0.0, 0.0]}
+
+
+def build_payload(plan: dict, ros_interface: str, service_name: str, topic_name: str, frame_id: str, default_ee_id: str) -> dict:
+    picks = {s["object_id"]: s for s in plan.get("steps", []) if s.get("type") == "pick"}
+    places = {s["object_id"]: s for s in plan.get("steps", []) if s.get("type") == "place"}
+    warnings: list[str] = []
+    targets = []
+
+    for idx, object_id in enumerate(sorted(picks.keys()), start=1):
+        pick = picks[object_id]
+        place = places.get(object_id)
+        if place is None:
+            continue
+        obj_frame = pick.get("object_frame", object_id)
+        dest_frame = place.get("destination_frame", place.get("destination_id"))
+        target_pose = _fallback_pose(obj_frame, idx)
+        destination_pose = _fallback_pose(dest_frame, idx + 10)
+        rel = place.get("release_offset_xyz_m", [0.0, 0.0, 0.03])
+        if isinstance(rel, list) and len(rel) == 3:
+            destination_pose["xyz"] = [destination_pose["xyz"][0], destination_pose["xyz"][1], round(destination_pose["xyz"][2] + float(rel[2]), 3)]
+        warnings.append(f"Using deterministic fallback xyz/rpy for object '{object_id}' and destination '{place.get('destination_id')}'.")
+
+        targets.append({
+            "object_id": object_id,
+            "target_type": "box",
+            "target_pose": target_pose,
+            "target_shape": {"type": "box", "dimensions": pick.get("approximate_size_m", [0.05, 0.05, 0.05])},
+            "grasp_methods": [{
+                "ee_id": default_ee_id,
+                "grasp_poses": [{"frame_id": obj_frame, "xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]}],
+                "grasp_ranks": [1.0],
+            }],
+            "destination_id": place.get("destination_id"),
+            "destination_pose": destination_pose,
+            "notes": [f"destination-aware release offset: {place.get('release_offset_xyz_m', [0.0,0.0,0.0])}"],
+        })
+
+    status = "PASS" if len(targets) == 3 else "WARN"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "scene_package": SCENE_PACKAGE,
+        "mode": "offline",
+        "status": status,
+        "summary": {"target_count": len(targets), "routing": [f"{t['object_id']}->{t['destination_id']}" for t in targets]},
+        "ros_interface": {
+            "service_name": service_name,
+            "topic_name": topic_name,
+            "message_type": "emd_msgs/msg/GraspTask",
+            "service_type": "emd_msgs/srv/GraspRequest",
+            "selected": ros_interface,
+        },
+        "grasp_task": {"task_id": "static_sorting_runtime_bridge", "grasp_targets": targets},
+        "warnings": warnings,
+        "errors": [],
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--ros-interface", choices=["service", "topic"], default="service")
+    parser.add_argument("--service-name", default="grasp_requests")
+    parser.add_argument("--topic-name", default="grasp_tasks")
+    parser.add_argument("--frame-id", default="world")
+    parser.add_argument("--default-ee-id", default="robotiq_2f")
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    manifest = runtime_plan.load_manifest(runtime_plan.find_manifest_path())
+    plan = runtime_plan.build_runtime_plan(manifest)
+    payload = build_payload(plan, args.ros_interface, args.service_name, args.topic_name, args.frame_id, args.default_ee_id)
+    out = json.dumps(payload, indent=2)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(out + "\n", encoding="utf-8")
+    if args.json:
+        print(out)
+    else:
+        print("Runtime-compatible static sorting bridge payload (offline only)")
+        print(f"status: {payload['status']}")
+        print(f"targets: {payload['summary']['target_count']}")
+        print("No ROS send performed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py
+++ b/scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py
@@ -84,6 +84,20 @@ def _run_ros2(args: list[str]) -> subprocess.CompletedProcess:
     return subprocess.run(["ros2", *args], check=False, capture_output=True, text=True, timeout=4)
 
 
+def _parse_controller_state(list_controllers_stdout: str, controller_name: str = "ur5_arm_controller") -> str:
+    for raw_line in list_controllers_stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        columns = line.split()
+        if not columns or columns[0] != controller_name:
+            continue
+        if len(columns) >= 3:
+            return columns[2].strip().lower()
+        return "inactive"
+    return "missing"
+
+
 def _runtime_checks() -> tuple[dict, list[str]]:
     checks = _initial_runtime_checks()
     warnings: list[str] = []
@@ -102,18 +116,9 @@ def _runtime_checks() -> tuple[dict, list[str]]:
         services = set(line.strip() for line in service_out.stdout.splitlines() if line.strip()) if service_out.returncode == 0 else set()
         checks["controller_manager"] = "present" if any("controller_manager" in svc for svc in services) else "missing"
 
-        checks["ur5_arm_controller"] = "inactive"
         ctrl_out = _run_ros2(["control", "list_controllers"])
         if ctrl_out.returncode == 0:
-            seen = False
-            for line in ctrl_out.stdout.splitlines():
-                if not line.strip().startswith("ur5_arm_controller"):
-                    continue
-                seen = True
-                checks["ur5_arm_controller"] = "active" if " active" in f" {line} " else "inactive"
-                break
-            if not seen:
-                checks["ur5_arm_controller"] = "missing"
+            checks["ur5_arm_controller"] = _parse_controller_state(ctrl_out.stdout)
         else:
             checks["ur5_arm_controller"] = "missing"
             warnings.append("ros2 control CLI unavailable; ur5_arm_controller status treated as missing.")
@@ -196,6 +201,8 @@ def build_report(args: argparse.Namespace) -> tuple[dict, int]:
         report["result"] = {"status": "ready_for_manual_runtime"}
         report["warnings"].append("Execution is enabled, but robot motion is still blocked until you also pass --execute.")
         report["warnings"].append("Next explicit command: ros2 run ur5_2f_sorting_test manual_static_sorting_executor --manual-enable-execution --execute")
+        report["warnings"].append("Generate runtime-shaped payload: ros2 run ur5_2f_sorting_test generate_static_sorting_runtime_bridge_payload --output /tmp/ur5_2f_sorting_runtime_bridge_payload.json")
+        report["warnings"].append("Validate payload only (no send): python3 scripts/replay_emd_bridge_payload.py --payload /tmp/ur5_2f_sorting_runtime_bridge_payload.json --scene-package ur5_2f_sorting_test --dry-run")
 
     must_check_runtime = args.require_active_runtime or args.execute
     if must_check_runtime:
@@ -219,6 +226,7 @@ def build_report(args: argparse.Namespace) -> tuple[dict, int]:
         report["mode"] = "execution_requested"
         report["result"] = {"status": "execution_api_missing"}
         report["warnings"].append("Execution API call was intentionally skipped: no documented dry-run/test-safe execution API was found.")
+        report["warnings"].append("Future manual send command only (not executed): python3 scripts/replay_emd_bridge_payload.py --payload /tmp/ur5_2f_sorting_runtime_bridge_payload.json --scene-package ur5_2f_sorting_test --ros-interface service --service-name grasp_requests")
         report["warnings"].append("No robot motion was requested. This adapter will not guess or call unknown services/actions.")
         return report, 2
 

--- a/scenes/ur5_2f_sorting_test/test/test_generate_static_sorting_runtime_bridge_payload.py
+++ b/scenes/ur5_2f_sorting_test/test/test_generate_static_sorting_runtime_bridge_payload.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import json, subprocess, sys, tempfile
+from pathlib import Path
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    script = root / 'scripts' / 'generate_static_sorting_runtime_bridge_payload.py'
+    replay = Path(__file__).resolve().parents[3] / 'scripts' / 'replay_emd_bridge_payload.py'
+
+    subprocess.run([sys.executable, str(script)], check=True, capture_output=True, text=True)
+    result = subprocess.run([sys.executable, str(script), '--json'], check=True, capture_output=True, text=True)
+    payload = json.loads(result.stdout)
+    assert payload['schema_version'] == 'emd_grasp_bridge_payload/v1'
+    assert payload['ros_interface']['selected'] == 'service'
+    assert payload['ros_interface']['service_name'] == 'grasp_requests'
+    targets = payload['grasp_task']['grasp_targets']
+    assert len(targets) == 3
+    ids = {t['object_id'] for t in targets}
+    assert ids == {'item_red','item_blue','item_green'}
+    dests = {t['destination_id'] for t in targets}
+    assert dests == {'bin_a','bin_b','reject_bin'}
+
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td)/'payload.json'
+        subprocess.run([sys.executable, str(script), '--output', str(out)], check=True)
+        loaded = json.loads(out.read_text())
+        assert loaded['schema_version'] == 'emd_grasp_bridge_payload/v1'
+        subprocess.run([sys.executable, str(replay), '--payload', str(out), '--scene-package', 'ur5_2f_sorting_test', '--dry-run'], check=True, capture_output=True, text=True)
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py
+++ b/scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py
@@ -55,6 +55,18 @@ def main() -> int:
     if invalid.returncode == 0:
         raise AssertionError("invalid target must fail")
 
+
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("m", script_path)
+    m = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(m)
+    sample = """joint_state_broadcaster      joint_state_broadcaster/JointStateBroadcaster  active
+ur5_arm_controller      joint_trajectory_controller/JointTrajectoryController  active
+"""
+    if m._parse_controller_state(sample) != "active":
+        raise AssertionError("controller parser failed to detect active state")
+
     runtime_required = _run(script_path, "--json", "--require-active-runtime", check=False)
     runtime_report = json.loads(runtime_required.stdout)
     if runtime_required.returncode == 0:


### PR DESCRIPTION
### Motivation
- Ensure the manual static executor correctly recognizes an active `ur5_arm_controller` reported by `ros2 control list_controllers` so `--require-active-runtime` can report a ready runtime instead of `runtime_missing`.
- Provide a safe, offline way to produce a runtime-shaped `emd_grasp_bridge_payload/v1` for the `ur5_2f_sorting_test` scene so payloads can be validated with existing replay tooling without touching the robot.

### Description
- Added `_parse_controller_state()` and updated `_runtime_checks()` in `scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py` to robustly parse `ros2 control list_controllers` output and detect `ur5_arm_controller` state as `active`/`inactive`/`missing`.
- Updated `manual_static_sorting_executor` to include explicit offline payload generation and replay dry-run command guidance and a future-manual-send hint while preserving dry-run/no-motion safety and not calling runtime services/actions.
- Added `scenes/ur5_2f_sorting_test/scripts/generate_static_sorting_runtime_bridge_payload.py` which builds a deterministic runtime-compatible `emd_grasp_bridge_payload/v1` JSON with one `GraspTarget` entry per static object (`item_red`, `item_blue`, `item_green`) and destination metadata (`bin_a`, `bin_b`, `reject_bin`), deterministic fallback poses, and configurable `--ros-interface`, `--service-name`, `--topic-name`, `--frame-id`, and `--default-ee-id` options.
- Added tests and packaging: new test `scenes/ur5_2f_sorting_test/test/test_generate_static_sorting_runtime_bridge_payload.py`, controller-parser assertion added to `test_manual_static_sorting_executor.py`, and `CMakeLists.txt` updated to install the new script and register the new test; README updated with usage and dry-run validation commands.

### Testing
- Ran `python3 scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py`, which passed and includes a sample-based assertion verifying `_parse_controller_state()` detects `active` from a `ros2 control list_controllers` sample.
- Ran `python3 scenes/ur5_2f_sorting_test/test/test_generate_static_sorting_runtime_bridge_payload.py`, which passed and validates JSON schema/version, `ros_interface` defaults, presence of 3 targets (`item_red`, `item_blue`, `item_green`), correct destinations, output writing via `--output`, and that the generated payload passes `scripts/replay_emd_bridge_payload.py --dry-run` validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f246ddf08331a964a03cba7e81ac)