### PR TITLE
Use shipping capability catalog as default offline registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Sorting is one scenario template inside Workcell Studio, not the product itself.
 
 Roadmap: `docs/manuals/WORKCELL_STUDIO_ROADMAP.md`
 
-Workcell Studio capability catalog lives at `catalog/capabilities/` and is the source for selectable robots, end effectors, sensors, tasks, and environment assets. It is currently metadata-only, offline-first, and safe/dry-run oriented (no robot-motion runtime changes). See `docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md`.
+Workcell Studio capability catalog lives at `catalog/capabilities/` and is now the default registry for offline capability resolution tooling. It is the source for selectable robots, end effectors, sensors, tasks, and environment assets, and remains metadata-only, offline-first, and safe/dry-run oriented (no robot-motion runtime changes). See `docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md`.
 
 ## Contents
 

--- a/docs/manuals/CELL_DEFINITION_V1.md
+++ b/docs/manuals/CELL_DEFINITION_V1.md
@@ -206,6 +206,8 @@ environment:
 ```
 
 Validation behavior:
+- By default, unresolved capability IDs are checked against `catalog/capabilities/` (shipping Workcell Studio catalog).
+- `--capabilities-dir` overrides the registry path for tests or experiments (for example `tests/fixtures/capabilities`).
 - Non-strict mode: unresolved capability IDs report WARN.
 - Strict mode (`--strict`): unresolved capability IDs report FAIL.
 - Compatibility checks are best-effort and conservative to preserve backward compatibility.

--- a/docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md
+++ b/docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md
@@ -18,8 +18,8 @@ All contracts include `schema_version` and use versioned identifiers:
 - `task_capability/v1`
 - `environment_asset/v1`
 
-Shipping Workcell Studio catalog lives under `catalog/capabilities/`.
-Regression fixtures remain under `tests/fixtures/capabilities/`.
+Shipping Workcell Studio catalog lives under `catalog/capabilities/` and is the default capability registry for offline tooling.
+Regression fixtures remain under `tests/fixtures/capabilities/` for backward-compatible tests.
 
 ---
 
@@ -35,6 +35,8 @@ Regression fixtures remain under `tests/fixtures/capabilities/`.
 - `catalog/capabilities/environment_assets/`
 
 `tests/fixtures/capabilities/` remains a regression-fixture set for validator and tooling tests.
+
+The capability loader scans recursively, so nested folders like `catalog/capabilities/robots/*.yaml` and legacy flat fixtures like `tests/fixtures/capabilities/*.yaml` are both supported.
 
 All capability files remain offline metadata only and do not alter ROS 2 launch, MoveIt planning, grasp execution, EPD, or robot-motion runtime behavior.
 
@@ -266,3 +268,12 @@ This is intentionally metadata-only and does not alter runtime launch/planning/p
 - `environment_layout/v1` describes where those existing assets are placed in a specific cell.
 
 This separation prepares future GUI import/export workflows while keeping runtime behavior unchanged in this phase.
+
+
+## Cell definition validation examples
+
+```bash
+python3 scripts/validate_cell_definition.py tests/fixtures/cell_definition_sort_by_colour.yaml
+python3 scripts/validate_cell_definition.py tests/fixtures/cell_definition_sort_by_colour.yaml --capabilities-dir catalog/capabilities
+python3 scripts/validate_cell_definition.py tests/fixtures/cell_definition_sort_by_colour.yaml --capabilities-dir tests/fixtures/capabilities
+```

--- a/scripts/capability_registry.py
+++ b/scripts/capability_registry.py
@@ -9,7 +9,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-DEFAULT_CAPABILITIES_DIR = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "capabilities"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CAPABILITIES_DIR = REPO_ROOT / "catalog" / "capabilities"
+FIXTURE_CAPABILITIES_DIR = REPO_ROOT / "tests" / "fixtures" / "capabilities"
 
 try:  # Optional dependency
     import yaml as _pyyaml
@@ -208,7 +210,7 @@ def load_capability_registry(capabilities_dir: Path | None = None) -> Capability
         notes.append(f"Capability directory not found: {cap_dir}")
         return CapabilityRegistry(records, parser_notes=notes)
 
-    for path in sorted(cap_dir.iterdir()):
+    for path in sorted(cap_dir.rglob("*")):
         if path.suffix.lower() not in {".yaml", ".yml", ".json"} or not path.is_file():
             continue
         try:
@@ -219,6 +221,11 @@ def load_capability_registry(capabilities_dir: Path | None = None) -> Capability
             if not cap_id:
                 notes.append(f"{path.name}: skipped (missing capability id)")
                 continue
+            if cap_id in records:
+                prev = records[cap_id].path.relative_to(cap_dir) if records[cap_id].path.is_relative_to(cap_dir) else records[cap_id].path
+                curr = path.relative_to(cap_dir) if path.is_relative_to(cap_dir) else path
+                notes.append(f"duplicate capability id '{cap_id}': {prev} overwritten by {curr}")
+
             records[cap_id] = CapabilityRecord(
                 capability_id=cap_id,
                 schema_version=str(doc.get("schema_version", "")),

--- a/tests/test_capability_contracts.py
+++ b/tests/test_capability_contracts.py
@@ -30,6 +30,45 @@ validator = _load_module(
     "validate_capability_contracts", REPO_ROOT / "scripts" / "validate_capability_contracts.py"
 )
 
+capability_registry = _load_module(
+    "capability_registry", REPO_ROOT / "scripts" / "capability_registry.py"
+)
+
+
+
+class CapabilityRegistryLoaderTests(unittest.TestCase):
+    def test_default_registry_uses_catalog(self) -> None:
+        registry = capability_registry.load_capability_registry()
+        self.assertEqual(capability_registry.DEFAULT_CAPABILITIES_DIR, CATALOG_DIR)
+        self.assertIsNotNone(registry.get("ur5"))
+        self.assertTrue(registry.get("ur5").path.is_relative_to(CATALOG_DIR))
+
+    def test_recursive_loading_from_catalog_subfolders(self) -> None:
+        registry = capability_registry.load_capability_registry(CATALOG_DIR)
+        self.assertIsNotNone(registry.get("ur5"))
+        self.assertIsNotNone(registry.get("robotiq_2f_85"))
+        self.assertIsNotNone(registry.get("intel_realsense_d435i"))
+        self.assertIsNotNone(registry.get("sort_by_colour"))
+        self.assertIsNotNone(registry.get("conveyor_2m"))
+
+    def test_fixture_registry_still_loads(self) -> None:
+        registry = capability_registry.load_capability_registry(FIXTURE_DIR)
+        self.assertIsNotNone(registry.get("ur5"))
+        self.assertIsNotNone(registry.get("robotiq_2f_85"))
+
+    def test_known_ids_present_in_default_catalog(self) -> None:
+        registry = capability_registry.load_capability_registry()
+        expected_ids = {
+            "ur5",
+            "generic_delta_900",
+            "robotiq_2f_85",
+            "onrobot_airpick_style",
+            "intel_realsense_d435i",
+            "conveyor_2m",
+            "sort_by_colour",
+        }
+        self.assertTrue(expected_ids.issubset(set(registry.ids())))
+
 
 class CapabilityFixturesTests(unittest.TestCase):
     def _assert_pass(self, target: Path) -> None:

--- a/tests/test_cell_definition_tools.py
+++ b/tests/test_cell_definition_tools.py
@@ -387,3 +387,32 @@ class CellDefinitionWizardTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class CellDefinitionCapabilityRegistryPathTests(unittest.TestCase):
+    def test_cli_uses_default_catalog_path(self) -> None:
+        fixture = FIXTURES / "cell_definition_sort_by_colour.yaml"
+        proc = subprocess.run(
+            [sys.executable, str(REPO_ROOT / "scripts" / "validate_cell_definition.py"), str(fixture)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+
+    def test_cli_accepts_fixture_capabilities_dir(self) -> None:
+        fixture = FIXTURES / "cell_definition_sort_by_colour.yaml"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "validate_cell_definition.py"),
+                str(fixture),
+                "--capabilities-dir",
+                str(FIXTURES / "capabilities"),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+


### PR DESCRIPTION
### Motivation
- Make the product-facing Workcell Studio capability catalog the default offline registry used by tooling so shipped product metadata is the primary source for validators and generators.
- Ensure the loader supports the new catalog layout (nested subfolders for robots, end effectors, sensors, tasks, environment assets) while preserving the legacy flat fixture set for regression tests.
- Keep changes limited to metadata/tooling only and avoid any runtime, launch, MoveIt, EPD, ROS message, or robot-motion behaviour changes.

### Description
- Change default registry path by introducing `REPO_ROOT`, `DEFAULT_CAPABILITIES_DIR = REPO_ROOT / "catalog" / "capabilities"`, and a fixture constant `FIXTURE_CAPABILITIES_DIR = REPO_ROOT / "tests" / "fixtures" / "capabilities"` in `scripts/capability_registry.py`.
- Make `load_capability_registry()` scan files recursively with `cap_dir.rglob("*")` and preserve existing parser fallbacks (`pyyaml`, `json`, fallback YAML parser).
- Add deterministic duplicate-ID handling that records parser notes describing which file overwrote a previous record (non-failing behaviour) and continue loading.
- Add tests that exercise registry loading and CLI behaviour: new loader tests in `tests/test_capability_contracts.py` to assert default catalog usage, recursive loading, fixture compatibility, and presence of known shipping IDs, and CLI tests in `tests/test_cell_definition_tools.py` to validate default and overridden `--capabilities-dir` flows.
- Update docs in `docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md`, `docs/manuals/CELL_DEFINITION_V1.md`, and `README.md` to state the new default catalog, recursive scan behaviour, `tests/fixtures/capabilities/` backward compatibility, and example `validate_cell_definition.py` commands.

### Testing
- Ran unit tests: `python3 -m pytest -q tests/test_capability_contracts.py` which passed (20 tests passed) and `python3 -m pytest -q tests/test_cell_definition_tools.py` which passed (29 tests passed with 7 subtests passed).
- Ran validators and CLI checks that use the catalog and fixtures: `python3 scripts/validate_capability_contracts.py catalog/capabilities`, `python3 scripts/validate_capability_contracts.py tests/fixtures/capabilities`, and `python3 scripts/validate_cell_definition.py tests/fixtures/cell_definition_sort_by_colour.yaml` plus the same command with `--capabilities-dir catalog/capabilities` and `--capabilities-dir tests/fixtures/capabilities`, all of which completed successfully.
- Performed an interactive check of `DEFAULT_CAPABILITIES_DIR` and `load_capability_registry()` which enumerated capability IDs from the shipping catalog and returned the expected set of IDs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1cb055cc8331920b1a5a8cb94ce8)