### PR TITLE
Add task-flow preview markers and readiness diagnostics for builder intent/recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1501,3 +1501,6 @@ Workcell Studio can now generate offline static preview artifacts (`static_previ
 ## Create Cell Wizard
 
 Use `python3 scripts/workcell_studio.py create-cell` for fast catalog/YAML cell creation with optional validation, static preview, and offline project bundle generation. This path is fake-hardware-first and does not start ROS launch or robot motion.
+
+## Task flow preview: pick → grasp → place
+Use `scripts/summarize_task_flow.py` and static preview task-flow markers for offline readiness diagnostics.

--- a/docs/manuals/BUILDER_TASK_INTENT_V1.md
+++ b/docs/manuals/BUILDER_TASK_INTENT_V1.md
@@ -34,3 +34,6 @@ safety:
   motion_started: false
   ros_launch_started: false
 ```
+
+## Task Flow Summary
+Builder task intent validation and preview now expose readiness classifications and missing fields.

--- a/docs/manuals/TASK_RECIPE_V1.md
+++ b/docs/manuals/TASK_RECIPE_V1.md
@@ -184,3 +184,6 @@ python3 scripts/validate_task_recipe.py tests/fixtures/task_recipes
 python3 scripts/validate_task_recipe.py tests/fixtures/task_recipes --json
 python3 scripts/generate_task_recipe_from_cell_definition.py tests/fixtures/cell_definition_sort_by_colour.yaml --output /tmp/task_recipe.preview.yaml
 ```
+
+## Task-flow summaries
+Generated task recipes can be summarized for visual task-flow previews and readiness checks.

--- a/scripts/generate_workcell_static_preview.py
+++ b/scripts/generate_workcell_static_preview.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import argparse, json, html, sys
+import argparse, json, html, sys, subprocess
 from pathlib import Path
 from typing import Any
 
@@ -30,7 +30,7 @@ def _xy(v: Any):
 def _scale(x: float, y: float):
     return 450 + x*220, 320 - y*220
 
-def gen_preview(cell: dict[str, Any], env: dict[str, Any] | None, title: str) -> tuple[str, str, dict[str, Any]]:
+def gen_preview(cell: dict[str, Any], env: dict[str, Any] | None, title: str, task_flow: dict[str, Any] | None=None) -> tuple[str, str, dict[str, Any]]:
     warnings: list[str] = []
     elements = []
     approx = 0
@@ -79,6 +79,17 @@ def gen_preview(cell: dict[str, Any], env: dict[str, Any] | None, title: str) ->
                 lx,minx=min(x1,x2),max(x1,x2); ty,by=min(y1,y2),max(y1,y2)
                 elements.append(f"<rect x='{lx:.1f}' y='{ty:.1f}' width='{minx-lx:.1f}' height='{by-ty:.1f}' fill='none' stroke='#f59e0b' stroke-dasharray='4 3'/><text x='{lx+4:.1f}' y='{ty+14:.1f}' fill='#92400e'>{html.escape(str(z.get('id','zone')))}</text>")
 
+
+    if task_flow:
+        pick_id = task_flow.get('pick_source_id') or 'unknown'
+        place_id = task_flow.get('place_target_id') or 'unknown'
+        gx,gy=_scale(-0.7,-0.55); elements.append(f"<text x='{gx:.1f}' y='{gy:.1f}' fill='#111827'>Task Flow</text>")
+        elements.append(f"<text x='{gx:.1f}' y='{gy+18:.1f}' fill='#1f2937'>Pick: {html.escape(str(pick_id))}</text>")
+        elements.append(f"<text x='{gx:.1f}' y='{gy+36:.1f}' fill='#1f2937'>Place: {html.escape(str(place_id))}</text>")
+        elements.append(f"<text x='{gx:.1f}' y='{gy+54:.1f}' fill='#1f2937'>Grasp: {html.escape(str(task_flow.get('grasp_strategy')))}</text>")
+        elements.append(f"<text x='{gx:.1f}' y='{gy+72:.1f}' fill='#1f2937'>Release: {html.escape(str(task_flow.get('release_strategy')))}</text>")
+        elements.append(f"<text x='{gx:.1f}' y='{gy+90:.1f}' fill='#1f2937'>Routes: {task_flow.get('routing_rule_count',0)}</text>")
+
     builder_task_intent = cell.get('builder_task_intent') if isinstance(cell.get('builder_task_intent'), dict) else {}
     if builder_task_intent and (not builder_task_intent.get('pick') or not builder_task_intent.get('place')):
         warnings.append('Task intent is present but exact pick/place coordinates could not be resolved.')
@@ -94,6 +105,7 @@ def gen_preview(cell: dict[str, Any], env: dict[str, Any] | None, title: str) ->
         'runtime_blocked': comm.get('runtime_mode')=='preview_only',
         'warnings': warnings,
         'approximate_placements': approx,
+        'task_flow_summary': task_flow or {},
         'builder_task_intent': {
             'pick': (builder_task_intent.get('pick') or {}),
             'grasp': (builder_task_intent.get('grasp') or {}),
@@ -101,7 +113,10 @@ def gen_preview(cell: dict[str, Any], env: dict[str, Any] | None, title: str) ->
         } if builder_task_intent else {},
     }
     svg=f"<svg xmlns='http://www.w3.org/2000/svg' width='{CANVAS_W}' height='{CANVAS_H}'><rect width='100%' height='100%' fill='#f8fafc'/><text x='20' y='30' font-size='20'>{html.escape(title)}</text><text x='20' y='55'>robot={html.escape(str(summary['robot']))}, ee={html.escape(str(summary['end_effector']))}, task={html.escape(str(summary['task']))}</text>{''.join(elements)}</svg>"
-    html_doc=f"<!doctype html><html><body><h1>{html.escape(title)}</h1><p>Offline static preview approximation (not collision/safety validation).</p>{svg}<pre>{html.escape(json.dumps(summary, indent=2))}</pre></body></html>"
+    task_flow_html = ''
+    if task_flow:
+        task_flow_html = f"<h2>Task Flow</h2><pre>{html.escape(json.dumps(task_flow, indent=2))}</pre>"
+    html_doc=f"<!doctype html><html><body><h1>{html.escape(title)}</h1><p>Offline static preview approximation (not collision/safety validation).</p>{task_flow_html}{svg}<pre>{html.escape(json.dumps(summary, indent=2))}</pre></body></html>"
     return svg, html_doc, summary
 
 
@@ -111,6 +126,8 @@ def main()->int:
     ap.add_argument('--environment-layout', type=Path)
     ap.add_argument('--output-dir', required=True, type=Path)
     ap.add_argument('--title', required=True)
+    ap.add_argument('--task-intent', type=Path)
+    ap.add_argument('--task-recipe', type=Path)
     ap.add_argument('--json', action='store_true')
     a=ap.parse_args()
     try:
@@ -123,7 +140,16 @@ def main()->int:
         elif a.environment_layout:
             env={}
         a.output_dir.mkdir(parents=True, exist_ok=True)
-        svg, html_doc, summary=gen_preview(cell, env, a.title)
+        task_flow=None
+        if a.task_intent or a.task_recipe or a.environment_layout:
+            cmd=[sys.executable, str(Path(__file__).resolve().parent/'summarize_task_flow.py'), '--json']
+            if a.task_intent: cmd += ['--task-intent', str(a.task_intent)]
+            if a.task_recipe: cmd += ['--task-recipe', str(a.task_recipe)]
+            if a.environment_layout: cmd += ['--environment-layout', str(a.environment_layout)]
+            run=subprocess.run(cmd,capture_output=True,text=True,check=False)
+            try: task_flow=json.loads(run.stdout) if run.stdout.strip() else {}
+            except Exception: task_flow={}
+        svg, html_doc, summary=gen_preview(cell, env, a.title, task_flow)
         if a.environment_layout and not a.environment_layout.exists():
             summary.setdefault("warnings", []).append("environment_layout path missing; used approximate/default placement")
         (a.output_dir/'static_preview.svg').write_text(svg, encoding='utf-8')

--- a/scripts/summarize_task_flow.py
+++ b/scripts/summarize_task_flow.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse,json
+from pathlib import Path
+from typing import Any
+import sys
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+from capability_registry import load_structured_data
+try:
+    import yaml
+except Exception:
+    yaml=None
+
+def _load(p: Path|None)->dict[str,Any]:
+    if not p or not p.exists(): return {}
+    if yaml is not None:
+        try:
+            d=yaml.safe_load(p.read_text())
+            return d if isinstance(d,dict) else {}
+        except Exception:
+            pass
+    d,_=load_structured_data(p)
+    return d if isinstance(d,dict) else {}
+
+def summarize(task_intent:Path|None=None, task_recipe:Path|None=None, scene_package:Path|None=None, environment_layout:Path|None=None)->dict[str,Any]:
+    intent=_load(task_intent); recipe=_load(task_recipe); layout=_load(environment_layout)
+    if recipe:
+        bti=recipe.get('builder_task_intent',{}) if isinstance(recipe.get('builder_task_intent'),dict) else {}
+        task=recipe.get('task',{}) if isinstance(recipe.get('task'),dict) else {}
+        pick=((bti.get('pick',{}) or {}).get('source',{}) if isinstance(bti.get('pick'),dict) else {})
+        place=((bti.get('place',{}) or {}).get('target',{}) if isinstance(bti.get('place'),dict) else {})
+        grasp=recipe.get('grasp',{}) if isinstance(recipe.get('grasp'),dict) else {}
+        release=((bti.get('place',{}) or {}).get('release_strategy') if isinstance(bti.get('place'),dict) else None)
+        routing=task.get('rules',[]) if isinstance(task.get('rules'),list) else []
+        readiness='task_recipe_generated'
+    elif intent:
+        task=intent.get('task',{}) if isinstance(intent.get('task'),dict) else {}
+        pick=((intent.get('pick',{}) or {}).get('source',{}) if isinstance(intent.get('pick'),dict) else {})
+        place=((intent.get('place',{}) or {}).get('target',{}) if isinstance(intent.get('place'),dict) else {})
+        grasp=intent.get('grasp',{}) if isinstance(intent.get('grasp'),dict) else {}
+        release=((intent.get('place',{}) or {}).get('release_strategy') if isinstance(intent.get('place'),dict) else None)
+        routing=((intent.get('routing',{}) or {}).get('rules',[]) if isinstance(intent.get('routing'),dict) else [])
+        readiness='task_intent_ready_offline'
+    elif scene_package:
+        return {'status':'WARN','readiness_classification':'physical_scene_only','warnings':['Task intent/recipe missing; physical scene only.'],'errors':[],'missing_required_fields':[],'suggested_next_actions':['Create builder task intent to define pick/place/grasp.'],'safety':{'metadata_only':True,'runtime_io_applied':False,'motion_started':False,'ros_launch_started':False},'visual_resolution':{'pick_coordinates_resolved':False,'place_coordinates_resolved':False,'approximate_coordinates_used':True,'notes':['No task flow input.']}}
+    else:
+        return {'status':'FAIL','readiness_classification':'task_intent_incomplete','warnings':[],'errors':['No task input'],'missing_required_fields':['task_intent_or_task_recipe'],'suggested_next_actions':[]}
+    missing=[]
+    if not pick.get('id'): missing.append('pick.source.id')
+    if not place.get('id'): missing.append('place.target.id')
+    if not (grasp.get('strategy_ref') or grasp.get('inline_strategy')): missing.append('grasp.strategy_ref')
+    if missing: readiness='task_intent_incomplete'
+    zones={z.get('id') for z in (layout.get('zones') or []) if isinstance(z,dict)}
+    pick_res=bool(pick.get('id') in zones) if zones else False
+    place_res=bool(place.get('id') in zones) if zones else False
+    approx=not (pick_res and place_res)
+    warnings=['Task flow present but exact pick/place coordinates could not be resolved.'] if approx else []
+    return {'status':'FAIL' if missing else ('WARN' if warnings else 'PASS'),'readiness_classification':readiness,'task_id':task.get('id'),'task_type':task.get('type'),'pick_source_id':pick.get('id'),'place_target_id':place.get('id'),'grasp_strategy':grasp.get('strategy_ref') or grasp.get('inline_strategy'),'release_strategy':release,'routing_rules':routing,'routing_rule_count':len(routing),'missing_required_fields':missing,'suggested_next_actions':['Select a pick source zone.' if 'pick.source.id' in missing else '', 'Select a place target.' if 'place.target.id' in missing else '', 'Choose a grasp strategy.' if 'grasp.strategy_ref' in missing else '','Generate task recipe from task intent.' if not recipe else ''],'warnings':warnings,'errors':[] if not missing else [f'{m} is required' for m in missing],'safety':{'metadata_only':True,'runtime_io_applied':False,'motion_started':False,'ros_launch_started':False},'visual_resolution':{'pick_coordinates_resolved':pick_res,'place_coordinates_resolved':place_res,'approximate_coordinates_used':approx,'notes':['Used deterministic fallback coordinates for preview markers.'] if approx else []}}
+
+def main()->int:
+    ap=argparse.ArgumentParser(); ap.add_argument('--task-intent',type=Path); ap.add_argument('--task-recipe',type=Path); ap.add_argument('--scene-package',type=Path); ap.add_argument('--environment-layout',type=Path); ap.add_argument('--json',action='store_true'); a=ap.parse_args()
+    out=summarize(a.task_intent,a.task_recipe,a.scene_package,a.environment_layout)
+    print(json.dumps(out,indent=2) if a.json else out)
+    return 1 if out.get('status')=='FAIL' else 0
+if __name__=='__main__': raise SystemExit(main())

--- a/scripts/validate_builder_generated_scene.py
+++ b/scripts/validate_builder_generated_scene.py
@@ -96,14 +96,18 @@ def validate_scene(scene_path: Path) -> dict[str, Any]:
     preview_only = bool(metadata.get("preview_only", False))
     fake_hw_ready = bool(metadata.get("fake_hardware_ready", True))
 
+    suggested_actions=[]
     if not task_intent_path:
         readiness = "physical_scene_only"
+        suggested_actions.append('Create builder task intent to define pick/place/grasp.')
     elif task_intent_report.get("status") == "FAIL":
         readiness = "task_intent_incomplete"
+        suggested_actions.append('Complete missing required task intent fields.')
     elif (scene_path / "generated" / "task_recipe_from_builder_intent.yaml").is_file():
         readiness = "task_recipe_generated"
     else:
         readiness = "task_intent_ready_offline"
+        suggested_actions.append('Generate task recipe from builder task intent.')
     if preview_only:
         readiness_runtime = "preview_only"
     elif not runtime_supported and fake_hw_ready:
@@ -115,6 +119,8 @@ def validate_scene(scene_path: Path) -> dict[str, Any]:
         "scene_path": str(scene_path),
         "ok": len(errors) == 0,
         "readiness": readiness,
+        "readiness_classification": readiness,
+        "suggested_next_actions": suggested_actions,
         "runtime_readiness": readiness_runtime,
         "checks": checks,
         "warnings": warnings,

--- a/scripts/validate_builder_task_intent.py
+++ b/scripts/validate_builder_task_intent.py
@@ -69,8 +69,19 @@ def validate(path: Path, scene_package: Path|None=None, grasp_dir: Path|None=Non
         if not (scene_package/'environment.yaml').is_file(): warnings.append('scene package missing environment.yaml')
         if pick.get('id') and not _exists_in_scene(scene_package,str(pick['id'])): warnings.append(f"pick.source.id '{pick['id']}' could not be verified in scene metadata")
         if place.get('id') and not _exists_in_scene(scene_package,str(place['id'])): warnings.append(f"place.target.id '{place['id']}' could not be verified in scene metadata")
+    missing_required_fields=[]
+    if not task.get('type'): missing_required_fields.append('task.type')
+    if not pick.get('id'): missing_required_fields.append('pick.source.id')
+    if not place.get('id'): missing_required_fields.append('place.target.id')
+    if not strategy_ref and not grasp.get('inline_strategy'): missing_required_fields.append('grasp.strategy_ref')
+    suggested_next_actions=[]
+    if 'pick.source.id' in missing_required_fields: suggested_next_actions.append('Select a pick source zone.')
+    if 'place.target.id' in missing_required_fields: suggested_next_actions.append('Select a place target.')
+    if 'grasp.strategy_ref' in missing_required_fields: suggested_next_actions.append('Choose a grasp strategy.')
+    if not missing_required_fields: suggested_next_actions.append('Generate task recipe from task intent.')
+    readiness_classification='task_intent_incomplete' if missing_required_fields else 'task_intent_ready_offline'
     status='FAIL' if errors else ('WARN' if warnings else 'PASS')
-    return {"status":status,"errors":errors,"warnings":warnings,"resolved_grasp_strategy":resolved,"pick_source":pick,"place_target":place,"safety":safety,"task_intent":payload}
+    return {"status":status,"errors":errors,"warnings":warnings,"resolved_grasp_strategy":resolved,"pick_source":pick,"place_target":place,"safety":safety,"task_intent":payload,"missing_required_fields":missing_required_fields,"suggested_next_actions":suggested_next_actions,"readiness_classification":readiness_classification}
 
 def main()->int:
     ap=argparse.ArgumentParser()

--- a/scripts/workcell_studio.py
+++ b/scripts/workcell_studio.py
@@ -360,9 +360,15 @@ def import_builder_scene(args: argparse.Namespace) -> int:
                 preflight_report_path = str(manifest_candidates[0].parent / preflight_rel)
 
     preview_dir = output_dir / "preview"
-    _, preview_payload = _generate_static_preview(cell_def, preview_dir, f"Builder Import: {_scene_name(scene_pkg)}", env_layout)
     recipe_gen = ((export_payload.get("task_recipe_generation", {}) if isinstance(export_payload, dict) else {}) or {})
     task_intent = ((export_payload.get("builder_task_intent", {}) if isinstance(export_payload, dict) else {}) or {})
+    task_intent_path = Path(task_intent.get('source_file', generated_dir / 'workcell_builder_task_intent.yaml')) if isinstance(task_intent, dict) and task_intent else None
+    task_recipe_path = generated_dir / 'task_recipe_from_builder_intent.yaml'
+    cmd=[sys.executable, str(SCRIPT_DIR / 'generate_workcell_static_preview.py'), '--cell-definition', str(cell_def), '--output-dir', str(preview_dir), '--title', f"Builder Import: {_scene_name(scene_pkg)}", '--json']
+    if env_layout: cmd += ['--environment-layout', str(env_layout)]
+    if task_intent_path and task_intent_path.exists(): cmd += ['--task-intent', str(task_intent_path)]
+    if task_recipe_path.exists(): cmd += ['--task-recipe', str(task_recipe_path)]
+    _, preview_payload = _run_json(cmd, 'static preview')
     if task_intent and recipe_gen.get("status") != "PASS":
         recipe_path = generated_dir / "task_recipe_from_builder_intent.yaml"
         rc, recipe_gen = _run_json([sys.executable, str(SCRIPT_DIR / "convert_builder_task_intent_to_task_recipe.py"), "--task-intent", str(Path(task_intent.get("source_file", generated_dir / "workcell_builder_task_intent.yaml"))), "--output", str(recipe_path), "--scene-package", str(scene_pkg), "--validate", "--json"], "task recipe conversion")
@@ -403,6 +409,10 @@ def import_builder_scene(args: argparse.Namespace) -> int:
         "grasp_strategy": recipe_gen.get("grasp_strategy"),
         "release_strategy": recipe_gen.get("release_strategy"),
         "routing_rule_count": recipe_gen.get("routing_rule_count", 0),
+        "task_flow_summary": preview_payload.get("task_flow_summary", {}),
+        "readiness_classification": (preview_payload.get("task_flow_summary", {}) or {}).get("readiness_classification", builder_readiness),
+        "missing_required_fields": (preview_payload.get("task_flow_summary", {}) or {}).get("missing_required_fields", []),
+        "visual_resolution": (preview_payload.get("task_flow_summary", {}) or {}).get("visual_resolution", {}),
         "task_recipe_safety": {"metadata_only": True, "runtime_io_applied": False, "motion_started": False, "ros_launch_started": False},
         "next_commands": [
             f"python3 scripts/validate_builder_generated_scene.py {scene_pkg} --json",

--- a/tests/test_builder_task_intent.py
+++ b/tests/test_builder_task_intent.py
@@ -25,3 +25,8 @@ def test_unknown_grasp_warns():
 def test_safety_conservative_required():
     payload=json.loads(_run('builder_task_intent_valid.yaml').stdout)
     s=payload['safety']; assert s['metadata_only'] is True and s['runtime_io_applied'] is False and s['motion_started'] is False and s['ros_launch_started'] is False
+
+
+def test_validator_additional_fields_present():
+    payload=json.loads(_run('builder_task_intent_missing_pick.yaml').stdout)
+    assert 'missing_required_fields' in payload and 'suggested_next_actions' in payload and 'readiness_classification' in payload

--- a/tests/test_task_flow_summary.py
+++ b/tests/test_task_flow_summary.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+import json, subprocess, tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI = REPO_ROOT / 'scripts' / 'summarize_task_flow.py'
+
+
+def run(*args:str):
+    p=subprocess.run(['python3',str(CLI),*args],capture_output=True,text=True,check=False)
+    return p, json.loads(p.stdout)
+
+
+def test_summarize_valid_builder_task_intent():
+    p,j=run('--task-intent',str(REPO_ROOT/'tests/fixtures/builder_task_intent_valid.yaml'),'--json')
+    assert p.returncode==0
+    assert j['readiness_classification']=='task_intent_ready_offline'
+    assert j['pick_source_id'] and j['place_target_id'] and j['grasp_strategy'] and j['release_strategy']
+
+
+def test_summarize_task_recipe():
+    with tempfile.TemporaryDirectory() as d:
+        out=Path(d)/'recipe.yaml'
+        subprocess.run(['python3',str(REPO_ROOT/'scripts/convert_builder_task_intent_to_task_recipe.py'),'--task-intent',str(REPO_ROOT/'tests/fixtures/builder_task_intent_valid.yaml'),'--output',str(out),'--validate'],check=False)
+        p,j=run('--task-recipe',str(out),'--json')
+        assert j['readiness_classification']=='task_recipe_generated'
+
+
+def test_missing_pick_place_fail():
+    p,j=run('--task-intent',str(REPO_ROOT/'tests/fixtures/builder_task_intent_missing_pick.yaml'),'--json')
+    assert j['status']=='FAIL'
+    assert 'pick.source.id' in j['missing_required_fields']
+
+
+def test_physical_scene_only():
+    with tempfile.TemporaryDirectory() as d:
+        p,j=run('--scene-package',d,'--json')
+        assert j['readiness_classification']=='physical_scene_only'
+
+
+def test_visual_resolution_flags():
+    layout=REPO_ROOT/'tests/fixtures/environment_layouts/ur5_table_bins_existing_assets.layout.yaml'
+    p,j=run('--task-intent',str(REPO_ROOT/'tests/fixtures/builder_task_intent_valid.yaml'),'--environment-layout',str(layout),'--json')
+    assert 'visual_resolution' in j

--- a/tests/test_workcell_static_preview.py
+++ b/tests/test_workcell_static_preview.py
@@ -43,3 +43,16 @@ def test_bad_cell_definition_fails():
         p=_run('--cell-definition',str(Path(d)/'missing.yaml'),'--output-dir',str(Path(d)/'o'),'--title','bad')
         assert p.returncode != 0
         assert 'ERROR' in p.stderr
+
+
+def test_preview_with_task_intent_includes_task_flow():
+    with tempfile.TemporaryDirectory() as d:
+        out=Path(d)
+        cell=REPO_ROOT/'tests/fixtures/cell_definition_ur5_suction_sorting.yaml'
+        intent=REPO_ROOT/'tests/fixtures/builder_task_intent_valid.yaml'
+        p=_run('--cell-definition',str(cell),'--task-intent',str(intent),'--output-dir',str(out),'--title','TF')
+        assert p.returncode==0
+        summary=json.loads((out/'static_preview_summary.json').read_text())
+        assert 'task_flow_summary' in summary
+        html=(out/'static_preview.html').read_text()
+        assert 'Task Flow' in html and 'Pick:' in html and 'Place:' in html

--- a/tests/test_workcell_studio_builder_import_cli.py
+++ b/tests/test_workcell_studio_builder_import_cli.py
@@ -80,3 +80,13 @@ def test_missing_scene_package_fails() -> None:
         proc = _run("import-builder-scene", "--scene-package", str(Path(d) / "missing"), "--output-dir", str(out), "--project-name", "demo", "--validate")
         assert proc.returncode != 0
         assert "does not exist" in (proc.stdout + proc.stderr)
+
+
+def test_import_summary_has_task_flow_summary():
+    with tempfile.TemporaryDirectory() as d:
+        scene=Path(d)/'scene'; scene.mkdir(); _write_scene(scene)
+        out=Path(d)/'out'
+        proc=_run('import-builder-scene','--scene-package',str(scene),'--output-dir',str(out),'--project-name','demo','--validate')
+        assert proc.returncode==0
+        summary=json.loads((out/'workcell_studio_import_summary.json').read_text(encoding='utf-8'))
+        assert 'task_flow_summary' in summary or 'readiness_classification' in summary

--- a/tests/test_workcell_studio_streamlit_backend.py
+++ b/tests/test_workcell_studio_streamlit_backend.py
@@ -117,3 +117,14 @@ def test_builder_task_intent_helpers_roundtrip() -> None:
         assert backend.find_builder_task_intent(scene).endswith("workcell_builder_task_intent.yaml")
         result = backend.validate_builder_task_intent(path)
         assert result["returncode"] in {0,1}
+
+
+def test_task_flow_backend_helpers():
+    intent = backend.repo_root() / 'tests' / 'fixtures' / 'builder_task_intent_valid.yaml'
+    result = backend.summarize_task_flow(task_intent_path=intent)
+    assert result['returncode'] in {0,1}
+    with tempfile.TemporaryDirectory() as d:
+        out=Path(d)/'preview'
+        cell=backend.repo_root()/'tests'/'fixtures'/'cell_definition_pick_place.yaml'
+        pr=backend.generate_static_preview_with_task_flow(cell,out,'x',task_intent_path=intent)
+        assert pr['returncode']==0

--- a/tools/workcell_studio_streamlit/README.md
+++ b/tools/workcell_studio_streamlit/README.md
@@ -57,3 +57,6 @@ Demo Gallery and Builder Scene Import now surface static preview artifacts when 
 ## Create Cell flow
 
 The Streamlit app now includes **Create Cell** for selecting catalog robot/tool/sensor/task/grasp strategy and generating `cell_definition.yaml`, `environment_layout.yaml`, summary files, static preview, and optional bundle outputs. Incompatible combos can be marked preview-only with explicit warnings.
+
+## Task Flow Summary panel
+Shows readiness classification, pick/place/grasp/release, routing, and offline safety/preview diagnostics.

--- a/tools/workcell_studio_streamlit/backend.py
+++ b/tools/workcell_studio_streamlit/backend.py
@@ -374,3 +374,25 @@ def validate_builder_task_intent(task_intent_path: str | Path, scene_package: st
     cmd=[sys.executable, str(rr/"scripts"/"validate_builder_task_intent.py"), str(task_intent_path), "--json"]
     if scene_package: cmd += ["--scene-package", str(scene_package)]
     return _parse_json_output(run_command(cmd, cwd=rr))
+
+
+def summarize_task_flow(task_intent_path: str | Path | None = None, task_recipe_path: str | Path | None = None, scene_package: str | Path | None = None, environment_layout_path: str | Path | None = None, root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    cmd = [sys.executable, str(rr / "scripts" / "summarize_task_flow.py"), "--json"]
+    if task_intent_path: cmd += ["--task-intent", str(task_intent_path)]
+    if task_recipe_path: cmd += ["--task-recipe", str(task_recipe_path)]
+    if scene_package: cmd += ["--scene-package", str(scene_package)]
+    if environment_layout_path: cmd += ["--environment-layout", str(environment_layout_path)]
+    return _parse_json_output(run_command(cmd, cwd=rr))
+
+def load_task_flow_summary(path: str | Path) -> dict[str, Any]:
+    p = Path(path)
+    return json.loads(p.read_text(encoding="utf-8")) if p.exists() else {}
+
+def generate_static_preview_with_task_flow(cell_definition_path: str | Path, output_dir: str | Path, title: str, task_intent_path: str | Path | None = None, task_recipe_path: str | Path | None = None, environment_layout_path: str | Path | None = None, root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    cmd = [sys.executable, str(rr / "scripts" / "generate_workcell_static_preview.py"), "--cell-definition", str(cell_definition_path), "--output-dir", str(output_dir), "--title", title, "--json"]
+    if environment_layout_path: cmd += ["--environment-layout", str(environment_layout_path)]
+    if task_intent_path: cmd += ["--task-intent", str(task_intent_path)]
+    if task_recipe_path: cmd += ["--task-recipe", str(task_recipe_path)]
+    return _parse_json_output(run_command(cmd, cwd=rr))


### PR DESCRIPTION
### Motivation
- Make builder task intent and generated task recipes explainable in the offline preview by surfacing pick/place locations, grasp/release strategies, routing rules, and which fields are missing before a task is usable offline. 
- Provide a simple readiness classification and visual-resolution hints so users can quickly see whether a scene is physical-only, intent-incomplete, offline-ready, recipe-generated, or preview-only/runtime-blocked. 

### Description
- Add a new CLI helper `scripts/summarize_task_flow.py` that normalizes either a builder `task_intent` or a generated `task_recipe` into a JSON task-flow summary containing readiness classification, pick/place/grasp/release fields, routing, missing fields, suggested next actions, safety flags, and visual-resolution hints. 
- Extend `scripts/generate_workcell_static_preview.py` to accept `--task-intent` / `--task-recipe`, call the summarizer, include `task_flow_summary` in `static_preview_summary.json`, and render a visible "Task Flow" section and SVG legend/labels (with deterministic fallback markers and approximate-coordinate warnings when coordinates cannot be resolved). 
- Enhance `scripts/validate_builder_task_intent.py` to add `missing_required_fields`, `suggested_next_actions`, and `readiness_classification` in its JSON output without breaking existing consumers. 
- Extend `scripts/validate_builder_generated_scene.py` to set `readiness_classification` and `suggested_next_actions` for physical-only, intent-incomplete/ready, and recipe-generated cases. 
- Integrate task-flow summaries into import/export flows by updating `scripts/workcell_studio.py` to call the static preview with task-flow inputs and include `task_flow_summary`, `readiness_classification`, `missing_required_fields`, and `visual_resolution` in the import summary. 
- Add Streamlit backend helpers in `tools/workcell_studio_streamlit/backend.py`: `summarize_task_flow()`, `load_task_flow_summary()`, and `generate_static_preview_with_task_flow()` that invoke the new CLI helpers consistently with existing backend patterns. 
- Add tests (`tests/test_task_flow_summary.py`) and extend existing tests to assert the new fields and preview/HTML/SVG behavior, and add brief docs/readme notes describing the Task Flow Summary and preview. 

### Testing
- Ran the new and updated unit tests: `pytest -q tests/test_task_flow_summary.py`, `pytest -q tests/test_workcell_static_preview.py`, `pytest -q tests/test_builder_task_intent.py`, `pytest -q tests/test_builder_task_intent_to_task_recipe.py`, `pytest -q tests/test_workcell_studio_builder_import_cli.py`, `pytest -q tests/test_workcell_studio_streamlit_backend.py`, and `pytest -q tests/test_cell_definition_tools.py`. 
- All automated tests passed in the final run (`74 passed` overall). 
- New tests exercise summarization for valid intents, generated recipes, missing fields, physical-scene-only behavior, and visual-resolution flags, and preview tests verify `task_flow_summary` appears in `static_preview_summary.json` and the HTML/SVG contains Task Flow labels.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbae53f0008331b052b03773523e51)