### PR TITLE
Promote capability fixtures into shipping Workcell Studio catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Sorting is one scenario template inside Workcell Studio, not the product itself.
 
 Roadmap: `docs/manuals/WORKCELL_STUDIO_ROADMAP.md`
 
+Workcell Studio capability catalog lives at `catalog/capabilities/` and is the source for selectable robots, end effectors, sensors, tasks, and environment assets. It is currently metadata-only, offline-first, and safe/dry-run oriented (no robot-motion runtime changes). See `docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md`.
+
 ## Contents
 
 - [Supported platform](#supported-platform)

--- a/catalog/capabilities/README.md
+++ b/catalog/capabilities/README.md
@@ -1,0 +1,13 @@
+# Workcell Studio capability catalog
+
+This directory is the **Workcell Studio product-facing capability registry**.
+
+It ships offline-first metadata used to describe selectable workcell components:
+
+- `robots/`: robot capability records.
+- `end_effectors/`: gripper, suction, and tooling capability records.
+- `sensors/`: perception and sensing capability records.
+- `tasks/`: task-family capability records.
+- `environment_assets/`: environment asset capability records.
+
+These files are metadata-only and do **not** change ROS 2 launch, MoveIt planning, grasp execution, EPD flows, or any robot-motion runtime behavior.

--- a/catalog/capabilities/end_effectors/ee_airpick_suction.yaml
+++ b/catalog/capabilities/end_effectors/ee_airpick_suction.yaml
@@ -1,0 +1,17 @@
+schema_version: end_effector_capability/v1
+end_effector:
+  id: onrobot_airpick_style
+  label: OnRobot Airpick Style
+  family: suction
+  compatible_robot_families: [serial_6_axis, collaborative_6_axis, delta]
+  required_frames: [tool0]
+  grasp_frames: [suction_tip]
+  contact_links: [suction_cup]
+  allowed_touch_links: [suction_cup]
+  max_object_mass_kg: 0.6
+  suction_area_mm2: 900
+  supported_grasp_strategies: [top_down_suction, side_pick]
+  required_io_signals: [vacuum_on, blowoff]
+  release_behaviour: vacuum_off_with_blowoff
+  limitations_warnings:
+    - Porous surfaces reduce holding force.

--- a/catalog/capabilities/end_effectors/ee_robotiq_2f.yaml
+++ b/catalog/capabilities/end_effectors/ee_robotiq_2f.yaml
@@ -1,0 +1,17 @@
+schema_version: end_effector_capability/v1
+end_effector:
+  id: robotiq_2f_85
+  label: Robotiq 2F-85
+  family: finger_gripper
+  compatible_robot_families: [serial_6_axis, collaborative_6_axis, scara]
+  required_frames: [tool0]
+  grasp_frames: [tool0]
+  contact_links: [left_inner_finger, right_inner_finger]
+  allowed_touch_links: [left_inner_finger, right_inner_finger]
+  max_object_mass_kg: 2.0
+  opening_width_mm: 85
+  supported_grasp_strategies: [pinch, side_pick]
+  required_io_signals: [gripper_open_cmd, gripper_close_cmd]
+  release_behaviour: open_until_clear
+  limitations_warnings:
+    - Requires parallel approach for reliable pinch grasps.

--- a/catalog/capabilities/end_effectors/ee_robotiq_3f.yaml
+++ b/catalog/capabilities/end_effectors/ee_robotiq_3f.yaml
@@ -1,0 +1,17 @@
+schema_version: end_effector_capability/v1
+end_effector:
+  id: robotiq_3f
+  label: Robotiq 3F
+  family: three_finger_gripper
+  compatible_robot_families: [serial_6_axis, collaborative_6_axis]
+  required_frames: [tool0]
+  grasp_frames: [tool0, palm_link]
+  contact_links: [finger_a, finger_b, finger_c]
+  allowed_touch_links: [finger_a, finger_b, finger_c]
+  max_object_mass_kg: 1.5
+  opening_width_mm: 155
+  supported_grasp_strategies: [pinch, enveloping]
+  required_io_signals: [mode_cmd, grip_cmd]
+  release_behaviour: adaptive_release
+  limitations_warnings:
+    - Enveloping grasp speed is slower than pinch mode.

--- a/catalog/capabilities/end_effectors/ee_vacuum_array.yaml
+++ b/catalog/capabilities/end_effectors/ee_vacuum_array.yaml
@@ -1,0 +1,17 @@
+schema_version: end_effector_capability/v1
+end_effector:
+  id: generic_vacuum_array
+  label: Generic Vacuum Array
+  family: vacuum_array
+  compatible_robot_families: [gantry, delta, serial_6_axis]
+  required_frames: [tool0]
+  grasp_frames: [array_center]
+  contact_links: [cup_1, cup_2, cup_3, cup_4]
+  allowed_touch_links: [cup_1, cup_2, cup_3, cup_4]
+  max_object_mass_kg: 8.0
+  suction_area_mm2: 8500
+  supported_grasp_strategies: [top_down_suction]
+  required_io_signals: [vacuum_zone_a, vacuum_zone_b]
+  release_behaviour: staged_zone_release
+  limitations_warnings:
+    - Needs flat target contact area for all active cups.

--- a/catalog/capabilities/environment_assets/asset_bin.yaml
+++ b/catalog/capabilities/environment_assets/asset_bin.yaml
@@ -1,0 +1,17 @@
+schema_version: environment_asset/v1
+asset:
+  id: bin_blue_large
+  label: Blue Sorting Bin
+  family: bin
+  dimensions:
+    length_m: 0.5
+    width_m: 0.4
+    height_m: 0.35
+  frame: world
+  pose: [0.3, -0.6, 0.175, 0.0, 0.0, 0.0]
+  collision_behaviour: rigid_container
+  mobility: movable
+  import_source: internal_catalog
+  mesh_path: assets/environment/bin_blue_large.stl
+  limitations_warnings:
+    - Keep 50 mm clearance around rim for placement.

--- a/catalog/capabilities/environment_assets/asset_conveyor.yaml
+++ b/catalog/capabilities/environment_assets/asset_conveyor.yaml
@@ -1,0 +1,17 @@
+schema_version: environment_asset/v1
+asset:
+  id: conveyor_2m
+  label: Belt Conveyor 2m
+  family: conveyor
+  dimensions:
+    length_m: 2.0
+    width_m: 0.5
+    height_m: 0.85
+  frame: world
+  pose: [1.5, -0.4, 0.425, 0.0, 0.0, 0.0]
+  collision_behaviour: dynamic_surface
+  mobility: static
+  import_source: vendor_model
+  mesh_path: assets/environment/conveyor_2m.stl
+  limitations_warnings:
+    - Motion surface speed configured externally.

--- a/catalog/capabilities/environment_assets/asset_machine_fixture.yaml
+++ b/catalog/capabilities/environment_assets/asset_machine_fixture.yaml
@@ -1,0 +1,17 @@
+schema_version: environment_asset/v1
+asset:
+  id: cnc_tending_fixture_a
+  label: CNC Tending Fixture A
+  family: fixture
+  dimensions:
+    length_m: 0.9
+    width_m: 0.6
+    height_m: 0.2
+  frame: machine_base
+  pose: [0.2, 0.0, 0.1, 0.0, 0.0, 0.0]
+  collision_behaviour: rigid_fixture
+  mobility: attachable
+  import_source: cad_import
+  mesh_path: assets/environment/cnc_tending_fixture_a.stl
+  limitations_warnings:
+    - Validate spindle clearance before deployment.

--- a/catalog/capabilities/environment_assets/asset_table.yaml
+++ b/catalog/capabilities/environment_assets/asset_table.yaml
@@ -1,0 +1,17 @@
+schema_version: environment_asset/v1
+asset:
+  id: table_standard_1200
+  label: Standard Table 1200
+  family: table
+  dimensions:
+    length_m: 1.2
+    width_m: 0.8
+    height_m: 0.9
+  frame: world
+  pose: [0.8, 0.0, 0.45, 0.0, 0.0, 0.0]
+  collision_behaviour: static_collision
+  mobility: static
+  import_source: internal_catalog
+  mesh_path: assets/environment/table_standard.stl
+  limitations_warnings:
+    - Payload limit depends on selected table model.

--- a/catalog/capabilities/robots/robot_generic_delta.yaml
+++ b/catalog/capabilities/robots/robot_generic_delta.yaml
@@ -1,0 +1,20 @@
+schema_version: robot_capability/v1
+robot:
+  id: generic_delta_900
+  label: Generic Delta 900
+  brand: Generic
+  family: delta
+  mounting: overhead
+  planning_groups: [delta_arm]
+  base_frame: delta_base
+  tool_frames: [delta_tool]
+  default_tool_frame: delta_tool
+  named_targets: [home]
+  payload_kg: 1.2
+  reach_m: 0.9
+  workspace_description: High-speed dome envelope above conveyor
+  controller_type: high_speed_trajectory
+  supported_interfaces: [moveit, ros2_control, cartesian_path]
+  supported_task_families: [pick_place, conveyor_sorting]
+  limitations_warnings:
+    - Limited orientation control at workspace edges.

--- a/catalog/capabilities/robots/robot_generic_gantry.yaml
+++ b/catalog/capabilities/robots/robot_generic_gantry.yaml
@@ -1,0 +1,20 @@
+schema_version: robot_capability/v1
+robot:
+  id: generic_gantry_xyz
+  label: Generic Gantry XYZ
+  brand: Generic
+  family: gantry
+  mounting: ceiling
+  planning_groups: [gantry]
+  base_frame: world
+  tool_frames: [gantry_tool]
+  default_tool_frame: gantry_tool
+  named_targets: [home, park]
+  payload_kg: 15.0
+  reach_m: 3.5
+  workspace_description: Rectangular cartesian envelope over multi-station line
+  controller_type: cartesian_controller
+  supported_interfaces: [moveit, ros2_control, joint_trajectory_controller, cartesian_path]
+  supported_task_families: [palletising, machine_tending, conveyor_sorting]
+  limitations_warnings:
+    - Dynamic acceleration constrained by bridge mass.

--- a/catalog/capabilities/robots/robot_generic_scara.yaml
+++ b/catalog/capabilities/robots/robot_generic_scara.yaml
@@ -1,0 +1,20 @@
+schema_version: robot_capability/v1
+robot:
+  id: generic_scara_600
+  label: Generic SCARA 600
+  brand: Generic
+  family: scara
+  mounting: table
+  planning_groups: [scara_arm]
+  base_frame: scara_base
+  tool_frames: [scara_tool]
+  default_tool_frame: scara_tool
+  named_targets: [home, service]
+  payload_kg: 3.0
+  reach_m: 0.6
+  workspace_description: Planar annulus with vertical stroke
+  controller_type: joint_trajectory
+  supported_interfaces: [moveit, joint_trajectory_controller, named_targets]
+  supported_task_families: [pick_place, sort_by_shape, machine_tending]
+  limitations_warnings:
+    - Not suitable for high-angle side picks.

--- a/catalog/capabilities/robots/robot_ur5.yaml
+++ b/catalog/capabilities/robots/robot_ur5.yaml
@@ -1,0 +1,20 @@
+schema_version: robot_capability/v1
+robot:
+  id: ur5
+  label: Universal Robots UR5
+  brand: Universal Robots
+  family: serial_6_axis
+  mounting: floor
+  planning_groups: [manipulator]
+  base_frame: base_link
+  tool_frames: [tool0, ee_link]
+  default_tool_frame: tool0
+  named_targets: [home, ready, stow]
+  payload_kg: 5.0
+  reach_m: 0.85
+  workspace_description: Cylindrical workstation envelope
+  controller_type: position_trajectory
+  supported_interfaces: [moveit, ros2_control, joint_trajectory_controller, cartesian_path, named_targets]
+  supported_task_families: [pick_place, sort_by_colour, sort_by_shape, machine_tending]
+  limitations_warnings:
+    - Demonstration metadata only.

--- a/catalog/capabilities/sensors/sensor_overhead_rgbd.yaml
+++ b/catalog/capabilities/sensors/sensor_overhead_rgbd.yaml
@@ -1,0 +1,13 @@
+schema_version: sensor_capability/v1
+sensor:
+  id: generic_overhead_rgbd
+  label: Generic Overhead RGBD Camera
+  family: rgbd_camera
+  frames: [overhead_camera_link, overhead_optical_frame]
+  topics: [/overhead/rgb, /overhead/depth]
+  detection_outputs: [class, colour, shape, pose, confidence]
+  supported_object_attributes: [class, colour, shape, pose, size, confidence]
+  mounting: overhead
+  calibration_requirements: [extrinsics_to_world, lens_distortion]
+  limitations_warnings:
+    - Occlusion increases near tall fixtures.

--- a/catalog/capabilities/sensors/sensor_realsense_d435i.yaml
+++ b/catalog/capabilities/sensors/sensor_realsense_d435i.yaml
@@ -1,0 +1,13 @@
+schema_version: sensor_capability/v1
+sensor:
+  id: intel_realsense_d435i
+  label: Intel RealSense D435i
+  family: rgbd_camera
+  frames: [camera_link, camera_color_optical_frame, camera_depth_optical_frame]
+  topics: [/camera/color/image_raw, /camera/depth/image_rect_raw, /camera/aligned_depth_to_color/image_raw]
+  detection_outputs: [pose, size, confidence, class]
+  supported_object_attributes: [class, colour, shape, pose, size, confidence]
+  mounting: fixed
+  calibration_requirements: [intrinsics, hand_eye_if_robot_relative]
+  limitations_warnings:
+    - IR interference can reduce depth quality on reflective parts.

--- a/catalog/capabilities/tasks/task_colour_sorting.yaml
+++ b/catalog/capabilities/tasks/task_colour_sorting.yaml
@@ -1,0 +1,12 @@
+schema_version: task_capability/v1
+task:
+  task_family: sort_by_colour
+  required_robot_capabilities: [named_targets, supported_task_families]
+  required_end_effector_capabilities: [supported_grasp_strategies]
+  required_sensor_attributes: [colour, class, confidence, pose]
+  required_destinations: [bin_red, bin_blue, reject_bin]
+  rule_model: attribute_threshold_rules
+  expected_validation_checks: [destination_defined_for_all_rules, confidence_threshold_defined]
+  runtime_requirements: [continuous_detection_loop]
+  limitations_warnings:
+    - Lighting changes may impact colour classification.

--- a/catalog/capabilities/tasks/task_conveyor_sorting.yaml
+++ b/catalog/capabilities/tasks/task_conveyor_sorting.yaml
@@ -1,0 +1,12 @@
+schema_version: task_capability/v1
+task:
+  task_family: conveyor_sorting
+  required_robot_capabilities: [cartesian_path, supported_task_families]
+  required_end_effector_capabilities: [required_io_signals]
+  required_sensor_attributes: [pose, class, confidence]
+  required_destinations: [lane_a, lane_b, reject_lane]
+  rule_model: conveyor_tracking_rules
+  expected_validation_checks: [pick_window_defined, tracking_latency_budget]
+  runtime_requirements: [time_synchronization, conveyor_encoder]
+  limitations_warnings:
+    - High conveyor speed can reduce pick success.

--- a/catalog/capabilities/tasks/task_garbage_sorting.yaml
+++ b/catalog/capabilities/tasks/task_garbage_sorting.yaml
@@ -1,0 +1,12 @@
+schema_version: task_capability/v1
+task:
+  task_family: garbage_sorting
+  required_robot_capabilities: [supported_task_families]
+  required_end_effector_capabilities: [supported_grasp_strategies]
+  required_sensor_attributes: [class, confidence, pose, size]
+  required_destinations: [plastic_bin, metal_bin, organic_bin, reject_bin]
+  rule_model: class_then_fallback
+  expected_validation_checks: [category_bins_exist, hazardous_fallback_defined]
+  runtime_requirements: [category_mapping_table]
+  limitations_warnings:
+    - Hazardous material handling must follow site policy.

--- a/catalog/capabilities/tasks/task_magnetic_pick_place.yaml
+++ b/catalog/capabilities/tasks/task_magnetic_pick_place.yaml
@@ -1,0 +1,13 @@
+schema_version: task_capability/v1
+task:
+  id: task_magnetic_pick_place
+  task_family: pick_place
+  required_robot_capabilities: [planning_groups]
+  required_end_effector_capabilities: [magnetic]
+  required_sensor_attributes: [pose, confidence]
+  required_destinations: [place_target]
+  rule_model: direct_target
+  expected_validation_checks: [reachable_pick]
+  runtime_requirements: [trajectory_execution]
+  limitations_warnings:
+    - Requires magnetic-compatible parts.

--- a/catalog/capabilities/tasks/task_pick_place.yaml
+++ b/catalog/capabilities/tasks/task_pick_place.yaml
@@ -1,0 +1,12 @@
+schema_version: task_capability/v1
+task:
+  task_family: pick_place
+  required_robot_capabilities: [planning_groups, base_frame, tool_frames]
+  required_end_effector_capabilities: [grasp_frames, release_behaviour]
+  required_sensor_attributes: [pose, confidence]
+  required_destinations: [place_target]
+  rule_model: direct_target
+  expected_validation_checks: [reachable_pick, reachable_place, payload_within_limit]
+  runtime_requirements: [trajectory_execution, gripper_command]
+  limitations_warnings:
+    - Assumes known pick and place poses.

--- a/catalog/capabilities/tasks/task_shape_sorting.yaml
+++ b/catalog/capabilities/tasks/task_shape_sorting.yaml
@@ -1,0 +1,12 @@
+schema_version: task_capability/v1
+task:
+  task_family: sort_by_shape
+  required_robot_capabilities: [planning_groups]
+  required_end_effector_capabilities: [supported_grasp_strategies]
+  required_sensor_attributes: [shape, pose, confidence]
+  required_destinations: [bin_cylinders, bin_cubes, reject_bin]
+  rule_model: shape_lookup
+  expected_validation_checks: [shape_rules_complete]
+  runtime_requirements: [shape_classifier]
+  limitations_warnings:
+    - Similar silhouettes may require multi-view sensing.

--- a/docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md
+++ b/docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md
@@ -18,7 +18,25 @@ All contracts include `schema_version` and use versioned identifiers:
 - `task_capability/v1`
 - `environment_asset/v1`
 
-Reference fixtures live under `tests/fixtures/capabilities/`.
+Shipping Workcell Studio catalog lives under `catalog/capabilities/`.
+Regression fixtures remain under `tests/fixtures/capabilities/`.
+
+---
+
+
+## Capability catalog layout
+
+`catalog/capabilities/` is now the shipping Workcell Studio catalog path:
+
+- `catalog/capabilities/robots/`
+- `catalog/capabilities/end_effectors/`
+- `catalog/capabilities/sensors/`
+- `catalog/capabilities/tasks/`
+- `catalog/capabilities/environment_assets/`
+
+`tests/fixtures/capabilities/` remains a regression-fixture set for validator and tooling tests.
+
+All capability files remain offline metadata only and do not alter ROS 2 launch, MoveIt planning, grasp execution, EPD, or robot-motion runtime behavior.
 
 ---
 
@@ -198,8 +216,9 @@ Examples:
 Validator:
 
 ```bash
+python3 scripts/validate_capability_contracts.py catalog/capabilities
+python3 scripts/validate_capability_contracts.py catalog/capabilities --json
 python3 scripts/validate_capability_contracts.py tests/fixtures/capabilities
-python3 scripts/validate_capability_contracts.py tests/fixtures/capabilities --json
 python3 scripts/validate_capability_contracts.py tests/fixtures/capabilities --strict
 ```
 

--- a/scripts/check_capability_contracts.sh
+++ b/scripts/check_capability_contracts.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 VALIDATOR="${SCRIPT_DIR}/validate_capability_contracts.py"
 FIXTURE_DIR="${REPO_ROOT}/tests/fixtures/capabilities"
+CATALOG_DIR="${REPO_ROOT}/catalog/capabilities"
 
 if [[ ! -x "${VALIDATOR}" ]]; then
   echo "Capability contract checks: FAIL"
@@ -12,25 +13,32 @@ if [[ ! -x "${VALIDATOR}" ]]; then
   exit 2
 fi
 
-if [[ ! -d "${FIXTURE_DIR}" ]]; then
-  echo "Capability contract checks: FAIL"
-  echo "Missing fixture directory: ${FIXTURE_DIR}" >&2
-  exit 2
-fi
+for DIR in "${FIXTURE_DIR}" "${CATALOG_DIR}"; do
+  if [[ ! -d "${DIR}" ]]; then
+    echo "Capability contract checks: FAIL"
+    echo "Missing capability directory: ${DIR}" >&2
+    exit 2
+  fi
 
-set +e
-OUTPUT="$(${VALIDATOR} "${FIXTURE_DIR}" 2>&1)"
-STATUS=$?
-set -e
+  echo "Validating ${DIR}"
+  set +e
+  OUTPUT="$(${VALIDATOR} "${DIR}" 2>&1)"
+  STATUS=$?
+  set -e
 
-printf '%s\n' "${OUTPUT}"
+  printf '%s\n' "${OUTPUT}"
 
-if [[ ${STATUS} -ne 0 ]]; then
-  echo "Capability contract checks: FAIL"
-  exit ${STATUS}
-fi
+  if [[ ${STATUS} -ne 0 ]]; then
+    echo "Capability contract checks: FAIL"
+    exit ${STATUS}
+  fi
 
-if grep -q "\[WARN\]" <<<"${OUTPUT}"; then
+  if grep -q "\[WARN\]" <<<"${OUTPUT}"; then
+    FINAL_STATUS="WARN"
+  fi
+done
+
+if [[ "${FINAL_STATUS:-PASS}" == "WARN" ]]; then
   echo "Capability contract checks: WARN"
 else
   echo "Capability contract checks: PASS"

--- a/tests/test_capability_contracts.py
+++ b/tests/test_capability_contracts.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "capabilities"
+CATALOG_DIR = REPO_ROOT / "catalog" / "capabilities"
+CATALOG_SUBDIRECTORIES = ["robots", "end_effectors", "sensors", "tasks", "environment_assets"]
 
 
 def _load_module(name: str, path: Path):
@@ -30,10 +32,57 @@ validator = _load_module(
 
 
 class CapabilityFixturesTests(unittest.TestCase):
-    def _assert_pass(self, filename: str) -> None:
-        results = validator.validate_path(FIXTURE_DIR / filename)
+    def _assert_pass(self, target: Path) -> None:
+        results = validator.validate_path(target)
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].status, "PASS", f"{filename}: {results[0].errors} {results[0].warnings}")
+        self.assertEqual(results[0].status, "PASS", f"{target.name}: {results[0].errors} {results[0].warnings}")
+
+    def _ids_for_schema_prefix(self, directory: Path, schema_prefix: str, key: str) -> set[str]:
+        ids: set[str] = set()
+        for result in validator.validate_path(directory):
+            self.assertEqual(result.status, "PASS", f"{result.path}: {result.errors} {result.warnings}")
+            contract, _notes = validator.load_contract(Path(result.path))
+            schema_version = str(contract.get("schema_version", ""))
+            if schema_version.startswith(schema_prefix) and isinstance(contract.get(key), dict):
+                item_id = contract[key].get("id")
+                if isinstance(item_id, str):
+                    ids.add(item_id)
+        return ids
+
+    def test_catalog_directory_exists(self) -> None:
+        self.assertTrue(CATALOG_DIR.exists())
+        self.assertTrue(CATALOG_DIR.is_dir())
+
+    def test_catalog_subdirectories_exist(self) -> None:
+        for subdir in CATALOG_SUBDIRECTORIES:
+            path = CATALOG_DIR / subdir
+            self.assertTrue(path.exists(), f"Missing {subdir}")
+            self.assertTrue(path.is_dir(), f"Not a directory: {subdir}")
+
+    def test_catalog_directory_validation(self) -> None:
+        results = validator.validate_path(CATALOG_DIR)
+        self.assertGreaterEqual(len(results), 10)
+        self.assertTrue(all(r.status == "PASS" for r in results))
+
+    def test_catalog_has_all_capability_kinds(self) -> None:
+        self.assertGreaterEqual(len(self._ids_for_schema_prefix(CATALOG_DIR, "robot_capability/", "robot")), 1)
+        self.assertGreaterEqual(len(self._ids_for_schema_prefix(CATALOG_DIR, "end_effector_capability/", "end_effector")), 1)
+        self.assertGreaterEqual(len(self._ids_for_schema_prefix(CATALOG_DIR, "sensor_capability/", "sensor")), 1)
+        self.assertGreaterEqual(len(self._ids_for_schema_prefix(CATALOG_DIR, "task_capability/", "task")), 1)
+        self.assertGreaterEqual(len(self._ids_for_schema_prefix(CATALOG_DIR, "environment_asset/", "asset")), 1)
+
+    def test_catalog_contains_important_ids(self) -> None:
+        robot_ids = self._ids_for_schema_prefix(CATALOG_DIR, "robot_capability/", "robot")
+        end_effector_ids = self._ids_for_schema_prefix(CATALOG_DIR, "end_effector_capability/", "end_effector")
+        sensor_ids = self._ids_for_schema_prefix(CATALOG_DIR, "sensor_capability/", "sensor")
+        asset_ids = self._ids_for_schema_prefix(CATALOG_DIR, "environment_asset/", "asset")
+
+        self.assertIn("ur5", robot_ids)
+        self.assertTrue(any("delta" in robot_id for robot_id in robot_ids))
+        self.assertTrue(any("2f" in end_effector_id or "robotiq_2f" in end_effector_id for end_effector_id in end_effector_ids))
+        self.assertTrue(any("airpick" in end_effector_id or "suction" in end_effector_id for end_effector_id in end_effector_ids))
+        self.assertTrue(any("realsense_d435i" in sensor_id for sensor_id in sensor_ids))
+        self.assertTrue(any("conveyor" in asset_id for asset_id in asset_ids))
 
     def test_valid_robot_fixtures(self) -> None:
         for name in [
@@ -42,7 +91,7 @@ class CapabilityFixturesTests(unittest.TestCase):
             "robot_generic_scara.yaml",
             "robot_generic_gantry.yaml",
         ]:
-            self._assert_pass(name)
+            self._assert_pass(FIXTURE_DIR / name)
 
     def test_valid_end_effector_fixtures(self) -> None:
         for name in [
@@ -51,11 +100,11 @@ class CapabilityFixturesTests(unittest.TestCase):
             "ee_airpick_suction.yaml",
             "ee_vacuum_array.yaml",
         ]:
-            self._assert_pass(name)
+            self._assert_pass(FIXTURE_DIR / name)
 
     def test_valid_sensor_fixtures(self) -> None:
         for name in ["sensor_realsense_d435i.yaml", "sensor_overhead_rgbd.yaml"]:
-            self._assert_pass(name)
+            self._assert_pass(FIXTURE_DIR / name)
 
     def test_valid_task_fixtures(self) -> None:
         for name in [
@@ -66,11 +115,16 @@ class CapabilityFixturesTests(unittest.TestCase):
             "task_conveyor_sorting.yaml",
             "task_magnetic_pick_place.yaml",
         ]:
-            self._assert_pass(name)
+            self._assert_pass(FIXTURE_DIR / name)
 
     def test_valid_asset_fixtures(self) -> None:
         for name in ["asset_table.yaml", "asset_conveyor.yaml", "asset_bin.yaml", "asset_machine_fixture.yaml"]:
-            self._assert_pass(name)
+            self._assert_pass(FIXTURE_DIR / name)
+
+    def test_fixture_directory_validation(self) -> None:
+        results = validator.validate_path(FIXTURE_DIR)
+        self.assertGreaterEqual(len(results), 10)
+        self.assertTrue(all(r.status == "PASS" for r in results))
 
     def test_invalid_missing_schema_version(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -123,11 +177,6 @@ robot:
         payload = json.loads(completed.stdout)
         self.assertIn("summary", payload)
         self.assertGreaterEqual(payload["summary"]["pass"], 1)
-
-    def test_directory_validation(self) -> None:
-        results = validator.validate_path(FIXTURE_DIR)
-        self.assertGreaterEqual(len(results), 10)
-        self.assertTrue(all(r.status == "PASS" for r in results))
 
     def test_check_scripts_have_valid_bash_syntax(self) -> None:
         subprocess.run(


### PR DESCRIPTION
### Motivation

- Promote the existing known-good offline capability YAML fixtures into a first-class, product-facing Workcell Studio capability catalog so future YAML/CLI/generator/Streamlit flows can load selectable robots, end effectors, sensors, tasks, and environment assets.
- Keep the change metadata-only and offline-first without altering runtime, launch, MoveIt/planning, EPD, ROS messages, or robot motion behavior.

### Description

- Add a new shipping catalog at `catalog/capabilities/` with subdirectories `robots/`, `end_effectors/`, `sensors/`, `tasks/`, and `environment_assets/` and promote the requested fixture YAMLs into those folders while retaining the original `tests/fixtures/capabilities/` fixtures.
- Add `catalog/capabilities/README.md` describing the product-facing registry and explicitly documenting that the files are metadata-only and do not change runtime behavior.
- Update `scripts/check_capability_contracts.sh` to validate both `tests/fixtures/capabilities` and `catalog/capabilities` with per-directory output while preserving PASS/WARN/FAIL semantics.
- Extend `tests/test_capability_contracts.py` to add `CATALOG_DIR`, assert the catalog and its subdirectories exist, validate all catalog files using the existing validator, confirm at-least-one record per capability kind, and assert key IDs are present; keep fixture tests intact.
- Update `docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md` and `README.md` to document the new catalog path, layout, and example validation commands.

### Testing

- Ran unit tests with `python3 -m pytest -q tests/test_capability_contracts.py` and all tests passed.
- Ran the validator against fixtures and catalog with `python3 scripts/validate_capability_contracts.py tests/fixtures/capabilities` and `python3 scripts/validate_capability_contracts.py catalog/capabilities` and both returned PASS; JSON output via `--json` also succeeded.
- Checked `scripts/check_capability_contracts.sh` syntax with `bash -n` and executed it (`./scripts/check_capability_contracts.sh`) and it reported PASS for both directories.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb193bd44083319eb430c435479b67)