### PR TITLE
Produce top-grasp offsets and single-target filtering for static sorting runtime bridge

### DIFF
--- a/scenes/ur5_2f_sorting_test/scripts/generate_static_sorting_runtime_bridge_payload.py
+++ b/scenes/ur5_2f_sorting_test/scripts/generate_static_sorting_runtime_bridge_payload.py
@@ -11,6 +11,9 @@ import importlib.util
 
 SCHEMA_VERSION = "emd_grasp_bridge_payload/v1"
 SCENE_PACKAGE = "ur5_2f_sorting_test"
+GRASP_CLEARANCE_ABOVE_OBJECT_M = 0.02
+PREGRASP_CLEARANCE_M = 0.05
+RELEASE_CLEARANCE_M = 0.03
 
 
 def _load_sibling_script_module(module_name: str):
@@ -56,13 +59,32 @@ def _fallback_pose(frame_id: str, index: int) -> dict:
     return {"frame_id": frame_id, "xyz": [round(0.1 * index, 3), 0.0, 0.1], "rpy": [0.0, 0.0, 0.0]}
 
 
-def build_payload(plan: dict, ros_interface: str, service_name: str, topic_name: str, frame_id: str, default_ee_id: str) -> dict:
+def _height_from_size(size: list[float] | tuple[float, ...] | None) -> float:
+    if not isinstance(size, (list, tuple)) or len(size) < 3:
+        return 0.05
+    return float(size[2])
+
+
+def build_payload(
+    plan: dict,
+    ros_interface: str,
+    service_name: str,
+    topic_name: str,
+    frame_id: str,
+    default_ee_id: str,
+    selected_targets: list[str] | None = None,
+) -> dict:
     picks = {s["object_id"]: s for s in plan.get("steps", []) if s.get("type") == "pick"}
     places = {s["object_id"]: s for s in plan.get("steps", []) if s.get("type") == "place"}
     warnings: list[str] = []
     targets = []
 
+    selected_set = set(selected_targets or [])
+    target_filter_applied = bool(selected_set)
+
     for idx, object_id in enumerate(sorted(picks.keys()), start=1):
+        if target_filter_applied and object_id not in selected_set:
+            continue
         pick = picks[object_id]
         place = places.get(object_id)
         if place is None:
@@ -71,33 +93,44 @@ def build_payload(plan: dict, ros_interface: str, service_name: str, topic_name:
         dest_frame = place.get("destination_frame", place.get("destination_id"))
         target_pose = _fallback_pose(obj_frame, idx)
         destination_pose = _fallback_pose(dest_frame, idx + 10)
+        obj_size = pick.get("approximate_size_m", [0.05, 0.05, 0.05])
+        object_height = _height_from_size(obj_size)
+        grasp_offset = [0.0, 0.0, round((object_height * 0.5) + GRASP_CLEARANCE_ABOVE_OBJECT_M, 3)]
+        pregrasp_offset = [0.0, 0.0, round(grasp_offset[2] + PREGRASP_CLEARANCE_M, 3)]
+        release_offset = [0.0, 0.0, round(RELEASE_CLEARANCE_M, 3)]
         rel = place.get("release_offset_xyz_m", [0.0, 0.0, 0.03])
         if isinstance(rel, list) and len(rel) == 3:
-            destination_pose["xyz"] = [destination_pose["xyz"][0], destination_pose["xyz"][1], round(destination_pose["xyz"][2] + float(rel[2]), 3)]
+            destination_pose["xyz"] = [destination_pose["xyz"][0], destination_pose["xyz"][1], round(destination_pose["xyz"][2] + float(rel[2]) + RELEASE_CLEARANCE_M, 3)]
         warnings.append(f"Using deterministic fallback xyz/rpy for object '{object_id}' and destination '{place.get('destination_id')}'.")
 
         targets.append({
             "object_id": object_id,
             "target_type": "box",
             "target_pose": target_pose,
-            "target_shape": {"type": "box", "dimensions": pick.get("approximate_size_m", [0.05, 0.05, 0.05])},
+            "target_shape": {"type": "box", "dimensions": obj_size},
             "grasp_methods": [{
                 "ee_id": default_ee_id,
-                "grasp_poses": [{"frame_id": obj_frame, "xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]}],
+                "grasp_poses": [{"frame_id": obj_frame, "xyz": grasp_offset, "rpy": [0.0, 0.0, 0.0]}],
                 "grasp_ranks": [1.0],
             }],
             "destination_id": place.get("destination_id"),
             "destination_pose": destination_pose,
             "notes": [f"destination-aware release offset: {place.get('release_offset_xyz_m', [0.0,0.0,0.0])}"],
+            "diagnostics": {
+                "target_object_height_m": round(object_height, 3),
+                "generated_grasp_local_offset_xyz_m": grasp_offset,
+                "generated_pregrasp_local_offset_xyz_m": pregrasp_offset,
+                "generated_destination_release_offset_xyz_m": release_offset,
+            },
         })
 
-    status = "PASS" if len(targets) == 3 else "WARN"
+    status = "PASS" if targets else "WARN"
     return {
         "schema_version": SCHEMA_VERSION,
         "scene_package": SCENE_PACKAGE,
         "mode": "offline",
         "status": status,
-        "summary": {"target_count": len(targets), "routing": [f"{t['object_id']}->{t['destination_id']}" for t in targets]},
+        "summary": {"target_count": len(targets), "routing": [f"{t['object_id']}->{t['destination_id']}" for t in targets], "target_filter_applied": target_filter_applied},
         "ros_interface": {
             "service_name": service_name,
             "topic_name": topic_name,
@@ -120,11 +153,12 @@ def main(argv=None):
     parser.add_argument("--topic-name", default="grasp_tasks")
     parser.add_argument("--frame-id", default="world")
     parser.add_argument("--default-ee-id", default="robotiq_2f")
+    parser.add_argument("--target", action="append", dest="targets", help="Optional object_id filter; repeat for multiple")
     args = parser.parse_args(argv if argv is not None else sys.argv[1:])
 
     manifest = runtime_plan.load_manifest(runtime_plan.find_manifest_path())
     plan = runtime_plan.build_runtime_plan(manifest)
-    payload = build_payload(plan, args.ros_interface, args.service_name, args.topic_name, args.frame_id, args.default_ee_id)
+    payload = build_payload(plan, args.ros_interface, args.service_name, args.topic_name, args.frame_id, args.default_ee_id, selected_targets=args.targets)
     out = json.dumps(payload, indent=2)
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py
+++ b/scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py
@@ -211,8 +211,10 @@ def _default_report(args: argparse.Namespace) -> dict:
     }
 
 
-def _generate_payload(path: Path) -> None:
+def _generate_payload(path: Path, targets: list[str] | None) -> None:
     cmd = ["ros2", "run", SCENE_PACKAGE, "generate_static_sorting_runtime_bridge_payload", "--output", str(path)]
+    for target in targets or []:
+        cmd += ["--target", target]
     result = _run_subprocess(cmd)
     if result.returncode != 0:
         raise ManualExecutorError(f"Payload generation failed: {' '.join(cmd)} :: {result.stderr.strip() or result.stdout.strip()}")
@@ -259,8 +261,18 @@ def build_report(args: argparse.Namespace) -> tuple[dict, int]:
         report["payload"] = {"path": str(payload_path), "source": "provided"}
     else:
         payload_path = args.payload_output if args.payload_output else Path(tempfile.gettempdir()) / "ur5_2f_sorting_runtime_bridge_payload.json"
-        _generate_payload(payload_path)
+        _generate_payload(payload_path, args.targets)
         report["payload"] = {"path": str(payload_path), "source": "generated"}
+
+    payload_json = json.loads(payload_path.read_text(encoding="utf-8"))
+    grasp_targets = payload_json.get("grasp_task", {}).get("grasp_targets", [])
+    payload_target_ids = [t.get("object_id") for t in grasp_targets]
+    report["payload"]["target_filter_applied"] = payload_json.get("summary", {}).get("target_filter_applied", False)
+    report["payload"]["target_count"] = len(grasp_targets)
+    if args.targets and set(payload_target_ids) != {t.get("object_id") for t in selected_targets}:
+        report["result"] = {"status": "failed_safely"}
+        report["warnings"].append("Generated payload targets do not match selected targets.")
+        return report, 2
 
     replay_script = _find_replay_script()
     dry_run_cmd = _build_replay_cmd(replay_script, payload_path, args, dry_run=True)

--- a/scenes/ur5_2f_sorting_test/test/test_generate_static_sorting_runtime_bridge_payload.py
+++ b/scenes/ur5_2f_sorting_test/test/test_generate_static_sorting_runtime_bridge_payload.py
@@ -19,6 +19,10 @@ def main() -> int:
     assert ids == {'item_red','item_blue','item_green'}
     dests = {t['destination_id'] for t in targets}
     assert dests == {'bin_a','bin_b','reject_bin'}
+    for t in targets:
+        grasp_xyz = t["grasp_methods"][0]["grasp_poses"][0]["xyz"]
+        assert grasp_xyz != [0.0, 0.0, 0.0]
+        assert grasp_xyz[2] > 0.0
 
     with tempfile.TemporaryDirectory() as td:
         out = Path(td)/'payload.json'
@@ -26,6 +30,12 @@ def main() -> int:
         loaded = json.loads(out.read_text())
         assert loaded['schema_version'] == 'emd_grasp_bridge_payload/v1'
         subprocess.run([sys.executable, str(replay), '--payload', str(out), '--scene-package', 'ur5_2f_sorting_test', '--dry-run'], check=True, capture_output=True, text=True)
+        single = subprocess.run([sys.executable, str(script), '--target', 'item_red', '--json'], check=True, capture_output=True, text=True)
+        single_payload = json.loads(single.stdout)
+        single_targets = single_payload["grasp_task"]["grasp_targets"]
+        assert len(single_targets) == 1
+        assert single_targets[0]["object_id"] == "item_red"
+        assert single_payload["summary"]["target_filter_applied"] is True
     return 0
 
 if __name__ == '__main__':

--- a/scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py
+++ b/scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py
@@ -3,6 +3,7 @@
 
 import argparse
 import importlib.util
+import json
 from pathlib import Path
 import sys
 from unittest.mock import patch
@@ -26,7 +27,12 @@ def main() -> int:
 
     def fake_run(cmd):
         if "generate_static_sorting_runtime_bridge_payload" in " ".join(cmd):
-            payload_path.write_text("{}", encoding="utf-8")
+            if "--target" in cmd:
+                target = cmd[cmd.index("--target") + 1]
+                payload = {"summary": {"target_filter_applied": True}, "grasp_task": {"grasp_targets": [{"object_id": target}]}}
+            else:
+                payload = {"summary": {"target_filter_applied": False}, "grasp_task": {"grasp_targets": [{"object_id": "item_red"}, {"object_id": "item_blue"}, {"object_id": "item_green"}]}}
+            payload_path.write_text(json.dumps(payload), encoding="utf-8")
         return R(0)
 
     base_args = dict(json=True, output=None, prepare_output=None, skip_send_dry_run_validation=False, runtime_payload=None,
@@ -49,6 +55,12 @@ def main() -> int:
         args = argparse.Namespace(**base_args, require_active_runtime=False, manual_enable_execution=True, execute=True, confirm_runtime_send=False)
         rep, rc = m.build_report(args)
         assert rc != 0 and rep["result"]["status"] == "blocked"
+
+        target_args = argparse.Namespace(**{**base_args, "targets": ["item_red"]}, require_active_runtime=False, manual_enable_execution=False, execute=False, confirm_runtime_send=False)
+        rep, rc = m.build_report(target_args)
+        assert rc == 0
+        assert rep["payload"]["target_count"] == 1
+        assert rep["payload"]["target_filter_applied"] is True
 
     commands = []
     def fake_run_send(cmd):


### PR DESCRIPTION
### Motivation
- The static EMD runtime bridge was emitting grasp poses at the object center (`[0,0,0]`) which caused IK/collision failures; payloads must provide realistic top-grasp poses above the object for safe pick attempts. 
- Make it possible to generate a payload for a single object so the first pick can be validated in isolation before multi-object flows.

### Description
- Generate top-grasp offsets using object height from `sorting_manifest.yaml` and configurable named constants `GRASP_CLEARANCE_ABOVE_OBJECT_M`, `PREGRASP_CLEARANCE_M`, and `RELEASE_CLEARANCE_M`. (changes in `generate_static_sorting_runtime_bridge_payload.py`).
- Compute per-target `grasp_poses` as a positive local Z offset above the object and include `pregrasp` and `release` offsets in diagnostics; keep payload schema compatible with the replay/runtime code and add `summary.target_filter_applied` flag. (changes in `generate_static_sorting_runtime_bridge_payload.py`).
- Add `--target` CLI filtering to `generate_static_sorting_runtime_bridge_payload` and thread selected targets through `manual_static_sorting_executor` so single-target payloads are produced when requested. (changes in `generate_static_sorting_runtime_bridge_payload.py` and `manual_static_sorting_executor.py`).
- Improve collision isolation checks by validating that generated payload targets match selected targets; the manual executor report now contains `payload.target_count` and `payload.target_filter_applied` and will fail safely if the generated payload does not match the requested targets. (changes in `manual_static_sorting_executor.py`).
- Add/extend tests to assert positive Z grasp offsets, single-target payload generation via `--target item_red`, and manual executor behavior while preserving existing safety-gate behavior. (changes in test files).
- Did not change or weaken runtime safety gates; `--require-active-runtime`, `--manual-enable-execution`, `--execute`, and `--confirm-runtime-send` remain required for a real send.

### Testing
- Ran `python scenes/ur5_2f_sorting_test/test/test_generate_static_sorting_runtime_bridge_payload.py` and it passed, verifying positive non-zero local grasp Z offsets and `--target` single-object output.
- Ran `python scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py` and it passed, verifying manual executor single-target flow and preserving existing safety-gate checks.
- All modified unit tests completed successfully (green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0964a944833189e18e6a5de11af9)