### PR TITLE
Add offline grasp_strategy/v1 schema, catalog, and validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Sorting is one scenario template inside Workcell Studio, not the product itself.
 
 Roadmap: `docs/manuals/WORKCELL_STUDIO_ROADMAP.md`
 
-Workcell Studio capability catalog lives at `catalog/capabilities/` and is now the default registry for offline capability resolution tooling. It is the source for selectable robots, end effectors, sensors, tasks, and environment assets, and remains metadata-only, offline-first, and safe/dry-run oriented (no robot-motion runtime changes). See `docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md`.
+Workcell Studio capability catalog lives at `catalog/capabilities/` and is now the default registry for offline capability resolution tooling. Workcell Studio also includes a grasp strategy catalog at `catalog/grasp_strategies/` for offline `grasp_strategy/v1` metadata. Both catalogs remain metadata-only, offline-first, and safe/dry-run oriented (no robot-motion runtime changes). See `docs/manuals/INDUSTRIAL_CAPABILITY_CONTRACTS.md`.
 
 ## Contents
 

--- a/catalog/grasp_strategies/finger_pinch_basic.yaml
+++ b/catalog/grasp_strategies/finger_pinch_basic.yaml
@@ -1,0 +1,21 @@
+schema_version: grasp_strategy/v1
+grasp_strategy:
+  id: finger_pinch_basic
+  label: Basic Parallel Finger Pinch
+  strategy: pinch
+  compatible_tool_families: [finger_gripper, three_finger_gripper]
+  compatible_end_effector_capabilities: [robotiq_2f_85, robotiq_3f]
+  approach_axis: tool_z
+  orientation_mode: tool_aligned
+  approach_distance_m: 0.09
+  retreat_distance_m: 0.1
+  allowed_yaw_angles_deg: [0, 90, 180, 270]
+  tool_frame_offset_xyz: [0.0, 0.0, 0.0]
+  tool_frame_offset_rpy: [0.0, 0.0, 0.0]
+  contact:
+    type: pinch
+    grip_mode: parallel
+    requires_force_limit_check: true
+  release:
+    type: fingers_open
+    retreat_after_release_m: 0.05

--- a/catalog/grasp_strategies/side_grip_basic.yaml
+++ b/catalog/grasp_strategies/side_grip_basic.yaml
@@ -1,0 +1,19 @@
+schema_version: grasp_strategy/v1
+grasp_strategy:
+  id: side_grip_basic
+  label: Basic Side Grip
+  strategy: side_grip
+  compatible_tool_families: [finger_gripper, three_finger_gripper]
+  compatible_end_effector_capabilities: [robotiq_2f_85]
+  approach_axis: x_plus
+  orientation_mode: horizontal
+  approach_distance_m: 0.08
+  retreat_distance_m: 0.08
+  tool_frame_offset_xyz: [0.0, 0.0, 0.0]
+  tool_frame_offset_rpy: [0.0, 0.0, 0.0]
+  contact:
+    type: side_contact
+    grip_mode: friction
+  release:
+    type: fingers_open
+    retreat_after_release_m: 0.04

--- a/catalog/grasp_strategies/suction_top_basic.yaml
+++ b/catalog/grasp_strategies/suction_top_basic.yaml
@@ -1,0 +1,25 @@
+schema_version: grasp_strategy/v1
+grasp_strategy:
+  id: suction_top_basic
+  label: Basic Top-Down Suction
+  strategy: suction_top
+  compatible_tool_families: [suction, vacuum_array]
+  compatible_end_effector_capabilities: [onrobot_airpick_style, generic_vacuum_array]
+  approach_axis: z_down
+  orientation_mode: vertical
+  approach_distance_m: 0.12
+  retreat_distance_m: 0.10
+  allowed_roll_angles_deg: [0, 90, 180, 270]
+  allowed_yaw_angles_deg: [0, 90, 180, 270]
+  tool_frame_offset_xyz: [0.0, 0.0, 0.0]
+  tool_frame_offset_rpy: [0.0, 0.0, 0.0]
+  contact:
+    type: suction
+    suction_cups: 1
+    requires_seal_check: false
+  release:
+    type: vacuum_off
+    retreat_after_release_m: 0.05
+  limitations_warnings:
+    - Requires flat enough top surface.
+    - Metadata only; not a suction reliability guarantee.

--- a/catalog/grasp_strategies/vacuum_array_top_basic.yaml
+++ b/catalog/grasp_strategies/vacuum_array_top_basic.yaml
@@ -1,0 +1,20 @@
+schema_version: grasp_strategy/v1
+grasp_strategy:
+  id: vacuum_array_top_basic
+  label: Basic Top Vacuum Array
+  strategy: vacuum_array_top
+  compatible_tool_families: [vacuum_array, suction]
+  compatible_end_effector_capabilities: [generic_vacuum_array]
+  approach_axis: z_down
+  orientation_mode: vertical
+  approach_distance_m: 0.1
+  retreat_distance_m: 0.08
+  tool_frame_offset_xyz: [0.0, 0.0, 0.0]
+  tool_frame_offset_rpy: [0.0, 0.0, 0.0]
+  contact:
+    type: vacuum_array
+    suction_cups: 4
+    requires_seal_check: false
+  release:
+    type: vacuum_off
+    retreat_after_release_m: 0.03

--- a/docs/manuals/CELL_DEFINITION_V1.md
+++ b/docs/manuals/CELL_DEFINITION_V1.md
@@ -230,3 +230,30 @@ Validation behavior:
 - Backward compatibility: cell definitions without `environment.layout` remain valid.
 
 See `docs/manuals/ENVIRONMENT_LAYOUT_V1.md`.
+
+## Optional grasp strategy
+
+Cell definitions may include an optional `grasp` block for metadata-only grasp intent. This is resolved from `catalog/grasp_strategies/` and does not change runtime motion, MoveIt planning, or execution behaviour yet.
+
+Reference form:
+```yaml
+grasp:
+  strategy_ref: suction_top_basic
+```
+
+Inline form:
+```yaml
+grasp:
+  strategy:
+    schema_version: grasp_strategy/v1
+    grasp_strategy:
+      id: inline_suction_top
+      label: Inline suction top
+      strategy: suction_top
+      approach_axis: z_down
+      orientation_mode: vertical
+      approach_distance_m: 0.1
+      retreat_distance_m: 0.1
+      contact: {type: suction}
+      release: {type: vacuum_off}
+```

--- a/docs/manuals/GRASP_STRATEGY_V1.md
+++ b/docs/manuals/GRASP_STRATEGY_V1.md
@@ -1,0 +1,21 @@
+# Grasp Strategy v1
+
+`grasp_strategy/v1` defines **offline metadata only** for grasp intent in Workcell Studio.
+
+It does **not** prove reachability, collision safety, suction reliability, IO safety, or runtime readiness. It does **not** change MoveIt planning, EMD execution, or robot runtime behaviour in this phase.
+
+A strategy describes how a tool should approach, orient, contact, retreat, and release for later YAML/CLI/generator/Streamlit workflows.
+
+Schema core:
+- `schema_version: grasp_strategy/v1`
+- `grasp_strategy.id`, `label`, `strategy`
+- optional compatibility hints (`compatible_tool_families`, `compatible_end_effector_capabilities`)
+- approach/orientation metadata (`approach_axis`, `orientation_mode`, distances, optional angle sets)
+- optional tool frame offsets
+- required `contact` and `release` mappings
+- optional `limitations_warnings`
+
+Validate:
+```bash
+python3 scripts/validate_grasp_strategy.py catalog/grasp_strategies
+```

--- a/scripts/check_grasp_strategies.sh
+++ b/scripts/check_grasp_strategies.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 scripts/validate_grasp_strategy.py catalog/grasp_strategies

--- a/scripts/validate_cell_definition.py
+++ b/scripts/validate_cell_definition.py
@@ -17,6 +17,7 @@ if str(SCRIPTS_DIR) not in sys.path:
 
 from capability_registry import DEFAULT_CAPABILITIES_DIR, load_capability_registry
 import validate_task_recipe as task_recipe_validator
+import validate_grasp_strategy as grasp_strategy_validator
 
 try:  # Optional dependency.
     import yaml as _pyyaml
@@ -49,6 +50,7 @@ class ValidationSummary:
     notes: list[str] = field(default_factory=list)
     capability_summary: dict[str, Any] = field(default_factory=dict)
     environment_layout_summary: dict[str, Any] = field(default_factory=dict)
+    grasp_strategy_summary: dict[str, Any] = field(default_factory=dict)
 
     @property
     def ok(self) -> bool:
@@ -393,6 +395,7 @@ def validate_cell_definition(
     environment = defn.get("environment") if isinstance(defn.get("environment"), dict) else {}
     objects = defn.get("objects") if isinstance(defn.get("objects"), list) else []
     task = defn.get("task") if isinstance(defn.get("task"), dict) else {}
+    grasp = defn.get("grasp") if isinstance(defn.get("grasp"), dict) else None
 
     if "safe_joint_state" not in robot:
         result.errors.append("robot.safe_joint_state key is required (empty list allowed when home_named_target exists).")
@@ -500,6 +503,48 @@ def validate_cell_definition(
 
     if task_type in SORTING_TASK_TYPES and not fallback_present:
         result.warnings.append("Sorting task has no explicit fallback rule with when.always=true.")
+
+    grasp_catalog_dir = Path(__file__).resolve().parents[1] / "catalog" / "grasp_strategies"
+    grasp_summary: dict[str, Any] = {"mode": "none", "status": "PASS", "ref": None, "resolved_path": None}
+    if grasp is not None:
+        grasp_summary["mode"] = "present"
+        strategy_ref = grasp.get("strategy_ref")
+        inline_strategy = grasp.get("strategy")
+        if strategy_ref and inline_strategy:
+            result.errors.append("grasp must provide either strategy_ref or strategy, not both.")
+        elif strategy_ref is not None:
+            if not isinstance(strategy_ref, str) or not strategy_ref.strip():
+                result.errors.append("grasp.strategy_ref must be a non-empty string when provided.")
+            else:
+                grasp_summary["mode"] = "strategy_ref"
+                grasp_summary["ref"] = strategy_ref
+                matches = [p for p in grasp_catalog_dir.rglob("*") if p.is_file() and p.suffix.lower() in {".yaml", ".yml", ".json"} and p.stem == strategy_ref]
+                if not matches:
+                    msg = f"Unknown grasp strategy_ref '{strategy_ref}' in catalog/grasp_strategies."
+                    (result.errors if strict else result.warnings).append(msg)
+                    grasp_summary["status"] = "FAIL" if strict else "WARN"
+                else:
+                    selected = sorted(matches)[0]
+                    grasp_summary["resolved_path"] = str(selected)
+                    doc, parser_used = grasp_strategy_validator.load_structured_data(selected)
+                    gs_result = grasp_strategy_validator.validate_doc(
+                        doc, selected, parser_used, strict=strict, capabilities_dir=capabilities_dir
+                    )
+                    result.warnings.extend([f"grasp.strategy_ref({strategy_ref}): {w}" for w in gs_result.warnings])
+                    result.errors.extend([f"grasp.strategy_ref({strategy_ref}): {e}" for e in gs_result.errors])
+        elif inline_strategy is not None:
+            if not isinstance(inline_strategy, dict):
+                result.errors.append("grasp.strategy must be a mapping when provided.")
+            else:
+                grasp_summary["mode"] = "inline"
+                gs_result = grasp_strategy_validator.validate_doc(
+                    inline_strategy, path, parser, strict=strict, capabilities_dir=capabilities_dir
+                )
+                result.warnings.extend([f"grasp.strategy: {w}" for w in gs_result.warnings])
+                result.errors.extend([f"grasp.strategy: {e}" for e in gs_result.errors])
+        else:
+            result.errors.append("grasp block must include strategy_ref or strategy.")
+    result.grasp_strategy_summary = grasp_summary
 
     recipe_ref = task.get("recipe")
     if recipe_ref is not None:
@@ -633,6 +678,7 @@ def main() -> int:
             "result": "PASS" if summary.ok and not summary.warnings else "WARN" if summary.ok else "FAIL",
             "capabilities": summary.capability_summary,
             "environment_layout": summary.environment_layout_summary,
+            "grasp_strategy": summary.grasp_strategy_summary,
         }
         print(json.dumps(payload, indent=2, sort_keys=True))
     elif not args.quiet:

--- a/scripts/validate_grasp_strategy.py
+++ b/scripts/validate_grasp_strategy.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Validate offline grasp_strategy/v1 metadata files."""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from capability_registry import DEFAULT_CAPABILITIES_DIR, load_capability_registry, load_structured_data
+
+ALLOWED_STRATEGIES = {"suction_top","suction_side","vacuum_array_top","pinch","enveloping","side_grip","magnetic_pick","custom"}
+ALLOWED_APPROACH_AXIS = {"z_down","z_up","x_plus","x_minus","y_plus","y_minus","tool_z","custom"}
+ALLOWED_ORIENTATION_MODE = {"vertical","horizontal","tool_aligned","object_aligned","free","custom"}
+ALLOWED_TOOL_FAMILIES = {"finger_gripper","three_finger_gripper","suction","vacuum_array","magnetic","tool_changer","custom"}
+
+@dataclass
+class Result:
+    path: Path
+    parser: str
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def status(self) -> str:
+        return "FAIL" if self.errors else ("WARN" if self.warnings else "PASS")
+
+def _num_list(v: Any, n: int|None=None) -> bool:
+    return isinstance(v,list) and (n is None or len(v)==n) and all(isinstance(i,(int,float)) for i in v)
+
+def validate_doc(doc: dict[str, Any], path: Path, parser: str, strict: bool=False, capabilities_dir: Path|None=None) -> Result:
+    r = Result(path=path, parser=parser)
+    gs = doc.get("grasp_strategy")
+    if doc.get("schema_version") != "grasp_strategy/v1":
+        r.errors.append("schema_version must be exactly 'grasp_strategy/v1'.")
+    if not isinstance(gs, dict):
+        r.errors.append("grasp_strategy mapping is required.")
+        return r
+    if not isinstance(gs.get("id"), str) or not gs["id"].strip(): r.errors.append("grasp_strategy.id must be a non-empty string.")
+    if not isinstance(gs.get("label"), str) or not gs["label"].strip(): r.errors.append("grasp_strategy.label must be a non-empty string.")
+    if not isinstance(gs.get("strategy"), str) or gs["strategy"] not in ALLOWED_STRATEGIES: r.errors.append("grasp_strategy.strategy must be a supported strategy enum.")
+    fams = gs.get("compatible_tool_families")
+    if fams is not None:
+        if not isinstance(fams, list) or not all(isinstance(f, str) for f in fams): r.errors.append("compatible_tool_families must be a list of strings when provided.")
+        else:
+            bad = [f for f in fams if f not in ALLOWED_TOOL_FAMILIES]
+            if bad: r.errors.append(f"Unsupported tool families: {bad}")
+    if gs.get("approach_axis") not in ALLOWED_APPROACH_AXIS: r.errors.append("approach_axis must be a supported enum.")
+    if gs.get("orientation_mode") not in ALLOWED_ORIENTATION_MODE: r.errors.append("orientation_mode must be a supported enum.")
+    if not isinstance(gs.get("approach_distance_m"),(int,float)) or gs["approach_distance_m"] <= 0: r.errors.append("approach_distance_m must be a positive number.")
+    if not isinstance(gs.get("retreat_distance_m"),(int,float)) or gs["retreat_distance_m"] <= 0: r.errors.append("retreat_distance_m must be a positive number.")
+    for key in ("tool_frame_offset_xyz","tool_frame_offset_rpy"):
+        if key in gs and not _num_list(gs.get(key),3): r.errors.append(f"{key} must be a numeric list length 3 when provided.")
+    for key in ("allowed_roll_angles_deg","allowed_yaw_angles_deg"):
+        if key in gs and not _num_list(gs.get(key)): r.errors.append(f"{key} must be a numeric list when provided.")
+    if not isinstance(gs.get("contact"), dict): r.errors.append("contact mapping is required.")
+    if not isinstance(gs.get("release"), dict): r.errors.append("release mapping is required.")
+
+    registry = load_capability_registry(capabilities_dir)
+    r.notes.extend(registry.parser_notes)
+    comp_ids = gs.get("compatible_end_effector_capabilities")
+    if isinstance(comp_ids, list):
+        for cap_id in comp_ids:
+            if not isinstance(cap_id, str):
+                r.errors.append("compatible_end_effector_capabilities must contain strings only.")
+                continue
+            rec = registry.get(cap_id)
+            if rec is None:
+                (r.errors if strict else r.warnings).append(f"Unknown compatible end-effector capability id '{cap_id}'.")
+                continue
+            if isinstance(fams, list) and rec.family and rec.family not in fams:
+                r.errors.append(f"Capability '{cap_id}' family '{rec.family}' is not in compatible_tool_families.")
+    return r
+
+def _iter_files(target: Path) -> list[Path]:
+    if target.is_file(): return [target]
+    return sorted(p for p in target.rglob("*") if p.is_file() and p.suffix.lower() in {".yaml",".yml",".json"})
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("path", type=Path)
+    ap.add_argument("--strict", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--capabilities-dir", type=Path, default=DEFAULT_CAPABILITIES_DIR)
+    args = ap.parse_args()
+    results=[]
+    for p in _iter_files(args.path):
+        try:
+            doc, parser = load_structured_data(p)
+            res = validate_doc(doc, p, parser, strict=args.strict, capabilities_dir=args.capabilities_dir)
+        except Exception as exc:
+            res = Result(path=p, parser="unknown", errors=[str(exc)])
+        results.append(res)
+    summary={"pass":sum(1 for r in results if r.status=="PASS"),"warn":sum(1 for r in results if r.status=="WARN"),"fail":sum(1 for r in results if r.status=="FAIL"),"total":len(results)}
+    if args.json:
+        print(json.dumps({"summary":summary,"results":[{"path":str(r.path),"parser":r.parser,"result":r.status,"errors":r.errors,"warnings":r.warnings,"notes":r.notes} for r in results]}, indent=2))
+    else:
+        for r in results:
+            print(f"{r.status}: {r.path}")
+            for n in r.notes: print(f"  NOTE: {n}")
+            for w in r.warnings: print(f"  WARN: {w}")
+            for e in r.errors: print(f"  FAIL: {e}")
+        print(f"SUMMARY: PASS={summary['pass']} WARN={summary['warn']} FAIL={summary['fail']} TOTAL={summary['total']}")
+    return 1 if summary["fail"] else 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/cell_definition_sort_by_colour_with_grasp_strategy.yaml
+++ b/tests/fixtures/cell_definition_sort_by_colour_with_grasp_strategy.yaml
@@ -1,0 +1,78 @@
+schema_version: cell_definition/v1
+cell:
+  id: ur5_colour_sort_cell
+  name: UR5 colour sort cell
+  description: Sort by colour preview
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: robotiq_2f
+  type: finger
+  brand: robotiq
+  grasp_frame: ee_palm
+  allowed_touch_links: [gripper_finger1_finger_tip_link, gripper_finger2_finger_tip_link]
+camera:
+  id: realsense_d435i
+  type: depth_camera
+  frame: camera_depth_optical_frame
+environment:
+  frame: world
+  support_surfaces:
+    - id: table_main
+      type: table
+      frame: world
+      pose_xyz: [0.0, 0.0, 0.0]
+      pose_rpy: [0.0, 0.0, 0.0]
+      dimensions: [1.0, 1.0, 0.05]
+objects:
+  - id: detected_object
+    class: part
+    shape: box
+    color: red
+    material: plastic
+    frame: world
+    dimensions: [0.04, 0.04, 0.04]
+    pose_xyz: [0.45, 0.0, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+task:
+  id: colour_sorting_task
+  type: sort_by_colour
+  source_object: detected_object
+  destinations:
+    - id: red_bin
+      frame: world
+      pose_xyz: [0.35, -0.30, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+    - id: blue_bin
+      frame: world
+      pose_xyz: [0.35, 0.30, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+    - id: reject_bin
+      frame: world
+      pose_xyz: [0.20, 0.0, 0.10]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: red_to_red_bin
+      when:
+        color: red
+      destination: red_bin
+    - id: blue_to_blue_bin
+      when:
+        color: blue
+      destination: blue_bin
+    - id: fallback
+      when:
+        always: true
+      destination: reject_bin
+grasp:
+  strategy_ref: suction_top_basic
+
+commissioning:
+  self_test_enabled: true
+  export_bundle: true
+  require_operator_review: true

--- a/tests/test_cell_definition_tools.py
+++ b/tests/test_cell_definition_tools.py
@@ -46,6 +46,9 @@ class CellDefinitionValidationTests(unittest.TestCase):
     def test_valid_sort_by_colour_cell_definition_passes(self) -> None:
         summary = self._validate_fixture("cell_definition_sort_by_colour.yaml")
         self.assertTrue(summary.ok)
+    def test_valid_sort_by_colour_with_grasp_strategy_ref_passes(self) -> None:
+        summary = self._validate_fixture("cell_definition_sort_by_colour_with_grasp_strategy.yaml")
+        self.assertTrue(summary.ok)
 
     def test_valid_sort_by_shape_cell_definition_passes(self) -> None:
         summary = self._validate_fixture("cell_definition_sort_by_shape.yaml")
@@ -82,6 +85,20 @@ class CellDefinitionValidationTests(unittest.TestCase):
         summary = validator.validate_cell_definition(loaded, FIXTURES / "cell_definition_sort_by_colour.yaml", parser, notes)
         self.assertFalse(summary.ok)
         self.assertIn("ghost_bin", " ".join(summary.errors))
+
+    def test_unknown_grasp_strategy_warns_by_default(self) -> None:
+        loaded, parser, notes = validator.load_yaml(FIXTURES / "cell_definition_sort_by_colour_with_grasp_strategy.yaml")
+        loaded["grasp"]["strategy_ref"] = "missing_grasp"
+        summary = validator.validate_cell_definition(loaded, FIXTURES / "cell_definition_sort_by_colour_with_grasp_strategy.yaml", parser, notes, strict=False)
+        self.assertTrue(summary.ok)
+        self.assertTrue(any("Unknown grasp strategy_ref" in w for w in summary.warnings))
+
+    def test_unknown_grasp_strategy_fails_in_strict_mode(self) -> None:
+        loaded, parser, notes = validator.load_yaml(FIXTURES / "cell_definition_sort_by_colour_with_grasp_strategy.yaml")
+        loaded["grasp"]["strategy_ref"] = "missing_grasp"
+        summary = validator.validate_cell_definition(loaded, FIXTURES / "cell_definition_sort_by_colour_with_grasp_strategy.yaml", parser, notes, strict=True)
+        self.assertFalse(summary.ok)
+        self.assertTrue(any("Unknown grasp strategy_ref" in e for e in summary.errors))
 
 
 class CellDefinitionGenerationTests(unittest.TestCase):
@@ -415,4 +432,3 @@ class CellDefinitionCapabilityRegistryPathTests(unittest.TestCase):
             check=False,
         )
         self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
-

--- a/tests/test_grasp_strategy_schema.py
+++ b/tests/test_grasp_strategy_schema.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+import json, subprocess, sys, tempfile, unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / 'scripts' / 'validate_grasp_strategy.py'
+CATALOG = REPO_ROOT / 'catalog' / 'grasp_strategies'
+
+class GraspStrategyTests(unittest.TestCase):
+    def run_cmd(self,*args):
+        return subprocess.run([sys.executable, str(SCRIPT), *args], capture_output=True, text=True, check=False)
+
+    def test_catalog_files_pass(self):
+        p=self.run_cmd(str(CATALOG)); self.assertEqual(p.returncode,0)
+    def test_single_file_passes(self):
+        p=self.run_cmd(str(CATALOG/'suction_top_basic.yaml')); self.assertEqual(p.returncode,0)
+    def test_missing_schema_version_fails(self):
+        with tempfile.TemporaryDirectory() as d:
+            f=Path(d)/'bad.yaml'; f.write_text('grasp_strategy: {}\n')
+            p=self.run_cmd(str(f)); self.assertNotEqual(p.returncode,0)
+    def test_missing_grasp_strategy_fails(self):
+        with tempfile.TemporaryDirectory() as d:
+            f=Path(d)/'bad.yaml'; f.write_text('schema_version: grasp_strategy/v1\n')
+            p=self.run_cmd(str(f)); self.assertNotEqual(p.returncode,0)
+    def test_non_positive_approach_fails(self):
+        with tempfile.TemporaryDirectory() as d:
+            f=Path(d)/'bad.yaml'; f.write_text((CATALOG/'suction_top_basic.yaml').read_text().replace('approach_distance_m: 0.12','approach_distance_m: 0.0'))
+            p=self.run_cmd(str(f)); self.assertNotEqual(p.returncode,0)
+    def test_unknown_ee_warn_default_fail_strict(self):
+        with tempfile.TemporaryDirectory() as d:
+            f=Path(d)/'warn.yaml'; t=(CATALOG/'suction_top_basic.yaml').read_text().replace('onrobot_airpick_style','unknown_ee')
+            f.write_text(t)
+            p=self.run_cmd(str(f)); self.assertEqual(p.returncode,0); self.assertIn('WARN',p.stdout)
+            s=self.run_cmd(str(f),'--strict'); self.assertNotEqual(s.returncode,0)
+    def test_json_output(self):
+        p=self.run_cmd(str(CATALOG),'--json'); self.assertEqual(p.returncode,0); o=json.loads(p.stdout); self.assertIn('summary',o); self.assertIn('results',o)
+    def test_recursive_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            nested=Path(d)/'a'/'b'; nested.mkdir(parents=True)
+            (nested/'x.yaml').write_text((CATALOG/'finger_pinch_basic.yaml').read_text())
+            p=self.run_cmd(d); self.assertEqual(p.returncode,0)
+
+if __name__=='__main__': unittest.main()


### PR DESCRIPTION
### Motivation
- Introduce a first-class offline `grasp_strategy/v1` metadata layer so Workcell Studio tooling can select and tune grasp behaviour without changing runtime systems. 
- Provide a small, practical schema that supports suction, vacuum-array and finger/pinch style strategies as metadata-only descriptors. 
- Keep all checks conservative and offline-only and integrate compatibility lookups with the existing capability registry for better commissioning feedback.

### Description
- Add schema manual `docs/manuals/GRASP_STRATEGY_V1.md` describing metadata-only scope, non-goals, and core fields for `grasp_strategy/v1`.
- Add example catalog entries under `catalog/grasp_strategies/`: `suction_top_basic.yaml`, `vacuum_array_top_basic.yaml`, `finger_pinch_basic.yaml`, and `side_grip_basic.yaml`.
- Add `scripts/validate_grasp_strategy.py` which recursively validates `.yaml/.yml/.json` inputs, supports `--json`, `--strict`, `--capabilities-dir`, reports PASS/WARN/FAIL per-file, and uses the capability registry for conservative compatibility warnings/fails.
- Integrate optional `grasp` support into `scripts/validate_cell_definition.py` to accept `grasp.strategy_ref` (resolved from `catalog/grasp_strategies/`) or inline `grasp.strategy`, to validate inline payloads, and to include a `grasp_strategy` summary in JSON output without affecting runtime behavior.
- Add helper `scripts/check_grasp_strategies.sh`, cell-definition fixture `tests/fixtures/cell_definition_sort_by_colour_with_grasp_strategy.yaml`, unit tests `tests/test_grasp_strategy_schema.py`, and extended cell-definition tests in `tests/test_cell_definition_tools.py`.
- Update `docs/manuals/CELL_DEFINITION_V1.md` and `README.md` to reference `catalog/grasp_strategies/` and clarify that grasp strategies are metadata-only.

### Testing
- Ran unit tests with `python3 -m pytest -q tests/test_grasp_strategy_schema.py` and `python3 -m pytest -q tests/test_cell_definition_tools.py`, both suites passed.
- Ran validator and integrations: `python3 scripts/validate_grasp_strategy.py catalog/grasp_strategies` and `python3 scripts/validate_grasp_strategy.py catalog/grasp_strategies --json`, both succeeded and produced expected PASS/WARN/FAIL output and JSON summary.
- Verified cell-definition integration with `python3 scripts/validate_cell_definition.py tests/fixtures/cell_definition_sort_by_colour_with_grasp_strategy.yaml` and its `--json` variant, and also validated the original fixture `tests/fixtures/cell_definition_sort_by_colour.yaml`, all succeeded.
- Syntax and helper checks `bash -n scripts/check_grasp_strategies.sh` and `./scripts/check_grasp_strategies.sh` succeeded, and manual checks for files and docs (e.g. `find catalog/grasp_strategies`, `grep -n "grasp_strategy/v1" docs/manuals/GRASP_STRATEGY_V1.md`) returned expected results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1dcb5f6c8331b92141bdeaef7673)