### PR TITLE
Add first Streamlit-based Workcell Studio prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1468,3 +1468,19 @@ python3 scripts/workcell_studio.py import-builder-scene \
   --validate \
   --generate-project
 ```
+
+## Workcell Studio Streamlit prototype
+
+A first practical Streamlit prototype is available at `tools/workcell_studio_streamlit/` as a thin UI over existing Workcell Studio backend tooling.
+
+- Catalog browser for `catalog/capabilities/` and `catalog/grasp_strategies/` metadata.
+- Cell definition and optional environment layout validation wrappers.
+- Builder scene import wrapper for `scripts/workcell_studio.py import-builder-scene` with summary and safety visibility.
+
+Safety/scope notes:
+- `workcell_builder` remains the visual scene editor.
+- This Streamlit UI is orchestration/readiness/demo only.
+- Runtime robot behavior, launch behavior, and EPD behavior are unchanged.
+- Offline validation and fake-hardware-first defaults are preserved.
+
+See `tools/workcell_studio_streamlit/README.md` for install and run commands.

--- a/tests/test_workcell_studio_streamlit_backend.py
+++ b/tests/test_workcell_studio_streamlit_backend.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from tools.workcell_studio_streamlit import backend
+
+
+def _write_scene(root: Path, metadata: str = "{}") -> None:
+    (root / "package.xml").write_text("<package/>", encoding="utf-8")
+    (root / "CMakeLists.txt").write_text("cmake_minimum_required(VERSION 3.5)", encoding="utf-8")
+    (root / "environment.yaml").write_text(
+        "robot: {name: ur5}\nend_effector: {name: robotiq_2f}\nobjects:\n  box1:\n    filepath: meshes/box1.stl\n    dimensions: [0.2, 0.2, 0.1]\n",
+        encoding="utf-8",
+    )
+    (root / "workcell_builder_metadata.yaml").write_text(metadata, encoding="utf-8")
+
+
+def test_catalog_loading_discovers_expected_entries() -> None:
+    caps = backend.load_capability_catalog()
+    grasps = backend.load_grasp_strategy_catalog()
+
+    robot_ids = {item.get("id") for item in caps["robots"]}
+    ee_ids = {item.get("id") for item in caps["end_effectors"]}
+    sensor_ids = {item.get("id") for item in caps["sensors"]}
+    assert "ur5" in robot_ids
+    assert any(token in (item or "") for item in ee_ids for token in {"robotiq", "suction", "vacuum"})
+    assert any("realsense" in (item or "") for item in sensor_ids)
+    assert len(grasps) >= 1
+
+
+def test_validate_cell_definition_wrapper() -> None:
+    fixture = backend.repo_root() / "tests" / "fixtures" / "cell_definition_pick_place.yaml"
+    result = backend.validate_cell_definition(fixture)
+    assert result["returncode"] == 0
+    assert result["json"]["result"] in {"PASS", "WARN"}
+
+
+def test_validate_environment_layout_wrapper() -> None:
+    fixture = backend.repo_root() / "tests" / "fixtures" / "environment_layouts" / "ur5_table_bins_existing_assets.layout.yaml"
+    result = backend.validate_environment_layout(fixture)
+    assert result["returncode"] == 0
+    assert result["json"]["result"] in {"PASS", "WARN"}
+
+
+def test_import_builder_scene_wrapper_returns_summary_paths() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        scene = Path(d) / "scene"
+        scene.mkdir()
+        _write_scene(scene)
+        generated = scene / "generated"
+        generated.mkdir()
+        generated_cell = backend.repo_root() / "tests" / "fixtures" / "cell_definition_pick_place.yaml"
+        generated_layout = backend.repo_root() / "tests" / "fixtures" / "environment_layouts" / "ur5_table_bins_existing_assets.layout.yaml"
+        (generated / "cell_definition.yaml").write_text(generated_cell.read_text(encoding="utf-8"), encoding="utf-8")
+        (generated / "environment_layout.yaml").write_text(generated_layout.read_text(encoding="utf-8"), encoding="utf-8")
+        out = Path(d) / "out"
+
+        result = backend.import_builder_scene(scene, out, "demo")
+        assert result["returncode"] == 0
+        summary = result["summary"]
+        assert summary["summary_json_path"]
+        assert summary["summary_markdown_path"]
+
+
+def test_missing_input_handling_returns_structured_error() -> None:
+    missing_cell = backend.validate_cell_definition("/tmp/definitely_missing_cell_definition.yaml")
+    assert not missing_cell["ok"]
+    assert "Missing" in missing_cell["error"]
+
+    missing_scene = backend.import_builder_scene("/tmp/definitely_missing_scene", "/tmp/out", "demo")
+    assert not missing_scene["ok"]
+    assert "does not exist" in missing_scene["error"]

--- a/tools/workcell_studio_streamlit/README.md
+++ b/tools/workcell_studio_streamlit/README.md
@@ -1,0 +1,31 @@
+# Workcell Studio Streamlit Prototype
+
+This prototype provides a lightweight orchestration/readiness/demo UI over existing Workcell Studio scripts.
+
+## Safety notes
+
+Workcell Studio defaults to offline validation and fake hardware. This UI does not command robot motion.
+It does not run launch files and is not a replacement for runtime execution flows.
+
+## Install
+
+```bash
+python3 -m pip install -r tools/workcell_studio_streamlit/requirements.txt
+```
+
+## Run
+
+```bash
+streamlit run tools/workcell_studio_streamlit/app.py
+```
+
+## Example builder import flow
+
+1. Open **Builder scene import**.
+2. Set scene package path, output directory, and project name.
+3. Click **Import builder scene** to run:
+   `python3 scripts/workcell_studio.py import-builder-scene --scene-package <scene-package> --output-dir <output-dir> --project-name <project-name> --validate --generate-project`
+4. Review import summary JSON/Markdown plus safety/readiness fields.
+
+`workcell_builder` remains the visual editor.
+This Streamlit Studio prototype is currently an orchestration/readiness/demo UI.

--- a/tools/workcell_studio_streamlit/app.py
+++ b/tools/workcell_studio_streamlit/app.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import backend
+import streamlit as st
+
+st.set_page_config(page_title="Workcell Studio Streamlit", layout="wide")
+st.title("Workcell Studio Streamlit Prototype")
+st.warning("Workcell Studio defaults to offline validation and fake hardware. This UI does not command robot motion.")
+
+workflow = st.sidebar.radio(
+    "Workflow",
+    ["Catalog browser", "Cell definition validator", "Builder scene import"],
+)
+
+if workflow == "Catalog browser":
+    st.header("Catalog browser")
+    if st.button("Load catalog metadata"):
+        caps = backend.load_capability_catalog()
+        grasps = backend.load_grasp_strategy_catalog()
+        for key in ["robots", "end_effectors", "sensors", "environment_assets", "tasks"]:
+            st.subheader(key.replace("_", " ").title())
+            st.dataframe(caps.get(key, []), use_container_width=True)
+        st.subheader("Grasp strategies")
+        st.dataframe(grasps, use_container_width=True)
+
+elif workflow == "Cell definition validator":
+    st.header("Cell definition validator")
+    cell_def_path = st.text_input("Path to cell_definition.yaml", value="tests/fixtures/cell_definition_pick_place.yaml")
+    env_layout_path = st.text_input("Optional path to environment_layout.yaml", value="")
+
+    if st.button("Run validation"):
+        result = backend.validate_cell_definition(cell_def_path)
+        st.subheader("Cell definition status")
+        st.json(result.get("json") or result)
+        st.code((result.get("stdout") or "") + "\n" + (result.get("stderr") or ""))
+
+        if env_layout_path.strip():
+            layout_result = backend.validate_environment_layout(env_layout_path)
+            st.subheader("Environment layout status")
+            st.json(layout_result.get("json") or layout_result)
+            st.code((layout_result.get("stdout") or "") + "\n" + (layout_result.get("stderr") or ""))
+
+else:
+    st.header("Builder scene import")
+    scene_package = st.text_input("Scene package path")
+    output_dir = st.text_input("Output directory", value="/tmp/workcell_studio_streamlit")
+    project_name = st.text_input("Project name", value="streamlit_demo")
+
+    if st.button("Import builder scene"):
+        result = backend.import_builder_scene(scene_package, output_dir, project_name)
+        if not result.get("ok"):
+            st.error(result.get("error") or result.get("stderr") or "Import failed")
+        st.subheader("Command output")
+        st.code((result.get("stdout") or "") + "\n" + (result.get("stderr") or ""))
+
+        summary_block = (result.get("summary") or {})
+        st.subheader("Import summary JSON")
+        st.json(summary_block.get("summary", {}))
+
+        md_path = summary_block.get("summary_markdown_path")
+        if md_path and Path(md_path).exists():
+            st.subheader("Import summary Markdown")
+            st.markdown(Path(md_path).read_text(encoding="utf-8"))
+
+        summary = summary_block.get("summary", {})
+        st.subheader("Key status")
+        st.write(
+            {
+                "generated_project_path": summary.get("generated_project_path"),
+                "dashboard_path": summary.get("dashboard_path"),
+                "preflight_report_path": summary.get("preflight_report_path"),
+                "safety_status": summary.get("safety_status"),
+                "runtime_preview_blockers": (summary.get("validation", {}).get("builder_scene", {}).get("runtime_blockers", [])),
+            }
+        )

--- a/tools/workcell_studio_streamlit/backend.py
+++ b/tools/workcell_studio_streamlit/backend.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except Exception:  # pragma: no cover
+    yaml = None
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_yaml_file(path: Path) -> dict[str, Any]:
+    if yaml is not None:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return loaded if isinstance(loaded, dict) else {}
+    script_path = repo_root() / "scripts"
+    if str(script_path) not in sys.path:
+        sys.path.insert(0, str(script_path))
+    import validate_cell_definition as yaml_support
+
+    loaded, _, _ = yaml_support.load_yaml(path)
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _catalog_entries(root: Path, group: str, key: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    directory = root / "catalog" / "capabilities" / group
+    for path in sorted(directory.glob("*.yaml")):
+        payload = _load_yaml_file(path)
+        data = payload.get(key, {}) if isinstance(payload.get(key), dict) else {}
+        out.append(
+            {
+                "file": str(path),
+                "group": group,
+                "id": data.get("id"),
+                "label": data.get("label") or data.get("name"),
+                "family": data.get("family") or data.get("strategy"),
+                "runtime_supported": bool(data.get("runtime_supported", True)),
+                "preview_only": bool(data.get("preview_only", False)),
+                "compatible_families": data.get("compatible_tool_families")
+                or data.get("supported_task_families")
+                or [],
+                "notes": data.get("limitations_warnings") or [],
+                "raw": data,
+            }
+        )
+    return out
+
+
+def load_capability_catalog(root: Path | None = None) -> dict[str, list[dict[str, Any]]]:
+    rr = root or repo_root()
+    return {
+        "robots": _catalog_entries(rr, "robots", "robot"),
+        "end_effectors": _catalog_entries(rr, "end_effectors", "end_effector"),
+        "sensors": _catalog_entries(rr, "sensors", "sensor"),
+        "environment_assets": _catalog_entries(rr, "environment_assets", "asset"),
+        "tasks": _catalog_entries(rr, "tasks", "task"),
+    }
+
+
+def load_grasp_strategy_catalog(root: Path | None = None) -> list[dict[str, Any]]:
+    rr = root or repo_root()
+    out: list[dict[str, Any]] = []
+    for path in sorted((rr / "catalog" / "grasp_strategies").glob("*.yaml")):
+        payload = _load_yaml_file(path)
+        data = payload.get("grasp_strategy", {}) if isinstance(payload.get("grasp_strategy"), dict) else {}
+        out.append(
+            {
+                "file": str(path),
+                "id": data.get("id"),
+                "label": data.get("label") or data.get("name"),
+                "type": data.get("strategy"),
+                "compatible_families": data.get("compatible_tool_families") or [],
+                "runtime_supported": bool(data.get("runtime_supported", False)),
+                "preview_only": True,
+                "notes": data.get("limitations_warnings") or [],
+                "raw": data,
+            }
+        )
+    return out
+
+
+def run_command(cmd: list[str], cwd: Path | None = None, timeout: int = 120) -> dict[str, Any]:
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    return {
+        "ok": proc.returncode == 0,
+        "returncode": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "command": cmd,
+    }
+
+
+def _parse_json_output(run_result: dict[str, Any]) -> dict[str, Any]:
+    out = dict(run_result)
+    text = (run_result.get("stdout") or "").strip()
+    if text:
+        try:
+            out["json"] = json.loads(text)
+        except json.JSONDecodeError:
+            out["json"] = None
+    else:
+        out["json"] = None
+    return out
+
+
+def validate_cell_definition(cell_definition_path: str | Path, root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    path = Path(cell_definition_path)
+    if not path.exists():
+        return {"ok": False, "error": f"Missing cell_definition file: {path}"}
+    cmd = [sys.executable, str(rr / "scripts" / "validate_cell_definition.py"), str(path), "--json"]
+    return _parse_json_output(run_command(cmd, cwd=rr))
+
+
+def validate_environment_layout(layout_path: str | Path, root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    path = Path(layout_path)
+    if not path.exists():
+        return {"ok": False, "error": f"Missing environment layout file: {path}"}
+    cmd = [sys.executable, str(rr / "scripts" / "validate_environment_layout.py"), str(path), "--json"]
+    return _parse_json_output(run_command(cmd, cwd=rr))
+
+
+def import_builder_scene(scene_package: str | Path, output_dir: str | Path, project_name: str, root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    scene_path = Path(scene_package)
+    out_dir = Path(output_dir)
+    if not scene_path.exists() or not scene_path.is_dir():
+        return {"ok": False, "error": f"Scene package path does not exist or is not a directory: {scene_path}"}
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        str(rr / "scripts" / "workcell_studio.py"),
+        "import-builder-scene",
+        "--scene-package",
+        str(scene_path),
+        "--output-dir",
+        str(out_dir),
+        "--project-name",
+        project_name,
+        "--validate",
+        "--generate-project",
+    ]
+    result = run_command(cmd, cwd=rr, timeout=300)
+    summary = load_import_summary(out_dir)
+    result["summary"] = summary
+    return result
+
+
+def load_import_summary(output_dir: str | Path) -> dict[str, Any]:
+    out_dir = Path(output_dir)
+    summary_json = out_dir / "workcell_studio_import_summary.json"
+    summary_md = out_dir / "workcell_studio_import_summary.md"
+    payload: dict[str, Any] = {
+        "summary_json_path": str(summary_json) if summary_json.exists() else "",
+        "summary_markdown_path": str(summary_md) if summary_md.exists() else "",
+    }
+    if summary_json.exists():
+        payload["summary"] = json.loads(summary_json.read_text(encoding="utf-8"))
+    else:
+        payload["summary"] = {}
+    return payload

--- a/tools/workcell_studio_streamlit/requirements.txt
+++ b/tools/workcell_studio_streamlit/requirements.txt
@@ -1,0 +1,2 @@
+streamlit
+PyYAML


### PR DESCRIPTION
### Motivation
- Provide a lightweight, button-driven Streamlit UI to orchestrate and inspect existing Workcell Studio backend tooling without changing runtime or robot behavior.
- Make catalog discovery, cell/environment validation, and builder-scene import workflows easily accessible for offline/demo validation and operator readiness checks.

### Description
- Add a new prototype UI under `tools/workcell_studio_streamlit/` including `app.py` (Streamlit frontend), `backend.py` (testable subprocess and catalog wrappers), `README.md`, and `requirements.txt` with minimal deps.
- `backend.py` exposes testable functions such as `repo_root()`, `load_capability_catalog()`, `load_grasp_strategy_catalog()`, `run_command()`, `validate_cell_definition()`, `validate_environment_layout()`, `import_builder_scene()`, and `load_import_summary()` and returns structured dictionaries using `pathlib` and `subprocess.run`.
- The Streamlit app implements three workflows: a read-only catalog browser (capabilities + grasp strategies), a cell definition validator (runs `scripts/validate_cell_definition.py` and optionally `scripts/validate_environment_layout.py`), and a builder scene import wrapper (calls `scripts/workcell_studio.py import-builder-scene` and surfaces import summary and safety fields), and includes a prominent safety banner stating offline/fake-hardware defaults.
- Add tests in `tests/test_workcell_studio_streamlit_backend.py` for catalog discovery, validation wrappers, builder import wrapper, and structured missing-input handling, and update the project `README.md` with a short Streamlit prototype section and safety/scope notes.

### Testing
- Ran `python3 -m pytest -q tests/test_workcell_studio_streamlit_backend.py` and the new backend tests passed locally (all tests green).
- Ran `python3 -m pytest -q tests/test_workcell_studio_builder_import_cli.py`, `python3 -m pytest -q tests/test_builder_scene_export_to_cell_definition.py`, `python3 -m pytest -q tests/test_cell_definition_tools.py`, and `python3 -m pytest -q tests/test_workcell_project_tools.py` and these suites passed locally (observed passing results shown in the rollout).
- Installed the Streamlit requirements via `python3 -m pip install -r tools/workcell_studio_streamlit/requirements.txt` successfully and performed a startup smoke check by running `streamlit run tools/workcell_studio_streamlit/app.py` with a short timeout, during which the server started successfully.
- No changes were made to robot runtime execution, launch files, EPD behavior, or hardware commands; tests and smoke checks were executed under those safety constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba04ddb848331bcaee6877ce72310)