### PR TITLE
Add canonical offline golden builder-to-readiness demo flow

### DIFF
--- a/docs/manuals/WORKCELL_STUDIO_ROADMAP.md
+++ b/docs/manuals/WORKCELL_STUDIO_ROADMAP.md
@@ -78,3 +78,22 @@ Readiness pipeline: builder scene -> task intent -> task recipe -> task flow -> 
 - `physical_scene_only`: cell/layout metadata exists but task flow authoring is missing or incomplete.
 - `task_intent_present` / `task_preview_ready`: builder task intent exists and validates for offline preview-oriented task flow checks.
 - `runtime_ready`: only when downstream runtime safety gates, launch checks, and existing commissioning requirements pass; task intent alone does not imply runtime execution readiness.
+
+## Canonical golden builder-to-readiness demo
+
+Use `scripts/run_golden_builder_readiness_demo.py` as the canonical acceptance path for builder-generated scenes.
+
+- Offline/fake-hardware only (no runtime execution, no real robot motion).
+- Proves: builder scene validation -> Workcell Studio export -> task intent validation -> readiness pack -> static preview/dashboard.
+- Uses existing Workcell Studio scripts and safety defaults; it does not replace `workcell_builder`.
+
+Manual run:
+
+```bash
+python3 scripts/run_golden_builder_readiness_demo.py \
+  --scene-package scenes/ur5_2f_test \
+  --output-dir /tmp/golden_builder_demo \
+  --force --json
+```
+
+This demo is for repeatable regression/acceptance checks only and is not a real-hardware readiness certificate.

--- a/scripts/run_golden_builder_readiness_demo.py
+++ b/scripts/run_golden_builder_readiness_demo.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, shutil, subprocess, sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+
+
+def _run_json(cmd: list[str], label: str) -> dict[str, Any]:
+    run = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    try:
+        payload = json.loads(run.stdout) if run.stdout.strip() else {}
+    except Exception:
+        payload = {"status": "FAIL", "errors": [f"{label} returned non-JSON output", run.stdout.strip(), run.stderr.strip()]}
+    payload["returncode"] = run.returncode
+    payload["command"] = cmd
+    return payload
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Canonical offline builder→readiness demo flow")
+    ap.add_argument("--scene-package", type=Path, default=REPO_ROOT / "scenes" / "ur5_2f_test")
+    ap.add_argument("--output-dir", type=Path, required=True)
+    ap.add_argument("--project-name", default="golden_builder_readiness_demo")
+    ap.add_argument("--force", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    scene = args.scene_package.resolve()
+    output = args.output_dir.resolve()
+    generated = scene / "generated"
+    generated.mkdir(parents=True, exist_ok=True)
+    if output.exists() and args.force:
+        shutil.rmtree(output)
+
+    intent_path = generated / "workcell_builder_task_intent.yaml"
+    steps: dict[str, Any] = {}
+    steps["create_or_update_builder_task_intent"] = _run_json([
+        sys.executable, str(SCRIPT_DIR / "create_or_update_builder_task_intent.py"),
+        "--scene-package", str(scene),
+        "--task-id", "golden_pick_place_001",
+        "--task-type", "pick_place",
+        "--pick-source", "pick_zone_main",
+        "--place-target", "bin_red",
+        "--grasp-strategy", "finger_pinch_basic",
+        "--approach-axis", "z_down",
+        "--approach-distance-m", "0.12",
+        "--retreat-axis", "z_up",
+        "--retreat-distance-m", "0.10",
+        "--release-strategy", "tool_release",
+        "--output", str(intent_path),
+        "--validate", "--json",
+    ], "create task intent")
+
+    steps["validate_builder_generated_scene"] = _run_json([sys.executable, str(SCRIPT_DIR / "validate_builder_generated_scene.py"), str(scene), "--json"], "scene validation")
+
+    steps["generate_workcell_studio_readiness_pack"] = _run_json([
+        sys.executable, str(SCRIPT_DIR / "generate_workcell_studio_readiness_pack.py"),
+        "--scene-package", str(scene),
+        "--output-dir", str(output),
+        "--project-name", args.project_name,
+        "--validate", "--prepare-rviz-preview", "--smoke-dry-run", "--force", "--json",
+    ], "readiness pack")
+
+    manifest = output / "readiness_pack_manifest.json"
+    manifest_json = json.loads(manifest.read_text(encoding="utf-8")) if manifest.exists() else {}
+
+    results = {
+        "result": "PASS" if manifest.exists() else "FAIL",
+        "scene_package": str(scene),
+        "output_dir": str(output),
+        "steps": steps,
+        "artifacts": manifest_json.get("artifacts", {}),
+        "readiness": manifest_json.get("results", {}),
+        "safety": manifest_json.get("safety", {}),
+        "next_commands": [
+            f"python3 scripts/validate_builder_generated_scene.py {scene}",
+            f"python3 scripts/workcell_studio.py validate-readiness-pack --manifest {manifest} --json",
+            f"python3 scripts/workcell_studio.py generate-readiness-dashboard --manifest {manifest} --output {output / 'readiness_dashboard_regenerated.html'} --json",
+            f"python3 scripts/run_fake_hardware_smoke_launch.py --session {output / 'plan_preview' / 'rviz_moveit_plan_preview_session.json'} --output-dir {output / 'smoke_launch'} --dry-run --json",
+        ],
+    }
+    (output / "golden_builder_demo_summary.json").write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+    if args.json:
+        print(json.dumps(results, indent=2))
+    return 0 if results["result"] == "PASS" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_golden_builder_readiness_demo.py
+++ b/tests/test_golden_builder_readiness_demo.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_golden_builder_readiness_demo_end_to_end(tmp_path: Path) -> None:
+    scene = tmp_path / "scene"
+    shutil.copytree("scenes/ur5_2f_test", scene)
+    out = tmp_path / "golden_pack"
+    run = subprocess.run([
+        sys.executable,
+        "scripts/run_golden_builder_readiness_demo.py",
+        "--scene-package", str(scene),
+        "--output-dir", str(out),
+        "--force",
+        "--json",
+    ], capture_output=True, text=True, check=False)
+    assert run.returncode == 0
+
+    manifest_path = out / "readiness_pack_manifest.json"
+    assert manifest_path.exists()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert Path(manifest["artifacts"]["cell_definition"]).exists()
+    assert Path(manifest["artifacts"]["environment_layout"]).exists()
+    assert Path(manifest["artifacts"]["builder_task_intent"]).exists()
+    assert Path(manifest["artifacts"]["task_flow_summary"]).exists()
+    assert Path(manifest["artifacts"]["readiness_dashboard"]).exists()
+
+    assert manifest["results"]["task_intent_status"] == "PASS"
+    assert manifest["results"].get("classification") != "physical_scene_only"
+    assert manifest["safety"]["real_hardware_enabled"] is False
+    assert manifest["safety"]["motion_command_sent"] is False
+    assert manifest["safety"]["runtime_execution_called"] is False
+
+    dashboard = Path(manifest["artifacts"]["readiness_dashboard"]).read_text(encoding="utf-8")
+    assert "Task flow: pick → grasp → place → release" in dashboard
+    assert "Offline/fake-hardware readiness review only" in dashboard


### PR DESCRIPTION
### Motivation

- Provide a single, repeatable golden acceptance path that proves a `workcell_builder`-generated scene can flow end-to-end into Workcell Studio exports, task-intent validation, readiness pack generation, and demo-friendly preview/dashboard outputs. 
- Keep the path offline/fake-hardware-first and dry-run safe so it does not change runtime execution or enable real robot motion.

### Description

- Add `scripts/run_golden_builder_readiness_demo.py` which authors/updates a builder `workcell_builder_task_intent.yaml`, validates the generated scene with `scripts/validate_builder_generated_scene.py`, runs the existing readiness-pack pipeline via `scripts/generate_workcell_studio_readiness_pack.py`, and writes a compact `golden_builder_demo_summary.json` with explicit next manual commands. 
- Add `tests/test_golden_builder_readiness_demo.py` to assert that generated artifacts (`cell_definition.yaml`, `environment_layout.yaml`, `workcell_builder_task_intent.yaml`, `task_flow_summary`, and dashboard) exist, that the builder task intent validates and classification is not `physical_scene_only`, and that safety flags remain offline (`real_hardware_enabled`, `motion_command_sent`, and `runtime_execution_called` are false). 
- Update `docs/manuals/WORKCELL_STUDIO_ROADMAP.md` with a short `Canonical golden builder-to-readiness demo` section and a `python3` command example for running the demo; the docs reinforce the offline/fake-hardware-only intent and that this does not replace `workcell_builder`.

### Testing

- Ran the focused pytest suite with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_validate_builder_generated_scene.py tests/test_workcell_builder_studio_integration.py tests/test_workcell_studio_readiness_pack.py tests/test_builder_scene_export_to_cell_definition.py tests/test_golden_builder_readiness_demo.py` as part of validation. 
- The test run succeeded: `23 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc862bb1848331b8fc5c92e4a46606)