### PR TITLE
Treat Workcell Studio export artifacts as WARN (not FAIL) in builder validation

### DIFF
--- a/scripts/validate_builder_generated_scene.py
+++ b/scripts/validate_builder_generated_scene.py
@@ -68,23 +68,25 @@ def validate_scene(scene_path: Path) -> dict[str, Any]:
 
     exported_cell = scene_path / "generated" / "cell_definition.yaml"
     exported_layout = scene_path / "generated" / "environment_layout.yaml"
-    checks.append({"check": "generated/cell_definition.yaml present", "ok": exported_cell.is_file()})
-    checks.append({"check": "generated/environment_layout.yaml present", "ok": exported_layout.is_file()})
+    checks.append({"check": "generated/cell_definition.yaml present", "ok": exported_cell.is_file(), "optional": True})
+    checks.append({"check": "generated/environment_layout.yaml present", "ok": exported_layout.is_file(), "optional": True})
     export_validation = {}
     if exported_cell.is_file():
         run = subprocess.run(["python3", str(SCRIPT_DIR / "validate_cell_definition.py"), str(exported_cell), "--json"], capture_output=True, text=True, check=False)
         export_validation["cell_definition"] = json.loads(run.stdout) if run.stdout.strip() else {"result": "FAIL"}
     else:
-        warnings.append("Builder export missing generated/cell_definition.yaml (legacy scenes are allowed).")
+        warnings.append("generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh")
     if exported_layout.is_file():
         run = subprocess.run(["python3", str(SCRIPT_DIR / "validate_environment_layout.py"), str(exported_layout), "--json"], capture_output=True, text=True, check=False)
         export_validation["environment_layout"] = json.loads(run.stdout) if run.stdout.strip() else {"result": "FAIL"}
     else:
-        warnings.append("Builder export missing generated/environment_layout.yaml (legacy scenes are allowed).")
+        warnings.append("generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh")
 
     task_intent_report = {}
+    task_intent_check = {"check": "generated/workcell_builder_task_intent.yaml present", "ok": False, "optional": True}
     task_intent_path = _find_task_intent(scene_path)
     if task_intent_path:
+        task_intent_check["ok"] = True
         run = subprocess.run(["python3", str(SCRIPT_DIR / "validate_builder_task_intent.py"), str(task_intent_path), "--scene-package", str(scene_path), "--json"], capture_output=True, text=True, check=False)
         task_intent_report = json.loads(run.stdout) if run.stdout.strip() else {"status": "FAIL", "errors": [run.stderr.strip()]}
         if task_intent_report.get("status") == "FAIL":
@@ -93,6 +95,7 @@ def validate_scene(scene_path: Path) -> dict[str, Any]:
             warnings.extend(task_intent_report.get("warnings", []))
     else:
         warnings.append("Task intent missing: physical scene only.")
+    checks.append(task_intent_check)
 
     runtime_supported = bool(metadata.get("runtime_supported", False))
     preview_only = bool(metadata.get("preview_only", False))
@@ -154,7 +157,13 @@ def main() -> int:
         print(f"Scene: {report['scene_path']}")
         print(f"Readiness: {report['readiness']}")
         for c in report["checks"]:
-            print(f" - {'PASS' if c['ok'] else 'FAIL'}: {c['check']}")
+            if c["ok"]:
+                state = "PASS"
+            elif c.get("optional"):
+                state = "WARN"
+            else:
+                state = "FAIL"
+            print(f" - {state}: {c['check']}")
         for w in report["warnings"]:
             print(f" - WARN: {w}")
         for e in report["errors"]:

--- a/tests/test_builder_scene_export_to_cell_definition.py
+++ b/tests/test_builder_scene_export_to_cell_definition.py
@@ -53,7 +53,8 @@ def test_builder_validator_warns_for_legacy_scene_without_exports() -> None:
         )
         payload = json.loads(out.stdout)
         assert payload["ok"] is True
-        assert any("legacy scenes" in w for w in payload["warnings"])
+        assert any("generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh" in w for w in payload["warnings"])
+        assert any("generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh" in w for w in payload["warnings"])
 
 
 def test_preview_only_metadata_emits_warning() -> None:

--- a/tests/test_validate_builder_generated_scene.py
+++ b/tests/test_validate_builder_generated_scene.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+validator = _load("validate_builder_generated_scene", REPO_ROOT / "scripts" / "validate_builder_generated_scene.py")
+
+
+def _write_required_scene_files(scene_root: Path) -> None:
+    (scene_root / "package.xml").write_text("<package/>", encoding="utf-8")
+    (scene_root / "CMakeLists.txt").write_text("cmake_minimum_required(VERSION 3.5)", encoding="utf-8")
+    (scene_root / "environment.yaml").write_text(
+        "robot: {name: ur5}\nend_effector: {name: robotiq}\nobjects: {}\n",
+        encoding="utf-8",
+    )
+
+
+def test_before_export_artifacts_are_warn_not_fail(tmp_path: Path) -> None:
+    _write_required_scene_files(tmp_path)
+    (tmp_path / "workcell_builder_metadata.yaml").write_text("{}", encoding="utf-8")
+
+    report = validator.validate_scene(tmp_path)
+
+    assert report["ok"] is True
+    assert report["readiness_classification"] == "physical_scene_only"
+    assert any("generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh" in w for w in report["warnings"])
+    assert any("generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh" in w for w in report["warnings"])
+    assert all("cell_definition.yaml" not in e for e in report["errors"])
+    assert all("environment_layout.yaml" not in e for e in report["errors"])
+
+
+def test_after_export_artifacts_present_are_pass(tmp_path: Path) -> None:
+    _write_required_scene_files(tmp_path)
+    (tmp_path / "workcell_builder_metadata.yaml").write_text("{}", encoding="utf-8")
+    generated = tmp_path / "generated"
+    generated.mkdir()
+    (generated / "cell_definition.yaml").write_text("schema_version: cell_definition/v1\n", encoding="utf-8")
+    (generated / "environment_layout.yaml").write_text("schema_version: environment_layout/v1\n", encoding="utf-8")
+
+    report = validator.validate_scene(tmp_path)
+
+    checks = {c["check"]: c for c in report["checks"]}
+    assert checks["generated/cell_definition.yaml present"]["ok"] is True
+    assert checks["generated/environment_layout.yaml present"]["ok"] is True
+
+
+def test_missing_required_package_xml_fails(tmp_path: Path) -> None:
+    (tmp_path / "CMakeLists.txt").write_text("cmake_minimum_required(VERSION 3.5)", encoding="utf-8")
+    (tmp_path / "environment.yaml").write_text("robot: {name: ur5}\n", encoding="utf-8")
+
+    report = validator.validate_scene(tmp_path)
+
+    assert report["ok"] is False
+    assert any("Missing required file: package.xml" in e for e in report["errors"])
+
+
+def test_missing_task_intent_is_warn_and_physical_scene_only(tmp_path: Path) -> None:
+    _write_required_scene_files(tmp_path)
+    (tmp_path / "workcell_builder_metadata.yaml").write_text("{}", encoding="utf-8")
+
+    report = validator.validate_scene(tmp_path)
+
+    assert report["ok"] is True
+    assert report["readiness"] == "physical_scene_only"
+    assert any("Task intent missing: physical scene only." in w for w in report["warnings"])


### PR DESCRIPTION
### Motivation
- Avoid confusing/contradictory validation output where missing Workcell Studio export artifacts were shown as hard `FAIL` or printed with misleading text.
- Make pre-export validation clearer by treating generated export artifacts as optional until `./generated/export_workcell_studio_sources.sh` is run.

### Description
- Marked `generated/cell_definition.yaml` and `generated/environment_layout.yaml` checks as optional and changed their missing messages to `generated/... missing; run ./generated/export_workcell_studio_sources.sh` in `scripts/validate_builder_generated_scene.py`.
- Added an explicit optional check for `generated/workcell_builder_task_intent.yaml` and preserved readiness semantics (`physical_scene_only` when task intent is absent).
- Updated CLI severity rendering so checks print `PASS` when present, `WARN` for optional missing checks, and `FAIL` only for missing required checks.
- Added `tests/test_validate_builder_generated_scene.py` and updated `tests/test_builder_scene_export_to_cell_definition.py` to cover pre-export WARN behavior, post-export PASS behavior, required-file FAIL, and task-intent WARN semantics.

### Testing
- Ran targeted tests and fixed expectations after an initial test mismatch: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_validate_builder_generated_scene.py tests/test_builder_scene_export_to_cell_definition.py` (initial run produced one failing expectation which was corrected).
- Re-ran broader test suites and all passed: `tests/test_workcell_builder_studio_integration.py` (9 passed), `tests/test_workcell_builder_metadata_flow.py` (4 passed), `tests/test_builder_scene_export_to_cell_definition.py` (3 passed), `tests/test_workcell_studio_readiness_pack.py` (6 passed), and `tests/test_cell_definition_tools.py` (42 passed).
- New validation tests confirm missing export artifacts are `WARN` (not `FAIL`) before export and `PASS` after export, and that missing required files still produce `FAIL`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc82b339448331af88b0798a10b6c3)