### PR TITLE
Add pick/place environment target authoring for real coordinate resolution

### DIFF
--- a/scripts/create_or_update_environment_target.py
+++ b/scripts/create_or_update_environment_target.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+from typing import Any
+try:
+    import yaml
+except Exception:
+    yaml = None
+
+def _load(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"schema_version":"environment_layout/v1","layout_id":"authored_layout","metadata":{"generated_defaults":False},"assets":[],"zones":[],"targets":[]}
+    if yaml is None:
+        raise RuntimeError("PyYAML is required")
+    data=yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data if isinstance(data,dict) else {}
+
+def _zone_from_args(a: argparse.Namespace) -> dict[str, Any]:
+    x,y,z=a.xyz; sx,sy,sz=a.size
+    return {"id":a.target_id,"type":a.target_type,"label":a.label,"frame":a.frame,"pose":{"frame":a.frame,"xyz":[x,y,z],"rpy":list(a.rpy)},"size":list(a.size),"bounds_xyz":{"min":[x-sx/2,y-sy/2,z-sz/2],"max":[x+sx/2,y+sy/2,z+sz/2]}}
+
+def main()->int:
+    ap=argparse.ArgumentParser()
+    ap.add_argument("--environment-layout", type=Path, required=True)
+    ap.add_argument("--target-id", required=True); ap.add_argument("--target-type", choices=["pick_zone","place_target","bin"], required=True)
+    ap.add_argument("--label", default=""); ap.add_argument("--frame", default="world")
+    ap.add_argument("--xyz", nargs=3, type=float, required=True); ap.add_argument("--rpy", nargs=3, type=float, required=True); ap.add_argument("--size", nargs=3, type=float, required=True)
+    ap.add_argument("--output", type=Path, required=True); ap.add_argument("--json", action="store_true")
+    a=ap.parse_args()
+    payload=_load(a.environment_layout)
+    payload.setdefault("schema_version","environment_layout/v1"); payload.setdefault("zones",[]); payload.setdefault("assets",[]); payload.setdefault("targets",[])
+    zone=_zone_from_args(a); updated=False
+    zones=payload["zones"] if isinstance(payload.get("zones"),list) else []
+    for i,z in enumerate(zones):
+        if isinstance(z,dict) and z.get("id")==a.target_id:
+            zones[i]=zone; updated=True; break
+    else:
+        zones.append(zone)
+    payload["zones"]=zones
+    t={"id":a.target_id,"type":a.target_type,"label":a.label,"frame":a.frame,"xyz":list(a.xyz),"rpy":list(a.rpy),"size":list(a.size)}
+    tlist=payload["targets"] if isinstance(payload.get("targets"),list) else []
+    for i,x in enumerate(tlist):
+        if isinstance(x,dict) and x.get("id")==a.target_id:
+            tlist[i]=t; break
+    else: tlist.append(t)
+    payload["targets"]=tlist
+    a.output.parent.mkdir(parents=True, exist_ok=True)
+    a.output.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    out={"result":"PASS","output_path":a.output.as_posix(),"target_id":a.target_id,"target_type":a.target_type,"frame":a.frame,"xyz":list(a.xyz),"rpy":list(a.rpy),"size":list(a.size),"updated_existing":updated,"warnings":[],"errors":[]}
+    print(json.dumps(out,indent=2) if a.json else out); return 0
+
+if __name__=="__main__":
+    raise SystemExit(main())

--- a/scripts/list_builder_scene_authoring_targets.py
+++ b/scripts/list_builder_scene_authoring_targets.py
@@ -27,22 +27,28 @@ def main()->int:
     for rel in ['generated/environment_layout.yaml','generated/cell_definition.yaml','environment_layout.yaml','cell_definition.yaml','environment.yaml','generated/workcell_builder_task_intent.yaml','workcell_builder_task_intent.yaml']:
         d=_load(a.scene_package/rel)
         if d: data[rel]=d
-    zones=[]; bins=[]; objs=[]; surfaces=[]; cams=[]
+    zones=[]; bins=[]; objs=[]; surfaces=[]; cams=[]; zone_details=[]
     for d in data.values():
-        zones += [z.get('id') for z in (d.get('zones') or []) if isinstance(z,dict) and z.get('id')]
+        for z in (d.get('zones') or []):
+            if isinstance(z,dict) and z.get('id'):
+                zones.append(z.get('id')); zone_details.append(z)
         objs += [o.get('id') for o in (d.get('objects') or []) if isinstance(o,dict) and o.get('id')]
         surfaces += [s.get('id') for s in ((d.get('environment') or {}).get('support_surfaces') or []) if isinstance(s,dict) and s.get('id')]
         cam=((d.get('camera') or {}).get('id') if isinstance(d.get('camera'),dict) else None)
         if cam: cams.append(cam)
         task=(d.get('task') or {}) if isinstance(d.get('task'),dict) else {}
         bins += [x.get('id') for x in (task.get('destinations') or []) if isinstance(x,dict) and x.get('id')]
-    pick_sources=sorted(set([z for z in zones if 'pick' in z] + objs))
-    place_targets=sorted(set([z for z in zones if ('bin' in z or 'place' in z)] + bins))
+    pick_sources=sorted(set([z.get('id') for z in zone_details if str(z.get('type','')).lower() in {'pick','pick_zone'}] + [z for z in zones if 'pick' in z] + objs))
+    place_targets=sorted(set([z.get('id') for z in zone_details if str(z.get('type','')).lower() in {'place','place_target','bin'}] + [z for z in zones if ('bin' in z or 'place' in z)] + bins))
     if not pick_sources:
         warnings.append('No explicit pick sources discovered; using fallback suggestion pick_zone_main.'); pick_sources=['pick_zone_main']
     if not place_targets:
         warnings.append('No explicit place targets discovered; using fallback suggestion bin_main.'); place_targets=['bin_main']
-    out={'result':'PASS','scene_package':a.scene_package.as_posix(),'pick_sources':pick_sources,'place_targets':place_targets,'zones':sorted(set(zones)),'bins':sorted(set(bins)),'objects':sorted(set(objs)),'support_surfaces':sorted(set(surfaces)),'cameras':sorted(set(cams)),'warnings':warnings}
+    def _coords(z):
+        p=(z.get('pose') or {}) if isinstance(z,dict) else {}
+        xyz=p.get('xyz') if isinstance(p.get('xyz'),list) else None
+        return xyz
+    out={'result':'PASS','scene_package':a.scene_package.as_posix(),'pick_sources':pick_sources,'place_targets':place_targets,'zone_targets':[{'id':z.get('id'),'type':z.get('type'),'label':z.get('label'),'xyz':_coords(z)} for z in zone_details if z.get('id')],'zones':sorted(set(zones)),'bins':sorted(set(bins)),'objects':sorted(set(objs)),'support_surfaces':sorted(set(surfaces)),'cameras':sorted(set(cams)),'warnings':warnings}
     print(json.dumps(out, indent=2) if a.json else out)
     return 0
 if __name__=='__main__': raise SystemExit(main())

--- a/scripts/summarize_task_flow.py
+++ b/scripts/summarize_task_flow.py
@@ -58,7 +58,7 @@ def summarize(task_intent:Path|None=None, task_recipe:Path|None=None, scene_pack
     if not place.get('id'): missing.append('place.target.id')
     if not (grasp.get('strategy_ref') or grasp.get('inline_strategy')): missing.append('grasp.strategy_ref')
     if missing: readiness='task_intent_incomplete'
-    zones={z.get('id') for z in (layout.get('zones') or []) if isinstance(z,dict)}
+    zones={z.get('id'):z for z in (layout.get('zones') or []) if isinstance(z,dict) and z.get('id')}
     pick_res=bool(pick.get('id') in zones) if zones else False
     place_res=bool(place.get('id') in zones) if zones else False
     approx=not (pick_res and place_res)

--- a/scripts/workcell_studio.py
+++ b/scripts/workcell_studio.py
@@ -592,6 +592,13 @@ def author_builder_task(args: argparse.Namespace) -> int:
     run=subprocess.run(cmd, capture_output=True, text=True, check=False)
     print(run.stdout if run.stdout else run.stderr)
     return run.returncode
+
+def author_environment_target(args: argparse.Namespace) -> int:
+    cmd=[sys.executable, str(SCRIPT_DIR/"create_or_update_environment_target.py"), "--environment-layout", str(args.environment_layout), "--target-id", args.target_id, "--target-type", args.target_type, "--label", args.label, "--frame", args.frame, "--xyz", *[str(x) for x in args.xyz], "--rpy", *[str(x) for x in args.rpy], "--size", *[str(x) for x in args.size], "--output", str(args.output)]
+    if args.json: cmd.append("--json")
+    run=subprocess.run(cmd, capture_output=True, text=True, check=False)
+    print(run.stdout if run.stdout else run.stderr)
+    return run.returncode
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
@@ -739,6 +746,18 @@ def _build_parser() -> argparse.ArgumentParser:
     abt.add_argument("--validate", action="store_true")
     abt.add_argument("--json", action="store_true")
     abt.set_defaults(func=author_builder_task)
+    aet = sub.add_parser("author-environment-target", help="Create or update environment pick/place target")
+    aet.add_argument("--environment-layout", type=Path, required=True)
+    aet.add_argument("--target-id", required=True)
+    aet.add_argument("--target-type", choices=["pick_zone","place_target","bin"], required=True)
+    aet.add_argument("--label", default="")
+    aet.add_argument("--frame", default="world")
+    aet.add_argument("--xyz", nargs=3, type=float, required=True)
+    aet.add_argument("--rpy", nargs=3, type=float, required=True)
+    aet.add_argument("--size", nargs=3, type=float, required=True)
+    aet.add_argument("--output", type=Path, required=True)
+    aet.add_argument("--json", action="store_true")
+    aet.set_defaults(func=author_environment_target)
 
     return parser
 

--- a/tests/test_environment_target_authoring.py
+++ b/tests/test_environment_target_authoring.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+import json, subprocess, sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+def _run(cmd):
+    return subprocess.run(cmd, cwd=REPO, capture_output=True, text=True, check=False)
+
+def test_environment_target_authoring_flow(tmp_path):
+    layout = tmp_path/'environment_layout.yaml'
+    r1=_run([sys.executable,'scripts/create_or_update_environment_target.py','--environment-layout',str(layout),'--target-id','pick_zone_main','--target-type','pick_zone','--label','Main pick zone','--frame','world','--xyz','0.45','0','0.08','--rpy','0','0','0','--size','0.3','0.2','0.1','--output',str(layout),'--json'])
+    assert r1.returncode==0 and layout.exists()
+    assert json.loads(r1.stdout)['updated_existing'] is False
+    r2=_run([sys.executable,'scripts/create_or_update_environment_target.py','--environment-layout',str(layout),'--target-id','bin_red','--target-type','place_target','--label','Red bin','--frame','world','--xyz','0.35','0.35','0.10','--rpy','0','0','0','--size','0.2','0.2','0.15','--output',str(layout),'--json'])
+    assert r2.returncode==0 and json.loads(r2.stdout)['updated_existing'] is False
+    r3=_run([sys.executable,'scripts/create_or_update_environment_target.py','--environment-layout',str(layout),'--target-id','pick_zone_main','--target-type','pick_zone','--label','Main pick zone','--frame','world','--xyz','0.50','0','0.08','--rpy','0','0','0','--size','0.3','0.2','0.1','--output',str(layout),'--json'])
+    assert json.loads(r3.stdout)['updated_existing'] is True

--- a/tests/test_workcell_studio_streamlit_backend.py
+++ b/tests/test_workcell_studio_streamlit_backend.py
@@ -168,6 +168,15 @@ def test_backend_planning_scene_readiness_helpers(tmp_path):
     val = backend.validate_planning_scene_readiness_report(out / "planning_scene_readiness_report.json")
     assert val["returncode"] == 0
 
+def test_backend_environment_target_wrappers(tmp_path):
+    layout = tmp_path/"environment_layout.yaml"
+    res = backend.create_or_update_environment_target(layout, "pick_zone_main", "pick_zone", "Main", "world", [0.45,0,0.08], [0,0,0], [0.3,0.2,0.1], output_path=layout)
+    assert res["returncode"] == 0
+    targets = backend.load_environment_targets(layout)
+    assert any(t.get("id") == "pick_zone_main" for t in targets)
+    summary = backend.summarize_environment_targets(layout)
+    assert "pick_zone_main" in summary["pick_sources"]
+
 
 def test_readiness_dashboard_backend_helpers(tmp_path):
     manifest = tmp_path/'manifest.json'

--- a/tools/workcell_studio_streamlit/app.py
+++ b/tools/workcell_studio_streamlit/app.py
@@ -95,6 +95,22 @@ elif workflow == "Builder Task Intent":
     output_path = st.text_input("Task intent output path", value=str(Path(scene_package) / "generated" / "workcell_builder_task_intent.yaml") if scene_package else "")
     if st.button("Discover scene targets"):
         st.session_state["builder_targets"] = backend.list_builder_scene_authoring_targets(scene_package).get("json", {})
+    st.subheader("Pick/Place Zones")
+    st.caption("Zones are metadata only. They do not move the robot.")
+    env_path = st.text_input("environment_layout.yaml path", value=str(Path(scene_package)/"generated"/"environment_layout.yaml"))
+    zc1, zc2, zc3 = st.columns(3)
+    zid = zc1.text_input("target id", value="pick_zone_main")
+    ztype = zc2.selectbox("target type", options=["pick_zone","place_target"])
+    zlabel = zc3.text_input("label", value="Main pick zone")
+    frame = st.text_input("frame", value="world")
+    cxyz = st.columns(3); x = cxyz[0].number_input("x", value=0.45); y = cxyz[1].number_input("y", value=0.0); z = cxyz[2].number_input("z", value=0.08)
+    crpy = st.columns(3); rr = crpy[0].number_input("roll", value=0.0); pp = crpy[1].number_input("pitch", value=0.0); yy = crpy[2].number_input("yaw", value=0.0)
+    csize = st.columns(3); sx = csize[0].number_input("size x", value=0.3); sy = csize[1].number_input("size y", value=0.2); sz = csize[2].number_input("size z", value=0.1)
+    zb1, zb2 = st.columns(2)
+    if zb1.button("Save/update target"):
+        st.json(backend.create_or_update_environment_target(env_path, zid, ztype, zlabel, frame, [x,y,z], [rr,pp,yy], [sx,sy,sz], output_path=env_path).get("json") or {})
+    if zb2.button("Refresh discovered targets"):
+        st.session_state["builder_targets"] = backend.list_builder_scene_authoring_targets(scene_package).get("json", {})
     targets = st.session_state.get("builder_targets", {})
     st.json(targets)
     grasps = [x["id"] for x in backend.resolve_catalog_choices().get("grasp_strategies", [])]

--- a/tools/workcell_studio_streamlit/backend.py
+++ b/tools/workcell_studio_streamlit/backend.py
@@ -365,6 +365,20 @@ def create_or_update_builder_task_intent(scene_package: str | Path, task_id: str
     if output_path: cmd += ["--output", str(output_path)]
     if validate: cmd.append("--validate")
     return _parse_json_output(run_command(cmd, cwd=rr))
+
+def create_or_update_environment_target(environment_layout_path: str | Path, target_id: str, target_type: str, label: str, frame: str, xyz: list[float], rpy: list[float], size: list[float], output_path: str | Path | None = None, root: Path | None = None) -> dict[str, Any]:
+    rr = root or repo_root()
+    out = output_path or environment_layout_path
+    cmd=[sys.executable, str(rr/"scripts"/"create_or_update_environment_target.py"), "--environment-layout", str(environment_layout_path), "--target-id", target_id, "--target-type", target_type, "--label", label, "--frame", frame, "--xyz", *[str(x) for x in xyz], "--rpy", *[str(x) for x in rpy], "--size", *[str(x) for x in size], "--output", str(out), "--json"]
+    return _parse_json_output(run_command(cmd, cwd=rr))
+
+def load_environment_targets(environment_layout_path: str | Path) -> list[dict[str, Any]]:
+    payload = _load_yaml_file(Path(environment_layout_path))
+    return [z for z in (payload.get("zones") or []) if isinstance(z, dict) and z.get("id")]
+
+def summarize_environment_targets(environment_layout_path: str | Path) -> dict[str, Any]:
+    zones = load_environment_targets(environment_layout_path)
+    return {"pick_sources":[z.get("id") for z in zones if str(z.get("type","")).lower() in {"pick","pick_zone"}], "place_targets":[z.get("id") for z in zones if str(z.get("type","")).lower() in {"place","place_target","bin"}], "count":len(zones)}
 def default_builder_task_intent(scene_package: str = "") -> dict[str, Any]:
     return {"schema":"workcell_builder_task_intent/v1","scene_package":scene_package,"task":{"id":"default_builder_task","type":"pick_place","mode":"offline_preview"},"pick":{"source":{"type":"zone","id":"pick_zone_main"},"object_filter":{"class_id":"any","color":"any"}},"grasp":{"strategy_ref":"suction_top_basic","approach_axis":"z_down","approach_distance_m":0.1,"retreat_axis":"z_up","retreat_distance_m":0.1},"place":{"target":{"type":"destination","id":"bin_main"},"release_strategy":"tool_release","place_offset_xyz":[0.0,0.0,0.05]},"routing":{"rules":[]},"safety":{"metadata_only":True,"runtime_io_applied":False,"motion_started":False,"ros_launch_started":False}}
 


### PR DESCRIPTION
### Motivation
- Task flows were using fallback IDs because authored scene layouts lacked explicit pick/place zone coordinates, causing the static preview and readiness checks to report unresolved coordinates.
- Provide a simple way to author pick/place zones with concrete `frame`/`xyz`/`rpy`/`size` metadata so task intent can reference real scene targets and previews/readiness packs can resolve coordinates.

### Description
- Add `scripts/create_or_update_environment_target.py` to create or update authored targets in an `environment_layout/v1` structure and emit a JSON result with `updated_existing`, `xyz`, `rpy`, `size`, and diagnostics.
- Extend `scripts/list_builder_scene_authoring_targets.py` to discover typed zone entries (e.g. `pick_zone`, `place_target`, `bin`) and include `zone_targets` with label and coordinates when present, while keeping deterministic fallbacks only when no real targets exist.
- Update `scripts/summarize_task_flow.py` to map zones by ID from the environment layout so `visual_resolution` flags like `pick_coordinates_resolved` and `place_coordinates_resolved` can be true when authored zones exist.
- Wire a new CLI wrapper `author-environment-target` into `scripts/workcell_studio.py` to call the authoring script with matching arguments and JSON support.
- Add Streamlit backend helpers `create_or_update_environment_target()`, `load_environment_targets()`, and `summarize_environment_targets()` in `tools/workcell_studio_streamlit/backend.py` and expose a new “Pick/Place Zones” UI block in `tools/workcell_studio_streamlit/app.py` that lets users author and refresh zone metadata with an explicit notice that zones are metadata-only.
- Add automated tests: new `tests/test_environment_target_authoring.py` and added backend wrapper assertions in `tests/test_workcell_studio_streamlit_backend.py` to verify authoring, discovery, and summary behavior.
- No runtime/robot/hardware/MoveIt/EPD/ROS launch behavior was changed by this PR.

### Testing
- Compiled updated scripts with `python3 -m py_compile` and confirmed no syntax errors for `scripts/create_or_update_environment_target.py`, `scripts/list_builder_scene_authoring_targets.py`, `scripts/generate_workcell_static_preview.py`, `scripts/summarize_task_flow.py`, and `scripts/workcell_studio.py`.
- Ran the pytest targets requested: `tests/test_environment_target_authoring.py`, `tests/test_builder_task_intent_authoring_flow.py`, `tests/test_workcell_static_preview.py`, `tests/test_workcell_studio_readiness_pack.py`, `tests/test_readiness_pack_dashboard.py`, `tests/test_workcell_studio_streamlit_backend.py`, and `tests/test_cell_definition_tools.py`; the suite completed successfully with `73 passed, 7 subtests passed`.
- The new Streamlit backend wrapper tests also exercised the CLI wrapper and file outputs, and all added assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5f3b397883319c07aa7e3c7b7d69)