### PR TITLE
Fix builder task intent label resolution and readiness-pack exit semantics

### DIFF
--- a/scripts/create_or_update_builder_task_intent.py
+++ b/scripts/create_or_update_builder_task_intent.py
@@ -32,6 +32,48 @@ def _dump(path: Path, payload: dict[str, Any]) -> None:
     else:
         path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding='utf-8')
 
+def _readable_label(identifier: str) -> str:
+    return " ".join(part.capitalize() for part in str(identifier).replace("-", "_").split("_") if part)
+
+def _extract_label_map(payload: dict[str, Any]) -> dict[str, str]:
+    label_map: dict[str, str] = {}
+    for key in ("zones", "targets", "objects", "assets"):
+        items = payload.get(key)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            item_id = item.get("id")
+            label = item.get("label") or item.get("name")
+            if item_id and isinstance(label, str) and label.strip():
+                label_map[str(item_id)] = label.strip()
+    meta = payload.get("metadata")
+    if isinstance(meta, dict):
+        labels = meta.get("labels")
+        if isinstance(labels, dict):
+            for key, value in labels.items():
+                if key and isinstance(value, str) and value.strip():
+                    label_map[str(key)] = value.strip()
+    return label_map
+
+def _resolve_scene_label(scene_package: Path, target_id: str) -> tuple[str, bool]:
+    candidates = [
+        scene_package / "generated" / "environment_layout.yaml",
+        scene_package / "exported" / "environment_layout.yaml",
+        scene_package / "workcell_builder_metadata.yaml",
+        scene_package / "scene_metadata.yaml",
+        scene_package / "environment.yaml",
+    ]
+    for candidate in candidates:
+        if not candidate.is_file():
+            continue
+        payload = _load(candidate)
+        label = _extract_label_map(payload).get(target_id)
+        if label:
+            return label, True
+    return _readable_label(target_id), False
+
 def _default(scene_package: str) -> dict[str, Any]:
     return {"schema":"workcell_builder_task_intent/v1","scene_package":scene_package,"task":{"id":"default_builder_task","type":"pick_place","mode":"offline_preview"},"pick":{"source":{"type":"zone","id":"pick_zone_main"},"object_filter":{"class_id":"any","color":"any"}},"grasp":{"strategy_ref":"finger_pinch_basic","approach_axis":"z_down","approach_distance_m":0.1,"retreat_axis":"z_up","retreat_distance_m":0.1},"place":{"target":{"type":"bin","id":"bin_red"},"release_strategy":"tool_release","retreat_axis":"z_up","retreat_distance_m":0.1},"routing":{"rules":[]},"safety":{"metadata_only":True,"runtime_io_applied":False,"motion_started":False,"ros_launch_started":False}}
 
@@ -72,11 +114,15 @@ def main() -> int:
     payload.setdefault('task',{}).update({'id':a.task_id,'type':a.task_type})
     source_type = {'epd_detected_object':'perception','epd_replay':'replay_object'}.get(a.pick_source_type, a.pick_source_type)
     payload.setdefault('pick',{}).setdefault('source',{}).update({'id':a.pick_source, 'type': source_type})
+    pick_label, pick_resolved = _resolve_scene_label(a.scene_package, a.pick_source)
+    payload['pick']['source']['label'] = pick_label
     payload['pick'].setdefault('object_filter',{}).update({'class_id':a.object_class,'color':a.object_color})
     payload.setdefault('grasp',{}).update({'strategy_ref':a.grasp_strategy,'approach_axis':a.approach_axis,'approach_distance_m':a.approach_distance_m,'retreat_axis':a.retreat_axis,'retreat_distance_m':a.retreat_distance_m})
     
     payload.setdefault('place',{}).setdefault('target',{}).update({'id':a.place_target})
     payload['place'].setdefault('target',{}).setdefault('type', 'place_target')
+    place_label, place_resolved = _resolve_scene_label(a.scene_package, a.place_target)
+    payload['place']['target']['label'] = place_label
     payload['place'].update({'release_strategy':a.release_strategy,'retreat_axis':a.retreat_axis,'retreat_distance_m':a.retreat_distance_m})
     payload.setdefault('routing', {})['rules'] = [{
         'id': 'route_any_to_selected_place',
@@ -88,7 +134,12 @@ def main() -> int:
     val={'status':'SKIP'}
     if a.validate:
         val = validate_intent(out, a.scene_package)
-    summary={'result':'PASS','output_path':str(out),'validation':val,'pick_source':a.pick_source,'pick_source_type':source_type,'place_target':a.place_target,'grasp_strategy':a.grasp_strategy,'release_strategy':a.release_strategy,'safety':payload['safety']}
+    warnings: list[str] = []
+    if not pick_resolved:
+        warnings.append(f"pick source label metadata missing for '{a.pick_source}', derived readable label used")
+    if not place_resolved:
+        warnings.append(f"place target label metadata missing for '{a.place_target}', derived readable label used")
+    summary={'result':'PASS','output_path':str(out),'validation':val,'pick_source':a.pick_source,'pick_source_type':source_type,'place_target':a.place_target,'grasp_strategy':a.grasp_strategy,'release_strategy':a.release_strategy,'safety':payload['safety'],'warnings':warnings}
     print(json.dumps(summary, indent=2) if a.json else f'Wrote {out}')
     return 0 if (not a.validate or val.get('status')!='FAIL') else 1
 

--- a/scripts/validate_builder_task_intent.py
+++ b/scripts/validate_builder_task_intent.py
@@ -109,10 +109,10 @@ def validate(path: Path, scene_package: Path|None=None, grasp_dir: Path|None=Non
         errors.append('pick.source.type must be one of perception/pick_zone/fixed_object/replay_object')
     if isinstance(place.get('type'), str) and place.get('type') in {'TODO','todo'}:
         errors.append('place.target.type cannot be TODO')
-    for token in ['TODO', 'todo', 'unset_destination']:
-        if token in json.dumps(payload):
-            errors.append('task intent contains TODO/unset placeholder values')
-            break
+    serialized = json.dumps(payload)
+    placeholder_tokens = ['TODO pick zone label', 'TODO place target label', 'TODO_place_target_id', 'unset_destination', '"type": "TODO"', '"type": "todo"']
+    if any(token in serialized for token in placeholder_tokens):
+        errors.append('task intent contains TODO/unset placeholder values')
     missing_required_fields=[]
     if not task.get('type'): missing_required_fields.append('task.type')
     if not pick.get('id'): missing_required_fields.append('pick.source.id')

--- a/scripts/workcell_studio.py
+++ b/scripts/workcell_studio.py
@@ -555,6 +555,14 @@ def generate_readiness_pack(args: argparse.Namespace) -> int:
         if flag: cmd.append(name)
     run=subprocess.run(cmd, capture_output=True, text=True, check=False)
     print(run.stdout if run.stdout else run.stderr)
+    try:
+        payload = json.loads(run.stdout) if run.stdout.strip() else {}
+    except Exception:
+        payload = {}
+    result = str(payload.get("result", "")).upper()
+    status = str(payload.get("status", "")).upper()
+    if run.returncode == 2 and (result in {"PASS", "WARN", "PARTIAL"} or status in {"PASS", "WARN", "PARTIAL"} or payload.get("manifest_path")):
+        return 0 if (result == "PASS" or status == "PASS") else 1
     return run.returncode
 
 def validate_readiness_pack(args: argparse.Namespace) -> int:


### PR DESCRIPTION
### Motivation
- Stop generating TODO placeholder labels in builder task intents by resolving pick/place labels from authored scene metadata or deriving readable fallbacks. 
- Ensure the task-intent validator fails only on real TODO/unset placeholders while allowing readable derived labels. 
- Normalize `generate-readiness-pack` exit codes so non-usage WARN/PARTIAL outcomes are not surfaced as CLI-usage errors (exit code 2). 

### Description
- `scripts/create_or_update_builder_task_intent.py` now resolves labels using `generated/environment_layout.yaml`, `exported/environment_layout.yaml`, `workcell_builder_metadata.yaml`, `scene_metadata.yaml`, then `environment.yaml`, and finally a readable ID-derived fallback (`pick_zone_main` -> `Pick Zone Main`), and writes `pick.source.label` and `place.target.label` without TODOs. 
- Added helper routines `_readable_label`, `_extract_label_map`, and `_resolve_scene_label` to extract and map authored labels and emit non-failing warnings when fallbacks are used while preserving perception semantics and routing rules. 
- `scripts/validate_builder_task_intent.py` tightens placeholder detection to explicitly fail on true TODO/unset tokens (`TODO pick zone label`, `TODO place target label`, `TODO_place_target_id`, `unset_destination`, and TODO type markers) and no longer flags generic unrelated text. 
- `scripts/workcell_studio.py` wrapper for `generate-readiness-pack` normalizes downstream return codes by remapping downstream `2` to `0` (PASS) or `1` (WARN/PARTIAL) when the child process produced a manifest/result payload, keeping `2` reserved for real CLI usage/hard failures. 

### Testing
- Ran the focused pytest suite with `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_studio_integration.py tests/test_validate_builder_generated_scene.py tests/test_golden_builder_readiness_demo.py tests/test_workcell_studio_readiness_pack.py`, which completed successfully with `18 passed`.
- The updated validator and task-intent generation changes cause the validation checks to fail on real TODO/unset placeholders while allowing derived/readable labels (verified by the automated tests above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb73c5f388331b242036ebacd7da7)