### PR TITLE
Add offline static Workcell Studio preview artifacts for bundles/imports/Streamlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1493,3 +1493,7 @@ Use curated offline demos and export demo bundles:
 - `python3 scripts/workcell_studio.py generate-demo-bundle --all --output-dir /tmp/workcell_studio_all_demos --force --continue-on-error`
 
 Demo bundles are offline/demo/validation artifacts only. Preview-only demos are for concept visualization and are not runtime-ready.
+
+## Static Workcell Preview
+
+Workcell Studio can now generate offline static preview artifacts (`static_preview.svg`, `static_preview.html`, `static_preview_summary.json`) from `cell_definition.yaml` (+ optional `environment_layout.yaml`). These are fast investor/demo visuals only and do not replace RViz/MoveIt collision checking, safety validation, or runtime execution.

--- a/docs/manuals/WORKCELL_PROJECT_GENERATOR.md
+++ b/docs/manuals/WORKCELL_PROJECT_GENERATOR.md
@@ -98,3 +98,7 @@ python3 scripts/workcell_studio.py import-builder-scene \
   --validate \
   --generate-project
 ```
+
+## Static preview artifacts
+
+Workcell Studio now emits static SVG/HTML/JSON preview artifacts as investor/demo collateral for generated cells. These are not collision checks, safety validation, or runtime readiness proof; they are quick layout approximations before deeper RViz/MoveIt review.

--- a/scripts/generate_workcell_static_preview.py
+++ b/scripts/generate_workcell_static_preview.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, html, sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except Exception:
+    yaml = None
+
+CANVAS_W, CANVAS_H = 900, 640
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    if yaml is not None:
+        data = yaml.safe_load(path.read_text(encoding='utf-8'))
+        return data if isinstance(data, dict) else {}
+    script_dir = Path(__file__).resolve().parent
+    if str(script_dir) not in sys.path:
+        sys.path.insert(0, str(script_dir))
+    import validate_cell_definition as yaml_support
+    loaded, _, _ = yaml_support.load_yaml(path)
+    return loaded if isinstance(loaded, dict) else {}
+
+def _xy(v: Any):
+    if isinstance(v, list) and len(v) >= 2:
+        return float(v[0]), float(v[1]), False
+    return 0.0, 0.0, True
+
+def _scale(x: float, y: float):
+    return 450 + x*220, 320 - y*220
+
+def gen_preview(cell: dict[str, Any], env: dict[str, Any] | None, title: str) -> tuple[str, str, dict[str, Any]]:
+    warnings: list[str] = []
+    elements = []
+    approx = 0
+    robot = (cell.get('robot') or {})
+    ee = (cell.get('end_effector') or {})
+    task = (cell.get('task') or {})
+    comm = (cell.get('commissioning') or {})
+
+    # robot marker
+    rx, ry = 0.0, 0.0
+    sx, sy = _scale(rx, ry)
+    elements.append(f"<circle cx='{sx:.1f}' cy='{sy:.1f}' r='26' fill='#0f766e'/><text x='{sx:.1f}' y='{sy+5:.1f}' text-anchor='middle' fill='white'>Robot</text>")
+
+    surfaces = ((cell.get('environment') or {}).get('support_surfaces') or [])
+    for i,s in enumerate(surfaces[:3]):
+        x,y,a = _xy((s.get('pose_xyz') if isinstance(s,dict) else None))
+        if a:
+            warnings.append(f"support_surface[{i}] missing pose_xyz; using approximate placement")
+            approx +=1
+            x,y=-0.2+0.3*i,0.25
+        dim=(s.get('dimensions') if isinstance(s,dict) else None) or [0.8,0.6,0.05]
+        w,h=float(dim[0]),float(dim[1])
+        cx,cy=_scale(x,y)
+        elements.append(f"<rect x='{cx-w*110:.1f}' y='{cy-h*110:.1f}' width='{w*220:.1f}' height='{h*220:.1f}' fill='none' stroke='#334155' stroke-width='2'/><text x='{cx:.1f}' y='{cy:.1f}' text-anchor='middle'>Table:{html.escape(str(s.get('id','surface')))}</text>")
+
+    dests = task.get('destinations') if isinstance(task.get('destinations'), list) else []
+    for i,d in enumerate(dests[:6]):
+        x,y,a = _xy((d.get('pose_xyz') if isinstance(d,dict) else None))
+        if a:
+            warnings.append(f"destination[{i}] missing pose_xyz; using approximate placement")
+            approx +=1
+            x,y=0.5, -0.4 + i*0.15
+        cx,cy=_scale(x,y)
+        elements.append(f"<rect x='{cx-34:.1f}' y='{cy-20:.1f}' width='68' height='40' fill='#bfdbfe' stroke='#1d4ed8'/><text x='{cx:.1f}' y='{cy+4:.1f}' text-anchor='middle'>Bin:{html.escape(str(d.get('id','dest')))}</text>")
+
+    cam = cell.get('camera') if isinstance(cell.get('camera'), dict) else {}
+    cx,cy=_scale(-0.55,0.55)
+    elements.append(f"<polygon points='{cx},{cy-18} {cx-14},{cy+12} {cx+14},{cy+12}' fill='#a855f7'/><text x='{cx:.1f}' y='{cy+28:.1f}' text-anchor='middle'>Camera</text>")
+
+    if env and isinstance(env.get('zones'), list):
+        for z in env['zones'][:4]:
+            b=((z.get('bounds_xyz') or {}) if isinstance(z,dict) else {})
+            mn,mx=b.get('min'),b.get('max')
+            if isinstance(mn,list) and isinstance(mx,list) and len(mn)>=2 and len(mx)>=2:
+                x1,y1=_scale(float(mn[0]),float(mn[1])); x2,y2=_scale(float(mx[0]),float(mx[1]))
+                lx,minx=min(x1,x2),max(x1,x2); ty,by=min(y1,y2),max(y1,y2)
+                elements.append(f"<rect x='{lx:.1f}' y='{ty:.1f}' width='{minx-lx:.1f}' height='{by-ty:.1f}' fill='none' stroke='#f59e0b' stroke-dasharray='4 3'/><text x='{lx+4:.1f}' y='{ty+14:.1f}' fill='#92400e'>{html.escape(str(z.get('id','zone')))}</text>")
+
+    summary={
+        'title': title,
+        'robot': robot.get('model','unknown'),
+        'end_effector': ee.get('id') or ee.get('type','unknown'),
+        'task': task.get('type','unknown'),
+        'runtime_mode': comm.get('runtime_mode','unknown'),
+        'safety_status': {'fake_hardware_default': bool(comm.get('fake_hardware_default', True)), 'require_operator_review': bool(comm.get('require_operator_review', False))},
+        'preview_only': comm.get('runtime_mode')=='preview_only' or bool(cell.get('preview_only', False)),
+        'runtime_blocked': comm.get('runtime_mode')=='preview_only',
+        'warnings': warnings,
+        'approximate_placements': approx,
+    }
+    svg=f"<svg xmlns='http://www.w3.org/2000/svg' width='{CANVAS_W}' height='{CANVAS_H}'><rect width='100%' height='100%' fill='#f8fafc'/><text x='20' y='30' font-size='20'>{html.escape(title)}</text><text x='20' y='55'>robot={html.escape(str(summary['robot']))}, ee={html.escape(str(summary['end_effector']))}, task={html.escape(str(summary['task']))}</text>{''.join(elements)}</svg>"
+    html_doc=f"<!doctype html><html><body><h1>{html.escape(title)}</h1><p>Offline static preview approximation (not collision/safety validation).</p>{svg}<pre>{html.escape(json.dumps(summary, indent=2))}</pre></body></html>"
+    return svg, html_doc, summary
+
+
+def main()->int:
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--cell-definition', required=True, type=Path)
+    ap.add_argument('--environment-layout', type=Path)
+    ap.add_argument('--output-dir', required=True, type=Path)
+    ap.add_argument('--title', required=True)
+    ap.add_argument('--json', action='store_true')
+    a=ap.parse_args()
+    try:
+        cell=load_yaml(a.cell_definition)
+        if not cell or 'robot' not in cell:
+            print('ERROR: cell definition structurally unusable', file=sys.stderr); return 2
+        env=None
+        if a.environment_layout and a.environment_layout.exists():
+            env=load_yaml(a.environment_layout)
+        elif a.environment_layout:
+            env={}
+        a.output_dir.mkdir(parents=True, exist_ok=True)
+        svg, html_doc, summary=gen_preview(cell, env, a.title)
+        if a.environment_layout and not a.environment_layout.exists():
+            summary.setdefault("warnings", []).append("environment_layout path missing; used approximate/default placement")
+        (a.output_dir/'static_preview.svg').write_text(svg, encoding='utf-8')
+        (a.output_dir/'static_preview.html').write_text(html_doc, encoding='utf-8')
+        (a.output_dir/'static_preview_summary.json').write_text(json.dumps(summary, indent=2)+'\n', encoding='utf-8')
+        if a.json:
+            print(json.dumps(summary, indent=2))
+        return 0
+    except Exception as exc:
+        print(f'ERROR: failed to load/parse cell definition: {exc}', file=sys.stderr)
+        return 2
+
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/scripts/workcell_studio.py
+++ b/scripts/workcell_studio.py
@@ -42,6 +42,14 @@ def _run_json(cmd: list[str], label: str) -> tuple[int, dict[str, Any]]:
     return proc.returncode, payload
 
 
+
+
+def _generate_static_preview(cell_def: Path, output_dir: Path, title: str, environment_layout: Path | None = None) -> tuple[int, dict[str, Any]]:
+    cmd = [sys.executable, str(SCRIPT_DIR / "generate_workcell_static_preview.py"), "--cell-definition", str(cell_def), "--output-dir", str(output_dir), "--title", title, "--json"]
+    if environment_layout:
+        cmd.extend(["--environment-layout", str(environment_layout)])
+    return _run_json(cmd, "static preview")
+
 def load_demo_catalog() -> list[dict[str, Any]]:
     if not DEMO_CATALOG_PATH.is_file():
         return []
@@ -108,6 +116,8 @@ def generate_demo_bundle(args: argparse.Namespace) -> int:
 
         copied_cell = demo_dir / "cell_definition.yaml"
         shutil.copy2(cell_def, copied_cell)
+        preview_dir = demo_dir / "preview"
+        _, preview_payload = _generate_static_preview(cell_def, preview_dir, demo.get("title", demo["id"]))
         manifests = list(demo_dir.glob("*/project_manifest.json"))
         project_path = str(manifests[0].parent) if manifests else ""
         summary = {
@@ -121,6 +131,10 @@ def generate_demo_bundle(args: argparse.Namespace) -> int:
             "dashboard_path": str(manifests[0].parent / "dashboard" / "index.html") if manifests else "",
             "preflight_report_path": str(manifests[0].parent / "reports" / "validation_summary.md") if manifests else "",
             "next_commands_path": str(demo_dir / "next_commands.md"),
+            "preview_svg": str(preview_dir / "static_preview.svg"),
+            "preview_html": str(preview_dir / "static_preview.html"),
+            "preview_summary_json": str(preview_dir / "static_preview_summary.json"),
+            "preview_warnings": preview_payload.get("warnings", []),
             "stdout": project_rc.stdout.strip(),
             "stderr": project_rc.stderr.strip(),
         }
@@ -133,7 +147,10 @@ def generate_demo_bundle(args: argparse.Namespace) -> int:
             f"- Preview only: `{summary['preview_only']}`\n"
             f"- Generated project path: `{project_path or '(none)'}`\n"
             f"- Dashboard: `{summary['dashboard_path'] or '(none)'}`\n"
-            f"- Preflight report: `{summary['preflight_report_path'] or '(none)'}`\n",
+            f"- Preflight report: `{summary['preflight_report_path'] or '(none)'}`\n"
+            f"- Preview SVG: `{summary['preview_svg']}`\n"
+            f"- Preview HTML: `{summary['preview_html']}`\n"
+            f"- Preview Summary JSON: `{summary['preview_summary_json']}`\n",
             encoding="utf-8",
         )
         (demo_dir / "next_commands.md").write_text(
@@ -141,6 +158,7 @@ def generate_demo_bundle(args: argparse.Namespace) -> int:
             "python3 scripts/workcell_studio.py list-demos\n"
             f"python3 scripts/workcell_studio.py generate-demo-bundle --demo-id {demo['id']} --output-dir {output_root} --force\n"
             f"python3 scripts/validate_cell_definition.py {copied_cell} --json\n"
+            f"python3 scripts/generate_workcell_static_preview.py --cell-definition {copied_cell} --output-dir {preview_dir} --title '{demo.get("title",demo["id"])}'\n"
             "```\n",
             encoding="utf-8",
         )
@@ -252,6 +270,9 @@ def import_builder_scene(args: argparse.Namespace) -> int:
             if preflight_rel:
                 preflight_report_path = str(manifest_candidates[0].parent / preflight_rel)
 
+    preview_dir = output_dir / "preview"
+    _, preview_payload = _generate_static_preview(cell_def, preview_dir, f"Builder Import: {_scene_name(scene_pkg)}", env_layout)
+
     builder_readiness = (validations.get("builder_scene", {}) or {}).get("readiness")
     safety = {
         "fake_hardware_default": True,
@@ -270,6 +291,10 @@ def import_builder_scene(args: argparse.Namespace) -> int:
         "dashboard_path": dashboard_path,
         "preflight_report_path": preflight_report_path,
         "safety_status": safety,
+        "preview_svg": str(preview_dir / "static_preview.svg"),
+        "preview_html": str(preview_dir / "static_preview.html"),
+        "preview_summary_json": str(preview_dir / "static_preview_summary.json"),
+        "preview_warnings": preview_payload.get("warnings", []),
         "next_commands": [
             f"python3 scripts/validate_builder_generated_scene.py {scene_pkg} --json",
             f"python3 scripts/validate_cell_definition.py {cell_def} --json",
@@ -292,6 +317,8 @@ def import_builder_scene(args: argparse.Namespace) -> int:
         f"- Environment layout: `{env_layout}`",
         f"- Generated project path: `{generated_project_path or '(not generated)'}`",
         f"- Runtime status: `{safety['runtime_status']}`",
+        f"- Preview SVG: `{summary['preview_svg']}`",
+        f"- Preview HTML: `{summary['preview_html']}`",
         "",
         "## Validation",
         f"- Builder scene: `{(validations.get('builder_scene', {}) or {}).get('ok', 'not-run')}`",

--- a/tests/test_workcell_static_preview.py
+++ b/tests/test_workcell_static_preview.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+import json, subprocess, tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI = REPO_ROOT / 'scripts' / 'generate_workcell_static_preview.py'
+
+def _run(*args:str):
+    return subprocess.run(['python3', str(CLI), *args], capture_output=True, text=True, check=False)
+
+def test_valid_ur5_preview_generates_artifacts():
+    with tempfile.TemporaryDirectory() as d:
+        out=Path(d)
+        cell=REPO_ROOT/'tests/fixtures/cell_definition_ur5_suction_sorting.yaml'
+        p=_run('--cell-definition',str(cell),'--output-dir',str(out),'--title','UR5 + Suction Sorting Demo')
+        assert p.returncode==0, p.stdout+p.stderr
+        assert (out/'static_preview.svg').is_file(); assert (out/'static_preview.html').is_file(); assert (out/'static_preview_summary.json').is_file()
+        s=json.loads((out/'static_preview_summary.json').read_text())
+        assert s['robot'] and s['end_effector'] and s['task'] and s['title']
+        svg=(out/'static_preview.svg').read_text()
+        assert 'Robot' in svg and ('Bin:' in svg or 'Table:' in svg)
+
+def test_preview_only_fixture_still_generates():
+    with tempfile.TemporaryDirectory() as d:
+        out=Path(d)
+        cell=REPO_ROOT/'tests/fixtures/cell_definition_generic_cartesian_suction_sorting.yaml'
+        p=_run('--cell-definition',str(cell),'--output-dir',str(out),'--title','Preview Only')
+        assert p.returncode==0
+        s=json.loads((out/'static_preview_summary.json').read_text())
+        assert 'preview_only' in s and 'runtime_blocked' in s
+
+def test_missing_optional_environment_layout_warns():
+    with tempfile.TemporaryDirectory() as d:
+        out=Path(d)
+        cell=REPO_ROOT/'tests/fixtures/cell_definition_pick_place.yaml'
+        p=_run('--cell-definition',str(cell),'--environment-layout',str(Path(d)/'missing.yaml'),'--output-dir',str(out),'--title','No Layout')
+        assert p.returncode==0
+        s=json.loads((out/'static_preview_summary.json').read_text())
+        assert isinstance(s.get('warnings',[]), list)
+
+def test_bad_cell_definition_fails():
+    with tempfile.TemporaryDirectory() as d:
+        p=_run('--cell-definition',str(Path(d)/'missing.yaml'),'--output-dir',str(Path(d)/'o'),'--title','bad')
+        assert p.returncode != 0
+        assert 'ERROR' in p.stderr

--- a/tests/test_workcell_studio_builder_import_cli.py
+++ b/tests/test_workcell_studio_builder_import_cli.py
@@ -43,6 +43,8 @@ def test_import_reuses_existing_exports_and_writes_summaries() -> None:
         assert summary["validation"]["cell_definition"]
         assert summary["validation"]["environment_layout"]
         assert summary["generated_project_path"]
+        assert (out / "preview" / "static_preview.svg").is_file()
+        assert summary.get("preview_svg") and summary.get("preview_html")
 
 
 def test_import_auto_exports_missing_generated_files() -> None:

--- a/tests/test_workcell_studio_demo_gallery.py
+++ b/tests/test_workcell_studio_demo_gallery.py
@@ -50,6 +50,10 @@ def test_generate_demo_bundle_for_ur5_suction() -> None:
     assert (bundle / "demo_bundle_summary.md").is_file()
     assert (bundle / "cell_definition.yaml").is_file()
     assert (bundle / "next_commands.md").is_file()
+    assert (bundle / "preview" / "static_preview.svg").is_file()
+    assert (bundle / "preview" / "static_preview.html").is_file()
+    payload = json.loads((bundle / "demo_bundle_summary.json").read_text(encoding="utf-8"))
+    assert payload.get("preview_svg") and payload.get("preview_html") and payload.get("preview_summary_json")
     assert list(bundle.glob("*/project_manifest.json"))
 
 

--- a/tests/test_workcell_studio_streamlit_backend.py
+++ b/tests/test_workcell_studio_streamlit_backend.py
@@ -71,3 +71,13 @@ def test_missing_input_handling_returns_structured_error() -> None:
     missing_scene = backend.import_builder_scene("/tmp/definitely_missing_scene", "/tmp/out", "demo")
     assert not missing_scene["ok"]
     assert "does not exist" in missing_scene["error"]
+
+
+def test_static_preview_backend_helpers() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        out = Path(d) / "preview"
+        fixture = backend.repo_root() / "tests" / "fixtures" / "cell_definition_pick_place.yaml"
+        result = backend.generate_static_preview(fixture, out, "Backend Preview")
+        assert result["returncode"] == 0
+        summary = backend.load_static_preview_summary(out)
+        assert summary.get("title") == "Backend Preview"

--- a/tools/workcell_studio_streamlit/README.md
+++ b/tools/workcell_studio_streamlit/README.md
@@ -49,3 +49,7 @@ Safety notes:
   - `runtime_ready`: intended runtime-capable configuration.
   - `fake_hardware_ready`: safe demo/validation default.
   - `preview_only`: concept/sales visualization only.
+
+## Static preview artifacts
+
+Demo Gallery and Builder Scene Import now surface static preview artifacts when generated. These previews are offline approximations for quick review only; RViz/MoveIt remains the real planning/visualisation path.

--- a/tools/workcell_studio_streamlit/app.py
+++ b/tools/workcell_studio_streamlit/app.py
@@ -70,12 +70,19 @@ elif workflow == "Builder scene import":
         st.write(
             {
                 "generated_project_path": summary.get("generated_project_path"),
+                "preview_svg": summary.get("preview_svg"),
+                "preview_html": summary.get("preview_html"),
                 "dashboard_path": summary.get("dashboard_path"),
                 "preflight_report_path": summary.get("preflight_report_path"),
                 "safety_status": summary.get("safety_status"),
                 "runtime_preview_blockers": (summary.get("validation", {}).get("builder_scene", {}).get("runtime_blockers", [])),
             }
         )
+        if summary.get("preview_svg") and Path(summary["preview_svg"]).exists():
+            st.subheader("Static Preview")
+            st.image(summary["preview_svg"])
+        if summary.get("preview_warnings"):
+            st.warning("\n".join(summary.get("preview_warnings", [])))
 
 
 if workflow == "Demo Gallery":
@@ -97,6 +104,12 @@ if workflow == "Demo Gallery":
         st.json(summary.get("summary", {}))
         if summary.get("markdown"):
             st.markdown(summary["markdown"])
+        payload = summary.get("summary", {})
+        if payload.get("preview_svg") and Path(payload["preview_svg"]).exists():
+            st.subheader("Static Preview")
+            st.image(payload["preview_svg"])
+        if payload.get("preview_warnings"):
+            st.warning("\n".join(payload.get("preview_warnings", [])))
     if col2.button("Generate all demo bundles"):
         result = backend.generate_demo_bundle(output_dir=output_dir, all_demos=True, force=True, continue_on_error=True)
         st.json(result.get("json") or result)

--- a/tools/workcell_studio_streamlit/backend.py
+++ b/tools/workcell_studio_streamlit/backend.py
@@ -220,3 +220,22 @@ def load_demo_bundle_summary(bundle_dir: str | Path) -> dict[str, Any]:
     if js.exists():
         out["summary"] = json.loads(js.read_text(encoding="utf-8"))
     return out
+
+
+def generate_static_preview(cell_definition_path: str | Path, output_dir: str | Path, title: str, environment_layout_path: str | Path | None = None, root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    cmd = [sys.executable, str(rr / "scripts" / "generate_workcell_static_preview.py"), "--cell-definition", str(cell_definition_path), "--output-dir", str(output_dir), "--title", title, "--json"]
+    if environment_layout_path:
+        cmd.extend(["--environment-layout", str(environment_layout_path)])
+    return _parse_json_output(run_command(cmd, cwd=rr))
+
+
+def load_static_preview_summary(preview_dir: str | Path) -> dict[str, Any]:
+    p = Path(preview_dir)
+    js = p / "static_preview_summary.json"
+    return json.loads(js.read_text(encoding="utf-8")) if js.exists() else {}
+
+
+def read_preview_html(preview_dir: str | Path) -> str:
+    html_path = Path(preview_dir) / "static_preview.html"
+    return html_path.read_text(encoding="utf-8") if html_path.exists() else ""


### PR DESCRIPTION
### Motivation
- Provide fast, deterministic offline visual previews of generated workcell bundles so stakeholders can inspect layouts before running RViz/MoveIt or runtime systems. 
- Surface simple HTML/SVG/JSON preview artifacts from `cell_definition` (+ optional `environment_layout`) in demo bundles and the Streamlit UI without changing runtime, ROS, or hardware behavior. 
- Keep the preview layer lightweight and safe by emitting warnings and approximate placements when optional metadata is missing rather than failing generation.

### Description
- Add `scripts/generate_workcell_static_preview.py` to produce `static_preview.svg`, `static_preview.html`, and `static_preview_summary.json` from a `cell_definition.yaml` (optional `--environment-layout`), using only stdlib + PyYAML where available and deterministic fallbacks and HTML/SVG escaping. 
- Integrate preview generation into CLI flows by calling the preview script from `scripts/workcell_studio.py` for both `generate-demo-bundle` and `import-builder-scene`, writing artifacts under `<bundle>/preview/` or `<output-dir>/preview/` and adding `preview_svg`, `preview_html`, `preview_summary_json`, and `preview_warnings` to summary artifacts and markdown. 
- Extend Streamlit backend with `generate_static_preview()`, `load_static_preview_summary()`, and `read_preview_html()` helpers in `tools/workcell_studio_streamlit/backend.py` and update `tools/workcell_studio_streamlit/app.py` to show preview SVG/HTML and warnings after explicit button actions. 
- Add `tests/test_workcell_static_preview.py` and extend existing CLI/backend tests to assert preview artifacts and summary wiring, and update documentation (`README.md`, Streamlit README, and project generator manual) to describe preview intent and scope.

### Testing
- Ran `pytest` for preview-related suites: `tests/test_workcell_static_preview.py`, `tests/test_workcell_studio_demo_gallery.py`, `tests/test_workcell_studio_builder_import_cli.py`, and `tests/test_workcell_studio_streamlit_backend.py`, which passed (20 passed). 
- Ran broader tool tests `tests/test_cell_definition_tools.py` and `tests/test_workcell_project_tools.py`, which passed (59 passed, 7 subtests passed). 
- Manually exercised the CLI preview generation with `python3 scripts/generate_workcell_static_preview.py --cell-definition tests/fixtures/cell_definition_ur5_suction_sorting.yaml --output-dir /tmp/workcell_static_preview --title "UR5 + Suction Sorting Demo"` and observed the three preview artifacts and a populated `static_preview_summary.json`. 
- Generated a demo bundle via `python3 scripts/workcell_studio.py generate-demo-bundle --demo-id ur5_suction_sorting_demo --output-dir /tmp/workcell_studio_demos --force` and verified `preview/static_preview.*` artifacts plus preview fields in `demo_bundle_summary.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba5ac43bc83318668d16b64cbfd47)