### PR TITLE
Fix generated workcell offline execution plan failures with grasp strategy metadata

### DIFF
--- a/scripts/generate_workcell_from_cell_definition.py
+++ b/scripts/generate_workcell_from_cell_definition.py
@@ -366,6 +366,21 @@ def _run_optional_bundle_export(
         warnings.append(f"Optional commissioning bundle export skipped: {exc}")
 
 
+def _summarize_plan_failure(plan_result: Any, dry_result: Any, manifest_path: Path) -> str:
+    dry_status = getattr(dry_result, "status", "UNKNOWN")
+    matched_rule = getattr(plan_result, "matched_rule_id", "(n/a)") or "(n/a)"
+    destination_id = getattr(plan_result, "destination_id", "(n/a)") or "(n/a)"
+    notes = [str(n).strip() for n in getattr(plan_result, "notes", []) if str(n).strip()]
+    note_text = "; ".join(notes[:3]) if notes else "no additional notes"
+    if len(notes) > 3:
+        note_text += f"; (+{len(notes)-3} more)"
+    return (
+        f"Execution plan generation status: {getattr(plan_result, 'status', 'UNKNOWN')} "
+        f"(dry-run={dry_status}, matched_rule={matched_rule}, destination={destination_id}, "
+        f"manifest={manifest_path}, notes={note_text})"
+    )
+
+
 def generate_package(
     cell_definition_path: Path,
     output_dir: Path,
@@ -476,7 +491,7 @@ def generate_package(
                 shutil.copy2(plan_result.markdown_path, package_dir / "generated" / "execution_plan.md")
                 shutil.copy2(plan_result.json_path, package_dir / "generated" / "execution_plan.json")
             else:
-                warnings.append(f"Execution plan generation status: {plan_result.status}")
+                warnings.append(_summarize_plan_failure(plan_result, dry_result, scene_manifest_path))
         finally:
             plan_generator.OUTPUT_DIR = original_plan_dir
 

--- a/scripts/validate_scene_contract.py
+++ b/scripts/validate_scene_contract.py
@@ -511,6 +511,15 @@ def _is_non_empty_string(value: Any) -> bool:
     return isinstance(value, str) and bool(value.strip())
 
 
+def _is_valid_pick_grasp_strategy(value: Any) -> bool:
+    if _is_non_empty_string(value):
+        return True
+    if isinstance(value, dict):
+        strategy_ref = value.get("strategy_ref")
+        return strategy_ref is None or _is_non_empty_string(strategy_ref)
+    return False
+
+
 def _is_int_and_not_bool(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
@@ -587,8 +596,11 @@ def validate_task_recipe_block(manifest: dict[str, Any]) -> tuple[str, list[str]
                     + "."
                 )
             grasp_strategy = pick.get("grasp_strategy")
-            if grasp_strategy is not None and not _is_non_empty_string(grasp_strategy):
-                notes.append("task_recipe.pick.grasp_strategy must be non-empty string when provided.")
+            if grasp_strategy is not None and not _is_valid_pick_grasp_strategy(grasp_strategy):
+                notes.append(
+                    "task_recipe.pick.grasp_strategy must be a non-empty string, "
+                    "or a mapping with optional non-empty strategy_ref."
+                )
             allowed_methods = pick.get("allowed_grasp_methods")
             if allowed_methods is not None and not isinstance(allowed_methods, list):
                 notes.append("task_recipe.pick.allowed_grasp_methods must be a list when provided.")

--- a/tests/test_cell_definition_tools.py
+++ b/tests/test_cell_definition_tools.py
@@ -284,6 +284,10 @@ class WorkcellPackageGenerationTests(unittest.TestCase):
                 (package_dir / "generated" / "generated_workcell_summary.json").read_text(encoding="utf-8")
             )
             self.assertIn("grasp_strategy", summary_payload)
+            self.assertTrue((package_dir / "generated" / "execution_plan.md").is_file())
+            self.assertTrue((package_dir / "generated" / "execution_plan.json").is_file())
+            warning_blob = "\n".join(summary_payload.get("warnings", []))
+            self.assertNotIn("Execution plan generation status: FAIL", warning_blob)
 
 
 class CellDefinitionWizardTests(unittest.TestCase):


### PR DESCRIPTION
### Motivation
- Reproduce a non-fatal `Execution plan generation status: FAIL` emitted for generated packages that include grasp-strategy metadata.
- Diagnose root cause as the scene contract validator requiring `task_recipe.pick.grasp_strategy` to be a non-empty string while generation now emits a mapping metadata form.
- Improve generator diagnostics so offline plan failures are actionable and to ensure generated grasp-strategy previews produce clean offline execution plans.

### Description
- Allow `task_recipe.pick.grasp_strategy` to be either a non-empty string or a mapping whose optional `strategy_ref` is a non-empty string by adding `_is_valid_pick_grasp_strategy` and using it in validation in `scripts/validate_scene_contract.py`.
- Add a `_summarize_plan_failure` helper to `scripts/generate_workcell_from_cell_definition.py` and use it to append bounded, actionable failure diagnostics including dry-run status, matched rule, destination id, manifest path, and trimmed notes when plan generation is not `PASS`.
- Ensure the generator still writes execution plan artifacts (`execution_plan.md` and `execution_plan.json`) on PASS and preserves grasp strategy metadata in generated summaries and manifests.
- Add regression assertions in `tests/test_cell_definition_tools.py` to check that the grasp-strategy fixture produces execution plan artifacts and that the generated summary warnings do not contain the old `Execution plan generation status: FAIL` message.

### Testing
- Ran unit/test suites: `python3 -m pytest -q tests/test_generated_cell_acceptance.py`, `python3 -m pytest -q tests/test_workcell_project_tools.py`, and `python3 -m pytest -q tests/test_cell_definition_tools.py`, and all tests passed.
- Exercised generation and validation for the problematic fixture using `python3 scripts/validate_cell_definition.py tests/fixtures/cell_definition_sort_by_colour_with_grasp_strategy.yaml` which reported `RESULT: PASS`.
- Generated preview and full package with `python3 scripts/generate_scene_from_cell_definition.py ...` and `python3 scripts/generate_workcell_from_cell_definition.py ...` and confirmed that the generated package now contains `generated/execution_plan.md` and `generated/execution_plan.json` and that the generated summary does not include the old `FAIL` warning.
- All automated checks above completed successfully and the new regression assertions also pass in CI-local test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5b08c5c08331a953be7a78beef1b)