### PR TITLE
Add Streamlit top-down Pick/Place Zones editor with backend helpers and tests

### DIFF
--- a/tests/test_streamlit_zone_editor_backend.py
+++ b/tests/test_streamlit_zone_editor_backend.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.workcell_studio_streamlit import backend
+
+
+def test_render_topdown_targets_svg_empty_targets() -> None:
+    svg = backend.render_topdown_targets_svg([])
+    assert "<svg" in svg
+    assert "No targets discovered yet" in svg
+    assert "Traceback" not in svg
+
+
+def test_render_topdown_targets_svg_with_pick_and_bin() -> None:
+    targets = [
+        {"id": "pick_zone_main", "type": "pick_zone", "label": "Main pick", "pose": {"frame": "world", "xyz": [0.45, 0.0, 0.08], "rpy": [0, 0, 0]}, "size": [0.3, 0.2, 0.1]},
+        {"id": "bin_red", "type": "bin", "label": "Red bin", "pose": {"frame": "world", "xyz": [0.30, 0.35, 0.10], "rpy": [0, 0, 0]}, "size": [0.2, 0.2, 0.1]},
+    ]
+    svg = backend.render_topdown_targets_svg(targets)
+    assert "pick_zone_main" in svg
+    assert "bin_red" in svg
+    assert "xyz=(0.45,0.00,0.08)" in svg
+    assert "<rect" in svg
+
+
+def test_list_targets_save_load_roundtrip(tmp_path: Path) -> None:
+    path = tmp_path / "environment_layout.yaml"
+    payload = {
+        "schema": "environment_layout/v1",
+        "zones": [
+            {"id": "pick_zone_main", "type": "pick_zone", "label": "Main", "pose": {"frame": "world", "xyz": [0.45, 0.0, 0.08], "rpy": [0, 0, 0]}, "size": [0.3, 0.2, 0.1]}
+        ],
+    }
+    backend.save_environment_layout(path, payload)
+    loaded = backend.load_environment_layout(path)
+    assert loaded["zones"][0]["id"] == "pick_zone_main"
+    targets = backend.list_environment_targets(path)
+    assert targets[0]["type"] == "pick_zone"
+    assert targets[0]["pose"]["xyz"][0] == 0.45
+
+
+def test_create_or_update_environment_target_with_topdown_flow(tmp_path: Path) -> None:
+    layout = tmp_path / "environment_layout.yaml"
+    res = backend.create_or_update_environment_target(layout, "pick_zone_main", "pick_zone", "Main", "world", [0.45, 0, 0.08], [0, 0, 0], [0.3, 0.2, 0.1], output_path=layout)
+    assert res["returncode"] == 0
+    targets = backend.list_environment_targets(layout)
+    svg = backend.render_topdown_targets_svg(targets)
+    assert "pick_zone_main" in svg
+
+
+def test_backend_does_not_import_streamlit() -> None:
+    text = (Path(__file__).resolve().parents[1] / "tools" / "workcell_studio_streamlit" / "backend.py").read_text(encoding="utf-8")
+    assert "import streamlit" not in text

--- a/tools/workcell_studio_streamlit/app.py
+++ b/tools/workcell_studio_streamlit/app.py
@@ -96,26 +96,48 @@ elif workflow == "Builder Task Intent":
     if st.button("Discover scene targets"):
         st.session_state["builder_targets"] = backend.list_builder_scene_authoring_targets(scene_package).get("json", {})
     st.subheader("Pick/Place Zones")
-    st.caption("Zones are metadata only. They do not move the robot.")
+    st.caption("Pick/place zones are metadata only. Saving zones does not command robot motion.")
     env_path = st.text_input("environment_layout.yaml path", value=str(Path(scene_package)/"generated"/"environment_layout.yaml"))
+    env_layout = backend.load_environment_layout(env_path)
+    env_targets = backend.list_environment_targets(env_layout)
+    ids = [t.get("id") for t in env_targets if t.get("id")]
+    selected_id = st.selectbox("Target selector", options=["<create new>"] + ids)
+    current = next((t for t in env_targets if t.get("id") == selected_id), {})
+    pose = current.get("pose", {}) if isinstance(current, dict) else {}
+    xyz = pose.get("xyz") if isinstance(pose.get("xyz"), list) else [0.45, 0.0, 0.08]
+    rpy = pose.get("rpy") if isinstance(pose.get("rpy"), list) else [0.0, 0.0, 0.0]
+    size = current.get("size") if isinstance(current.get("size"), list) else [0.3, 0.2, 0.1]
     zc1, zc2, zc3 = st.columns(3)
-    zid = zc1.text_input("target id", value="pick_zone_main")
-    ztype = zc2.selectbox("target type", options=["pick_zone","place_target"])
-    zlabel = zc3.text_input("label", value="Main pick zone")
-    frame = st.text_input("frame", value="world")
-    cxyz = st.columns(3); x = cxyz[0].number_input("x", value=0.45); y = cxyz[1].number_input("y", value=0.0); z = cxyz[2].number_input("z", value=0.08)
-    crpy = st.columns(3); rr = crpy[0].number_input("roll", value=0.0); pp = crpy[1].number_input("pitch", value=0.0); yy = crpy[2].number_input("yaw", value=0.0)
-    csize = st.columns(3); sx = csize[0].number_input("size x", value=0.3); sy = csize[1].number_input("size y", value=0.2); sz = csize[2].number_input("size z", value=0.1)
-    zb1, zb2 = st.columns(2)
+    zid = zc1.text_input("target id", value=(current.get("id") if current else "pick_zone_main"))
+    ztype = zc2.selectbox("target type", options=["pick_zone","place_target","bin"], index=["pick_zone","place_target","bin"].index(current.get("type")) if current and current.get("type") in ["pick_zone","place_target","bin"] else 0)
+    zlabel = zc3.text_input("label", value=(current.get("label") if current else "Main pick zone"))
+    frame = st.text_input("frame", value=(pose.get("frame") if isinstance(pose, dict) and pose.get("frame") else "world"))
+    cxyz = st.columns(3); x = cxyz[0].number_input("x", value=float(xyz[0]), step=0.01); y = cxyz[1].number_input("y", value=float(xyz[1]), step=0.01); z = cxyz[2].number_input("z", value=float(xyz[2]), step=0.01)
+    crpy = st.columns(3); rr = crpy[0].number_input("roll", value=float(rpy[0]), step=0.01); pp = crpy[1].number_input("pitch", value=float(rpy[1]), step=0.01); yy = crpy[2].number_input("yaw", value=float(rpy[2]), step=0.01)
+    csize = st.columns(3); sx = csize[0].number_input("size x", min_value=0.01, value=float(size[0]), step=0.01); sy = csize[1].number_input("size y", min_value=0.01, value=float(size[1]), step=0.01); sz = csize[2].number_input("size z", min_value=0.01, value=float(size[2]), step=0.01)
+    svg = backend.render_topdown_targets_svg(env_targets)
+    st.components.v1.html(svg, height=530, scrolling=False)
+    zb1, zb2, zb3, zb4 = st.columns(4)
     if zb1.button("Save/update target"):
         st.json(backend.create_or_update_environment_target(env_path, zid, ztype, zlabel, frame, [x,y,z], [rr,pp,yy], [sx,sy,sz], output_path=env_path).get("json") or {})
+        env_layout = backend.load_environment_layout(env_path)
+        env_targets = backend.list_environment_targets(env_layout)
+        st.components.v1.html(backend.render_topdown_targets_svg(env_targets), height=530, scrolling=False)
     if zb2.button("Refresh discovered targets"):
         st.session_state["builder_targets"] = backend.list_builder_scene_authoring_targets(scene_package).get("json", {})
+    if zb3.button("Generate static preview"):
+        preview_dir = str(Path(scene_package) / "generated" / "static_preview")
+        cell_path = str(Path(scene_package) / "generated" / "cell_definition.yaml")
+        st.json(backend.generate_static_preview_with_task_flow(cell_path, preview_dir, "Builder Task Intent Preview", task_intent_path=output_path, environment_layout_path=env_path).get("json") or {})
+        st.caption(f"Preview HTML: {Path(preview_dir) / 'static_preview.html'}")
+    if zb4.button("Generate readiness pack"):
+        st.json(backend.generate_readiness_pack(scene_package, "/tmp/workcell_readiness_pack", "builder_intent_demo", validate=True, prepare_rviz_preview=False, smoke_dry_run=True).get("json") or {})
     targets = st.session_state.get("builder_targets", {})
     st.json(targets)
     grasps = [x["id"] for x in backend.resolve_catalog_choices().get("grasp_strategies", [])]
-    pick_opts = targets.get("pick_sources") or ["pick_zone_main"]
-    place_opts = targets.get("place_targets") or ["bin_main"]
+    discovered = backend.summarize_environment_targets(env_path) if Path(env_path).exists() else {"pick_sources": [], "place_targets": []}
+    pick_opts = discovered.get("pick_sources") or targets.get("pick_sources") or ["pick_zone_main"]
+    place_opts = discovered.get("place_targets") or targets.get("place_targets") or ["bin_main"]
     task_id = st.text_input("Task id", value="sorting_task_001")
     task_type = st.text_input("Task type", value="pick_place")
     pick_source = st.selectbox("Pick source", options=pick_opts)
@@ -131,6 +153,10 @@ elif workflow == "Builder Task Intent":
     c1,c2,c3,c4 = st.columns(4)
     if c1.button("Save task intent"):
         st.json(backend.create_or_update_builder_task_intent(scene_package, task_id, task_type, pick_source, place_target, grasp, output_path=output_path, approach_axis=approach_axis, approach_distance_m=approach_dist, retreat_axis=retreat_axis, retreat_distance_m=retreat_dist, release_strategy=release_strategy, object_class=object_class, object_color=object_color, validate=False).get("json") or {})
+    if discovered.get("pick_sources") and pick_source not in discovered.get("pick_sources", []):
+        st.warning(f"Selected pick source '{pick_source}' is not present in environment_layout.yaml")
+    if discovered.get("place_targets") and place_target not in discovered.get("place_targets", []):
+        st.warning(f"Selected place target '{place_target}' is not present in environment_layout.yaml")
     if c2.button("Validate task intent"):
         st.json(backend.validate_builder_task_intent(output_path, scene_package).get("json") or {})
     if c3.button("Generate task recipe"):

--- a/tools/workcell_studio_streamlit/backend.py
+++ b/tools/workcell_studio_streamlit/backend.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from html import escape
 from pathlib import Path
 from typing import Any
 
@@ -373,8 +374,97 @@ def create_or_update_environment_target(environment_layout_path: str | Path, tar
     return _parse_json_output(run_command(cmd, cwd=rr))
 
 def load_environment_targets(environment_layout_path: str | Path) -> list[dict[str, Any]]:
-    payload = _load_yaml_file(Path(environment_layout_path))
-    return [z for z in (payload.get("zones") or []) if isinstance(z, dict) and z.get("id")]
+    payload = load_environment_layout(environment_layout_path)
+    return list_environment_targets(payload)
+
+
+def load_environment_layout(path: str | Path) -> dict[str, Any]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return _load_yaml_file(p)
+
+
+def save_environment_layout(path: str | Path, data: dict[str, Any]) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    if yaml is not None:
+        p.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    else:
+        p.write_text(_to_yaml(data) + "\n", encoding="utf-8")
+
+
+def list_environment_targets(layout_or_path: dict[str, Any] | str | Path) -> list[dict[str, Any]]:
+    payload = layout_or_path if isinstance(layout_or_path, dict) else load_environment_layout(layout_or_path)
+    zones = payload.get("zones") if isinstance(payload, dict) else []
+    return [z for z in (zones or []) if isinstance(z, dict) and z.get("id")]
+
+
+def compute_scene_bounds(targets: list[dict[str, Any]]) -> dict[str, float]:
+    if not targets:
+        return {"min_x": -0.5, "max_x": 0.5, "min_y": -0.4, "max_y": 0.4}
+    min_x, max_x, min_y, max_y = 9e9, -9e9, 9e9, -9e9
+    for t in targets:
+        pose = t.get("pose", {}) if isinstance(t.get("pose"), dict) else {}
+        xyz = pose.get("xyz") if isinstance(pose.get("xyz"), list) else [0.0, 0.0, 0.0]
+        size = t.get("size") if isinstance(t.get("size"), list) else [0.2, 0.2, 0.1]
+        x = float(xyz[0]) if len(xyz) > 0 else 0.0
+        y = float(xyz[1]) if len(xyz) > 1 else 0.0
+        sx = max(float(size[0]) if len(size) > 0 else 0.2, 0.01)
+        sy = max(float(size[1]) if len(size) > 1 else 0.2, 0.01)
+        min_x = min(min_x, x - sx / 2)
+        max_x = max(max_x, x + sx / 2)
+        min_y = min(min_y, y - sy / 2)
+        max_y = max(max_y, y + sy / 2)
+    pad = 0.15
+    return {"min_x": min_x - pad, "max_x": max_x + pad, "min_y": min_y - pad, "max_y": max_y + pad}
+
+
+def render_topdown_targets_svg(targets: list[dict[str, Any]], width: int = 700, height: int = 500, scale_m_to_px: int = 500) -> str:
+    safe_targets = sorted(targets, key=lambda t: str(t.get("id", "")))
+    bounds = compute_scene_bounds(safe_targets)
+    world_w = max(bounds["max_x"] - bounds["min_x"], width / scale_m_to_px)
+    world_h = max(bounds["max_y"] - bounds["min_y"], height / scale_m_to_px)
+
+    def to_px(x: float, y: float) -> tuple[float, float]:
+        px = ((x - bounds["min_x"]) / world_w) * width
+        py = height - (((y - bounds["min_y"]) / world_h) * height)
+        return px, py
+
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        '<rect x="0" y="0" width="100%" height="100%" fill="#f8fafc"/>',
+    ]
+    for gx in range(0, width + 1, 50):
+        lines.append(f'<line x1="{gx}" y1="0" x2="{gx}" y2="{height}" stroke="#e2e8f0" stroke-width="1"/>')
+    for gy in range(0, height + 1, 50):
+        lines.append(f'<line x1="0" y1="{gy}" x2="{width}" y2="{gy}" stroke="#e2e8f0" stroke-width="1"/>')
+    origin_x, origin_y = to_px(0.0, 0.0)
+    lines.append(f'<line x1="0" y1="{origin_y:.2f}" x2="{width}" y2="{origin_y:.2f}" stroke="#64748b" stroke-width="1.5"/>')
+    lines.append(f'<line x1="{origin_x:.2f}" y1="0" x2="{origin_x:.2f}" y2="{height}" stroke="#64748b" stroke-width="1.5"/>')
+    lines.append(f'<text x="{min(width-60, origin_x+4):.2f}" y="{max(14, origin_y-4):.2f}" font-size="11" fill="#334155">world (0,0)</text>')
+
+    if not safe_targets:
+        lines.append('<text x="18" y="28" font-size="14" fill="#475569">No targets discovered yet.</text>')
+    for t in safe_targets:
+        tid = escape(str(t.get("id", "")))
+        ttype = str(t.get("type", ""))
+        label = escape(str(t.get("label") or tid))
+        pose = t.get("pose", {}) if isinstance(t.get("pose"), dict) else {}
+        xyz = pose.get("xyz") if isinstance(pose.get("xyz"), list) else [0.0, 0.0, 0.0]
+        x, y, z = float(xyz[0]), float(xyz[1]), float(xyz[2] if len(xyz) > 2 else 0.0)
+        size = t.get("size") if isinstance(t.get("size"), list) else [0.2, 0.2, 0.1]
+        sx = max(float(size[0]), 0.01); sy = max(float(size[1]), 0.01)
+        cx, cy = to_px(x, y)
+        rw = (sx / world_w) * width
+        rh = (sy / world_h) * height
+        rx, ry = cx - rw/2, cy - rh/2
+        color = "#16a34a" if ttype == "pick_zone" else "#2563eb" if ttype in {"place_target", "bin"} else "#7c3aed"
+        lines.append(f'<rect x="{rx:.2f}" y="{ry:.2f}" width="{rw:.2f}" height="{rh:.2f}" fill="{color}" fill-opacity="0.20" stroke="{color}" stroke-width="2"/>')
+        lines.append(f'<circle cx="{cx:.2f}" cy="{cy:.2f}" r="3" fill="{color}"/>')
+        lines.append(f'<text x="{(rx+4):.2f}" y="{max(12, ry-6):.2f}" font-size="11" fill="#0f172a">{label} ({tid}) [{escape(ttype)}] xyz=({x:.2f},{y:.2f},{z:.2f})</text>')
+    lines.append("</svg>")
+    return "\n".join(lines)
 
 def summarize_environment_targets(environment_layout_path: str | Path) -> dict[str, Any]:
     zones = load_environment_targets(environment_layout_path)


### PR DESCRIPTION
### Motivation
- Make pick/place zone authoring in the Streamlit Workcell Studio UI visual and easier to use by replacing CLI-only XYZ/size typing with an interactive editor and preview. 
- Provide unit-testable backend helpers to load/save/list environment layouts and produce a deterministic top-down SVG preview of authored zones without extra runtime dependencies. 
- Keep safety/shape of the system unchanged by ensuring zone edits are metadata-only and by not introducing ROS, MoveIt, hardware, EPD, Gazebo/Isaac/RViz, or motion execution behavior. 

### Description
- Added backend helpers in `tools/workcell_studio_streamlit/backend.py`: `load_environment_layout`, `save_environment_layout`, `list_environment_targets`, `compute_scene_bounds`, and `render_topdown_targets_svg` (returns an SVG string, draws grid/axes, labeled rectangles/center points, safely escapes labels, deterministic layout, no external deps). 
- Kept the backend free of Streamlit imports and preserved YAML read/write behavior (uses `yaml` when available and falls back to the internal `_to_yaml` serializer). 
- Extended the Builder Task Intent UI in `tools/workcell_studio_streamlit/app.py` with a Pick/Place Zones visual editor that provides scene/env path input, target selector (`<create new>` + discovered IDs), editable `id/type/label/frame/xyz/rpy/size` fields, a button-driven top-down SVG preview via `st.components.v1.html`, and buttons for `Save/update target`, `Refresh discovered targets`, `Generate static preview`, and `Generate readiness pack`. 
- Integrated discovered environment targets into the task intent flow so pick/place dropdowns prefer discovered `pick_zone` and `place_target`/`bin` IDs and warn when a selected ID is not present in `environment_layout.yaml`. 
- Added unit tests `tests/test_streamlit_zone_editor_backend.py` that cover empty and populated SVG rendering, save/load/list roundtrip, integration with the `create_or_update_environment_target` wrapper, and verification that the backend module does not import Streamlit. 

### Testing
- Ran `python3 -m py_compile tools/workcell_studio_streamlit/backend.py` and `python3 -m py_compile tools/workcell_studio_streamlit/app.py`, both succeeded. 
- Ran `pytest` for the new and related test suites and all targeted automated tests passed: `tests/test_streamlit_zone_editor_backend.py`, `tests/test_environment_target_authoring.py`, `tests/test_workcell_studio_streamlit_backend.py`, `tests/test_workcell_studio_readiness_pack.py`, and `tests/test_cell_definition_tools.py` all succeeded. 
- The new tests assert SVG output contains expected elements/labels, YAML save/load preserves data, and the authoring wrapper remains compatible with existing scripts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc62fd4df08331a563523432a886b8)