### PR TITLE
Fix Streamlit readiness status rendering and dashboard serving guidance

### DIFF
--- a/tests/test_streamlit_app_static.py
+++ b/tests/test_streamlit_app_static.py
@@ -44,6 +44,7 @@ def test_task_intent_readiness_options_present() -> None:
 
 def test_dashboard_preview_guidance_present() -> None:
     src = _source()
-    assert "Readiness dashboard path:" in src
+    assert "backend.load_readiness_pack_manifest(Path(manifest_path).parent)" in src
+    assert "http://localhost:8767/readiness_dashboard.html" in src
+    assert "may not work with sandboxed Firefox/Snap" in src
     assert "xdg-open" in src
-    assert "python3 -m http.server 8767" in src

--- a/tests/test_workcell_studio_streamlit_backend.py
+++ b/tests/test_workcell_studio_streamlit_backend.py
@@ -186,3 +186,16 @@ def test_readiness_dashboard_backend_helpers(tmp_path):
     assert run['returncode'] == 0
     assert 'Workcell Studio' in backend.read_readiness_dashboard(out)
     assert backend.dashboard_path_from_manifest({'artifacts': {'readiness_dashboard': 'x.html'}}) == 'x.html'
+
+
+def test_dashboard_server_helpers_and_manifest_summary():
+    assert backend.dashboard_server_command("/tmp/workcell_readiness_pack", 8767) == "cd /tmp/workcell_readiness_pack && python3 -m http.server 8767"
+    assert backend.dashboard_local_url(8767) == "http://localhost:8767/readiness_dashboard.html"
+    manifest = {
+        "artifacts": {"readiness_dashboard": "/tmp/workcell_readiness_pack/readiness_dashboard.html"},
+        "summary": {"manifest_path": "/tmp/workcell_readiness_pack/readiness_pack_manifest.json"},
+        "results": {"final_readiness": "PASS", "classification": "task_planning_ready", "blockers": [], "warnings": []},
+    }
+    summary = backend.readiness_summary_from_manifest(manifest)
+    assert summary["final_readiness"] == "PASS"
+    assert summary["classification"] == "task_planning_ready"

--- a/tools/workcell_studio_streamlit/app.py
+++ b/tools/workcell_studio_streamlit/app.py
@@ -10,6 +10,36 @@ st.set_page_config(page_title="Workcell Studio Streamlit", layout="wide")
 st.title("Workcell Studio Streamlit Prototype")
 st.warning("Workcell Studio defaults to offline validation and fake hardware. This UI does not command robot motion.")
 
+
+def _render_readiness_pack_result(readiness_result: dict[str, object], readiness_output_dir: str) -> None:
+    st.json(readiness_result)
+    manifest_path = str(readiness_result.get("manifest") or "")
+    manifest = backend.load_readiness_pack_manifest(Path(manifest_path).parent) if manifest_path else {}
+    summary = backend.readiness_summary_from_manifest(manifest)
+    dashboard_path = summary.get("dashboard_path") or str(readiness_result.get("dashboard_path") or "")
+    final_readiness = summary.get("final_readiness") or readiness_result.get("result")
+    classification = summary.get("classification")
+
+    if manifest_path:
+        st.write(f"Manifest path: {manifest_path}")
+    if dashboard_path:
+        st.write(f"Dashboard path: {dashboard_path}")
+    st.write(f"Output dir: {readiness_output_dir}")
+    st.write(f"Final readiness: {final_readiness}")
+    st.write(f"Classification: {classification}")
+
+    st.subheader("Dashboard options")
+    if dashboard_path and Path(str(dashboard_path)).exists():
+        with st.expander("Preview readiness dashboard HTML"):
+            st.components.v1.html(Path(str(dashboard_path)).read_text(encoding="utf-8"), height=530, scrolling=True)
+    st.caption("Reliable browser flow:")
+    st.code(backend.dashboard_server_command(readiness_output_dir, 8767))
+    st.caption("Open this URL after starting the local server: http://localhost:8767/readiness_dashboard.html")
+    st.code(backend.dashboard_local_url(8767))
+    st.caption("Optional direct open command (may not work with sandboxed Firefox/Snap):")
+    if dashboard_path:
+        st.code(f"xdg-open {dashboard_path}")
+
 workflow = st.sidebar.radio(
     "Workflow",
     ["Catalog browser", "Cell definition validator", "Builder scene import", "Builder Task Intent", "Demo Gallery", "RViz Plan Preview", "Planning Scene Readiness", "Create Cell", "Readiness Pack"],
@@ -150,21 +180,7 @@ elif workflow == "Builder Task Intent":
             strict=readiness_strict,
             continue_on_error=readiness_continue_on_error,
         ).get("json") or {}
-        st.json(readiness_result)
-        readiness_manifest_path = readiness_result.get("manifest_path")
-        readiness_dashboard_path = readiness_result.get("dashboard_path")
-        if readiness_manifest_path:
-            st.write(f"Manifest path: {readiness_manifest_path}")
-        if readiness_dashboard_path:
-            st.write(f"Readiness dashboard path: {readiness_dashboard_path}")
-        st.write(f"Output dir: {readiness_output_dir}")
-        st.write(f"Final readiness: {readiness_result.get('final_readiness')}")
-        st.write(f"Classification: {readiness_result.get('classification')}")
-        if readiness_dashboard_path and Path(readiness_dashboard_path).exists():
-            with st.expander("Preview readiness dashboard HTML"):
-                st.components.v1.html(Path(readiness_dashboard_path).read_text(encoding="utf-8"), height=530, scrolling=True)
-            st.code(f"xdg-open {readiness_dashboard_path}")
-            st.code(f"cd {readiness_output_dir} && python3 -m http.server 8767")
+        _render_readiness_pack_result(readiness_result, readiness_output_dir)
     targets = st.session_state.get("builder_targets", {})
     st.json(targets)
     grasps = [x["id"] for x in backend.resolve_catalog_choices().get("grasp_strategies", [])]
@@ -206,21 +222,7 @@ elif workflow == "Builder Task Intent":
             strict=readiness_strict,
             continue_on_error=readiness_continue_on_error,
         ).get("json") or {}
-        st.json(readiness_result)
-        readiness_manifest_path = readiness_result.get("manifest_path")
-        readiness_dashboard_path = readiness_result.get("dashboard_path")
-        if readiness_manifest_path:
-            st.write(f"Manifest path: {readiness_manifest_path}")
-        if readiness_dashboard_path:
-            st.write(f"Readiness dashboard path: {readiness_dashboard_path}")
-        st.write(f"Output dir: {readiness_output_dir}")
-        st.write(f"Final readiness: {readiness_result.get('final_readiness')}")
-        st.write(f"Classification: {readiness_result.get('classification')}")
-        if readiness_dashboard_path and Path(readiness_dashboard_path).exists():
-            with st.expander("Preview readiness dashboard HTML"):
-                st.components.v1.html(Path(readiness_dashboard_path).read_text(encoding="utf-8"), height=530, scrolling=True)
-            st.code(f"xdg-open {readiness_dashboard_path}")
-            st.code(f"cd {readiness_output_dir} && python3 -m http.server 8767")
+        _render_readiness_pack_result(readiness_result, readiness_output_dir)
 
 if workflow == "Demo Gallery":
     st.header("Demo Gallery")

--- a/tools/workcell_studio_streamlit/backend.py
+++ b/tools/workcell_studio_streamlit/backend.py
@@ -652,6 +652,27 @@ def dashboard_path_from_manifest(manifest: dict[str, Any]) -> str:
     arts = manifest.get("artifacts", {}) if isinstance(manifest.get("artifacts"), dict) else {}
     return str(arts.get("readiness_dashboard", ""))
 
+
+def dashboard_server_command(output_dir: str | Path, port: int = 8767) -> str:
+    return f"cd {Path(output_dir)} && python3 -m http.server {port}"
+
+
+def dashboard_local_url(port: int = 8767) -> str:
+    return f"http://localhost:{port}/readiness_dashboard.html"
+
+
+def readiness_summary_from_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    results = manifest.get("results", {}) if isinstance(manifest.get("results"), dict) else {}
+    summary = manifest.get("summary", {}) if isinstance(manifest.get("summary"), dict) else {}
+    return {
+        "final_readiness": results.get("final_readiness"),
+        "classification": results.get("classification"),
+        "dashboard_path": dashboard_path_from_manifest(manifest),
+        "manifest_path": summary.get("manifest_path"),
+        "blockers": results.get("blockers", []),
+        "warnings": results.get("warnings", []),
+    }
+
 def generate_readiness_dashboard(manifest: str | Path, output: str | Path, root: Path | None = None) -> dict[str, Any]:
     rr = root or repo_root()
     cmd = [sys.executable, str(rr / "scripts" / "workcell_studio.py"), "generate-readiness-dashboard", "--manifest", str(manifest), "--output", str(output), "--json"]


### PR DESCRIPTION
### Motivation
- Ensure the Streamlit UI displays canonical readiness results after a readiness-pack is generated by reloading the generated manifest and reading the `results` fields instead of relying on the limited command output.
- Provide reliable, platform-agnostic guidance for opening the generated HTML dashboard because direct `xdg-open /tmp/...` is unreliable in some Ubuntu/Firefox (Snap) environments.
- Add small backend helpers to make the dashboard guidance portable and to centralize readiness-summary extraction.

### Description
- UI: Introduced `_render_readiness_pack_result(readiness_result, readiness_output_dir)` in `tools/workcell_studio_streamlit/app.py` which reloads the manifest using the path from `readiness_result['manifest']` and reads `results.final_readiness` and `results.classification` for display, and replaced duplicated readiness rendering for both readiness buttons with this helper.
- UI: Added explicit dashboard guidance shown after readiness generation including a reliable server command via `python3 -m http.server` plus a ready-to-open local URL and an optional `xdg-open` instruction labeled as potentially unreliable.
- Backend: Added three pure helpers in `tools/workcell_studio_streamlit/backend.py`: `dashboard_server_command(output_dir, port=8767)`, `dashboard_local_url(port=8767)`, and `readiness_summary_from_manifest(manifest)` which extracts `final_readiness`, `classification`, `dashboard_path`, `manifest_path`, `blockers`, and `warnings`.
- Tests: Extended `tests/test_workcell_studio_streamlit_backend.py` to cover the new backend helpers and `readiness_summary_from_manifest`, and updated `tests/test_streamlit_app_static.py` to assert the manifest-reload call and the new dashboard guidance strings are present.

### Testing
- Compiled updated modules with `python3 -m py_compile tools/workcell_studio_streamlit/app.py` and `python3 -m py_compile tools/workcell_studio_streamlit/backend.py` which succeeded.
- Ran the updated unit tests with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_streamlit_app_static.py tests/test_workcell_studio_streamlit_backend.py tests/test_streamlit_zone_editor_backend.py tests/test_workcell_studio_readiness_pack.py tests/test_cell_definition_tools.py`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6c843a048331b586e68ff66e3f5e)