### PR TITLE
Add environment asset palette primitives for Workcell Builder

### DIFF
--- a/scripts/validate_environment_layout.py
+++ b/scripts/validate_environment_layout.py
@@ -77,6 +77,13 @@ def validate_layout(defn: dict[str, Any], path: Path, parser: str, notes: list[s
     safety_zones = safety.get("zones") if isinstance(safety.get("zones"), list) else []
 
     seen_asset_ids: set[str] = set()
+
+    has_robot_base = False
+    has_table = False
+    has_pick_area = False
+    has_camera = False
+    perception_enabled = False
+    conveyor_present = False
     for idx, asset in enumerate(assets):
         if not isinstance(asset, dict):
             result.errors.append(f"assets[{idx}] must be an object.")
@@ -109,6 +116,15 @@ def validate_layout(defn: dict[str, Any], path: Path, parser: str, notes: list[s
         if isinstance(src_uri, str) and src_uri.startswith("package://"):
             pass
 
+        atype = str(asset.get("type", ""))
+        has_robot_base = has_robot_base or atype == "robot_base"
+        has_table = has_table or atype in {"table", "support_surface"}
+        has_pick_area = has_pick_area or atype == "object_spawn_area"
+        has_camera = has_camera or atype == "camera_mount"
+        conveyor_present = conveyor_present or atype == "conveyor_placeholder"
+        cam_meta = asset.get("camera") if isinstance(asset.get("camera"), dict) else {}
+        perception_enabled = perception_enabled or bool(cam_meta.get("perception_enabled"))
+
         ref = asset.get("asset_ref")
         if isinstance(ref, str) and ref.strip() and ref not in manifests:
             message = f"assets[{idx}].asset_ref '{ref}' not found in optional asset manifests."
@@ -136,6 +152,20 @@ def validate_layout(defn: dict[str, Any], path: Path, parser: str, notes: list[s
         _validate_zone(zone, f"zones[{idx}]", seen_zone_ids)
     for idx, zone in enumerate(safety_zones):
         _validate_zone(zone, f"safety.zones[{idx}]", seen_zone_ids)
+
+    zone_types = {str(z.get("type", "")) for z in zones if isinstance(z, dict)}
+    has_pick_area = has_pick_area or ("pick_zone" in zone_types)
+
+    if not has_robot_base:
+        result.warnings.append("Missing robot base asset in environment layout.")
+    if not has_table:
+        result.warnings.append("Missing table/support surface asset in environment layout.")
+    if not has_pick_area:
+        result.warnings.append("Missing pick area (object_spawn_area or pick_zone).")
+    if perception_enabled and not has_camera:
+        result.warnings.append("Perception enabled but camera pose metadata missing.")
+    if conveyor_present:
+        result.warnings.append("Conveyor selected is placeholder/visual metadata only; physics backend unavailable.")
 
     result.summary = {
         "layout_id": defn.get("layout_id"),

--- a/scripts/workcell_builder_environment_palette.py
+++ b/scripts/workcell_builder_environment_palette.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from typing import Any
+
+ASSET_TYPES: dict[str, dict[str, Any]] = {
+    "table": {"supports_dimensions": True, "supports_mesh": True, "preview_status": "supported"},
+    "bin": {"supports_dimensions": True, "supports_mesh": True, "preview_status": "supported"},
+    "conveyor_placeholder": {"supports_dimensions": True, "supports_mesh": False, "preview_status": "preview_only", "placeholder_only": True},
+    "camera_mount": {"supports_dimensions": False, "supports_mesh": True, "preview_status": "supported"},
+    "robot_base": {"supports_dimensions": True, "supports_mesh": False, "preview_status": "supported"},
+    "object_spawn_area": {"supports_dimensions": True, "supports_mesh": False, "preview_status": "supported"},
+    "fixture_placeholder": {"supports_dimensions": True, "supports_mesh": True, "preview_status": "preview_only"},
+}
+
+
+def default_asset_catalog() -> list[dict[str, Any]]:
+    return [
+        {"type": k, **v} for k, v in ASSET_TYPES.items()
+    ]
+
+
+def build_environment_asset(
+    *,
+    asset_id: str,
+    asset_type: str,
+    xyz: list[float],
+    rpy: list[float],
+    dimensions: list[float] | None = None,
+    mesh_path: str | None = None,
+    perception_enabled: bool = False,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if asset_type not in ASSET_TYPES:
+        raise ValueError(f"Unsupported environment asset type: {asset_type}")
+    spec = ASSET_TYPES[asset_type]
+    asset: dict[str, Any] = {
+        "id": asset_id,
+        "name": asset_id,
+        "type": asset_type,
+        "pose": {"frame": "world", "xyz": xyz, "rpy": rpy},
+        "preview_status": spec["preview_status"],
+        "runtime_supported": spec["preview_status"] == "supported",
+    }
+    if dimensions is not None and spec.get("supports_dimensions"):
+        asset["dimensions"] = dimensions
+    if mesh_path and spec.get("supports_mesh"):
+        asset["mesh_path"] = mesh_path
+    if asset_type == "conveyor_placeholder":
+        asset["notes"] = ["Conveyor is placeholder metadata only and has no runtime physics backend."]
+    if asset_type == "camera_mount":
+        asset["camera"] = {
+            "model": "RealSense D435i",
+            "device_id": "intel_realsense_d435i",
+            "perception_enabled": bool(perception_enabled),
+        }
+    if metadata:
+        asset["metadata"] = metadata
+    return asset
+
+
+def build_environment_layout(layout_id: str, assets: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": "environment_layout/v1",
+        "layout_id": layout_id,
+        "metadata": {"generated_by": "workcell_builder", "environment_palette_enabled": True},
+        "assets": assets,
+        "zones": [],
+    }

--- a/tests/test_workcell_builder_environment_palette.py
+++ b/tests/test_workcell_builder_environment_palette.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from scripts.validate_environment_layout import validate_layout
+from scripts.workcell_builder_environment_palette import build_environment_asset, build_environment_layout
+
+
+def test_table_bin_camera_conveyor_asset_metadata_created() -> None:
+    assets = [
+        build_environment_asset(asset_id="table_main", asset_type="table", xyz=[0, 0, 0], rpy=[0, 0, 0], dimensions=[1.2, 0.8, 0.05], mesh_path="assets/table.stl"),
+        build_environment_asset(asset_id="bin_red", asset_type="bin", xyz=[0.4, 0.3, 0.1], rpy=[0, 0, 0], dimensions=[0.2, 0.2, 0.15]),
+        build_environment_asset(asset_id="cam_overhead", asset_type="camera_mount", xyz=[0.6, 0, 1.2], rpy=[0, 0, 0], perception_enabled=True),
+        build_environment_asset(asset_id="conv_preview", asset_type="conveyor_placeholder", xyz=[1.2, 0, 0], rpy=[0, 0, 0], dimensions=[2.0, 0.5, 0.2]),
+        build_environment_asset(asset_id="robot_base_1", asset_type="robot_base", xyz=[0, 0, 0], rpy=[0, 0, 0], dimensions=[0.4, 0.4, 0.2]),
+        build_environment_asset(asset_id="spawn_main", asset_type="object_spawn_area", xyz=[0.45, 0, 0.08], rpy=[0, 0, 0], dimensions=[0.3, 0.2, 0.1]),
+        build_environment_asset(asset_id="fixture_1", asset_type="fixture_placeholder", xyz=[0.2, -0.3, 0.1], rpy=[0, 0, 0], dimensions=[0.1, 0.1, 0.1]),
+    ]
+    assert assets[2]["camera"]["device_id"] == "intel_realsense_d435i"
+    assert assets[3]["preview_status"] == "preview_only"
+
+
+def test_xyz_rpy_values_are_saved() -> None:
+    asset = build_environment_asset(asset_id="bin_blue", asset_type="bin", xyz=[0.1, 0.2, 0.3], rpy=[0.4, 0.5, 0.6], dimensions=[0.2, 0.2, 0.2])
+    assert asset["pose"]["xyz"] == [0.1, 0.2, 0.3]
+    assert asset["pose"]["rpy"] == [0.4, 0.5, 0.6]
+
+
+def test_conveyor_marked_preview_warn() -> None:
+    layout = build_environment_layout("demo", [
+        build_environment_asset(asset_id="conv_preview", asset_type="conveyor_placeholder", xyz=[1, 0, 0], rpy=[0, 0, 0], dimensions=[1, 1, 1])
+    ])
+    result = validate_layout(layout, path=__import__('pathlib').Path('in-memory.yaml'), parser='yaml', notes=[])
+    assert any("placeholder/visual metadata only" in w for w in result.warnings)
+
+
+def test_generated_environment_metadata_validates() -> None:
+    layout = build_environment_layout("valid", [
+        build_environment_asset(asset_id="table_main", asset_type="table", xyz=[0, 0, 0], rpy=[0, 0, 0], dimensions=[1, 1, 0.1]),
+        build_environment_asset(asset_id="robot_base_1", asset_type="robot_base", xyz=[0, 0, 0], rpy=[0, 0, 0], dimensions=[0.4, 0.4, 0.2]),
+        build_environment_asset(asset_id="spawn_main", asset_type="object_spawn_area", xyz=[0.4, 0, 0.1], rpy=[0, 0, 0], dimensions=[0.3, 0.2, 0.1]),
+    ])
+    result = validate_layout(layout, path=__import__('pathlib').Path('in-memory.yaml'), parser='yaml', notes=[])
+    assert result.ok
+
+
+def test_ur5_table_bins_still_generates() -> None:
+    layout = build_environment_layout("ur5_bins", [
+        build_environment_asset(asset_id="table_main", asset_type="table", xyz=[0.5, 0, 0], rpy=[0, 0, 0], dimensions=[1.2, 0.8, 0.05]),
+        build_environment_asset(asset_id="bin_red", asset_type="bin", xyz=[0.4, 0.3, 0.1], rpy=[0, 0, 0], dimensions=[0.2, 0.2, 0.15]),
+        build_environment_asset(asset_id="bin_blue", asset_type="bin", xyz=[0.4, -0.3, 0.1], rpy=[0, 0, 0], dimensions=[0.2, 0.2, 0.15]),
+        build_environment_asset(asset_id="robot_base_1", asset_type="robot_base", xyz=[0, 0, 0], rpy=[0, 0, 0], dimensions=[0.4, 0.4, 0.2]),
+        build_environment_asset(asset_id="spawn_main", asset_type="object_spawn_area", xyz=[0.45, 0, 0.08], rpy=[0, 0, 0], dimensions=[0.3, 0.2, 0.1]),
+    ])
+    assert layout["layout_id"] == "ur5_bins"
+    assert len(layout["assets"]) >= 5


### PR DESCRIPTION
### Motivation
- Enable Workcell Studio workcell_builder to author environment layouts visually by providing a programmatic palette of environment assets instead of manual YAML editing.
- Provide common environment primitives (table, bins, conveyors, camera, robot base, spawn area, fixtures) with metadata useful for preview, validation, and downstream export.

### Description
- Add `scripts/workcell_builder_environment_palette.py` which defines an asset catalog and helpers `build_environment_asset` and `build_environment_layout` for creating structured environment assets (id/name/type, `pose.xyz`/`pose.rpy`, optional `dimensions`, `mesh_path`, `preview_status`, and optional `metadata`).
- Include palette entries for `table`, `bin`, `conveyor_placeholder`, `camera_mount` (with RealSense D435i metadata), `robot_base`, `object_spawn_area`, and `fixture_placeholder`, and mark conveyors/fixtures as preview-only where appropriate.
- Extend `scripts/validate_environment_layout.py` to emit builder-focused warnings for missing `robot_base`, missing table/support surface, missing pick area, perception enabled but no camera pose, and conveyor selected as placeholder with no physics backend, and to include palette-generated metadata (`generated_by: workcell_builder`, `environment_palette_enabled`).
- Add tests in `tests/test_workcell_builder_environment_palette.py` to verify asset metadata creation (table/bin/camera/conveyor), `xyz`/`rpy` persistence, conveyor preview warnings, overall layout validation, and UR5+table+bins layout generation continuity.

### Testing
- Ran `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_environment_palette.py tests/test_validate_builder_generated_scene.py tests/test_workcell_builder_generation.py` and all tests passed.
- Test output: `24 passed`.
- The new test file is `tests/test_workcell_builder_environment_palette.py` and it covers asset creation, persistence, validation warnings, and layout generation checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcecb79d088331ab2296ff702e88a6)