### PR TITLE
Fix NameError in cell definition validator and add regression test

### DIFF
--- a/scripts/validate_cell_definition.py
+++ b/scripts/validate_cell_definition.py
@@ -265,8 +265,6 @@ def _extract_refs(defn: dict[str, Any]) -> dict[str, Any]:
     if not sensors and isinstance(defn.get("camera"), dict) and defn["camera"].get("capability"):
         sensors = [{"capability": defn["camera"].get("capability")}]
     task = defn.get("task") if isinstance(defn.get("task"), dict) else {}
-    if not isinstance(robot.get("model"), str) or not robot.get("model", "").strip():
-        result.errors.append("robot.model must be a non-empty string.")
     environment = defn.get("environment") if isinstance(defn.get("environment"), dict) else {}
     assets = environment.get("assets") if isinstance(environment.get("assets"), list) else []
     return {
@@ -396,6 +394,9 @@ def validate_cell_definition(
     objects = defn.get("objects") if isinstance(defn.get("objects"), list) else []
     task = defn.get("task") if isinstance(defn.get("task"), dict) else {}
     grasp = defn.get("grasp") if isinstance(defn.get("grasp"), dict) else None
+
+    if not isinstance(robot.get("model"), str) or not robot.get("model", "").strip():
+        result.errors.append("robot.model must be a non-empty string.")
 
     if "safe_joint_state" not in robot:
         result.errors.append("robot.safe_joint_state key is required (empty list allowed when home_named_target exists).")

--- a/tests/test_cell_definition_tools.py
+++ b/tests/test_cell_definition_tools.py
@@ -96,6 +96,23 @@ class CellDefinitionValidationTests(unittest.TestCase):
         self.assertFalse(summary.ok)
         self.assertIn("ghost_bin", " ".join(summary.errors))
 
+
+    def test_missing_robot_model_reports_validation_error_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fixture = Path(tmpdir) / "missing_robot_model.yaml"
+            fixture.write_text("schema_version: cell_definition/v1\ncell: {}\n", encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, str(REPO_ROOT / "scripts" / "validate_cell_definition.py"), str(fixture), "--json"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 1)
+            payload = json.loads(proc.stdout)
+            self.assertEqual(payload["result"], "FAIL")
+            self.assertTrue(any("robot.model must be a non-empty string." in e for e in payload["errors"]))
+            self.assertNotIn("Traceback", proc.stderr + proc.stdout)
+
     def test_unknown_grasp_strategy_warns_by_default(self) -> None:
         loaded, parser, notes = validator.load_yaml(FIXTURES / "cell_definition_sort_by_colour_with_grasp_strategy.yaml")
         loaded["grasp"]["strategy_ref"] = "missing_grasp"


### PR DESCRIPTION
### Motivation
- A `NameError` occurred when validating minimal/malformed cell definitions because `_extract_refs()` attempted to write to `result.errors` which is out of scope. 
- This surfaced during a broader test run and prevented clean validator behavior and machine-readable (`--json`) error payloads.

### Description
- Removed the out-of-scope `result.errors.append(...)` call from `_extract_refs()` and kept `_extract_refs()` as a pure capability-reference extractor (`_extract_refs(defn)`).
- Moved the `robot.model` presence/format validation into `validate_cell_definition()` where the `ValidationSummary` (`result`) is available, preserving existing `PASS`/`WARN`/`FAIL` semantics and JSON output structure.
- Added a regression CLI test `test_missing_robot_model_reports_validation_error_without_traceback` to `tests/test_cell_definition_tools.py` that invokes the validator in `--json` mode on a minimal invalid input and asserts a structured `FAIL` payload with the expected error and no traceback.
- Kept fixes minimal and safe: no runtime robot behavior, ROS launch, MoveIt, EPD, hardware, or readiness-pack semantics changes were introduced.

### Testing
- Ran `python3 -m pytest -q tests/test_cell_definition_tools.py` and it passed (`42 passed, 7 subtests passed`).
- Ran the downstream test suites `python3 -m pytest -q tests/test_workcell_studio_readiness_pack.py`, `python3 -m pytest -q tests/test_readiness_pack_dashboard.py`, `python3 -m pytest -q tests/test_builder_scene_export_to_cell_definition.py`, and `python3 -m pytest -q tests/test_workcell_studio_builder_import_cli.py`, and all passed.
- Manually exercised CLI validator and readiness-pack flows with `python3 scripts/validate_cell_definition.py tests/fixtures/cell_definition_ur5_suction_sorting.yaml`, `python3 scripts/validate_cell_definition.py --json`, and `scripts/workcell_studio.py` generate/validate readiness-pack commands and verified JSON outputs and return codes were as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4c9749f48331a50c1cd3f46c5755)