### PR TITLE
Resolve metadata renderer path in workcell_builder and mark metadata as optional (WARN)

### DIFF
--- a/scripts/validate_builder_generated_scene.py
+++ b/scripts/validate_builder_generated_scene.py
@@ -47,7 +47,9 @@ def validate_scene(scene_path: Path) -> dict[str, Any]:
 
     metadata_path = scene_path / "workcell_builder_metadata.yaml"
     metadata = _load_yaml_like(metadata_path) if metadata_path.is_file() else {}
-    checks.append({"check": "workcell_builder_metadata.yaml present (optional)", "ok": metadata_path.is_file()})
+    checks.append({"check": "workcell_builder_metadata.yaml present", "ok": metadata_path.is_file(), "optional": True})
+    if not metadata_path.is_file():
+        warnings.append("workcell_builder_metadata.yaml missing (optional)")
 
     robot = env.get("robot", {}) if isinstance(env.get("robot"), dict) else {}
     ee = env.get("end_effector", {}) if isinstance(env.get("end_effector"), dict) else {}

--- a/tests/test_workcell_builder_metadata_flow.py
+++ b/tests/test_workcell_builder_metadata_flow.py
@@ -53,7 +53,8 @@ def test_validator_accepts_scene_with_metadata_and_warns_without_metadata():
       (root / 'workcell_builder_metadata.yaml').unlink()
       warn = validator.validate_scene(root)
       assert warn['ok'] is True
-      assert any('optional' in c['check'] for c in warn['checks'])
+      assert any(c['check'] == 'workcell_builder_metadata.yaml present' and c.get('optional') is True for c in warn['checks'])
+      assert any('workcell_builder_metadata.yaml missing (optional)' in w for w in warn['warnings'])
 
 
 def test_scene_builder_readme_and_export_helper_are_documented():

--- a/tests/test_workcell_builder_studio_integration.py
+++ b/tests/test_workcell_builder_studio_integration.py
@@ -58,3 +58,24 @@ def test_readme_fallback_env_hint_present() -> None:
     assert "generate_readiness_pack.sh /tmp/workcell_readiness_pack test_scene" in text
     assert "If helpers cannot locate tooling, set:" in text
     assert "export WORKCELL_STUDIO_REPO_ROOT=~/workcell_ws/src/easy_manipulation_deployment" in text
+
+
+def test_scene_select_uses_absolute_metadata_renderer_path_resolution() -> None:
+    text = SCENE_SELECT_CPP.read_text(encoding="utf-8")
+    assert "python3 scripts/render_workcell_builder_metadata.py" not in text
+    assert "WORKCELL_STUDIO_REPO_ROOT" in text
+    assert "render_workcell_builder_metadata.py" in text
+    assert "resolve_tool_root(" in text
+
+
+def test_scene_select_missing_metadata_script_warning_mentions_env_var() -> None:
+    text = SCENE_SELECT_CPP.read_text(encoding="utf-8")
+    assert "Could not locate render_workcell_builder_metadata.py" in text
+    assert "Set WORKCELL_STUDIO_REPO_ROOT=/path/to/easy_manipulation_deployment" in text
+
+
+def test_validate_scene_metadata_optional_is_warn_when_missing_and_pass_when_present() -> None:
+    text = (REPO_ROOT / "scripts/validate_builder_generated_scene.py").read_text(encoding="utf-8")
+    assert "workcell_builder_metadata.yaml missing (optional)" in text
+    assert "workcell_builder_metadata.yaml present" in text
+    assert "present (optional)" not in text

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -170,6 +170,36 @@ fs::path root_from_override(const std::string & override_value)
   return override_path;
 }
 
+
+fs::path resolve_tool_root(const fs::path & scene_root, const fs::path & scene_dir)
+{
+  std::vector<fs::path> candidates;
+  const char * env_root = std::getenv("WORKCELL_STUDIO_REPO_ROOT");
+  if (env_root != nullptr && std::strlen(env_root) > 0) {
+    candidates.emplace_back(env_root);
+  }
+  candidates.push_back(scene_root);
+  candidates.push_back(scene_dir.parent_path());
+  candidates.push_back(scene_dir.parent_path().parent_path());
+  const char * home = std::getenv("HOME");
+  if (home != nullptr && std::strlen(home) > 0) {
+    candidates.emplace_back(fs::path(home) / "workcell_ws" / "src" / "easy_manipulation_deployment");
+  }
+
+  for (const auto & raw_candidate : candidates) {
+    if (raw_candidate.empty()) {
+      continue;
+    }
+    const fs::path candidate = raw_candidate.lexically_normal();
+    const fs::path script_path = candidate / "scripts" / "render_workcell_builder_metadata.py";
+    boost::system::error_code ec;
+    if (fs::exists(script_path, ec) && !ec) {
+      return candidate;
+    }
+  }
+  return fs::path();
+}
+
 fs::path select_scene_root(const fs::path & cwd)
 {
   std::vector<SceneRootCandidate> candidates;
@@ -689,13 +719,19 @@ void SceneSelect::generate_scene_files(Scene scene)
   std::string robot_name = scene.robot_loaded && !scene.robot_vector.empty() ? scene.robot_vector[0].name : "";
   std::string ee_name = scene.ee_loaded && !scene.ee_vector.empty() ? scene.ee_vector[0].name : "";
   const fs::path metadata_path = scene_dir / "workcell_builder_metadata.yaml";
-  const std::string cmd =
-    "python3 scripts/render_workcell_builder_metadata.py --robot \"" + robot_name +
-    "\" --end-effector \"" + ee_name + "\" --scene-path \"" + scene_dir.string() +
-    "\" --output \"" + metadata_path.string() + "\"";
-  const int metadata_rc = std::system(cmd.c_str());
-  if (metadata_rc != 0) {
-    append_warning("Workcell Studio metadata generation command failed with exit code " + std::to_string(metadata_rc) + ".");
+  const fs::path tool_root = resolve_tool_root(workcell_path, scene_dir);
+  if (tool_root.empty()) {
+    append_warning("Could not locate render_workcell_builder_metadata.py. Set WORKCELL_STUDIO_REPO_ROOT=/path/to/easy_manipulation_deployment.");
+  } else {
+    const fs::path metadata_script = tool_root / "scripts" / "render_workcell_builder_metadata.py";
+    const std::string cmd =
+      "python3 \"" + metadata_script.string() + "\" --robot \"" + robot_name +
+      "\" --end-effector \"" + ee_name + "\" --scene-path \"" + scene_dir.string() +
+      "\" --output \"" + metadata_path.string() + "\"";
+    const int metadata_rc = std::system(cmd.c_str());
+    if (metadata_rc != 0) {
+      append_warning("Workcell Studio metadata generation command failed with exit code " + std::to_string(metadata_rc) + ".");
+    }
   }
   write_builder_validation_helper(scene_dir);
   append_info("Workcell Studio metadata generated/updated.");


### PR DESCRIPTION
### Motivation
- Metadata generation in `SceneSelect::generate_scene_files()` used a relative `scripts/render_workcell_builder_metadata.py` path which could fail when the current working directory is an asset folder. 
- The workcell metadata file is optional and a missing metadata file should be reported as a `WARN` rather than a `FAIL` to avoid confusing validation output. 
- Tests should assert the new absolute-path lookup behavior and the corrected validation semantics. 

### Description
- Added `resolve_tool_root()` to `workcell_builder/workcell_builder/gui/scene_select.cpp` which looks for a Workcell Studio tool root using `WORKCELL_STUDIO_REPO_ROOT`, the workcell path, scene-parent candidates, and `$HOME/workcell_ws/src/easy_manipulation_deployment` and returns the candidate containing `scripts/render_workcell_builder_metadata.py`. 
- Replaced the relative `python3 scripts/render_workcell_builder_metadata.py ...` invocation with an absolute script invocation built from the resolved tool root, and emit a clear warning `Could not locate render_workcell_builder_metadata.py. Set WORKCELL_STUDIO_REPO_ROOT=/path/to/easy_manipulation_deployment.` when not found. 
- Updated `scripts/validate_builder_generated_scene.py` to mark the metadata check as optional by adding `"optional": True` to the check and to append a warning `workcell_builder_metadata.yaml missing (optional)` when the file is absent. 
- Extended tests in `tests/test_workcell_builder_studio_integration.py` and updated `tests/test_workcell_builder_metadata_flow.py` to cover absolute-path resolution, presence of `WORKCELL_STUDIO_REPO_ROOT` hooks, the missing-script warning text, and the optional metadata validation semantics. 
- Kept generation flow robust to changes of process `cwd` by invoking the renderer via absolute path and did not change any ROS launch, runtime robot, MoveIt, EPD, or hardware behavior. 

### Testing
- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_studio_integration.py` and the integration tests passed. 
- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_builder_scene_export_to_cell_definition.py tests/test_workcell_builder_metadata_flow.py` and the suite passed. 
- Ran the combined suite `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_studio_integration.py tests/test_builder_scene_export_to_cell_definition.py tests/test_workcell_builder_metadata_flow.py` and observed `16 passed` (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7849b7f88331bbb7ed7077146079)