### PR TITLE
Add custom STL importer metadata model and export support

### DIFF
--- a/scripts/workcell_builder_studio_summary.py
+++ b/scripts/workcell_builder_studio_summary.py
@@ -54,6 +54,8 @@ def summarize_builder_scene(scene_package: Path, *, source_project_path: Path | 
     validation = validate_scene(scene_package)
     status = _status_from_validation(validation)
 
+    custom_stl_assets = metadata.get("custom_stl_assets", []) if isinstance(metadata.get("custom_stl_assets"), list) else []
+
     summary = {
         "project_name": scene_package.name,
         "cell_name": scene_package.name,
@@ -83,6 +85,7 @@ def summarize_builder_scene(scene_package: Path, *, source_project_path: Path | 
         "generator": {"name": "workcell_builder", "version": metadata.get("generator_version", "unknown")},
         "source_builder_project_path": str(source_project_path or scene_package),
         "no_runtime_execution_default": True,
+        "custom_stl_assets": custom_stl_assets,
     }
     return summary
 

--- a/tests/test_workcell_builder_custom_stl_importer.py
+++ b/tests/test_workcell_builder_custom_stl_importer.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+import pytest
+
+from workcell_builder.workcell_builder.workcell_asset_catalog import CustomStlMetadata
+from scripts.render_workcell_builder_metadata import render_metadata
+
+
+def test_stl_metadata_creation(tmp_path: Path) -> None:
+    mesh = tmp_path / "fixture.stl"
+    mesh.write_text("solid fixture\nendsolid fixture\n", encoding="utf-8")
+    payload = CustomStlMetadata(
+        source_path=str(mesh),
+        copied_asset_path="assets/custom/fixture.stl",
+        display_name="Fixture A",
+        category="fixture",
+        support_status="supported",
+    )
+    assert payload.validate() == []
+    dumped = payload.to_dict()
+    assert dumped["source_path"] == str(mesh)
+    assert dumped["category"] == "fixture"
+
+
+def test_invalid_file_extension_fails(tmp_path: Path) -> None:
+    mesh = tmp_path / "fixture.ply"
+    mesh.write_text("ply", encoding="utf-8")
+    payload = CustomStlMetadata(source_path=str(mesh), display_name="Fixture A")
+    errors = payload.validate()
+    assert any("extensions" in e for e in errors)
+
+
+def test_scale_pose_and_collision_mode_saved(tmp_path: Path) -> None:
+    mesh = tmp_path / "box.obj"
+    mesh.write_text("o box", encoding="utf-8")
+    payload = CustomStlMetadata(
+        source_path=str(mesh),
+        display_name="Box",
+        category="object",
+        scale=[1.2, 0.8, 0.5],
+        xyz=[0.1, 0.2, 0.3],
+        rpy=[0.0, 1.57, 0.0],
+        collision_mode="visual_only",
+    )
+    dumped = payload.to_dict()
+    assert dumped["scale"] == [1.2, 0.8, 0.5]
+    assert dumped["xyz"] == [0.1, 0.2, 0.3]
+    assert dumped["rpy"] == [0.0, 1.57, 0.0]
+    assert dumped["collision_mode"] == "visual_only"
+
+
+def test_generated_metadata_includes_imported_stl_asset(tmp_path: Path) -> None:
+    mesh = tmp_path / "asset.dae"
+    mesh.write_text("<COLLADA/>", encoding="utf-8")
+    custom = CustomStlMetadata(source_path=str(mesh), display_name="Env", category="environment_asset").to_dict()
+    metadata = render_metadata("UR5", "2f", "d435i", "finger_pinch_basic", custom_stl_assets=[{**custom, "collision_known": False}])
+    reasons = metadata["compatibility"]["reasons"]
+    assert any("Custom STL assets" in reason for reason in reasons)
+
+
+def test_visual_only_custom_stl_does_not_break_generation(tmp_path: Path) -> None:
+    mesh = tmp_path / "safe.stl"
+    mesh.write_text("solid s\nendsolid s\n", encoding="utf-8")
+    payload = CustomStlMetadata(source_path=str(mesh), display_name="Safe", collision_mode="visual_only")
+    assert payload.validate() == []
+    assert payload.to_dict()["collision_mode"] == "visual_only"
+
+
+def test_mesh_collision_falls_back_with_warn_status(tmp_path: Path) -> None:
+    mesh = tmp_path / "machine.stl"
+    mesh.write_text("solid m\nendsolid m\n", encoding="utf-8")
+    payload = CustomStlMetadata(source_path=str(mesh), display_name="Machine", category="machine", collision_mode="mesh_collision")
+    dumped = payload.to_dict()
+    assert dumped["collision_mode"] == "bounding_box_collision"
+    assert dumped["support_status"] == "warn"
+    assert "fallback" in dumped["notes"]

--- a/tests/test_workcell_builder_custom_stl_metadata.py
+++ b/tests/test_workcell_builder_custom_stl_metadata.py
@@ -1,18 +1,19 @@
 from workcell_builder.workcell_builder.workcell_asset_catalog import CustomStlMetadata
 
 
-def test_custom_stl_metadata_roundtrip() -> None:
+def test_custom_stl_metadata_roundtrip(tmp_path) -> None:
+    path = tmp_path / "custom.stl"
+    path.write_text("solid c\nendsolid c\n", encoding="utf-8")
     payload = CustomStlMetadata(
-        file_path="/tmp/custom.stl",
+        source_path=str(path),
         display_name="Custom Fixture",
         category="fixture",
         scale=[1.0, 1.0, 1.0],
         xyz=[0.1, 0.2, 0.3],
         rpy=[0.0, 0.0, 1.57],
-        collision_enabled=False,
-        visual_only=True,
+        collision_mode="visual_only",
         notes="approximate collision",
     )
     loaded = CustomStlMetadata.from_dict(payload.to_dict())
-    assert loaded.file_path == payload.file_path
-    assert loaded.visual_only is True
+    assert loaded.source_path == payload.source_path
+    assert loaded.collision_mode == "visual_only"

--- a/workcell_builder/workcell_builder/workcell_asset_catalog.py
+++ b/workcell_builder/workcell_builder/workcell_asset_catalog.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from pathlib import Path
 from typing import Any
+
+VALID_CUSTOM_STL_CATEGORIES = {"object", "environment_asset", "fixture", "machine", "bin", "conveyor_visual", "tool_visual", "safety_visual", "custom_visual"}
+VALID_CUSTOM_STL_EXTENSIONS = {".stl", ".dae", ".obj"}
+VALID_CUSTOM_STL_COLLISION_MODES = {"visual_only", "bounding_box_collision", "mesh_collision"}
 
 import yaml
 
@@ -62,23 +66,61 @@ def grouped_selection(payload: dict[str, Any]) -> dict[str, list[dict[str, Any]]
 
 @dataclass
 class CustomStlMetadata:
-    file_path: str
+    source_path: str
     display_name: str
-    category: str = "custom"
-    scale: list[float] | None = None
-    xyz: list[float] | None = None
-    rpy: list[float] | None = None
-    collision_enabled: bool = True
-    visual_only: bool = False
+    category: str = "custom_visual"
+    copied_asset_path: str | None = None
+    scale: list[float] = field(default_factory=lambda: [1.0, 1.0, 1.0])
+    xyz: list[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
+    rpy: list[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
+    collision_mode: str = "bounding_box_collision"
+    support_status: str = "supported"
     notes: str = ""
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        path = Path(self.source_path)
+        if not path.is_file():
+            errors.append(f"source_path does not exist: {self.source_path}")
+        if path.suffix.lower() not in VALID_CUSTOM_STL_EXTENSIONS:
+            errors.append("source_path must have one of extensions: .stl, .dae, .obj")
+        if self.category not in VALID_CUSTOM_STL_CATEGORIES:
+            errors.append(f"invalid category: {self.category}")
+        if self.collision_mode not in VALID_CUSTOM_STL_COLLISION_MODES:
+            errors.append(f"invalid collision mode: {self.collision_mode}")
+        if len(self.scale) != 3 or any(s <= 0 for s in self.scale):
+            errors.append("scale must be a 3-element vector with values > 0")
+        if len(self.xyz) != 3:
+            errors.append("xyz must contain exactly 3 values")
+        if len(self.rpy) != 3:
+            errors.append("rpy must contain exactly 3 values")
+        return errors
+
+    def _effective_collision_mode(self) -> str:
+        if self.collision_mode == "mesh_collision":
+            return "bounding_box_collision"
+        return self.collision_mode
 
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)
-        data.setdefault("scale", [1.0, 1.0, 1.0])
-        data.setdefault("xyz", [0.0, 0.0, 0.0])
-        data.setdefault("rpy", [0.0, 0.0, 0.0])
+        if self.collision_mode == "mesh_collision":
+            note = "mesh_collision requested but not supported in lightweight builder; fallback to bounding_box_collision"
+            data["support_status"] = "warn"
+            data["collision_mode"] = self._effective_collision_mode()
+            data["notes"] = f"{self.notes}; {note}" if self.notes else note
         return data
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> "CustomStlMetadata":
-        return cls(**payload)
+        remapped = dict(payload)
+        # Backward compatibility
+        if "source_path" not in remapped and "file_path" in remapped:
+            remapped["source_path"] = remapped.pop("file_path")
+        if "collision_mode" not in remapped:
+            if remapped.pop("visual_only", False):
+                remapped["collision_mode"] = "visual_only"
+            elif remapped.pop("collision_enabled", True):
+                remapped["collision_mode"] = "bounding_box_collision"
+        remapped.pop("collision_enabled", None)
+        remapped.pop("visual_only", None)
+        return cls(**remapped)


### PR DESCRIPTION
### Motivation
- Enable users to import custom mesh assets into the builder and have those assets carried through into generated metadata and summaries.
- Provide a lightweight, dependency-free model for classifying imported meshes, validating them, and recording pose/scale/collision intent for later export.

### Description
- Introduces a richer `CustomStlMetadata` dataclass in `workcell_builder/workcell_builder/workcell_asset_catalog.py` with fields: `source_path`, `copied_asset_path`, `display_name`, `category`, `scale`, `xyz`, `rpy`, `collision_mode`, `support_status`, and `notes` plus a `validate()` helper and `from_dict` backward-compat remapping from legacy keys (`file_path`, `visual_only`, `collision_enabled`).
- Adds lightweight collision handling where `mesh_collision` requests are downgraded to `bounding_box_collision` and `support_status` is set to `warn` with a explanatory note (avoids adding heavy mesh-processing dependencies).
- Adds enum-like sets for valid categories, extensions, and collision modes and basic validation rules for file existence, extension (`.stl/.dae/.obj`), positive 3-element `scale`, and valid `category`/`collision_mode` values.
- Exports `custom_stl_assets` from `workcell_builder_metadata.yaml` into the builder export summary in `scripts/workcell_builder_studio_summary.py` so imported asset metadata is visible to downstream tooling.
- Adds tests in `tests/test_workcell_builder_custom_stl_importer.py` and updates `tests/test_workcell_builder_custom_stl_metadata.py` to cover creation, validation, extension checks, scale/pose/collision persistence, mesh-collision fallback behavior, and inclusion in generated metadata.

### Testing
- Ran: `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_custom_stl_importer.py tests/test_workcell_builder_generation.py tests/test_workcell_builder_custom_stl_metadata.py`.
- Result: all tests passed (`22 passed`).
- No heavy mesh-processing dependencies were added; mesh-collision requests are explicitly downgraded with a WARN marker when not supported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf851edd48331b26d0670546c5779)