### PR TITLE
Add workcell_builder compatibility matrix and surface status in metadata/summary

### DIFF
--- a/scripts/render_workcell_builder_metadata.py
+++ b/scripts/render_workcell_builder_metadata.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from scripts.workcell_builder_capability_catalog import load_workcell_capability_catalog
 from scripts.workcell_builder_grasp_strategy import normalize_grasp_strategy
+from scripts.workcell_builder_compatibility_matrix import evaluate_compatibility
 
 
 def _norm(text: str | None) -> str:
@@ -30,7 +31,7 @@ def _catalog_lookup(group: list[dict[str, Any]], selected_name: str | None) -> d
     return {}
 
 
-def render_metadata(robot: str | None, end_effector: str | None, sensor: str | None, grasp_strategy: str | None, scene_path: Path | None = None, grasp_config: dict[str, Any] | None = None) -> dict[str, Any]:
+def render_metadata(robot: str | None, end_effector: str | None, sensor: str | None, grasp_strategy: str | None, scene_path: Path | None = None, grasp_config: dict[str, Any] | None = None, task_template: str | None = None, environment_assets: list[str] | None = None, custom_stl_assets: list[dict[str, Any]] | None = None, hardware_mode: str | None = "fake") -> dict[str, Any]:
     catalog = load_workcell_capability_catalog()
     robot_cat = _catalog_lookup(catalog.get("robots", []), robot)
     ee_cat = _catalog_lookup(catalog.get("end_effectors", []), end_effector)
@@ -52,7 +53,7 @@ def render_metadata(robot: str | None, end_effector: str | None, sensor: str | N
     warnings.extend(robot_cat.get("warnings", []))
     warnings.extend(ee_cat.get("warnings", []))
     warnings.extend(grasp_warnings)
-    status = "preview_only" if robot_info.get("preview_only") or ee_info.get("preview_only") else "fake_hardware_ready"
+    base_status = "preview_only" if robot_info.get("preview_only") or ee_info.get("preview_only") else "fake_hardware_ready"
     imported = []
     object_count = 0
     if scene_path:
@@ -63,6 +64,16 @@ def render_metadata(robot: str | None, end_effector: str | None, sensor: str | N
                 if "filepath:" in line:
                     imported.append(line.split("filepath:", 1)[1].strip().strip('"'))
             object_count = txt.count("filepath:")
+
+    compatibility = evaluate_compatibility(
+        robot=robot,
+        gripper_tool=end_effector,
+        task_template=task_template,
+        grasp_strategy=grasp_strategy,
+        environment_assets=environment_assets,
+        custom_stl_assets=custom_stl_assets,
+        hardware_mode=hardware_mode,
+    )
 
     return {
         "selected_capabilities": {
@@ -80,7 +91,8 @@ def render_metadata(robot: str | None, end_effector: str | None, sensor: str | N
         "grasp_strategy": {"selected_name": grasp_strategy, **grasp_payload},
         "sensors": [{"selected_name": sensor, **sensor_info}] if sensor else [],
         "environment": {"generated_objects_count": object_count, "imported_stl_references": imported},
-        "readiness": {"status": status, "blockers": [], "warnings": warnings},
+        "readiness": {"status": base_status, "blockers": [], "warnings": warnings},
+        "compatibility": compatibility.to_dict(),
     }
 
 
@@ -92,12 +104,14 @@ def main() -> int:
     ap.add_argument("--grasp-strategy")
     ap.add_argument("--scene-path", type=Path)
     ap.add_argument("--grasp-config", type=Path)
+    ap.add_argument("--task-template")
+    ap.add_argument("--hardware-mode", default="fake")
     ap.add_argument("--output", type=Path, required=True)
     args = ap.parse_args()
     grasp_config = None
     if args.grasp_config and args.grasp_config.is_file():
         grasp_config = json.loads(args.grasp_config.read_text(encoding="utf-8"))
-    data = render_metadata(args.robot, args.end_effector, args.sensor, args.grasp_strategy, args.scene_path, grasp_config)
+    data = render_metadata(args.robot, args.end_effector, args.sensor, args.grasp_strategy, args.scene_path, grasp_config, task_template=args.task_template, hardware_mode=args.hardware_mode)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return 0

--- a/scripts/workcell_builder_compatibility_matrix.py
+++ b/scripts/workcell_builder_compatibility_matrix.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class CompatibilityStatus(str, Enum):
+    SUPPORTED = "SUPPORTED"
+    FAKE_HARDWARE_ONLY = "FAKE_HARDWARE_ONLY"
+    PREVIEW_ONLY = "PREVIEW_ONLY"
+    WARN = "WARN"
+    INVALID = "INVALID"
+
+
+@dataclass
+class CompatibilityResult:
+    status: CompatibilityStatus
+    reasons: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"status": self.status.value, "reasons": self.reasons}
+
+
+def _n(value: str | None) -> str:
+    return (value or "").strip().lower().replace("_", " ")
+
+
+def evaluate_compatibility(*, robot: str | None, gripper_tool: str | None, task_template: str | None,
+                           grasp_strategy: str | None, environment_assets: list[str] | None = None,
+                           custom_stl_assets: list[dict[str, Any]] | None = None,
+                           hardware_mode: str | None = "fake") -> CompatibilityResult:
+    robot_n = _n(robot)
+    tool_n = _n(gripper_tool)
+    task_n = _n(task_template)
+    grasp_n = _n(grasp_strategy)
+    assets = [_n(a) for a in (environment_assets or [])]
+    stls = custom_stl_assets or []
+    mode_n = _n(hardware_mode)
+
+    reasons: list[str] = []
+    status = CompatibilityStatus.SUPPORTED
+
+    placeholder_robot = any(x in robot_n for x in ("fanuc", "abb", "kuka", "yaskawa"))
+    if placeholder_robot or "generic delta" in robot_n or "generic gantry" in robot_n or "cartesian" in robot_n:
+        status = CompatibilityStatus.PREVIEW_ONLY
+        reasons.append("Selected robot is currently treated as placeholder/preview-only in Workcell Studio.")
+
+    if ("delta" in robot_n or "gantry" in robot_n or "cartesian" in robot_n) and "suction" in tool_n:
+        status = CompatibilityStatus.PREVIEW_ONLY
+        reasons.append("Delta/gantry + suction combinations are preview-only.")
+
+    if "conveyor" in assets:
+        status = CompatibilityStatus.PREVIEW_ONLY if status != CompatibilityStatus.INVALID else status
+        reasons.append("Conveyor assets are preview-only without a physics backend.")
+
+    if any(a in assets for a in ("cnc", "machine tending", "machine_fixture")) or "machine tending" in task_n:
+        status = CompatibilityStatus.PREVIEW_ONLY if status != CompatibilityStatus.INVALID else status
+        reasons.append("CNC/machine-tending scenarios are currently placeholders (preview-only).")
+
+    if "suction" in tool_n and "finger" in grasp_n:
+        return CompatibilityResult(CompatibilityStatus.INVALID, ["Finger pinch grasp strategy is invalid for suction tools."])
+    if ("robotiq" in tool_n or "2f" in tool_n) and "suction" in grasp_n:
+        return CompatibilityResult(CompatibilityStatus.INVALID, ["Suction grasp strategy is invalid for finger grippers."])
+
+    if "ur5" in robot_n and ("robotiq" in tool_n or "2f" in tool_n) and "pick" in task_n and "place" in task_n:
+        status = CompatibilityStatus.FAKE_HARDWARE_ONLY
+        reasons.append("UR5 + Robotiq 2F + pick_place is supported in fake hardware mode.")
+
+    if "ur5" in robot_n and ("robotiq" in tool_n or "2f" in tool_n) and "sorting" in task_n:
+        reasons.append("UR5 + Robotiq 2F + sorting depends on scene-template coverage.")
+        status = CompatibilityStatus.WARN if status == CompatibilityStatus.SUPPORTED else status
+
+    if "ur5" in robot_n and "suction" in tool_n and "suction top" in grasp_n:
+        reasons.append("UR5 + suction + suction_top depends on AirPick package coverage.")
+        status = CompatibilityStatus.WARN if status == CompatibilityStatus.SUPPORTED else status
+
+    if mode_n in ("real", "real hardware", "real_hardware"):
+        if status == CompatibilityStatus.SUPPORTED:
+            status = CompatibilityStatus.WARN
+        reasons.append("Real hardware mode is guarded and requires explicit runtime support.")
+
+    unknown_collision = any(not bool(item.get("collision_known")) for item in stls if isinstance(item, dict))
+    if unknown_collision:
+        if status == CompatibilityStatus.SUPPORTED:
+            status = CompatibilityStatus.WARN
+        reasons.append("Custom STL assets with unknown collision quality require manual validation.")
+
+    return CompatibilityResult(status, reasons)

--- a/scripts/workcell_builder_studio_summary.py
+++ b/scripts/workcell_builder_studio_summary.py
@@ -75,6 +75,8 @@ def summarize_builder_scene(scene_package: Path, *, source_project_path: Path | 
         "generated_scene_package_path": str(scene_package),
         "use_fake_hardware_default": True,
         "readiness_status": status,
+        "compatibility_status": ((metadata.get("compatibility") or {}).get("status") if isinstance(metadata.get("compatibility"), dict) else "unknown"),
+        "compatibility_reasons": ((metadata.get("compatibility") or {}).get("reasons") if isinstance(metadata.get("compatibility"), dict) else []),
         "blockers": list(validation.get("errors") or []),
         "warnings": list(validation.get("warnings") or []),
         "validation_readiness_classification": validation.get("readiness", "unknown"),

--- a/tests/test_workcell_builder_compatibility_matrix.py
+++ b/tests/test_workcell_builder_compatibility_matrix.py
@@ -1,0 +1,65 @@
+from scripts.workcell_builder_compatibility_matrix import CompatibilityStatus, evaluate_compatibility
+from scripts.render_workcell_builder_metadata import render_metadata
+
+
+def test_supported_ur5_robotiq_baseline_fake_hw() -> None:
+    result = evaluate_compatibility(
+        robot="UR5",
+        gripper_tool="Robotiq 2F",
+        task_template="pick_place",
+        grasp_strategy="finger_pinch_basic",
+        hardware_mode="fake",
+    )
+    assert result.status == CompatibilityStatus.FAKE_HARDWARE_ONLY
+
+
+def test_placeholder_robot_preview_only() -> None:
+    result = evaluate_compatibility(
+        robot="Fanuc placeholder",
+        gripper_tool="suction",
+        task_template="pick_place",
+        grasp_strategy="suction_top_basic",
+    )
+    assert result.status == CompatibilityStatus.PREVIEW_ONLY
+
+
+def test_invalid_tool_grasp_combinations() -> None:
+    result = evaluate_compatibility(
+        robot="UR5",
+        gripper_tool="suction",
+        task_template="pick_place",
+        grasp_strategy="finger_pinch_basic",
+    )
+    assert result.status == CompatibilityStatus.INVALID
+
+
+def test_real_hardware_mode_produces_guarded_warning() -> None:
+    result = evaluate_compatibility(
+        robot="UR5",
+        gripper_tool="suction",
+        task_template="sorting",
+        grasp_strategy="suction_top_basic",
+        hardware_mode="real",
+    )
+    assert result.status == CompatibilityStatus.WARN
+    assert any("Real hardware mode" in r for r in result.reasons)
+
+
+def test_custom_stl_unknown_collision_warns() -> None:
+    result = evaluate_compatibility(
+        robot="UR5",
+        gripper_tool="Robotiq 2F",
+        task_template="sorting",
+        grasp_strategy="finger_pinch_basic",
+        custom_stl_assets=[{"path": "foo.stl", "collision_known": False}],
+    )
+    assert result.status in (CompatibilityStatus.WARN, CompatibilityStatus.FAKE_HARDWARE_ONLY)
+    assert any("unknown collision" in r.lower() for r in result.reasons)
+
+
+def test_generated_metadata_includes_compatibility_result() -> None:
+    payload = render_metadata(
+        "UR5", "Robotiq 2F", "RealSense D435i", "finger_pinch_basic", task_template="pick_place"
+    )
+    assert payload["compatibility"]["status"] == "FAKE_HARDWARE_ONLY"
+    assert payload["compatibility"]["reasons"]


### PR DESCRIPTION
### Motivation
- Provide an honest compatibility classification for combinations of robot, gripper/tool, task template, grasp strategy, environment assets, custom STL assets, and hardware mode so Workcell Studio can show runtime-readiness vs preview-only scenarios.
- Ensure placeholder vendors and non-runtime assets are treated as preview-only or warned rather than implicitly claimed as supported.
- Keep EPD/runtime execution paths separate and avoid adding runtime GUI controls to `workcell_builder` (metadata-only change). 

### Description
- Add a new compatibility module `scripts/workcell_builder_compatibility_matrix.py` implementing `CompatibilityStatus` and `evaluate_compatibility(...)` with statuses `SUPPORTED`, `FAKE_HARDWARE_ONLY`, `PREVIEW_ONLY`, `WARN`, and `INVALID` and human-readable reasons.
- Integrate compatibility evaluation into metadata generation by calling `evaluate_compatibility` from `render_metadata(...)` and emitting a `compatibility` object in generated metadata (CLI extended with `--task-template` and `--hardware-mode`).
- Surface compatibility results in builder summaries by exposing `compatibility_status` and `compatibility_reasons` in `summarize_builder_scene(...)` output.
- Add unit tests `tests/test_workcell_builder_compatibility_matrix.py` covering UR5+Robotiq baseline, preview-only placeholders, invalid tool/grasp combos, guarded real-hardware warnings, custom STL unknown-collision warnings, and metadata propagation via `render_metadata`.

### Testing
- Ran the compatibility unit tests and integration checks with: `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_compatibility_matrix.py tests/test_workcell_builder_generation.py tests/test_workcell_builder_studio_integration.py`.
- All tests completed successfully: `27 passed` (the compatibility tests plus the two integration-related test files).
- The changes are metadata-only and do not modify runtime execution paths or EPD GUI controls.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf77010688331b1c124c6e8d48a92)