### PR TITLE
Add guarded fake-hardware RViz/MoveIt plan-preview session preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1504,3 +1504,6 @@ Use `python3 scripts/workcell_studio.py create-cell` for fast catalog/YAML cell 
 
 ## Task flow preview: pick → grasp → place
 Use `scripts/summarize_task_flow.py` and static preview task-flow markers for offline readiness diagnostics.
+
+## Guarded RViz/MoveIt plan preview preparation
+Use `scripts/generate_rviz_moveit_plan_preview_session.py` or `scripts/workcell_studio.py prepare-rviz-plan-preview` to generate fake-hardware-only manual launch suggestions and readiness reports.

--- a/docs/manuals/OFFLINE_PLAN_PREVIEW_REQUEST_V1.md
+++ b/docs/manuals/OFFLINE_PLAN_PREVIEW_REQUEST_V1.md
@@ -51,3 +51,6 @@ safety:
   moveit_service_called: false
   runtime_io_applied: false
 ```
+
+
+This request can be consumed by `rviz_moveit_plan_preview_session/v1` preparation tooling to produce guarded fake-hardware RViz/MoveIt preview session artifacts.

--- a/docs/manuals/RVIZ_MOVEIT_PLAN_PREVIEW_SESSION_V1.md
+++ b/docs/manuals/RVIZ_MOVEIT_PLAN_PREVIEW_SESSION_V1.md
@@ -1,0 +1,11 @@
+# RVIZ_MOVEIT_PLAN_PREVIEW_SESSION_V1
+
+`rviz_moveit_plan_preview_session/v1` is a **session-preparation artifact** for guarded offline plan preview.
+
+- It does **not** start ROS.
+- It does **not** call MoveIt services.
+- It does **not** move the robot.
+- Suggested commands are generated only; the user must run them manually.
+- Real mode remains blocked/guarded.
+
+Schema highlights include `source`, `session`, `rviz_moveit`, `plan_preview`, and `safety` with fake-hardware-required defaults.

--- a/docs/manuals/WORKCELL_STUDIO_ROADMAP.md
+++ b/docs/manuals/WORKCELL_STUDIO_ROADMAP.md
@@ -63,3 +63,6 @@ High-level ownership boundaries:
 ## Create-cell wizard
 
 `workcell_builder` remains the visual scene editor. `workcell_studio.py create-cell` is a fast catalog-driven YAML creation path that generates cell definition/layout, validates, produces static previews, and can optionally emit offline bundle artifacts.
+
+
+Next safe bridge: guarded RViz/MoveIt plan-preview session preparation from offline plan-preview requests, without ROS launch or motion execution.

--- a/scripts/generate_rviz_moveit_plan_preview_session.py
+++ b/scripts/generate_rviz_moveit_plan_preview_session.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except Exception:
+    yaml=None
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+from validate_offline_plan_preview_request import validate_request
+
+
+def _load(path: Path) -> dict[str, Any]:
+    if not path or not path.exists():
+        return {}
+    if yaml is not None:
+        data = yaml.safe_load(path.read_text(encoding='utf-8'))
+        return data if isinstance(data, dict) else {}
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def _find_launch(scene_package: Path) -> Path | None:
+    for c in [scene_package / 'launch' / 'demo.launch.py', scene_package / 'demo.launch.py']:
+        if c.is_file():
+            return c
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--scene-package', required=True)
+    ap.add_argument('--plan-preview-request', required=True, type=Path)
+    ap.add_argument('--output-dir', required=True, type=Path)
+    ap.add_argument('--cell-definition', type=Path)
+    ap.add_argument('--task-recipe', type=Path)
+    ap.add_argument('--project-dir', type=Path)
+    ap.add_argument('--allow-missing-launch', action='store_true')
+    ap.add_argument('--package-name', type=str)
+    ap.add_argument('--json', action='store_true')
+    a = ap.parse_args()
+
+    scene_as_path = Path(a.scene_package)
+    pkg_name = a.package_name or scene_as_path.name
+    launch = _find_launch(scene_as_path) if scene_as_path.exists() else None
+    req = _load(a.plan_preview_request)
+    req_valid = validate_request(req) if req else {'status': 'FAIL', 'errors': ['missing request']}
+    req_ok = req.get('schema') == 'offline_plan_preview_request/v1'
+    waypoint_count = len((((req.get('request') or {}).get('waypoints')) or [])) if req_ok else 0
+    pick = ((req.get('request') or {}).get('pick') or {}).get('source_id')
+    place = ((req.get('request') or {}).get('place') or {}).get('target_id')
+    grasp = ((req.get('request') or {}).get('tool') or {}).get('grasp_strategy')
+
+    cmd = f"ros2 launch {pkg_name} demo.launch.py use_fake_hardware:=true launch_rviz:=true"
+    blockers, warnings = [], []
+    if not scene_as_path.exists() and '/' in a.scene_package:
+        blockers.append('scene_package path does not exist')
+    if not launch:
+        msg = 'demo.launch.py not found'
+        if a.allow_missing_launch:
+            warnings.append(msg)
+        else:
+            blockers.append(msg)
+    if not req_ok:
+        blockers.append('offline_plan_preview_request invalid schema')
+    elif req_valid.get('status') == 'FAIL':
+        warnings.append('offline_plan_preview_request has validation errors; session remains metadata-only')
+
+    status = 'PASS' if not blockers else ('WARN' if a.allow_missing_launch and blockers == ['demo.launch.py not found'] else 'FAIL')
+    report = {
+        'schema': 'rviz_moveit_plan_preview_session/v1',
+        'source': {
+            'scene_package': a.scene_package,
+            'offline_plan_preview_request': str(a.plan_preview_request),
+            'cell_definition': str(a.cell_definition) if a.cell_definition else '',
+            'task_recipe': str(a.task_recipe) if a.task_recipe else '',
+        },
+        'session': {
+            'id': f'plan_preview_session_{pkg_name}',
+            'mode': 'fake_hardware_visual_preview',
+            'launch_allowed': False,
+            'generated_commands_only': True,
+            'user_must_run_commands_manually': True,
+        },
+        'rviz_moveit': {
+            'suggested_launch': {'command': cmd, 'requires_sourced_workspace': True},
+            'forbidden_defaults': {'use_fake_hardware_false': True, 'real_hardware': True, 'runtime_io': True},
+            'expected_inputs': {
+                'scene_package_exists': scene_as_path.exists(),
+                'demo_launch_exists': bool(launch),
+                'offline_plan_preview_request_valid': req_ok,
+                'fake_hardware_default': True if launch else 'unknown',
+            },
+        },
+        'plan_preview': {'waypoint_count': waypoint_count, 'pick_source_id': pick, 'place_target_id': place, 'grasp_strategy': grasp, 'warnings': warnings},
+        'safety': {'motion_started': False, 'moveit_service_called': False, 'ros_launch_started': False, 'runtime_io_applied': False, 'fake_hardware_required': True},
+        'readiness': {'status': status, 'blockers': blockers, 'warnings': warnings},
+        'next_manual_steps': ['Review suggested_commands.sh', 'Source workspace manually (if needed)', 'Run ros2 launch command manually only for fake hardware preview.'],
+    }
+
+    out = a.output_dir; out.mkdir(parents=True, exist_ok=True)
+    js = out / 'rviz_moveit_plan_preview_session.json'; md = out / 'rviz_moveit_plan_preview_session.md'; sh = out / 'suggested_commands.sh'
+    js.write_text(json.dumps(report, indent=2) + '\n', encoding='utf-8')
+    md.write_text("# RViz/MoveIt Plan Preview Session (v1)\n\n"
+                  "This is a **session-preparation artifact** only.\n\n"
+                  "- Does not start ROS\n- Does not call MoveIt\n- Does not move the robot\n- User must run suggested command manually\n- Real mode remains blocked/guarded\n\n"
+                  f"- Readiness: **{status}**\n- Scene package: `{a.scene_package}`\n- Launch file: `{launch or '(missing)'}`\n- Suggested command: `{cmd}`\n- Blockers: {blockers or ['(none)']}\n- Warnings: {warnings or ['(none)']}\n", encoding='utf-8')
+    sh.write_text("#!/usr/bin/env bash\n# Fake-hardware-only preview helper. DO NOT use for real hardware.\n# This script is generated and NOT executed automatically.\n# Optionally source your workspace first, e.g.: source install/setup.bash\n"+cmd+"\n", encoding='utf-8')
+    sh.chmod(0o755)
+
+    summary = {'status': status, 'json': str(js), 'markdown': str(md), 'suggested_commands': str(sh), 'blockers': blockers, 'warnings': warnings}
+    print(json.dumps(summary, indent=2) if a.json else f"{status}: {js}")
+    return 1 if status == 'FAIL' else 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/validate_rviz_moveit_plan_preview_session.py
+++ b/scripts/validate_rviz_moveit_plan_preview_session.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+
+def main()->int:
+    ap=argparse.ArgumentParser(); ap.add_argument('session',type=Path); ap.add_argument('--json',action='store_true'); a=ap.parse_args()
+    data=json.loads(a.session.read_text(encoding='utf-8'))
+    errs=[]; warns=[]
+    if data.get('schema')!='rviz_moveit_plan_preview_session/v1': errs.append('schema mismatch')
+    s=data.get('safety',{})
+    checks={'motion_started':False,'moveit_service_called':False,'ros_launch_started':False,'runtime_io_applied':False,'fake_hardware_required':True}
+    for k,v in checks.items():
+        if s.get(k)!=v: errs.append(f'safety.{k} must be {v}')
+    sess=data.get('session',{})
+    if sess.get('launch_allowed') is not False: errs.append('session.launch_allowed must be false')
+    if sess.get('generated_commands_only') is not True: errs.append('session.generated_commands_only must be true')
+    cmd=((data.get('rviz_moveit') or {}).get('suggested_launch') or {}).get('command','')
+    bad=['use_fake_hardware:=false','real_hardware','runtime execution','execute runtime']
+    for b in bad:
+        if b in cmd: errs.append(f'forbidden command token: {b}')
+    src=data.get('source',{})
+    req_path=Path(src.get('offline_plan_preview_request','')) if src.get('offline_plan_preview_request') else None
+    if req_path and not req_path.exists(): warns.append('offline plan preview request path missing')
+    req_valid=((data.get('rviz_moveit') or {}).get('expected_inputs') or {}).get('offline_plan_preview_request_valid')
+    if req_valid and (data.get('plan_preview') or {}).get('waypoint_count') is None: errs.append('waypoint_count required when request valid')
+    status='FAIL' if errs else ('WARN' if warns else 'PASS')
+    out={'status':status,'errors':errs,'warnings':warns}
+    print(json.dumps(out,indent=2) if a.json else status)
+    return 1 if status=='FAIL' else 0
+if __name__=='__main__': raise SystemExit(main())

--- a/scripts/workcell_studio.py
+++ b/scripts/workcell_studio.py
@@ -421,7 +421,20 @@ def import_builder_scene(args: argparse.Namespace) -> int:
             f"python3 scripts/create_workcell_project.py --cell-definition {cell_def} --output-dir {output_dir} --force",
         ],
         "export_summary": export_payload,
+        "rviz_plan_preview_session_path": "",
+        "rviz_plan_preview_suggested_commands_path": "",
     }
+
+    
+    if summary.get("generated_task_recipe_path"):
+        sess_dir = output_dir / "plan_preview_session"
+        preview_cmd = [sys.executable, str(SCRIPT_DIR / "generate_rviz_moveit_plan_preview_session.py"), "--scene-package", str(scene_pkg), "--plan-preview-request", str(generated_dir / "offline_plan_preview_request.yaml"), "--output-dir", str(sess_dir), "--allow-missing-launch", "--json"]
+        if Path(summary.get("generated_task_recipe_path")).exists():
+            req_cmd=[sys.executable, str(SCRIPT_DIR/"generate_offline_plan_preview_request.py"), "--task-recipe", summary.get("generated_task_recipe_path"), "--output", str(generated_dir / "offline_plan_preview_request.yaml"), "--validate", "--json"]
+            _run_json(req_cmd, "offline request")
+        _run_json(preview_cmd, "rviz plan preview prepare")
+        summary["rviz_plan_preview_session_path"] = str(sess_dir / "rviz_moveit_plan_preview_session.json")
+        summary["rviz_plan_preview_suggested_commands_path"] = str(sess_dir / "suggested_commands.sh")
 
     summary_json = output_dir / "workcell_studio_import_summary.json"
     summary_md = output_dir / "workcell_studio_import_summary.md"
@@ -456,6 +469,26 @@ def import_builder_scene(args: argparse.Namespace) -> int:
     return 0
 
 
+
+
+def prepare_rviz_plan_preview(args: argparse.Namespace) -> int:
+    cmd=[sys.executable, str(SCRIPT_DIR / "generate_rviz_moveit_plan_preview_session.py"), "--scene-package", str(args.scene_package), "--plan-preview-request", str(args.plan_preview_request), "--output-dir", str(args.output_dir)]
+    if args.cell_definition: cmd += ["--cell-definition", str(args.cell_definition)]
+    if args.task_recipe: cmd += ["--task-recipe", str(args.task_recipe)]
+    if args.project_dir: cmd += ["--project-dir", str(args.project_dir)]
+    if args.allow_missing_launch: cmd.append("--allow-missing-launch")
+    if args.json: cmd.append("--json")
+    run=subprocess.run(cmd, capture_output=True, text=True, check=False)
+    print(run.stdout if run.stdout else run.stderr)
+    return run.returncode
+
+
+def validate_rviz_plan_preview(args: argparse.Namespace) -> int:
+    cmd=[sys.executable, str(SCRIPT_DIR / "validate_rviz_moveit_plan_preview_session.py"), str(args.session)]
+    if args.json: cmd.append("--json")
+    run=subprocess.run(cmd, capture_output=True, text=True, check=False)
+    print(run.stdout if run.stdout else run.stderr)
+    return run.returncode
 
 def validate_builder_task(args: argparse.Namespace) -> int:
     cmd = [sys.executable, str(SCRIPT_DIR / "validate_builder_task_intent.py"), str(args.task_intent)]
@@ -496,6 +529,23 @@ def _build_parser() -> argparse.ArgumentParser:
     import_parser.add_argument("--validate", action="store_true")
     import_parser.add_argument("--generate-project", action="store_true")
     import_parser.set_defaults(func=import_builder_scene)
+
+    prep = sub.add_parser("prepare-rviz-plan-preview", help="Prepare guarded fake-hardware RViz/MoveIt plan preview session artifacts")
+    prep.add_argument("--scene-package", required=True)
+    prep.add_argument("--plan-preview-request", type=Path, required=True)
+    prep.add_argument("--output-dir", type=Path, required=True)
+    prep.add_argument("--cell-definition", type=Path)
+    prep.add_argument("--task-recipe", type=Path)
+    prep.add_argument("--project-dir", type=Path)
+    prep.add_argument("--allow-missing-launch", action="store_true")
+    prep.add_argument("--json", action="store_true")
+    prep.set_defaults(func=prepare_rviz_plan_preview)
+
+    vprep = sub.add_parser("validate-rviz-plan-preview", help="Validate rviz_moveit_plan_preview_session/v1 artifacts")
+    vprep.add_argument("--session", type=Path, required=True)
+    vprep.add_argument("--json", action="store_true")
+    vprep.set_defaults(func=validate_rviz_plan_preview)
+
     cc = sub.add_parser("create-cell", help="Create a catalog-driven cell_definition + environment layout + optional preview/bundle")
     cc.add_argument("--cell-id", required=True)
     cc.add_argument("--robot", required=True)

--- a/tests/test_rviz_moveit_plan_preview_session.py
+++ b/tests/test_rviz_moveit_plan_preview_session.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import json, subprocess, tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+def _run(*args:str):
+    return subprocess.run(["python3", *args], cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+
+def test_generate_and_validate_session():
+    with tempfile.TemporaryDirectory() as d:
+        recipe=Path(d)/'task_recipe.yaml'
+        recipe.write_text((REPO_ROOT/'tests/fixtures/task_recipes/valid_pick_place.yaml').read_text(), encoding='utf-8')
+        req=Path(d)/'offline.yaml'
+        r1=_run('scripts/generate_offline_plan_preview_request.py','--task-recipe',str(recipe),'--output',str(req),'--allow-incomplete','--json')
+        assert r1.returncode==0
+        out=Path(d)/'sess'
+        r2=_run('scripts/generate_rviz_moveit_plan_preview_session.py','--scene-package','scenes/ur5_2f_test','--plan-preview-request',str(req),'--output-dir',str(out),'--allow-missing-launch','--json')
+        assert r2.returncode==0
+        assert (out/'rviz_moveit_plan_preview_session.json').is_file()
+        assert (out/'rviz_moveit_plan_preview_session.md').is_file()
+        cmd=(out/'suggested_commands.sh').read_text()
+        assert 'use_fake_hardware:=false' not in cmd
+        assert 'use_fake_hardware:=true' in cmd
+        r3=_run('scripts/validate_rviz_moveit_plan_preview_session.py',str(out/'rviz_moveit_plan_preview_session.json'),'--json')
+        assert r3.returncode==0
+
+def test_unsafe_command_fails_validation():
+    with tempfile.TemporaryDirectory() as d:
+        p=Path(d)/'s.json'
+        p.write_text(json.dumps({'schema':'rviz_moveit_plan_preview_session/v1','session':{'launch_allowed':False,'generated_commands_only':True},'safety':{'motion_started':False,'moveit_service_called':False,'ros_launch_started':False,'runtime_io_applied':False,'fake_hardware_required':True},'rviz_moveit':{'suggested_launch':{'command':'ros2 launch x demo.launch.py use_fake_hardware:=false'}}}, indent=2))
+        r=_run('scripts/validate_rviz_moveit_plan_preview_session.py',str(p),'--json')
+        assert r.returncode!=0

--- a/tests/test_workcell_studio_builder_import_cli.py
+++ b/tests/test_workcell_studio_builder_import_cli.py
@@ -90,3 +90,15 @@ def test_import_summary_has_task_flow_summary():
         assert proc.returncode==0
         summary=json.loads((out/'workcell_studio_import_summary.json').read_text(encoding='utf-8'))
         assert 'task_flow_summary' in summary or 'readiness_classification' in summary
+
+
+def test_import_summary_references_plan_preview_session_when_generated() -> None:
+    import tempfile, json
+    from pathlib import Path
+    with tempfile.TemporaryDirectory() as d:
+        scene=Path(d)/"scene"; scene.mkdir(); _write_scene(scene)
+        out=Path(d)/"out"
+        proc=_run("import-builder-scene","--scene-package",str(scene),"--output-dir",str(out),"--project-name","demo","--validate")
+        assert proc.returncode==0
+        summary=json.loads((out/"workcell_studio_import_summary.json").read_text(encoding="utf-8"))
+        assert "rviz_plan_preview_session_path" in summary

--- a/tests/test_workcell_studio_streamlit_backend.py
+++ b/tests/test_workcell_studio_streamlit_backend.py
@@ -128,3 +128,21 @@ def test_task_flow_backend_helpers():
         cell=backend.repo_root()/'tests'/'fixtures'/'cell_definition_pick_place.yaml'
         pr=backend.generate_static_preview_with_task_flow(cell,out,'x',task_intent_path=intent)
         assert pr['returncode']==0
+
+
+def test_backend_prepare_and_validate_rviz_plan_preview_session(tmp_path):
+    from tools.workcell_studio_streamlit import backend
+    recipe = tmp_path/"recipe.yaml"
+    recipe.write_text((Path(__file__).resolve().parents[1]/"tests/fixtures/task_recipes/valid_pick_place.yaml").read_text(encoding="utf-8"), encoding="utf-8")
+    req = tmp_path/"offline.yaml"
+    gen = backend.run_command(["python3", str(backend.repo_root()/"scripts"/"generate_offline_plan_preview_request.py"), "--task-recipe", str(recipe), "--output", str(req), "--allow-incomplete", "--json"], cwd=backend.repo_root())
+    assert gen["returncode"] == 0
+    out = tmp_path/"session"
+    prep = backend.prepare_rviz_plan_preview("scenes/ur5_2f_test", req, out)
+    assert prep["ok"]
+    payload = backend.load_rviz_plan_preview_session(out)
+    assert payload.get("schema") == "rviz_moveit_plan_preview_session/v1"
+    text = backend.read_suggested_commands(out)
+    assert "use_fake_hardware:=false" not in text
+    val = backend.validate_rviz_plan_preview_session(out/"rviz_moveit_plan_preview_session.json")
+    assert val["ok"]

--- a/tools/workcell_studio_streamlit/README.md
+++ b/tools/workcell_studio_streamlit/README.md
@@ -60,3 +60,6 @@ The Streamlit app now includes **Create Cell** for selecting catalog robot/tool/
 
 ## Task Flow Summary panel
 Shows readiness classification, pick/place/grasp/release, routing, and offline safety/preview diagnostics.
+
+
+Includes a **Prepare RViz/MoveIt plan preview** action that only generates manual fake-hardware commands and safety/readiness reports. It does not start ROS, call MoveIt, or move hardware.

--- a/tools/workcell_studio_streamlit/backend.py
+++ b/tools/workcell_studio_streamlit/backend.py
@@ -433,3 +433,28 @@ def generate_static_preview_with_task_flow(cell_definition_path: str | Path, out
     if task_intent_path: cmd += ["--task-intent", str(task_intent_path)]
     if task_recipe_path: cmd += ["--task-recipe", str(task_recipe_path)]
     return _parse_json_output(run_command(cmd, cwd=rr))
+
+
+def prepare_rviz_plan_preview(scene_package: str | Path, plan_preview_request: str | Path, output_dir: str | Path, allow_missing_launch: bool = True, root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    cmd = [sys.executable, str(rr / "scripts" / "workcell_studio.py"), "prepare-rviz-plan-preview", "--scene-package", str(scene_package), "--plan-preview-request", str(plan_preview_request), "--output-dir", str(output_dir), "--json"]
+    if allow_missing_launch:
+        cmd.append("--allow-missing-launch")
+    return _parse_json_output(run_command(cmd, cwd=rr))
+
+
+def validate_rviz_plan_preview_session(session_path: str | Path, root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    cmd = [sys.executable, str(rr / "scripts" / "workcell_studio.py"), "validate-rviz-plan-preview", "--session", str(session_path), "--json"]
+    return _parse_json_output(run_command(cmd, cwd=rr))
+
+
+def load_rviz_plan_preview_session(output_dir: str | Path) -> dict[str, Any]:
+    d = Path(output_dir)
+    p = d / "rviz_moveit_plan_preview_session.json"
+    return json.loads(p.read_text(encoding="utf-8")) if p.exists() else {}
+
+
+def read_suggested_commands(output_dir: str | Path) -> str:
+    p = Path(output_dir) / "suggested_commands.sh"
+    return p.read_text(encoding="utf-8") if p.exists() else ""


### PR DESCRIPTION
### Motivation
- Provide a safe, offline preparation step that bridges `offline_plan_preview_request/v1` outputs to a manual RViz/MoveIt visual review without starting ROS, calling MoveIt, or moving hardware. 
- Ensure any suggested launch commands are fake-hardware-only, require explicit user action, and make safety/readiness obvious to downstream UIs and automation.

### Description
- Add session schema documentation at `docs/manuals/RVIZ_MOVEIT_PLAN_PREVIEW_SESSION_V1.md` describing `rviz_moveit_plan_preview_session/v1` as a preparation-only artifact that does not start ROS, call MoveIt, or move the robot.
- Add `scripts/generate_rviz_moveit_plan_preview_session.py` to produce `rviz_moveit_plan_preview_session.json`, `rviz_moveit_plan_preview_session.md`, and `suggested_commands.sh`; the generator reports readiness/blockers, waypoint summary, safety flags, and emits fake-hardware-only suggested commands using `use_fake_hardware:=true` when applicable.
- Add `scripts/validate_rviz_moveit_plan_preview_session.py` to validate session schema and enforce safety constraints, including checks that `session.launch_allowed` is `false`, `session.generated_commands_only` is `true`, and that suggested commands do not contain forbidden tokens like `use_fake_hardware:=false` or `real_hardware`.
- Integrate CLI hooks into `scripts/workcell_studio.py` with `prepare-rviz-plan-preview` and `validate-rviz-plan-preview` subcommands, and augment `import-builder-scene` to generate a plan-preview session under `<output-dir>/plan_preview_session/` when a generated offline preview request exists, storing paths in the import summary JSON/MD.
- Add Streamlit backend helpers in `tools/workcell_studio_streamlit/backend.py`: `prepare_rviz_plan_preview()`, `validate_rviz_plan_preview_session()`, `load_rviz_plan_preview_session()`, and `read_suggested_commands()` for UI integration.
- Add tests in `tests/test_rviz_moveit_plan_preview_session.py` and extend relevant integration tests to assert generation, safety of suggested commands, validator behavior, and import/backend linkage.
- Update docs/READMEs to mention the guarded fake-hardware-only preview preparation and safety posture.

### Testing
- Unit and integration tests were run with pytest, including the new session tests and related suites via `python3 -m pytest -q tests/test_rviz_moveit_plan_preview_session.py tests/test_offline_plan_preview_request.py tests/test_workcell_studio_builder_import_cli.py tests/test_workcell_studio_streamlit_backend.py tests/test_task_flow_summary.py tests/test_cell_definition_tools.py`.
- Full test run completed successfully: `66 passed, 7 subtests passed` (all new and modified tests passed).
- Specific safety cases covered: generated session contains `suggested_commands.sh` with `use_fake_hardware:=true` and validator rejects unsafe command tokens (tests assert validator exits non-zero on unsafe commands).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbb35289208331af4b7d2a7caf4835)