### PR TITLE
Workcell Builder: add task template selection and metadata

### DIFF
--- a/scripts/create_or_update_builder_task_intent.py
+++ b/scripts/create_or_update_builder_task_intent.py
@@ -75,7 +75,7 @@ def _resolve_scene_label(scene_package: Path, target_id: str) -> tuple[str, bool
     return _readable_label(target_id), False
 
 def _default(scene_package: str) -> dict[str, Any]:
-    return {"schema":"workcell_builder_task_intent/v1","scene_package":scene_package,"task":{"id":"default_builder_task","type":"pick_place","mode":"offline_preview"},"pick":{"source":{"type":"zone","id":"pick_zone_main"},"object_filter":{"class_id":"any","color":"any"}},"grasp":{"strategy_ref":"finger_pinch_basic","approach_axis":"z_down","approach_distance_m":0.1,"retreat_axis":"z_up","retreat_distance_m":0.1},"place":{"target":{"type":"bin","id":"bin_red"},"release_strategy":"tool_release","retreat_axis":"z_up","retreat_distance_m":0.1},"routing":{"rules":[]},"safety":{"metadata_only":True,"runtime_io_applied":False,"motion_started":False,"ros_launch_started":False}}
+    return {"schema":"workcell_builder_task_intent/v1","scene_package":scene_package,"task":{"id":"default_builder_task","type":"pick_place","mode":"offline_preview","template":"pick_place"},"task_template":{"id":"pick_place","scenario":"pick_place","runtime_status":"supported","notes":"Template metadata only; runtime remains existing pick/place and sorting flows."},"pick":{"source":{"type":"zone","id":"pick_zone_main"},"object_filter":{"class_id":"any","color":"any"}},"grasp":{"strategy_ref":"finger_pinch_basic","approach_axis":"z_down","approach_distance_m":0.1,"retreat_axis":"z_up","retreat_distance_m":0.1},"place":{"target":{"type":"bin","id":"bin_red"},"release_strategy":"tool_release","retreat_axis":"z_up","retreat_distance_m":0.1},"routing":{"rules":[]},"safety":{"metadata_only":True,"runtime_io_applied":False,"motion_started":False,"ros_launch_started":False}}
 
 def _seed(scene_package: Path, output: Path | None) -> tuple[dict[str, Any], Path | None]:
     cands = [output] if output else []
@@ -90,6 +90,7 @@ def main() -> int:
     ap.add_argument('--scene-package', required=True, type=Path)
     ap.add_argument('--task-id', required=True)
     ap.add_argument('--task-type', required=True)
+    ap.add_argument('--task-template', default='pick_place', choices=['pick_place', 'sorting', 'inspection', 'machine_tending', 'conveyor_picking'])
     ap.add_argument('--pick-source', required=True, help='Pick source id (e.g. epd_detected_object or pick_zone_main)')
     ap.add_argument('--pick-source-type', choices=['epd_detected_object','epd_replay','fixed_object','pick_zone','perception'], default='epd_detected_object')
     ap.add_argument('--place-target', required=True)
@@ -111,7 +112,44 @@ def main() -> int:
     payload, _ = _seed(a.scene_package, a.output)
     out = a.output or (a.scene_package/'generated'/'workcell_builder_task_intent.yaml')
     payload['schema']='workcell_builder_task_intent/v1'; payload['scene_package']=a.scene_package.as_posix()
-    payload.setdefault('task',{}).update({'id':a.task_id,'type':a.task_type})
+    payload.setdefault('task',{}).update({'id':a.task_id,'type':a.task_type, 'template': a.task_template})
+    template_meta: dict[str, Any] = {
+        'id': a.task_template,
+        'scenario': a.task_template,
+        'runtime_status': 'supported' if a.task_template in {'pick_place', 'sorting', 'conveyor_picking'} else 'preview_only',
+    }
+    if a.task_template == 'pick_place':
+        template_meta['pick_place'] = {
+            'pick_source': a.pick_source,
+            'place_target': a.place_target,
+            'object_class': a.object_class,
+            'grasp_strategy_ref': a.grasp_strategy,
+        }
+    elif a.task_template == 'sorting':
+        template_meta['sorting'] = {
+            'source_area': a.pick_source,
+            'destination_bins': [a.place_target],
+            'classification_key': 'class_id' if a.object_class not in {'', 'any'} else 'manual',
+            'fallback_bin': a.place_target,
+        }
+    elif a.task_template == 'inspection':
+        template_meta['inspection'] = {
+            'inspection_camera': 'TODO_camera',
+            'object_pose_source': a.pick_source,
+            'pass_fail_output_target': a.place_target,
+            'warning': 'no full runtime yet',
+        }
+    elif a.task_template == 'machine_tending':
+        template_meta['machine_tending'] = {
+            'machine_pose': 'TODO_machine_pose',
+            'load_pose': a.pick_source,
+            'unload_pose': a.place_target,
+            'door_open_close': 'placeholder_only',
+            'warning': 'no full runtime yet',
+        }
+    elif a.task_template == 'conveyor_picking':
+        template_meta['conveyor_picking'] = {'source_area': a.pick_source, 'drop_target': a.place_target}
+    payload['task_template'] = template_meta
     source_type = {'epd_detected_object':'perception','epd_replay':'replay_object'}.get(a.pick_source_type, a.pick_source_type)
     payload.setdefault('pick',{}).setdefault('source',{}).update({'id':a.pick_source, 'type': source_type})
     pick_label, pick_resolved = _resolve_scene_label(a.scene_package, a.pick_source)

--- a/scripts/validate_builder_task_intent.py
+++ b/scripts/validate_builder_task_intent.py
@@ -59,6 +59,10 @@ def validate(path: Path, scene_package: Path|None=None, grasp_dir: Path|None=Non
     grasp=payload.get('grasp') if isinstance(payload.get('grasp'),dict) else {}
     safety=payload.get('safety') if isinstance(payload.get('safety'),dict) else {}
     if not task.get('type'): errors.append('task.type is required')
+    task_template = payload.get('task_template') if isinstance(payload.get('task_template'), dict) else {}
+    template_id = str(task_template.get('id') or task.get('template') or '').strip()
+    if template_id in {'inspection', 'machine_tending', 'conveyor_picking'}:
+        warnings.append(f"task template '{template_id}' is preview-only; no full runtime yet")
     if not pick.get('id'): errors.append('Pick source is not selected.')
     if not pick.get('id'): errors.append('pick.source.id is required')
     if not place.get('id'):

--- a/scripts/workcell_builder_studio_panel.py
+++ b/scripts/workcell_builder_studio_panel.py
@@ -51,6 +51,7 @@ def detect_scene_context(scene_package: Path) -> dict[str, str]:
         "selected_pick_zone": str((pick.get("source") or {}).get("id", "unknown")),
         "selected_place_target": str((place.get("target") or {}).get("id", "unknown")),
         "selected_task_type": str((intent.get("task") or {}).get("type", "unknown")),
+        "selected_task_template": str((intent.get("task_template") or {}).get("id", (intent.get("task") or {}).get("template", "unknown"))),
         "selected_grasp_strategy": str(grasp.get("strategy_ref", "unknown")),
         "selected_release_strategy": str(place.get("release_strategy", "unknown")),
         "selected_routing_target": str((rules[0].get("place_target") if rules and isinstance(rules[0], dict) else "unknown")),
@@ -103,8 +104,8 @@ def panel_state_from_validation(report: dict[str, Any], scene_package: Path) -> 
         "readiness_status": report.get("readiness", report.get("readiness_classification", "unknown")),
         "preview_status": "MANUAL_ONLY",
         "safety_status": "FAKE_HARDWARE_ONLY",
-        "workflow_steps": ["Build Cell", "Define Task", "Validate", "Export", "Preview", "Review Safety"],
-        "sections": ["Cell Setup", "Pick Source", "Place Target", "Grasp Strategy", "Validation", "Export", "Preview Commands", "Safety"],
+        "workflow_steps": ["Build Cell", "Select Task Template", "Define Task", "Validate", "Export", "Preview", "Review Safety"],
+        "sections": ["Cell Setup", "Task Template", "Pick Source", "Place Target", "Grasp Strategy", "Validation", "Export", "Preview Commands", "Safety"],
         "help_text": {
             "pick_source": "Pick source: where the object comes from.",
             "epd_detected": "Use EPD detected object when the camera/perception system supplies the object pose.",

--- a/scripts/workcell_builder_studio_summary.py
+++ b/scripts/workcell_builder_studio_summary.py
@@ -69,6 +69,8 @@ def summarize_builder_scene(scene_package: Path, *, source_project_path: Path | 
             "object_spawn_area": "pick_zone" in zone_types,
         },
         "task_type": ((intent.get("task") or {}).get("type") if isinstance(intent.get("task"), dict) else "unknown") or "unknown",
+        "task_template": ((intent.get("task_template") or {}).get("id") if isinstance(intent.get("task_template"), dict) else ((intent.get("task") or {}).get("template") if isinstance(intent.get("task"), dict) else "unknown")) or "unknown",
+        "task_template_metadata": intent.get("task_template") if isinstance(intent.get("task_template"), dict) else {},
         "grasp_strategy": ((intent.get("grasp") or {}).get("strategy_ref") if isinstance(intent.get("grasp"), dict) else "unknown") or "unknown",
         "generated_scene_package_path": str(scene_package),
         "use_fake_hardware_default": True,

--- a/tests/test_workcell_builder_task_templates.py
+++ b/tests/test_workcell_builder_task_templates.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from scripts.validate_builder_task_intent import validate
+from scripts.workcell_builder_studio_summary import summarize_builder_scene
+
+
+def _write_yaml(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _scene(tmp_path: Path, template_id: str, task_type: str = "pick_place") -> tuple[Path, Path]:
+    scene = tmp_path / f"scene_{template_id}"
+    (scene / "generated").mkdir(parents=True, exist_ok=True)
+    (scene / "package.xml").write_text("<package/>", encoding="utf-8")
+    _write_yaml(scene / "environment.yaml", {"robot": {"name": "ur5"}, "end_effector": {"name": "2f"}})
+    _write_yaml(scene / "generated" / "environment_layout.yaml", {
+        "assets": [{"id": "cam1", "type": "camera"}],
+        "zones": [{"id": "pick_zone_main", "type": "pick_zone"}, {"id": "bin_red", "type": "bin"}],
+    })
+    _write_yaml(scene / "workcell_builder_metadata.yaml", {"generator_version": "test"})
+    intent = scene / "generated" / "workcell_builder_task_intent.yaml"
+    _write_yaml(intent, {
+        "schema": "workcell_builder_task_intent/v1",
+        "scene_package": str(scene),
+        "task": {"id": "t1", "type": task_type, "template": template_id},
+        "task_template": {"id": template_id, "runtime_status": "preview_only" if template_id in {"inspection", "machine_tending"} else "supported"},
+        "pick": {"source": {"id": "pick_zone_main", "type": "pick_zone"}},
+        "grasp": {"strategy_ref": "finger_pinch_basic", "approach_distance_m": 0.1, "retreat_distance_m": 0.1},
+        "place": {"target": {"id": "bin_red", "type": "bin"}},
+        "routing": {"rules": [{"place_target": "bin_red"}]},
+        "safety": {"metadata_only": True, "runtime_io_applied": False, "motion_started": False, "ros_launch_started": False},
+    })
+    return scene, intent
+
+
+def test_pick_place_metadata_validates(tmp_path: Path) -> None:
+    scene, intent = _scene(tmp_path, "pick_place")
+    report = validate(intent, scene)
+    assert report["status"] == "PASS"
+
+
+def test_sorting_metadata_validates(tmp_path: Path) -> None:
+    scene, intent = _scene(tmp_path, "sorting", task_type="sort_by_colour")
+    report = validate(intent, scene)
+    assert report["status"] == "PASS"
+
+
+def test_preview_templates_warn_only(tmp_path: Path) -> None:
+    for template in ("inspection", "machine_tending"):
+        scene, intent = _scene(tmp_path, template)
+        report = validate(intent, scene)
+        assert report["status"] == "WARN"
+        assert any("preview-only" in warning for warning in report["warnings"])
+
+
+def test_generated_metadata_marks_sorting_as_template_scenario(tmp_path: Path) -> None:
+    scene, _ = _scene(tmp_path, "sorting", task_type="sort_by_colour")
+    summary = summarize_builder_scene(scene)
+    assert summary["task_template"] == "sorting"
+    assert summary["task_template_metadata"]["id"] == "sorting"


### PR DESCRIPTION
### Motivation
- Make `workcell_builder` the primary Workcell Studio UI by treating sorting as one template/scenario among many rather than the whole product.
- Provide explicit task-template metadata so UI and downstream tooling can support multiple cell templates (pick/place, sorting, inspection, machine tending, conveyor picking).
- Surface preview-only templates clearly as placeholders and avoid adding any runtime execution logic.

### Description
- Add `--task-template` input and export `task_template` metadata in `scripts/create_or_update_builder_task_intent.py`, including template-specific blocks for `pick_place`, `sorting`, `inspection`, `machine_tending`, and `conveyor_picking` and a seeded default template.  
- Extend builder summary and panel context in `scripts/workcell_builder_studio_summary.py` and `scripts/workcell_builder_studio_panel.py` to include `task_template` and `task_template_metadata`, and add a `Task Template` workflow step/section.  
- Update `scripts/validate_builder_task_intent.py` to emit a warning (not a failure) when the template is preview-only (`inspection`, `machine_tending`, `conveyor_picking`).  
- Add unit tests in `tests/test_workcell_builder_task_templates.py` to exercise pick/place and sorting metadata validation, to assert preview templates produce WARN status, and to verify generated summary metadata represents sorting as a template scenario.
- No runtime execution logic added and placeholders are explicitly marked as preview-only in metadata.

### Testing
- Added `tests/test_workcell_builder_task_templates.py` covering template validation and summary behavior.  
- Ran `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_task_templates.py tests/test_workcell_builder_generation.py tests/test_validate_builder_generated_scene.py` and observed `23 passed` (all tests passed).
- Existing generation and scene validation tests remained green, confirming sorting/pick-place demos remain valid under the new metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcef555ecc8331a064cc29f5cc8100)