### PR TITLE
Honor `--require-active-runtime` checks in all manual static executor modes

### DIFF
--- a/scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py
+++ b/scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py
@@ -281,6 +281,17 @@ def build_report(args: argparse.Namespace) -> tuple[dict, int]:
         report["payload_validation"]["dry_run_replay_status"] = "skipped"
         report["warnings"].append("Dry-run validation was skipped by explicit override; sending may move the robot in active runtime.")
 
+    if args.require_active_runtime:
+        checks, warnings = _runtime_checks(args.service_name, args.topic_name)
+        report["runtime_checks"] = checks
+        report["warnings"].extend(warnings)
+        runtime_ready = checks["grasp_execution_node"] == "present" and checks["joint_states"] == "present" and checks["controller_manager"] == "present" and checks["ur5_arm_controller"] == "active"
+        interface_ready = checks["grasp_requests_service"] == "present" if args.ros_interface == "service" else checks["grasp_tasks_topic"] == "present"
+        if not (runtime_ready and interface_ready):
+            report["result"] = {"status": "runtime_missing"}
+            report["warnings"].append("Runtime missing or incomplete; safe block before send.")
+            return report, 2
+
     if args.execute and args.manual_enable_execution and not args.confirm_runtime_send:
         report["result"] = {"status": "blocked"}
         report["warnings"].append("Execution blocked: --confirm-runtime-send is required before any runtime send.")
@@ -293,16 +304,6 @@ def build_report(args: argparse.Namespace) -> tuple[dict, int]:
     if not final_send_flags:
         report["result"] = {"status": "dry_run_only"}
         return report, 0
-
-    checks, warnings = _runtime_checks(args.service_name, args.topic_name)
-    report["runtime_checks"] = checks
-    report["warnings"].extend(warnings)
-    runtime_ready = checks["grasp_execution_node"] == "present" and checks["joint_states"] == "present" and checks["controller_manager"] == "present" and checks["ur5_arm_controller"] == "active"
-    interface_ready = checks["grasp_requests_service"] == "present" if args.ros_interface == "service" else checks["grasp_tasks_topic"] == "present"
-    if not (runtime_ready and interface_ready):
-        report["result"] = {"status": "runtime_missing"}
-        report["warnings"].append("Runtime missing or incomplete; safe block before send.")
-        return report, 2
 
     send_cmd = _build_replay_cmd(replay_script, payload_path, args, dry_run=False)
     report["execution_attempted"] = True

--- a/scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py
+++ b/scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py
@@ -65,6 +65,56 @@ def main() -> int:
         assert any("--dry-run" in c for c in commands)
         assert any("--dry-run" not in c and "replay.py" in " ".join(c) for c in commands)
 
+    runtime_calls = []
+    def fake_runtime_checks(_service_name, _topic_name):
+        runtime_calls.append(True)
+        return {"checked": True, "grasp_execution_node": "present", "joint_states": "present", "controller_manager": "present", "ur5_arm_controller": "active", "grasp_requests_service": "present", "grasp_tasks_topic": "present"}, []
+
+    with patch.object(m, "_run_subprocess", side_effect=fake_run), patch.object(m, "_find_replay_script", return_value=Path("/tmp/replay.py")), patch.object(
+        m, "_runtime_checks", side_effect=fake_runtime_checks
+    ):
+        args = argparse.Namespace(**base_args, require_active_runtime=True, manual_enable_execution=False, execute=False, confirm_runtime_send=False)
+        rep, rc = m.build_report(args)
+        assert rc == 0 and rep["result"]["status"] == "dry_run_only"
+        assert rep["runtime_checks"]["checked"] is True
+        assert len(runtime_calls) == 1
+        assert rep["execution_attempted"] is False and rep["robot_motion_requested"] is False
+
+        args = argparse.Namespace(**base_args, require_active_runtime=True, manual_enable_execution=True, execute=True, confirm_runtime_send=False)
+        rep, rc = m.build_report(args)
+        assert rc != 0 and rep["result"]["status"] == "blocked"
+        assert rep["runtime_checks"]["checked"] is True
+        assert rep["execution_attempted"] is False and rep["robot_motion_requested"] is False
+
+    with patch.object(m, "_run_subprocess", side_effect=fake_run), patch.object(m, "_find_replay_script", return_value=Path("/tmp/replay.py")), patch.object(
+        m, "_runtime_checks", return_value=({"checked": True, "grasp_execution_node": "missing", "joint_states": "missing", "controller_manager": "missing", "ur5_arm_controller": "missing", "grasp_requests_service": "missing", "grasp_tasks_topic": "missing"}, [])
+    ):
+        args = argparse.Namespace(**base_args, require_active_runtime=True, manual_enable_execution=False, execute=False, confirm_runtime_send=False)
+        rep, rc = m.build_report(args)
+        assert rc == 2 and rep["result"]["status"] == "runtime_missing"
+        assert rep["runtime_checks"]["checked"] is True
+        assert rep["execution_attempted"] is False and rep["robot_motion_requested"] is False
+
+        args = argparse.Namespace(**base_args, require_active_runtime=True, manual_enable_execution=True, execute=True, confirm_runtime_send=True)
+        rep, rc = m.build_report(args)
+        assert rc == 2 and rep["result"]["status"] == "runtime_missing"
+        assert rep["execution_attempted"] is False and rep["robot_motion_requested"] is False
+
+    send_commands = []
+    def fake_run_record(cmd):
+        send_commands.append(cmd)
+        return R(0)
+
+    with patch.object(m, "_run_subprocess", side_effect=fake_run_record), patch.object(m, "_find_replay_script", return_value=Path("/tmp/replay.py")), patch.object(
+        m, "_runtime_checks", return_value=({"checked": True, "grasp_execution_node": "present", "joint_states": "present", "controller_manager": "present", "ur5_arm_controller": "active", "grasp_requests_service": "present", "grasp_tasks_topic": "present"}, [])
+    ):
+        args = argparse.Namespace(**base_args, require_active_runtime=True, manual_enable_execution=True, execute=True, confirm_runtime_send=True)
+        rep, rc = m.build_report(args)
+        assert rc == 0 and rep["result"]["status"] == "sent_to_runtime"
+        dry_idx = next(i for i, c in enumerate(send_commands) if "--dry-run" in c)
+        send_idx = next(i for i, c in enumerate(send_commands) if "--dry-run" not in c and "replay.py" in " ".join(c))
+        assert dry_idx < send_idx
+
     return 0
 
 


### PR DESCRIPTION
### Motivation
- A safety regression caused runtime health checks to run only in the final send path, so `--require-active-runtime` was not honored for dry-run or blocked-preview flows. 
- The intent is to ensure that when `--require-active-runtime` is requested the runtime checks are always executed and reflected in the report regardless of execution mode. 
- Final sends must remain strictly gated and payload dry-run validation must still run before any attempt to send to runtime. 

### Description
- Move runtime health/interface checks earlier in `build_report` to execute whenever `args.require_active_runtime` is true so `report["runtime_checks"]["checked"]` is set across dry-run, blocked preview, and guarded send paths. 
- Preserve payload dry-run replay validation before any send and keep the final send behind the four guarded flags: `--require-active-runtime`, `--manual-enable-execution`, `--execute`, and `--confirm-runtime-send`. 
- Adjust control flow ordering so blocked preview and non-send returns still occur but only after the required runtime checks when requested. 
- Add and update offline/mocked tests in `scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py` to cover require-runtime in dry-run, missing-runtime behavior, blocked preview with runtime checks, guarded-send missing runtime blocking, and dry-run-before-send ordering. 

### Testing
- Executed the updated unit script `python3 scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py`, and the tests completed successfully (exit 0). 
- Tests validate that `--require-active-runtime` sets `runtime_checks.checked == true` in dry-run-only and blocked-preview modes and that missing runtime yields `result.status == "runtime_missing"` with exit code 2. 
- Tests also verify that dry-run replay occurs before non-dry-run send and that `robot_motion_requested` remains false until a final guarded send attempt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa076419e48331857186ec31c7b775)