### PR TITLE
Extend golden builder demo with safe RViz/MoveIt fake-hardware preview readiness summary

### DIFF
--- a/docs/manuals/CELL_READINESS_PREFLIGHT.md
+++ b/docs/manuals/CELL_READINESS_PREFLIGHT.md
@@ -56,3 +56,24 @@ The operator panel includes a **Run Preflight Check** button that runs this scri
 6. Do not proceed to replay/motion unless all blockers are clear
 
 This path is dry-run only and never executes robot motion.
+
+## 6) Golden builder-to-readiness demo + safe preview handoff
+Run the canonical golden flow:
+
+```bash
+python3 scripts/run_golden_builder_readiness_demo.py \
+  --scene-package scenes/ur5_2f_test \
+  --output-dir /tmp/golden_builder_demo \
+  --force --json
+```
+
+Then inspect `/tmp/golden_builder_demo/golden_builder_demo_summary.json` for:
+- readiness pack path,
+- static preview path,
+- dashboard path,
+- RViz/MoveIt fake-hardware preview command (when launch metadata is available),
+- explicit no-motion safety flags.
+
+If a preview command is present, run it manually only after sourcing ROS/workspace and only in fake hardware mode. The golden demo itself does not launch ROS, does not call MoveIt planning services, and does not command real robot motion.
+
+This preview demonstrates visualization/metadata readiness only. It is not proof of real hardware commissioning readiness.

--- a/docs/manuals/WORKCELL_STUDIO_ROADMAP.md
+++ b/docs/manuals/WORKCELL_STUDIO_ROADMAP.md
@@ -97,3 +97,12 @@ python3 scripts/run_golden_builder_readiness_demo.py \
 ```
 
 This demo is for repeatable regression/acceptance checks only and is not a real-hardware readiness certificate.
+
+### Safe RViz/MoveIt fake-hardware visual preview extension
+
+The golden demo now also emits an RViz/MoveIt preview-readiness section in `golden_builder_demo_summary.json`.
+
+- It reports preview readiness for robot description, end effector metadata, support/table context, pick/place zones, task-flow markers, and fake-hardware launch metadata.
+- If a safe command can be generated, it is included as a manual command (for example with `use_fake_hardware:=true`).
+- If preview metadata is incomplete, the summary is explicitly classified `rviz_preview_partial` and lists concrete blockers/warnings.
+- This remains offline/no-motion by default and does **not** call runtime execution or send robot motion commands.

--- a/scripts/run_golden_builder_readiness_demo.py
+++ b/scripts/run_golden_builder_readiness_demo.py
@@ -66,15 +66,55 @@ def main() -> int:
 
     manifest = output / "readiness_pack_manifest.json"
     manifest_json = json.loads(manifest.read_text(encoding="utf-8")) if manifest.exists() else {}
+    artifacts = manifest_json.get("artifacts", {})
+
+    def _path_exists(value: Any) -> bool:
+        return isinstance(value, str) and Path(value).exists()
+
+    rviz_session_path = artifacts.get("rviz_moveit_plan_preview_session")
+    rviz_session = json.loads(Path(rviz_session_path).read_text(encoding="utf-8")) if _path_exists(rviz_session_path) else {}
+    rviz_readiness = (rviz_session.get("readiness") or {}) if isinstance(rviz_session, dict) else {}
+    rviz_inputs = (((rviz_session.get("rviz_moveit") or {}).get("expected_inputs")) or {}) if isinstance(rviz_session, dict) else {}
+    plan_preview = (rviz_session.get("plan_preview") or {}) if isinstance(rviz_session, dict) else {}
+    launch_cmd = ((((rviz_session.get("rviz_moveit") or {}).get("suggested_launch")) or {}).get("command")) if isinstance(rviz_session, dict) else None
+
+    rviz_blockers = list(rviz_readiness.get("blockers") or [])
+    rviz_warnings = list(rviz_readiness.get("warnings") or [])
+    rviz_status = rviz_readiness.get("status", "WARN")
+    rviz_classification = "rviz_preview_ready" if rviz_status == "PASS" and not rviz_blockers else "rviz_preview_partial"
+
+    rviz_preview_readiness = {
+        "status": rviz_status,
+        "classification": rviz_classification,
+        "robot_description": bool(rviz_inputs.get("scene_package_exists")),
+        "end_effector_metadata": bool(plan_preview.get("grasp_strategy")),
+        "support_surface_or_table": bool(plan_preview.get("pick_source_id")),
+        "pick_zone": bool(plan_preview.get("pick_source_id")),
+        "place_zone": bool(plan_preview.get("place_target_id")),
+        "task_flow_markers": bool((manifest_json.get("artifacts", {}) or {}).get("task_flow_summary")),
+        "fake_hardware_launch_command": bool(launch_cmd),
+        "rviz_config_or_preview_markers": _path_exists(artifacts.get("static_preview", {}).get("summary") if isinstance(artifacts.get("static_preview"), dict) else None),
+        "preview_command": launch_cmd,
+        "blockers": rviz_blockers,
+        "warnings": rviz_warnings,
+    }
 
     results = {
         "result": "PASS" if manifest.exists() else "FAIL",
         "scene_package": str(scene),
         "output_dir": str(output),
         "steps": steps,
-        "artifacts": manifest_json.get("artifacts", {}),
+        "artifacts": artifacts,
         "readiness": manifest_json.get("results", {}),
-        "safety": manifest_json.get("safety", {}),
+        "rviz_moveit_preview": rviz_preview_readiness,
+        "safety": {
+            "use_fake_hardware": True,
+            "real_hardware_enabled": False,
+            "motion_command_sent": False,
+            "runtime_execution_called": False,
+            "moveit_plan_service_called": False,
+            **(manifest_json.get("safety", {}) if isinstance(manifest_json.get("safety", {}), dict) else {}),
+        },
         "next_commands": [
             f"python3 scripts/validate_builder_generated_scene.py {scene}",
             f"python3 scripts/workcell_studio.py validate-readiness-pack --manifest {manifest} --json",

--- a/tests/test_golden_builder_readiness_demo.py
+++ b/tests/test_golden_builder_readiness_demo.py
@@ -40,3 +40,34 @@ def test_golden_builder_readiness_demo_end_to_end(tmp_path: Path) -> None:
     dashboard = Path(manifest["artifacts"]["readiness_dashboard"]).read_text(encoding="utf-8")
     assert "Task flow: pick → grasp → place → release" in dashboard
     assert "Offline/fake-hardware readiness review only" in dashboard
+
+    summary_path = out / "golden_builder_demo_summary.json"
+    assert summary_path.exists()
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+    rviz = summary.get("rviz_moveit_preview", {})
+    assert isinstance(rviz, dict)
+    assert "status" in rviz
+    assert rviz.get("classification") in ("rviz_preview_ready", "rviz_preview_partial")
+    assert "robot_description" in rviz
+    assert "end_effector_metadata" in rviz
+    assert "support_surface_or_table" in rviz
+    assert "pick_zone" in rviz
+    assert "place_zone" in rviz
+    assert "task_flow_markers" in rviz
+    assert "fake_hardware_launch_command" in rviz
+    assert "rviz_config_or_preview_markers" in rviz
+
+    if rviz.get("fake_hardware_launch_command"):
+        assert isinstance(rviz.get("preview_command"), str)
+        assert "use_fake_hardware:=true" in rviz["preview_command"]
+    else:
+        assert rviz.get("classification") == "rviz_preview_partial"
+        assert rviz.get("blockers") or rviz.get("warnings")
+
+    safety = summary.get("safety", {})
+    assert safety.get("use_fake_hardware") is True
+    assert safety.get("real_hardware_enabled") is False
+    assert safety.get("motion_command_sent") is False
+    assert safety.get("runtime_execution_called") is False
+    assert safety.get("moveit_plan_service_called") is False


### PR DESCRIPTION
### Motivation
- Add an investor-friendly visual preview handoff to the canonical builder→readiness golden demo so it can report RViz/MoveIt fake-hardware preview readiness without changing runtime or enabling real robot motion. 
- Preserve fake-hardware-first, offline/no-motion safety defaults and continue to build on the existing readiness-pack flow introduced previously. 
- Surface concrete blockers/warnings instead of faking success when preview metadata is incomplete so the readiness pack remains useful for reviewers.

### Description
- Enhance `scripts/run_golden_builder_readiness_demo.py` to load the generated `rviz_moveit_plan_preview_session.json`, synthesize a `rviz_moveit_preview` section in the `golden_builder_demo_summary.json`, and include a `preview_command` when a safe launch command can be generated. 
- Explicitly emit safety flags in the demo summary (`use_fake_hardware=true`, `real_hardware_enabled=false`, `motion_command_sent=false`, `runtime_execution_called=false`, `moveit_plan_service_called=false`) while merging any existing safety entries from the readiness pack. 
- Classify preview readiness as `rviz_preview_ready` or `rviz_preview_partial` and list exact `blockers`/`warnings` when metadata or launch files are missing instead of reporting false PASS. 
- Add assertions to `tests/test_golden_builder_readiness_demo.py` to validate the new `rviz_moveit_preview` section, conditional presence of the preview command (must include `use_fake_hardware:=true` when present), and the preserved fake-hardware/no-motion safety defaults. 
- Update docs: add a short section to `docs/manuals/WORKCELL_STUDIO_ROADMAP.md` and a runbook entry in `docs/manuals/CELL_READINESS_PREFLIGHT.md` describing the golden demo run and the safe manual preview handoff (explicitly noting no automatic ROS/MoveIt launch or robot motion by the demo).

### Testing
- Ran the targeted test suite with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_golden_builder_readiness_demo.py tests/test_workcell_studio_readiness_pack.py tests/test_validate_builder_generated_scene.py tests/test_generated_cell_acceptance.py` and observed all tests pass. 
- Test result: `16 passed` (the run completed successfully without introducing runtime or motion execution in tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc87e3787883318f1e1cdb81e9eab3)