### PR TITLE
Populate Workcell Studio builder with large local asset catalog

### DIFF
--- a/docs/manuals/WORKCELL_STUDIO_ASSET_LIBRARY.md
+++ b/docs/manuals/WORKCELL_STUDIO_ASSET_LIBRARY.md
@@ -1,0 +1,39 @@
+# Workcell Studio Asset Library
+
+This catalog powers the Workcell Studio builder selection area for EMD/workcell_builder only.
+
+## Catalog structure
+- Root file: `workcell_studio_catalog/catalog.yaml`
+- Mesh placeholders: `workcell_studio_catalog/meshes/...`
+- Categories include robots, end effectors/tools, sensors, environment, fixtures, conveyors, machines, safety, objects.
+
+## Adding a new robot
+1. Add item in `catalog.yaml` with `category: robots`.
+2. Set `support_status` and `runtime_status` honestly.
+3. Reference real mesh/package only when available.
+
+## Adding a new gripper
+1. Add item with `category: end_effectors` or `tools`.
+2. Include `tcp_frame`, `flange_frame`, compatibility fields.
+
+## Adding a new STL
+- Use `CustomStlMetadata` model in `workcell_asset_catalog.py`.
+- Include file path, scale, placement, collision flags, and notes.
+
+## support_status meanings
+- `supported`: integrated and validated in EMD flow.
+- `preview_only`: shown in builder but not runtime integrated.
+- `placeholder`: synthetic primitive mesh.
+- `unsupported`: intentionally unavailable.
+
+## runtime_status meanings
+- `supported`: runtime launch path exists.
+- `fake_hardware_only`: fake-hardware workflows only.
+- `preview_only`: selection/preview only.
+- `unsupported`: no runtime path.
+
+## Licensing rule
+Do not add downloaded third-party meshes without license metadata and attribution.
+
+## Placeholder vs supported
+Placeholder assets are clearly tagged to avoid false runtime claims.

--- a/tests/test_workcell_asset_catalog.py
+++ b/tests/test_workcell_asset_catalog.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from workcell_builder.workcell_builder.workcell_asset_catalog import load_catalog, validate_catalog
+
+
+def test_catalog_loads_without_ros() -> None:
+    payload = load_catalog(Path.cwd())
+    assert payload.get("schema_version")
+
+
+def test_catalog_minimum_counts_and_required_fields() -> None:
+    payload = load_catalog(Path.cwd())
+    items = payload["items"]
+    assert len([i for i in items if i["category"] == "robots"]) >= 20
+    assert len([i for i in items if i["category"] in {"end_effectors", "tools"}]) >= 20
+    assert len([i for i in items if i["category"] in {"environment", "fixtures", "conveyors", "machines", "safety", "sensors"}]) >= 30
+    assert len([i for i in items if i["category"] == "objects"]) >= 15
+    for item in items:
+        for req in ("id", "display_name", "category", "support_status", "runtime_status"):
+            assert item.get(req)
+
+
+def test_required_named_assets_and_placeholders() -> None:
+    payload = load_catalog(Path.cwd())
+    by_id = {i["id"]: i for i in payload["items"]}
+    assert by_id["ur5"]["support_status"] == "supported"
+    assert by_id["robotiq_2f_85"]["id"] == "robotiq_2f_85"
+    assert by_id["onrobot_airpick"]["id"] == "onrobot_airpick"
+    assert by_id["onrobot_airpick4"]["id"] == "onrobot_airpick4"
+    assert by_id["generic_delta_robot"]["support_status"] in {"preview_only", "placeholder"}
+    assert by_id["generic_cartesian_gantry"]["support_status"] in {"preview_only", "placeholder"}
+    errors = validate_catalog(payload, Path.cwd())
+    assert not errors

--- a/tests/test_workcell_builder_asset_selection.py
+++ b/tests/test_workcell_builder_asset_selection.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from workcell_builder.workcell_builder.workcell_asset_catalog import grouped_selection, load_catalog
+
+
+def test_selection_groups_items_by_category() -> None:
+    payload = load_catalog(Path.cwd())
+    groups = grouped_selection(payload)
+    assert groups["Robots"]
+    assert groups["End Effectors"]
+    assert groups["Objects"]
+    assert "Custom STL" in groups
+
+
+def test_placeholder_items_are_marked() -> None:
+    payload = load_catalog(Path.cwd())
+    placeholders = [i for i in payload["items"] if i["support_status"] == "placeholder"]
+    assert placeholders
+    assert all(i["runtime_status"] in {"placeholder", "preview_only"} for i in placeholders)

--- a/tests/test_workcell_builder_custom_stl_metadata.py
+++ b/tests/test_workcell_builder_custom_stl_metadata.py
@@ -1,0 +1,18 @@
+from workcell_builder.workcell_builder.workcell_asset_catalog import CustomStlMetadata
+
+
+def test_custom_stl_metadata_roundtrip() -> None:
+    payload = CustomStlMetadata(
+        file_path="/tmp/custom.stl",
+        display_name="Custom Fixture",
+        category="fixture",
+        scale=[1.0, 1.0, 1.0],
+        xyz=[0.1, 0.2, 0.3],
+        rpy=[0.0, 0.0, 1.57],
+        collision_enabled=False,
+        visual_only=True,
+        notes="approximate collision",
+    )
+    loaded = CustomStlMetadata.from_dict(payload.to_dict())
+    assert loaded.file_path == payload.file_path
+    assert loaded.visual_only is True

--- a/workcell_builder/workcell_builder/workcell_asset_catalog.py
+++ b/workcell_builder/workcell_builder/workcell_asset_catalog.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+VALID_RUNTIME_STATUS = {"supported", "fake_hardware_only", "preview_only", "unsupported", "placeholder"}
+
+
+def catalog_path(root: Path | None = None) -> Path:
+    base = root or Path(__file__).resolve().parents[2]
+    return base / "workcell_studio_catalog" / "catalog.yaml"
+
+
+def load_catalog(root: Path | None = None) -> dict[str, Any]:
+    payload = yaml.safe_load(catalog_path(root).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return {"items": []}
+    return payload
+
+
+def validate_catalog(payload: dict[str, Any], root: Path | None = None) -> list[str]:
+    errors: list[str] = []
+    base = root or Path(__file__).resolve().parents[2]
+    for idx, item in enumerate(payload.get("items", [])):
+        for req in ("id", "display_name", "category", "support_status", "runtime_status"):
+            if not item.get(req):
+                errors.append(f"item[{idx}] missing {req}")
+        if item.get("runtime_status") not in VALID_RUNTIME_STATUS:
+            errors.append(f"item[{idx}] invalid runtime_status")
+        if item.get("preview_mesh_path") and not (base / item["preview_mesh_path"]).exists():
+            errors.append(f"item[{idx}] preview mesh missing")
+        if item.get("category") == "robots" and item.get("support_status") == "supported" and item.get("id") != "ur5":
+            errors.append(f"item[{idx}] unsupported robot marked supported")
+    return errors
+
+
+def grouped_selection(payload: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    groups = {
+        "Robots": [], "End Effectors": [], "Tools": [], "Sensors": [], "Tables": [], "Bins": [],
+        "Conveyors": [], "Fixtures": [], "Machines": [], "Safety": [], "Objects": [], "Custom STL": []
+    }
+    for item in payload.get("items", []):
+        c = item.get("category", "")
+        if c == "robots": groups["Robots"].append(item)
+        elif c == "end_effectors": groups["End Effectors"].append(item)
+        elif c == "tools": groups["Tools"].append(item)
+        elif c == "sensors": groups["Sensors"].append(item)
+        elif c == "conveyors": groups["Conveyors"].append(item)
+        elif c == "fixtures": groups["Fixtures"].append(item)
+        elif c == "machines": groups["Machines"].append(item)
+        elif c == "safety": groups["Safety"].append(item)
+        elif c == "objects": groups["Objects"].append(item)
+        elif c == "environment":
+            iid = item.get("id", "")
+            if "table" in iid or "bench" in iid: groups["Tables"].append(item)
+            elif "bin" in iid or "box" in iid or "tote" in iid: groups["Bins"].append(item)
+    return groups
+
+
+@dataclass
+class CustomStlMetadata:
+    file_path: str
+    display_name: str
+    category: str = "custom"
+    scale: list[float] | None = None
+    xyz: list[float] | None = None
+    rpy: list[float] | None = None
+    collision_enabled: bool = True
+    visual_only: bool = False
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data.setdefault("scale", [1.0, 1.0, 1.0])
+        data.setdefault("xyz", [0.0, 0.0, 0.0])
+        data.setdefault("rpy", [0.0, 0.0, 0.0])
+        return data
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "CustomStlMetadata":
+        return cls(**payload)

--- a/workcell_studio_catalog/catalog.yaml
+++ b/workcell_studio_catalog/catalog.yaml
@@ -1,0 +1,3144 @@
+schema_version: workcell_studio_asset_catalog/v1
+items:
+- id: ur3
+  display_name: Ur3
+  category: robots
+  family: robot_arm
+  vendor: UR3
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: ur3e
+  display_name: Ur3E
+  category: robots
+  family: robot_arm
+  vendor: UR3E
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: ur5
+  display_name: Ur5
+  category: robots
+  family: robot_arm
+  vendor: UR5
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: workcell_builder
+  moveit_config_package: ur5_moveit_config
+  support_status: supported
+  runtime_status: supported
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: ur5e
+  display_name: Ur5E
+  category: robots
+  family: robot_arm
+  vendor: UR5E
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: ur10
+  display_name: Ur10
+  category: robots
+  family: robot_arm
+  vendor: UR10
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: ur10e
+  display_name: Ur10E
+  category: robots
+  family: robot_arm
+  vendor: UR10E
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: ur16e
+  display_name: Ur16E
+  category: robots
+  family: robot_arm
+  vendor: UR16E
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: ur20
+  display_name: Ur20
+  category: robots
+  family: robot_arm
+  vendor: UR20
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: ur30
+  display_name: Ur30
+  category: robots
+  family: robot_arm
+  vendor: UR30
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: fanuc_lr_mate_200id
+  display_name: Fanuc Lr Mate 200Id
+  category: robots
+  family: robot_arm
+  vendor: FANUC
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: fanuc_m10ia
+  display_name: Fanuc M10Ia
+  category: robots
+  family: robot_arm
+  vendor: FANUC
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: fanuc_m20ia
+  display_name: Fanuc M20Ia
+  category: robots
+  family: robot_arm
+  vendor: FANUC
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: fanuc_crx_10ia
+  display_name: Fanuc Crx 10Ia
+  category: robots
+  family: robot_arm
+  vendor: FANUC
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: fanuc_crx_20ia
+  display_name: Fanuc Crx 20Ia
+  category: robots
+  family: robot_arm
+  vendor: FANUC
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: abb_irb_120
+  display_name: Abb Irb 120
+  category: robots
+  family: robot_arm
+  vendor: ABB
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: abb_irb_1200
+  display_name: Abb Irb 1200
+  category: robots
+  family: robot_arm
+  vendor: ABB
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: abb_irb_1600
+  display_name: Abb Irb 1600
+  category: robots
+  family: robot_arm
+  vendor: ABB
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: abb_gofa
+  display_name: Abb Gofa
+  category: robots
+  family: robot_arm
+  vendor: ABB
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: abb_yumi
+  display_name: Abb Yumi
+  category: robots
+  family: robot_arm
+  vendor: ABB
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: kuka_kr6
+  display_name: Kuka Kr6
+  category: robots
+  family: robot_arm
+  vendor: KUKA
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: kuka_kr10
+  display_name: Kuka Kr10
+  category: robots
+  family: robot_arm
+  vendor: KUKA
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: kuka_lbr_iiwa
+  display_name: Kuka Lbr Iiwa
+  category: robots
+  family: robot_arm
+  vendor: KUKA
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: kuka_lbr_med
+  display_name: Kuka Lbr Med
+  category: robots
+  family: robot_arm
+  vendor: KUKA
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: motoman_gp7
+  display_name: Motoman Gp7
+  category: robots
+  family: robot_arm
+  vendor: MOTOMAN
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: motoman_gp12
+  display_name: Motoman Gp12
+  category: robots
+  family: robot_arm
+  vendor: MOTOMAN
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: motoman_gp25
+  display_name: Motoman Gp25
+  category: robots
+  family: robot_arm
+  vendor: MOTOMAN
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: motoman_hc10
+  display_name: Motoman Hc10
+  category: robots
+  family: robot_arm
+  vendor: MOTOMAN
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: franka_panda
+  display_name: Franka Panda
+  category: robots
+  family: robot_arm
+  vendor: FRANKA
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: kinova_gen3
+  display_name: Kinova Gen3
+  category: robots
+  family: robot_arm
+  vendor: KINOVA
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: xarm6
+  display_name: Xarm6
+  category: robots
+  family: robot_arm
+  vendor: XARM6
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: xarm7
+  display_name: Xarm7
+  category: robots
+  family: robot_arm
+  vendor: XARM7
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: dobot_cr5
+  display_name: Dobot Cr5
+  category: robots
+  family: robot_arm
+  vendor: DOBOT
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: dobot_cr10
+  display_name: Dobot Cr10
+  category: robots
+  family: robot_arm
+  vendor: DOBOT
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: elephant_my_cobot
+  display_name: Elephant My Cobot
+  category: robots
+  family: robot_arm
+  vendor: ELEPHANT
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: elephant_my_arm
+  display_name: Elephant My Arm
+  category: robots
+  family: robot_arm
+  vendor: ELEPHANT
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: ufactory_lite6
+  display_name: Ufactory Lite6
+  category: robots
+  family: robot_arm
+  vendor: UFACTORY
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: generic_6dof_aliexpress_arm
+  display_name: Generic 6Dof Aliexpress Arm
+  category: robots
+  family: robot_arm
+  vendor: GENERIC
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: homemade_3d_printed_6dof_arm
+  display_name: Homemade 3D Printed 6Dof Arm
+  category: robots
+  family: robot_arm
+  vendor: HOMEMADE
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: generic_scara
+  display_name: Generic Scara
+  category: robots
+  family: robot_arm
+  vendor: GENERIC
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: generic_delta_robot
+  display_name: Generic Delta Robot
+  category: robots
+  family: robot_arm
+  vendor: GENERIC
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: generic_cartesian_gantry
+  display_name: Generic Cartesian Gantry
+  category: robots
+  family: robot_arm
+  vendor: GENERIC
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: generic_3_axis_cartesian
+  display_name: Generic 3 Axis Cartesian
+  category: robots
+  family: robot_arm
+  vendor: GENERIC
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: generic_4_axis_palletizer
+  display_name: Generic 4 Axis Palletizer
+  category: robots
+  family: robot_arm
+  vendor: GENERIC
+  mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+  urdf_package: ''
+  moveit_config_package: ''
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Catalog entry for Workcell Studio.
+  tags:
+  - robot
+  - arm
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+  - suction_top_basic
+- id: robotiq_2f_85
+  display_name: Robotiq 2F 85
+  category: end_effectors
+  family: gripper
+  vendor: Robotiq
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: supported
+  runtime_status: fake_hardware_only
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: robotiq_2f_140
+  display_name: Robotiq 2F 140
+  category: end_effectors
+  family: gripper
+  vendor: Robotiq
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: robotiq_3f
+  display_name: Robotiq 3F
+  category: end_effectors
+  family: gripper
+  vendor: Robotiq
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: onrobot_rg2
+  display_name: Onrobot Rg2
+  category: end_effectors
+  family: gripper
+  vendor: Onrobot
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: onrobot_rg6
+  display_name: Onrobot Rg6
+  category: end_effectors
+  family: gripper
+  vendor: Onrobot
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: schunk_egp
+  display_name: Schunk Egp
+  category: end_effectors
+  family: gripper
+  vendor: Schunk
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: schunk_egk
+  display_name: Schunk Egk
+  category: end_effectors
+  family: gripper
+  vendor: Schunk
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: schunk_pg
+  display_name: Schunk Pg
+  category: end_effectors
+  family: gripper
+  vendor: Schunk
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: weiss_wsg_50
+  display_name: Weiss Wsg 50
+  category: end_effectors
+  family: gripper
+  vendor: Weiss
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: generic_parallel_jaw_small
+  display_name: Generic Parallel Jaw Small
+  category: end_effectors
+  family: gripper
+  vendor: Generic
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: generic_parallel_jaw_large
+  display_name: Generic Parallel Jaw Large
+  category: end_effectors
+  family: gripper
+  vendor: Generic
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: generic_3_finger_gripper
+  display_name: Generic 3 Finger Gripper
+  category: end_effectors
+  family: gripper
+  vendor: Generic
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: generic_servo_gripper
+  display_name: Generic Servo Gripper
+  category: end_effectors
+  family: gripper
+  vendor: Generic
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: onrobot_airpick
+  display_name: Onrobot Airpick
+  category: end_effectors
+  family: gripper
+  vendor: Onrobot
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: preview_only
+  runtime_status: fake_hardware_only
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: onrobot_airpick4
+  display_name: Onrobot Airpick4
+  category: end_effectors
+  family: gripper
+  vendor: Onrobot
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: preview_only
+  runtime_status: fake_hardware_only
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: onrobot_vgc10
+  display_name: Onrobot Vgc10
+  category: end_effectors
+  family: gripper
+  vendor: Onrobot
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: piab_single_cup
+  display_name: Piab Single Cup
+  category: end_effectors
+  family: gripper
+  vendor: Piab
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: piab_multi_cup
+  display_name: Piab Multi Cup
+  category: end_effectors
+  family: gripper
+  vendor: Piab
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: generic_single_suction_cup
+  display_name: Generic Single Suction Cup
+  category: end_effectors
+  family: gripper
+  vendor: Generic
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: generic_dual_suction_cup
+  display_name: Generic Dual Suction Cup
+  category: end_effectors
+  family: gripper
+  vendor: Generic
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: generic_4_cup_vacuum_array
+  display_name: Generic 4 Cup Vacuum Array
+  category: end_effectors
+  family: gripper
+  vendor: Generic
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: generic_8_cup_vacuum_array
+  display_name: Generic 8 Cup Vacuum Array
+  category: end_effectors
+  family: gripper
+  vendor: Generic
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: generic_foam_vacuum_gripper
+  display_name: Generic Foam Vacuum Gripper
+  category: end_effectors
+  family: gripper
+  vendor: Generic
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: generic_vacuum_plate
+  display_name: Generic Vacuum Plate
+  category: end_effectors
+  family: gripper
+  vendor: Generic
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: magnetic_gripper_placeholder
+  display_name: Magnetic Gripper Placeholder
+  category: end_effectors
+  family: gripper
+  vendor: Magnetic
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: soft_gripper_placeholder
+  display_name: Soft Gripper Placeholder
+  category: end_effectors
+  family: gripper
+  vendor: Soft
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: tool_changer_placeholder
+  display_name: Tool Changer Placeholder
+  category: tools
+  family: gripper
+  vendor: Tool
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: screwdriver_tool_placeholder
+  display_name: Screwdriver Tool Placeholder
+  category: tools
+  family: gripper
+  vendor: Screwdriver
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: inspection_camera_tool_placeholder
+  display_name: Inspection Camera Tool Placeholder
+  category: tools
+  family: gripper
+  vendor: Inspection
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: barcode_scanner_tool_placeholder
+  display_name: Barcode Scanner Tool Placeholder
+  category: tools
+  family: gripper
+  vendor: Barcode
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: welding_torch_placeholder
+  display_name: Welding Torch Placeholder
+  category: end_effectors
+  family: gripper
+  vendor: Welding
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: glue_dispenser_placeholder
+  display_name: Glue Dispenser Placeholder
+  category: end_effectors
+  family: gripper
+  vendor: Glue
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: spindle_tool_placeholder
+  display_name: Spindle Tool Placeholder
+  category: tools
+  family: gripper
+  vendor: Spindle
+  mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+  support_status: placeholder
+  runtime_status: placeholder
+  notes: Selection metadata only.
+  tags:
+  - gripper
+  tcp_frame: tool0
+  flange_frame: flange
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  compatible_grasp_strategies:
+  - finger_pinch_basic
+- id: basic_table_small
+  display_name: Basic Table Small
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: basic_table_large
+  display_name: Basic Table Large
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: aluminium_profile_table
+  display_name: Aluminium Profile Table
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: workbench
+  display_name: Workbench
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: mobile_workbench
+  display_name: Mobile Workbench
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: machine_side_table
+  display_name: Machine Side Table
+  category: machines
+  family: machines
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - machines
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: small_bin
+  display_name: Small Bin
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: medium_bin
+  display_name: Medium Bin
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: large_bin
+  display_name: Large Bin
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: euro_box
+  display_name: Euro Box
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: tote_box
+  display_name: Tote Box
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: klt_bin
+  display_name: Klt Bin
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: sorting_bin_red
+  display_name: Sorting Bin Red
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: sorting_bin_green
+  display_name: Sorting Bin Green
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: sorting_bin_blue
+  display_name: Sorting Bin Blue
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: reject_bin
+  display_name: Reject Bin
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: pass_bin
+  display_name: Pass Bin
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: fail_bin
+  display_name: Fail Bin
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: conveyor_1m_placeholder
+  display_name: Conveyor 1M Placeholder
+  category: conveyors
+  family: conveyors
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - conveyors
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: conveyor_2m_placeholder
+  display_name: Conveyor 2M Placeholder
+  category: conveyors
+  family: conveyors
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - conveyors
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: belt_conveyor_placeholder
+  display_name: Belt Conveyor Placeholder
+  category: conveyors
+  family: conveyors
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - conveyors
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: roller_conveyor_placeholder
+  display_name: Roller Conveyor Placeholder
+  category: conveyors
+  family: conveyors
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - conveyors
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: indexing_conveyor_placeholder
+  display_name: Indexing Conveyor Placeholder
+  category: conveyors
+  family: conveyors
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - conveyors
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: outfeed_conveyor_placeholder
+  display_name: Outfeed Conveyor Placeholder
+  category: conveyors
+  family: conveyors
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - conveyors
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: infeed_conveyor_placeholder
+  display_name: Infeed Conveyor Placeholder
+  category: conveyors
+  family: conveyors
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - conveyors
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: simple_fixture_plate
+  display_name: Simple Fixture Plate
+  category: fixtures
+  family: fixtures
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - fixtures
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: peg_fixture
+  display_name: Peg Fixture
+  category: fixtures
+  family: fixtures
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - fixtures
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: vice_fixture
+  display_name: Vice Fixture
+  category: fixtures
+  family: fixtures
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - fixtures
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: nest_fixture
+  display_name: Nest Fixture
+  category: fixtures
+  family: fixtures
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - fixtures
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: locating_pins_fixture
+  display_name: Locating Pins Fixture
+  category: fixtures
+  family: fixtures
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - fixtures
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: tray_fixture
+  display_name: Tray Fixture
+  category: fixtures
+  family: fixtures
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - fixtures
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: part_holder_fixture
+  display_name: Part Holder Fixture
+  category: fixtures
+  family: fixtures
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - fixtures
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: adjustable_stop_fixture
+  display_name: Adjustable Stop Fixture
+  category: fixtures
+  family: fixtures
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - fixtures
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: safety_fence_panel
+  display_name: Safety Fence Panel
+  category: safety
+  family: safety
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - safety
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: safety_gate
+  display_name: Safety Gate
+  category: safety
+  family: safety
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - safety
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: light_curtain
+  display_name: Light Curtain
+  category: safety
+  family: safety
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - safety
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: emergency_stop_pedestal
+  display_name: Emergency Stop Pedestal
+  category: fixtures
+  family: fixtures
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - fixtures
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: floor_marking_zone
+  display_name: Floor Marking Zone
+  category: safety
+  family: safety
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - safety
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: robot_keepout_zone
+  display_name: Robot Keepout Zone
+  category: safety
+  family: safety
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - safety
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: operator_zone
+  display_name: Operator Zone
+  category: safety
+  family: safety
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - safety
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: realsense_d435i
+  display_name: Realsense D435I
+  category: sensors
+  family: sensors
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - sensors
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: overhead_rgbd_camera_placeholder
+  display_name: Overhead Rgbd Camera Placeholder
+  category: sensors
+  family: sensors
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - sensors
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: area_scan_camera_placeholder
+  display_name: Area Scan Camera Placeholder
+  category: sensors
+  family: sensors
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - sensors
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: line_scan_camera_placeholder
+  display_name: Line Scan Camera Placeholder
+  category: sensors
+  family: sensors
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - sensors
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: barcode_scanner_placeholder
+  display_name: Barcode Scanner Placeholder
+  category: sensors
+  family: sensors
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - sensors
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: safety_scanner_placeholder
+  display_name: Safety Scanner Placeholder
+  category: safety
+  family: safety
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - safety
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: cnc_machine_placeholder
+  display_name: Cnc Machine Placeholder
+  category: machines
+  family: machines
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - machines
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: lathe_placeholder
+  display_name: Lathe Placeholder
+  category: machines
+  family: machines
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - machines
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: injection_moulding_machine_placeholder
+  display_name: Injection Moulding Machine Placeholder
+  category: machines
+  family: machines
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - machines
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: press_machine_placeholder
+  display_name: Press Machine Placeholder
+  category: machines
+  family: machines
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - machines
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: test_station_placeholder
+  display_name: Test Station Placeholder
+  category: machines
+  family: machines
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - machines
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: inspection_station_placeholder
+  display_name: Inspection Station Placeholder
+  category: machines
+  family: machines
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - machines
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: packaging_machine_placeholder
+  display_name: Packaging Machine Placeholder
+  category: machines
+  family: machines
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - machines
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: pallet
+  display_name: Pallet
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: pallet_stack
+  display_name: Pallet Stack
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: shelf_rack
+  display_name: Shelf Rack
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: small_parts_rack
+  display_name: Small Parts Rack
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: tray_stack
+  display_name: Tray Stack
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: cardboard_box
+  display_name: Cardboard Box
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: crate
+  display_name: Crate
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: dunnage_tray
+  display_name: Dunnage Tray
+  category: environment
+  family: environment
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/environment/env_placeholder.stl
+  support_status: preview_only
+  runtime_status: preview_only
+  notes: Environment asset placeholder.
+  tags:
+  - environment
+  default_pose:
+    xyz:
+    - 0
+    - 0
+    - 0
+    rpy:
+    - 0
+    - 0
+    - 0
+  dimensions:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+- id: cube_small
+  display_name: Cube Small
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: cube_large
+  display_name: Cube Large
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: cylinder_small
+  display_name: Cylinder Small
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: cylinder_large
+  display_name: Cylinder Large
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: bottle
+  display_name: Bottle
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: can
+  display_name: Can
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: pouch
+  display_name: Pouch
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: box
+  display_name: Box
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: parcel
+  display_name: Parcel
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: gear_placeholder
+  display_name: Gear Placeholder
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: bracket_placeholder
+  display_name: Bracket Placeholder
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: washer_placeholder
+  display_name: Washer Placeholder
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: bolt_placeholder
+  display_name: Bolt Placeholder
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: plastic_part_placeholder
+  display_name: Plastic Part Placeholder
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: metal_part_placeholder
+  display_name: Metal Part Placeholder
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: food_pack_placeholder
+  display_name: Food Pack Placeholder
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: medical_tray_placeholder
+  display_name: Medical Tray Placeholder
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object
+- id: electronics_part_placeholder
+  display_name: Electronics Part Placeholder
+  category: objects
+  family: object
+  vendor: ''
+  mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  preview_mesh_path: workcell_studio_catalog/meshes/objects/object_placeholder.stl
+  support_status: placeholder
+  runtime_status: preview_only
+  notes: Demo object placeholder.
+  tags:
+  - object

--- a/workcell_studio_catalog/meshes/conveyors/conveyor_placeholder.stl
+++ b/workcell_studio_catalog/meshes/conveyors/conveyor_placeholder.stl
@@ -1,0 +1,16 @@
+solid box
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 0 0
+   vertex 1 1 0
+  endloop
+ endfacet
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 1 0
+   vertex 0 1 0
+  endloop
+ endfacet
+endsolid box

--- a/workcell_studio_catalog/meshes/environment/env_placeholder.stl
+++ b/workcell_studio_catalog/meshes/environment/env_placeholder.stl
@@ -1,0 +1,16 @@
+solid box
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 0 0
+   vertex 1 1 0
+  endloop
+ endfacet
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 1 0
+   vertex 0 1 0
+  endloop
+ endfacet
+endsolid box

--- a/workcell_studio_catalog/meshes/fixtures/fixture_placeholder.stl
+++ b/workcell_studio_catalog/meshes/fixtures/fixture_placeholder.stl
@@ -1,0 +1,16 @@
+solid box
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 0 0
+   vertex 1 1 0
+  endloop
+ endfacet
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 1 0
+   vertex 0 1 0
+  endloop
+ endfacet
+endsolid box

--- a/workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
+++ b/workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl
@@ -1,0 +1,16 @@
+solid box
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 0 0
+   vertex 1 1 0
+  endloop
+ endfacet
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 1 0
+   vertex 0 1 0
+  endloop
+ endfacet
+endsolid box

--- a/workcell_studio_catalog/meshes/machines/machine_placeholder.stl
+++ b/workcell_studio_catalog/meshes/machines/machine_placeholder.stl
@@ -1,0 +1,16 @@
+solid box
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 0 0
+   vertex 1 1 0
+  endloop
+ endfacet
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 1 0
+   vertex 0 1 0
+  endloop
+ endfacet
+endsolid box

--- a/workcell_studio_catalog/meshes/objects/object_placeholder.stl
+++ b/workcell_studio_catalog/meshes/objects/object_placeholder.stl
@@ -1,0 +1,16 @@
+solid box
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 0 0
+   vertex 1 1 0
+  endloop
+ endfacet
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 1 0
+   vertex 0 1 0
+  endloop
+ endfacet
+endsolid box

--- a/workcell_studio_catalog/meshes/robots/robot_placeholder.stl
+++ b/workcell_studio_catalog/meshes/robots/robot_placeholder.stl
@@ -1,0 +1,16 @@
+solid box
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 0 0
+   vertex 1 1 0
+  endloop
+ endfacet
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 1 0
+   vertex 0 1 0
+  endloop
+ endfacet
+endsolid box

--- a/workcell_studio_catalog/meshes/safety/safety_placeholder.stl
+++ b/workcell_studio_catalog/meshes/safety/safety_placeholder.stl
@@ -1,0 +1,16 @@
+solid box
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 0 0
+   vertex 1 1 0
+  endloop
+ endfacet
+ facet normal 0 0 0
+  outer loop
+   vertex 0 0 0
+   vertex 1 1 0
+   vertex 0 1 0
+  endloop
+ endfacet
+endsolid box


### PR DESCRIPTION
### Motivation
- Provide a product-facing asset library so the EMD/workcell_builder visual Workcell Studio has a rich selection of robots, end effectors, tools, environment assets, fixtures, conveyors, machines, safety items and example objects. 
- Keep EPD GUI separate and avoid introducing external dependencies or unlicensed third-party meshes. 
- Make placeholder assets honest about runtime/support status and preserve existing UR5 + Robotiq 2F demo defaults.

### Description
- Add a new product-facing catalog at `workcell_studio_catalog/catalog.yaml` populated with many robot, gripper/tool, sensor, environment, fixture, conveyor, machine, safety and object entries and associated metadata fields (id, display_name, category, family, vendor, mesh_path, preview_mesh_path, urdf_package, moveit_config_package, support_status, runtime_status, notes, tags, default_pose, dimensions, tcp_frame, compatible fields, etc.).
- Add primitive placeholder meshes under `workcell_studio_catalog/meshes/...` (locally generated ASCII STL boxes) so the builder preview can be populated without downloading external assets.
- Add `workcell_builder/workcell_builder/workcell_asset_catalog.py` with catalog loading, validation rules (required fields, runtime_status validation, preview mesh existence checks, guardrail to prevent marking unvalidated robots as supported), grouping logic for builder selection UI (`grouped_selection`) and a `CustomStlMetadata` dataclass with serialize/deserialize helpers for Custom STL import metadata.
- Add tests and documentation: `tests/test_workcell_asset_catalog.py`, `tests/test_workcell_builder_asset_selection.py`, `tests/test_workcell_builder_custom_stl_metadata.py`, and `docs/manuals/WORKCELL_STUDIO_ASSET_LIBRARY.md` describing catalog structure, adding assets, status semantics and licensing rules.

### Testing
- Ran the builder/catalog focused test command: `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_asset_catalog.py tests/test_workcell_builder_asset_selection.py tests/test_workcell_builder_custom_stl_metadata.py tests/test_workcell_builder_generation.py tests/test_workcell_builder_studio_integration.py tests/test_validate_builder_generated_scene.py`.
- Result: all tests passed (31 passed).
- Validation checks exercised include catalog load without ROS, minimum counts for robots/grippers/environment/objects, required metadata presence, placeholder marking, UR5 and Robotiq/OnRobot entries present, and round-trip serialization for custom STL metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf53d4f7083319be917f62584a048)