### PR TITLE
Make UR5 + suction a first-class generated Workcell Studio path

### DIFF
--- a/scripts/create_cell_definition_wizard.py
+++ b/scripts/create_cell_definition_wizard.py
@@ -497,6 +497,8 @@ def _build_definition(args: argparse.Namespace) -> dict[str, Any]:
     if capability_args["environment_assets"]:
         data.setdefault("environment", {}).setdefault("assets", [])
         data["environment"]["assets"] = [{"capability": cap} for cap in capability_args["environment_assets"]]
+    if isinstance(args.grasp_strategy, str) and args.grasp_strategy.strip():
+        data["grasp"] = {"strategy_ref": args.grasp_strategy.strip()}
 
     return data
 
@@ -539,6 +541,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--end-effector-capability", type=str, help="Optional end-effector capability id")
     parser.add_argument("--sensor-capability", type=str, help="Optional sensor capability ids (comma-separated)")
     parser.add_argument("--task-capability", type=str, help="Optional task capability id")
+    parser.add_argument("--grasp-strategy", type=str, help="Optional grasp strategy reference id")
     parser.add_argument("--asset-capability", action="append", default=[], help="Optional asset capability id (repeatable)")
     parser.add_argument("--asset-capabilities", dest="asset_capabilities_csv", type=str, help="Optional asset capability ids comma-separated")
     parser.add_argument("--pick-source", type=str, default="commissioning_object", help="Source object id")

--- a/scripts/generate_scene_from_cell_definition.py
+++ b/scripts/generate_scene_from_cell_definition.py
@@ -142,6 +142,8 @@ def build_scene_manifest(cell_def: dict[str, Any], capability_summary: dict[str,
 
     self_test_object = objects[0] if objects else {}
 
+    ee_type = str(end_effector.get("type", "unknown")).strip().lower()
+    is_suction = ee_type in {"suction", "vacuum", "vacuum_array"}
     manifest = {
         "schema_version": "1.0",
         "scene": {"name": cell.get("id", "generated_cell")},
@@ -154,10 +156,11 @@ def build_scene_manifest(cell_def: dict[str, Any], capability_summary: dict[str,
         },
         "planning": {"pipeline": "ompl", "planner_id": "RRTConnectkConfigDefault"},
         "end_effector": {
-            "type": end_effector.get("type", "unknown"),
+            "type": "vacuum_array" if ee_type == "vacuum_array" else ("suction" if is_suction else end_effector.get("type", "unknown")),
             "brand": end_effector.get("brand", "unknown"),
             "grasp_frame": end_effector.get("grasp_frame", "tool0"),
             "allowed_touch_links": end_effector.get("allowed_touch_links", []),
+            "contact_links": end_effector.get("contact_links", end_effector.get("allowed_touch_links", [])),
         },
         "frames": {
             "world": environment.get("frame", "world"),
@@ -236,6 +239,12 @@ def build_scene_manifest(cell_def: dict[str, Any], capability_summary: dict[str,
                 else 0,
                 "rules_count": len(rules) if isinstance(rules, list) else 0,
             }
+    if is_suction:
+        manifest["end_effector"]["supported_grasp_strategies"] = end_effector.get("supported_grasp_strategies", [])
+        manifest["end_effector"]["required_io_signals"] = end_effector.get("required_io_signals", [])
+        manifest["end_effector"]["release_behavior"] = end_effector.get("release_behavior", {"mode": "vacuum_off"})
+        manifest["end_effector"]["metadata_only"] = True
+        manifest["end_effector"]["runtime_io_applied"] = False
 
     return manifest
 
@@ -267,9 +276,12 @@ def build_task_recipe(cell_def: dict[str, Any]) -> dict[str, Any]:
     task_type = str(task.get("type", "custom"))
     grasp_strategy = extract_grasp_strategy_metadata(cell_def)
     strategy_type = str((grasp_strategy or {}).get("strategy", "")).lower()
+    strategy_ref = str((grasp_strategy or {}).get("strategy_ref", "")).lower()
     default_methods = ["finger", "suction"]
-    if strategy_type:
+    if strategy_type or strategy_ref:
         if any(token in strategy_type for token in ("suction", "vacuum")):
+            default_methods = ["suction"]
+        elif any(token in strategy_ref for token in ("suction", "vacuum")):
             default_methods = ["suction"]
         elif any(token in strategy_type for token in ("pinch", "side_grip", "finger")):
             default_methods = ["finger"]
@@ -287,6 +299,8 @@ def build_task_recipe(cell_def: dict[str, Any]) -> dict[str, Any]:
             "source": task.get("source_object", "detected_object"),
             "object_source": "self_test",
             "allowed_grasp_methods": default_methods,
+            "runtime_note": "Suction/vacuum grasp is metadata only; runtime IO application is disabled.",
+            "runtime_io_applied": False,
             **({"grasp_strategy": grasp_strategy} if grasp_strategy else {}),
         },
         "decision_rules": [

--- a/tests/fixtures/cell_definition_ur5_suction_sorting.yaml
+++ b/tests/fixtures/cell_definition_ur5_suction_sorting.yaml
@@ -1,0 +1,93 @@
+schema_version: cell_definition/v1
+cell:
+  id: ur5_suction_sorting_cell
+  name: UR5 Suction Sorting Cell
+  description: UR5 + suction metadata-first generated workcell path.
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+  capability: ur5
+end_effector:
+  id: onrobot_airpick4
+  type: suction
+  brand: onrobot
+  grasp_frame: suction_tip
+  allowed_touch_links: [suction_cup]
+  contact_links: [suction_cup]
+  required_io_signals: [vacuum_enable, blowoff_enable]
+  release_behavior:
+    mode: vacuum_off_then_blowoff
+    timeout_s: 0.3
+  supported_grasp_strategies: [suction_top_basic, vacuum_array_top_basic]
+  capability: onrobot_airpick_style
+camera:
+  id: realsense_d435i
+  type: depth_camera
+  frame: camera_depth_optical_frame
+sensors:
+  - capability: intel_realsense_d435i
+environment:
+  frame: world
+  support_surfaces:
+    - id: table_main
+      type: table
+      frame: world
+      pose_xyz: [0.0, 0.0, 0.0]
+      pose_rpy: [0.0, 0.0, 0.0]
+      dimensions: [1.2, 0.8, 0.05]
+  assets:
+    - capability: table_standard_1200
+    - capability: bin_blue_large
+objects:
+  - id: part1
+    class: unknown
+    shape: box
+    color: red
+    material: plastic
+    frame: world
+    dimensions: [0.04, 0.04, 0.04]
+    pose_xyz: [0.45, 0.0, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+task:
+  id: ur5_suction_colour_sort_task
+  type: sort_by_colour
+  capability: sort_by_colour
+  source_object: part1
+  destinations:
+    - id: red_bin
+      frame: world
+      pose_xyz: [0.3, -0.3, 0.1]
+      pose_rpy: [0, 0, 0]
+    - id: blue_bin
+      frame: world
+      pose_xyz: [0.3, -0.15, 0.1]
+      pose_rpy: [0, 0, 0]
+    - id: reject_bin
+      frame: world
+      pose_xyz: [0.3, 0.0, 0.1]
+      pose_rpy: [0, 0, 0]
+  rules:
+    - id: route_red
+      when:
+        color: red
+      destination: red_bin
+    - id: route_blue
+      when:
+        color: blue
+      destination: blue_bin
+    - id: fallback
+      when:
+        always: true
+      destination: reject_bin
+grasp:
+  strategy_ref: suction_top_basic
+commissioning:
+  self_test_enabled: true
+  export_bundle: true
+  require_operator_review: true
+  fake_hardware_default: true
+  runtime_note: Offline metadata generation only; suction IO runtime remains disabled.

--- a/tests/test_cell_definition_tools.py
+++ b/tests/test_cell_definition_tools.py
@@ -50,6 +50,9 @@ class CellDefinitionValidationTests(unittest.TestCase):
     def test_valid_sort_by_colour_with_grasp_strategy_ref_passes(self) -> None:
         summary = self._validate_fixture("cell_definition_sort_by_colour_with_grasp_strategy.yaml")
         self.assertTrue(summary.ok)
+    def test_valid_ur5_suction_sorting_fixture_passes(self) -> None:
+        summary = self._validate_fixture("cell_definition_ur5_suction_sorting.yaml")
+        self.assertTrue(summary.ok)
 
     def test_valid_sort_by_shape_cell_definition_passes(self) -> None:
         summary = self._validate_fixture("cell_definition_sort_by_shape.yaml")
@@ -150,6 +153,18 @@ class CellDefinitionGenerationTests(unittest.TestCase):
         self.assertIn("grasp_strategy", task_recipe["pick"])
         commissioning = generator.build_commissioning_summary(loaded, summary.warnings)
         self.assertIn("## Grasp strategy", commissioning)
+    def test_suction_metadata_propagates_to_preview_artifacts(self) -> None:
+        loaded, parser, notes = validator.load_yaml(FIXTURES / "cell_definition_ur5_suction_sorting.yaml")
+        summary = validator.validate_cell_definition(loaded, FIXTURES / "cell_definition_ur5_suction_sorting.yaml", parser, notes)
+        self.assertTrue(summary.ok)
+        scene_manifest = generator.build_scene_manifest(loaded)
+        ee = scene_manifest["end_effector"]
+        self.assertEqual(ee["type"], "suction")
+        self.assertTrue(ee["metadata_only"])
+        self.assertFalse(ee["runtime_io_applied"])
+        task_recipe = generator.build_task_recipe(loaded)
+        self.assertEqual(task_recipe["pick"]["allowed_grasp_methods"], ["suction"])
+        self.assertIn("grasp_strategy", task_recipe["pick"])
 
 
 class WorkcellPackageGenerationTests(unittest.TestCase):
@@ -428,6 +443,29 @@ class CellDefinitionWizardTests(unittest.TestCase):
             manifest, _, _ = scene_contract_validator._read_manifest(str(package_dir / "scene_manifest.yaml"))
             status, _ = scene_contract_validator.validate_task_recipe_block(manifest)
             self.assertIn(status, {"PASS", "WARN"})
+
+    def test_non_interactive_ur5_suction_wizard_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            yaml_path = tmp / "ur5_suction.yaml"
+            out_dir = tmp / "generated"
+            proc = self._run(
+                "--template", "sort_by_colour",
+                "--cell-name", "UR5 Suction Sorting Demo",
+                "--cell-id", "ur5_suction_sorting_demo",
+                "--robot", "ur5",
+                "--end-effector", "suction",
+                "--camera", "realsense_d435i",
+                "--grasp-strategy", "suction_top_basic",
+                "--output", str(yaml_path),
+                "--generate-workcell",
+                "--workcell-output-dir", str(out_dir),
+                "--package-name", "generated_ur5_suction_sorting_from_wizard",
+                "--force",
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            valid = subprocess.run([sys.executable, str(self.validator_script), str(yaml_path)], capture_output=True, text=True, check=False)
+            self.assertEqual(valid.returncode, 0, msg=valid.stdout + valid.stderr)
 
     def test_expected_wizard_fixtures_validate(self) -> None:
         fixtures = [


### PR DESCRIPTION
### Motivation
- Make UR5 + suction/vacuum a supported, end-to-end generation path so generated Workcell Studio outputs carry correct suction metadata for offline review and packaging.
- Surface suction-specific fields (contacts, required IO, release behaviour, supported grasp strategies) in generated manifests while keeping runtime IO disabled and preserving existing finger-based paths.

### Description
- Added a canonical fixture `tests/fixtures/cell_definition_ur5_suction_sorting.yaml` that uses the `ur5` robot capability, an Airpick-style suction end-effector capability, `intel_realsense_d435i` sensor capability, `sort_by_colour` task capability, and `grasp.strategy_ref: suction_top_basic`.
- Extended the non-interactive wizard (`scripts/create_cell_definition_wizard.py`) with a `--grasp-strategy` CLI option and wired it to emit `grasp.strategy_ref` into generated YAML.
- Enhanced scene generation (`scripts/generate_scene_from_cell_definition.py`) to detect suction/vacuum end-effectors and emit normalized `end_effector.type` (e.g. `suction` / `vacuum_array`), `contact_links`, `supported_grasp_strategies`, `required_io_signals`, `release_behavior`, and the safe flags `metadata_only: true` and `runtime_io_applied: false`.
- Updated task recipe generation to prefer `suction` in `pick.allowed_grasp_methods` when grasp metadata/`strategy_ref` indicates suction/vacuum and added conservative runtime notes (`runtime_note`, `runtime_io_applied: false`) while preserving finger/magnetic behaviors for other strategies.
- Added tests to cover the new path and wizard: `tests/test_cell_definition_tools.py` gains a fixture validation test, preview propagation assertions for suction metadata, and a non-interactive wizard generation test.

### Testing
- Ran unit/test suites: `python3 -m pytest -q tests/test_capability_contracts.py` and they passed.
- Ran `python3 -m pytest -q tests/test_grasp_strategy_schema.py` and they passed.
- Ran `python3 -m pytest -q tests/test_cell_definition_tools.py` (including new UR5+suction and wizard tests) and they passed.
- Ran `python3 -m pytest -q tests/test_generated_cell_acceptance.py` and `python3 -m pytest -q tests/test_workcell_project_tools.py` and both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5d27b4f883319c73d5cf7ad795e8)