### PR TITLE
Add preview-only generated templates for generic cartesian/gantry and delta suction cells

### DIFF
--- a/catalog/capabilities/end_effectors/ee_airpick_suction.yaml
+++ b/catalog/capabilities/end_effectors/ee_airpick_suction.yaml
@@ -3,7 +3,7 @@ end_effector:
   id: onrobot_airpick_style
   label: OnRobot Airpick Style
   family: suction
-  compatible_robot_families: [serial_6_axis, collaborative_6_axis, delta]
+  compatible_robot_families: [serial_6_axis, collaborative_6_axis, delta, gantry]
   required_frames: [tool0]
   grasp_frames: [suction_tip]
   contact_links: [suction_cup]

--- a/catalog/capabilities/robots/robot_generic_delta.yaml
+++ b/catalog/capabilities/robots/robot_generic_delta.yaml
@@ -15,6 +15,6 @@ robot:
   workspace_description: High-speed dome envelope above conveyor
   controller_type: high_speed_trajectory
   supported_interfaces: [moveit, ros2_control, cartesian_path]
-  supported_task_families: [pick_place, conveyor_sorting]
+  supported_task_families: [pick_place, conveyor_sorting, sort_by_colour]
   limitations_warnings:
     - Limited orientation control at workspace edges.

--- a/catalog/capabilities/robots/robot_generic_gantry.yaml
+++ b/catalog/capabilities/robots/robot_generic_gantry.yaml
@@ -15,6 +15,6 @@ robot:
   workspace_description: Rectangular cartesian envelope over multi-station line
   controller_type: cartesian_controller
   supported_interfaces: [moveit, ros2_control, joint_trajectory_controller, cartesian_path]
-  supported_task_families: [palletising, machine_tending, conveyor_sorting]
+  supported_task_families: [palletising, machine_tending, conveyor_sorting, sort_by_colour, pick_place]
   limitations_warnings:
     - Dynamic acceleration constrained by bridge mass.

--- a/scripts/create_cell_definition_wizard.py
+++ b/scripts/create_cell_definition_wizard.py
@@ -44,6 +44,33 @@ ROBOT_PRESETS: dict[str, dict[str, Any]] = {
         "home_named_target": "home",
         "safe_joint_state": [],
     },
+    "generic_cartesian": {
+        "model": "generic_cartesian",
+        "planning_group": "manipulator",
+        "base_frame": "world",
+        "tool_link": "tool0",
+        "home_named_target": "home",
+        "safe_joint_state": [],
+        "capability": "generic_gantry_xyz",
+    },
+    "generic_gantry": {
+        "model": "generic_gantry",
+        "planning_group": "manipulator",
+        "base_frame": "world",
+        "tool_link": "tool0",
+        "home_named_target": "home",
+        "safe_joint_state": [],
+        "capability": "generic_gantry_xyz",
+    },
+    "generic_delta": {
+        "model": "generic_delta",
+        "planning_group": "manipulator",
+        "base_frame": "world",
+        "tool_link": "tool0",
+        "home_named_target": "home",
+        "safe_joint_state": [],
+        "capability": "generic_delta_900",
+    },
 }
 
 END_EFFECTOR_PRESETS: dict[str, dict[str, Any]] = {
@@ -70,6 +97,7 @@ END_EFFECTOR_PRESETS: dict[str, dict[str, Any]] = {
         "brand": "generic",
         "grasp_frame": "suction_tip",
         "allowed_touch_links": [],
+        "capability": "onrobot_airpick_style",
     },
     "generic": {
         "id": "generic_ee",

--- a/scripts/generate_scene_from_cell_definition.py
+++ b/scripts/generate_scene_from_cell_definition.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import validate_cell_definition as cell_validator
+from capability_registry import load_capability_registry
 
 
 def _task_recipe_type(task_type: str) -> str:
@@ -144,15 +145,40 @@ def build_scene_manifest(cell_def: dict[str, Any], capability_summary: dict[str,
 
     ee_type = str(end_effector.get("type", "unknown")).strip().lower()
     is_suction = ee_type in {"suction", "vacuum", "vacuum_array"}
+    robot_capability_id = robot.get("capability")
+    robot_family = None
+    if isinstance(robot_capability_id, str) and robot_capability_id.strip():
+        record = load_capability_registry().get(robot_capability_id.strip())
+        if record and isinstance(record.family, str):
+            robot_family = record.family
+    if not robot_family:
+        model_lower = str(robot.get("model", "")).lower()
+        if "delta" in model_lower:
+            robot_family = "delta"
+        elif "gantry" in model_lower or "cartesian" in model_lower:
+            robot_family = "gantry"
+        else:
+            robot_family = "articulated"
+    is_placeholder_family = robot_family in {"delta", "gantry", "cartesian"}
+    runtime_blockers = [
+        "Placeholder robot family has no approved MoveIt/ros2_control runtime stack yet.",
+        "Real hardware execution is disabled for this generated template.",
+        "Motion execution requires robot-specific MoveIt/ros2_control integration.",
+    ] if is_placeholder_family else []
     manifest = {
         "schema_version": "1.0",
         "scene": {"name": cell.get("id", "generated_cell")},
         "robot": {
+            "capability": robot_capability_id,
+            "family": robot_family,
             "model": robot.get("model", "unknown"),
             "planning_group": robot.get("planning_group", "manipulator"),
             "base_frame": robot.get("base_frame", "world"),
             "ee_link": robot.get("tool_link", "tool0"),
             "home_named_target": robot.get("home_named_target", "home"),
+            "runtime_supported": not is_placeholder_family,
+            "preview_only": is_placeholder_family,
+            "runtime_blockers": runtime_blockers,
         },
         "planning": {"pipeline": "ompl", "planner_id": "RRTConnectkConfigDefault"},
         "end_effector": {
@@ -245,6 +271,8 @@ def build_scene_manifest(cell_def: dict[str, Any], capability_summary: dict[str,
         manifest["end_effector"]["release_behavior"] = end_effector.get("release_behavior", {"mode": "vacuum_off"})
         manifest["end_effector"]["metadata_only"] = True
         manifest["end_effector"]["runtime_io_applied"] = False
+    if is_placeholder_family:
+        manifest["runtime_status"] = "BLOCKED_PREVIEW_ONLY"
 
     return manifest
 

--- a/tests/fixtures/cell_definition_generic_cartesian_suction_sorting.yaml
+++ b/tests/fixtures/cell_definition_generic_cartesian_suction_sorting.yaml
@@ -1,0 +1,95 @@
+schema_version: cell_definition/v1
+cell:
+  id: generic_cartesian_suction_sorting_cell
+  name: Generic Cartesian Suction Sorting Cell
+  description: Preview-only generated template for gantry/cartesian + suction.
+robot:
+  model: generic_cartesian
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+  capability: generic_gantry_xyz
+end_effector:
+  id: suction
+  type: suction
+  brand: generic
+  grasp_frame: suction_tip
+  allowed_touch_links: [suction_cup]
+  contact_links: [suction_cup]
+  required_io_signals: [vacuum_enable]
+  release_behavior:
+    mode: vacuum_off
+  supported_grasp_strategies: [suction_top_basic, vacuum_array_top_basic]
+  capability: onrobot_airpick_style
+camera:
+  id: realsense_d435i
+  type: depth_camera
+  frame: camera_depth_optical_frame
+sensors:
+  - capability: intel_realsense_d435i
+environment:
+  frame: world
+  support_surfaces:
+    - id: table_main
+      type: table
+      frame: world
+      pose_xyz: [0.0, 0.0, 0.0]
+      pose_rpy: [0.0, 0.0, 0.0]
+      dimensions: [1.2, 0.8, 0.05]
+  assets:
+    - capability: table_standard_1200
+    - capability: bin_blue_large
+objects:
+  - id: part1
+    class: unknown
+    shape: box
+    color: red
+    material: plastic
+    frame: world
+    dimensions: [0.04, 0.04, 0.04]
+    pose_xyz: [0.45, 0.0, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+task:
+  id: generic_cartesian_suction_colour_sort_task
+  type: sort_by_colour
+  capability: sort_by_colour
+  source_object: part1
+  destinations:
+    - id: red_bin
+      frame: world
+      pose_xyz: [0.3, -0.3, 0.1]
+      pose_rpy: [0, 0, 0]
+    - id: blue_bin
+      frame: world
+      pose_xyz: [0.3, -0.15, 0.1]
+      pose_rpy: [0, 0, 0]
+    - id: reject_bin
+      frame: world
+      pose_xyz: [0.3, 0.0, 0.1]
+      pose_rpy: [0, 0, 0]
+  rules:
+    - id: route_red
+      when:
+        color: red
+      destination: red_bin
+    - id: route_blue
+      when:
+        color: blue
+      destination: blue_bin
+    - id: fallback
+      when:
+        always: true
+      destination: reject_bin
+grasp:
+  strategy_ref: suction_top_basic
+commissioning:
+  self_test_enabled: true
+  export_bundle: true
+  require_operator_review: true
+  runtime_mode:
+    preview_only: true
+    runtime_supported: false
+    generated_motion_launch_supported: false
+    reason: Placeholder robot family has no approved runtime launch/control stack yet.

--- a/tests/fixtures/cell_definition_generic_delta_suction_sorting.yaml
+++ b/tests/fixtures/cell_definition_generic_delta_suction_sorting.yaml
@@ -1,0 +1,92 @@
+schema_version: cell_definition/v1
+cell:
+  id: generic_delta_suction_sorting_cell
+  name: Generic Delta Suction Sorting Cell
+  description: Preview-only generated template for generic delta + suction.
+robot:
+  model: generic_delta
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+  capability: generic_delta_900
+end_effector:
+  id: suction
+  type: suction
+  brand: generic
+  grasp_frame: suction_tip
+  allowed_touch_links: [suction_cup]
+  contact_links: [suction_cup]
+  required_io_signals: [vacuum_enable]
+  release_behavior:
+    mode: vacuum_off
+  supported_grasp_strategies: [suction_top_basic, vacuum_array_top_basic]
+  capability: onrobot_airpick_style
+camera:
+  id: realsense_d435i
+  type: depth_camera
+  frame: camera_depth_optical_frame
+sensors:
+  - capability: intel_realsense_d435i
+environment:
+  frame: world
+  support_surfaces:
+    - id: conveyor_main
+      type: conveyor
+      frame: world
+      pose_xyz: [0.0, 0.0, 0.0]
+      pose_rpy: [0.0, 0.0, 0.0]
+      dimensions: [1.0, 0.4, 0.1]
+objects:
+  - id: part1
+    class: unknown
+    shape: box
+    color: red
+    material: plastic
+    frame: world
+    dimensions: [0.03, 0.03, 0.02]
+    pose_xyz: [0.3, 0.0, 0.15]
+    pose_rpy: [0.0, 0.0, 0.0]
+task:
+  id: generic_delta_suction_colour_sort_task
+  type: sort_by_colour
+  capability: sort_by_colour
+  source_object: part1
+  destinations:
+    - id: red_bin
+      frame: world
+      pose_xyz: [0.45, -0.2, 0.12]
+      pose_rpy: [0, 0, 0]
+    - id: blue_bin
+      frame: world
+      pose_xyz: [0.45, 0.0, 0.12]
+      pose_rpy: [0, 0, 0]
+    - id: reject_bin
+      frame: world
+      pose_xyz: [0.45, 0.2, 0.12]
+      pose_rpy: [0, 0, 0]
+  rules:
+    - id: route_red
+      when:
+        color: red
+      destination: red_bin
+    - id: route_blue
+      when:
+        color: blue
+      destination: blue_bin
+    - id: fallback
+      when:
+        always: true
+      destination: reject_bin
+grasp:
+  strategy_ref: suction_top_basic
+commissioning:
+  self_test_enabled: true
+  export_bundle: true
+  require_operator_review: true
+  runtime_mode:
+    preview_only: true
+    runtime_supported: false
+    generated_motion_launch_supported: false
+    reason: Placeholder robot family has no approved runtime launch/control stack yet.

--- a/tests/test_cell_definition_tools.py
+++ b/tests/test_cell_definition_tools.py
@@ -53,6 +53,12 @@ class CellDefinitionValidationTests(unittest.TestCase):
     def test_valid_ur5_suction_sorting_fixture_passes(self) -> None:
         summary = self._validate_fixture("cell_definition_ur5_suction_sorting.yaml")
         self.assertTrue(summary.ok)
+    def test_valid_generic_cartesian_suction_sorting_fixture_passes(self) -> None:
+        summary = self._validate_fixture("cell_definition_generic_cartesian_suction_sorting.yaml")
+        self.assertTrue(summary.ok)
+    def test_valid_generic_delta_suction_sorting_fixture_passes(self) -> None:
+        summary = self._validate_fixture("cell_definition_generic_delta_suction_sorting.yaml")
+        self.assertTrue(summary.ok)
 
     def test_valid_sort_by_shape_cell_definition_passes(self) -> None:
         summary = self._validate_fixture("cell_definition_sort_by_shape.yaml")
@@ -165,6 +171,15 @@ class CellDefinitionGenerationTests(unittest.TestCase):
         task_recipe = generator.build_task_recipe(loaded)
         self.assertEqual(task_recipe["pick"]["allowed_grasp_methods"], ["suction"])
         self.assertIn("grasp_strategy", task_recipe["pick"])
+    def test_placeholder_robot_preview_runtime_blockers_present(self) -> None:
+        loaded, parser, notes = validator.load_yaml(FIXTURES / "cell_definition_generic_delta_suction_sorting.yaml")
+        summary = validator.validate_cell_definition(loaded, FIXTURES / "cell_definition_generic_delta_suction_sorting.yaml", parser, notes)
+        self.assertTrue(summary.ok)
+        scene_manifest = generator.build_scene_manifest(loaded)
+        self.assertEqual(scene_manifest["robot"]["family"], "delta")
+        self.assertTrue(scene_manifest["robot"]["preview_only"])
+        self.assertFalse(scene_manifest["robot"]["runtime_supported"])
+        self.assertTrue(scene_manifest["robot"]["runtime_blockers"])
 
 
 class WorkcellPackageGenerationTests(unittest.TestCase):
@@ -204,6 +219,9 @@ class WorkcellPackageGenerationTests(unittest.TestCase):
 
     def test_garbage_sorting_generates_package(self) -> None:
         self._assert_generate_fixture("cell_definition_garbage_sorting.yaml", "generated_garbage_sort")
+    def test_placeholder_templates_generate_packages(self) -> None:
+        self._assert_generate_fixture("cell_definition_generic_cartesian_suction_sorting.yaml", "generated_cart_suction")
+        self._assert_generate_fixture("cell_definition_generic_delta_suction_sorting.yaml", "generated_delta_suction")
 
     def test_dry_run_does_not_write_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
### Motivation
- Provide first-class generated templates for placeholder robot families so Workcell Studio can produce metadata-first previews for generic cartesian/gantry + suction and generic delta + suction without claiming runtime motion support.
- Keep existing UR5 generated paths unchanged while enabling template-driven project generation, summaries, and readiness reports for business/demo scenarios.

### Description
- Add two canonical cell-definition fixtures: `tests/fixtures/cell_definition_generic_cartesian_suction_sorting.yaml` and `tests/fixtures/cell_definition_generic_delta_suction_sorting.yaml` with suction grasp strategy refs and explicit `runtime_mode` preview-only metadata.
- Extend scene preview generation in `scripts/generate_scene_from_cell_definition.py` to resolve `robot.family` from capability registry or model hint, preserve `robot.capability`/`family`, and emit gating fields `preview_only`, `runtime_supported`, `runtime_blockers`, and top-level `runtime_status: BLOCKED_PREVIEW_ONLY` for placeholder families.
- Update wizard presets in `scripts/create_cell_definition_wizard.py` to include `generic_cartesian`, `generic_gantry`, and `generic_delta` and add default suction capability metadata to the suction EE preset.
- Adjust capability catalog entries to make placeholder combinations validate: add `sort_by_colour`/`pick_place` support to gantry/delta robot capability fixtures and mark airpick suction EE compatible with `gantry` (files in `catalog/capabilities/robots/` and `catalog/capabilities/end_effectors/`).
- Add tests and test coverage adjustments in `tests/test_cell_definition_tools.py` to validate the new fixtures, ensure suction/grasp metadata propagates, confirm preview runtime blockers are present, and exercise package generation for both templates.

### Testing
- Ran the full affected unit suite: `python3 -m pytest -q tests/test_capability_contracts.py tests/test_grasp_strategy_schema.py tests/test_cell_definition_tools.py tests/test_generated_cell_acceptance.py tests/test_workcell_project_tools.py`, which passed with `92 passed, 7 subtests passed`.
- Validated fixtures with the validator: `python3 scripts/validate_cell_definition.py tests/fixtures/cell_definition_generic_cartesian_suction_sorting.yaml` and `python3 scripts/validate_cell_definition.py tests/fixtures/cell_definition_generic_delta_suction_sorting.yaml`, both returned `PASS`.
- Generated previews and packages with the generator scripts and project creator (scene preview, workcell package, and workcell project) for both new fixtures, all reporting `PASS` and producing the expected artifacts (scene manifests, task recipes, commissioning/validation reports, and generated package outputs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5f23e6688331968955c70abc6152)