### PR TITLE
Fix legacy readiness-pack exit-code handling for manifest-producing legacy scenes

### DIFF
--- a/scripts/workcell_studio.py
+++ b/scripts/workcell_studio.py
@@ -561,8 +561,22 @@ def generate_readiness_pack(args: argparse.Namespace) -> int:
         payload = {}
     result = str(payload.get("result", "")).upper()
     status = str(payload.get("status", "")).upper()
-    if run.returncode == 2 and (result in {"PASS", "WARN", "PARTIAL"} or status in {"PASS", "WARN", "PARTIAL"} or payload.get("manifest_path")):
-        return 0 if (result == "PASS" or status == "PASS") else 1
+    manifest_path = payload.get("manifest_path") or payload.get("manifest")
+    safety_violation = any(
+        bool(payload.get(flag))
+        for flag in (
+            "real_hardware_enabled",
+            "motion_command_sent",
+            "runtime_execution_called",
+            "moveit_plan_service_called",
+        )
+    )
+    downgraded_nonfatal = result in {"WARN", "PARTIAL"} or status in {"WARN", "PARTIAL"}
+    downgraded_pass = result == "PASS" or status == "PASS"
+    if run.returncode == 2 and not safety_violation and (
+        downgraded_pass or downgraded_nonfatal or manifest_path
+    ):
+        return 0 if downgraded_pass else 1
     return run.returncode
 
 def validate_readiness_pack(args: argparse.Namespace) -> int:


### PR DESCRIPTION
### Motivation
- Legacy/partial scenes that produce a readiness manifest were being propagated as hard CLI failures (exit code 2) even when the outcome was WARN/PARTIAL and no safety violation occurred.  
- The change should keep legacy scenes like `scenes/ur5_2f_test` supported while preserving strict behavior for real-hardware/motion/runtime safety flags.  
- CLI exit codes must follow the policy: `0` for PASS, `1` for WARN/PARTIAL/nonfatal issues, and `2` only for real CLI usage errors or true hard failures.

### Description
- Updated `scripts/workcell_studio.py` `generate_readiness_pack` wrapper to treat subprocess return code `2` as downgradeable to `0`/`1` when a manifest is produced or the payload reports `PASS`/`WARN`/`PARTIAL`, provided no safety flags indicate real hardware or motion/runtime execution.  
- Recognize both `manifest_path` and `manifest` keys when inspecting the child script JSON payload.  
- Added explicit checks for safety-critical payload flags `real_hardware_enabled`, `motion_command_sent`, `runtime_execution_called`, and `moveit_plan_service_called` to prevent downgrading when any are true.  
- Preserves original return semantics in all other cases by returning the child process return code.

### Testing
- Ran focused pytest suite with `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_studio_integration.py tests/test_validate_builder_generated_scene.py tests/test_golden_builder_readiness_demo.py tests/test_workcell_studio_readiness_pack.py` which passed (`18 passed`).  
- Verified SOTA builder demo with `python3 scripts/run_golden_builder_readiness_demo.py --scene-package scenes/ur5_2f_builder_pick_place_demo --output-dir /tmp/workcell_builder_pick_place_demo --force --json` returned `PASS` and expected artifacts.  
- Verified legacy scene behavior with `python3 scripts/workcell_studio.py generate-readiness-pack --scene-package scenes/ur5_2f_test --output-dir /tmp/legacy_ur5_2f_test_pack --project-name demo --validate --smoke-dry-run --force --json` produced a manifest and returned a non-2 CLI exit while reporting `WARN` (legacy warnings/partial readiness accepted) and safety flags remained false.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcba7b02008331b111646a90471d44)