### PR TITLE
Fix Workcell Studio CLI f-string syntax error in demo bundle command generation

### DIFF
--- a/scripts/workcell_studio.py
+++ b/scripts/workcell_studio.py
@@ -242,12 +242,13 @@ def generate_demo_bundle(args: argparse.Namespace) -> int:
             f"- Preview Summary JSON: `{summary['preview_summary_json']}`\n",
             encoding="utf-8",
         )
+        demo_title = demo.get("title", demo["id"])
         (demo_dir / "next_commands.md").write_text(
             "# Next Commands\n\n```bash\n"
             "python3 scripts/workcell_studio.py list-demos\n"
             f"python3 scripts/workcell_studio.py generate-demo-bundle --demo-id {demo['id']} --output-dir {output_root} --force\n"
             f"python3 scripts/validate_cell_definition.py {copied_cell} --json\n"
-            f"python3 scripts/generate_workcell_static_preview.py --cell-definition {copied_cell} --output-dir {preview_dir} --title '{demo.get("title",demo["id"])}'\n"
+            f"python3 scripts/generate_workcell_static_preview.py --cell-definition {copied_cell} --output-dir {preview_dir} --title '{demo_title}'\n"
             "```\n",
             encoding="utf-8",
         )


### PR DESCRIPTION
### Motivation
- Fix a `SyntaxError: f-string: unmatched '('` caused by a nested double-quoted expression inside a double-quoted f-string when generating `next_commands.md` in `generate_demo_bundle`.

### Description
- Precompute `demo_title = demo.get("title", demo["id"])` and use `demo_title` inside the f-string for the `generate_workcell_static_preview.py` command to eliminate nested quotes and restore valid Python syntax; no runtime robot logic, ROS launch behavior, MoveIt calls, EPD, or hardware behavior were modified and a search for similar nested-quote f-string patterns found none.

### Testing
- Ran `python3 -m py_compile scripts/workcell_studio.py`, verified `python3 scripts/workcell_studio.py --help` and the subcommand `--help` outputs, executed `python3 -m pytest -q` for `tests/test_workcell_studio_readiness_pack.py`, `tests/test_readiness_pack_dashboard.py`, `tests/test_workcell_studio_builder_import_cli.py`, `tests/test_workcell_studio_streamlit_backend.py`, and `tests/test_cell_definition_tools.py` (all passed), and exercised `generate-readiness-pack` / `validate-readiness-pack` smoke commands which returned the expected manifest and `PASS/WARN` results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5209329c83319dec67004cd7152b)