### PR TITLE
Add Workcell Studio Create Cell wizard (CLI + Streamlit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1497,3 +1497,7 @@ Demo bundles are offline/demo/validation artifacts only. Preview-only demos are 
 ## Static Workcell Preview
 
 Workcell Studio can now generate offline static preview artifacts (`static_preview.svg`, `static_preview.html`, `static_preview_summary.json`) from `cell_definition.yaml` (+ optional `environment_layout.yaml`). These are fast investor/demo visuals only and do not replace RViz/MoveIt collision checking, safety validation, or runtime execution.
+
+## Create Cell Wizard
+
+Use `python3 scripts/workcell_studio.py create-cell` for fast catalog/YAML cell creation with optional validation, static preview, and offline project bundle generation. This path is fake-hardware-first and does not start ROS launch or robot motion.

--- a/docs/manuals/WORKCELL_STUDIO_ROADMAP.md
+++ b/docs/manuals/WORKCELL_STUDIO_ROADMAP.md
@@ -59,3 +59,7 @@ High-level ownership boundaries:
 ## Curated Demo Catalog
 
 `catalog/workcell_studio_demos.yaml` defines investor/customer-friendly offline demo templates. Generated demo bundles are strictly offline/demo/validation artifacts and do not alter runtime robot behavior or launch behavior. Preview-only demos support sales/concept visualization and must not be treated as real runtime support.
+
+## Create-cell wizard
+
+`workcell_builder` remains the visual scene editor. `workcell_studio.py create-cell` is a fast catalog-driven YAML creation path that generates cell definition/layout, validates, produces static previews, and can optionally emit offline bundle artifacts.

--- a/scripts/workcell_studio.py
+++ b/scripts/workcell_studio.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -49,6 +50,94 @@ def _generate_static_preview(cell_def: Path, output_dir: Path, title: str, envir
     if environment_layout:
         cmd.extend(["--environment-layout", str(environment_layout)])
     return _run_json(cmd, "static preview")
+
+
+def _catalog_index() -> dict[str, dict[str, dict[str, Any]]]:
+    def _entries(group: str, key: str) -> dict[str, dict[str, Any]]:
+        out: dict[str, dict[str, Any]] = {}
+        for path in sorted((REPO_ROOT / "catalog" / "capabilities" / group).glob("*.yaml")):
+            payload = _load_yaml(path)
+            data = payload.get(key, {}) if isinstance(payload.get(key), dict) else {}
+            if data.get("id"):
+                out[data["id"]] = {"id": data["id"], "family": data.get("family"), "compatible_families": data.get("compatible_tool_families") or data.get("supported_task_families") or []}
+        return out
+    grasp: dict[str, dict[str, Any]] = {}
+    for path in sorted((REPO_ROOT / "catalog" / "grasp_strategies").glob("*.yaml")):
+        payload = _load_yaml(path)
+        data = payload.get("grasp_strategy", {}) if isinstance(payload.get("grasp_strategy"), dict) else {}
+        if data.get("id"):
+            grasp[data["id"]] = {"id": data["id"], "compatible_families": data.get("compatible_tool_families") or []}
+    return {"robots": _entries("robots", "robot"), "end_effectors": _entries("end_effectors", "end_effector"), "sensors": _entries("sensors", "sensor"), "tasks": _entries("tasks", "task"), "grasp_strategies": grasp}
+
+
+def _resolve(group: str, value: str, ids: dict[str, dict[str, Any]]) -> tuple[str, list[str]]:
+    aliases = {"robotiq_2f": "robotiq_2f_85", "suction": "onrobot_airpick_style", "realsense_d435i": "intel_realsense_d435i", "sort_by_colour": "task_magnetic_pick_place"}
+    resolved = aliases.get(value, value)
+    if resolved not in ids:
+        raise ValueError(f"Unknown {group}: {value}")
+    out = []
+    if resolved != value:
+        out.append(f"Resolved alias '{value}' -> '{resolved}'")
+    return resolved, out
+
+
+def _default_environment_layout(cell_id: str, sensor_id: str, task_id: str) -> dict[str, Any]:
+    assets = [{"id": "main_table", "asset_ref": "table_standard_1200", "type": "table", "pose": {"frame": "world", "xyz": [0.5, 0.0, 0.0], "rpy": [0, 0, 0]}}, {"id": "overhead_sensor", "asset_ref": sensor_id, "type": "sensor", "pose": {"frame": "world", "xyz": [0.65, 0.0, 1.2], "rpy": [0, 0, 0]}}]
+    if "conveyor" in task_id:
+        assets.append({"id": "optional_conveyor", "asset_ref": "conveyor_2m", "type": "conveyor", "pose": {"frame": "world", "xyz": [1.2, 0.0, 0.0], "rpy": [0, 0, 0]}})
+    return {"schema_version": "environment_layout/v1", "layout_id": f"{cell_id}_layout", "metadata": {"name": f"{cell_id} generated layout", "generated_defaults": True, "placement_accuracy": "approximate_defaults_for_preview_only"}, "assets": assets, "zones": [{"id": "pick_zone", "type": "pick", "frame": "world", "bounds_xyz": {"min": [0.2, -0.5, 0.35], "max": [0.8, -0.1, 0.75]}}, {"id": "bin_a_zone", "type": "place", "frame": "world", "bounds_xyz": {"min": [0.55, 0.2, 0.35], "max": [0.8, 0.45, 0.75]}}, {"id": "bin_b_zone", "type": "place", "frame": "world", "bounds_xyz": {"min": [0.55, -0.45, 0.35], "max": [0.8, -0.2, 0.75]}}]}
+
+
+def create_cell(args: argparse.Namespace) -> int:
+    if str(SCRIPT_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPT_DIR))
+    import create_cell_definition_wizard as wizard
+    out = args.output_dir.resolve()
+    if out.exists() and args.force:
+        shutil.rmtree(out)
+    out.mkdir(parents=True, exist_ok=True)
+    idx = _catalog_index()
+    warnings: list[str] = []
+    robot_id, w = _resolve("robot", args.robot, idx["robots"]); warnings += w
+    ee_id, w = _resolve("end_effector", args.end_effector, idx["end_effectors"]); warnings += w
+    sensor_id, w = _resolve("sensor", args.sensor, idx["sensors"]); warnings += w
+    task_id, w = _resolve("task", args.task, idx["tasks"]); warnings += w
+    grasp_id, w = _resolve("grasp_strategy", args.grasp_strategy, idx["grasp_strategies"]); warnings += w
+    blockers = []
+    compat = "compatible"
+    allowed_fams = idx["end_effectors"][ee_id]["compatible_families"] or []
+    robot_family = idx["robots"][robot_id].get("family")
+    if allowed_fams and robot_family and robot_family not in allowed_fams:
+        blockers.append(f"Tool {ee_id} incompatible with robot family {robot_family}")
+    grasp_fams = idx["grasp_strategies"][grasp_id]["compatible_families"] or []
+    if grasp_fams and idx["end_effectors"][ee_id].get("family") not in grasp_fams:
+        blockers.append(f"Grasp {grasp_id} incompatible with end-effector family")
+    if blockers and not args.allow_incompatible:
+        print(json.dumps({"result": "FAIL", "blockers": blockers}, indent=2))
+        return 2
+    if blockers:
+        compat = "incompatible_allowed_preview_only"
+    cell_def_data = {"schema_version": "cell_definition/v1", "cell": {"id": args.cell_id, "name": args.cell_id, "description": "Generated by Workcell Studio create-cell wizard"}, "robot": wizard.ROBOT_PRESETS.get(args.robot, wizard.ROBOT_PRESETS["ur5"]), "end_effector": {"id": ee_id, "type": "suction" if "suction" in ee_id or "airpick" in ee_id else "finger", "brand": "catalog", "grasp_frame": "tool0", "allowed_touch_links": []}, "camera": {"id": sensor_id, "type": "depth_camera", "frame": "camera_depth_optical_frame"}, "environment": {"frame": "world", "support_surfaces": [{"id": "table_main", "type": "table", "frame": "world", "pose_xyz": [0.0, 0.0, 0.0], "pose_rpy": [0, 0, 0], "dimensions": [1.0, 1.0, 0.05]}]}, "objects": [{"id": "spawn_object", "class": "box", "shape": "box", "color": "unknown", "material": "unknown", "frame": "world", "dimensions": [0.05, 0.05, 0.05], "pose_xyz": [0.45, 0.0, 0.08], "pose_rpy": [0, 0, 0]}], "task": {"id": task_id, "type": "sort_by_colour", "source_object": "spawn_object", "destinations": [{"id": "bin_a", "frame": "world", "pose_xyz": [0.30, 0.30, 0.1], "pose_rpy": [0, 0, 0]}, {"id": "bin_b", "frame": "world", "pose_xyz": [0.30, -0.30, 0.1], "pose_rpy": [0, 0, 0]}], "rules": [{"id": "route_default", "when": {"always": True}, "destination": "bin_a"}]}, "grasp": {"strategy_ref": grasp_id}, "commissioning": {"self_test_enabled": True, "export_bundle": True, "require_operator_review": True}}
+    cell_def_path = out / "cell_definition.yaml"
+    cell_def_path.write_text(wizard.to_yaml_text(cell_def_data), encoding="utf-8")
+    layout_path = out / "environment_layout.yaml"
+    layout_path.write_text(wizard.to_yaml_text(_default_environment_layout(args.cell_id, sensor_id, task_id)), encoding="utf-8")
+    validation = {}
+    if args.validate:
+        _, validation = _run_json([sys.executable, str(SCRIPT_DIR / "validate_cell_definition.py"), str(cell_def_path), "--json"], "validate")
+    preview = {}
+    if args.preview:
+        _, preview = _generate_static_preview(cell_def_path, out / "preview", args.cell_id, layout_path)
+    bundle_path = ""
+    if args.generate_bundle:
+        subprocess.run([sys.executable, str(SCRIPT_DIR / "create_workcell_project.py"), "--cell-definition", str(cell_def_path), "--output-dir", str(out / "project"), "--force"], check=False)
+        bundle_path = str(out / "project")
+    runtime_mode = "fake_hardware_ready" if robot_id == "ur5" and not blockers else "preview_only"
+    summary = {"selected": {"robot": args.robot, "end_effector": args.end_effector, "sensor": args.sensor, "task": args.task, "grasp_strategy": args.grasp_strategy}, "resolved_catalog_ids": {"robot": robot_id, "end_effector": ee_id, "sensor": sensor_id, "task": task_id, "grasp_strategy": grasp_id}, "compatibility_status": compat, "warnings": warnings, "blockers": blockers, "cell_definition_path": str(cell_def_path), "environment_layout_path": str(layout_path), "validation": validation, "preview_paths": {"svg": str(out / "preview" / "static_preview.svg"), "html": str(out / "preview" / "static_preview.html"), "summary_json": str(out / "preview" / "static_preview_summary.json")}, "generated_bundle_project_path": bundle_path, "runtime_mode": runtime_mode, "safety_status": {"fake_hardware_default": True, "runtime_io_applied": False, "motion_started": False, "ros_launch_started": False}}
+    (out / "create_cell_summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    (out / "create_cell_summary.md").write_text("# Create Cell Summary\n\n- Runtime mode: `%s`\n- Compatibility: `%s`\n- Cell definition: `%s`\n- Environment layout: `%s`\n" % (runtime_mode, compat, cell_def_path, layout_path), encoding="utf-8")
+    print(json.dumps({"result": "PASS", "summary": str(out / "create_cell_summary.json")}, indent=2))
+    return 0
 
 def load_demo_catalog() -> list[dict[str, Any]]:
     if not DEMO_CATALOG_PATH.is_file():
@@ -358,6 +447,20 @@ def _build_parser() -> argparse.ArgumentParser:
     import_parser.add_argument("--validate", action="store_true")
     import_parser.add_argument("--generate-project", action="store_true")
     import_parser.set_defaults(func=import_builder_scene)
+    cc = sub.add_parser("create-cell", help="Create a catalog-driven cell_definition + environment layout + optional preview/bundle")
+    cc.add_argument("--cell-id", required=True)
+    cc.add_argument("--robot", required=True)
+    cc.add_argument("--end-effector", required=True)
+    cc.add_argument("--sensor", required=True)
+    cc.add_argument("--task", required=True)
+    cc.add_argument("--grasp-strategy", required=True)
+    cc.add_argument("--output-dir", type=Path, required=True)
+    cc.add_argument("--validate", action="store_true")
+    cc.add_argument("--preview", action="store_true")
+    cc.add_argument("--generate-bundle", action="store_true")
+    cc.add_argument("--allow-incompatible", action="store_true")
+    cc.add_argument("--force", action="store_true")
+    cc.set_defaults(func=create_cell)
     return parser
 
 def main() -> int:

--- a/tests/test_workcell_studio_create_cell.py
+++ b/tests/test_workcell_studio_create_cell.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import json, subprocess, tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run(cmd: list[str]):
+    return subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+
+
+def test_create_cell_help() -> None:
+    r = _run(["python3", "scripts/workcell_studio.py", "create-cell", "--help"])
+    assert r.returncode == 0
+
+
+def test_create_ur5_finger_cell() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        out = Path(d) / "cell"
+        r = _run(["python3", "scripts/workcell_studio.py", "create-cell", "--cell-id", "ur5_2f", "--robot", "ur5", "--end-effector", "robotiq_2f", "--sensor", "intel_realsense_d435i", "--task", "task_magnetic_pick_place", "--grasp-strategy", "finger_pinch_basic", "--output-dir", str(out), "--validate", "--force"])
+        assert r.returncode == 0
+        s = json.loads((out / "create_cell_summary.json").read_text())
+        assert (out / "cell_definition.yaml").exists()
+        assert s["safety_status"]["fake_hardware_default"] is True
+        assert s["safety_status"]["motion_started"] is False
+        assert s["safety_status"]["ros_launch_started"] is False
+
+
+def test_incompatible_combo_handling() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        out = Path(d) / "bad"
+        bad = _run(["python3", "scripts/workcell_studio.py", "create-cell", "--cell-id", "bad", "--robot", "generic_delta_900", "--end-effector", "robotiq_2f_85", "--sensor", "intel_realsense_d435i", "--task", "task_magnetic_pick_place", "--grasp-strategy", "suction_top_basic", "--output-dir", str(out), "--force"])
+        assert bad.returncode != 0
+        ok = _run(["python3", "scripts/workcell_studio.py", "create-cell", "--cell-id", "bad2", "--robot", "generic_delta_900", "--end-effector", "robotiq_2f_85", "--sensor", "intel_realsense_d435i", "--task", "task_magnetic_pick_place", "--grasp-strategy", "suction_top_basic", "--output-dir", str(out), "--allow-incompatible", "--preview", "--force"])
+        assert ok.returncode == 0
+        s = json.loads((out / "create_cell_summary.json").read_text())
+        assert s["runtime_mode"] in {"preview_only", "blocked"}
+        assert s["blockers"]

--- a/tests/test_workcell_studio_streamlit_backend.py
+++ b/tests/test_workcell_studio_streamlit_backend.py
@@ -81,3 +81,26 @@ def test_static_preview_backend_helpers() -> None:
         assert result["returncode"] == 0
         summary = backend.load_static_preview_summary(out)
         assert summary.get("title") == "Backend Preview"
+
+
+def test_create_cell_backend_helpers() -> None:
+    choices = backend.resolve_catalog_choices()
+    assert "robots" in choices and choices["robots"]
+    with tempfile.TemporaryDirectory() as d:
+        out = Path(d) / "cell"
+        result = backend.create_cell(
+            cell_id="backend_cell",
+            robot="ur5",
+            end_effector="robotiq_2f",
+            sensor="intel_realsense_d435i",
+            task="task_magnetic_pick_place",
+            grasp_strategy="finger_pinch_basic",
+            output_dir=out,
+            validate=True,
+            preview=False,
+            generate_bundle=False,
+            force=True,
+        )
+        assert result["returncode"] == 0
+        summary = backend.load_create_cell_summary(out)
+        assert summary["summary_json_path"]

--- a/tools/workcell_studio_streamlit/README.md
+++ b/tools/workcell_studio_streamlit/README.md
@@ -53,3 +53,7 @@ Safety notes:
 ## Static preview artifacts
 
 Demo Gallery and Builder Scene Import now surface static preview artifacts when generated. These previews are offline approximations for quick review only; RViz/MoveIt remains the real planning/visualisation path.
+
+## Create Cell flow
+
+The Streamlit app now includes **Create Cell** for selecting catalog robot/tool/sensor/task/grasp strategy and generating `cell_definition.yaml`, `environment_layout.yaml`, summary files, static preview, and optional bundle outputs. Incompatible combos can be marked preview-only with explicit warnings.

--- a/tools/workcell_studio_streamlit/app.py
+++ b/tools/workcell_studio_streamlit/app.py
@@ -12,7 +12,7 @@ st.warning("Workcell Studio defaults to offline validation and fake hardware. Th
 
 workflow = st.sidebar.radio(
     "Workflow",
-    ["Catalog browser", "Cell definition validator", "Builder scene import", "Demo Gallery"],
+    ["Catalog browser", "Cell definition validator", "Builder scene import", "Demo Gallery", "Create Cell"],
 )
 
 if workflow == "Catalog browser":
@@ -113,3 +113,26 @@ if workflow == "Demo Gallery":
     if col2.button("Generate all demo bundles"):
         result = backend.generate_demo_bundle(output_dir=output_dir, all_demos=True, force=True, continue_on_error=True)
         st.json(result.get("json") or result)
+
+if workflow == "Create Cell":
+    st.header("Create Cell")
+    choices = backend.resolve_catalog_choices()
+    robot = st.selectbox("Robot", [x["id"] for x in choices["robots"]])
+    ee = st.selectbox("End effector", [x["id"] for x in choices["end_effectors"]])
+    sensor = st.selectbox("Sensor", [x["id"] for x in choices["sensors"]])
+    task = st.selectbox("Task", [x["id"] for x in choices["tasks"]])
+    grasp = st.selectbox("Grasp strategy", [x["id"] for x in choices["grasp_strategies"]])
+    cell_id = st.text_input("Cell ID", value="my_first_cell")
+    output_dir = st.text_input("Output directory", value="/tmp/workcell_studio_create_cell")
+    validate = st.checkbox("Validate", value=True)
+    preview = st.checkbox("Generate static preview", value=True)
+    bundle = st.checkbox("Generate project/demo bundle", value=False)
+    allow = st.checkbox("Allow incompatible as preview-only", value=False)
+    if st.button("Create cell"):
+        result = backend.create_cell(cell_id, robot, ee, sensor, task, grasp, output_dir, validate=validate, preview=preview, generate_bundle=bundle, allow_incompatible=allow, force=True)
+        st.json(result.get("json") or result)
+        summary = result.get("summary", {})
+        st.subheader("Create Cell Summary")
+        st.json(summary.get("summary", {}))
+        if summary.get("markdown"):
+            st.markdown(summary["markdown"])

--- a/tools/workcell_studio_streamlit/backend.py
+++ b/tools/workcell_studio_streamlit/backend.py
@@ -239,3 +239,45 @@ def load_static_preview_summary(preview_dir: str | Path) -> dict[str, Any]:
 def read_preview_html(preview_dir: str | Path) -> str:
     html_path = Path(preview_dir) / "static_preview.html"
     return html_path.read_text(encoding="utf-8") if html_path.exists() else ""
+
+
+def resolve_catalog_choices(root: Path | None = None) -> dict[str, list[dict[str, str]]]:
+    caps = load_capability_catalog(root)
+    grasps = load_grasp_strategy_catalog(root)
+    return {
+        "robots": [{"id": x.get("id"), "label": x.get("label") or x.get("id")} for x in caps.get("robots", []) if x.get("id")],
+        "end_effectors": [{"id": x.get("id"), "label": x.get("label") or x.get("id")} for x in caps.get("end_effectors", []) if x.get("id")],
+        "sensors": [{"id": x.get("id"), "label": x.get("label") or x.get("id")} for x in caps.get("sensors", []) if x.get("id")],
+        "tasks": [{"id": x.get("id"), "label": x.get("label") or x.get("id")} for x in caps.get("tasks", []) if x.get("id")],
+        "grasp_strategies": [{"id": x.get("id"), "label": x.get("label") or x.get("id")} for x in grasps if x.get("id")],
+    }
+
+
+def create_cell(cell_id: str, robot: str, end_effector: str, sensor: str, task: str, grasp_strategy: str, output_dir: str | Path, validate: bool = True, preview: bool = True, generate_bundle: bool = False, allow_incompatible: bool = False, force: bool = True, root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    cmd = [sys.executable, str(rr / "scripts" / "workcell_studio.py"), "create-cell", "--cell-id", cell_id, "--robot", robot, "--end-effector", end_effector, "--sensor", sensor, "--task", task, "--grasp-strategy", grasp_strategy, "--output-dir", str(output_dir)]
+    if validate:
+        cmd.append("--validate")
+    if preview:
+        cmd.append("--preview")
+    if generate_bundle:
+        cmd.append("--generate-bundle")
+    if allow_incompatible:
+        cmd.append("--allow-incompatible")
+    if force:
+        cmd.append("--force")
+    result = _parse_json_output(run_command(cmd, cwd=rr, timeout=600))
+    result["summary"] = load_create_cell_summary(output_dir)
+    return result
+
+
+def load_create_cell_summary(output_dir: str | Path) -> dict[str, Any]:
+    out_dir = Path(output_dir)
+    js = out_dir / "create_cell_summary.json"
+    md = out_dir / "create_cell_summary.md"
+    return {
+        "summary_json_path": str(js) if js.exists() else "",
+        "summary_markdown_path": str(md) if md.exists() else "",
+        "summary": json.loads(js.read_text(encoding="utf-8")) if js.exists() else {},
+        "markdown": md.read_text(encoding="utf-8") if md.exists() else "",
+    }


### PR DESCRIPTION
### Motivation
- Provide a fast, catalog-driven path to produce canonical `cell_definition.yaml` and a deterministic default `environment_layout.yaml` for quick preview and offline bundle generation without opening the visual `workcell_builder` editor. 
- Give users a compact CLI and Streamlit flow to select robot/end-effector/sensor/task/grasp strategy, perform pragmatic compatibility checks, and emit preview/project artifacts while preserving offline/fake-hardware-first safety defaults. 
- Keep runtime/launch behavior unchanged and avoid any robot motion, EPD, or simulator/hardware dependencies; this is a YAML/catalog-based creation and preview path only.

### Description
- Added a `create-cell` subcommand to `scripts/workcell_studio.py` that: resolves catalog IDs (with deterministic aliases), indexes `catalog/capabilities/` and `catalog/grasp_strategies/`, performs simple compatibility checks (fails unless `--allow-incompatible`), generates `cell_definition.yaml` and a deterministic default `environment_layout.yaml`, optionally validates (`--validate`), invokes static preview generation (`--preview`) and optionally calls the existing project generator (`--generate-bundle`), and writes `create_cell_summary.json` and `create_cell_summary.md` including runtime/safety fields (`fake_hardware_default`, `runtime_io_applied`, `motion_started`, `ros_launch_started`).
- Implemented lightweight alias resolution and catalog lookup helpers plus a deterministic `_default_environment_layout()` that places a table, camera, pick zone and two bins and an optional conveyor placeholder for conveyor-like tasks; generated placements are flagged as approximate/defaults. 
- Extended Streamlit backend (`tools/workcell_studio_streamlit/backend.py`) with testable helpers: `resolve_catalog_choices()`, `create_cell(...)`, and `load_create_cell_summary()` that call the new CLI command and return structured summaries. 
- Added a new Streamlit UI page “Create Cell” in `tools/workcell_studio_streamlit/app.py` with catalog dropdowns, checkboxes for `Validate`/`Preview`/`Generate bundle`/`Allow incompatible`, and a `Create cell` button that shows the summary artifacts and preview if present. 
- Added focused tests in `tests/test_workcell_studio_create_cell.py` and extended backend tests in `tests/test_workcell_studio_streamlit_backend.py`, and updated documentation (`README.md`, `tools/workcell_studio_streamlit/README.md`, `docs/manuals/WORKCELL_STUDIO_ROADMAP.md`) describing the Create Cell flow and safety scope.

### Testing
- Ran the new CLI/backend tests: `python3 -m pytest -q tests/test_workcell_studio_create_cell.py tests/test_workcell_studio_streamlit_backend.py` and they passed (new tests exercises `create-cell` CLI exit codes, generated files, compatibility handling, and backend helpers).
- Ran the broader test suite: `python3 -m pytest -q tests/test_workcell_static_preview.py`, `python3 -m pytest -q tests/test_workcell_studio_demo_gallery.py`, `python3 -m pytest -q tests/test_cell_definition_tools.py`, and `python3 -m pytest -q tests/test_workcell_project_tools.py` and all suites passed (no failures).
- Verified CLI help: `python3 scripts/workcell_studio.py create-cell --help` prints the new options and exits with code 0.
- All automated tests completed successfully and no runtime robot motion, ROS launch, or hardware access was performed during tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba83ba8648331957642577c53ebe3)