### PR TITLE
Wire explicit release launch args into grasp execution params

### DIFF
--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/launch/grasp_execution.launch.py
@@ -37,6 +37,8 @@ SCENE_PACKAGE_ARGUMENT = 'scene_package'
 MOVEIT_CONFIG_PACKAGE_ARGUMENT = 'moveit_config_package'
 PLANNING_FRAME_ARGUMENT = 'planning_frame'
 SPAWN_ARM_CONTROLLER_ARGUMENT = 'spawn_arm_controller'
+EXPLICIT_RELEASE_POSE_SOURCE_ARGUMENT = 'explicit_release_pose_source'
+EXPLICIT_RELEASE_POSE_BRIDGE_PAYLOAD_PATH_ARGUMENT = 'explicit_release_pose_bridge_payload_path'
 
 
 GRIPPER_CONTROLLER_JOINTS_BY_END_EFFECTOR = {
@@ -748,6 +750,12 @@ def launch_setup(context, *args, **kwargs):
         )
     moveit_config_package = LaunchConfiguration(MOVEIT_CONFIG_PACKAGE_ARGUMENT).perform(context)
     planning_frame = LaunchConfiguration(PLANNING_FRAME_ARGUMENT).perform(context).strip()
+    explicit_release_pose_source = LaunchConfiguration(
+        EXPLICIT_RELEASE_POSE_SOURCE_ARGUMENT
+    ).perform(context)
+    explicit_release_pose_bridge_payload_path = LaunchConfiguration(
+        EXPLICIT_RELEASE_POSE_BRIDGE_PAYLOAD_PATH_ARGUMENT
+    ).perform(context)
     if not planning_frame:
         raise RuntimeError(
             f"Launch argument '{PLANNING_FRAME_ARGUMENT}' resolved to an empty frame after trimming whitespace."
@@ -953,6 +961,12 @@ def launch_setup(context, *args, **kwargs):
     grasp_execution_config = sanitize_grasp_execution_params(
         load_yaml(PACKAGE_NAME, 'config/grasp_execution.yaml')
     )
+    grasp_execution_node = grasp_execution_config.setdefault("grasp_execution_node", {})
+    grasp_execution_ros_params = grasp_execution_node.setdefault("ros__parameters", {})
+    grasp_execution_ros_params["explicit_release_pose_source"] = explicit_release_pose_source
+    grasp_execution_ros_params[
+        "explicit_release_pose_bridge_payload_path"
+    ] = explicit_release_pose_bridge_payload_path
     grasp_execution_yaml = write_temp_yaml_params(
         grasp_execution_config,
         prefix='grasp_execution_',
@@ -1132,6 +1146,16 @@ def generate_launch_description():
                 SPAWN_ARM_CONTROLLER_ARGUMENT,
                 default_value='true',
                 description='Spawn ur5_arm_controller via controller_manager spawner.',
+            ),
+            DeclareLaunchArgument(
+                EXPLICIT_RELEASE_POSE_SOURCE_ARGUMENT,
+                default_value='auto',
+                description='Explicit release pose source selection for grasp execution.',
+            ),
+            DeclareLaunchArgument(
+                EXPLICIT_RELEASE_POSE_BRIDGE_PAYLOAD_PATH_ARGUMENT,
+                default_value='',
+                description='Path to runtime bridge payload used by explicit release pose adapter.',
             ),
             OpaqueFunction(function=launch_setup),
         ]

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py
@@ -894,3 +894,79 @@ def test_sanitize_grasp_execution_params_preserves_non_empty_safe_joint_state(gr
         -1.57,
         1.57,
     ]
+
+
+def test_launch_setup_propagates_explicit_release_pose_launch_arguments(
+    grasp_launch_module,
+    monkeypatch,
+):
+    captured_grasp_execution_config = {}
+
+    class FakeLaunchConfiguration:
+        def __init__(self, name):
+            self.name = name
+
+        def perform(self, context):
+            return context[self.name]
+
+    monkeypatch.setattr(grasp_launch_module, 'LaunchConfiguration', FakeLaunchConfiguration)
+    monkeypatch.setattr(grasp_launch_module, 'get_package_share_directory', lambda _package: '/tmp/fake_share')
+    monkeypatch.setattr(grasp_launch_module, 'resolve_scene_package_share_dir', lambda _scene_package: '/tmp/fake')
+    monkeypatch.setattr(grasp_launch_module, 'resolve_required_package_share_dir', lambda *_args, **_kwargs: '/tmp/fake')
+    monkeypatch.setattr(grasp_launch_module, 'load_scene_environment', lambda _scene: {'end_effector': {}})
+    monkeypatch.setattr(grasp_launch_module, 'resolve_gripper_controller_joints', lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(grasp_launch_module, '_extract_scene_xacro_args', lambda _path: set())
+    monkeypatch.setattr(grasp_launch_module, '_extract_ur_robot_macro_params', lambda: set())
+    monkeypatch.setattr(grasp_launch_module, 'load_file', lambda *_args, **_kwargs: '<robot name="demo"></robot>')
+    monkeypatch.setattr(grasp_launch_module, '_normalize_srdf_for_ur_base_inertia', lambda _a, b, _c: b)
+    monkeypatch.setattr(
+        grasp_launch_module,
+        'build_workcell_context_for_scene',
+        lambda *_args, **_kwargs: ({'workcell_context': {}}, 'robotiq_2f', 'tool0', 'tool0'),
+    )
+    monkeypatch.setattr(grasp_launch_module, '_extract_link_names_from_urdf', lambda _xml: {'tool0'})
+    monkeypatch.setattr(
+        grasp_launch_module,
+        'validate_and_normalize_workcell_end_effector_frames',
+        lambda *_args, **_kwargs: ('robotiq_2f', 'tool0', 'tool0'),
+    )
+    monkeypatch.setattr(grasp_launch_module, 'build_workcell_context', lambda *_args, **_kwargs: {'ctx': 'ok'})
+    monkeypatch.setattr(grasp_launch_module, 'require_yaml_mapping', lambda data, *_args, **_kwargs: data)
+    monkeypatch.setattr(grasp_launch_module, 'align_gripper_controller_joints', lambda *_args, **_kwargs: None)
+
+    def fake_load_yaml(package_name, file_path):
+        if package_name == grasp_launch_module.PACKAGE_NAME and file_path == 'config/grasp_execution.yaml':
+            return {'grasp_execution_node': {'ros__parameters': {}}}
+        return {'grasp_execution_node': {'ros__parameters': {}}}
+
+    monkeypatch.setattr(grasp_launch_module, 'load_yaml', fake_load_yaml)
+
+    def fake_write_temp_yaml_params(data, prefix='tmp_'):
+        if prefix == 'grasp_execution_':
+            captured_grasp_execution_config.clear()
+            captured_grasp_execution_config.update(data)
+        return f'/tmp/{prefix}params.yaml'
+
+    monkeypatch.setattr(grasp_launch_module, 'write_temp_yaml_params', fake_write_temp_yaml_params)
+    monkeypatch.setattr(grasp_launch_module, 'Node', lambda *args, **kwargs: ('node', kwargs))
+    monkeypatch.setattr(grasp_launch_module, 'ExecuteProcess', lambda *args, **kwargs: ('process', kwargs))
+    monkeypatch.setattr(grasp_launch_module, 'TimerAction', lambda *args, **kwargs: ('timer', kwargs))
+    monkeypatch.setattr(grasp_launch_module, 'IfCondition', lambda value: value)
+    monkeypatch.setattr(grasp_launch_module, 'PythonExpression', lambda expr: expr)
+
+    grasp_launch_module.launch_setup(
+        {
+            grasp_launch_module.SCENE_PACKAGE_ARGUMENT: 'scene_pkg',
+            grasp_launch_module.MOVEIT_CONFIG_PACKAGE_ARGUMENT: 'moveit_pkg',
+            grasp_launch_module.PLANNING_FRAME_ARGUMENT: 'world',
+            grasp_launch_module.EXPLICIT_RELEASE_POSE_SOURCE_ARGUMENT: 'bridge_payload',
+            grasp_launch_module.EXPLICIT_RELEASE_POSE_BRIDGE_PAYLOAD_PATH_ARGUMENT: '/tmp/payload.json',
+            'debug': 'false',
+            'launch_rviz': 'false',
+            grasp_launch_module.SPAWN_ARM_CONTROLLER_ARGUMENT: 'false',
+        }
+    )
+
+    ros_params = captured_grasp_execution_config['grasp_execution_node']['ros__parameters']
+    assert ros_params['explicit_release_pose_source'] == 'bridge_payload'
+    assert ros_params['explicit_release_pose_bridge_payload_path'] == '/tmp/payload.json'


### PR DESCRIPTION
### Motivation
- The launch invocation accepted `explicit_release_pose_source` and `explicit_release_pose_bridge_payload_path` but they were not propagated into the `grasp_execution_node` parameters, causing the explicit-release adapter to never load and the runtime to fall back to legacy release behavior.

### Description
- Add two launch argument constants and declarations: `explicit_release_pose_source` (default `"auto"`) and `explicit_release_pose_bridge_payload_path` (default `""`).
- Read both `LaunchConfiguration` values in `launch_setup()` and capture them into local variables.
- After sanitizing/loading `grasp_execution.yaml`, inject/override `grasp_execution_node.ros__parameters.explicit_release_pose_source` and `grasp_execution_node.ros__parameters.explicit_release_pose_bridge_payload_path` with the launch values while preserving existing behavior when the user omits overrides.
- Add a lightweight unit test `test_launch_setup_propagates_explicit_release_pose_launch_arguments` that stubs launch dependencies and verifies the two arguments are present in the generated `grasp_execution` node parameter mapping.

### Testing
- Ran the targeted unit test with `pytest -q easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/test/test_grasp_execution_launch_helpers.py -k explicit_release_pose_launch_arguments`, which was skipped in this environment due to the module guard `pytest.importorskip('xacro')` (skip reported by pytest). 
- Attempted `colcon test --packages-select run_grasp_execution ur5_2f_sorting_test --event-handlers console_direct+`, but `colcon` is not available in this environment so the command failed to run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa133f48e88331b6ca11016c20d8ea)