### PR TITLE
Make workcell_builder selections catalog-driven with offline capability loader

### DIFF
--- a/catalog/capabilities/environment_assets/asset_camera_mount.yaml
+++ b/catalog/capabilities/environment_assets/asset_camera_mount.yaml
@@ -1,0 +1,17 @@
+schema_version: environment_asset/v1
+asset:
+  id: camera_mount_overhead_a
+  label: Camera Mount Overhead A
+  family: camera_mount
+  dimensions:
+    length_m: 0.4
+    width_m: 0.1
+    height_m: 1.2
+  frame: world
+  pose: [0.6, 0.0, 0.6, 0.0, 0.0, 0.0]
+  collision_behaviour: static_collision
+  mobility: static
+  import_source: internal_catalog
+  mesh_path: assets/environment/camera_mount_overhead_a.stl
+  limitations_warnings:
+    - Placeholder mount geometry; verify real bracket dimensions before deployment.

--- a/catalog/capabilities/tasks/task_inspection_placeholder.yaml
+++ b/catalog/capabilities/tasks/task_inspection_placeholder.yaml
@@ -1,0 +1,13 @@
+schema_version: task_capability/v1
+task:
+  task_family: inspection_routing
+  label: Inspection Routing (Placeholder)
+  required_robot_capabilities: [planning_groups, base_frame]
+  required_end_effector_capabilities: [grasp_frames]
+  required_sensor_attributes: [pose, class, confidence]
+  required_destinations: [inspection_pass, inspection_fail]
+  rule_model: inspection_decision_routing
+  expected_validation_checks: [inspection_route_defined]
+  runtime_requirements: [classification_pipeline]
+  limitations_warnings:
+    - Placeholder template for preview/workflow authoring only.

--- a/catalog/capabilities/tasks/task_machine_tending_placeholder.yaml
+++ b/catalog/capabilities/tasks/task_machine_tending_placeholder.yaml
@@ -1,0 +1,13 @@
+schema_version: task_capability/v1
+task:
+  task_family: machine_tending
+  label: Machine Tending (Placeholder)
+  required_robot_capabilities: [planning_groups, named_targets]
+  required_end_effector_capabilities: [grasp_frames, release_behaviour]
+  required_sensor_attributes: [pose]
+  required_destinations: [machine_chuck, unload_bin]
+  rule_model: station_cycle
+  expected_validation_checks: [machine_station_defined]
+  runtime_requirements: [io_handshake, machine_state_interlock]
+  limitations_warnings:
+    - Placeholder template only; runtime interlocks must be implemented separately.

--- a/scripts/render_workcell_builder_metadata.py
+++ b/scripts/render_workcell_builder_metadata.py
@@ -4,6 +4,8 @@ import argparse, json
 from pathlib import Path
 from typing import Any
 
+from scripts.workcell_builder_capability_catalog import load_workcell_capability_catalog
+
 
 def _norm(text: str | None) -> str:
     return (text or "").strip().lower().replace("_", " ")
@@ -17,7 +19,22 @@ def _match(name: str | None, mapping: list[tuple[list[str], dict[str, Any]]]) ->
     return {"capability_id": None, "family": None, "runtime_supported": False, "preview_only": True, "warning": f"Could not resolve catalog capability id for selection '{name}'"}
 
 
+def _catalog_lookup(group: list[dict[str, Any]], selected_name: str | None) -> dict[str, Any]:
+    selected = _norm(selected_name)
+    for item in group:
+        name = _norm(item.get("display_name"))
+        cid = _norm(item.get("capability_id"))
+        if selected and (selected in name or selected in cid):
+            return item
+    return {}
+
+
 def render_metadata(robot: str | None, end_effector: str | None, sensor: str | None, grasp_strategy: str | None, scene_path: Path | None = None) -> dict[str, Any]:
+    catalog = load_workcell_capability_catalog()
+    robot_cat = _catalog_lookup(catalog.get("robots", []), robot)
+    ee_cat = _catalog_lookup(catalog.get("end_effectors", []), end_effector)
+    sensor_cat = _catalog_lookup(catalog.get("sensors", []), sensor)
+
     robot_info = _match(robot, [
         (["ur5", "universal robot ur5", "universalrobot ur5"], {"capability_id": "ur5", "family": "articulated", "runtime_supported": True, "preview_only": False}),
         (["generic delta", "delta"], {"capability_id": "generic_delta_900", "family": "delta", "runtime_supported": False, "preview_only": True}),
@@ -30,6 +47,8 @@ def render_metadata(robot: str | None, end_effector: str | None, sensor: str | N
     sensor_info = _match(sensor, [(["realsense", "d435i"], {"capability_id": "realsense_d435i", "family": "depth_camera", "runtime_supported": True, "preview_only": False})])
 
     warnings = [x for x in [robot_info.pop("warning", None), ee_info.pop("warning", None), sensor_info.pop("warning", None)] if x]
+    warnings.extend(robot_cat.get("warnings", []))
+    warnings.extend(ee_cat.get("warnings", []))
     status = "preview_only" if robot_info.get("preview_only") or ee_info.get("preview_only") else "fake_hardware_ready"
     imported = []
     object_count = 0
@@ -43,6 +62,13 @@ def render_metadata(robot: str | None, end_effector: str | None, sensor: str | N
             object_count = txt.count("filepath:")
 
     return {
+        "selected_capabilities": {
+            "robot": {"capability_id": robot_cat.get("capability_id", robot_info.get("capability_id")), "display_name": robot_cat.get("display_name", robot)},
+            "end_effector": {"capability_id": ee_cat.get("capability_id", ee_info.get("capability_id")), "display_name": ee_cat.get("display_name", end_effector)},
+            "sensor": {"capability_id": sensor_cat.get("capability_id", sensor_info.get("capability_id")), "display_name": sensor_cat.get("display_name", sensor)},
+            "environment_assets": [],
+            "task_template": {"capability_id": None, "display_name": None},
+        },
         "schema_version": "workcell_builder_metadata/v1",
         "generated_by": "workcell_builder",
         "workcell_studio_compatible": True,

--- a/scripts/workcell_builder_capability_catalog.py
+++ b/scripts/workcell_builder_capability_catalog.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.capability_registry import DEFAULT_CAPABILITIES_DIR, load_structured_data
+
+
+@dataclass
+class CatalogCapability:
+    capability_id: str
+    display_name: str
+    family: str
+    group: str
+    source_path: str
+    runtime_supported: bool
+    preview_only: bool
+    warnings: list[str]
+
+
+def _is_placeholder(item: dict[str, Any]) -> bool:
+    cid = str(item.get("id", "")).lower()
+    label = str(item.get("label", "")).lower()
+    fam = str(item.get("family", "")).lower()
+    return any(token in text for token in ("generic", "placeholder", "preview") for text in (cid, label, fam))
+
+
+def _read_group(path: Path, payload_key: str, group: str) -> tuple[list[CatalogCapability], list[str]]:
+    out: list[CatalogCapability] = []
+    warnings: list[str] = []
+    for doc_path in sorted(path.glob("*.yaml")):
+        try:
+            doc, _ = load_structured_data(doc_path)
+        except Exception as exc:
+            warnings.append(f"{doc_path.name}: failed to load ({exc})")
+            continue
+        item = doc.get(payload_key, {}) if isinstance(doc.get(payload_key), dict) else {}
+        cap_id = item.get("id")
+        if not isinstance(cap_id, str) and payload_key == "task":
+            cap_id = item.get("task_family")
+        if not isinstance(cap_id, str) or not cap_id.strip():
+            warnings.append(f"{doc_path.name}: missing capability id")
+            continue
+        label = item.get("label") if isinstance(item.get("label"), str) else cap_id
+        family = str(item.get("family") or item.get("task_family") or "unknown")
+        item_warnings = [str(v) for v in (item.get("limitations_warnings") or []) if isinstance(v, str)]
+        preview_only = _is_placeholder(item)
+        if preview_only:
+            item_warnings.append("Preview-only placeholder: runtime launch/motion support is not claimed.")
+        out.append(CatalogCapability(capability_id=cap_id, display_name=label, family=family, group=group, source_path=str(doc_path), runtime_supported=not preview_only, preview_only=preview_only, warnings=item_warnings))
+    return out, warnings
+
+
+def load_workcell_capability_catalog(catalog_dir: Path | None = None) -> dict[str, Any]:
+    base = (catalog_dir or DEFAULT_CAPABILITIES_DIR).resolve()
+    grouped = {
+        "robots": ("robots", "robot"),
+        "end_effectors": ("end_effectors", "end_effector"),
+        "sensors": ("sensors", "sensor"),
+        "environment_assets": ("environment_assets", "asset"),
+        "task_templates": ("tasks", "task"),
+    }
+    payload: dict[str, Any] = {"catalog_path": str(base), "warnings": []}
+    for key, (folder, item_key) in grouped.items():
+        entries, warns = _read_group(base / folder, item_key, key)
+        payload[key] = [entry.__dict__ for entry in entries]
+        payload["warnings"].extend(warns)
+    return payload

--- a/tests/test_workcell_builder_catalog_integration.py
+++ b/tests/test_workcell_builder_catalog_integration.py
@@ -1,0 +1,23 @@
+from scripts.render_workcell_builder_metadata import render_metadata
+
+
+def test_ur5_robotiq_remains_runtime_ready() -> None:
+    payload = render_metadata("ur5", "robotiq_2f", "realsense_d435i", "finger_pinch_basic")
+    assert payload["selected_capabilities"]["robot"]["capability_id"] == "ur5"
+    assert payload["selected_capabilities"]["end_effector"]["capability_id"] == "robotiq_2f_85"
+    assert payload["readiness"]["status"] == "fake_hardware_ready"
+
+
+def test_placeholder_robot_marked_preview_only_warn() -> None:
+    payload = render_metadata("generic delta", "suction", "realsense_d435i", "suction_top_basic")
+    assert payload["robot"]["preview_only"] is True
+    assert payload["robot"]["runtime_supported"] is False
+    assert payload["readiness"]["status"] == "preview_only"
+
+
+def test_generated_metadata_contains_selected_capability_ids() -> None:
+    payload = render_metadata("ur5", "robotiq 2f", "intel realsense d435i", "finger_pinch_basic")
+    selected = payload["selected_capabilities"]
+    assert selected["robot"]["capability_id"] == "ur5"
+    assert selected["end_effector"]["capability_id"] == "robotiq_2f_85"
+    assert selected["sensor"]["capability_id"] in {"intel_realsense_d435i", "realsense_d435i"}

--- a/tests/test_workcell_studio_capability_catalog.py
+++ b/tests/test_workcell_studio_capability_catalog.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from scripts.workcell_builder_capability_catalog import load_workcell_capability_catalog
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_shipping_catalog_loads_offline_and_groups() -> None:
+    payload = load_workcell_capability_catalog(REPO_ROOT / "catalog" / "capabilities")
+    assert payload["robots"]
+    assert payload["end_effectors"]
+    assert payload["sensors"]
+    assert payload["environment_assets"]
+    assert payload["task_templates"]
+
+
+def test_required_minimum_capabilities_exist() -> None:
+    payload = load_workcell_capability_catalog(REPO_ROOT / "catalog" / "capabilities")
+    ids = {
+        "robots": {x["capability_id"] for x in payload["robots"]},
+        "end_effectors": {x["capability_id"] for x in payload["end_effectors"]},
+        "sensors": {x["capability_id"] for x in payload["sensors"]},
+        "environment_assets": {x["capability_id"] for x in payload["environment_assets"]},
+        "task_templates": {x["capability_id"] for x in payload["task_templates"]},
+    }
+    assert {"ur5", "generic_delta_900", "generic_gantry_xyz"}.issubset(ids["robots"])
+    assert {"robotiq_2f_85", "onrobot_airpick_style", "generic_vacuum_array"}.issubset(ids["end_effectors"])
+    assert "intel_realsense_d435i" in ids["sensors"]
+    assert {"table_standard_1200", "bin_blue_large", "conveyor_2m", "camera_mount_overhead_a"}.issubset(ids["environment_assets"])
+    assert {"pick_place", "sort_by_colour", "inspection_routing", "machine_tending"}.issubset(ids["task_templates"])


### PR DESCRIPTION
### Motivation
- Move workcell_builder toward Workcell Studio by replacing hardcoded/UR-only selection sources with an offline product-facing capability catalog so UI selections (robot, end effector, sensor, environment asset, task) come from real capability records.
- Ensure placeholder/generic capabilities are honest (preview-only/WARN) and preserve existing fake-hardware-first safety defaults and the UR5+Robotiq 2F generation path.

### Description
- Add a small offline catalog loader `scripts/workcell_builder_capability_catalog.py` that reads `catalog/capabilities/*`, groups entries into `robots`, `end_effectors`, `sensors`, `environment_assets`, and `task_templates`, validates minimal fields, and flags placeholder entries as preview-only with warnings.
- Integrate catalog lookup into builder metadata generation by updating `scripts/render_workcell_builder_metadata.py` to call `load_workcell_capability_catalog()` and include a new `selected_capabilities` block with selected capability IDs and display names while preserving prior UR5/Robotiq fallbacks and preview semantics.
- Expand the shipped product catalog with required entries: `asset_camera_mount.yaml` and placeholder task templates `task_inspection_placeholder.yaml` and `task_machine_tending_placeholder.yaml` under `catalog/capabilities/`.
- Add automated tests `tests/test_workcell_studio_capability_catalog.py` and `tests/test_workcell_builder_catalog_integration.py` to ensure the catalog loads offline, required minimum capabilities exist, metadata integrates catalog IDs, and placeholder robots are marked preview-only.

### Testing
- Ran the requested pytest suite: `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_studio_capability_catalog.py tests/test_workcell_builder_catalog_integration.py tests/test_capability_contracts.py tests/test_workcell_builder_generation.py tests/test_workcell_builder_studio_integration.py tests/test_validate_builder_generated_scene.py` and all tests passed (`50 passed`).
- Ran the capability contract validator: `PYTHONPATH=$PWD:$PYTHONPATH python3 scripts/validate_capability_contracts.py catalog/capabilities --json` and it returned a passing summary for all catalog files (`pass: 23, fail: 0`).
- Confirmed no runtime/ROS dependencies were introduced and UR5 + Robotiq 2F generation and fake-hardware defaults remain intact via the added integration tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce883cea08331a934920dfa8366e3)