### PR TITLE
Add offline static sorting scene contract validator and tests

### DIFF
--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -26,7 +26,9 @@ install(FILES
   environment.yaml
   scene_manifest.yaml
   sorting_manifest.yaml
+  config/sorting_manifest.yaml
   README.md
+  docs/static_sorting_scene_contract.md
   fixtures/detected_objects_sample.json
   DESTINATION share/${PROJECT_NAME}
 )
@@ -109,6 +111,12 @@ install(PROGRAMS
   RENAME static_sorting_sequence_runner
 )
 
+install(PROGRAMS
+  scripts/validate_static_sorting_scene_contract.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME validate_static_sorting_scene_contract
+)
+
 if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_sorting_manifest_validation
@@ -178,6 +186,11 @@ if(BUILD_TESTING)
   add_test(
     NAME ur5_2f_sorting_test_static_sorting_sequence_runner
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_static_sorting_sequence_runner.py
+  )
+
+  add_test(
+    NAME ur5_2f_sorting_test_validate_static_sorting_scene_contract
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test_validate_static_sorting_scene_contract.py
   )
 endif()
 

--- a/scenes/ur5_2f_sorting_test/config/sorting_manifest.yaml
+++ b/scenes/ur5_2f_sorting_test/config/sorting_manifest.yaml
@@ -1,0 +1,63 @@
+sorting_manifest:
+  version: 1
+  scene: ur5_2f_sorting_test
+  description: >-
+    Scene-local sorting configuration for object-to-bin routing metadata.
+
+  objects:
+    - id: item_red
+      label: red_item
+      class_name: part
+      frame_id: item_red
+      approximate_size_m: [0.05, 0.05, 0.05]
+      pick_hint: top_grasp
+      destination: bin_a
+
+    - id: item_blue
+      label: blue_item
+      class_name: part
+      frame_id: item_blue
+      approximate_size_m: [0.05, 0.05, 0.05]
+      pick_hint: top_grasp
+      destination: bin_b
+
+    - id: item_green
+      label: green_item
+      class_name: part
+      frame_id: item_green
+      approximate_size_m: [0.05, 0.05, 0.05]
+      pick_hint: top_grasp
+      destination: reject_bin
+
+  destinations:
+    - id: bin_a
+      name: Bin A
+      frame_id: bin_a
+      release_offset_xyz_m: [0.0, 0.0, 0.03]
+
+    - id: bin_b
+      name: Bin B
+      frame_id: bin_b
+      release_offset_xyz_m: [0.0, 0.0, 0.03]
+
+    - id: reject_bin
+      name: Reject Bin
+      frame_id: reject_bin
+      release_offset_xyz_m: [0.0, 0.0, 0.03]
+
+  routing:
+    - object: item_red
+      destination: bin_a
+    - object: item_blue
+      destination: bin_b
+    - object: item_green
+      destination: reject_bin
+  class_routing:
+    red_block: bin_a
+    blue_block: bin_b
+    green_block: reject_bin
+
+  class_routing_defaults:
+    unknown_class_destination: reject_bin
+    low_confidence_destination: reject_bin
+

--- a/scenes/ur5_2f_sorting_test/docs/static_sorting_scene_contract.md
+++ b/scenes/ur5_2f_sorting_test/docs/static_sorting_scene_contract.md
@@ -1,0 +1,33 @@
+# Static Sorting Scene Contract Validator
+
+This validator performs **offline-only** checks that a static sorting scene package is structurally valid and ready for dry-run/runtime testing handoff.
+
+## What it checks
+- Manifest existence/readability and required sections (`objects`, `destinations`, `routing`)
+- Target field completeness (`id`, `frame_id`, `destination`, and pick/grasp hint support)
+- Duplicate target/destination IDs and missing destination references
+- Routing consistency between manifest and generated payload
+- Payload generator readiness (status PASS, expected target count)
+- Per-target payload contract fields (`object_id`, `target_pose.frame_id`, `target_shape`, grasp methods/poses, positive top-grasp local Z, destination fields)
+- Destination world-frame enforcement (`destination_pose.frame_id == world`)
+- Sequence runner dry-run report generation for `--all`
+- No runtime send is attempted by validation
+
+## Usage
+### Dry contract validation
+```bash
+ros2 run ur5_2f_sorting_test validate_static_sorting_scene_contract --print-summary
+```
+
+### JSON validation
+```bash
+ros2 run ur5_2f_sorting_test validate_static_sorting_scene_contract --json
+```
+
+### Strict validation (warnings fail)
+```bash
+ros2 run ur5_2f_sorting_test validate_static_sorting_scene_contract --strict --print-summary
+```
+
+## Why this is a template
+`ur5_2f_sorting_test` now has a scene contract gate that can be copied to future sorting/inspection/machine-tending scene packages. New scenes can prove manifest/payload/routing/dry-run readiness before runtime integration.

--- a/scenes/ur5_2f_sorting_test/scripts/validate_static_sorting_scene_contract.py
+++ b/scenes/ur5_2f_sorting_test/scripts/validate_static_sorting_scene_contract.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Offline contract validator for static sorting scenes."""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+
+SCHEMA = "static_sorting_scene_contract/v1"
+DEFAULT_MANIFEST = Path("scenes/ur5_2f_sorting_test/config/sorting_manifest.yaml")
+DEFAULT_PAYLOAD_OUTPUT = Path("/tmp/ur5_2f_sorting_contract_payload.json")
+
+
+def _load_sibling_script_module(module_name: str):
+    script_dir = Path(__file__).resolve().parent
+    candidate = script_dir / f"{module_name}.py"
+    unique_name = f"_ur5_2f_sorting_test_{module_name}"
+    spec = importlib.util.spec_from_file_location(unique_name, candidate)
+    if spec is None or spec.loader is None:
+        raise ModuleNotFoundError(f"Could not load sibling script module '{module_name}'")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+payload_generator = _load_sibling_script_module("generate_static_sorting_runtime_bridge_payload")
+sequence_runner = _load_sibling_script_module("static_sorting_sequence_runner")
+
+
+def _resolve_manifest_path(manifest: Path) -> Path:
+    if manifest.exists():
+        return manifest
+    fallback = Path(__file__).resolve().parents[1] / "sorting_manifest.yaml"
+    if manifest == DEFAULT_MANIFEST and fallback.exists():
+        return fallback
+    return manifest
+
+
+def _load_manifest(path: Path):
+    return payload_generator.runtime_plan.load_manifest(path)
+
+
+def build_report(args: argparse.Namespace) -> tuple[dict, int]:
+    warnings: list[str] = []
+    errors: list[str] = []
+    checks = {k: False for k in [
+        "manifest_loaded", "manifest_structure_valid", "no_duplicate_targets", "no_duplicate_destinations",
+        "routing_valid", "payload_generated", "payload_contract_valid", "destination_poses_world_frame",
+        "sequence_runner_dry_run_valid",
+    ]}
+    resolved_manifest = _resolve_manifest_path(args.manifest)
+    report = {
+        "schema": SCHEMA,
+        "scene_package": args.scene_package,
+        "manifest_path": str(resolved_manifest),
+        "payload_path": str(args.payload_output),
+        "target_count": 0,
+        "destination_count": 0,
+        "checks": checks,
+        "targets": [],
+        "warnings": warnings,
+        "errors": errors,
+        "result": {"status": "FAIL"},
+    }
+
+    try:
+        manifest = _load_manifest(resolved_manifest)
+        checks["manifest_loaded"] = True
+    except Exception as exc:
+        errors.append(f"Manifest load failed: {exc}")
+        return report, 2
+
+    objects = manifest.get("objects", [])
+    destinations = manifest.get("destinations", [])
+    routing = manifest.get("routing", [])
+    if isinstance(objects, list) and isinstance(destinations, list) and isinstance(routing, list):
+        checks["manifest_structure_valid"] = True
+    else:
+        errors.append("Manifest must include list sections: objects, destinations, routing.")
+        return report, 2
+
+    report["target_count"] = len(objects)
+    report["destination_count"] = len(destinations)
+
+    target_ids = [o.get("id") for o in objects]
+    dest_ids = [d.get("id") for d in destinations]
+    if len(set(target_ids)) == len(target_ids):
+        checks["no_duplicate_targets"] = True
+    else:
+        errors.append("Duplicate target ids detected.")
+
+    if len(set(dest_ids)) == len(dest_ids):
+        checks["no_duplicate_destinations"] = True
+    else:
+        errors.append("Duplicate destination ids detected.")
+
+    dest_set = set(dest_ids)
+    routing_map = {}
+    for obj in objects:
+        oid = obj.get("id")
+        obj_frame = obj.get("frame_id")
+        dest = obj.get("destination")
+        pick_hint = obj.get("pick_hint") or obj.get("grasp_hint")
+        if not oid or not obj_frame or not dest:
+            errors.append(f"Target missing required fields: {obj}")
+        if not pick_hint:
+            warnings.append(f"Target '{oid}' missing pick_hint/grasp_hint.")
+        if dest not in dest_set:
+            errors.append(f"Target '{oid}' references missing destination '{dest}'.")
+        routing_map[oid] = dest
+
+    manifest_routes = {r.get("object"): r.get("destination") for r in routing}
+    if manifest_routes == routing_map:
+        checks["routing_valid"] = True
+    else:
+        errors.append("Manifest routing does not match object destination mapping.")
+
+    try:
+        plan = payload_generator.runtime_plan.build_runtime_plan(payload_generator.runtime_plan.load_manifest(payload_generator.runtime_plan.find_manifest_path()))
+        payload = payload_generator.build_payload(
+            plan, "service", "grasp_requests", "grasp_tasks", "world", "robotiq_2f", selected_targets=None
+        )
+        args.payload_output.parent.mkdir(parents=True, exist_ok=True)
+        args.payload_output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        checks["payload_generated"] = True
+    except Exception as exc:
+        errors.append(f"Payload generation failed: {exc}")
+        payload = {}
+
+    payload_targets = {t.get("object_id"): t for t in payload.get("grasp_task", {}).get("grasp_targets", [])}
+    if payload.get("status") != "PASS":
+        errors.append("Generated payload status is not PASS.")
+    if payload.get("summary", {}).get("target_count") != len(objects):
+        errors.append("Generated payload target_count mismatch.")
+
+    payload_routes = {t.get("object_id"): t.get("destination_id") for t in payload_targets.values()}
+    if payload_routes != routing_map:
+        errors.append("Generated payload routing does not match manifest routing.")
+
+    world_ok = True
+    contract_ok = True
+    for oid in target_ids:
+        target = payload_targets.get(oid, {})
+        gmethods = target.get("grasp_methods") or []
+        gposes = (gmethods[0].get("grasp_poses") if gmethods else []) or []
+        z_offset = None
+        if gposes:
+            xyz = gposes[0].get("xyz") if isinstance(gposes[0], dict) else None
+            if isinstance(xyz, list) and len(xyz) >= 3:
+                z_offset = xyz[2]
+        entry = {
+            "object_id": oid,
+            "object_frame": next((o.get("frame_id") for o in objects if o.get("id") == oid), None),
+            "destination_id": routing_map.get(oid),
+            "generated_payload_present": bool(target),
+            "grasp_pose_count": len(gposes),
+            "top_grasp_z_offset": z_offset,
+            "destination_frame": (target.get("destination_pose") or {}).get("frame_id"),
+        }
+        report["targets"].append(entry)
+
+        if not target.get("object_id") or not (target.get("target_pose") or {}).get("frame_id") or not target.get("target_shape"):
+            contract_ok = False
+        if not gmethods or not gposes:
+            contract_ok = False
+        if not isinstance(z_offset, (float, int)) or float(z_offset) <= 0.0:
+            contract_ok = False
+            errors.append(f"Target '{oid}' has non-positive top grasp local Z offset.")
+        if not target.get("destination_id") or not target.get("destination_pose"):
+            contract_ok = False
+        if entry["destination_frame"] != "world":
+            world_ok = False
+            contract_ok = False
+            errors.append(f"Target '{oid}' destination_pose.frame_id must be world.")
+
+    checks["destination_poses_world_frame"] = world_ok
+    checks["payload_contract_valid"] = contract_ok and checks["payload_generated"]
+
+    try:
+        original_manual_build_report = sequence_runner.manual_executor.build_report
+        sequence_runner.manual_executor.build_report = lambda _ns: ({"result": {"status": "dry_run_only"}}, 0)
+        s_args = argparse.Namespace(json=True, print_commands=False, target=None, all_targets=True, payload_output_dir=Path("/tmp/ur5_2f_sorting_contract_sequence"), require_active_runtime=False, execute=False, confirm_runtime_send=False, allow_batch_runtime_send=False)
+        seq_report, seq_rc = sequence_runner.build_report(s_args)
+        if seq_rc == 0 and seq_report.get("mode") == "dry_run" and not seq_report.get("safety", {}).get("robot_motion_requested", True):
+            checks["sequence_runner_dry_run_valid"] = True
+        else:
+            errors.append("Sequence runner dry-run contract failed.")
+        sequence_runner.manual_executor.build_report = original_manual_build_report
+    except Exception as exc:
+        errors.append(f"Sequence runner dry-run failed: {exc}")
+
+    if errors:
+        status = "FAIL"
+        rc = 2
+    elif warnings:
+        status = "WARN"
+        rc = 2 if args.strict else 1
+    else:
+        status = "PASS"
+        rc = 0
+    report["result"] = {"status": status}
+    return report, rc
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--json", action="store_true")
+    p.add_argument("--scene-package", default="ur5_2f_sorting_test")
+    p.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    p.add_argument("--payload-output", type=Path, default=DEFAULT_PAYLOAD_OUTPUT)
+    p.add_argument("--strict", action="store_true")
+    p.add_argument("--print-summary", action="store_true")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    report, rc = build_report(args)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print("Static sorting scene contract validation (offline)")
+        print(f"status: {report['result']['status']}")
+        print(f"checks passed: {sum(1 for v in report['checks'].values() if v)}/{len(report['checks'])}")
+        if args.print_summary:
+            print(json.dumps(report, indent=2))
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scenes/ur5_2f_sorting_test/test/test_validate_static_sorting_scene_contract.py
+++ b/scenes/ur5_2f_sorting_test/test/test_validate_static_sorting_scene_contract.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Tests for validate_static_sorting_scene_contract."""
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+from unittest.mock import patch
+
+
+
+def _load_module():
+    scene_root = Path(__file__).resolve().parents[1]
+    script_path = scene_root / "scripts" / "validate_static_sorting_scene_contract.py"
+    spec = importlib.util.spec_from_file_location("contract", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(module, **overrides):
+    base = dict(json=True, scene_package="ur5_2f_sorting_test", manifest=Path("scenes/ur5_2f_sorting_test/config/sorting_manifest.yaml"), payload_output=Path("/tmp/contract_payload_test.json"), strict=False, print_summary=False)
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def main() -> int:
+    mod = _load_module()
+
+    rep, rc = mod.build_report(_args(mod))
+    assert rc == 0 and rep["result"]["status"] == "PASS"
+
+    for key in ["schema", "scene_package", "manifest_path", "payload_path", "checks", "targets", "result"]:
+        assert key in rep
+    assert rep["schema"] == "static_sorting_scene_contract/v1"
+
+    with tempfile.TemporaryDirectory() as td:
+        src = Path(__file__).resolve().parents[1] / "sorting_manifest.yaml"
+        mf = Path(td) / "sorting_manifest.yaml"
+        shutil.copyfile(src, mf)
+        text = mf.read_text(encoding="utf-8")
+        mf.write_text(text.replace("    - id: item_blue", "    - id: item_red", 1), encoding="utf-8")
+        rep, rc = mod.build_report(_args(mod, manifest=mf))
+        assert rc == 2
+        assert any("Duplicate target ids" in e for e in rep["errors"])
+
+    with tempfile.TemporaryDirectory() as td:
+        src = Path(__file__).resolve().parents[1] / "sorting_manifest.yaml"
+        mf = Path(td) / "sorting_manifest.yaml"
+        shutil.copyfile(src, mf)
+        text = mf.read_text(encoding="utf-8")
+        mf.write_text(text.replace("destination: bin_a", "destination: missing_bin", 1), encoding="utf-8")
+        rep, rc = mod.build_report(_args(mod, manifest=mf))
+        assert rc == 2
+        assert any("missing destination" in e for e in rep["errors"])
+
+    original_build_payload = mod.payload_generator.build_payload
+
+    def bad_frame_payload(*args, **kwargs):
+        payload = original_build_payload(*args, **kwargs)
+        payload["grasp_task"]["grasp_targets"][0]["destination_pose"]["frame_id"] = "table"
+        return payload
+
+    with patch.object(mod.payload_generator, "build_payload", side_effect=bad_frame_payload):
+        rep, rc = mod.build_report(_args(mod))
+        assert rc == 2
+        assert rep["checks"]["destination_poses_world_frame"] is False
+
+    def bad_grasp_payload(*args, **kwargs):
+        payload = original_build_payload(*args, **kwargs)
+        payload["grasp_task"]["grasp_targets"][0]["grasp_methods"][0]["grasp_poses"][0]["xyz"][2] = 0.0
+        return payload
+
+    with patch.object(mod.payload_generator, "build_payload", side_effect=bad_grasp_payload):
+        rep, rc = mod.build_report(_args(mod))
+        assert rc == 2
+        assert any("non-positive top grasp" in e for e in rep["errors"])
+
+    with tempfile.TemporaryDirectory() as td:
+        src = Path(__file__).resolve().parents[1] / "sorting_manifest.yaml"
+        mf = Path(td) / "sorting_manifest.yaml"
+        shutil.copyfile(src, mf)
+        text = mf.read_text(encoding="utf-8")
+        mf.write_text(text.replace("      pick_hint: top_grasp\n", "", 1), encoding="utf-8")
+        rep, rc = mod.build_report(_args(mod, manifest=mf, strict=True))
+        assert rep["result"]["status"] == "WARN"
+        assert rc == 2
+
+    with patch.object(mod.sequence_runner, "build_report", return_value=({"mode": "dry_run", "safety": {"robot_motion_requested": False}}, 0)):
+        rep, rc = mod.build_report(_args(mod))
+        assert rc == 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide an offline-only validator that ensures a static sorting scene package is structurally valid and ready for dry-run/runtime testing, so `ur5_2f_sorting_test` can serve as a reusable template for future robotic-cell scenarios. 
- Keep the change small and safe: no changes to robot planning, URDF/SRDF/controllers/collision/object geometry/poses/grasp offsets/release poses or any runtime sends; validator must be safe-by-default.

### Description
- Add `scenes/ur5_2f_sorting_test/scripts/validate_static_sorting_scene_contract.py` which implements the offline validator and supports CLI flags `--json`, `--scene-package`, `--manifest`, `--payload-output`, `--strict`, and `--print-summary` and returns exit codes according to `PASS=0`, `WARN=1 (or 2 if --strict)`, `FAIL=2`.
- Validator performs manifest loading and structure checks, duplicate ID checks, routing consistency, invokes the offline payload generator for a payload sanity check (status, count, per-target fields and positive top-grasp Z offsets), enforces `destination_pose.frame_id == "world"`, and verifies the sequence runner can produce a dry-run report while ensuring no runtime sends are attempted.
- Wire the script into the package install list and add a packaged `config/sorting_manifest.yaml` and short docs at `scenes/ur5_2f_sorting_test/docs/static_sorting_scene_contract.md` describing checks and example commands.
- Add unit tests `scenes/ur5_2f_sorting_test/test/test_validate_static_sorting_scene_contract.py` covering PASS/WARN/FAIL paths, manifest mutation cases (duplicate ids, missing destination), mocked payload errors (non-world destination frame and non-positive grasp Z), strict-mode behavior, and offline-only sequence-run dry-run validation, and register the test in `CMakeLists.txt`.

### Testing
- Ran the new validator unit test with `python3 scenes/ur5_2f_sorting_test/test/test_validate_static_sorting_scene_contract.py` which exercised PASS/WARN/FAIL paths and strict-mode behavior and completed successfully.
- Ran related scene tests to confirm no regressions: `python3 scenes/ur5_2f_sorting_test/test/test_generate_static_sorting_runtime_bridge_payload.py`, `python3 scenes/ur5_2f_sorting_test/test/test_manual_static_sorting_executor.py`, `python3 scenes/ur5_2f_sorting_test/test/test_static_sorting_runtime_smoke_test.py`, and `python3 scenes/ur5_2f_sorting_test/test/test_static_sorting_sequence_runner.py`, all of which succeeded.
- The validator is offline-only and uses local payload/sequence modules (with a short, safe monkeypatch in-process during checks) so no ROS runtime or runtime sends were required during tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa6ac8ab18833190dcecf1ee4319ea)