### PR TITLE
Add grasp strategy editor metadata flow for Workcell Builder exports

### DIFF
--- a/scripts/convert_builder_task_intent_to_task_recipe.py
+++ b/scripts/convert_builder_task_intent_to_task_recipe.py
@@ -58,7 +58,7 @@ def convert(task_intent_path: Path, scene_package: Path | None = None) -> tuple[
             'destinations': [{'id': place.get('id') or '', 'frame': 'world', 'pose_xyz': place_block.get('offset_xyz') or [0.4, 0.0, 0.2], 'pose_rpy': [0.0, 0.0, 0.0]}],
             'rules': routing.get('rules') if isinstance(routing.get('rules'), list) else [],
         },
-        'grasp': {'strategy_ref': grasp.get('strategy_ref')},
+        'grasp': {'strategy_ref': grasp.get('strategy_ref'), 'orientation_mode': grasp.get('orientation_mode'), 'approach_axis': grasp.get('approach_axis'), 'approach_distance_m': grasp.get('approach_distance_m'), 'retreat_distance_m': grasp.get('retreat_distance_m'), 'allowed_roll_angles_deg': grasp.get('allowed_roll_angles_deg'), 'allowed_yaw_angles_deg': grasp.get('allowed_yaw_angles_deg'), 'gripper_tcp_offset': grasp.get('gripper_tcp_offset'), 'suction_cups': grasp.get('suction_cups')},
         'builder_task_intent': {
             'source_file': str(task_intent_path),
             'pick': payload.get('pick') or {},

--- a/scripts/export_builder_scene_to_cell_definition.py
+++ b/scripts/export_builder_scene_to_cell_definition.py
@@ -14,6 +14,7 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 from capability_registry import load_structured_data
+from workcell_builder_grasp_strategy import normalize_grasp_strategy
 
 try:
     import yaml as _pyyaml
@@ -135,6 +136,8 @@ def _build_task_intent_from_scene(scene_path: Path, env_layout: dict[str, Any], 
     missing=[]
     task_type = "pick_place"
     grasp_meta = meta.get("grasp_strategy") if isinstance(meta.get("grasp_strategy"), dict) else {}
+    ee_meta = meta.get("end_effector") if isinstance(meta.get("end_effector"), dict) else {}
+    normalized_grasp, grasp_warnings = normalize_grasp_strategy(grasp_meta, ee_meta)
     strategy = grasp_meta.get("strategy_id")
     pick_id = None
     place_id = None
@@ -166,7 +169,7 @@ def _build_task_intent_from_scene(scene_path: Path, env_layout: dict[str, Any], 
         "scene_package": scene_path.as_posix(),
         "task": {"id": "default_builder_task", "type": task_type, "mode": "offline_preview"},
         "pick": {"source": {"type": "zone", "id": pick_id}},
-        "grasp": {"strategy_ref": strategy, "approach_axis": "z_down", "approach_distance_m": 0.1, "retreat_axis": "z_up", "retreat_distance_m": 0.1},
+        "grasp": {"strategy_ref": strategy, "approach_axis": normalized_grasp.get("approach_axis", "z_down"), "orientation_mode": normalized_grasp.get("orientation_mode", "auto_align"), "approach_distance_m": normalized_grasp.get("approach_distance_m", 0.1), "retreat_axis": "z_up", "retreat_distance_m": normalized_grasp.get("retreat_distance_m", 0.1), "allowed_roll_angles_deg": normalized_grasp.get("allowed_roll_angles_deg", [0.0]), "allowed_yaw_angles_deg": normalized_grasp.get("allowed_yaw_angles_deg", [0.0, 180.0]), "gripper_tcp_offset": normalized_grasp.get("gripper_tcp_offset", {"xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]}), "suction_cups": normalized_grasp.get("suction_cups")},
         "place": {"target": {"type": "bin", "id": place_id}, "release_strategy": release_strategy, "retreat_axis": "z_up", "retreat_distance_m": 0.1},
         "routing": {"rules": routing_rules},
         "safety": {"metadata_only": True, "runtime_io_applied": False, "motion_started": False, "ros_launch_started": False},
@@ -189,6 +192,8 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
     robot_meta = meta.get("robot") if isinstance(meta.get("robot"), dict) else {}
     ee_meta = meta.get("end_effector") if isinstance(meta.get("end_effector"), dict) else {}
     grasp_meta = meta.get("grasp_strategy") if isinstance(meta.get("grasp_strategy"), dict) else {}
+    ee_meta = meta.get("end_effector") if isinstance(meta.get("end_effector"), dict) else {}
+    normalized_grasp, grasp_warnings = normalize_grasp_strategy(grasp_meta, ee_meta)
     sensors_meta = meta.get("sensors") if isinstance(meta.get("sensors"), list) else []
 
     robot_name = robot_env.get("name") or robot_meta.get("selected_name") or "unknown_robot"
@@ -280,9 +285,11 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
             "destinations": [{"id": "default_drop", "frame": "world", "pose_xyz": [0.4, 0.0, 0.2], "pose_rpy": [0.0, 0.0, 0.0]}],
             "rules": [{"id": "default_rule", "when": {"always": True}, "destination": "default_drop"}],
         },
-        "grasp": {"strategy_ref": grasp_meta.get("strategy_id")},
+        "grasp": {"strategy_ref": normalized_grasp.get("strategy_id"), "strategy": normalized_grasp},
         "commissioning": {"self_test_enabled": True, "export_bundle": False, "generated_by": "workcell_builder", "review_required": True, "fake_hardware_first": True, "runtime_send_disabled_by_default": True},
     }
+
+    warnings.extend(grasp_warnings)
 
     if not robot_meta.get("capability_id"):
         warnings.append("Robot capability is unknown; review required before runtime commissioning.")

--- a/scripts/render_workcell_builder_metadata.py
+++ b/scripts/render_workcell_builder_metadata.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.workcell_builder_capability_catalog import load_workcell_capability_catalog
+from scripts.workcell_builder_grasp_strategy import normalize_grasp_strategy
 
 
 def _norm(text: str | None) -> str:
@@ -29,7 +30,7 @@ def _catalog_lookup(group: list[dict[str, Any]], selected_name: str | None) -> d
     return {}
 
 
-def render_metadata(robot: str | None, end_effector: str | None, sensor: str | None, grasp_strategy: str | None, scene_path: Path | None = None) -> dict[str, Any]:
+def render_metadata(robot: str | None, end_effector: str | None, sensor: str | None, grasp_strategy: str | None, scene_path: Path | None = None, grasp_config: dict[str, Any] | None = None) -> dict[str, Any]:
     catalog = load_workcell_capability_catalog()
     robot_cat = _catalog_lookup(catalog.get("robots", []), robot)
     ee_cat = _catalog_lookup(catalog.get("end_effectors", []), end_effector)
@@ -45,10 +46,12 @@ def render_metadata(robot: str | None, end_effector: str | None, sensor: str | N
         (["airpick", "suction", "onrobot"], {"capability_id": "onrobot_airpick_style", "family": "suction", "runtime_supported": False, "preview_only": True, "required_io_signals": ["vacuum_enable", "vacuum_feedback"]}),
     ])
     sensor_info = _match(sensor, [(["realsense", "d435i"], {"capability_id": "realsense_d435i", "family": "depth_camera", "runtime_supported": True, "preview_only": False})])
+    grasp_payload, grasp_warnings = normalize_grasp_strategy({"strategy_id": grasp_strategy, **(grasp_config or {})}, ee_info)
 
     warnings = [x for x in [robot_info.pop("warning", None), ee_info.pop("warning", None), sensor_info.pop("warning", None)] if x]
     warnings.extend(robot_cat.get("warnings", []))
     warnings.extend(ee_cat.get("warnings", []))
+    warnings.extend(grasp_warnings)
     status = "preview_only" if robot_info.get("preview_only") or ee_info.get("preview_only") else "fake_hardware_ready"
     imported = []
     object_count = 0
@@ -74,7 +77,7 @@ def render_metadata(robot: str | None, end_effector: str | None, sensor: str | N
         "workcell_studio_compatible": True,
         "robot": {"selected_name": robot, **robot_info},
         "end_effector": {"selected_name": end_effector, **ee_info, "runtime_io_applied": False},
-        "grasp_strategy": {"selected_name": grasp_strategy, "strategy_id": grasp_strategy, "metadata_only": True, "runtime_applied": False},
+        "grasp_strategy": {"selected_name": grasp_strategy, **grasp_payload},
         "sensors": [{"selected_name": sensor, **sensor_info}] if sensor else [],
         "environment": {"generated_objects_count": object_count, "imported_stl_references": imported},
         "readiness": {"status": status, "blockers": [], "warnings": warnings},
@@ -88,9 +91,13 @@ def main() -> int:
     ap.add_argument("--sensor")
     ap.add_argument("--grasp-strategy")
     ap.add_argument("--scene-path", type=Path)
+    ap.add_argument("--grasp-config", type=Path)
     ap.add_argument("--output", type=Path, required=True)
     args = ap.parse_args()
-    data = render_metadata(args.robot, args.end_effector, args.sensor, args.grasp_strategy, args.scene_path)
+    grasp_config = None
+    if args.grasp_config and args.grasp_config.is_file():
+        grasp_config = json.loads(args.grasp_config.read_text(encoding="utf-8"))
+    data = render_metadata(args.robot, args.end_effector, args.sensor, args.grasp_strategy, args.scene_path, grasp_config)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return 0

--- a/scripts/workcell_builder_grasp_strategy.py
+++ b/scripts/workcell_builder_grasp_strategy.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_STRATEGY = {
+    "strategy_id": "auto",
+    "approach_axis": "z_down",
+    "orientation_mode": "auto_align",
+    "approach_distance_m": 0.1,
+    "retreat_distance_m": 0.1,
+    "allowed_roll_angles_deg": [0.0],
+    "allowed_yaw_angles_deg": [0.0, 180.0],
+    "gripper_tcp_offset": {"xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
+}
+
+FINGER_STRATEGIES = {"finger_top", "finger_side"}
+SUCTION_STRATEGIES = {"suction_top", "suction_side"}
+SUPPORTED_STRATEGIES = {"auto", *FINGER_STRATEGIES, *SUCTION_STRATEGIES}
+
+
+def normalize_grasp_strategy(selected: dict[str, Any] | None, end_effector: dict[str, Any] | None) -> tuple[dict[str, Any], list[str]]:
+    payload = dict(DEFAULT_STRATEGY)
+    payload.update(selected or {})
+    payload["strategy_id"] = str(payload.get("strategy_id") or "auto").strip()
+    warnings: list[str] = []
+
+    if payload["strategy_id"] not in SUPPORTED_STRATEGIES:
+        warnings.append(f"Unsupported grasp strategy '{payload['strategy_id']}' selected; using metadata WARN mode.")
+
+    ee = end_effector or {}
+    family = str(ee.get("family") or ee.get("type") or "").lower()
+    capability = str(ee.get("capability_id") or ee.get("capability") or ee.get("name") or "").lower()
+    is_finger = ("finger" in family) or ("2f" in capability) or ("robotiq" in capability)
+    is_suction = ("suction" in family) or ("vacuum" in family) or ("airpick" in capability)
+
+    sid = payload["strategy_id"]
+    if sid in FINGER_STRATEGIES and not is_finger:
+        warnings.append(f"Strategy '{sid}' is typically for finger grippers; selected tool may be incompatible.")
+    if sid in SUCTION_STRATEGIES and not is_suction:
+        warnings.append(f"Strategy '{sid}' is typically for suction tools; selected tool may be incompatible.")
+    if sid == "suction_side":
+        warnings.append("'suction_side' is currently a placeholder strategy; kept as WARN metadata only.")
+
+    payload["metadata_only"] = True
+    payload["runtime_applied"] = False
+    payload["compatibility_status"] = "WARN" if warnings else "PASS"
+    payload["compatibility_warnings"] = warnings
+    return payload, warnings
+

--- a/tests/test_workcell_builder_grasp_strategy.py
+++ b/tests/test_workcell_builder_grasp_strategy.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from scripts.workcell_builder_grasp_strategy import normalize_grasp_strategy
+from scripts.export_builder_scene_to_cell_definition import export_scene
+
+
+def test_default_grasp_strategy_exists() -> None:
+    payload, warns = normalize_grasp_strategy({}, {"family": "finger", "capability_id": "robotiq_2f_85"})
+    assert payload["strategy_id"] == "auto"
+    assert payload["approach_axis"] == "z_down"
+    assert payload["compatibility_status"] == "PASS"
+    assert not warns
+
+
+def test_suction_top_allowed_only_for_suction_tools() -> None:
+    suction_payload, suction_warns = normalize_grasp_strategy({"strategy_id": "suction_top"}, {"family": "suction"})
+    assert suction_payload["compatibility_status"] == "PASS"
+    assert not suction_warns
+
+    finger_payload, finger_warns = normalize_grasp_strategy({"strategy_id": "suction_top"}, {"family": "finger", "capability_id": "robotiq_2f_85"})
+    assert finger_payload["compatibility_status"] == "WARN"
+    assert any("incompatible" in w or "typically" in w for w in finger_warns)
+
+
+def test_finger_strategies_allowed_for_robotiq_2f() -> None:
+    for sid in ("finger_top", "finger_side"):
+        payload, warns = normalize_grasp_strategy({"strategy_id": sid}, {"family": "finger", "capability_id": "robotiq_2f_85"})
+        assert payload["compatibility_status"] == "PASS"
+        assert warns == []
+
+
+def test_invalid_combinations_produce_warn_metadata() -> None:
+    payload, warns = normalize_grasp_strategy({"strategy_id": "suction_side"}, {"family": "finger", "capability_id": "robotiq_2f_85"})
+    assert payload["compatibility_status"] == "WARN"
+    assert payload["compatibility_warnings"]
+    assert any("placeholder" in w for w in warns)
+
+
+def test_generated_metadata_includes_grasp_strategy() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d) / "scene"
+        root.mkdir()
+        (root / "package.xml").write_text("<package/>", encoding="utf-8")
+        (root / "CMakeLists.txt").write_text("cmake_minimum_required(VERSION 3.5)", encoding="utf-8")
+        (root / "environment.yaml").write_text(
+            "robot: {name: ur5}\nend_effector: {name: robotiq_2f}\nobjects: {box1: {filepath: meshes/box.stl, dimensions: [0.1,0.1,0.1]}}\n",
+            encoding="utf-8",
+        )
+        (root / "workcell_builder_metadata.yaml").write_text(
+            '{"robot":{"capability_id":"ur5"},"end_effector":{"capability_id":"robotiq_2f_85","family":"finger"},"grasp_strategy":{"strategy_id":"finger_top","orientation_mode":"fixed","approach_distance_m":0.12}}',
+            encoding="utf-8",
+        )
+        out = root / "generated"
+        summary = export_scene(root, out, validate=False)
+        assert summary["generated_by"] == "workcell_builder"
+        cell = (out / "cell_definition.yaml").read_text(encoding="utf-8")
+        assert "strategy_ref: finger_top" in cell
+        assert "orientation_mode: fixed" in cell


### PR DESCRIPTION
### Motivation
- Make grasp behaviour configurable in Workcell Builder metadata so Workcell Studio can author grasp strategies visually instead of hardcoding them per scene.
- Surface grasp configuration and compatibility information in exported metadata while preserving metadata-only safety semantics.
- Ensure generated `cell_definition` and `task_recipe` include the selected grasp strategy and detailed fields for downstream tooling and previews.

### Description
- Added a new normalization module `scripts/workcell_builder_grasp_strategy.py` that provides defaults, supported strategies (`auto`, `finger_top`, `finger_side`, `suction_top`, `suction_side`), and compatibility warnings for tool/strategy mismatches.
- Integrated normalized grasp payload into metadata rendering by updating `scripts/render_workcell_builder_metadata.py` to include an optional `--grasp-config` and to emit the normalized `grasp_strategy` payload and warnings.
- Updated export flow in `scripts/export_builder_scene_to_cell_definition.py` to normalize and embed detailed grasp fields into generated builder task intent defaults and the exported `cell_definition.grasp` (fields include `approach_axis`, `orientation_mode`, `approach_distance_m`, `retreat_distance_m`, `allowed_roll_angles_deg`, `allowed_yaw_angles_deg`, `gripper_tcp_offset`, and `suction_cups`).
- Propagated grasp fields into generated task recipes by extending `scripts/convert_builder_task_intent_to_task_recipe.py` to carry the new grasp attributes into the `task_recipe` `grasp` block.
- Added non-fatal compatibility behavior that records WARN metadata when a selected strategy does not match the selected tool family (for example, `suction_top` with a finger gripper), and provides a placeholder WARN for `suction_side` instead of failing generation.
- Did not introduce any robot motion, MoveIt service calls, or runtime execution changes; all changes are metadata-only and preserve `metadata_only` safety flags.

### Testing
- Added `tests/test_workcell_builder_grasp_strategy.py` which verifies default strategy, allowed strategy/tool combinations, WARN behaviour for invalid combinations, and inclusion of grasp metadata in exports.
- Ran: `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_grasp_strategy.py tests/test_workcell_builder_generation.py tests/test_workcell_builder_studio_integration.py` and observed all tests passing.
- Result: `26 passed` on the CI-like local run, and the new tests exercise normalization, warnings, and exported metadata content as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fceb0542808331a3d1f5edd43f74fc)