### PR TITLE
Add guarded bridge-payload → RViz/MoveIt plan-preview handoff

### DIFF
--- a/docs/manuals/EMD_GRASP_BRIDGE_PAYLOAD.md
+++ b/docs/manuals/EMD_GRASP_BRIDGE_PAYLOAD.md
@@ -107,3 +107,30 @@ This artifact is **preview-only** and explicitly sets: dry-run, no robot motion,
   - keep `fallback_to_legacy_release:=true` to safely recover when destination pose is missing, malformed, wrong-frame, or unreachable.
 - synthesized grasp poses are conservative first-pass placeholders.
 - this bridge is not full production sequencing or a safety certification layer.
+
+## Bridge payload → RViz/MoveIt plan-preview handoff (guarded offline)
+
+The golden readiness flow now emits `generated/bridge_payload_plan_preview_handoff.json`.
+
+What it means:
+- it links the offline `generated/emd_bridge_payload_preview.json` artifact to the existing fake-hardware RViz/MoveIt preview metadata,
+- it may provide a **manual-only** preview command when launch metadata exists,
+- it preserves strict safety flags (`fake_hardware_default=true`, `real_hardware_enabled=false`, `motion_command_sent=false`, `runtime_execution_called=false`, `moveit_plan_service_called=false`).
+
+Manual preview command usage (example shape, generated per-scene):
+
+```bash
+ros2 launch <scene_pkg> demo.launch.py use_fake_hardware:=true launch_rviz:=true \
+  explicit_release_pose_source:=bridge_payload \
+  explicit_release_pose_bridge_payload_path:=<scene>/generated/emd_bridge_payload_preview.json
+```
+
+What this proves:
+- the bridge payload preview is structured well enough to hand into plan-preview metadata,
+- fake-hardware-first preview command generation is available where launch metadata is known.
+
+What this does **not** prove:
+- no runtime execution path was called,
+- no robot motion was executed,
+- no MoveIt planning service call was executed,
+- it is **not** certification of real-hardware readiness.

--- a/scripts/generate_bridge_payload_plan_preview_handoff.py
+++ b/scripts/generate_bridge_payload_plan_preview_handoff.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+from typing import Any
+
+
+def _load(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--bridge-payload', type=Path, required=True)
+    ap.add_argument('--rviz-session', type=Path)
+    ap.add_argument('--scene-package')
+    ap.add_argument('--output', type=Path, required=True)
+    ap.add_argument('--json', action='store_true')
+    a = ap.parse_args()
+
+    bridge = _load(a.bridge_payload)
+    rviz = _load(a.rviz_session) if a.rviz_session else {}
+    blockers: list[str] = []
+    warnings: list[str] = []
+
+    bridge_status = bridge.get('status')
+    if bridge_status not in ('bridge_preview_ready', 'bridge_preview_partial'):
+        blockers.append('Bridge payload preview is not ready for handoff')
+
+    bridge_safe = all([
+        bridge.get('preview_only') is True,
+        bridge.get('dry_run') is True,
+        bridge.get('no_robot_motion') is True,
+        bridge.get('no_runtime_execution') is True,
+        bridge.get('real_hardware_enabled') is False,
+        bridge.get('runtime_execution_called') is False,
+        bridge.get('motion_command_sent') is False,
+        bridge.get('moveit_plan_service_called') is False,
+    ])
+    if not bridge_safe:
+        blockers.append('Bridge payload safety flags are not preview-only/no-motion')
+
+    cmd = None
+    bridge_arg_supported = False
+    session_cmd = ((((rviz.get('rviz_moveit') or {}).get('suggested_launch')) or {}).get('command') if isinstance(rviz, dict) else None)
+    if isinstance(session_cmd, str) and session_cmd.strip():
+        cmd = session_cmd.strip() + (
+            f" explicit_release_pose_source:=bridge_payload explicit_release_pose_bridge_payload_path:={a.bridge_payload}"
+        )
+        bridge_arg_supported = True
+    else:
+        warnings.append('RViz/MoveIt launch metadata missing; command not generated')
+
+    status = 'plan_preview_ready'
+    if blockers:
+        status = 'plan_preview_blocked'
+    elif warnings:
+        status = 'plan_preview_partial'
+
+    out = {
+        'schema': 'bridge_payload_plan_preview_handoff/v1',
+        'status': status,
+        'source_bridge_payload_path': str(a.bridge_payload),
+        'scene_package': a.scene_package,
+        'rviz_moveit_plan_preview_session_path': str(a.rviz_session) if a.rviz_session else None,
+        'bridge_payload_launch_argument_supported': bridge_arg_supported,
+        'preview_command': cmd,
+        'preview_flags': {
+            'use_fake_hardware': True,
+            'launch_rviz': True,
+            'preview_only': True,
+            'no_robot_motion': True,
+            'no_runtime_execution': True,
+        },
+        'safety_flags': {
+            'fake_hardware_default': True,
+            'real_hardware_enabled': False,
+            'motion_command_sent': False,
+            'runtime_execution_called': False,
+            'moveit_plan_service_called': False,
+        },
+        'selected_object': bridge.get('selected_object', {}),
+        'task_bridge': bridge.get('task_bridge', {}),
+        'warnings': warnings,
+        'blockers': blockers,
+    }
+    a.output.parent.mkdir(parents=True, exist_ok=True)
+    a.output.write_text(json.dumps(out, indent=2) + '\n', encoding='utf-8')
+    if a.json:
+        print(json.dumps({'status': status, 'output': str(a.output), 'command': cmd, 'warnings': warnings, 'blockers': blockers}, indent=2))
+    return 1 if status == 'plan_preview_blocked' else 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/generate_readiness_pack_dashboard.py
+++ b/scripts/generate_readiness_pack_dashboard.py
@@ -92,6 +92,7 @@ def main() -> int:
     src = m.get('source', {}) if isinstance(m.get('source'), dict) else {}
     perception = m.get('perception', {}) if isinstance(m.get('perception'), dict) else {}
     perception_bridge = m.get('perception_bridge', {}) if isinstance(m.get('perception_bridge'), dict) else {}
+    plan_preview_handoff = m.get('plan_preview_handoff', {}) if isinstance(m.get('plan_preview_handoff'), dict) else {}
     bridge_payload = _load_structured(Path(arts.get('emd_bridge_payload_preview', ''))) if arts.get('emd_bridge_payload_preview') else {}
     bridge_object = bridge_payload.get('selected_object', {}) if isinstance(bridge_payload.get('selected_object'), dict) else {}
     bridge_task = bridge_payload.get('task_bridge', {}) if isinstance(bridge_payload.get('task_bridge'), dict) else {}
@@ -125,6 +126,7 @@ def main() -> int:
         ('planning scene readiness report', arts.get('planning_scene_readiness_report', '')),
         ('emd bridge payload preview', arts.get('emd_bridge_payload_preview', '')),
         ('perception bridge preview report', arts.get('perception_bridge_preview_report', '')),
+        ('bridge payload plan preview handoff', arts.get('bridge_payload_plan_preview_handoff', '')),
     ]
 
     preview_block = ''
@@ -164,6 +166,15 @@ def main() -> int:
 <li>Place target: {_safe(bridge_task.get('place_target', 'missing'))}</li>
 <li>Bridge preview status: <b>{_safe(perception_bridge.get('status', 'bridge_preview_missing'))}</b></li>
 <li>Safety: no robot motion / no runtime execution: <b>Yes</b></li>
+</ul></div>
+
+<div class='panel'><h3>Bridge Payload → RViz/MoveIt Plan Preview</h3><ul>
+<li>Bridge payload available: <b>{_safe('Yes' if arts.get('emd_bridge_payload_preview') else 'No')}</b></li>
+<li>Handoff status: <b>{_safe(plan_preview_handoff.get('status', 'plan_preview_blocked'))}</b></li>
+<li>Manual preview command: <pre>{_safe(plan_preview_handoff.get('command', 'blocked or metadata missing'))}</pre></li>
+<li>Blockers: {_safe(', '.join(plan_preview_handoff.get('blockers', [])) or 'none')}</li>
+<li>Warnings: {_safe(', '.join(plan_preview_handoff.get('warnings', [])) or 'none')}</li>
+<li><b>This does not execute robot motion.</b></li>
 </ul></div>
 <div class='panel'><h3>Task flow: pick → grasp → place → release</h3><ul>
 <li>pick source: {_safe(tf.get('pick_source_id','missing'))}</li><li>grasp strategy: {_safe(tf.get('grasp_strategy','missing'))}</li><li>approach/retreat: {_safe(tf.get('approach_axis', tf.get('approach','missing')))}{_safe((' '+str(tf.get('approach_distance_m'))+'m') if tf.get('approach_distance_m') is not None else '')} / {_safe(tf.get('retreat_axis', tf.get('retreat','missing')))}{_safe((' '+str(tf.get('retreat_distance_m'))+'m') if tf.get('retreat_distance_m') is not None else '')}</li><li>place target: {_safe(tf.get('place_target_id','missing'))}</li><li>release strategy: {_safe(tf.get('release_strategy','missing'))}</li><li>routing rules: {_safe(tf.get('routing_rule_count', tf.get('routing_rules','missing')))}</li>

--- a/scripts/generate_workcell_studio_readiness_pack.py
+++ b/scripts/generate_workcell_studio_readiness_pack.py
@@ -180,6 +180,22 @@ def main()->int:
         rc,rv=step('rviz_session',[sys.executable,str(SCRIPT_DIR/'generate_rviz_moveit_plan_preview_session.py'),'--scene-package',str(scene),'--plan-preview-request',str(req),'--output-dir',str(paths['plan']),'--allow-missing-launch','--json'])
         art['rviz_moveit_plan_preview_session']=str(session); results['rviz_preview_session_status']='PASS' if rc==0 else 'WARN'
     else: results['rviz_preview_session_status']='WARN'
+
+    handoff_path = scene / 'generated' / 'bridge_payload_plan_preview_handoff.json'
+    if bridge_payload.exists():
+        rc, handoff = step('bridge_plan_preview_handoff', [
+            sys.executable, str(SCRIPT_DIR / 'generate_bridge_payload_plan_preview_handoff.py'),
+            '--bridge-payload', str(bridge_payload),
+            '--rviz-session', str(session),
+            '--scene-package', str(scene),
+            '--output', str(handoff_path),
+            '--json',
+        ])
+        art['bridge_payload_plan_preview_handoff'] = str(handoff_path)
+        results['bridge_payload_plan_preview_handoff_status'] = 'PASS' if rc == 0 else 'WARN'
+    else:
+        results['bridge_payload_plan_preview_handoff_status'] = 'WARN'
+
     if a.smoke_execute: safety['smoke_execute_used']=True
     if a.smoke_dry_run or a.smoke_execute:
         cmd=[sys.executable,str(SCRIPT_DIR/'run_fake_hardware_smoke_launch.py'),'--session',str(session),'--output-dir',str(paths['smoke']),'--timeout-s',str(a.smoke_timeout_s),'--json', '--execute' if a.smoke_execute else '--dry-run']
@@ -207,7 +223,24 @@ def main()->int:
         'blockers': (perception_bridge_report.get('blockers') if isinstance(perception_bridge_report, dict) else []),
         'safety_flags': {'real_hardware_enabled': False, 'motion_command_sent': False, 'runtime_execution_called': False, 'moveit_plan_service_called': False, 'preview_only': True},
     }
-    manifest={'schema':'workcell_studio_readiness_pack/v1','source':{'scene_package':str(scene),'project_name':a.project_name,'created_at':datetime.now(timezone.utc).isoformat()},'artifacts':art,'results':results,'safety':safety,'summary':summary,'perception':perception_section,'perception_bridge':perception_bridge_section}
+
+    handoff_report = _read_json(handoff_path) if handoff_path.exists() else {}
+    plan_preview_handoff_section = {
+        'handoff_path': str(handoff_path),
+        'status': handoff_report.get('status', 'plan_preview_blocked'),
+        'command': handoff_report.get('preview_command'),
+        'warnings': handoff_report.get('warnings', []),
+        'blockers': handoff_report.get('blockers', []),
+        'safety_flags': handoff_report.get('safety_flags', {
+            'fake_hardware_default': True,
+            'real_hardware_enabled': False,
+            'motion_command_sent': False,
+            'runtime_execution_called': False,
+            'moveit_plan_service_called': False,
+        }),
+    }
+
+    manifest={'schema':'workcell_studio_readiness_pack/v1','source':{'scene_package':str(scene),'project_name':a.project_name,'created_at':datetime.now(timezone.utc).isoformat()},'artifacts':art,'results':results,'safety':safety,'summary':summary,'perception':perception_section,'perception_bridge':perception_bridge_section,'plan_preview_handoff':plan_preview_handoff_section}
     (out/'logs'/'command_outputs.json').write_text(json.dumps(logs,indent=2)+"\n",encoding='utf-8')
     (out/'readiness_pack_manifest.json').write_text(json.dumps(manifest,indent=2)+"\n",encoding='utf-8')
 

--- a/scripts/run_golden_builder_readiness_demo.py
+++ b/scripts/run_golden_builder_readiness_demo.py
@@ -138,6 +138,14 @@ def main() -> int:
             "blockers": (manifest_json.get("perception_bridge", {}) if isinstance(manifest_json.get("perception_bridge", {}), dict) else {}).get("blockers", []),
             "safety_flags": (manifest_json.get("perception_bridge", {}) if isinstance(manifest_json.get("perception_bridge", {}), dict) else {}).get("safety_flags", {}),
         },
+        "plan_preview_handoff": {
+            "bridge_payload_plan_preview_handoff": artifacts.get("bridge_payload_plan_preview_handoff"),
+            "status": (manifest_json.get("plan_preview_handoff", {}) if isinstance(manifest_json.get("plan_preview_handoff", {}), dict) else {}).get("status", "plan_preview_blocked"),
+            "command": (manifest_json.get("plan_preview_handoff", {}) if isinstance(manifest_json.get("plan_preview_handoff", {}), dict) else {}).get("command"),
+            "warnings": (manifest_json.get("plan_preview_handoff", {}) if isinstance(manifest_json.get("plan_preview_handoff", {}), dict) else {}).get("warnings", []),
+            "blockers": (manifest_json.get("plan_preview_handoff", {}) if isinstance(manifest_json.get("plan_preview_handoff", {}), dict) else {}).get("blockers", []),
+            "safety_flags": (manifest_json.get("plan_preview_handoff", {}) if isinstance(manifest_json.get("plan_preview_handoff", {}), dict) else {}).get("safety_flags", {}),
+        },
         "safety": {
             "use_fake_hardware": True,
             "real_hardware_enabled": False,

--- a/scripts/validate_bridge_payload_plan_preview_handoff.py
+++ b/scripts/validate_bridge_payload_plan_preview_handoff.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('handoff', type=Path)
+    ap.add_argument('--json', action='store_true')
+    a = ap.parse_args()
+    data = json.loads(a.handoff.read_text(encoding='utf-8')) if a.handoff.exists() else {}
+    errors = []
+    warnings = []
+
+    if data.get('schema') != 'bridge_payload_plan_preview_handoff/v1':
+        errors.append('invalid schema')
+    status = data.get('status')
+    if status not in ('plan_preview_ready', 'plan_preview_partial', 'plan_preview_blocked'):
+        errors.append('invalid status')
+
+    src = Path(data.get('source_bridge_payload_path', '')) if data.get('source_bridge_payload_path') else None
+    if not src or not src.exists():
+        errors.append('referenced bridge payload does not exist')
+
+    sf = data.get('safety_flags', {}) if isinstance(data.get('safety_flags'), dict) else {}
+    for key in ('real_hardware_enabled', 'motion_command_sent', 'runtime_execution_called', 'moveit_plan_service_called'):
+        if sf.get(key) is not False:
+            errors.append(f'safety_flags.{key} must be false')
+    if sf.get('fake_hardware_default') is not True:
+        errors.append('safety_flags.fake_hardware_default must be true')
+
+    pf = data.get('preview_flags', {}) if isinstance(data.get('preview_flags'), dict) else {}
+    for key in ('preview_only', 'no_robot_motion', 'no_runtime_execution', 'use_fake_hardware', 'launch_rviz'):
+        if pf.get(key) is not True:
+            errors.append(f'preview_flags.{key} must be true')
+
+    cmd = data.get('preview_command')
+    if cmd:
+        if 'use_fake_hardware:=true' not in cmd:
+            errors.append('preview command must include use_fake_hardware:=true')
+        for forbidden in ('use_fake_hardware:=false', 'real_hardware:=true', '--execute'):
+            if forbidden in cmd:
+                errors.append(f'preview command must not contain {forbidden}')
+    elif status == 'plan_preview_ready':
+        warnings.append('ready status without preview command')
+
+    out = {'status': 'FAIL' if errors else ('WARN' if warnings else 'PASS'), 'errors': errors, 'warnings': warnings}
+    if a.json:
+        print(json.dumps(out, indent=2))
+    return 1 if errors else 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_bridge_payload_plan_preview_handoff.py
+++ b/tests/test_bridge_payload_plan_preview_handoff.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+import json, subprocess, sys
+from pathlib import Path
+
+
+def test_generate_and_validate_handoff(tmp_path: Path) -> None:
+    scene = Path('scenes/ur5_2f_test').resolve()
+    bridge = scene / 'generated' / 'emd_bridge_payload_preview.json'
+    report = scene / 'generated' / 'perception_bridge_preview_report.json'
+    task = scene / 'generated' / 'workcell_builder_task_intent.yaml'
+
+    subprocess.run([sys.executable, 'scripts/generate_perception_bridge_preview.py', '--perception-profile', str(scene / 'generated' / 'perception_profile.yaml'), '--detected-objects', 'tests/fixtures/perception/detected_objects_snapshot_golden.yaml', '--task-intent', str(task), '--environment-layout', str(scene / 'generated' / 'environment_layout.yaml'), '--output-payload', str(bridge), '--output-report', str(report), '--json'], check=False)
+
+    rviz = tmp_path / 'rviz_moveit_plan_preview_session.json'
+    rviz.write_text(json.dumps({'rviz_moveit': {'suggested_launch': {'command': 'ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true'}}}), encoding='utf-8')
+    handoff = tmp_path / 'bridge_payload_plan_preview_handoff.json'
+    gen = subprocess.run([sys.executable, 'scripts/generate_bridge_payload_plan_preview_handoff.py', '--bridge-payload', str(bridge), '--rviz-session', str(rviz), '--scene-package', str(scene), '--output', str(handoff), '--json'], capture_output=True, text=True, check=False)
+    assert gen.returncode in (0, 1)
+    assert handoff.exists()
+    payload = json.loads(handoff.read_text(encoding='utf-8'))
+    assert payload['source_bridge_payload_path'].endswith('generated/emd_bridge_payload_preview.json')
+    assert payload['safety_flags']['real_hardware_enabled'] is False
+    assert payload['safety_flags']['motion_command_sent'] is False
+    assert payload['safety_flags']['runtime_execution_called'] is False
+    assert payload['safety_flags']['moveit_plan_service_called'] is False
+
+    val = subprocess.run([sys.executable, 'scripts/validate_bridge_payload_plan_preview_handoff.py', str(handoff), '--json'], capture_output=True, text=True, check=False)
+    assert val.returncode == 0

--- a/tests/test_golden_builder_readiness_demo.py
+++ b/tests/test_golden_builder_readiness_demo.py
@@ -88,3 +88,7 @@ def test_golden_builder_readiness_demo_end_to_end(tmp_path: Path) -> None:
     assert bridge.get("status") in ("bridge_preview_ready", "bridge_preview_partial", "bridge_preview_blocked")
     assert Path(bridge.get("emd_bridge_payload_preview")).exists()
     assert Path(bridge.get("perception_bridge_preview_report")).exists()
+
+    handoff = summary.get("plan_preview_handoff", {})
+    assert handoff.get("status") in ("plan_preview_ready", "plan_preview_partial", "plan_preview_blocked")
+    assert Path(handoff.get("bridge_payload_plan_preview_handoff")).exists()

--- a/tests/test_workcell_studio_readiness_pack.py
+++ b/tests/test_workcell_studio_readiness_pack.py
@@ -15,6 +15,7 @@ def test_generate_and_validate_readiness_pack(tmp_path: Path):
     assert payload["safety"]["motion_command_sent"] is False
     assert "perception_bridge" in payload
     assert payload["perception_bridge"]["status"] in ("bridge_preview_ready", "bridge_preview_partial", "bridge_preview_blocked")
+    assert payload["plan_preview_handoff"]["status"] in ("plan_preview_ready", "plan_preview_partial", "plan_preview_blocked")
     if "emd_bridge_payload_preview" in payload["artifacts"]:
         assert Path(payload["artifacts"]["emd_bridge_payload_preview"]).exists()
     vrun = subprocess.run([sys.executable, "scripts/workcell_studio.py", "validate-readiness-pack", "--manifest", str(manifest), "--json"], capture_output=True, text=True, check=False)
@@ -128,3 +129,4 @@ def test_pack_visual_markers_and_safety_banner(tmp_path: Path):
     assert preview_summary.get("safety_banner_present") is True
     dashboard = (out / "readiness_dashboard.html").read_text(encoding="utf-8")
     assert "Perception → Task Bridge Preview" in dashboard
+    assert "Bridge Payload → RViz/MoveIt Plan Preview" in dashboard


### PR DESCRIPTION
### Motivation
- Provide a guarded offline handoff from the golden demo’s EMD bridge payload preview into the existing RViz/MoveIt fake-hardware plan-preview workflow while preserving strict no-motion/no-runtime safety defaults. 
- Surface a manual, fake-hardware-only preview command where launch metadata is available so users can run visual plan previews without executing motion or enabling real hardware. 
- Persist handoff metadata in the readiness pack and dashboard so the golden demo can demonstrate a safe progression from perception replay toward a MoveIt/RViz preview. 

### Description
- Add `scripts/generate_bridge_payload_plan_preview_handoff.py` to emit `bridge_payload_plan_preview_handoff/v1` metadata containing schema/version, source bridge payload path, scene package, preview command (when derivable), preview/safety flags, selected object/task_bridge, and blockers/warnings. 
- Add `scripts/validate_bridge_payload_plan_preview_handoff.py` to enforce preview-only/no-motion safety flags, require the referenced bridge payload exists, and validate that any generated preview command contains fake-hardware-only markers and no forbidden execution tokens. 
- Extend readiness-pack generation (`scripts/generate_workcell_studio_readiness_pack.py`) and golden demo summary (`scripts/run_golden_builder_readiness_demo.py`) to generate and include `generated/bridge_payload_plan_preview_handoff.json` and a `plan_preview_handoff` section in manifests and summaries. 
- Extend dashboard generation (`scripts/generate_readiness_pack_dashboard.py`) with an artifact row and a new panel titled “Bridge Payload → RViz/MoveIt Plan Preview” showing handoff availability, status, the manual preview command (if available), blockers/warnings, and an explicit "This does not execute robot motion." warning. 
- Add tests `tests/test_bridge_payload_plan_preview_handoff.py` and update existing tests to assert new manifest/summary/dashboard sections and preserve safety flags such as `fake_hardware_default=true`, `real_hardware_enabled=false`, `motion_command_sent=false`, `runtime_execution_called=false`, and `moveit_plan_service_called=false`. 
- Update docs (`docs/manuals/EMD_GRASP_BRIDGE_PAYLOAD.md`) with a new section explaining the handoff artifact, example manual preview command shape, and explicit non-certification / no-motion warnings. 

### Testing
- Ran the repository test suite for the modified areas with: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_perception_bridge_preview.py tests/test_golden_builder_readiness_demo.py tests/test_workcell_studio_readiness_pack.py tests/test_generated_cell_acceptance.py tests/test_bridge_payload_plan_preview_handoff.py` and all tests passed (`15 passed`). 
- Also ran a focused suite: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_golden_builder_readiness_demo.py tests/test_workcell_studio_readiness_pack.py tests/test_bridge_payload_plan_preview_handoff.py` which passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc91e3d2dc833187d08c03fc9d1434)