### PR TITLE
Add guarded static sorting sequence runner for ur5_2f_sorting_test

### DIFF
--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -103,6 +103,12 @@ install(PROGRAMS
   RENAME static_sorting_runtime_smoke_test
 )
 
+install(PROGRAMS
+  scripts/static_sorting_sequence_runner.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME static_sorting_sequence_runner
+)
+
 if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_sorting_manifest_validation
@@ -167,6 +173,11 @@ if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_static_sorting_runtime_smoke_test
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_static_sorting_runtime_smoke_test.py
+  )
+
+  add_test(
+    NAME ur5_2f_sorting_test_static_sorting_sequence_runner
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_static_sorting_sequence_runner.py
   )
 endif()
 

--- a/scenes/ur5_2f_sorting_test/scripts/static_sorting_sequence_runner.py
+++ b/scenes/ur5_2f_sorting_test/scripts/static_sorting_sequence_runner.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Safe sequential wrapper around manual_static_sorting_executor."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+SCHEMA = "static_sorting_sequence_runner/v1"
+SCENE_PACKAGE = "ur5_2f_sorting_test"
+DEFAULT_PAYLOAD_OUTPUT_DIR = Path("/tmp/ur5_2f_sorting_sequence")
+
+
+def _load_sibling_script_module(module_name: str):
+    script_dir = Path(__file__).resolve().parent
+    candidate = script_dir / f"{module_name}.py"
+    unique_name = f"_ur5_2f_sorting_test_{module_name}"
+    spec = importlib.util.spec_from_file_location(unique_name, candidate)
+    if spec is None or spec.loader is None:
+        raise ModuleNotFoundError(f"Could not load sibling script module '{module_name}'")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+runtime_plan = _load_sibling_script_module("generate_sorting_runtime_plan")
+manual_executor = _load_sibling_script_module("manual_static_sorting_executor")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--json", action="store_true")
+    p.add_argument("--print-commands", action="store_true")
+    p.add_argument("--target", choices=["item_red", "item_blue", "item_green"])
+    p.add_argument("--all", action="store_true", dest="all_targets")
+    p.add_argument("--payload-output-dir", type=Path, default=DEFAULT_PAYLOAD_OUTPUT_DIR)
+    p.add_argument("--require-active-runtime", action="store_true")
+    p.add_argument("--execute", action="store_true")
+    p.add_argument("--confirm-runtime-send", action="store_true")
+    p.add_argument("--allow-batch-runtime-send", action="store_true")
+    return p.parse_args(argv)
+
+
+def _sequence() -> list[dict]:
+    manifest = runtime_plan.load_manifest(runtime_plan.find_manifest_path())
+    plan = runtime_plan.build_runtime_plan(manifest)
+    return [
+        {"target_id": step.get("object_id"), "destination_id": step.get("destination_id")}
+        for step in plan.get("steps", []) if step.get("type") == "pick"
+    ]
+
+
+def _selected_targets(args: argparse.Namespace) -> list[dict]:
+    seq = _sequence()
+    if args.target and args.all_targets:
+        raise ValueError("Use either --target or --all, not both.")
+    if args.target:
+        return [entry for entry in seq if entry["target_id"] == args.target]
+    return seq if args.all_targets or not args.target else []
+
+
+def _manual_args(args: argparse.Namespace, target_id: str, payload_path: Path) -> argparse.Namespace:
+    batch_send = args.all_targets and args.execute and args.confirm_runtime_send and args.allow_batch_runtime_send
+    single_send = (not args.all_targets) and args.execute and args.confirm_runtime_send
+    do_send = batch_send or single_send
+    return argparse.Namespace(
+        json=True,
+        output=None,
+        prepare_output=None,
+        require_active_runtime=args.require_active_runtime,
+        manual_enable_execution=do_send,
+        execute=do_send,
+        confirm_runtime_send=do_send,
+        skip_send_dry_run_validation=False,
+        runtime_payload=None,
+        payload_output=payload_path,
+        ros_interface="service",
+        service_name="grasp_requests",
+        topic_name="grasp_tasks",
+        targets=[target_id],
+    )
+
+
+def build_report(args: argparse.Namespace) -> tuple[dict, int]:
+    selected = _selected_targets(args)
+    args.payload_output_dir.mkdir(parents=True, exist_ok=True)
+    blocked_batch = args.all_targets and args.execute and args.confirm_runtime_send and not args.allow_batch_runtime_send
+    mode = "runtime_send" if args.execute and args.confirm_runtime_send else "dry_run"
+    report = {
+        "schema": SCHEMA,
+        "scene_package": SCENE_PACKAGE,
+        "mode": mode,
+        "target_count": len(selected),
+        "selected_targets": [e["target_id"] for e in selected],
+        "sequence": [],
+        "safety": {
+            "execution_requested": bool(args.execute),
+            "runtime_send_confirmed": bool(args.confirm_runtime_send),
+            "batch_runtime_send_allowed": bool(args.allow_batch_runtime_send),
+            "robot_motion_requested": bool(args.execute and args.confirm_runtime_send and ((not args.all_targets) or args.allow_batch_runtime_send)),
+        },
+        "result": {"status": "dry_run_only"},
+        "warnings": [],
+    }
+    if blocked_batch:
+        report["result"] = {"status": "blocked"}
+        report["warnings"].append("Batch runtime send blocked: add --allow-batch-runtime-send to execute with --all.")
+        return report, 2
+
+    for entry in selected:
+        payload_path = args.payload_output_dir / f"{entry['target_id']}_runtime_payload.json"
+        m_args = _manual_args(args, entry["target_id"], payload_path)
+        m_report, m_rc = manual_executor.build_report(m_args)
+        seq_entry = {
+            "target_id": entry["target_id"],
+            "destination_id": entry["destination_id"],
+            "payload_path": str(payload_path),
+            "manual_executor_command": ["ros2", "run", SCENE_PACKAGE, "manual_static_sorting_executor", "--target", entry["target_id"]],
+            "manual_executor_result": m_report.get("result", {}),
+        }
+        if "runtime_send" in m_report:
+            seq_entry["runtime_send"] = m_report["runtime_send"]
+        report["sequence"].append(seq_entry)
+        if m_rc != 0:
+            report["result"] = {"status": "sequence_runtime_send_failed", "failed_target": entry["target_id"]}
+            report["warnings"].append(f"Sequence stopped at failed target: {entry['target_id']}")
+            return report, 2
+
+    if args.execute and args.confirm_runtime_send:
+        report["result"] = {"status": "sequence_runtime_send_succeeded"}
+    return report, 0
+
+
+def _print_commands() -> None:
+    print("Terminal 1 (runtime): ros2 launch easy_manipulation_deployment grasp_execution_real.launch.py scene_package:=ur5_2f_sorting_test release_payload_file:=<path-to-release-payload.json>")
+    print("Dry-run: ros2 run ur5_2f_sorting_test static_sorting_sequence_runner --all --json")
+    print("Single-target execute: ros2 run ur5_2f_sorting_test static_sorting_sequence_runner --target item_red --execute --confirm-runtime-send --require-active-runtime --json")
+    print("All-target execute (guarded): ros2 run ur5_2f_sorting_test static_sorting_sequence_runner --all --execute --confirm-runtime-send --allow-batch-runtime-send --require-active-runtime --json")
+    print("NOTE: --all runtime execution is BLOCKED unless --allow-batch-runtime-send is provided.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    if args.print_commands:
+        _print_commands()
+    try:
+        report, rc = build_report(args)
+    except ValueError as exc:
+        report = {"schema": SCHEMA, "scene_package": SCENE_PACKAGE, "result": {"status": "blocked"}, "warnings": [str(exc)]}
+        rc = 2
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(json.dumps(report, indent=2))
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scenes/ur5_2f_sorting_test/test/test_static_sorting_sequence_runner.py
+++ b/scenes/ur5_2f_sorting_test/test/test_static_sorting_sequence_runner.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Tests for static_sorting_sequence_runner."""
+
+import argparse
+import importlib.util
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+
+def main() -> int:
+    scene_root = Path(__file__).resolve().parents[1]
+    script_path = scene_root / "scripts" / "static_sorting_sequence_runner.py"
+    spec = importlib.util.spec_from_file_location("seq", script_path)
+    seq = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(seq)
+
+    payload_dir = Path("/tmp/ur5_2f_sorting_sequence_tests")
+
+    def ns(**overrides):
+        base = dict(json=True, print_commands=False, target=None, all_targets=False, payload_output_dir=payload_dir,
+                    require_active_runtime=False, execute=False, confirm_runtime_send=False, allow_batch_runtime_send=False)
+        base.update(overrides)
+        return argparse.Namespace(**base)
+
+    calls = []
+    def fake_build_report(ns):
+        calls.append(ns)
+        return ({"result": {"status": "dry_run_only"}, "runtime_send": {"executed": False}}, 0)
+
+    with patch.object(seq.manual_executor, "build_report", side_effect=fake_build_report):
+        rep, rc = seq.build_report(ns())
+        assert rc == 0
+        assert rep["result"]["status"] == "dry_run_only"
+        assert rep["safety"]["robot_motion_requested"] is False
+
+    calls.clear()
+    with patch.object(seq.manual_executor, "build_report", side_effect=fake_build_report):
+        rep, _ = seq.build_report(ns(target="item_red"))
+        assert rep["selected_targets"] == ["item_red"]
+        assert len(rep["sequence"]) == 1
+
+    calls.clear()
+    with patch.object(seq.manual_executor, "build_report", side_effect=fake_build_report):
+        rep, _ = seq.build_report(ns(all_targets=True))
+        assert rep["selected_targets"] == ["item_red", "item_blue", "item_green"]
+
+    with patch.object(seq.manual_executor, "build_report", side_effect=fake_build_report):
+        rep, rc = seq.build_report(ns(all_targets=True, execute=True, confirm_runtime_send=True))
+        assert rc == 2
+        assert rep["result"]["status"] == "blocked"
+
+    calls.clear()
+    with patch.object(seq.manual_executor, "build_report", side_effect=fake_build_report):
+        rep, rc = seq.build_report(ns(target="item_red", execute=True, confirm_runtime_send=True))
+        assert rc == 0
+        assert rep["result"]["status"] == "sequence_runtime_send_succeeded"
+        assert calls[0].manual_enable_execution is True
+
+    calls.clear()
+    with patch.object(seq.manual_executor, "build_report", side_effect=fake_build_report):
+        rep, rc = seq.build_report(ns(all_targets=True, execute=True, confirm_runtime_send=True, allow_batch_runtime_send=True))
+        assert rc == 0
+        assert len(calls) == 3
+        assert all(c.manual_enable_execution for c in calls)
+        assert rep["result"]["status"] == "sequence_runtime_send_succeeded"
+
+    idx = 0
+    def fail_second(ns):
+        nonlocal idx
+        idx += 1
+        if idx == 2:
+            return ({"result": {"status": "runtime_send_failed"}, "runtime_send": {"executed": True}}, 2)
+        return ({"result": {"status": "runtime_send_succeeded"}, "runtime_send": {"executed": True}}, 0)
+
+    with patch.object(seq.manual_executor, "build_report", side_effect=fail_second):
+        rep, rc = seq.build_report(ns(all_targets=True, execute=True, confirm_runtime_send=True, allow_batch_runtime_send=True))
+        assert rc == 2
+        assert rep["result"]["status"] == "sequence_runtime_send_failed"
+        assert rep["result"]["failed_target"] == "item_blue"
+
+    assert "safety" in rep and "result" in rep and "sequence" in rep
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide a safe, operator-friendly sequential runner for the `ur5_2f_sorting_test` sorting demo so targets can be prepared and validated one-at-a-time while keeping default behaviour dry-run/no-motion. 
- Move from ad-hoc manual single-target sends toward a repeatable, deterministic cell workflow that enforces explicit runtime-send confirmations and batch-send guards. 
- Reuse the existing `manual_static_sorting_executor` and its safety gates rather than duplicating runtime-send logic.

### Description
- Added `scenes/ur5_2f_sorting_test/scripts/static_sorting_sequence_runner.py` which implements CLI flags (`--json`, `--print-commands`, `--target`, `--all`, `--payload-output-dir`, `--require-active-runtime`, `--execute`, `--confirm-runtime-send`, `--allow-batch-runtime-send`) and produces JSON reports conforming to `static_sorting_sequence_runner/v1` with `safety`, `sequence`, and `result` sections. 
- The runner loads targets in deterministic order from the sorting manifest and delegates each target to `manual_static_sorting_executor.build_report()` with a unique per-target payload path, preserving dry-run defaults and requiring explicit flags to allow runtime sends; batch runtime sends are blocked unless `--allow-batch-runtime-send` is present. 
- Added operator guidance via `--print-commands` that prints the runtime launch and guarded single/all execution examples. 
- Registered the new script as an installed executable in `scenes/ur5_2f_sorting_test/CMakeLists.txt` and added tests in `scenes/ur5_2f_sorting_test/test/test_static_sorting_sequence_runner.py` to validate selection, ordering, blocking gates, delegation, failure-stop behavior, and JSON sections.

### Testing
- Ran the new unit test and related scene tests with: `python3 scenes/ur5_2f_sorting_test/test/test_static_sorting_sequence_runner.py`, `python3 scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py`, `python3 scenes/ur5_2f_sorting_test/test/test_static_sorting_runtime_smoke_test.py`, and `python3 scenes/ur5_2f_sorting_test/test/test_replay_emd_bridge_payload_diagnostics.py`. 
- The combined test run (`python3 scenes/ur5_2f_sorting_test/test/test_static_sorting_sequence_runner.py && python3 scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py && python3 scenes/ur5_2f_sorting_test/test/test_static_sorting_runtime_smoke_test.py && python3 scenes/ur5_2f_sorting_test/test/test_replay_emd_bridge_payload_diagnostics.py`) completed successfully. 
- No robot motion or runtime sends occur by default and existing safety gates in the manual executor remain unchanged and enforced by the sequence runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa676509dc833194a4fb04143a8eb0)