### PR TITLE
Add safe offline Perception→EMD bridge preview to golden readiness flow

### DIFF
--- a/docs/manuals/EMD_GRASP_BRIDGE_PAYLOAD.md
+++ b/docs/manuals/EMD_GRASP_BRIDGE_PAYLOAD.md
@@ -70,6 +70,29 @@ python3 scripts/convert_runtime_plan_to_emd_grasp.py \
 
 If ROS Python modules are unavailable, status is `FAIL` with an explicit error message.
 
+## Perception replay to bridge preview (offline-only)
+
+Golden demo readiness now includes an **offline adapter preview**:
+
+- input replay snapshot: `detected_objects_snapshot/v1` (EPD-style)
+- output preview payload: `generated/emd_bridge_payload_preview.json`
+- output report: `generated/perception_bridge_preview_report.json`
+
+Run manually:
+
+```bash
+python3 scripts/generate_perception_bridge_preview.py \
+  --perception-profile <scene>/generated/perception_profile.yaml \
+  --detected-objects tests/fixtures/perception/detected_objects_snapshot_golden.yaml \
+  --task-intent <scene>/generated/workcell_builder_task_intent.yaml \
+  --environment-layout <pack>/exported/environment_layout.yaml \
+  --output-payload <scene>/generated/emd_bridge_payload_preview.json \
+  --output-report <scene>/generated/perception_bridge_preview_report.json \
+  --json
+```
+
+This artifact is **preview-only** and explicitly sets: dry-run, no robot motion, no runtime execution, no MoveIt plan service calls, and no real hardware enablement. It is not published to ROS topics/services and does not execute grasp runtime behavior.
+
 ## Limitations
 
 - The current EMD runtime request (`emd_msgs/srv/GraspRequest`) and target message (`emd_msgs/msg/GraspTarget`) do not carry an explicit release/place destination pose field.

--- a/scripts/generate_perception_bridge_preview.py
+++ b/scripts/generate_perception_bridge_preview.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+from typing import Any
+
+
+def _load(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    txt = path.read_text(encoding='utf-8')
+    if path.suffix.lower() == '.json':
+        data = json.loads(txt)
+        return data if isinstance(data, dict) else {}
+    try:
+        import yaml  # type: ignore
+        data = yaml.safe_load(txt)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--perception-profile', type=Path, required=True)
+    ap.add_argument('--detected-objects', type=Path, required=True)
+    ap.add_argument('--task-intent', type=Path, required=True)
+    ap.add_argument('--environment-layout', type=Path)
+    ap.add_argument('--output-payload', type=Path, required=True)
+    ap.add_argument('--output-report', type=Path, required=True)
+    ap.add_argument('--json', action='store_true')
+    a = ap.parse_args()
+
+    prof = _load(a.perception_profile)
+    snap = _load(a.detected_objects)
+    intent = _load(a.task_intent)
+    layout = _load(a.environment_layout) if a.environment_layout else {}
+
+    warnings: list[str] = []
+    blockers: list[str] = []
+
+    objs = snap.get('objects') if isinstance(snap.get('objects'), list) else []
+    obj = objs[0] if objs and isinstance(objs[0], dict) else {}
+
+    label = obj.get('label') or obj.get('class')
+    confidence = obj.get('confidence')
+    pose = obj.get('pose') if isinstance(obj.get('pose'), dict) else {}
+    xyz = pose.get('xyz') if isinstance(pose.get('xyz'), list) else []
+    obj_frame = obj.get('frame_id') or snap.get('frame_id')
+    scene_frame = ((prof.get('frames') or {}).get('scene_frame') if isinstance(prof.get('frames'), dict) else None)
+    frame_match = bool(obj_frame and scene_frame and obj_frame == scene_frame)
+    if not frame_match:
+        warnings.append('Detected object frame does not match expected scene frame')
+
+    if not label:
+        blockers.append('Detected object label/class missing')
+    if confidence is None:
+        blockers.append('Detected object confidence missing')
+    if len(xyz) != 3:
+        blockers.append('Detected object pose.xyz missing or invalid')
+
+    pick = intent.get('pick', {}) if isinstance(intent.get('pick'), dict) else {}
+    place = intent.get('place', {}) if isinstance(intent.get('place'), dict) else {}
+    grasp = intent.get('grasp', {}) if isinstance(intent.get('grasp'), dict) else {}
+
+    pick_source = (pick.get('source') or {}).get('id') if isinstance(pick.get('source'), dict) else None
+    place_target = (place.get('target') or {}).get('id') if isinstance(place.get('target'), dict) else None
+    grasp_strategy = grasp.get('strategy_ref') or grasp.get('inline_strategy')
+    release_strategy = place.get('release_strategy') if isinstance(place, dict) else None
+    approach_distance = grasp.get('approach_distance_m')
+    retreat_distance = grasp.get('retreat_distance_m')
+
+    if not pick_source:
+        blockers.append('pick.source.id missing from task intent')
+    if not place_target:
+        blockers.append('place.target.id missing from task intent')
+    if not grasp_strategy:
+        blockers.append('grasp strategy missing from task intent')
+    if approach_distance is None or retreat_distance is None:
+        blockers.append('approach/retreat distance metadata missing')
+    if not release_strategy:
+        blockers.append('release strategy missing')
+
+    route_result = 'routed' if (label and pick_source and place_target) else 'unroutable'
+    if route_result != 'routed':
+        blockers.append('object label/class cannot be routed by task intent')
+
+    status = 'bridge_preview_ready'
+    if blockers:
+        status = 'bridge_preview_blocked'
+    elif warnings:
+        status = 'bridge_preview_partial'
+
+    payload = {
+        'schema': 'emd_bridge_payload_preview/v1',
+        'source': 'perception_replay',
+        'preview_only': True,
+        'dry_run': True,
+        'no_robot_motion': True,
+        'no_runtime_execution': True,
+        'moveit_plan_service_called': False,
+        'real_hardware_enabled': False,
+        'motion_command_sent': False,
+        'runtime_execution_called': False,
+        'status': status,
+        'selected_object': {
+            'id': obj.get('id'), 'label': label, 'class': obj.get('class'), 'confidence': confidence,
+            'frame_id': obj_frame, 'pick_pose': pose,
+        },
+        'task_bridge': {
+            'routing_result': route_result,
+            'pick_source': pick_source,
+            'grasp_strategy': grasp_strategy,
+            'approach': {'axis': grasp.get('approach_axis'), 'distance_m': approach_distance},
+            'retreat': {'axis': grasp.get('retreat_axis'), 'distance_m': retreat_distance},
+            'place_target': place_target,
+            'release_strategy': release_strategy,
+        },
+        'safety_flags': {
+            'dry_run': True, 'preview_only': True, 'no_robot_motion': True, 'no_runtime_execution': True,
+            'moveit_plan_service_called': False, 'real_hardware_enabled': False,
+        },
+    }
+    report = {
+        'schema': 'perception_bridge_preview_report/v1',
+        'status': status,
+        'inputs': {
+            'perception_profile': str(a.perception_profile),
+            'detected_objects': str(a.detected_objects),
+            'task_intent': str(a.task_intent),
+            'environment_layout': str(a.environment_layout) if a.environment_layout else None,
+        },
+        'checks': {
+            'label_class_confidence_pose_present': bool(label and confidence is not None and len(xyz) == 3),
+            'frame_match': frame_match,
+            'routable': route_result == 'routed',
+            'grasp_selected': bool(grasp_strategy),
+            'approach_retreat_present': bool(approach_distance is not None and retreat_distance is not None),
+            'place_target_resolved': bool(place_target),
+            'release_strategy_present': bool(release_strategy),
+        },
+        'warnings': warnings,
+        'blockers': blockers,
+        'output_payload': str(a.output_payload),
+        'safety_flags': payload['safety_flags'],
+    }
+
+    a.output_payload.parent.mkdir(parents=True, exist_ok=True)
+    a.output_report.parent.mkdir(parents=True, exist_ok=True)
+    a.output_payload.write_text(json.dumps(payload, indent=2) + '\n', encoding='utf-8')
+    a.output_report.write_text(json.dumps(report, indent=2) + '\n', encoding='utf-8')
+
+    if a.json:
+        print(json.dumps({'result': status, 'payload': str(a.output_payload), 'report': str(a.output_report)}, indent=2))
+    return 0 if status != 'bridge_preview_blocked' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/generate_readiness_pack_dashboard.py
+++ b/scripts/generate_readiness_pack_dashboard.py
@@ -91,6 +91,10 @@ def main() -> int:
     summary = m.get('summary', {}) if isinstance(m.get('summary'), dict) else {}
     src = m.get('source', {}) if isinstance(m.get('source'), dict) else {}
     perception = m.get('perception', {}) if isinstance(m.get('perception'), dict) else {}
+    perception_bridge = m.get('perception_bridge', {}) if isinstance(m.get('perception_bridge'), dict) else {}
+    bridge_payload = _load_structured(Path(arts.get('emd_bridge_payload_preview', ''))) if arts.get('emd_bridge_payload_preview') else {}
+    bridge_object = bridge_payload.get('selected_object', {}) if isinstance(bridge_payload.get('selected_object'), dict) else {}
+    bridge_task = bridge_payload.get('task_bridge', {}) if isinstance(bridge_payload.get('task_bridge'), dict) else {}
 
     pack_dir = a.manifest.parent
     dashboard_dir = a.output.parent
@@ -119,6 +123,8 @@ def main() -> int:
         ('RViz/MoveIt plan preview session', arts.get('rviz_moveit_plan_preview_session', '')),
         ('smoke report', arts.get('fake_hardware_smoke_launch_report', '')),
         ('planning scene readiness report', arts.get('planning_scene_readiness_report', '')),
+        ('emd bridge payload preview', arts.get('emd_bridge_payload_preview', '')),
+        ('perception bridge preview report', arts.get('perception_bridge_preview_report', '')),
     ]
 
     preview_block = ''
@@ -148,6 +154,16 @@ def main() -> int:
 <li>No robot motion: <b>Yes</b></li>
 <li>No runtime execution: <b>Yes</b></li>
 <li>Status: <b>{_safe(perception.get('status','perception_missing'))}</b></li>
+</ul></div>
+<div class='panel'><h3>Perception → Task Bridge Preview</h3><ul>
+<li>Detected object label/class: {_safe(bridge_object.get('label', 'missing'))}</li>
+<li>Confidence: {_safe(bridge_object.get('confidence', 'missing'))}</li>
+<li>Route result: {_safe(bridge_task.get('routing_result', 'missing'))}</li>
+<li>Pick source: {_safe(bridge_task.get('pick_source', 'missing'))}</li>
+<li>Grasp strategy: {_safe(bridge_task.get('grasp_strategy', 'missing'))}</li>
+<li>Place target: {_safe(bridge_task.get('place_target', 'missing'))}</li>
+<li>Bridge preview status: <b>{_safe(perception_bridge.get('status', 'bridge_preview_missing'))}</b></li>
+<li>Safety: no robot motion / no runtime execution: <b>Yes</b></li>
 </ul></div>
 <div class='panel'><h3>Task flow: pick → grasp → place → release</h3><ul>
 <li>pick source: {_safe(tf.get('pick_source_id','missing'))}</li><li>grasp strategy: {_safe(tf.get('grasp_strategy','missing'))}</li><li>approach/retreat: {_safe(tf.get('approach_axis', tf.get('approach','missing')))}{_safe((' '+str(tf.get('approach_distance_m'))+'m') if tf.get('approach_distance_m') is not None else '')} / {_safe(tf.get('retreat_axis', tf.get('retreat','missing')))}{_safe((' '+str(tf.get('retreat_distance_m'))+'m') if tf.get('retreat_distance_m') is not None else '')}</li><li>place target: {_safe(tf.get('place_target_id','missing'))}</li><li>release strategy: {_safe(tf.get('release_strategy','missing'))}</li><li>routing rules: {_safe(tf.get('routing_rule_count', tf.get('routing_rules','missing')))}</li>

--- a/scripts/generate_workcell_studio_readiness_pack.py
+++ b/scripts/generate_workcell_studio_readiness_pack.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from typing import Any
 SCRIPT_DIR = Path(__file__).resolve().parent
 
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding='utf-8')) if path.exists() else {}
+
 def _run_json(cmd:list[str], label:str)->tuple[int,dict[str,Any]]:
     p=subprocess.run(cmd,capture_output=True,text=True,check=False)
     try:data=json.loads(p.stdout) if p.stdout.strip() else {}
@@ -104,6 +107,8 @@ def main()->int:
     pr_status, pr_warnings, pr_blockers = _generate_perception_readiness(perception_profile_path, snapshot_path, scene/'generated'/'perception_readiness_report.json')
     art['perception_readiness_report']=str(scene/'generated'/'perception_readiness_report.json')
     results['perception_status']=pr_status
+    bridge_payload = scene / 'generated' / 'emd_bridge_payload_preview.json'
+    bridge_report = scene / 'generated' / 'perception_bridge_preview_report.json'
     rc,scene_v=step('validate_scene',[sys.executable,str(SCRIPT_DIR/'validate_builder_generated_scene.py'),str(scene),'--json'],hard=True)
     results['builder_scene_validation']='PASS' if scene_v.get('ok') else 'FAIL'
     rc,ppv=step('validate_perception_profile',[sys.executable,str(SCRIPT_DIR/'validate_perception_profile.py'),str(perception_profile_path),'--json'])
@@ -123,6 +128,22 @@ def main()->int:
         if recipe.exists(): art['task_recipe']=str(recipe); results['task_recipe_status']='PASS' if rc==0 else 'WARN'
     else:
         results['task_intent_status']='WARN'; summary['warnings'].append('Missing task intent (physical scene only)')
+    if ti.exists() and (paths['exported'] / 'environment_layout.yaml').exists():
+        rc, pb = step('perception_bridge_preview', [
+            sys.executable, str(SCRIPT_DIR / 'generate_perception_bridge_preview.py'),
+            '--perception-profile', str(perception_profile_path),
+            '--detected-objects', str(snapshot_path),
+            '--task-intent', str(ti),
+            '--environment-layout', str(paths['exported'] / 'environment_layout.yaml'),
+            '--output-payload', str(bridge_payload),
+            '--output-report', str(bridge_report),
+            '--json',
+        ])
+        art['emd_bridge_payload_preview'] = str(bridge_payload)
+        art['perception_bridge_preview_report'] = str(bridge_report)
+        results['perception_bridge_status'] = 'PASS' if rc == 0 else 'WARN'
+    else:
+        results['perception_bridge_status'] = 'WARN'
 
     tf=paths['task']/'task_flow_summary.json'
     task_flow_cmd=None
@@ -176,8 +197,17 @@ def main()->int:
     elif not ti.exists(): results['final_readiness']='WARN'; results['classification']='physical_scene_only'
     elif recipe.exists() and req.exists() and (paths['read']/'planning_scene_readiness_report.json').exists() and results['planning_scene_readiness']=='PASS': results['final_readiness']='PASS'; results['classification']='task_planning_ready'
     else: results['final_readiness']='WARN'; results['classification']='partial_task_pipeline'
+    perception_bridge_report = _read_json(bridge_report) if bridge_report.exists() else {}
     perception_section={'perception_profile_path':str(perception_profile_path),'detected_object_snapshot_path':str(snapshot_path),'perception_readiness_report_path':str(scene/'generated'/'perception_readiness_report.json'),'status':pr_status,'topic_frame_checks':{'profile_valid':results.get('perception_profile_validation')=='PASS'},'safety_flags':{'real_hardware_enabled':False,'motion_command_sent':False,'runtime_execution_called':False,'perception_only':True}}
-    manifest={'schema':'workcell_studio_readiness_pack/v1','source':{'scene_package':str(scene),'project_name':a.project_name,'created_at':datetime.now(timezone.utc).isoformat()},'artifacts':art,'results':results,'safety':safety,'summary':summary,'perception':perception_section}
+    perception_bridge_section = {
+        'payload_preview_path': str(bridge_payload),
+        'report_path': str(bridge_report),
+        'status': (perception_bridge_report.get('status') if isinstance(perception_bridge_report, dict) and perception_bridge_report.get('status') else 'bridge_preview_blocked'),
+        'warnings': (perception_bridge_report.get('warnings') if isinstance(perception_bridge_report, dict) else []),
+        'blockers': (perception_bridge_report.get('blockers') if isinstance(perception_bridge_report, dict) else []),
+        'safety_flags': {'real_hardware_enabled': False, 'motion_command_sent': False, 'runtime_execution_called': False, 'moveit_plan_service_called': False, 'preview_only': True},
+    }
+    manifest={'schema':'workcell_studio_readiness_pack/v1','source':{'scene_package':str(scene),'project_name':a.project_name,'created_at':datetime.now(timezone.utc).isoformat()},'artifacts':art,'results':results,'safety':safety,'summary':summary,'perception':perception_section,'perception_bridge':perception_bridge_section}
     (out/'logs'/'command_outputs.json').write_text(json.dumps(logs,indent=2)+"\n",encoding='utf-8')
     (out/'readiness_pack_manifest.json').write_text(json.dumps(manifest,indent=2)+"\n",encoding='utf-8')
 

--- a/scripts/run_golden_builder_readiness_demo.py
+++ b/scripts/run_golden_builder_readiness_demo.py
@@ -130,6 +130,14 @@ def main() -> int:
             "warnings": (manifest_json.get("summary", {}) if isinstance(manifest_json.get("summary", {}), dict) else {}).get("warnings", []),
             "blockers": (manifest_json.get("summary", {}) if isinstance(manifest_json.get("summary", {}), dict) else {}).get("blockers", []),
         },
+        "perception_bridge": {
+            "emd_bridge_payload_preview": artifacts.get("emd_bridge_payload_preview"),
+            "perception_bridge_preview_report": artifacts.get("perception_bridge_preview_report"),
+            "status": (manifest_json.get("perception_bridge", {}) if isinstance(manifest_json.get("perception_bridge", {}), dict) else {}).get("status", "bridge_preview_missing"),
+            "warnings": (manifest_json.get("perception_bridge", {}) if isinstance(manifest_json.get("perception_bridge", {}), dict) else {}).get("warnings", []),
+            "blockers": (manifest_json.get("perception_bridge", {}) if isinstance(manifest_json.get("perception_bridge", {}), dict) else {}).get("blockers", []),
+            "safety_flags": (manifest_json.get("perception_bridge", {}) if isinstance(manifest_json.get("perception_bridge", {}), dict) else {}).get("safety_flags", {}),
+        },
         "safety": {
             "use_fake_hardware": True,
             "real_hardware_enabled": False,

--- a/scripts/validate_perception_bridge_preview.py
+++ b/scripts/validate_perception_bridge_preview.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('payload', type=Path)
+    ap.add_argument('--json', action='store_true')
+    a = ap.parse_args()
+    data = json.loads(a.payload.read_text(encoding='utf-8')) if a.payload.exists() else {}
+    errors = []
+    warnings = []
+    for key in ['source', 'selected_object', 'task_bridge', 'safety_flags', 'status']:
+        if key not in data:
+            errors.append(f'missing field: {key}')
+    if data.get('status') not in ('bridge_preview_ready', 'bridge_preview_partial', 'bridge_preview_blocked'):
+        errors.append('invalid status')
+    sf = data.get('safety_flags', {}) if isinstance(data.get('safety_flags'), dict) else {}
+    for k in ['dry_run', 'preview_only', 'no_robot_motion', 'no_runtime_execution']:
+        if sf.get(k) is not True:
+            errors.append(f'safety_flags.{k} must be true')
+    for k in ['moveit_plan_service_called', 'real_hardware_enabled']:
+        if sf.get(k) is not False:
+            errors.append(f'safety_flags.{k} must be false')
+    tb = data.get('task_bridge', {}) if isinstance(data.get('task_bridge'), dict) else {}
+    if not tb.get('release_strategy'):
+        warnings.append('release strategy missing')
+    if not tb.get('place_target'):
+        warnings.append('place target missing')
+    status = 'FAIL' if errors else ('WARN' if warnings else 'PASS')
+    out = {'status': status, 'errors': errors, 'warnings': warnings}
+    if a.json:
+        print(json.dumps(out, indent=2))
+    return 1 if errors else 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_golden_builder_readiness_demo.py
+++ b/tests/test_golden_builder_readiness_demo.py
@@ -84,3 +84,7 @@ def test_golden_builder_readiness_demo_end_to_end(tmp_path: Path) -> None:
     assert safety.get("motion_command_sent") is False
     assert safety.get("runtime_execution_called") is False
     assert safety.get("moveit_plan_service_called") is False
+    bridge = summary.get("perception_bridge", {})
+    assert bridge.get("status") in ("bridge_preview_ready", "bridge_preview_partial", "bridge_preview_blocked")
+    assert Path(bridge.get("emd_bridge_payload_preview")).exists()
+    assert Path(bridge.get("perception_bridge_preview_report")).exists()

--- a/tests/test_perception_bridge_preview.py
+++ b/tests/test_perception_bridge_preview.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+import json, shutil, subprocess, sys
+from pathlib import Path
+
+
+def test_perception_bridge_preview_generation_and_validation(tmp_path: Path) -> None:
+    scene = tmp_path / 'scene'
+    shutil.copytree('scenes/ur5_2f_test', scene)
+    out = tmp_path / 'out'
+    run = subprocess.run([sys.executable, 'scripts/run_golden_builder_readiness_demo.py', '--scene-package', str(scene), '--output-dir', str(out), '--force', '--json'], capture_output=True, text=True, check=False)
+    assert run.returncode == 0
+    payload = scene / 'generated' / 'emd_bridge_payload_preview.json'
+    report = scene / 'generated' / 'perception_bridge_preview_report.json'
+    assert payload.exists() and report.exists()
+    v = subprocess.run([sys.executable, 'scripts/validate_perception_bridge_preview.py', str(payload), '--json'], capture_output=True, text=True, check=False)
+    assert v.returncode == 0
+    p = json.loads(payload.read_text(encoding='utf-8'))
+    assert p['source'] == 'perception_replay'
+    assert p['task_bridge']['routing_result'] == 'routed'
+    assert p['task_bridge']['grasp_strategy']
+    assert p['task_bridge']['place_target']
+    assert p['task_bridge']['release_strategy']
+    assert p['real_hardware_enabled'] is False
+    assert p['moveit_plan_service_called'] is False

--- a/tests/test_workcell_studio_readiness_pack.py
+++ b/tests/test_workcell_studio_readiness_pack.py
@@ -13,6 +13,10 @@ def test_generate_and_validate_readiness_pack(tmp_path: Path):
     payload = json.loads(manifest.read_text(encoding="utf-8"))
     assert payload["schema"] == "workcell_studio_readiness_pack/v1"
     assert payload["safety"]["motion_command_sent"] is False
+    assert "perception_bridge" in payload
+    assert payload["perception_bridge"]["status"] in ("bridge_preview_ready", "bridge_preview_partial", "bridge_preview_blocked")
+    if "emd_bridge_payload_preview" in payload["artifacts"]:
+        assert Path(payload["artifacts"]["emd_bridge_payload_preview"]).exists()
     vrun = subprocess.run([sys.executable, "scripts/workcell_studio.py", "validate-readiness-pack", "--manifest", str(manifest), "--json"], capture_output=True, text=True, check=False)
     assert vrun.returncode == 0
 
@@ -122,3 +126,5 @@ def test_pack_visual_markers_and_safety_banner(tmp_path: Path):
     assert "pick_zone_source" in names and "place_zone_target" in names
     preview_summary = json.loads((out / "preview" / "static_preview_summary.json").read_text(encoding="utf-8"))
     assert preview_summary.get("safety_banner_present") is True
+    dashboard = (out / "readiness_dashboard.html").read_text(encoding="utf-8")
+    assert "Perception → Task Bridge Preview" in dashboard


### PR DESCRIPTION
### Motivation

- Provide an offline-only adapter that converts an EPD-style detected-object replay snapshot into a safe, reviewable EMD bridge payload preview without invoking runtime execution, MoveIt, or real hardware.
- Surface the preview in the existing golden demo/readiness-pack/dashboard so perception readiness can be reviewed end-to-end while preserving fake-hardware/no-motion safety defaults.

### Description

- Added `scripts/generate_perception_bridge_preview.py` to produce `generated/emd_bridge_payload_preview.json` and `generated/perception_bridge_preview_report.json` from a perception profile, detected-object snapshot, task intent, and optional environment layout while enforcing dry-run/no-motion safety flags.
- Added `scripts/validate_perception_bridge_preview.py` to validate required preview fields, status values, and strict safety flags (`dry_run`, `preview_only`, `no_robot_motion`, `no_runtime_execution`, etc.).
- Integrated preview generation into `scripts/generate_workcell_studio_readiness_pack.py`, publishing preview artifacts and a new manifest `perception_bridge` section containing payload/report paths, status, warnings, blockers, and preview safety flags.
- Extended `scripts/run_golden_builder_readiness_demo.py` to include a `perception_bridge` section in the demo summary and added a “Perception → Task Bridge Preview” panel and artifact links to `scripts/generate_readiness_pack_dashboard.py`.
- Added tests (`tests/test_perception_bridge_preview.py`) and updated existing readiness/golden-demo tests to assert artifact creation, validation, dashboard presence, routing/grasp/place fields, and preservation of no-motion/no-runtime safety defaults.
- Updated `docs/manuals/EMD_GRASP_BRIDGE_PAYLOAD.md` with offline replay→bridge preview usage and explicit non-execution safety guarantees.

### Testing

- Ran the focused pytest selection: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_perception_profile.py tests/test_golden_demo_perception_readiness.py tests/test_golden_builder_readiness_demo.py tests/test_workcell_studio_readiness_pack.py tests/test_perception_bridge_preview.py` and all tests passed (`11 passed`).
- Unit tests verify preview artifact creation, `validate_perception_bridge_preview.py` acceptance, manifest/dashboard integration, routing/grasp/place fields presence, and that safety flags remain set to prevent robot motion or runtime execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8ff024b8833199adf0465548aae1)