### PR TITLE
Strip ANSI controller output in manual sorting executor

### DIFF
--- a/scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py
+++ b/scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py
@@ -7,7 +7,9 @@ import argparse
 import importlib.machinery
 import importlib.util
 import json
+import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 
@@ -80,12 +82,38 @@ def _initial_runtime_checks() -> dict:
     }
 
 
+ANSI_ESCAPE_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+def _strip_ansi(value: str) -> str:
+    return ANSI_ESCAPE_RE.sub("", value)
+
+
 def _run_ros2(args: list[str]) -> subprocess.CompletedProcess:
-    return subprocess.run(["ros2", *args], check=False, capture_output=True, text=True, timeout=4)
+    env = os.environ.copy()
+    env.update(
+        {
+            "NO_COLOR": "1",
+            "CLICOLOR": "0",
+            "CLICOLOR_FORCE": "0",
+            "PY_COLORS": "0",
+            "RCUTILS_COLORIZED_OUTPUT": "0",
+            "TERM": "dumb",
+        }
+    )
+    return subprocess.run(
+        ["ros2", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=4,
+        env=env,
+    )
 
 
 def _parse_controller_state(list_controllers_stdout: str, controller_name: str = "ur5_arm_controller") -> str:
-    for raw_line in list_controllers_stdout.splitlines():
+    clean_stdout = _strip_ansi(list_controllers_stdout)
+    for raw_line in clean_stdout.splitlines():
         line = raw_line.strip()
         if not line:
             continue

--- a/scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py
+++ b/scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py
@@ -67,6 +67,12 @@ ur5_arm_controller      joint_trajectory_controller/JointTrajectoryController  a
     if m._parse_controller_state(sample) != "active":
         raise AssertionError("controller parser failed to detect active state")
 
+    coloured_sample = """\x1b[92mjoint_state_broadcaster\x1b[0m joint_state_broadcaster/JointStateBroadcaster          \x1b[92mactive\x1b[0m
+\x1b[92mur5_arm_controller     \x1b[0m joint_trajectory_controller/JointTrajectoryController  \x1b[92mactive\x1b[0m
+"""
+    if m._parse_controller_state(coloured_sample) != "active":
+        raise AssertionError("controller parser failed to detect ANSI-coloured active state")
+
     runtime_required = _run(script_path, "--json", "--require-active-runtime", check=False)
     runtime_report = json.loads(runtime_required.stdout)
     if runtime_required.returncode == 0:


### PR DESCRIPTION
## Summary

Fixes runtime readiness detection in `manual_static_sorting_executor`.

`ros2 control list_controllers` can emit ANSI-coloured output, causing the controller parser to miss `ur5_arm_controller` even when it is active.

## Changes

- Disable colour for ROS CLI subprocess calls where possible.
- Strip ANSI escape sequences before parsing controller output.
- Add regression coverage for ANSI-coloured `ros2 control list_controllers` output.

## Validation

- `ros2 control list_controllers` showed `ur5_arm_controller active`
- `manual_static_sorting_executor --require-active-runtime --json` now detects the active controller
- `colcon test --packages-select ur5_2f_sorting_test`