### PR TITLE
Promote builder-authored task intent into generated Workcell Studio exports

### DIFF
--- a/docs/manuals/WORKCELL_STUDIO_ROADMAP.md
+++ b/docs/manuals/WORKCELL_STUDIO_ROADMAP.md
@@ -54,7 +54,7 @@ High-level ownership boundaries:
 
 ## Builder scene exports for Workcell Studio
 
-`workcell_builder` remains the primary visual workflow. Generated scenes can now export portable Workcell Studio source files using `scripts/export_builder_scene_to_cell_definition.py`. The export writes `generated/cell_definition.yaml`, `generated/environment_layout.yaml`, and `generated/builder_export_summary.json`. These files are for offline commissioning and backend tooling, and are not proof of reachability or runtime safety. Keep fake-hardware-first defaults and runtime send disabled unless separately commissioned.
+`workcell_builder` remains the primary visual workflow. Generated scenes can now export portable Workcell Studio source files using `scripts/export_builder_scene_to_cell_definition.py`. The export writes `generated/cell_definition.yaml`, `generated/environment_layout.yaml`, `generated/workcell_builder_task_intent.yaml` (when enough task authoring metadata exists), and `generated/builder_export_summary.json`. These files are for offline commissioning and backend tooling, and are not proof of reachability or runtime safety. Keep fake-hardware-first defaults and runtime send disabled unless separately commissioned.
 
 ## Curated Demo Catalog
 
@@ -71,3 +71,10 @@ Next safe bridge: guarded RViz/MoveIt plan-preview session preparation from offl
 
 
 Readiness pipeline: builder scene -> task intent -> task recipe -> task flow -> static preview -> offline plan request -> RViz preview session -> smoke launch -> planning scene readiness -> readiness pack.
+
+
+## Readiness classification shorthand
+
+- `physical_scene_only`: cell/layout metadata exists but task flow authoring is missing or incomplete.
+- `task_intent_present` / `task_preview_ready`: builder task intent exists and validates for offline preview-oriented task flow checks.
+- `runtime_ready`: only when downstream runtime safety gates, launch checks, and existing commissioning requirements pass; task intent alone does not imply runtime execution readiness.

--- a/scripts/export_builder_scene_to_cell_definition.py
+++ b/scripts/export_builder_scene_to_cell_definition.py
@@ -129,6 +129,49 @@ def _generate_plan_preview(task_recipe_path: Path, output_path: Path, cell_path:
         return {"status": "FAIL", "errors": [run.stdout.strip() or run.stderr.strip()]}
 
 
+
+
+def _build_task_intent_from_scene(scene_path: Path, env_layout: dict[str, Any], meta: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    missing=[]
+    task_type = "pick_place"
+    grasp_meta = meta.get("grasp_strategy") if isinstance(meta.get("grasp_strategy"), dict) else {}
+    strategy = grasp_meta.get("strategy_id")
+    pick_id = None
+    place_id = None
+    zones = env_layout.get("zones") if isinstance(env_layout.get("zones"), list) else []
+    targets = env_layout.get("targets") if isinstance(env_layout.get("targets"), list) else []
+    for z in zones + targets:
+        if not isinstance(z, dict):
+            continue
+        zid = z.get("id")
+        ztype = str(z.get("type", "")).lower()
+        if not pick_id and ("pick" in ztype or "pick" in str(zid).lower()):
+            pick_id = zid
+        if not place_id and ("place" in ztype or "bin" in ztype or any(k in str(zid).lower() for k in ["place","bin","drop"])):
+            place_id = zid
+    if not pick_id:
+        missing.append("pick source missing")
+    if not strategy:
+        missing.append("grasp strategy missing")
+    if not place_id:
+        missing.append("place target missing")
+    release_strategy = "tool_release"
+    routing_rules = [{"id": "default_route", "when": {"always": True}, "destination": place_id or "unset_destination"}]
+    if not release_strategy:
+        missing.append("release strategy missing")
+    if not routing_rules:
+        missing.append("routing rule missing")
+    intent = {
+        "schema": "workcell_builder_task_intent/v1",
+        "scene_package": scene_path.as_posix(),
+        "task": {"id": "default_builder_task", "type": task_type, "mode": "offline_preview"},
+        "pick": {"source": {"type": "zone", "id": pick_id}},
+        "grasp": {"strategy_ref": strategy, "approach_axis": "z_down", "approach_distance_m": 0.1, "retreat_axis": "z_up", "retreat_distance_m": 0.1},
+        "place": {"target": {"type": "destination", "id": place_id}, "release_strategy": release_strategy, "retreat_axis": "z_up", "retreat_distance_m": 0.1},
+        "routing": {"rules": routing_rules},
+        "safety": {"metadata_only": True, "runtime_io_applied": False, "motion_started": False, "ros_launch_started": False},
+    }
+    return intent, missing
 def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str, Any]:
     env = _load_optional(scene_path / "environment.yaml")
     meta = _load_optional(scene_path / "workcell_builder_metadata.yaml")
@@ -175,6 +218,14 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
         object_entries.append({"id": str(obj_name), "name": str(obj_name), "mesh": filepath, "dimensions": dims, "index": idx})
 
     authored_layout = _load_environment_layout(scene_path)
+    if not task_intent_path:
+        generated_intent, missing_msgs = _build_task_intent_from_scene(scene_path, authored_layout, meta)
+        if missing_msgs:
+            warnings.append("Builder-authored task intent is incomplete: " + ", ".join(missing_msgs))
+        else:
+            generated_task_intent_path = output_dir / "workcell_builder_task_intent.yaml"
+            _write_structured(generated_task_intent_path, generated_intent)
+            task_intent_path = generated_task_intent_path
     environment_layout = {
         "schema_version": authored_layout.get("schema_version", "environment_layout/v1"),
         "layout_id": authored_layout.get("layout_id", f"{scene_path.name}_layout"),
@@ -268,7 +319,7 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
         "scene_path": str(scene_path),
         "output_dir": str(output_dir),
         "warnings": warnings,
-        "exported_files": [str(cell_path), str(layout_path)],
+        "exported_files": [str(cell_path), str(layout_path)] + ([str(task_intent_path)] if task_intent_path else []),
         "validation": {},
         "builder_task_intent": builder_task_intent,
         "task_intent_validation": task_intent_validation,

--- a/scripts/validate_builder_generated_scene.py
+++ b/scripts/validate_builder_generated_scene.py
@@ -90,7 +90,21 @@ def validate_scene(scene_path: Path) -> dict[str, Any]:
         run = subprocess.run(["python3", str(SCRIPT_DIR / "validate_builder_task_intent.py"), str(task_intent_path), "--scene-package", str(scene_path), "--json"], capture_output=True, text=True, check=False)
         task_intent_report = json.loads(run.stdout) if run.stdout.strip() else {"status": "FAIL", "errors": [run.stderr.strip()]}
         if task_intent_report.get("status") == "FAIL":
-            errors.extend(task_intent_report.get("errors", []))
+            missing = task_intent_report.get("missing_required_fields", [])
+            if missing:
+                mapping = {
+                    "pick.source.id": "pick source missing",
+                    "grasp.strategy_ref": "grasp strategy missing",
+                    "place.target.id": "place target missing",
+                }
+                for m in missing:
+                    warnings.append(mapping.get(m, f"task intent missing: {m}"))
+                if not ((task_intent_report.get("task_intent", {}).get("place") or {}).get("release_strategy")):
+                    warnings.append("release strategy missing")
+                if not ((task_intent_report.get("task_intent", {}).get("routing") or {}).get("rules")):
+                    warnings.append("routing rule missing")
+            else:
+                errors.extend(task_intent_report.get("errors", []))
         elif task_intent_report.get("status") == "WARN":
             warnings.extend(task_intent_report.get("warnings", []))
     else:
@@ -106,8 +120,12 @@ def validate_scene(scene_path: Path) -> dict[str, Any]:
         readiness = "physical_scene_only"
         suggested_actions.append('Create builder task intent to define pick/place/grasp.')
     elif task_intent_report.get("status") == "FAIL":
-        readiness = "task_intent_incomplete"
-        suggested_actions.append('Complete missing required task intent fields.')
+        if task_intent_report.get("missing_required_fields"):
+            readiness = "physical_scene_only"
+            suggested_actions.append('Complete missing required task intent fields.')
+        else:
+            readiness = "task_intent_incomplete"
+            suggested_actions.append('Complete invalid task intent errors.')
     elif (scene_path / "generated" / "task_recipe_from_builder_intent.yaml").is_file():
         readiness = "task_recipe_generated"
     else:


### PR DESCRIPTION
### Motivation

- Advance workcell_builder export readiness by allowing generated scenes to emit a validated Workcell Studio `workcell_builder_task_intent.yaml` so scenes can move beyond `physical_scene_only` toward task-preview readiness while preserving offline/fake-hardware-first safety semantics.

### Description

- Add `_build_task_intent_from_scene` in `scripts/export_builder_scene_to_cell_definition.py` to synthesize a `workcell_builder_task_intent/v1` payload from authored environment layout and metadata and write `generated/workcell_builder_task_intent.yaml` when enough authoring exists.  
- Wire synthesized task intent into the export summary (`exported_files`) and run validation + task-recipe conversion attempts while keeping failures as WARN-level and not changing runtime execution behavior.  
- Modify `scripts/validate_builder_generated_scene.py` to treat missing builder task-intent required fields as WARN (with clear messages for pick source, grasp strategy, place target, release strategy, and routing rule) and to preserve `physical_scene_only` readiness when task authoring is incomplete.  
- Update `docs/manuals/WORKCELL_STUDIO_ROADMAP.md` to document that exports may include `generated/workcell_builder_task_intent.yaml` and to clarify readiness shorthand (`physical_scene_only`, `task_intent_present`/`task_preview_ready`, `runtime_ready`).

### Testing

- Ran unit tests: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_validate_builder_generated_scene.py tests/test_builder_scene_export_to_cell_definition.py tests/test_workcell_builder_studio_integration.py tests/test_workcell_studio_readiness_pack.py tests/test_builder_task_intent.py`.  
- Result: all tests passed (`28 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8449eb388331896b526c4a38ea32)