### PR TITLE
Add offline plan preview request artifact generation and validation

### DIFF
--- a/docs/manuals/OFFLINE_PLAN_PREVIEW_REQUEST_V1.md
+++ b/docs/manuals/OFFLINE_PLAN_PREVIEW_REQUEST_V1.md
@@ -1,0 +1,53 @@
+# OFFLINE_PLAN_PREVIEW_REQUEST_V1
+
+Schema id: `offline_plan_preview_request/v1`.
+
+This artifact is **offline metadata only** and is a safe bridge from `task_recipe/v1` toward future MoveIt/RViz visual plan preview.
+
+- It does **not** execute motion.
+- It does **not** launch ROS.
+- It does **not** call MoveIt services.
+- It is **not** a safety certificate.
+- Real runtime execution remains separately guarded.
+
+```yaml
+schema: offline_plan_preview_request/v1
+source:
+  task_recipe: path/or/id
+  task_flow_summary: path/or/generated
+request:
+  id: plan_preview_<task_id>
+  mode: offline_preview
+  robot:
+    id: <robot/capability if known>
+    planning_group: <if known or null>
+  tool:
+    id: <end_effector/capability if known>
+    grasp_strategy: <strategy_ref>
+  pick:
+    source_id: <pick_source>
+    object_filter: {...}
+    approach_axis: z_down
+    approach_distance_m: 0.12
+    retreat_axis: z_up
+    retreat_distance_m: 0.10
+  place:
+    target_id: <place_target>
+    place_offset_xyz: [0, 0, 0.08]
+    release_strategy: tool_release
+    retreat_axis: z_up
+    retreat_distance_m: 0.12
+  waypoints: [home, pre_pick, pick, post_pick, pre_place, place, post_place]
+  checks:
+    require_pick_source: true
+    require_place_target: true
+    require_grasp_strategy: true
+    require_collision_scene: true
+    require_fake_hardware_default: true
+safety:
+  metadata_only: true
+  motion_started: false
+  ros_launch_started: false
+  moveit_service_called: false
+  runtime_io_applied: false
+```

--- a/scripts/export_builder_scene_to_cell_definition.py
+++ b/scripts/export_builder_scene_to_cell_definition.py
@@ -113,6 +113,14 @@ def _generate_task_recipe(task_intent_path: Path, output_path: Path, scene_path:
     except Exception:
         return {"status": "FAIL", "errors": [run.stdout.strip() or run.stderr.strip()]}
 
+def _generate_plan_preview(task_recipe_path: Path, output_path: Path, cell_path: Path, layout_path: Path) -> dict[str, Any]:
+    cmd = ["python3", str(SCRIPT_DIR / "generate_offline_plan_preview_request.py"), "--task-recipe", str(task_recipe_path), "--output", str(output_path), "--cell-definition", str(cell_path), "--environment-layout", str(layout_path), "--validate", "--json"]
+    run = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    try:
+        return json.loads(run.stdout) if run.stdout.strip() else {"status": "FAIL", "errors": [run.stderr.strip()]}
+    except Exception:
+        return {"status": "FAIL", "errors": [run.stdout.strip() or run.stderr.strip()]}
+
 
 def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str, Any]:
     env = _load_optional(scene_path / "environment.yaml")
@@ -122,6 +130,7 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
     builder_task_intent: dict[str, Any] = {}
     task_intent_validation: dict[str, Any] = {}
     task_recipe_generation: dict[str, Any] = {}
+    plan_preview_generation: dict[str, Any] = {}
 
     robot_env = env.get("robot") if isinstance(env.get("robot"), dict) else {}
     ee_env = env.get("end_effector") if isinstance(env.get("end_effector"), dict) else {}
@@ -238,6 +247,9 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
     layout_path = output_dir / "environment_layout.yaml"
     _write_structured(cell_path, cell_def)
     _write_structured(layout_path, environment_layout)
+    recipe_path = output_dir / "task_recipe_from_builder_intent.yaml"
+    if recipe_path.is_file():
+        plan_preview_generation = _generate_plan_preview(recipe_path, output_dir / "offline_plan_preview_request.yaml", cell_path, layout_path)
 
     summary: dict[str, Any] = {
         "generated_by": "workcell_builder",
@@ -249,6 +261,7 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
         "builder_task_intent": builder_task_intent,
         "task_intent_validation": task_intent_validation,
         "task_recipe_generation": task_recipe_generation,
+        "offline_plan_preview_request": plan_preview_generation,
     }
 
     if validate:

--- a/scripts/generate_offline_plan_preview_request.py
+++ b/scripts/generate_offline_plan_preview_request.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except Exception:
+    yaml = None
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+from capability_registry import load_structured_data
+
+
+def _load(path: Path) -> dict[str, Any]:
+    if not path or not path.exists():
+        return {}
+    if yaml is not None:
+        data = yaml.safe_load(path.read_text(encoding='utf-8'))
+        return data if isinstance(data, dict) else {}
+    data, _ = load_structured_data(path)
+    return data if isinstance(data, dict) else {}
+
+
+def _dump(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if yaml is None:
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding='utf-8')
+    else:
+        path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding='utf-8')
+
+
+def generate(task_recipe: dict[str, Any], task_recipe_path: Path, task_flow_summary: dict[str, Any], cell: dict[str, Any], env: dict[str, Any]) -> tuple[dict[str, Any], list[str], list[str]]:
+    warnings, missing = [], []
+    task = task_recipe.get('task') if isinstance(task_recipe.get('task'), dict) else {}
+    pick_source = task.get('source_object') or task.get('pick_source') or task.get('source') or ''
+    dests = task.get('destinations') if isinstance(task.get('destinations'), list) else []
+    place_target = dests[0].get('id') if dests and isinstance(dests[0], dict) else ''
+    grasp_block = task_recipe.get('grasp') if isinstance(task_recipe.get('grasp'), dict) else {}
+    grasp = grasp_block.get('strategy_ref')
+    if not pick_source: missing.append('pick.source_id')
+    if not place_target: missing.append('place.target_id')
+    if not grasp: missing.append('tool.grasp_strategy')
+    robot = (cell.get('robot') if isinstance(cell.get('robot'), dict) else {})
+    tool = (cell.get('end_effector') if isinstance(cell.get('end_effector'), dict) else {})
+    task_id = task.get('id') or 'task'
+    req = {
+        'schema': 'offline_plan_preview_request/v1',
+        'source': {
+            'task_recipe': str(task_recipe_path),
+            'task_flow_summary': str(task_flow_summary.get('source') or 'generated')
+        },
+        'request': {
+            'id': f'plan_preview_{task_id}',
+            'mode': 'offline_preview',
+            'robot': {'id': robot.get('capability') or robot.get('name') or None, 'planning_group': robot.get('planning_group')},
+            'tool': {'id': tool.get('capability') or tool.get('id') or None, 'grasp_strategy': grasp},
+            'pick': {'source_id': pick_source, 'object_filter': task.get('object_filter') or {}, 'approach_axis': 'z_down', 'approach_distance_m': 0.12, 'retreat_axis': 'z_up', 'retreat_distance_m': 0.10},
+            'place': {'target_id': place_target, 'place_offset_xyz': [0,0,0.08], 'release_strategy': 'tool_release', 'retreat_axis': 'z_up', 'retreat_distance_m': 0.12},
+            'waypoints': [
+                {'id':'home','type':'named_pose','required':False},
+                {'id':'pre_pick','type':'computed_offset','from':'pick.source_id','offset_axis':'approach_axis','distance_m':0.12},
+                {'id':'pick','type':'target_pose','from':'pick.source_id'},
+                {'id':'post_pick','type':'computed_offset','from':'pick.source_id','offset_axis':'retreat_axis','distance_m':0.10},
+                {'id':'pre_place','type':'computed_offset','from':'place.target_id','offset_axis':'approach_axis','distance_m':0.12},
+                {'id':'place','type':'target_pose','from':'place.target_id'},
+                {'id':'post_place','type':'computed_offset','from':'place.target_id','offset_axis':'retreat_axis','distance_m':0.12},
+            ],
+            'checks': {
+                'require_pick_source': True, 'require_place_target': True, 'require_grasp_strategy': True,
+                'require_collision_scene': True, 'require_fake_hardware_default': True
+            }
+        },
+        'safety': {'metadata_only': True, 'motion_started': False, 'ros_launch_started': False, 'moveit_service_called': False, 'runtime_io_applied': False}
+    }
+    return req, warnings, missing
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--task-recipe', required=True, type=Path)
+    ap.add_argument('--output', required=True, type=Path)
+    ap.add_argument('--json', action='store_true')
+    ap.add_argument('--cell-definition', type=Path)
+    ap.add_argument('--environment-layout', type=Path)
+    ap.add_argument('--task-flow-summary', type=Path)
+    ap.add_argument('--validate', action='store_true')
+    ap.add_argument('--allow-incomplete', action='store_true')
+    a = ap.parse_args()
+    recipe = _load(a.task_recipe)
+    flow = _load(a.task_flow_summary) if a.task_flow_summary else {}
+    cell = _load(a.cell_definition) if a.cell_definition else {}
+    env = _load(a.environment_layout) if a.environment_layout else {}
+    payload, warns, missing = generate(recipe, a.task_recipe, flow, cell, env)
+    status = 'PASS'
+    readiness = 'plan_preview_request_generated'
+    errors = []
+    if missing:
+        if a.allow_incomplete:
+            status = 'WARN'; readiness = 'plan_preview_request_incomplete'; warns.append('Missing required fields: ' + ', '.join(missing))
+        else:
+            status = 'FAIL'; errors.append('Missing required fields: ' + ', '.join(missing))
+    if status != 'FAIL':
+        _dump(a.output, payload)
+    summary = {'status': status, 'output_path': str(a.output), 'task_id': (recipe.get('task') or {}).get('id'), 'pick_source_id': payload['request']['pick']['source_id'], 'place_target_id': payload['request']['place']['target_id'], 'grasp_strategy': payload['request']['tool']['grasp_strategy'], 'waypoint_count': len(payload['request']['waypoints']), 'missing_required_fields': missing, 'warnings': warns, 'errors': errors, 'readiness_classification': readiness, 'safety': payload['safety']}
+    if a.validate and status != 'FAIL':
+        from validate_offline_plan_preview_request import validate_request
+        v = validate_request(payload)
+        if v['status'] == 'FAIL':
+            summary['status'] = 'FAIL'; summary['errors'].extend(v['errors'])
+    if a.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        print(f"{summary['status']}: {a.output}")
+    return 1 if summary['status'] == 'FAIL' else 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/validate_offline_plan_preview_request.py
+++ b/scripts/validate_offline_plan_preview_request.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+from typing import Any
+try:
+    import yaml
+except Exception:
+    yaml=None
+
+def _load(path: Path)->dict[str,Any]:
+    if yaml is not None:
+        d=yaml.safe_load(path.read_text(encoding='utf-8')); return d if isinstance(d,dict) else {}
+    return json.loads(path.read_text(encoding='utf-8'))
+
+def validate_request(payload: dict[str,Any])->dict[str,Any]:
+    errs=[]; warns=[]
+    if payload.get('schema')!='offline_plan_preview_request/v1': errs.append('schema mismatch')
+    req=payload.get('request') if isinstance(payload.get('request'),dict) else {}
+    pick=(req.get('pick') or {}); place=(req.get('place') or {}); tool=(req.get('tool') or {})
+    if not pick.get('source_id'): errs.append('pick.source_id missing')
+    if not place.get('target_id'): errs.append('place.target_id missing')
+    if not tool.get('grasp_strategy'): errs.append('tool.grasp_strategy missing')
+    wps=req.get('waypoints') if isinstance(req.get('waypoints'),list) else []
+    ids={w.get('id') for w in wps if isinstance(w,dict)}
+    for rid in ['pre_pick','pick','post_pick','pre_place','place','post_place']:
+        if rid not in ids: errs.append(f'waypoint missing: {rid}')
+    safety=payload.get('safety') if isinstance(payload.get('safety'),dict) else {}
+    must={'metadata_only':True,'motion_started':False,'ros_launch_started':False,'moveit_service_called':False,'runtime_io_applied':False}
+    for k,v in must.items():
+        if safety.get(k)!=v: errs.append(f'safety.{k} must be {v}')
+    for k in ['approach_distance_m','retreat_distance_m']:
+        if pick.get(k) is not None and float(pick.get(k))<=0: errs.append(f'pick.{k} must be >0')
+    if place.get('retreat_distance_m') is not None and float(place.get('retreat_distance_m'))<=0: errs.append('place.retreat_distance_m must be >0')
+    return {'status':'FAIL' if errs else ('WARN' if warns else 'PASS'),'warnings':warns,'errors':errs}
+
+def main()->int:
+    ap=argparse.ArgumentParser(); ap.add_argument('request',type=Path); ap.add_argument('--json',action='store_true'); a=ap.parse_args()
+    out=validate_request(_load(a.request));
+    if a.json: print(json.dumps(out,indent=2))
+    else: print(out['status'])
+    return 1 if out['status']=='FAIL' else 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tests/test_offline_plan_preview_request.py
+++ b/tests/test_offline_plan_preview_request.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+import json, subprocess, tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def test_generate_and_validate_request() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        out = Path(d)/'req.yaml'
+        recipe = Path(d)/'recipe.yaml'
+        recipe.write_text("""schema_version: task_recipe/v1\ntask:\n  id: pick_place_demo\n  source: src\n  destinations:\n    - id: bin\ngrasp:\n  strategy_ref: suction_top_basic\n""", encoding='utf-8')
+        run = subprocess.run(['python3', str(REPO/'scripts'/'generate_offline_plan_preview_request.py'),'--task-recipe',str(recipe),'--output',str(out),'--validate','--json'],capture_output=True,text=True,check=False)
+        assert run.returncode == 0
+        data = json.loads(run.stdout)
+        assert data['status'] in {'PASS','WARN'}
+        assert out.exists()
+        v = subprocess.run(['python3', str(REPO/'scripts'/'validate_offline_plan_preview_request.py'), str(out), '--json'],capture_output=True,text=True,check=False)
+        assert v.returncode == 0
+
+
+def test_allow_incomplete() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        recipe = Path(d)/'bad.yaml'
+        recipe.write_text("""schema_version: task_recipe/v1\ntask:\n  id: x\ngrasp: {}\n""", encoding='utf-8')
+        out = Path(d)/'req.yaml'
+        run = subprocess.run(['python3', str(REPO/'scripts'/'generate_offline_plan_preview_request.py'),'--task-recipe',str(recipe),'--output',str(out),'--allow-incomplete','--json'],capture_output=True,text=True,check=False)
+        assert run.returncode == 0
+        assert json.loads(run.stdout)['readiness_classification'] == 'plan_preview_request_incomplete'

--- a/tools/workcell_studio_streamlit/backend.py
+++ b/tools/workcell_studio_streamlit/backend.py
@@ -258,6 +258,43 @@ def load_generated_task_recipe(path: str | Path) -> dict[str, Any]:
 
 def summarize_task_recipe(path: str | Path) -> dict[str, Any]:
     payload = load_generated_task_recipe(path)
+
+def generate_plan_preview_request(task_recipe_path: str | Path, output_path: str | Path, cell_definition_path: str | Path | None = None, environment_layout_path: str | Path | None = None, allow_incomplete: bool = False, validate: bool = True, root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    cmd = [sys.executable, str(rr / "scripts" / "generate_offline_plan_preview_request.py"), "--task-recipe", str(task_recipe_path), "--output", str(output_path), "--json"]
+    if cell_definition_path:
+        cmd.extend(["--cell-definition", str(cell_definition_path)])
+    if environment_layout_path:
+        cmd.extend(["--environment-layout", str(environment_layout_path)])
+    if allow_incomplete:
+        cmd.append("--allow-incomplete")
+    if validate:
+        cmd.append("--validate")
+    return _parse_json_output(run_command(cmd, cwd=rr))
+
+
+def validate_plan_preview_request(request_path: str | Path, root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    cmd = [sys.executable, str(rr / "scripts" / "validate_offline_plan_preview_request.py"), str(request_path), "--json"]
+    return _parse_json_output(run_command(cmd, cwd=rr))
+
+
+def load_plan_preview_request(path: str | Path) -> dict[str, Any]:
+    p = Path(path)
+    return _load_yaml_file(p) if p.exists() else {}
+
+
+def summarize_plan_preview_request(path: str | Path) -> dict[str, Any]:
+    payload = load_plan_preview_request(path)
+    req = payload.get("request", {}) if isinstance(payload.get("request"), dict) else {}
+    return {
+        "schema": payload.get("schema"),
+        "pick_source": (req.get("pick") or {}).get("source_id"),
+        "place_target": (req.get("place") or {}).get("target_id"),
+        "grasp_strategy": (req.get("tool") or {}).get("grasp_strategy"),
+        "waypoint_count": len(req.get("waypoints") or []),
+        "safety": payload.get("safety", {}),
+    }
     bti = payload.get("builder_task_intent", {}) if isinstance(payload.get("builder_task_intent"), dict) else {}
     task = payload.get("task", {}) if isinstance(payload.get("task"), dict) else {}
     return {


### PR DESCRIPTION
### Motivation

- Provide a safe, metadata-only bridge from `task_recipe/v1` to future MoveIt/RViz visual plan previews without executing any robot motion or launching ROS.
- Capture pick/place/grasp intent, waypoint intent, planning checks, and conservative safety flags as an offline artifact to support upcoming planner/visualization integration.

### Description

- Add the `offline_plan_preview_request/v1` specification and usage notes in `docs/manuals/OFFLINE_PLAN_PREVIEW_REQUEST_V1.md` documenting that the artifact is offline-only and not a safety certificate.
- Implement `scripts/generate_offline_plan_preview_request.py` to synthesize a structured plan-preview request from a `task_recipe` plus optional `cell_definition`/`environment_layout`/`task_flow_summary`, supporting `--allow-incomplete`, `--validate`, and `--json` summary output.
- Implement `scripts/validate_offline_plan_preview_request.py` to check schema, required pick/place/grasp fields, waypoint presence, safety flags, and positive distances, returning PASS/WARN/FAIL semantics.
- Integrate generation into builder export by emitting `generated/offline_plan_preview_request.yaml` when a generated task recipe exists and include generation status in export summaries via `scripts/export_builder_scene_to_cell_definition.py`.
- Add Streamlit backend helpers in `tools/workcell_studio_streamlit/backend.py` for `generate_plan_preview_request`, `validate_plan_preview_request`, `load_plan_preview_request`, and `summarize_plan_preview_request` for UI integration.
- Add focused tests in `tests/test_offline_plan_preview_request.py` to validate generation, validation, and `--allow-incomplete` behavior.

### Testing

- Ran the new unit/integration tests with `python3 -m pytest -q tests/test_offline_plan_preview_request.py` and supporting integration tests for export/import and Streamlit backend, and all tests passed (24 passed).
- Exercised `scripts/generate_offline_plan_preview_request.py` with `--validate`/`--json` to confirm summary fields include `status`, `output_path`, `task_id`, `pick_source_id`, `place_target_id`, `grasp_strategy`, `waypoint_count`, `missing_required_fields`, `warnings`, `errors`, `readiness_classification`, and conservative `safety` flags.
- Confirmed `scripts/validate_offline_plan_preview_request.py` exits `0` for PASS/WARN and non-zero for FAIL when required fields or safety flags are violated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbb11c1df48331ac2fdfdd3302f2a3)