### PR TITLE
Use builder-authored pick/place geometry in golden readiness demo

### DIFF
--- a/docs/manuals/BUILDER_TASK_INTENT_V1.md
+++ b/docs/manuals/BUILDER_TASK_INTENT_V1.md
@@ -37,3 +37,13 @@ safety:
 
 ## Task Flow Summary
 Builder task intent validation and preview now expose readiness classifications and missing fields.
+
+
+## Readiness levels
+
+- **Visual scene ready**: robot/support assets and metadata load; no runtime calls.
+- **Task-planning ready**: pick/place IDs resolve to authored layout coordinates and routing rules resolve.
+- **Grasp-flow preview ready**: offline preview artifacts (task flow, bridge payload previews, RViz prep) are generated in fake-hardware mode.
+- **Real hardware ready**: separate commissioning stage, outside this metadata-only workflow.
+
+> `run_grasp_execution` remains a manual next step only when supported by the target cell/runtime.

--- a/docs/manuals/ENVIRONMENT_LAYOUT_V1.md
+++ b/docs/manuals/ENVIRONMENT_LAYOUT_V1.md
@@ -82,3 +82,15 @@ No runtime ROS launch behavior, MoveIt planning behavior, grasp execution behavi
 ## Builder scene exports for Workcell Studio
 
 `workcell_builder` remains the primary visual workflow. Generated scenes can now export portable Workcell Studio source files using `scripts/export_builder_scene_to_cell_definition.py`. The export writes `generated/cell_definition.yaml`, `generated/environment_layout.yaml`, and `generated/builder_export_summary.json`. These files are for offline commissioning and backend tooling, and are not proof of reachability or runtime safety. Keep fake-hardware-first defaults and runtime send disabled unless separately commissioned.
+
+
+## Authoring pick/place geometry for builder exports
+
+To make Workcell Studio previews resolve exact coordinates (no fallback), author these entities with stable IDs:
+
+- `zones[]`: pick zones (`id`, `label`, `frame`, `pose.xyz`, `pose.rpy`, `dimensions`)
+- `targets[]`: place targets/bins (`id`, `label`, `frame`, `pose.xyz`, `pose.rpy`, `dimensions`)
+- `objects[]`: objects (`id`, `class`/`label`/`color`, `frame`, `pose`, `dimensions` or mesh reference)
+- optional `camera` pose for preview/readiness reporting
+
+Builder task intent and routing should reference these IDs directly (for example `pick_zone_main` and `bin_red`).

--- a/scenes/ur5_2f_test/environment_layout.yaml
+++ b/scenes/ur5_2f_test/environment_layout.yaml
@@ -1,0 +1,46 @@
+schema_version: environment_layout/v1
+layout_id: ur5_2f_test_layout
+name: UR5 2F Builder Authored Layout
+frame: world
+zones:
+  - id: pick_zone_main
+    type: pick_zone
+    label: Main Pick Zone
+    frame: world
+    pose:
+      xyz: [0.45, 0.0, 0.09]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.30, 0.20, 0.08]
+targets:
+  - id: bin_red
+    type: place_target
+    label: Red Bin
+    frame: world
+    pose:
+      xyz: [0.35, 0.35, 0.10]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.22, 0.22, 0.14]
+objects:
+  - id: red_box_001
+    class: box
+    label: Red Box
+    color: red
+    frame: world
+    pose:
+      xyz: [0.45, 0.0, 0.12]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.05, 0.05, 0.05]
+  - id: table_surface
+    class: support_surface
+    label: Table Support Surface
+    frame: world
+    pose:
+      xyz: [0.4, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [1.0, 0.8, 0.04]
+camera:
+  id: builder_camera_main
+  frame: world
+  pose:
+    xyz: [0.80, -0.15, 0.95]
+    rpy: [0.0, 0.45, 1.57]

--- a/scenes/ur5_2f_test/workcell_builder_task_intent.yaml
+++ b/scenes/ur5_2f_test/workcell_builder_task_intent.yaml
@@ -1,0 +1,38 @@
+schema: workcell_builder_task_intent/v1
+scene_package: scenes/ur5_2f_test
+task:
+  id: sorting_task_001
+  type: pick_place
+  mode: offline_preview
+pick:
+  source:
+    type: zone
+    id: pick_zone_main
+  object_filter:
+    class_id: box
+    color: red
+grasp:
+  strategy_ref: finger_pinch_basic
+  approach_axis: z_down
+  approach_distance_m: 0.12
+  retreat_axis: z_up
+  retreat_distance_m: 0.10
+place:
+  target:
+    type: destination
+    id: bin_red
+  release_strategy: tool_release
+  retreat_axis: z_up
+  retreat_distance_m: 0.10
+routing:
+  rules:
+    - id: route_red_box_to_bin_red
+      when:
+        object_class: box
+        object_color: red
+      destination: bin_red
+safety:
+  metadata_only: true
+  runtime_io_applied: false
+  motion_started: false
+  ros_launch_started: false

--- a/scripts/export_builder_scene_to_cell_definition.py
+++ b/scripts/export_builder_scene_to_cell_definition.py
@@ -241,6 +241,10 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
         environment_layout["zones"] = authored_layout["zones"]
     if isinstance(authored_layout.get("targets"), list):
         environment_layout["targets"] = authored_layout["targets"]
+    if isinstance(authored_layout.get("objects"), list):
+        environment_layout["objects"] = authored_layout["objects"]
+    if isinstance(authored_layout.get("camera"), dict):
+        environment_layout["camera"] = authored_layout["camera"]
 
     cell_def = {
         "schema_version": "cell_definition/v1",

--- a/scripts/validate_builder_generated_scene.py
+++ b/scripts/validate_builder_generated_scene.py
@@ -83,6 +83,7 @@ def validate_scene(scene_path: Path) -> dict[str, Any]:
         warnings.append("generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh")
 
     task_intent_report = {}
+    task_flow_summary: dict[str, Any] = {}
     task_intent_check = {"check": "generated/workcell_builder_task_intent.yaml present", "ok": False, "optional": True}
     task_intent_path = _find_task_intent(scene_path)
     if task_intent_path:
@@ -107,6 +108,14 @@ def validate_scene(scene_path: Path) -> dict[str, Any]:
                 errors.extend(task_intent_report.get("errors", []))
         elif task_intent_report.get("status") == "WARN":
             warnings.extend(task_intent_report.get("warnings", []))
+        flow_cmd = ["python3", str(SCRIPT_DIR / "summarize_task_flow.py"), "--task-intent", str(task_intent_path), "--environment-layout", str(exported_layout if exported_layout.is_file() else (scene_path / "environment_layout.yaml")), "--json"]
+        flow_run = subprocess.run(flow_cmd, capture_output=True, text=True, check=False)
+        task_flow_summary = json.loads(flow_run.stdout) if flow_run.stdout.strip() else {}
+        vr = task_flow_summary.get("visual_resolution", {}) if isinstance(task_flow_summary, dict) else {}
+        if not vr.get("pick_coordinates_resolved", False):
+            warnings.append("pick coordinates could not be resolved from scene/layout metadata")
+        if not vr.get("place_coordinates_resolved", False):
+            warnings.append("place coordinates could not be resolved from scene/layout metadata")
     else:
         warnings.append("Task intent missing: physical scene only.")
     checks.append(task_intent_check)
@@ -150,6 +159,7 @@ def validate_scene(scene_path: Path) -> dict[str, Any]:
         "errors": errors,
         "export_validation": export_validation,
         "task_intent": task_intent_report,
+        "task_flow_summary": task_flow_summary,
         "discovered": {
             "robot_name": robot.get("name"),
             "end_effector_name": ee.get("name"),

--- a/scripts/validate_builder_task_intent.py
+++ b/scripts/validate_builder_task_intent.py
@@ -30,6 +30,21 @@ def _exists_in_scene(scene: Path, token: str)->bool:
             return True
     return False
 
+def _load_scene_layout_ids(scene: Path) -> set[str]:
+    ids: set[str] = set()
+    for rel in ["generated/environment_layout.yaml", "environment_layout.yaml", "workcell_builder_metadata.yaml"]:
+        p = scene / rel
+        if not p.is_file():
+            continue
+        payload = _load(p)
+        for key in ("zones", "targets", "objects", "assets"):
+            items = payload.get(key)
+            if isinstance(items, list):
+                for item in items:
+                    if isinstance(item, dict) and item.get("id"):
+                        ids.add(str(item.get("id")))
+    return ids
+
 def validate(path: Path, scene_package: Path|None=None, grasp_dir: Path|None=None)->dict[str,Any]:
     errors=[]; warnings=[]
     payload=_load(path)
@@ -67,8 +82,19 @@ def validate(path: Path, scene_package: Path|None=None, grasp_dir: Path|None=Non
     if scene_package:
         if not (scene_package/'package.xml').is_file(): errors.append('scene package missing package.xml')
         if not (scene_package/'environment.yaml').is_file(): warnings.append('scene package missing environment.yaml')
-        if pick.get('id') and not _exists_in_scene(scene_package,str(pick['id'])): warnings.append(f"pick.source.id '{pick['id']}' could not be verified in scene metadata")
-        if place.get('id') and not _exists_in_scene(scene_package,str(place['id'])): warnings.append(f"place.target.id '{place['id']}' could not be verified in scene metadata")
+        scene_ids = _load_scene_layout_ids(scene_package)
+        if pick.get('id') and str(pick['id']) not in scene_ids and not _exists_in_scene(scene_package,str(pick['id'])):
+            warnings.append(f"pick.source.id '{pick['id']}' could not be verified in scene metadata")
+        if place.get('id') and str(place['id']) not in scene_ids and not _exists_in_scene(scene_package,str(place['id'])):
+            warnings.append(f"place.target.id '{place['id']}' could not be verified in scene metadata")
+        routing = payload.get('routing') if isinstance(payload.get('routing'), dict) else {}
+        rules = routing.get('rules') if isinstance(routing.get('rules'), list) else []
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            destination = rule.get('destination')
+            if isinstance(destination, str) and destination and destination not in scene_ids:
+                warnings.append(f"routing rule destination '{destination}' could not be verified in scene metadata")
     missing_required_fields=[]
     if not task.get('type'): missing_required_fields.append('task.type')
     if not pick.get('id'): missing_required_fields.append('pick.source.id')

--- a/tests/test_golden_builder_readiness_demo.py
+++ b/tests/test_golden_builder_readiness_demo.py
@@ -4,6 +4,8 @@ import json
 import shutil
 import subprocess
 import sys
+
+import yaml
 from pathlib import Path
 
 
@@ -36,9 +38,18 @@ def test_golden_builder_readiness_demo_end_to_end(tmp_path: Path) -> None:
     marker_names = {m.get("name") for m in marker_payload.get("markers", []) if isinstance(m, dict)}
     assert "pick_zone_source" in marker_names
     assert "place_zone_target" in marker_names
+    exported_layout = yaml.safe_load(Path(manifest["artifacts"]["environment_layout"]).read_text(encoding="utf-8"))
+    assert "pick_zone_main" in json.dumps(exported_layout)
+    assert "bin_red" in json.dumps(exported_layout)
+    assert "red_box_001" in json.dumps(exported_layout)
     assert any(str(name).startswith("task_flow") for name in marker_names)
 
     assert manifest["results"]["task_intent_status"] == "PASS"
+    ti = json.loads(Path(manifest["artifacts"]["task_flow_summary"]).read_text(encoding="utf-8"))
+    assert ti.get("pick_source_id") == "pick_zone_main"
+    assert ti.get("place_target_id") == "bin_red"
+    assert ti.get("visual_resolution", {}).get("approximate_coordinates_used") is False
+    assert "TODO" not in json.dumps(ti)
     assert manifest["results"].get("classification") != "physical_scene_only"
     assert manifest["safety"]["real_hardware_enabled"] is False
     assert manifest["safety"]["motion_command_sent"] is False


### PR DESCRIPTION
### Motivation

- The golden Workcell Studio demo used fallback/TODO metadata so RViz/static previews lacked real pick/place geometry and produced misleading readiness warnings. 
- Scene export and validation needed to accept and preserve authored pick/place/object/camera metadata so previews can resolve exact coordinates for pick/place and routing.

### Description

- Added authored golden scene metadata files `scenes/ur5_2f_test/environment_layout.yaml` and `scenes/ur5_2f_test/workcell_builder_task_intent.yaml` containing real `pick_zone_main`, `bin_red`, `red_box_001`, table/support surface, and a camera pose. 
- Export path updated in `scripts/export_builder_scene_to_cell_definition.py` to preserve authored `objects` and `camera` into the exported Workcell Studio `environment_layout` so static previews include those entities. 
- Task-intent validation (`scripts/validate_builder_task_intent.py`) now loads layout IDs from authored layout keys (`zones`, `targets`, `objects`, `assets`) and verifies `pick.source.id`, `place.target.id`, and routing `destination` IDs against that set (falling back to text search if needed). 
- Generated-scene validation (`scripts/validate_builder_generated_scene.py`) now invokes `summarize_task_flow.py` for coordinate resolution and emits explicit warnings when pick/place coordinates are not resolvable, and returns the task-flow summary in the scene report. 
- Tests updated to assert that the golden demo and readiness pack include real authored metadata, no TODO/fallback values, routing to `bin_red`, resolved pick/place coordinates, and preserved fake-hardware safety flags. 
- Documentation updated to describe how to author pick zones, place targets, objects and camera for builder exports and to clarify the different readiness levels (visual / task-planning / grasp-preview / real hardware).

### Testing

- Ran the focused test suite: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_golden_builder_readiness_demo.py tests/test_workcell_studio_readiness_pack.py tests/test_validate_builder_generated_scene.py tests/test_perception_bridge_preview.py`. 
- Result: all tests passed (13 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9c3bd17c8331855f06b29aea4cc7)