### PR TITLE
Add regression test to ensure readiness-pack exit codes are non-usage for SOTA builder scenes

### DIFF
--- a/tests/test_workcell_studio_readiness_pack.py
+++ b/tests/test_workcell_studio_readiness_pack.py
@@ -130,3 +130,23 @@ def test_pack_visual_markers_and_safety_banner(tmp_path: Path):
     dashboard = (out / "readiness_dashboard.html").read_text(encoding="utf-8")
     assert "Perception → Task Bridge Preview" in dashboard
     assert "Bridge Payload → RViz/MoveIt Plan Preview" in dashboard
+
+
+def test_generate_readiness_pack_non_usage_exit_codes(tmp_path: Path):
+    for scene in ("scenes/ur5_2f_builder_pick_place_demo", "scenes/ur5_2f_test"):
+        out = tmp_path / scene.split('/')[-1]
+        run = subprocess.run([
+            sys.executable,
+            "scripts/workcell_studio.py",
+            "generate-readiness-pack",
+            "--scene-package", scene,
+            "--output-dir", str(out),
+            "--project-name", "demo",
+            "--validate",
+            "--smoke-dry-run",
+            "--force",
+            "--json",
+        ], capture_output=True, text=True, check=False)
+        assert run.returncode in (0, 1)
+        assert run.returncode != 2
+


### PR DESCRIPTION
### Motivation
- Prevent non-usage/validation outcomes for readiness-pack generation from being misclassified as CLI usage errors (`exit code 2`) after making `workcell_builder` the primary SOTA Workcell Studio UI.

### Description
- Add a regression test to `tests/test_workcell_studio_readiness_pack.py` that runs `scripts/workcell_studio.py generate-readiness-pack` against both `scenes/ur5_2f_builder_pick_place_demo` and `scenes/ur5_2f_test` and asserts returned exit codes are `0` or `1` and never `2`.

### Testing
- Ran the focused suite with `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_studio_integration.py tests/test_validate_builder_generated_scene.py tests/test_golden_builder_readiness_demo.py tests/test_workcell_studio_readiness_pack.py` and all tests passed (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb1bbd350833189f5516403d13aaf)