### PR TITLE
docs: position Workcell Studio as platform and add roadmap regression test

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Modular ROS 2 manipulation packages for grasp planning, grasp execution, and wor
 
 This package was tested with [easy_perception_deployment](https://github.com/ros-industrial/easy_perception_deployment), but any perception system publishing compatible ROS 2 messages will work.
 
+
+## Workcell Studio
+
+Workcell Studio is the internal configurable robotic-cell platform direction in this repository. It focuses on generating, validating, and integrating reusable workcell artifacts while preserving safe default workflows (fake hardware first, offline/dry-run validation first).
+
+Sorting is one scenario template inside Workcell Studio, not the product itself.
+
+Roadmap: `docs/manuals/WORKCELL_STUDIO_ROADMAP.md`
+
 ## Contents
 
 - [Supported platform](#supported-platform)

--- a/docs/manuals/WORKCELL_STUDIO_ROADMAP.md
+++ b/docs/manuals/WORKCELL_STUDIO_ROADMAP.md
@@ -1,0 +1,43 @@
+# Workcell Studio Roadmap
+
+## Purpose
+
+Workcell Studio is the internal configurable robotic-cell platform for defining, generating, validating, and operating deployment-ready workcells. It is the product platform direction for this repository.
+
+Sorting is only one scenario template in Workcell Studio, alongside other templates such as inspection routing, reject handling, and palletizing.
+
+## Near-term visual target
+
+The near-term operator experience target is:
+
+- RViz for robot/cell visualization and planning introspection.
+- A simple web/Streamlit Studio layer for task and cell configuration, validation status, and artifact review.
+
+This keeps the baseline practical for ROS 2 Humble teams while preserving fake-hardware-first and offline/dry-run validation workflows.
+
+## Recommended simulation sequence
+
+1. **RViz + MoveIt now**
+   - Baseline for ROS 2 Humble commissioning and motion-planning workflows.
+   - Keep fake hardware and headless validation paths as defaults.
+2. **Gazebo Sim later**
+   - Add conveyors and basic physics simulation when needed.
+   - Optional extension, not a baseline requirement.
+3. **Isaac Sim later**
+   - Use for investor-grade visuals and advanced simulation demos.
+   - Optional extension, not mandatory for functional deployment.
+
+## Repository boundaries
+
+High-level ownership boundaries:
+
+- **EPD (Easy Perception Deployment)** owns perception pipelines and detected-object outputs.
+- **Easy_Manipulator_Improved** owns Workcell Studio orchestration: generation, validation, and execution integration.
+- **Generated scene packages** own launch/config output artifacts for specific workcell instances.
+
+## Scope guardrails
+
+- Preserve ROS 2 Humble as the supported baseline.
+- Do not require Gazebo Sim or Isaac Sim for core operation.
+- Preserve fake-hardware-first defaults and dry-run/offline validation language.
+- Keep runtime launch behavior backward compatible.

--- a/tests/test_workcell_studio_docs.py
+++ b/tests/test_workcell_studio_docs.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Documentation regression checks for Workcell Studio positioning."""
+
+from pathlib import Path
+
+
+def test_workcell_studio_docs_positioning() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    readme = repo_root / "README.md"
+    roadmap = repo_root / "docs" / "manuals" / "WORKCELL_STUDIO_ROADMAP.md"
+
+    readme_text = readme.read_text(encoding="utf-8")
+    roadmap_text = roadmap.read_text(encoding="utf-8")
+
+    assert "Workcell Studio" in readme_text
+    assert "WORKCELL_STUDIO_ROADMAP.md" in readme_text
+
+    assert roadmap.is_file()
+    assert "sorting is only one scenario template" in roadmap_text.lower()
+    assert "RViz + MoveIt" in roadmap_text
+    assert "Gazebo Sim" in roadmap_text
+    assert "Isaac Sim" in roadmap_text
+    assert "Streamlit" in roadmap_text


### PR DESCRIPTION
### Motivation

- Align repository documentation to present Workcell Studio as the internal configurable robotic-cell platform for defining/generating/validating workcells. 
- Make clear that sorting is a scenario template (one of many) rather than the overarching product. 
- Preserve existing safety defaults and supported baseline (fake-hardware-first, offline/dry-run validation, ROS 2 Humble) while guiding future UI/simulation staging.

### Description

- Add `docs/manuals/WORKCELL_STUDIO_ROADMAP.md` to define Workcell Studio, state that "sorting is only one scenario template", describe the near-term visual target as `RViz + MoveIt` with a simple web/Streamlit Studio, and recommend a staged simulation sequence (`RViz + MoveIt` now, `Gazebo Sim` later, `Isaac Sim` later). 
- Update `README.md` near the top with a concise `Workcell Studio` section that reframes sorting as a template and links to the new roadmap while leaving install/build/safety guidance intact. 
- Add a lightweight documentation regression test `tests/test_workcell_studio_docs.py` that verifies the `README.md` mentions `Workcell Studio` and the roadmap, and checks the roadmap contains the required phrases (`sorting is only one scenario template`, `RViz + MoveIt`, `Gazebo Sim`, `Isaac Sim`, `Streamlit`). 
- No runtime logic, launch behavior, dependencies, or safety defaults were changed in this PR.

### Testing

- Ran `python3 -m pytest -q tests/test_workcell_studio_docs.py` which passed (`1 passed`).
- Verified README and roadmap content presence with the grep checks: `grep -n "Workcell Studio" README.md`, `grep -n "WORKCELL_STUDIO_ROADMAP.md" README.md`, and `grep -n` checks for `RViz + MoveIt`, `Gazebo Sim`, `Isaac Sim`, and `Streamlit` in `docs/manuals/WORKCELL_STUDIO_ROADMAP.md`, all of which succeeded.
- The change set is limited to documentation and the added test; no automated runtime tests were altered or added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1754df9483319e9c51815fc4d750)