### PR TITLE
Promote workcell_builder into Workcell Studio command-centre (panel + pick/place/task improvements)

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Local scripts package for tests."""

--- a/scripts/create_or_update_builder_task_intent.py
+++ b/scripts/create_or_update_builder_task_intent.py
@@ -33,7 +33,7 @@ def _dump(path: Path, payload: dict[str, Any]) -> None:
         path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding='utf-8')
 
 def _default(scene_package: str) -> dict[str, Any]:
-    return {"schema":"workcell_builder_task_intent/v1","scene_package":scene_package,"task":{"id":"default_builder_task","type":"pick_place","mode":"offline_preview"},"pick":{"source":{"type":"zone","id":"pick_zone_main"},"object_filter":{"class_id":"any","color":"any"}},"grasp":{"strategy_ref":"finger_pinch_basic","approach_axis":"z_down","approach_distance_m":0.1,"retreat_axis":"z_up","retreat_distance_m":0.1},"place":{"target":{"type":"bin","id":"bin_main"},"release_strategy":"tool_release","retreat_axis":"z_up","retreat_distance_m":0.1},"routing":{"rules":[]},"safety":{"metadata_only":True,"runtime_io_applied":False,"motion_started":False,"ros_launch_started":False}}
+    return {"schema":"workcell_builder_task_intent/v1","scene_package":scene_package,"task":{"id":"default_builder_task","type":"pick_place","mode":"offline_preview"},"pick":{"source":{"type":"zone","id":"pick_zone_main"},"object_filter":{"class_id":"any","color":"any"}},"grasp":{"strategy_ref":"finger_pinch_basic","approach_axis":"z_down","approach_distance_m":0.1,"retreat_axis":"z_up","retreat_distance_m":0.1},"place":{"target":{"type":"bin","id":"bin_red"},"release_strategy":"tool_release","retreat_axis":"z_up","retreat_distance_m":0.1},"routing":{"rules":[]},"safety":{"metadata_only":True,"runtime_io_applied":False,"motion_started":False,"ros_launch_started":False}}
 
 def _seed(scene_package: Path, output: Path | None) -> tuple[dict[str, Any], Path | None]:
     cands = [output] if output else []
@@ -48,8 +48,8 @@ def main() -> int:
     ap.add_argument('--scene-package', required=True, type=Path)
     ap.add_argument('--task-id', required=True)
     ap.add_argument('--task-type', required=True)
-    ap.add_argument('--pick-source', required=True, help='Pick source id (e.g. pick_zone_main or epd_detected_object)')
-    ap.add_argument('--pick-source-type', choices=['perception','pick_zone','fixed_object','replay_object'], default='perception')
+    ap.add_argument('--pick-source', required=True, help='Pick source id (e.g. epd_detected_object or pick_zone_main)')
+    ap.add_argument('--pick-source-type', choices=['epd_detected_object','epd_replay','fixed_object','pick_zone','perception'], default='epd_detected_object')
     ap.add_argument('--place-target', required=True)
     ap.add_argument('--grasp-strategy', required=True)
     ap.add_argument('--approach-axis', default='z_down')
@@ -70,7 +70,8 @@ def main() -> int:
     out = a.output or (a.scene_package/'generated'/'workcell_builder_task_intent.yaml')
     payload['schema']='workcell_builder_task_intent/v1'; payload['scene_package']=a.scene_package.as_posix()
     payload.setdefault('task',{}).update({'id':a.task_id,'type':a.task_type})
-    payload.setdefault('pick',{}).setdefault('source',{}).update({'id':a.pick_source, 'type': a.pick_source_type})
+    source_type = {'epd_detected_object':'perception','epd_replay':'replay_object'}.get(a.pick_source_type, a.pick_source_type)
+    payload.setdefault('pick',{}).setdefault('source',{}).update({'id':a.pick_source, 'type': source_type})
     payload['pick'].setdefault('object_filter',{}).update({'class_id':a.object_class,'color':a.object_color})
     payload.setdefault('grasp',{}).update({'strategy_ref':a.grasp_strategy,'approach_axis':a.approach_axis,'approach_distance_m':a.approach_distance_m,'retreat_axis':a.retreat_axis,'retreat_distance_m':a.retreat_distance_m})
     
@@ -87,7 +88,7 @@ def main() -> int:
     val={'status':'SKIP'}
     if a.validate:
         val = validate_intent(out, a.scene_package)
-    summary={'result':'PASS','output_path':str(out),'validation':val,'pick_source':a.pick_source,'pick_source_type':a.pick_source_type,'place_target':a.place_target,'grasp_strategy':a.grasp_strategy,'release_strategy':a.release_strategy,'safety':payload['safety']}
+    summary={'result':'PASS','output_path':str(out),'validation':val,'pick_source':a.pick_source,'pick_source_type':source_type,'place_target':a.place_target,'grasp_strategy':a.grasp_strategy,'release_strategy':a.release_strategy,'safety':payload['safety']}
     print(json.dumps(summary, indent=2) if a.json else f'Wrote {out}')
     return 0 if (not a.validate or val.get('status')!='FAIL') else 1
 

--- a/scripts/workcell_builder_studio_panel.py
+++ b/scripts/workcell_builder_studio_panel.py
@@ -14,21 +14,46 @@ def _read_yaml_like(path: Path) -> dict[str, Any]:
         return {}
 
 
+def _find_intent(scene_package: Path) -> Path | None:
+    for rel in ("generated/workcell_builder_task_intent.yaml", "workcell_builder_task_intent.yaml"):
+        p = scene_package / rel
+        if p.is_file():
+            return p
+    return None
+
+
 def detect_scene_context(scene_package: Path) -> dict[str, str]:
     scene_package = Path(scene_package)
-    intent = _read_yaml_like(scene_package / "generated" / "workcell_builder_task_intent.yaml")
+    intent = _read_yaml_like(_find_intent(scene_package) or scene_package / "missing.yaml")
     env = _read_yaml_like(scene_package / "environment.yaml")
+    layout = _read_yaml_like(scene_package / "generated" / "environment_layout.yaml") or _read_yaml_like(scene_package / "environment_layout.yaml")
+
+    pick = intent.get("pick", {}) if isinstance(intent.get("pick"), dict) else {}
+    place = intent.get("place", {}) if isinstance(intent.get("place"), dict) else {}
+    grasp = intent.get("grasp", {}) if isinstance(intent.get("grasp"), dict) else {}
+    routing = intent.get("routing", {}) if isinstance(intent.get("routing"), dict) else {}
+    rules = routing.get("rules", []) if isinstance(routing.get("rules"), list) else []
+
+    zones = layout.get("zones", []) if isinstance(layout.get("zones"), list) else []
+    camera = next((a for a in (layout.get("assets") or []) if isinstance(a, dict) and a.get("type") == "camera"), {})
+    table = next((a for a in (layout.get("assets") or []) if isinstance(a, dict) and a.get("type") in {"table", "support_surface"}), {})
+
     return {
         "scene_package_path": str(scene_package),
         "scene_package_name": scene_package.name,
         "selected_robot": str((env.get("robot") or {}).get("name", "unknown")),
         "selected_end_effector": str((env.get("end_effector") or {}).get("name", "unknown")),
-        "selected_pick_source": str(intent.get("pick_source", "unknown")),
-        "selected_place_target": str(intent.get("place_target", "unknown")),
-        "selected_object": str(intent.get("object", "unknown")),
-        "selected_grasp_strategy": str(intent.get("grasp_strategy", "unknown")),
-        "selected_release_strategy": str(intent.get("release_strategy", "unknown")),
-        "selected_routing_target": str(intent.get("routing_target", "unknown")),
+        "selected_camera": str(camera.get("id", "unknown")),
+        "selected_table": str(table.get("id", "unknown")),
+        "selected_pick_source": str((pick.get("source") or {}).get("type", "unknown")),
+        "selected_pick_zone": str((pick.get("source") or {}).get("id", "unknown")),
+        "selected_place_target": str((place.get("target") or {}).get("id", "unknown")),
+        "selected_task_type": str((intent.get("task") or {}).get("type", "unknown")),
+        "selected_grasp_strategy": str(grasp.get("strategy_ref", "unknown")),
+        "selected_release_strategy": str(place.get("release_strategy", "unknown")),
+        "selected_routing_target": str((rules[0].get("place_target") if rules and isinstance(rules[0], dict) else "unknown")),
+        "pick_zone_count": str(sum(1 for z in zones if isinstance(z, dict) and z.get("type") == "pick_zone")),
+        "place_target_count": str(sum(1 for z in zones if isinstance(z, dict) and z.get("type") in {"bin", "place_target", "table_zone", "fixture", "conveyor_drop", "custom_pose"})),
     }
 
 
@@ -66,10 +91,6 @@ def build_grasp_flow_preview_command(scene_package_name: str, bridge_payload_pat
 def panel_state_from_validation(report: dict[str, Any], scene_package: Path) -> dict[str, Any]:
     warnings = list(report.get("warnings") or [])
     blockers = list(report.get("errors") or report.get("blockers") or [])
-    text = "\n".join(warnings + blockers)
-    for needle in ["place target", "pick source", "object", "TODO", "fallback", "missing"]:
-        if needle.lower() in text.lower():
-            pass
     return {
         **detect_scene_context(scene_package),
         "scene_validation_status": report.get("status", "UNKNOWN"),
@@ -77,6 +98,17 @@ def panel_state_from_validation(report: dict[str, Any], scene_package: Path) -> 
         "readiness_status": report.get("readiness", report.get("readiness_classification", "unknown")),
         "preview_status": "MANUAL_ONLY",
         "safety_status": "FAKE_HARDWARE_ONLY",
+        "workflow_steps": ["Build Cell", "Define Task", "Validate", "Export", "Preview", "Review Safety"],
+        "sections": ["Cell Setup", "Pick Source", "Place Target", "Grasp Strategy", "Validation", "Export", "Preview Commands", "Safety"],
+        "help_text": {
+            "pick_source": "Pick source: where the object comes from.",
+            "epd_detected": "Use EPD detected object when the camera/perception system supplies the object pose.",
+            "pick_zone": "Pick zone: area where detected objects are allowed to be picked.",
+            "place_target": "Place target: where the robot releases the object.",
+            "routing_rule": "Routing rule: decides which place target receives which object.",
+            "fake_hw": "Fake hardware preview does not move a real robot.",
+            "safety_notice": "Generated readiness reports are not safety certificates.",
+        },
         "warnings": warnings,
         "blockers": blockers,
         "safety_banner": [

--- a/tests/test_golden_builder_readiness_demo.py
+++ b/tests/test_golden_builder_readiness_demo.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 def test_golden_builder_readiness_demo_end_to_end(tmp_path: Path) -> None:
     scene = tmp_path / "scene"
-    shutil.copytree("scenes/ur5_2f_test", scene)
+    shutil.copytree("scenes/ur5_2f_builder_pick_place_demo", scene)
     out = tmp_path / "golden_pack"
     run = subprocess.run([
         sys.executable,


### PR DESCRIPTION
### Motivation
- Make `workcell_builder` the single Workcell Studio command centre for authoring, validating, previewing, and exporting pick/place workcells while keeping fake-hardware-first safety defaults. 
- Surface first-class place-target and pick-source editing and make EPD-detected objects a primary pick source for the authored workflow. 

### Description
- Extended the panel backend state model in `scripts/workcell_builder_studio_panel.py` to detect and expose authored scene state (robot, end effector, camera, table/support, pick source & zone, place target, task type, grasp/release strategy, routing target, zone counts), add workflow step names and UI sections, and embed short help text and a safety banner. 
- Updated `scripts/create_or_update_builder_task_intent.py` to accept EPD-facing pick-source options (`epd_detected_object`, `epd_replay`) and normalize them to validator-compatible types (`perception`, `replay_object`), default the template place target to `bin_red`, and write a consistent `generated/workcell_builder_task_intent.yaml`. 
- Added `scripts/__init__.py` to ensure local `scripts` package resolution in tests and avoid accidental import of external `/opt/ros/.../scripts`. 
- Updated the golden demo test to use the authored fixture `scenes/ur5_2f_builder_pick_place_demo` instead of the legacy scene to reflect clean authored pick/place expectations. 

### Testing
- Ran the focused builder/readiness test suite with `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_studio_integration.py tests/test_validate_builder_generated_scene.py tests/test_golden_builder_readiness_demo.py tests/test_workcell_studio_readiness_pack.py`. 
- All targeted automated tests passed: `17 passed` in the final run (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcaeef691c8331b40a5754dead8dff)