### PR TITLE
Fix readiness-pack authored target coordinate resolution

### DIFF
--- a/scripts/export_builder_scene_to_cell_definition.py
+++ b/scripts/export_builder_scene_to_cell_definition.py
@@ -28,6 +28,13 @@ def _load_optional(path: Path) -> dict[str, Any]:
     return loaded if isinstance(loaded, dict) else {}
 
 
+def _load_environment_layout(scene_path: Path) -> dict[str, Any]:
+    for rel in ["generated/environment_layout.yaml", "environment_layout.yaml"]:
+        cand = scene_path / rel
+        loaded = _load_optional(cand)
+        if loaded:
+            return loaded
+    return {}
 
 
 def _to_yaml(value: Any, indent: int = 0) -> str:
@@ -167,17 +174,22 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
         })
         object_entries.append({"id": str(obj_name), "name": str(obj_name), "mesh": filepath, "dimensions": dims, "index": idx})
 
+    authored_layout = _load_environment_layout(scene_path)
     environment_layout = {
-        "schema_version": "environment_layout/v1",
-        "layout_id": f"{scene_path.name}_layout",
-        "name": f"{scene_path.name} Builder Layout",
-        "frame": "world",
+        "schema_version": authored_layout.get("schema_version", "environment_layout/v1"),
+        "layout_id": authored_layout.get("layout_id", f"{scene_path.name}_layout"),
+        "name": authored_layout.get("name", f"{scene_path.name} Builder Layout"),
+        "frame": authored_layout.get("frame", "world"),
         "assets": assets,
         "source_metadata": {
             "generated_by": "workcell_builder",
             "raw_environment_keys": sorted(env.keys()),
         },
     }
+    if isinstance(authored_layout.get("zones"), list):
+        environment_layout["zones"] = authored_layout["zones"]
+    if isinstance(authored_layout.get("targets"), list):
+        environment_layout["targets"] = authored_layout["targets"]
 
     cell_def = {
         "schema_version": "cell_definition/v1",

--- a/scripts/generate_workcell_studio_readiness_pack.py
+++ b/scripts/generate_workcell_studio_readiness_pack.py
@@ -51,9 +51,9 @@ def main()->int:
     tf=paths['task']/'task_flow_summary.json'
     task_flow_cmd=None
     if recipe.exists():
-        task_flow_cmd=[sys.executable,str(SCRIPT_DIR/'summarize_task_flow.py'),'--task-recipe',str(recipe),'--output',str(tf),'--json']
+        task_flow_cmd=[sys.executable,str(SCRIPT_DIR/'summarize_task_flow.py'),'--task-recipe',str(recipe),'--environment-layout',str(paths['exported']/'environment_layout.yaml'),'--output',str(tf),'--json']
     elif (paths['task']/ti.name).exists():
-        task_flow_cmd=[sys.executable,str(SCRIPT_DIR/'summarize_task_flow.py'),'--task-intent',str(paths['task']/ti.name),'--output',str(tf),'--json']
+        task_flow_cmd=[sys.executable,str(SCRIPT_DIR/'summarize_task_flow.py'),'--task-intent',str(paths['task']/ti.name),'--environment-layout',str(paths['exported']/'environment_layout.yaml'),'--output',str(tf),'--json']
     if task_flow_cmd:
         rc,tfp=step('task_flow',task_flow_cmd)
         if tf.exists():

--- a/scripts/summarize_task_flow.py
+++ b/scripts/summarize_task_flow.py
@@ -58,9 +58,33 @@ def summarize(task_intent:Path|None=None, task_recipe:Path|None=None, scene_pack
     if not place.get('id'): missing.append('place.target.id')
     if not (grasp.get('strategy_ref') or grasp.get('inline_strategy')): missing.append('grasp.strategy_ref')
     if missing: readiness='task_intent_incomplete'
-    zones={z.get('id'):z for z in (layout.get('zones') or []) if isinstance(z,dict) and z.get('id')}
-    pick_res=bool(pick.get('id') in zones) if zones else False
-    place_res=bool(place.get('id') in zones) if zones else False
+    def _xyz_from_entry(entry: dict[str, Any]) -> list[float] | None:
+        xyz = entry.get('xyz')
+        if isinstance(xyz, list) and len(xyz) >= 3:
+            return [float(xyz[0]), float(xyz[1]), float(xyz[2])]
+        pose = entry.get('pose') if isinstance(entry.get('pose'), dict) else {}
+        pxyz = pose.get('xyz') if isinstance(pose, dict) else None
+        if isinstance(pxyz, list) and len(pxyz) >= 3:
+            return [float(pxyz[0]), float(pxyz[1]), float(pxyz[2])]
+        bounds = entry.get('bounds_xyz') if isinstance(entry.get('bounds_xyz'), dict) else {}
+        mn, mx = bounds.get('min'), bounds.get('max')
+        if isinstance(mn, list) and isinstance(mx, list) and len(mn) >= 3 and len(mx) >= 3:
+            return [float((mn[0] + mx[0]) / 2.0), float((mn[1] + mx[1]) / 2.0), float((mn[2] + mx[2]) / 2.0)]
+        return None
+
+    resolver: dict[str, list[float]] = {}
+    for container in (layout.get('zones') or [], layout.get('targets') or []):
+        if not isinstance(container, list):
+            continue
+        for entry in container:
+            if not isinstance(entry, dict) or not entry.get('id'):
+                continue
+            xyz = _xyz_from_entry(entry)
+            if xyz is not None:
+                resolver[str(entry['id'])] = xyz
+
+    pick_res=bool(str(pick.get('id')) in resolver) if resolver else False
+    place_res=bool(str(place.get('id')) in resolver) if resolver else False
     approx=not (pick_res and place_res)
     warnings=['Task flow present but exact pick/place coordinates could not be resolved.'] if approx else []
     return {'status':'FAIL' if missing else ('WARN' if warnings else 'PASS'),'readiness_classification':readiness,'task_id':task.get('id'),'task_type':task.get('type'),'pick_source_id':pick.get('id'),'place_target_id':place.get('id'),'grasp_strategy':grasp.get('strategy_ref') or grasp.get('inline_strategy'),'release_strategy':release,'approach_axis':approach.get('axis'),'approach_distance_m':approach.get('distance_m'),'retreat_axis':retreat.get('axis'),'retreat_distance_m':retreat.get('distance_m'),'routing_rules':routing,'routing_rule_count':len(routing),'missing_required_fields':missing,'suggested_next_actions':['Select a pick source zone.' if 'pick.source.id' in missing else '', 'Select a place target.' if 'place.target.id' in missing else '', 'Choose a grasp strategy.' if 'grasp.strategy_ref' in missing else '','Generate task recipe from task intent.' if not recipe else ''],'warnings':warnings,'errors':[] if not missing else [f'{m} is required' for m in missing],'safety':{'metadata_only':True,'runtime_io_applied':False,'motion_started':False,'ros_launch_started':False},'visual_resolution':{'pick_coordinates_resolved':pick_res,'place_coordinates_resolved':place_res,'approximate_coordinates_used':approx,'notes':['Used deterministic fallback coordinates for preview markers.'] if approx else []}}

--- a/tests/test_workcell_studio_readiness_pack.py
+++ b/tests/test_workcell_studio_readiness_pack.py
@@ -65,3 +65,46 @@ def test_pack_static_preview_receives_task_flow(tmp_path: Path):
     assert tf.get('place_target_id') == 'bin_red'
     assert tf.get('grasp_strategy') == 'finger_pinch_basic'
     assert tf.get('release_strategy') == 'tool_release'
+
+
+def test_pack_preserves_authored_targets_and_resolves_coordinates(tmp_path: Path):
+    import shutil
+    import yaml
+    scene = tmp_path / 'scene_authored_targets'
+    shutil.copytree('scenes/ur5_2f_test', scene)
+    gen = scene / 'generated'
+    gen.mkdir(parents=True, exist_ok=True)
+    layout = gen / 'environment_layout.yaml'
+
+    subprocess.run([sys.executable,'scripts/create_or_update_environment_target.py','--environment-layout',str(layout),'--target-id','pick_zone_main','--target-type','pick_zone','--label','Main pick zone','--frame','world','--xyz','0.45','0.00','0.08','--rpy','0','0','0','--size','0.30','0.20','0.10','--output',str(layout),'--json'], check=True)
+    subprocess.run([sys.executable,'scripts/create_or_update_environment_target.py','--environment-layout',str(layout),'--target-id','bin_red','--target-type','place_target','--label','Red bin','--frame','world','--xyz','0.35','0.35','0.10','--rpy','0','0','0','--size','0.20','0.20','0.15','--output',str(layout),'--json'], check=True)
+    subprocess.run([sys.executable,'scripts/create_or_update_builder_task_intent.py','--scene-package',str(scene),'--task-id','sorting_task_001','--task-type','pick_place','--pick-source','pick_zone_main','--place-target','bin_red','--grasp-strategy','finger_pinch_basic','--approach-axis','z_down','--approach-distance-m','0.12','--retreat-axis','z_up','--retreat-distance-m','0.10','--release-strategy','tool_release','--output',str(gen/'workcell_builder_task_intent.yaml'),'--validate','--json'],check=True)
+
+    out = tmp_path / 'pack_authored_targets'
+    run = subprocess.run([sys.executable, 'scripts/workcell_studio.py', 'generate-readiness-pack', '--scene-package', str(scene), '--output-dir', str(out), '--project-name', 'demo', '--validate', '--smoke-dry-run', '--force', '--json'], capture_output=True, text=True, check=False)
+    assert run.returncode in (0,1)
+
+    exported_layout = yaml.safe_load((out/'exported'/'environment_layout.yaml').read_text(encoding='utf-8'))
+    zone_ids = {z.get('id') for z in (exported_layout.get('zones') or []) if isinstance(z, dict)}
+    target_ids = {z.get('id') for z in (exported_layout.get('targets') or []) if isinstance(z, dict)}
+    assert 'pick_zone_main' in zone_ids and 'bin_red' in zone_ids
+    assert 'pick_zone_main' in target_ids and 'bin_red' in target_ids
+
+    tf = json.loads((out/'task'/'task_flow_summary.json').read_text(encoding='utf-8'))
+    vr = tf.get('visual_resolution', {})
+    assert vr.get('pick_coordinates_resolved') is True
+    assert vr.get('place_coordinates_resolved') is True
+    assert vr.get('approximate_coordinates_used') is False
+    assert 'Task flow present but exact pick/place coordinates could not be resolved.' not in (tf.get('warnings') or [])
+
+    preview = json.loads((out/'preview'/'static_preview_summary.json').read_text(encoding='utf-8'))
+    pvr = (preview.get('task_flow_summary') or {}).get('visual_resolution', {})
+    assert pvr.get('pick_coordinates_resolved') is True
+    assert pvr.get('place_coordinates_resolved') is True
+    assert pvr.get('approximate_coordinates_used') is False
+    preview_warnings = json.dumps(preview)
+    assert 'exact pick/place coordinates could not be resolved' not in preview_warnings
+
+    dashboard = (out/'readiness_dashboard.html').read_text(encoding='utf-8')
+    assert 'pick_zone_main' in dashboard
+    assert 'bin_red' in dashboard


### PR DESCRIPTION
### Motivation
- Readiness-pack generation could not resolve authored pick/place coordinates because authored `zones`/`targets` in `generated/environment_layout.yaml` were lost during export and the summarizer was invoked without the exported layout.
- The goal is to preserve authored targets and use that authored environment layout during task-flow and static-preview summarization so exact pick/place coordinates resolve when present.

### Description
- Preserve authored layout when exporting: `export_builder_scene_to_cell_definition.py` now loads a scene-authored layout (preferring `generated/environment_layout.yaml`) and carries forward `zones` and `targets` into `exported/environment_layout.yaml` while still generating exported assets. 
- Pass environment layout into summarization: `generate_workcell_studio_readiness_pack.py` now includes `--environment-layout <pack>/exported/environment_layout.yaml` when invoking `summarize_task_flow.py` for both task-recipe and task-intent flows. 
- Improve coordinate resolution: `summarize_task_flow.py` now resolves IDs from both `layout.zones` and `layout.targets` and extracts coordinates from `xyz`, `pose.xyz`, or the center of `bounds_xyz.min/max`. 
- Add regression test: a new test in `tests/test_workcell_studio_readiness_pack.py` reproduces the authored `pick_zone_main`/`bin_red` flow and asserts exported layout preservation and that visual resolution fields (`pick_coordinates_resolved`/`place_coordinates_resolved`/`approximate_coordinates_used`) are correct, and that the static preview and dashboard reflect authored IDs.

### Testing
- Ran Python compile checks on touched scripts: `generate_workcell_studio_readiness_pack.py`, `export_builder_scene_to_cell_definition.py`, `summarize_task_flow.py`, `generate_workcell_static_preview.py`, and `workcell_studio.py` with no syntax failures. 
- Ran the readiness-pack and authoring test suites via `pytest`, including the new regression test: all tests passed (summary: 74 passed, 7 subtests passed).
- Verified that readiness-pack output contains preserved authored `zones`/`targets` and that both task-flow summary and static preview report resolved pick/place coordinates with no unresolved-coordinate warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc61a18f7483319af3e40217402d88)