### PR TITLE
Increase runtime service timeout and emit world-frame release poses for static sorting

### DIFF
--- a/scenes/ur5_2f_sorting_test/scripts/generate_static_sorting_runtime_bridge_payload.py
+++ b/scenes/ur5_2f_sorting_test/scripts/generate_static_sorting_runtime_bridge_payload.py
@@ -14,6 +14,13 @@ SCENE_PACKAGE = "ur5_2f_sorting_test"
 GRASP_CLEARANCE_ABOVE_OBJECT_M = 0.02
 PREGRASP_CLEARANCE_M = 0.05
 RELEASE_CLEARANCE_M = 0.03
+WORLD_TO_TABLE = [0.15, 0.0, 0.74]
+STATIC_WORLD_RELEASE_Z_M = 0.97
+STATIC_DESTINATION_WORLD_XY = {
+    "bin_a": [WORLD_TO_TABLE[0] + 0.44, WORLD_TO_TABLE[1] - 0.24],
+    "bin_b": [WORLD_TO_TABLE[0] + 0.44, WORLD_TO_TABLE[1] + 0.0],
+    "reject_bin": [WORLD_TO_TABLE[0] + 0.44, WORLD_TO_TABLE[1] + 0.24],
+}
 
 
 def _load_sibling_script_module(module_name: str):
@@ -90,7 +97,8 @@ def build_payload(
         if place is None:
             continue
         obj_frame = pick.get("object_frame", object_id)
-        dest_frame = place.get("destination_frame", place.get("destination_id"))
+        dest_id = place.get("destination_id")
+        dest_frame = "world"
         target_pose = _fallback_pose(obj_frame, idx)
         destination_pose = _fallback_pose(dest_frame, idx + 10)
         obj_size = pick.get("approximate_size_m", [0.05, 0.05, 0.05])
@@ -98,9 +106,9 @@ def build_payload(
         grasp_offset = [0.0, 0.0, round((object_height * 0.5) + GRASP_CLEARANCE_ABOVE_OBJECT_M, 3)]
         pregrasp_offset = [0.0, 0.0, round(grasp_offset[2] + PREGRASP_CLEARANCE_M, 3)]
         release_offset = [0.0, 0.0, round(RELEASE_CLEARANCE_M, 3)]
-        rel = place.get("release_offset_xyz_m", [0.0, 0.0, 0.03])
-        if isinstance(rel, list) and len(rel) == 3:
-            destination_pose["xyz"] = [destination_pose["xyz"][0], destination_pose["xyz"][1], round(destination_pose["xyz"][2] + float(rel[2]) + RELEASE_CLEARANCE_M, 3)]
+        world_xy = STATIC_DESTINATION_WORLD_XY.get(str(dest_id))
+        if world_xy is not None:
+            destination_pose["xyz"] = [round(float(world_xy[0]), 3), round(float(world_xy[1]), 3), round(STATIC_WORLD_RELEASE_Z_M, 3)]
         warnings.append(f"Using deterministic fallback xyz/rpy for object '{object_id}' and destination '{place.get('destination_id')}'.")
 
         targets.append({

--- a/scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py
+++ b/scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py
@@ -224,6 +224,8 @@ def _build_replay_cmd(replay_script: Path, payload: Path, args: argparse.Namespa
     cmd = [sys.executable, str(replay_script), "--payload", str(payload), "--scene-package", SCENE_PACKAGE, "--ros-interface", args.ros_interface]
     if args.ros_interface == "service":
         cmd += ["--service-name", args.service_name]
+        if not dry_run:
+            cmd += ["--service-timeout-sec", "60.0"]
     else:
         cmd += ["--topic-name", args.topic_name]
     if dry_run:

--- a/scenes/ur5_2f_sorting_test/test/test_generate_static_sorting_runtime_bridge_payload.py
+++ b/scenes/ur5_2f_sorting_test/test/test_generate_static_sorting_runtime_bridge_payload.py
@@ -23,13 +23,27 @@ def main() -> int:
         grasp_xyz = t["grasp_methods"][0]["grasp_poses"][0]["xyz"]
         assert grasp_xyz != [0.0, 0.0, 0.0]
         assert grasp_xyz[2] > 0.0
+        assert t["destination_pose"]["frame_id"] == "world"
+
+    expected_world_xy = {
+        "bin_a": [0.59, -0.24],
+        "bin_b": [0.59, 0.0],
+        "reject_bin": [0.59, 0.24],
+    }
+    for t in targets:
+        expected_xy = expected_world_xy[t["destination_id"]]
+        got = t["destination_pose"]["xyz"]
+        assert got[:2] == expected_xy
+        assert got[2] == 0.97
 
     with tempfile.TemporaryDirectory() as td:
         out = Path(td)/'payload.json'
         subprocess.run([sys.executable, str(script), '--output', str(out)], check=True)
         loaded = json.loads(out.read_text())
         assert loaded['schema_version'] == 'emd_grasp_bridge_payload/v1'
-        subprocess.run([sys.executable, str(replay), '--payload', str(out), '--scene-package', 'ur5_2f_sorting_test', '--dry-run'], check=True, capture_output=True, text=True)
+        replay_dry = subprocess.run([sys.executable, str(replay), '--payload', str(out), '--scene-package', 'ur5_2f_sorting_test', '--dry-run'], check=True, capture_output=True, text=True)
+        assert "dest_frame=world" in replay_dry.stdout
+        assert "release=destination-aware" in replay_dry.stdout
         single = subprocess.run([sys.executable, str(script), '--target', 'item_red', '--json'], check=True, capture_output=True, text=True)
         single_payload = json.loads(single.stdout)
         single_targets = single_payload["grasp_task"]["grasp_targets"]

--- a/scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py
+++ b/scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py
@@ -76,6 +76,7 @@ def main() -> int:
         assert rep["execution_attempted"] is True and rep["robot_motion_requested"] is True
         assert any("--dry-run" in c for c in commands)
         assert any("--dry-run" not in c and "replay.py" in " ".join(c) for c in commands)
+        assert any("--dry-run" not in c and "--service-timeout-sec" in c and "60.0" in c for c in commands)
 
     runtime_calls = []
     def fake_runtime_checks(_service_name, _topic_name):
@@ -126,6 +127,8 @@ def main() -> int:
         dry_idx = next(i for i, c in enumerate(send_commands) if "--dry-run" in c)
         send_idx = next(i for i, c in enumerate(send_commands) if "--dry-run" not in c and "replay.py" in " ".join(c))
         assert dry_idx < send_idx
+        assert "--service-timeout-sec" in send_commands[send_idx]
+        assert "60.0" in send_commands[send_idx]
 
     return 0
 

--- a/scripts/replay_emd_bridge_payload.py
+++ b/scripts/replay_emd_bridge_payload.py
@@ -139,7 +139,7 @@ def _send_runtime(payload: dict[str, Any], args: argparse.Namespace) -> tuple[bo
         req = GraspRequest.Request()
         req.grasp_targets = task.grasp_targets
         fut = client.call_async(req)
-        rclpy.spin_until_future_complete(node, fut, timeout_sec=5.0)
+        rclpy.spin_until_future_complete(node, fut, timeout_sec=float(args.service_timeout_sec))
         if not fut.done() or fut.result() is None:
             return False, f"Runtime endpoint unavailable: service '{args.service_name}' timed out."
         res = fut.result()
@@ -158,6 +158,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--ros-interface", choices=["service", "topic"], default="service")
     parser.add_argument("--service-name", default="grasp_requests")
+    parser.add_argument("--service-timeout-sec", type=float, default=60.0)
     parser.add_argument("--topic-name", default="grasp_tasks")
     parser.add_argument("--frame-id", default="base_link")
     args = parser.parse_args(argv)


### PR DESCRIPTION
### Motivation
- Runtime send was timing out because the replay bridge waited only 5 seconds for a `GraspRequest` service response, causing `runtime_send_failed` despite successful robot motion. 
- Static UR5 sorting payloads emitted bin-frame destination poses that needed to be world-frame for this scene so runtime can use destination-aware release targets. 
- Dry-run validation should remain unchanged while the actual runtime send must wait longer. 

### Description
- Add a CLI option `--service-timeout-sec` (default `60.0`) to `scripts/replay_emd_bridge_payload.py` and use it for `rclpy.spin_until_future_complete(...)` instead of the hard-coded `5.0` timeout. 
- Update `scenes/ur5_2f_sorting_test/scripts/manual_static_sorting_executor.py` to include `--service-timeout-sec 60.0` when building the non-dry-run runtime send command while leaving dry-run invocations unchanged. 
- Change `scenes/ur5_2f_sorting_test/scripts/generate_static_sorting_runtime_bridge_payload.py` to emit `destination_pose.frame_id == "world"` for `bin_a`, `bin_b`, and `reject_bin` using scene constants (`world_to_table = [0.15, 0.0, 0.74]`, per-destination XY offsets and `z = 0.97`) and preserve the existing payload schema and ROS message definitions. 
- Add/adjust unit tests to assert propagation of `--service-timeout-sec` in executor send commands, that generated payloads use `destination_pose.frame_id == "world"` with expected XY/Z, and that replay dry-run output contains `dest_frame=world` and `release=destination-aware`. 

### Testing
- Ran focused unit tests with `python3 -m pytest -q tests/test_replay_emd_bridge_payload.py scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py scenes/ur5_2f_sorting_test/test/test_generate_static_sorting_runtime_bridge_payload.py` and all tests passed (`6 passed`). 
- Tests validate dry-run behavior remains unchanged, that `--service-timeout-sec` is included for actual sends, and that generated payloads contain world-frame destination poses with the expected XY/Z values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa17a0d3d48331b0b29e870de4ce19)