### PR TITLE
Fix workcell_builder generated helper scripts for external scene packages

### DIFF
--- a/tests/test_workcell_builder_studio_integration.py
+++ b/tests/test_workcell_builder_studio_integration.py
@@ -17,13 +17,26 @@ def test_readme_builder_instructions_present() -> None:
 
 def test_generate_readiness_pack_helper_content_is_offline_safe() -> None:
     text = SCENE_SELECT_CPP.read_text(encoding="utf-8")
-    assert "scripts/workcell_studio.py generate-readiness-pack" in text
+    assert "WORKCELL_STUDIO_REPO_ROOT" in text
+    assert "find_tool_root()" in text
+    assert "$TOOL_ROOT/scripts/workcell_studio.py" in text
+    assert "$TOOL_ROOT/scripts/validate_builder_generated_scene.py" in text
+    assert "$TOOL_ROOT/scripts/export_builder_scene_to_cell_definition.py" in text
     assert "--validate" in text
     assert "--prepare-rviz-preview" in text
     assert "--smoke-dry-run" in text
+    assert "--scene-package \\\"$SCENE_DIR\\\"" in text
     assert "--force" in text
     assert "--real-hardware" not in text
     assert "move_group" not in text
+
+
+def test_generated_shell_scripts_are_marked_executable() -> None:
+    text = SCENE_SELECT_CPP.read_text(encoding="utf-8")
+    assert "set_script_permissions" in text
+    assert "fs::owner_exe" in text
+    assert "fs::group_exe" in text
+    assert "fs::others_exe" in text
 
 
 def test_preservation_flow_hints_present() -> None:
@@ -38,3 +51,10 @@ def test_metadata_system_return_code_is_checked() -> None:
     assert "const int metadata_rc = std::system(cmd.c_str());" in text
     assert "if (metadata_rc != 0)" in text
     assert "append_warning(" in text
+
+
+def test_readme_fallback_env_hint_present() -> None:
+    text = SCENE_SELECT_CPP.read_text(encoding="utf-8")
+    assert "generate_readiness_pack.sh /tmp/workcell_readiness_pack test_scene" in text
+    assert "If helpers cannot locate tooling, set:" in text
+    assert "export WORKCELL_STUDIO_REPO_ROOT=~/workcell_ws/src/easy_manipulation_deployment" in text

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -491,34 +491,79 @@ void write_builder_validation_helper(const fs::path & scene_dir)
   if (!boost::filesystem::exists(generated_dir)) {
     boost::filesystem::create_directories(generated_dir);
   }
+  const auto write_tool_root_discovery = [](std::ofstream & stream) {
+      stream << "SCRIPT_DIR=\"$(cd \"$(dirname \"$0\")\" && pwd)\"\n";
+      stream << "SCENE_DIR=\"$(cd \"$SCRIPT_DIR/..\" && pwd)\"\n";
+      stream << "TOOL_ROOT=\"${WORKCELL_STUDIO_REPO_ROOT:-}\"\n";
+      stream << "find_tool_root() {\n";
+      stream << "  local candidate=\"$1\"\n";
+      stream << "  [ -n \"$candidate\" ] || return 1\n";
+      stream << "  if [ -f \"$candidate/scripts/workcell_studio.py\" ] && [ -f \"$candidate/scripts/validate_builder_generated_scene.py\" ]; then\n";
+      stream << "    TOOL_ROOT=\"$candidate\"\n";
+      stream << "    return 0\n";
+      stream << "  fi\n";
+      stream << "  return 1\n";
+      stream << "}\n";
+      stream << "if [ -z \"$TOOL_ROOT\" ]; then\n";
+      stream << "  for candidate in \"$PWD\" \"$SCENE_DIR\" \"$SCENE_DIR/..\" \"$SCENE_DIR/../easy_manipulation_deployment\" \"$SCENE_DIR/../../easy_manipulation_deployment\" \"$HOME/workcell_ws/src/easy_manipulation_deployment\"; do\n";
+      stream << "    if find_tool_root \"$candidate\"; then\n";
+      stream << "      break\n";
+      stream << "    fi\n";
+      stream << "  done\n";
+      stream << "fi\n";
+      stream << "if ! find_tool_root \"$TOOL_ROOT\"; then\n";
+      stream << "  echo \"Could not locate Workcell Studio scripts. Set WORKCELL_STUDIO_REPO_ROOT=/path/to/easy_manipulation_deployment\" >&2\n";
+      stream << "  exit 1\n";
+      stream << "fi\n";
+    };
+  const auto set_script_permissions = [](const fs::path & script_file) {
+      boost::system::error_code ec;
+      fs::permissions(
+        script_file,
+        fs::owner_read | fs::owner_write | fs::owner_exe |
+        fs::group_read | fs::group_exe |
+        fs::others_read | fs::others_exe,
+        ec);
+      if (ec) {
+        RCLCPP_WARN(
+          rclcpp::get_logger("workcell_builder"),
+          "Failed to set executable permissions on %s: %s",
+          script_file.string().c_str(), ec.message().c_str());
+      }
+    };
   const fs::path script_path = generated_dir / "run_builder_validation.sh";
   std::ofstream out(script_path.string());
   if (out.is_open()) {
     out << "#!/usr/bin/env bash\n";
     out << "set -euo pipefail\n";
-    out << "python3 scripts/validate_builder_generated_scene.py \"$(cd \"$(dirname \"$0\")\" && pwd)/..\"\n";
+    write_tool_root_discovery(out);
+    out << "python3 \"$TOOL_ROOT/scripts/validate_builder_generated_scene.py\" \"$SCENE_DIR\"\n";
+    out.close();
+    set_script_permissions(script_path);
   }
   const fs::path export_path = generated_dir / "export_workcell_studio_sources.sh";
   std::ofstream export_out(export_path.string());
   if (export_out.is_open()) {
     export_out << "#!/usr/bin/env bash\n";
     export_out << "set -euo pipefail\n";
-    export_out << "SCENE_DIR=\"$(cd \"$(dirname \"$0\")\" && pwd)/..\"\n";
-    export_out << "python3 scripts/export_builder_scene_to_cell_definition.py \"$SCENE_DIR\" --output-dir \"$SCENE_DIR/generated\" --validate\n";
+    write_tool_root_discovery(export_out);
+    export_out << "python3 \"$TOOL_ROOT/scripts/export_builder_scene_to_cell_definition.py\" \"$SCENE_DIR\" --output-dir \"$SCENE_DIR/generated\" --validate\n";
     export_out << "if [ ! -f \"$SCENE_DIR/generated/workcell_builder_task_intent.yaml\" ]; then\n";
     export_out << "  echo \"INFO: No workcell_builder_task_intent.yaml found yet.\"\n";
     export_out << "  echo \"INFO: Author task intent via scripts/create_or_update_builder_task_intent.py or Workcell Studio helper.\"\n";
     export_out << "fi\n";
+    export_out.close();
+    set_script_permissions(export_path);
   }
   const fs::path readiness_path = generated_dir / "generate_readiness_pack.sh";
   std::ofstream readiness_out(readiness_path.string());
   if (readiness_out.is_open()) {
     readiness_out << "#!/usr/bin/env bash\n";
     readiness_out << "set -euo pipefail\n";
-    readiness_out << "SCENE_DIR=\"$(cd \"$(dirname \"$0\")\" && pwd)/..\"\n";
+    write_tool_root_discovery(readiness_out);
     readiness_out << "OUT_DIR=\"${1:-/tmp/workcell_readiness_pack}\"\n";
     readiness_out << "PROJECT_NAME=\"${2:-$(basename \"$SCENE_DIR\")}\"\n";
-    readiness_out << "python3 scripts/workcell_studio.py generate-readiness-pack \\\n";
+    readiness_out << "python3 \"$TOOL_ROOT/scripts/workcell_studio.py\" generate-readiness-pack \\\n";
     readiness_out << "  --scene-package \"$SCENE_DIR\" \\\n";
     readiness_out << "  --output-dir \"$OUT_DIR\" \\\n";
     readiness_out << "  --project-name \"$PROJECT_NAME\" \\\n";
@@ -527,6 +572,8 @@ void write_builder_validation_helper(const fs::path & scene_dir)
     readiness_out << "  --smoke-dry-run \\\n";
     readiness_out << "  --force \\\n";
     readiness_out << "  --json\n";
+    readiness_out.close();
+    set_script_permissions(readiness_path);
   }
   const fs::path dashboard_help_path = generated_dir / "open_dashboard_help.md";
   std::ofstream dashboard_help_out(dashboard_help_path.string());
@@ -537,6 +584,10 @@ void write_builder_validation_helper(const fs::path & scene_dir)
     dashboard_help_out << "```bash\ncd /tmp/workcell_readiness_pack && python3 -m http.server 8767\n```\n\n";
     dashboard_help_out << "Then open: `http://localhost:8767/readiness_dashboard.html`\n\n";
     dashboard_help_out << "Note: direct `xdg-open` may not work in sandboxed Firefox/Snap environments.\n\n";
+    dashboard_help_out << "Run generated helpers directly from any directory:\n\n";
+    dashboard_help_out << "```bash\n./generated/run_builder_validation.sh\n./generated/export_workcell_studio_sources.sh\n./generated/generate_readiness_pack.sh /tmp/workcell_readiness_pack test_scene\n```\n\n";
+    dashboard_help_out << "If scripts cannot locate tooling, set:\n\n";
+    dashboard_help_out << "```bash\nexport WORKCELL_STUDIO_REPO_ROOT=~/workcell_ws/src/easy_manipulation_deployment\n```\n\n";
     dashboard_help_out << "Dashboard output is review-only and is not a safety certificate.\n";
   }
 }
@@ -567,9 +618,10 @@ void SceneSelect::generate_scene_package(
     readme << "3. Define pick/place task intent:\n";
     readme << "   - use Workcell Studio Streamlit helper, or\n";
     readme << "   - use scripts/create_or_update_environment_target.py and scripts/create_or_update_builder_task_intent.py\n\n";
-    readme << "4. Generate readiness pack:\n\n```bash\n./generated/generate_readiness_pack.sh\n```\n\n";
+    readme << "4. Generate readiness pack:\n\n```bash\n./generated/generate_readiness_pack.sh /tmp/workcell_readiness_pack test_scene\n```\n\n";
     readme << "5. Open dashboard:\n\n```bash\ncd /tmp/workcell_readiness_pack && python3 -m http.server 8767\n```\n\n";
     readme << "http://localhost:8767/readiness_dashboard.html\n\n";
+    readme << "If helpers cannot locate tooling, set:\n\n```bash\nexport WORKCELL_STUDIO_REPO_ROOT=~/workcell_ws/src/easy_manipulation_deployment\n```\n\n";
     readme << "Safety note: offline/fake-hardware only, no robot motion, no MoveIt service call, not a safety certificate.\n";
   }
 }


### PR DESCRIPTION
### Motivation
- Generated helper scripts were not executable and assumed `scripts/...` was available relative to the current working directory, which breaks when scene packages live outside the `easy_manipulation_deployment` repo.
- Ensure generated helpers work when run from the scene folder, repo root, or any other CWD without requiring manual `chmod` or moving files.
- Preserve safety defaults and avoid changing runtime/ROS/MoveIt/hardware behavior.

### Description
- Added robust Workcell Studio tooling-root discovery to generated helpers with an optional `WORKCELL_STUDIO_REPO_ROOT` override and a prioritized candidate search (`$PWD`, scene-relative paths, and `$HOME/workcell_ws/src/easy_manipulation_deployment`).
- Switched generated helper invocations to absolute paths using `"$TOOL_ROOT/scripts/..."` so helpers do not rely on the caller's CWD.
- Mark generated shell helpers executable at generation time using `boost::filesystem::permissions` and log a warning on failure.
- Updated generated help/README content to show direct helper invocation examples and the `WORKCELL_STUDIO_REPO_ROOT` fallback.
- Modified `tests/test_workcell_builder_studio_integration.py` to assert presence of tool-root discovery logic, absolute `$TOOL_ROOT` usage, the readiness-pack flags and `--scene-package` argument, executable-permission logic, and the README fallback hint.
- Changes are limited to helper script generation and tests; no ROS launch behavior, robot motion, MoveIt service calls, or hardware/EPD changes were introduced.

### Testing
- Compiled helper scripts: `python3 -m py_compile scripts/export_builder_scene_to_cell_definition.py` and `python3 -m py_compile scripts/workcell_studio.py` (both succeeded).
- Ran integration/unit tests: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q` for the affected test modules including `tests/test_workcell_builder_studio_integration.py`, `tests/test_builder_scene_export_to_cell_definition.py`, `tests/test_workcell_studio_builder_import_cli.py`, `tests/test_workcell_studio_readiness_pack.py`, and `tests/test_cell_definition_tools.py` (all passed in this environment).
- Attempted local build check (`colcon build --packages-select workcell_builder`) but it could not be run here because the expected local workspace path (`~/workcell_ws`) was not present in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc752b00f48331bfa7fa4753ab9d68)