### PR TITLE
Convert builder task intent into offline task_recipe artifacts

### DIFF
--- a/scripts/convert_builder_task_intent_to_task_recipe.py
+++ b/scripts/convert_builder_task_intent_to_task_recipe.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from capability_registry import load_structured_data
+from validate_builder_task_intent import validate as validate_intent
+
+try:
+    import yaml
+except Exception:
+    yaml = None
+
+
+def _load(path: Path) -> dict[str, Any]:
+    if yaml is not None:
+        d = yaml.safe_load(path.read_text(encoding='utf-8'))
+        return d if isinstance(d, dict) else {}
+    d, _ = load_structured_data(path)
+    return d if isinstance(d, dict) else {}
+
+
+def _dump(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if yaml is None:
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding='utf-8')
+    else:
+        path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding='utf-8')
+
+
+def convert(task_intent_path: Path, scene_package: Path | None = None) -> tuple[dict[str, Any], list[str]]:
+    payload = _load(task_intent_path)
+    warnings: list[str] = []
+    task = payload.get('task') if isinstance(payload.get('task'), dict) else {}
+    pick = (payload.get('pick') or {}).get('source') if isinstance((payload.get('pick') or {}).get('source'), dict) else {}
+    pick_filter = (payload.get('pick') or {}).get('object_filter') if isinstance((payload.get('pick') or {}).get('object_filter'), dict) else {}
+    place = (payload.get('place') or {}).get('target') if isinstance((payload.get('place') or {}).get('target'), dict) else {}
+    grasp = payload.get('grasp') if isinstance(payload.get('grasp'), dict) else {}
+    place_block = payload.get('place') if isinstance(payload.get('place'), dict) else {}
+    routing = payload.get('routing') if isinstance(payload.get('routing'), dict) else {}
+    safety = payload.get('safety') if isinstance(payload.get('safety'), dict) else {}
+
+    recipe = {
+        'schema_version': 'task_recipe/v1',
+        'task': {
+            'id': task.get('id') or 'builder_generated_task',
+            'type': task.get('type') or 'pick_place',
+            'source_object': pick.get('id') or '',
+            'object_filter': {
+                'class_id': pick_filter.get('class_id'),
+                'color': pick_filter.get('color'),
+            },
+            'destinations': [{'id': place.get('id') or '', 'frame': 'world', 'pose_xyz': place_block.get('offset_xyz') or [0.4, 0.0, 0.2], 'pose_rpy': [0.0, 0.0, 0.0]}],
+            'rules': routing.get('rules') if isinstance(routing.get('rules'), list) else [],
+        },
+        'grasp': {'strategy_ref': grasp.get('strategy_ref')},
+        'builder_task_intent': {
+            'source_file': str(task_intent_path),
+            'pick': payload.get('pick') or {},
+            'grasp': payload.get('grasp') or {},
+            'place': payload.get('place') or {},
+            'routing': routing,
+            'release_strategy': place_block.get('release_strategy'),
+            'safety': {
+                'metadata_only': bool(safety.get('metadata_only', True)),
+                'runtime_io_applied': bool(safety.get('runtime_io_applied', False)),
+                'motion_started': bool(safety.get('motion_started', False)),
+                'ros_launch_started': bool(safety.get('ros_launch_started', False)),
+            }
+        }
+    }
+    if not recipe['task']['rules']:
+        recipe['task']['rules'] = [{'id': 'default_route', 'when': {'always': True}, 'destination': place.get('id') or ''}]
+        warnings.append('Routing rules missing; generated default always-true rule.')
+    return recipe, warnings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--task-intent', required=True, type=Path)
+    ap.add_argument('--output', required=True, type=Path)
+    ap.add_argument('--validate', action='store_true')
+    ap.add_argument('--scene-package', type=Path)
+    ap.add_argument('--cell-definition', type=Path)
+    ap.add_argument('--json', action='store_true')
+    args = ap.parse_args()
+
+    if args.validate:
+        report = validate_intent(args.task_intent, args.scene_package)
+        if report.get('status') == 'FAIL':
+            if args.json:
+                print(json.dumps({'status': 'FAIL', 'errors': report.get('errors', [])}, indent=2))
+            else:
+                for e in report.get('errors', []):
+                    print(f'FAIL: {e}')
+            return 1
+
+    recipe, warns = convert(args.task_intent, args.scene_package)
+    _dump(args.output, recipe)
+    summary = {
+        'status': 'PASS',
+        'generated_task_recipe_path': str(args.output),
+        'pick_source': ((recipe.get('builder_task_intent') or {}).get('pick') or {}).get('source', {}).get('id'),
+        'place_target': ((recipe.get('builder_task_intent') or {}).get('place') or {}).get('target', {}).get('id'),
+        'grasp_strategy': (recipe.get('grasp') or {}).get('strategy_ref'),
+        'release_strategy': (recipe.get('builder_task_intent') or {}).get('release_strategy'),
+        'routing_rule_count': len(((recipe.get('task') or {}).get('rules') or [])),
+        'warnings': warns,
+    }
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        print(f"Wrote: {args.output}")
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/export_builder_scene_to_cell_definition.py
+++ b/scripts/export_builder_scene_to_cell_definition.py
@@ -105,6 +105,14 @@ def _validate_task_intent(task_intent_path: Path, scene_path: Path) -> dict[str,
     except Exception:
         return {"status": "FAIL", "errors": [run.stdout.strip() or run.stderr.strip()]}
 
+def _generate_task_recipe(task_intent_path: Path, output_path: Path, scene_path: Path) -> dict[str, Any]:
+    cmd = ["python3", str(SCRIPT_DIR / "convert_builder_task_intent_to_task_recipe.py"), "--task-intent", str(task_intent_path), "--output", str(output_path), "--scene-package", str(scene_path), "--validate", "--json"]
+    run = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    try:
+        return json.loads(run.stdout) if run.stdout.strip() else {"status": "FAIL", "errors": [run.stderr.strip()]}
+    except Exception:
+        return {"status": "FAIL", "errors": [run.stdout.strip() or run.stderr.strip()]}
+
 
 def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str, Any]:
     env = _load_optional(scene_path / "environment.yaml")
@@ -113,6 +121,7 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
     task_intent_path = _find_task_intent(scene_path)
     builder_task_intent: dict[str, Any] = {}
     task_intent_validation: dict[str, Any] = {}
+    task_recipe_generation: dict[str, Any] = {}
 
     robot_env = env.get("robot") if isinstance(env.get("robot"), dict) else {}
     ee_env = env.get("end_effector") if isinstance(env.get("end_effector"), dict) else {}
@@ -219,6 +228,9 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
             "safety": ti.get("safety"),
         }
         cell_def["builder_task_intent"] = builder_task_intent
+        task_recipe_generation = _generate_task_recipe(task_intent_path, output_dir / "task_recipe_from_builder_intent.yaml", scene_path)
+        if task_recipe_generation.get("status") != "PASS":
+            warnings.append("Task recipe generation from builder intent is partial or failed.")
     else:
         warnings.append("No builder task intent file found; exported scene has physical layout metadata but no pick/place/grasp task intent.")
 
@@ -236,6 +248,7 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
         "validation": {},
         "builder_task_intent": builder_task_intent,
         "task_intent_validation": task_intent_validation,
+        "task_recipe_generation": task_recipe_generation,
     }
 
     if validate:

--- a/scripts/validate_builder_generated_scene.py
+++ b/scripts/validate_builder_generated_scene.py
@@ -96,19 +96,26 @@ def validate_scene(scene_path: Path) -> dict[str, Any]:
     preview_only = bool(metadata.get("preview_only", False))
     fake_hw_ready = bool(metadata.get("fake_hardware_ready", True))
 
-    if preview_only:
-        readiness = "preview_only"
-    elif not task_intent_path:
-        readiness = "task_intent_missing"
-    elif runtime_supported:
-        readiness = "runtime_ready"
+    if not task_intent_path:
+        readiness = "physical_scene_only"
+    elif task_intent_report.get("status") == "FAIL":
+        readiness = "task_intent_incomplete"
+    elif (scene_path / "generated" / "task_recipe_from_builder_intent.yaml").is_file():
+        readiness = "task_recipe_generated"
     else:
-        readiness = "fake_hardware_ready" if fake_hw_ready else "preview_only"
+        readiness = "task_intent_ready_offline"
+    if preview_only:
+        readiness_runtime = "preview_only"
+    elif not runtime_supported and fake_hw_ready:
+        readiness_runtime = "runtime_blocked_or_preview_only"
+    else:
+        readiness_runtime = "runtime_possible"
 
     return {
         "scene_path": str(scene_path),
         "ok": len(errors) == 0,
         "readiness": readiness,
+        "runtime_readiness": readiness_runtime,
         "checks": checks,
         "warnings": warnings,
         "errors": errors,

--- a/scripts/workcell_studio.py
+++ b/scripts/workcell_studio.py
@@ -361,13 +361,25 @@ def import_builder_scene(args: argparse.Namespace) -> int:
 
     preview_dir = output_dir / "preview"
     _, preview_payload = _generate_static_preview(cell_def, preview_dir, f"Builder Import: {_scene_name(scene_pkg)}", env_layout)
+    recipe_gen = ((export_payload.get("task_recipe_generation", {}) if isinstance(export_payload, dict) else {}) or {})
+    task_intent = ((export_payload.get("builder_task_intent", {}) if isinstance(export_payload, dict) else {}) or {})
+    if task_intent and recipe_gen.get("status") != "PASS":
+        recipe_path = generated_dir / "task_recipe_from_builder_intent.yaml"
+        rc, recipe_gen = _run_json([sys.executable, str(SCRIPT_DIR / "convert_builder_task_intent_to_task_recipe.py"), "--task-intent", str(Path(task_intent.get("source_file", generated_dir / "workcell_builder_task_intent.yaml"))), "--output", str(recipe_path), "--scene-package", str(scene_pkg), "--validate", "--json"], "task recipe conversion")
 
-    builder_readiness = (validations.get("builder_scene", {}) or {}).get("readiness")
+    builder_scene_validation = (validations.get("builder_scene", {}) or {})
+    builder_readiness = builder_scene_validation.get("readiness")
+    runtime_readiness = builder_scene_validation.get("runtime_readiness")
     safety = {
         "fake_hardware_default": True,
         "runtime_io_applied": False,
-        "runtime_status": builder_readiness or "unknown",
+        "runtime_status": runtime_readiness or builder_readiness or "unknown",
     }
+    task_intent_status = "missing"
+    if task_intent:
+        task_intent_status = "present"
+    if recipe_gen.get("status") == "PASS":
+        task_intent_status = "task_recipe_generated"
 
     summary = {
         "source_scene_package": str(scene_pkg),
@@ -384,6 +396,14 @@ def import_builder_scene(args: argparse.Namespace) -> int:
         "preview_html": str(preview_dir / "static_preview.html"),
         "preview_summary_json": str(preview_dir / "static_preview_summary.json"),
         "preview_warnings": preview_payload.get("warnings", []),
+        "task_intent_status": task_intent_status,
+        "generated_task_recipe_path": recipe_gen.get("generated_task_recipe_path", ""),
+        "pick_source": recipe_gen.get("pick_source"),
+        "place_target": recipe_gen.get("place_target"),
+        "grasp_strategy": recipe_gen.get("grasp_strategy"),
+        "release_strategy": recipe_gen.get("release_strategy"),
+        "routing_rule_count": recipe_gen.get("routing_rule_count", 0),
+        "task_recipe_safety": {"metadata_only": True, "runtime_io_applied": False, "motion_started": False, "ros_launch_started": False},
         "next_commands": [
             f"python3 scripts/validate_builder_generated_scene.py {scene_pkg} --json",
             f"python3 scripts/validate_cell_definition.py {cell_def} --json",
@@ -408,6 +428,8 @@ def import_builder_scene(args: argparse.Namespace) -> int:
         f"- Runtime status: `{safety['runtime_status']}`",
         f"- Preview SVG: `{summary['preview_svg']}`",
         f"- Preview HTML: `{summary['preview_html']}`",
+        f"- Task intent status: `{task_intent_status}`",
+        f"- Generated task recipe: `{summary.get('generated_task_recipe_path') or '(none)'}`",
         "",
         "## Validation",
         f"- Builder scene: `{(validations.get('builder_scene', {}) or {}).get('ok', 'not-run')}`",

--- a/tests/test_builder_task_intent_to_task_recipe.py
+++ b/tests/test_builder_task_intent_to_task_recipe.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+import json, subprocess, sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI = REPO_ROOT / 'scripts' / 'convert_builder_task_intent_to_task_recipe.py'
+
+
+def test_valid_conversion(tmp_path: Path) -> None:
+    out = tmp_path / 'task_recipe.yaml'
+    proc = subprocess.run([sys.executable, str(CLI), '--task-intent', str(REPO_ROOT/'tests/fixtures/builder_task_intent_valid.yaml'), '--output', str(out), '--validate', '--json'], capture_output=True, text=True)
+    assert proc.returncode == 0
+    assert out.is_file()
+    payload = out.read_text()
+    assert 'pick_zone_main' in payload
+    assert 'bin_red' in payload
+    assert 'suction_top_basic' in payload
+    assert 'tool_release' in payload
+
+
+def test_missing_pick_place_fails(tmp_path: Path) -> None:
+    out = tmp_path / 'task_recipe.yaml'
+    proc = subprocess.run([sys.executable, str(CLI), '--task-intent', str(REPO_ROOT/'tests/fixtures/builder_task_intent_missing_pick.yaml'), '--output', str(out), '--validate'], capture_output=True, text=True)
+    assert proc.returncode != 0
+
+
+def test_json_output_fields(tmp_path: Path) -> None:
+    out = tmp_path / 'task_recipe.yaml'
+    proc = subprocess.run([sys.executable, str(CLI), '--task-intent', str(REPO_ROOT/'tests/fixtures/builder_task_intent_valid.yaml'), '--output', str(out), '--validate', '--json'], capture_output=True, text=True)
+    data = json.loads(proc.stdout)
+    for k in ['status','generated_task_recipe_path','pick_source','place_target','grasp_strategy','routing_rule_count']:
+        assert k in data

--- a/tools/workcell_studio_streamlit/app.py
+++ b/tools/workcell_studio_streamlit/app.py
@@ -76,6 +76,8 @@ elif workflow == "Builder scene import":
                 "preflight_report_path": summary.get("preflight_report_path"),
                 "safety_status": summary.get("safety_status"),
                 "runtime_preview_blockers": (summary.get("validation", {}).get("builder_scene", {}).get("runtime_blockers", [])),
+                "generated_task_recipe_path": summary.get("generated_task_recipe_path"),
+                "readiness": (summary.get("validation", {}).get("builder_scene", {}).get("readiness")),
             }
         )
         if summary.get("preview_svg") and Path(summary["preview_svg"]).exists():
@@ -120,6 +122,12 @@ elif workflow == "Builder Task Intent":
     if st.button("Validate task intent"):
         result = backend.validate_builder_task_intent(task_path, scene_package if scene_package else None)
         st.json(result.get("json") or result)
+    st.warning("This generates offline task recipe metadata only. It does not command robot motion.")
+    if st.button("Generate task recipe"):
+        out_recipe = str(Path(scene_package) / "generated" / "task_recipe_from_builder_intent.yaml") if scene_package else "/tmp/task_recipe_from_builder_intent.yaml"
+        result = backend.convert_builder_task_intent_to_task_recipe(task_path, out_recipe, scene_package if scene_package else None)
+        st.json(result.get("json") or result)
+        st.json(backend.summarize_task_recipe(out_recipe))
     st.subheader("Safety metadata")
     st.json(data.get("safety", {}))
 

--- a/tools/workcell_studio_streamlit/backend.py
+++ b/tools/workcell_studio_streamlit/backend.py
@@ -241,6 +241,38 @@ def read_preview_html(preview_dir: str | Path) -> str:
     return html_path.read_text(encoding="utf-8") if html_path.exists() else ""
 
 
+def convert_builder_task_intent_to_task_recipe(task_intent_path: str | Path, output_path: str | Path, scene_package: str | Path | None = None, root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    cmd = [sys.executable, str(rr / "scripts" / "convert_builder_task_intent_to_task_recipe.py"), "--task-intent", str(task_intent_path), "--output", str(output_path), "--validate", "--json"]
+    if scene_package:
+        cmd.extend(["--scene-package", str(scene_package)])
+    return _parse_json_output(run_command(cmd, cwd=rr))
+
+
+def load_generated_task_recipe(path: str | Path) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return _load_yaml_file(p)
+
+
+def summarize_task_recipe(path: str | Path) -> dict[str, Any]:
+    payload = load_generated_task_recipe(path)
+    bti = payload.get("builder_task_intent", {}) if isinstance(payload.get("builder_task_intent"), dict) else {}
+    task = payload.get("task", {}) if isinstance(payload.get("task"), dict) else {}
+    return {
+        "path": str(path),
+        "task_id": task.get("id"),
+        "task_type": task.get("type"),
+        "pick_source": ((bti.get("pick", {}) or {}).get("source", {}) or {}).get("id"),
+        "place_target": ((bti.get("place", {}) or {}).get("target", {}) or {}).get("id"),
+        "grasp_strategy": (payload.get("grasp", {}) if isinstance(payload.get("grasp"), dict) else {}).get("strategy_ref"),
+        "release_strategy": bti.get("release_strategy"),
+        "routing_rules": len(task.get("rules", []) if isinstance(task.get("rules"), list) else []),
+        "safety": bti.get("safety", {}),
+    }
+
+
 def resolve_catalog_choices(root: Path | None = None) -> dict[str, list[dict[str, str]]]:
     caps = load_capability_catalog(root)
     grasps = load_grasp_strategy_catalog(root)


### PR DESCRIPTION
### Motivation

- Provide an offline translation from builder authoring metadata (`workcell_builder_task_intent/v1`) into concrete `task_recipe/v1` artifacts so Workcell Studio can surface pick/place/grasp/release/routing intent without starting runtime motion. 
- Surface readiness and generation status during export/import/preview flows so operators and UIs can see whether a scene is physical-only, intent-incomplete, offline-ready, or has a generated recipe. 
- Preserve conservative safety defaults (metadata-only, no runtime IO/motion/ROS launch) and keep fake-hardware-first offline validation behavior.

### Description

- Added `scripts/convert_builder_task_intent_to_task_recipe.py` which validates a `workcell_builder_task_intent/v1` YAML and emits a `task_recipe/v1` YAML while preserving task id/type, pick source and object filters, grasp strategy and approach/retreat axes/distances, place target/offset, release strategy, routing rules, and conservative safety metadata; it supports `--json` summary output. 
- Integrated conversion into `scripts/export_builder_scene_to_cell_definition.py` to generate `generated/task_recipe_from_builder_intent.yaml` when an intent exists and to record conversion results in `generated/builder_export_summary.json` under `task_recipe_generation`. 
- Wired generation/status into import flow (`scripts/workcell_studio.py import-builder-scene`) and added summary fields such as `task_intent_status`, `generated_task_recipe_path`, `pick_source`, `place_target`, `grasp_strategy`, `release_strategy`, `routing_rule_count`, and conservative `task_recipe_safety`. 
- Extended builder scene offline validation (`scripts/validate_builder_generated_scene.py`) to classify readiness as `physical_scene_only`, `task_intent_incomplete`, `task_intent_ready_offline`, `task_recipe_generated`, and to include a `runtime_readiness` value. 
- Added Streamlit backend helpers `convert_builder_task_intent_to_task_recipe()`, `load_generated_task_recipe()`, and `summarize_task_recipe()` and updated the Builder Task Intent UI to include a "Generate task recipe" button and an explicit offline-safety warning. 
- Added unit tests `tests/test_builder_task_intent_to_task_recipe.py` that verify successful conversion, failure on missing pick/place, and presence of JSON summary fields; the change is strictly metadata-only and does not alter runtime/ROS/E�PD/real-hardware behavior.

### Testing

- New unit tests executed: `python3 -m pytest -q tests/test_builder_task_intent_to_task_recipe.py` and full test suite runs used during development; the invoked test suite reported `86 passed, 7 subtests passed`. 
- The converter tests assert that the generated YAML exists and preserves `pick_source`, `place_target`, `grasp_strategy`, and `release_strategy`, that missing pick/place fails conversion, and that `--json` returns expected summary fields. 
- Export/import/preview integration is covered by existing automated tests (builder export, import CLI, static preview and Streamlit backend helpers) which passed in the combined test run above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbac75fc00833180ac238254f38e9f)