### PR TITLE
Add Workcell Studio Demo Gallery and demo bundle exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1484,3 +1484,12 @@ Safety/scope notes:
 - Offline validation and fake-hardware-first defaults are preserved.
 
 See `tools/workcell_studio_streamlit/README.md` for install and run commands.
+
+## Workcell Studio Demo Gallery
+
+Use curated offline demos and export demo bundles:
+- `python3 scripts/workcell_studio.py list-demos`
+- `python3 scripts/workcell_studio.py generate-demo-bundle --demo-id ur5_suction_sorting_demo --output-dir /tmp/workcell_studio_demos --force`
+- `python3 scripts/workcell_studio.py generate-demo-bundle --all --output-dir /tmp/workcell_studio_all_demos --force --continue-on-error`
+
+Demo bundles are offline/demo/validation artifacts only. Preview-only demos are for concept visualization and are not runtime-ready.

--- a/catalog/workcell_studio_demos.yaml
+++ b/catalog/workcell_studio_demos.yaml
@@ -1,0 +1,33 @@
+schema_version: workcell_studio_demo_catalog/v1
+demos:
+  - id: ur5_2f_sorting_demo
+    title: UR5 + Robotiq 2F Sorting Demo
+    description: Baseline fake-hardware Workcell Studio demo using UR5 and 2-finger gripper.
+    cell_definition: tests/fixtures/cell_definition_pick_place.yaml
+    runtime_mode: fake_hardware_ready
+    investor_visible: true
+    tags: [ur5, robotiq_2f, sorting, fake_hardware, baseline]
+
+  - id: ur5_suction_sorting_demo
+    title: UR5 + Suction Sorting Demo
+    description: Baseline suction metadata/demo path with runtime IO disabled.
+    cell_definition: tests/fixtures/cell_definition_ur5_suction_sorting.yaml
+    runtime_mode: fake_hardware_ready
+    investor_visible: true
+    tags: [ur5, suction, sorting, grasp_strategy]
+
+  - id: generic_cartesian_suction_preview
+    title: Generic Cartesian/Gantry + Suction Preview
+    description: Preview-only generated cell for non-UR robot-family planning and customer concept demos.
+    cell_definition: tests/fixtures/cell_definition_generic_cartesian_suction_sorting.yaml
+    runtime_mode: preview_only
+    investor_visible: true
+    tags: [cartesian, gantry, suction, preview_only]
+
+  - id: generic_delta_suction_preview
+    title: Generic Delta + Suction Preview
+    description: Preview-only generated cell for fast delta robot concept demos.
+    cell_definition: tests/fixtures/cell_definition_generic_delta_suction_sorting.yaml
+    runtime_mode: preview_only
+    investor_visible: true
+    tags: [delta, suction, preview_only]

--- a/docs/manuals/WORKCELL_STUDIO_ROADMAP.md
+++ b/docs/manuals/WORKCELL_STUDIO_ROADMAP.md
@@ -55,3 +55,7 @@ High-level ownership boundaries:
 ## Builder scene exports for Workcell Studio
 
 `workcell_builder` remains the primary visual workflow. Generated scenes can now export portable Workcell Studio source files using `scripts/export_builder_scene_to_cell_definition.py`. The export writes `generated/cell_definition.yaml`, `generated/environment_layout.yaml`, and `generated/builder_export_summary.json`. These files are for offline commissioning and backend tooling, and are not proof of reachability or runtime safety. Keep fake-hardware-first defaults and runtime send disabled unless separately commissioned.
+
+## Curated Demo Catalog
+
+`catalog/workcell_studio_demos.yaml` defines investor/customer-friendly offline demo templates. Generated demo bundles are strictly offline/demo/validation artifacts and do not alter runtime robot behavior or launch behavior. Preview-only demos support sales/concept visualization and must not be treated as real runtime support.

--- a/scripts/workcell_studio.py
+++ b/scripts/workcell_studio.py
@@ -4,12 +4,29 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+DEMO_CATALOG_PATH = REPO_ROOT / "catalog" / "workcell_studio_demos.yaml"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    try:
+        import yaml
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return loaded if isinstance(loaded, dict) else {}
+    except Exception:
+        if str(SCRIPT_DIR) not in sys.path:
+            sys.path.insert(0, str(SCRIPT_DIR))
+        import validate_cell_definition as yaml_support
+
+        loaded, _, _ = yaml_support.load_yaml(path)
+        return loaded if isinstance(loaded, dict) else {}
 
 
 def _run_json(cmd: list[str], label: str) -> tuple[int, dict[str, Any]]:
@@ -18,20 +35,133 @@ def _run_json(cmd: list[str], label: str) -> tuple[int, dict[str, Any]]:
     try:
         payload = json.loads(proc.stdout) if proc.stdout.strip() else {}
     except Exception:
-        payload = {
-            "result": "FAIL",
-            "errors": [f"{label} returned non-JSON output", proc.stdout.strip(), proc.stderr.strip()],
-        }
+        payload = {"result": "FAIL", "errors": [f"{label} returned non-JSON output", proc.stdout.strip(), proc.stderr.strip()]}
     payload.setdefault("stdout", proc.stdout.strip())
     payload.setdefault("stderr", proc.stderr.strip())
     payload.setdefault("returncode", proc.returncode)
     return proc.returncode, payload
 
 
+def load_demo_catalog() -> list[dict[str, Any]]:
+    if not DEMO_CATALOG_PATH.is_file():
+        return []
+    payload = _load_yaml(DEMO_CATALOG_PATH)
+    demos = payload.get("demos") if isinstance(payload.get("demos"), list) else []
+    out = []
+    for item in demos:
+        if isinstance(item, dict) and item.get("id") and item.get("cell_definition"):
+            out.append(item)
+    return out
+
+
+def list_demos(args: argparse.Namespace) -> int:
+    demos = load_demo_catalog()
+    if args.json:
+        print(json.dumps({"catalog": str(DEMO_CATALOG_PATH), "demos": demos}, indent=2))
+        return 0
+    print("Workcell Studio Demo Gallery")
+    print(f"Catalog: {DEMO_CATALOG_PATH}")
+    for demo in demos:
+        tags = ",".join(demo.get("tags", []))
+        print(f"- {demo['id']}: {demo.get('title','')} | runtime_mode={demo.get('runtime_mode','unknown')} | tags=[{tags}]")
+    return 0
+
+
+def generate_demo_bundle(args: argparse.Namespace) -> int:
+    demos = load_demo_catalog()
+    by_id = {d["id"]: d for d in demos}
+    selected = demos if args.all else ([by_id.get(args.demo_id)] if args.demo_id else [])
+    selected = [s for s in selected if s]
+    if not selected:
+        print(json.dumps({"result": "FAIL", "error": f"Unknown or missing demo id: {args.demo_id}"}, indent=2))
+        return 2
+
+    output_root = args.output_dir.resolve()
+    output_root.mkdir(parents=True, exist_ok=True)
+    failures = []
+    for demo in selected:
+        demo_dir = output_root / demo["id"]
+        if demo_dir.exists() and args.force:
+            shutil.rmtree(demo_dir)
+        demo_dir.mkdir(parents=True, exist_ok=True)
+        cell_def = (REPO_ROOT / demo["cell_definition"]).resolve()
+        if not cell_def.is_file():
+            msg = f"Missing cell_definition for demo {demo['id']}: {cell_def}"
+            failures.append(msg)
+            if not args.continue_on_error:
+                print(msg)
+                return 3
+            continue
+
+        _, val = _run_json([sys.executable, str(SCRIPT_DIR / "validate_cell_definition.py"), str(cell_def), "--json"], "validate")
+        if val.get("result") == "FAIL":
+            msg = f"Invalid cell_definition for demo {demo['id']}"
+            failures.append(msg)
+            if not args.continue_on_error:
+                print(msg)
+                return 4
+
+        project_rc = subprocess.run([
+            sys.executable, str(SCRIPT_DIR / "create_workcell_project.py"),
+            "--cell-definition", str(cell_def), "--output-dir", str(demo_dir), "--force"
+        ], capture_output=True, text=True, check=False)
+
+        copied_cell = demo_dir / "cell_definition.yaml"
+        shutil.copy2(cell_def, copied_cell)
+        manifests = list(demo_dir.glob("*/project_manifest.json"))
+        project_path = str(manifests[0].parent) if manifests else ""
+        summary = {
+            "result": "PASS" if project_rc.returncode == 0 else "FAIL",
+            "demo": demo,
+            "runtime_mode": demo.get("runtime_mode"),
+            "preview_only": demo.get("runtime_mode") == "preview_only",
+            "source_cell_definition": str(cell_def),
+            "copied_cell_definition": str(copied_cell),
+            "generated_project_path": project_path,
+            "dashboard_path": str(manifests[0].parent / "dashboard" / "index.html") if manifests else "",
+            "preflight_report_path": str(manifests[0].parent / "reports" / "validation_summary.md") if manifests else "",
+            "next_commands_path": str(demo_dir / "next_commands.md"),
+            "stdout": project_rc.stdout.strip(),
+            "stderr": project_rc.stderr.strip(),
+        }
+        (demo_dir / "demo_bundle_summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+        (demo_dir / "demo_bundle_summary.md").write_text(
+            "# Demo Bundle Summary\n\n"
+            f"- Demo id: `{demo['id']}`\n"
+            f"- Title: `{demo.get('title','')}`\n"
+            f"- Runtime mode: `{demo.get('runtime_mode','unknown')}`\n"
+            f"- Preview only: `{summary['preview_only']}`\n"
+            f"- Generated project path: `{project_path or '(none)'}`\n"
+            f"- Dashboard: `{summary['dashboard_path'] or '(none)'}`\n"
+            f"- Preflight report: `{summary['preflight_report_path'] or '(none)'}`\n",
+            encoding="utf-8",
+        )
+        (demo_dir / "next_commands.md").write_text(
+            "# Next Commands\n\n```bash\n"
+            "python3 scripts/workcell_studio.py list-demos\n"
+            f"python3 scripts/workcell_studio.py generate-demo-bundle --demo-id {demo['id']} --output-dir {output_root} --force\n"
+            f"python3 scripts/validate_cell_definition.py {copied_cell} --json\n"
+            "```\n",
+            encoding="utf-8",
+        )
+        if project_rc.returncode != 0:
+            failures.append(f"Project generation failed for {demo['id']}")
+            if not args.continue_on_error:
+                return 5
+
+    if failures and not args.continue_on_error:
+        return 6
+    if failures:
+        print(json.dumps({"result": "WARN", "failures": failures}, indent=2))
+        return 1
+    print(json.dumps({"result": "PASS", "generated": [d["id"] for d in selected], "output_dir": str(output_root)}, indent=2))
+    return 0
+
+
 def _scene_name(path: Path) -> str:
     return path.name
 
-
+# existing import_builder_scene unchanged below
 def import_builder_scene(args: argparse.Namespace) -> int:
     scene_pkg = args.scene_package.resolve()
     output_dir = args.output_dir.resolve()
@@ -182,6 +312,18 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
 
+    demos_list = sub.add_parser("list-demos", help="List curated Workcell Studio demos")
+    demos_list.add_argument("--json", action="store_true")
+    demos_list.set_defaults(func=list_demos)
+
+    demos_gen = sub.add_parser("generate-demo-bundle", help="Generate one or all curated demo bundles")
+    demos_gen.add_argument("--demo-id", type=str)
+    demos_gen.add_argument("--all", action="store_true")
+    demos_gen.add_argument("--output-dir", type=Path, required=True)
+    demos_gen.add_argument("--force", action="store_true")
+    demos_gen.add_argument("--continue-on-error", action="store_true")
+    demos_gen.set_defaults(func=generate_demo_bundle)
+
     import_parser = sub.add_parser("import-builder-scene", help="Import a workcell_builder-generated scene package")
     import_parser.add_argument("--scene-package", type=Path, required=True)
     import_parser.add_argument("--output-dir", type=Path, required=True)
@@ -190,7 +332,6 @@ def _build_parser() -> argparse.ArgumentParser:
     import_parser.add_argument("--generate-project", action="store_true")
     import_parser.set_defaults(func=import_builder_scene)
     return parser
-
 
 def main() -> int:
     parser = _build_parser()

--- a/tests/test_workcell_studio_demo_gallery.py
+++ b/tests/test_workcell_studio_demo_gallery.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from tools.workcell_studio_streamlit import backend
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI = REPO_ROOT / "scripts" / "workcell_studio.py"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["python3", str(CLI), *args], capture_output=True, text=True, check=False)
+
+
+def test_demo_catalog_loads_with_expected_demo_types() -> None:
+    payload = backend.load_demo_catalog()
+    demos = payload["demos"]
+    ids = {d.get("id", "") for d in demos}
+    assert any("ur5" in i for i in ids)
+    assert any("suction" in i for i in ids)
+    assert any((d.get("runtime_mode") == "preview_only") for d in demos)
+
+
+def test_demo_cell_definition_paths_exist_and_validate() -> None:
+    for demo in backend.load_demo_catalog()["demos"]:
+        cell = REPO_ROOT / demo["cell_definition"]
+        assert cell.exists()
+        proc = subprocess.run(["python3", str(REPO_ROOT / "scripts" / "validate_cell_definition.py"), str(cell), "--json"], capture_output=True, text=True, check=False)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_cli_list_demos_text_and_json() -> None:
+    txt = _run("list-demos")
+    js = _run("list-demos", "--json")
+    assert txt.returncode == 0
+    assert "ur5_suction_sorting_demo" in txt.stdout
+    assert js.returncode == 0
+    payload = json.loads(js.stdout)
+    assert "demos" in payload
+
+
+def test_generate_demo_bundle_for_ur5_suction() -> None:
+    out = Path("/tmp/workcell_studio_demos_test")
+    proc = _run("generate-demo-bundle", "--demo-id", "ur5_suction_sorting_demo", "--output-dir", str(out), "--force")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    bundle = out / "ur5_suction_sorting_demo"
+    assert (bundle / "demo_bundle_summary.json").is_file()
+    assert (bundle / "demo_bundle_summary.md").is_file()
+    assert (bundle / "cell_definition.yaml").is_file()
+    assert (bundle / "next_commands.md").is_file()
+    assert list(bundle.glob("*/project_manifest.json"))
+
+
+def test_generate_all_demo_bundles_and_preview_only_reported() -> None:
+    out = Path("/tmp/workcell_studio_all_demos_test")
+    proc = _run("generate-demo-bundle", "--all", "--output-dir", str(out), "--force", "--continue-on-error")
+    assert proc.returncode in {0, 1}
+    for demo in backend.load_demo_catalog()["demos"]:
+        bundle = out / demo["id"]
+        if bundle.exists() and (bundle / "demo_bundle_summary.json").exists():
+            payload = json.loads((bundle / "demo_bundle_summary.json").read_text(encoding="utf-8"))
+            if demo.get("runtime_mode") == "preview_only":
+                assert payload.get("preview_only") is True
+
+
+def test_backend_demo_wrappers_and_invalid_demo_id() -> None:
+    listed = backend.list_demos()
+    assert listed["ok"]
+    out = Path("/tmp/workcell_studio_backend_demo")
+    generated = backend.generate_demo_bundle(out, demo_id="ur5_suction_sorting_demo")
+    assert generated["ok"]
+    summary = backend.load_demo_bundle_summary(out / "ur5_suction_sorting_demo")
+    assert summary["summary_json_path"]
+
+    invalid = _run("generate-demo-bundle", "--demo-id", "missing_demo", "--output-dir", str(out), "--force")
+    assert invalid.returncode != 0
+    assert "Unknown or missing demo id" in (invalid.stdout + invalid.stderr)

--- a/tools/workcell_studio_streamlit/README.md
+++ b/tools/workcell_studio_streamlit/README.md
@@ -29,3 +29,23 @@ streamlit run tools/workcell_studio_streamlit/app.py
 
 `workcell_builder` remains the visual editor.
 This Streamlit Studio prototype is currently an orchestration/readiness/demo UI.
+
+## Demo Gallery
+
+Open the Streamlit app and select **Demo Gallery**.
+
+Generate one demo bundle:
+- choose a demo id
+- choose output directory
+- click **Generate demo bundle**
+
+Generate all demo bundles:
+- click **Generate all demo bundles**
+
+Safety notes:
+- UI is offline-first and fake-hardware-first.
+- No robot motion commands are issued.
+- Runtime modes:
+  - `runtime_ready`: intended runtime-capable configuration.
+  - `fake_hardware_ready`: safe demo/validation default.
+  - `preview_only`: concept/sales visualization only.

--- a/tools/workcell_studio_streamlit/app.py
+++ b/tools/workcell_studio_streamlit/app.py
@@ -12,7 +12,7 @@ st.warning("Workcell Studio defaults to offline validation and fake hardware. Th
 
 workflow = st.sidebar.radio(
     "Workflow",
-    ["Catalog browser", "Cell definition validator", "Builder scene import"],
+    ["Catalog browser", "Cell definition validator", "Builder scene import", "Demo Gallery"],
 )
 
 if workflow == "Catalog browser":
@@ -43,7 +43,7 @@ elif workflow == "Cell definition validator":
             st.json(layout_result.get("json") or layout_result)
             st.code((layout_result.get("stdout") or "") + "\n" + (layout_result.get("stderr") or ""))
 
-else:
+elif workflow == "Builder scene import":
     st.header("Builder scene import")
     scene_package = st.text_input("Scene package path")
     output_dir = st.text_input("Output directory", value="/tmp/workcell_studio_streamlit")
@@ -76,3 +76,27 @@ else:
                 "runtime_preview_blockers": (summary.get("validation", {}).get("builder_scene", {}).get("runtime_blockers", [])),
             }
         )
+
+
+if workflow == "Demo Gallery":
+    st.header("Demo Gallery")
+    st.info("Preview-only demos are concept/demo artifacts only and are not runtime-ready.")
+    catalog = backend.load_demo_catalog()
+    demos = catalog.get("demos", [])
+    st.caption(f"Catalog: {catalog.get('catalog_path','')}")
+    st.dataframe(demos, use_container_width=True)
+    demo_ids = [d.get("id") for d in demos if isinstance(d, dict) and d.get("id")]
+    selected_demo = st.selectbox("Select demo", options=demo_ids) if demo_ids else ""
+    output_dir = st.text_input("Output directory", value="/tmp/workcell_studio_demos")
+    col1, col2 = st.columns(2)
+    if col1.button("Generate demo bundle") and selected_demo:
+        result = backend.generate_demo_bundle(output_dir=output_dir, demo_id=selected_demo, all_demos=False, force=True)
+        st.json(result.get("json") or result)
+        summary = backend.load_demo_bundle_summary(Path(output_dir) / selected_demo)
+        st.subheader("Demo bundle summary")
+        st.json(summary.get("summary", {}))
+        if summary.get("markdown"):
+            st.markdown(summary["markdown"])
+    if col2.button("Generate all demo bundles"):
+        result = backend.generate_demo_bundle(output_dir=output_dir, all_demos=True, force=True, continue_on_error=True)
+        st.json(result.get("json") or result)

--- a/tools/workcell_studio_streamlit/backend.py
+++ b/tools/workcell_studio_streamlit/backend.py
@@ -175,3 +175,48 @@ def load_import_summary(output_dir: str | Path) -> dict[str, Any]:
     else:
         payload["summary"] = {}
     return payload
+
+
+def load_demo_catalog(root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    catalog = rr / "catalog" / "workcell_studio_demos.yaml"
+    if not catalog.exists():
+        return {"catalog_path": str(catalog), "demos": []}
+    payload = _load_yaml_file(catalog)
+    demos = payload.get("demos") if isinstance(payload.get("demos"), list) else []
+    return {"catalog_path": str(catalog), "demos": demos}
+
+
+def list_demos(root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    cmd = [sys.executable, str(rr / "scripts" / "workcell_studio.py"), "list-demos", "--json"]
+    return _parse_json_output(run_command(cmd, cwd=rr))
+
+
+def generate_demo_bundle(output_dir: str | Path, demo_id: str | None = None, all_demos: bool = False, force: bool = True, continue_on_error: bool = False, root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    cmd = [sys.executable, str(rr / "scripts" / "workcell_studio.py"), "generate-demo-bundle", "--output-dir", str(output_dir)]
+    if all_demos:
+        cmd.append("--all")
+    elif demo_id:
+        cmd.extend(["--demo-id", demo_id])
+    if force:
+        cmd.append("--force")
+    if continue_on_error:
+        cmd.append("--continue-on-error")
+    return _parse_json_output(run_command(cmd, cwd=rr, timeout=600))
+
+
+def load_demo_bundle_summary(bundle_dir: str | Path) -> dict[str, Any]:
+    b = Path(bundle_dir)
+    js = b / "demo_bundle_summary.json"
+    md = b / "demo_bundle_summary.md"
+    out: dict[str, Any] = {
+        "summary_json_path": str(js) if js.exists() else "",
+        "summary_markdown_path": str(md) if md.exists() else "",
+        "summary": {},
+        "markdown": md.read_text(encoding="utf-8") if md.exists() else "",
+    }
+    if js.exists():
+        out["summary"] = json.loads(js.read_text(encoding="utf-8"))
+    return out


### PR DESCRIPTION
### Motivation

- Provide a curated set of offline demo templates so the Streamlit Workcell Studio prototype is immediately useful for investor/customer demos and validation without requiring real hardware or runtime changes. 
- Offer a one-command demo bundle exporter to produce portable offline demo artifacts (project, README, next-commands, dashboard/report paths) for review and sales previews. 
- Keep safety scope: offline-first, fake-hardware-first, no robot motion, no ROS launch/EPD/runtime behavior changes.

### Description

- Added a curated demo catalog at `catalog/workcell_studio_demos.yaml` listing four validated demos (UR5 + Robotiq 2F, UR5 + suction, generic cartesian + suction preview-only, generic delta + suction preview-only). 
- Extended `scripts/workcell_studio.py` with two new CLI flows: `list-demos` (human readable + `--json`) and `generate-demo-bundle` (single demo via `--demo-id` or all via `--all`, `--force`, `--continue-on-error`) that validate cell definitions, invoke the existing `create_workcell_project.py` generator, and write demo artifacts including `demo_bundle_summary.json`, `demo_bundle_summary.md`, copied `cell_definition.yaml`, and `next_commands.md`. 
- Added Streamlit backend wrappers in `tools/workcell_studio_streamlit/backend.py`: `load_demo_catalog()`, `list_demos()`, `generate_demo_bundle()`, and `load_demo_bundle_summary()` to allow UI-driven operations without importing Streamlit. 
- Extended the Streamlit UI (`tools/workcell_studio_streamlit/app.py`) with a new “Demo Gallery” workflow that lists demos, shows safety/preview info, allows selecting a demo or generating all demos, and displays generated summary JSON/Markdown and next commands; generation only occurs on explicit button clicks. 
- Added tests `tests/test_workcell_studio_demo_gallery.py` covering catalog loading, fixture existence and validation, CLI `list-demos`/`generate-demo-bundle` behavior (single and `--all`), preview-only handling, backend wrappers, and invalid demo-id handling. 
- Documentation updates: short demo gallery usage and safety notes added to `README.md`, `tools/workcell_studio_streamlit/README.md`, and `docs/manuals/WORKCELL_STUDIO_ROADMAP.md` to explain purpose and runtime-mode semantics.

### Testing

- Ran the focused demo-gallery test suite and integration tests: `python3 -m pytest -q tests/test_workcell_studio_demo_gallery.py` and the broader related suites: `tests/test_workcell_studio_streamlit_backend.py`, `tests/test_workcell_studio_builder_import_cli.py`, `tests/test_cell_definition_tools.py`, and `tests/test_workcell_project_tools.py`, and all tests passed (full run: 74 passed, 7 subtests passed). 
- Exercised CLI flows manually during validation: `python3 scripts/workcell_studio.py list-demos`, `python3 scripts/workcell_studio.py list-demos --json`, `python3 scripts/workcell_studio.py generate-demo-bundle --demo-id ur5_suction_sorting_demo --output-dir /tmp/workcell_studio_demos --force`, and `python3 scripts/workcell_studio.py generate-demo-bundle --all --output-dir /tmp/workcell_studio_all_demos --force --continue-on-error`, and verified that `demo_bundle_summary.json`, `demo_bundle_summary.md`, `cell_definition.yaml`, and `next_commands.md` were produced for generated bundles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba2e657548331af6e456a021b2acc)