### PR TITLE
Add safe static sorting runtime smoke-test helper

### DIFF
--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -97,6 +97,12 @@ install(PROGRAMS
   RENAME generate_static_sorting_runtime_bridge_payload
 )
 
+install(PROGRAMS
+  scripts/static_sorting_runtime_smoke_test.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME static_sorting_runtime_smoke_test
+)
+
 if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_sorting_manifest_validation
@@ -156,6 +162,11 @@ if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_generate_static_sorting_runtime_bridge_payload
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_generate_static_sorting_runtime_bridge_payload.py
+  )
+
+  add_test(
+    NAME ur5_2f_sorting_test_static_sorting_runtime_smoke_test
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_static_sorting_runtime_smoke_test.py
   )
 endif()
 

--- a/scenes/ur5_2f_sorting_test/scripts/static_sorting_runtime_smoke_test.py
+++ b/scenes/ur5_2f_sorting_test/scripts/static_sorting_runtime_smoke_test.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Safe static sorting runtime smoke-test helper."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+
+SCHEMA = "static_sorting_runtime_smoke_test/v1"
+SCENE_PACKAGE = "ur5_2f_sorting_test"
+DEFAULT_PAYLOAD_PATH = Path("/tmp/ur5_2f_sorting_runtime_bridge_payload.json")
+SEQUENTIAL_ORDER = ["item_red", "item_blue", "item_green"]
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--target", choices=SEQUENTIAL_ORDER, help="Single target for repeatable smoke test")
+    p.add_argument("--all", action="store_true", help="Preview all known targets conservatively")
+    p.add_argument("--allow-batch-runtime-send", action="store_true", help="Allow runtime send when --all is selected")
+    p.add_argument("--payload-output", type=Path, default=DEFAULT_PAYLOAD_PATH)
+    p.add_argument("--json", action="store_true")
+    p.add_argument("--print-commands", action="store_true")
+    p.add_argument("--require-active-runtime", action="store_true")
+    p.add_argument("--execute", action="store_true")
+    p.add_argument("--confirm-runtime-send", action="store_true")
+    return p.parse_args(argv)
+
+
+def _run_subprocess(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, check=False, capture_output=True, text=True)
+
+
+def _launch_command(payload_path: Path) -> str:
+    return (
+        "ros2 launch ur5_2f_sorting_test demo.launch.py "
+        "explicit_release_pose_source:=bridge_payload "
+        f"explicit_release_pose_bridge_payload_path:={payload_path}"
+    )
+
+
+def _executor_command(args: argparse.Namespace, targets: list[str]) -> str:
+    cmd = ["ros2", "run", SCENE_PACKAGE, "manual_static_sorting_executor"]
+    for t in targets:
+        cmd += ["--target", t]
+    cmd += ["--require-active-runtime", "--manual-enable-execution", "--execute", "--confirm-runtime-send", "--json"]
+    return " ".join(shlex.quote(x) for x in cmd)
+
+
+def build_report(args: argparse.Namespace) -> tuple[dict, int]:
+    targets = SEQUENTIAL_ORDER[:] if args.all else ([args.target] if args.target else [SEQUENTIAL_ORDER[0]])
+    payload_output = args.payload_output
+    send_guarded = args.require_active_runtime and args.execute and args.confirm_runtime_send
+    batch_blocked = args.all and send_guarded and not args.allow_batch_runtime_send
+
+    cmd = [
+        "ros2", "run", SCENE_PACKAGE, "manual_static_sorting_executor",
+        "--payload-output", str(payload_output), "--json",
+    ]
+    for t in targets:
+        cmd += ["--target", t]
+    if args.require_active_runtime:
+        cmd.append("--require-active-runtime")
+    if send_guarded and not batch_blocked:
+        cmd += ["--manual-enable-execution", "--execute", "--confirm-runtime-send"]
+
+    rep = {
+        "schema": SCHEMA,
+        "payload_output": str(payload_output),
+        "target_count": len(targets),
+        "selected_target_ids": targets,
+        "recommended_sequential_order": SEQUENTIAL_ORDER,
+        "replay_dry_run_status": "unknown",
+        "runtime_check_status": "not_requested",
+        "robot_motion_requested": False,
+        "final_send_command": _executor_command(args, targets),
+        "final_send_command_executed": False,
+        "launch_command": _launch_command(payload_output),
+        "execution_command": _executor_command(args, targets),
+        "warnings": [],
+        "targets": [],
+    }
+
+    if args.all:
+        rep["warnings"].append("Conservative mode: recommended sequential test order is item_red -> item_blue -> item_green.")
+    if batch_blocked:
+        rep["warnings"].append("Batch runtime send blocked for --all. Add --allow-batch-runtime-send to permit it.")
+
+    run = _run_subprocess(cmd)
+    if run.returncode != 0:
+        rep["replay_dry_run_status"] = "fail"
+        rep["runtime_check_status"] = "failed_or_missing" if args.require_active_runtime else "not_requested"
+        rep["warnings"].append((run.stderr or run.stdout).strip())
+        return rep, 2
+
+    payload = json.loads(run.stdout)
+    rep["replay_dry_run_status"] = payload.get("payload_validation", {}).get("dry_run_replay_status", "unknown")
+    runtime_checks = payload.get("runtime_checks", {})
+    rep["runtime_check_status"] = "requested" if args.require_active_runtime else "not_requested"
+    if args.require_active_runtime:
+        rep["runtime_check_status"] = "pass" if payload.get("result", {}).get("status") != "runtime_missing" else "runtime_missing"
+    rep["robot_motion_requested"] = bool(payload.get("robot_motion_requested", False))
+    rep["final_send_command_executed"] = bool(payload.get("execution_attempted", False))
+
+    for t in payload.get("grasp_task", {}).get("grasp_targets", []):
+        rep["targets"].append({
+            "object_id": t.get("object_id"),
+            "destination_id": t.get("destination_id"),
+            "destination_pose": {"frame_id": (t.get("destination_pose") or {}).get("frame_id")},
+        })
+
+    # manual executor report doesn't expose grasp_targets directly; read payload file for observability.
+    try:
+        payload_json = json.loads(Path(payload.get("payload", {}).get("path", str(payload_output))).read_text(encoding="utf-8"))
+        rep["targets"] = [{
+            "object_id": gt.get("object_id"),
+            "destination_id": gt.get("destination_id"),
+            "destination_pose": {"frame_id": (gt.get("destination_pose") or {}).get("frame_id")},
+        } for gt in payload_json.get("grasp_task", {}).get("grasp_targets", [])]
+    except Exception as exc:
+        rep["warnings"].append(f"Could not read payload target observability fields: {exc}")
+
+    return rep, 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    report, code = build_report(args)
+
+    should_print_commands = args.print_commands or True
+    if should_print_commands and not args.json:
+        print(f"Terminal 1: {report['launch_command']}")
+        print(f"Terminal 2: {report['execution_command']}")
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(json.dumps(report, indent=2))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scenes/ur5_2f_sorting_test/test/test_static_sorting_runtime_smoke_test.py
+++ b/scenes/ur5_2f_sorting_test/test/test_static_sorting_runtime_smoke_test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Tests for static_sorting_runtime_smoke_test helper safety and observability."""
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+
+def main() -> int:
+    scene_root = Path(__file__).resolve().parents[1]
+    script_path = scene_root / "scripts" / "static_sorting_runtime_smoke_test.py"
+    spec = importlib.util.spec_from_file_location("smoke", script_path)
+    smoke = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(smoke)
+
+    class R:
+        def __init__(self, stdout: str, code: int = 0):
+            self.returncode = code
+            self.stdout = stdout
+            self.stderr = ""
+
+    payload_path = Path("/tmp/ur5_2f_sorting_runtime_bridge_payload.json")
+
+    def fake_manual_executor(cmd):
+        selected = []
+        i = 0
+        while i < len(cmd):
+            if cmd[i] == "--target":
+                selected.append(cmd[i + 1])
+                i += 2
+            else:
+                i += 1
+        if not selected:
+            selected = ["item_red"]
+        payload = {
+            "grasp_task": {"grasp_targets": [{"object_id": t, "destination_id": "bin_a", "destination_pose": {"frame_id": "world"}} for t in selected]}
+        }
+        payload_path.write_text(json.dumps(payload), encoding="utf-8")
+        report = {
+            "payload": {"path": str(payload_path)},
+            "payload_validation": {"dry_run_replay_status": "pass"},
+            "runtime_checks": {"checked": "--require-active-runtime" in cmd},
+            "execution_attempted": "--manual-enable-execution" in cmd,
+            "robot_motion_requested": "--manual-enable-execution" in cmd,
+            "result": {"status": "dry_run_only"},
+        }
+        return R(json.dumps(report))
+
+    with patch.object(smoke, "_run_subprocess", side_effect=fake_manual_executor):
+        args = argparse.Namespace(target="item_red", all=False, allow_batch_runtime_send=False, payload_output=payload_path, json=True, print_commands=False, require_active_runtime=False, execute=False, confirm_runtime_send=False)
+        rep, rc = smoke.build_report(args)
+        assert rc == 0
+        assert rep["robot_motion_requested"] is False
+
+        one_args = argparse.Namespace(target="item_red", all=False, allow_batch_runtime_send=False, payload_output=payload_path, json=True, print_commands=False, require_active_runtime=False, execute=False, confirm_runtime_send=False)
+        rep, _ = smoke.build_report(one_args)
+        assert rep["target_count"] == 1
+        assert rep["selected_target_ids"] == ["item_red"]
+
+        all_args = argparse.Namespace(target=None, all=True, allow_batch_runtime_send=False, payload_output=payload_path, json=True, print_commands=False, require_active_runtime=False, execute=False, confirm_runtime_send=False)
+        rep, _ = smoke.build_report(all_args)
+        assert rep["target_count"] == 3
+        assert rep["recommended_sequential_order"] == ["item_red", "item_blue", "item_green"]
+
+        cmd_args = argparse.Namespace(target="item_red", all=False, allow_batch_runtime_send=False, payload_output=payload_path, json=True, print_commands=True, require_active_runtime=False, execute=False, confirm_runtime_send=False)
+        rep, _ = smoke.build_report(cmd_args)
+        assert "explicit_release_pose_source:=bridge_payload" in rep["launch_command"]
+        assert "explicit_release_pose_bridge_payload_path:=/tmp/ur5_2f_sorting_runtime_bridge_payload.json" in rep["launch_command"]
+        assert "ros2 run ur5_2f_sorting_test manual_static_sorting_executor --target item_red --require-active-runtime --manual-enable-execution --execute --confirm-runtime-send --json" == rep["execution_command"]
+
+        guarded_args = argparse.Namespace(target="item_red", all=False, allow_batch_runtime_send=False, payload_output=payload_path, json=True, print_commands=False, require_active_runtime=False, execute=True, confirm_runtime_send=True)
+        rep, _ = smoke.build_report(guarded_args)
+        assert rep["final_send_command_executed"] is False
+        assert rep["robot_motion_requested"] is False
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide a focused, repeatable, and safe runtime smoke-test helper for `ur5_2f_sorting_test` to make tomorrow's runtime validation more observable and repeatable without changing any planning, geometry, URDF, SRDF, controllers, or ROS messages.
- Ensure the default behavior is conservative (no robot motion) while exposing an exact guarded workflow and terminal commands for operators to perform manual, safe sends when the runtime is available.

### Description
- Add a new helper script `scenes/ur5_2f_sorting_test/scripts/static_sorting_runtime_smoke_test.py` that supports `--target item_red|item_blue|item_green`, `--all`, `--payload-output /tmp/ur5_2f_sorting_runtime_bridge_payload.json`, `--json`, `--print-commands`, `--require-active-runtime`, `--execute`, and `--confirm-runtime-send`, plus a conservative `--allow-batch-runtime-send` for explicit multi-target batch sends. 
- The helper delegates to the existing `manual_static_sorting_executor` for payload generation and dry-run validation, defaults to dry-run only (no runtime send / no robot motion), and only assembles runtime-send flags when the guarded combination is present; it also blocks automatic batch sends for `--all` unless `--allow-batch-runtime-send` is provided. 
- Improve observability by reporting the generated payload path, `target_count`, selected target IDs, destination IDs and `destination_pose.frame_id` for each target, replay dry-run status, runtime check status (if requested), and the exact final send command while indicating whether it was executed. 
- Register the new script for install and add `test_static_sorting_runtime_smoke_test.py` under `scenes/ur5_2f_sorting_test/test/` and a CMake test entry in `CMakeLists.txt`.

### Testing
- Ran the new smoke-test unit: `python3 scenes/ur5_2f_sorting_test/test/test_static_sorting_runtime_smoke_test.py`, which passed. 
- Re-ran the existing manual executor tests: `python3 scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py`, which passed.
- The tests verify default no-motion behavior, single-target payload generation for `--target item_red`, `--all` reporting three targets and recommending a sequential order, correct printing of the launch command containing `explicit_release_pose_source:=bridge_payload` and the `explicit_release_pose_bridge_payload_path` set to `/tmp/ur5_2f_sorting_runtime_bridge_payload.json`, and that no runtime send occurs without the explicit guarded flags.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa635f6ddc83319c505c61ae373bd3)