### PR TITLE
Add Workcell Studio asset placement editor model, quick placement actions, and validations

### DIFF
--- a/scripts/workcell_builder_environment_palette.py
+++ b/scripts/workcell_builder_environment_palette.py
@@ -67,3 +67,148 @@ def build_environment_layout(layout_id: str, assets: list[dict[str, Any]]) -> di
         "assets": assets,
         "zones": [],
     }
+
+
+ASSET_ROLES = {
+    "support_surface",
+    "obstacle",
+    "pick_area",
+    "place_target",
+    "camera_mount",
+    "safety_zone",
+    "visual_only",
+}
+
+
+class PlacementEditorError(ValueError):
+    """Raised when placement editor input is invalid."""
+
+
+def _as_vec3(values: list[float], *, field_name: str) -> list[float]:
+    if len(values) != 3:
+        raise PlacementEditorError(f"{field_name} must contain exactly 3 numeric values")
+    return [float(v) for v in values]
+
+
+def create_asset_placement_editor_model(
+    *,
+    asset: dict[str, Any],
+    role: str = "obstacle",
+    visible: bool = True,
+    collision_enabled: bool = True,
+    lock_asset: bool = False,
+    scale: float = 1.0,
+) -> dict[str, Any]:
+    if scale <= 0.0:
+        raise PlacementEditorError("scale must be greater than zero")
+    if role not in ASSET_ROLES:
+        raise PlacementEditorError(f"unsupported asset role: {role}")
+    pose = asset.get("pose") if isinstance(asset.get("pose"), dict) else {"frame": "world", "xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]}
+    xyz = _as_vec3(list(pose.get("xyz", [0.0, 0.0, 0.0])), field_name="xyz")
+    rpy = _as_vec3(list(pose.get("rpy", [0.0, 0.0, 0.0])), field_name="rpy")
+    model = {
+        "asset_id": asset.get("id", ""),
+        "pose": {"frame": str(pose.get("frame", "world")), "xyz": xyz, "rpy": rpy},
+        "scale": float(scale),
+        "visible": bool(visible),
+        "collision_enabled": bool(collision_enabled),
+        "lock_asset": bool(lock_asset),
+        "role": role,
+    }
+    dimensions = asset.get("dimensions")
+    if isinstance(dimensions, list) and len(dimensions) == 3:
+        model["dimensions"] = _as_vec3([float(x) for x in dimensions], field_name="dimensions")
+    return model
+
+
+def apply_quick_placement(asset: dict[str, Any], action: str, assets: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    pose = asset.setdefault("pose", {"frame": "world", "xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]})
+    xyz = pose.setdefault("xyz", [0.0, 0.0, 0.0])
+    table = next((a for a in (assets or []) if a.get("type") == "table"), None)
+    robot = next((a for a in (assets or []) if a.get("type") == "robot_base"), None)
+
+    if action == "on_table" and table and table.get("dimensions"):
+        table_top = float(table["pose"]["xyz"][2]) + float(table["dimensions"][2])
+        xyz[2] = table_top
+    elif action == "left_of_robot" and robot:
+        xyz[1] = float(robot["pose"]["xyz"][1]) + 0.5
+    elif action == "right_of_robot" and robot:
+        xyz[1] = float(robot["pose"]["xyz"][1]) - 0.5
+    elif action == "in_front_of_robot" and robot:
+        xyz[0] = float(robot["pose"]["xyz"][0]) + 0.5
+    elif action == "behind_robot" and robot:
+        xyz[0] = float(robot["pose"]["xyz"][0]) - 0.5
+    elif action == "align_to_table" and table:
+        xyz[0] = float(table["pose"]["xyz"][0])
+        xyz[1] = float(table["pose"]["xyz"][1])
+    elif action == "duplicate_asset":
+        duplicated = {**asset, "id": f"{asset.get('id', 'asset')}_copy", "name": f"{asset.get('name', asset.get('id', 'asset'))} Copy", "pose": {**pose, "xyz": [xyz[0] + 0.2, xyz[1], xyz[2]], "rpy": list(pose.get("rpy", [0.0, 0.0, 0.0]))}}
+        return duplicated
+    return asset
+
+
+def _bbox(asset: dict[str, Any]) -> tuple[list[float], list[float]] | None:
+    dims = asset.get("dimensions")
+    pose = asset.get("pose") if isinstance(asset.get("pose"), dict) else None
+    if not (isinstance(dims, list) and len(dims) == 3 and pose and isinstance(pose.get("xyz"), list) and len(pose["xyz"]) == 3):
+        return None
+    half = [float(d) / 2.0 for d in dims]
+    xyz = [float(v) for v in pose["xyz"]]
+    return ([xyz[i] - half[i] for i in range(3)], [xyz[i] + half[i] for i in range(3)])
+
+
+def _overlap(a: tuple[list[float], list[float]], b: tuple[list[float], list[float]]) -> bool:
+    return all(a[0][i] <= b[1][i] and b[0][i] <= a[1][i] for i in range(3))
+
+
+def validate_asset_placements(layout: dict[str, Any]) -> list[str]:
+    warnings: list[str] = []
+    assets = layout.get("assets") if isinstance(layout.get("assets"), list) else []
+    if not any(a.get("type") == "robot_base" for a in assets):
+        warnings.append("robot base missing")
+    if not any(a.get("role") == "pick_area" for a in assets):
+        warnings.append("pick area missing")
+    if not any(a.get("role") == "place_target" for a in assets):
+        warnings.append("place target missing")
+
+    robot = next((a for a in assets if a.get("type") == "robot_base"), None)
+    table = next((a for a in assets if a.get("type") == "table"), None)
+    table_bbox = _bbox(table) if table else None
+    robot_bbox = _bbox(robot) if robot else None
+
+    for asset in assets:
+        pose = asset.get("pose") if isinstance(asset.get("pose"), dict) else {}
+        xyz = pose.get("xyz", [0, 0, 0])
+        if isinstance(xyz, list) and len(xyz) == 3 and float(xyz[2]) < 0.0:
+            warnings.append(f"{asset.get('id', 'asset')} below floor")
+        if asset.get("type") == "camera_mount" and (not isinstance(pose.get("xyz"), list) or not isinstance(pose.get("rpy"), list)):
+            warnings.append(f"camera missing pose: {asset.get('id', 'camera')}")
+        if asset.get("type") == "bin":
+            bb = _bbox(asset)
+            if bb and table_bbox and _overlap(bb, table_bbox):
+                warnings.append(f"bin overlaps table: {asset.get('id', 'bin')}")
+            if bb and robot_bbox and _overlap(bb, robot_bbox):
+                warnings.append(f"bin overlaps robot: {asset.get('id', 'bin')}")
+    return warnings
+
+
+def export_environment_layout_with_placement(layout_id: str, assets: list[dict[str, Any]]) -> dict[str, Any]:
+    layout = build_environment_layout(layout_id, assets)
+    layout.setdefault("metadata", {})["placement_editor"] = {
+        "enabled": True,
+        "schema": "workcell_asset_placement/v1",
+        "asset_poses": {
+            a.get("id", "asset"): {
+                "xyz": list((a.get("pose") or {}).get("xyz", [0.0, 0.0, 0.0])),
+                "rpy": list((a.get("pose") or {}).get("rpy", [0.0, 0.0, 0.0])),
+                "scale": float(a.get("scale", 1.0)),
+                "visible": bool(a.get("visible", True)),
+                "collision_enabled": bool(a.get("collision_enabled", True)),
+                "lock_asset": bool(a.get("lock_asset", False)),
+                "role": a.get("role", "obstacle"),
+            }
+            for a in assets
+        },
+    }
+    layout["metadata"]["placement_warnings"] = validate_asset_placements(layout)
+    return layout

--- a/tests/test_workcell_builder_asset_placement.py
+++ b/tests/test_workcell_builder_asset_placement.py
@@ -1,0 +1,58 @@
+from scripts.workcell_builder_environment_palette import (
+    PlacementEditorError,
+    apply_quick_placement,
+    build_environment_asset,
+    create_asset_placement_editor_model,
+    export_environment_layout_with_placement,
+    validate_asset_placements,
+)
+
+
+def test_xyz_rpy_serialization() -> None:
+    asset = build_environment_asset(asset_id="bin_a", asset_type="bin", xyz=[0.2, 0.3, 0.1], rpy=[0.0, 0.1, 0.2], dimensions=[0.2, 0.2, 0.2])
+    model = create_asset_placement_editor_model(asset=asset, role="pick_area", scale=1.1)
+    assert model["pose"]["xyz"] == [0.2, 0.3, 0.1]
+    assert model["pose"]["rpy"] == [0.0, 0.1, 0.2]
+    exported = export_environment_layout_with_placement("layout_a", [{**asset, **model}])
+    pose = exported["metadata"]["placement_editor"]["asset_poses"]["bin_a"]
+    assert pose["xyz"] == [0.2, 0.3, 0.1]
+    assert pose["rpy"] == [0.0, 0.1, 0.2]
+
+
+def test_quick_placement_functions() -> None:
+    table = build_environment_asset(asset_id="table", asset_type="table", xyz=[0.5, 0.0, 0.0], rpy=[0, 0, 0], dimensions=[1.2, 0.8, 0.05])
+    robot = build_environment_asset(asset_id="robot", asset_type="robot_base", xyz=[0.0, 0.0, 0.0], rpy=[0, 0, 0], dimensions=[0.4, 0.4, 0.2])
+    bin_asset = build_environment_asset(asset_id="bin", asset_type="bin", xyz=[0, 0, 0], rpy=[0, 0, 0], dimensions=[0.2, 0.2, 0.15])
+    placed = apply_quick_placement(bin_asset, "on_table", [table, robot])
+    assert placed["pose"]["xyz"][2] == 0.05
+    assert apply_quick_placement(bin_asset, "left_of_robot", [table, robot])["pose"]["xyz"][1] == 0.5
+    dup = apply_quick_placement(bin_asset, "duplicate_asset", [table, robot])
+    assert dup["id"] == "bin_copy"
+
+
+def test_invalid_scale_fails() -> None:
+    asset = build_environment_asset(asset_id="bad_scale", asset_type="bin", xyz=[0, 0, 0], rpy=[0, 0, 0], dimensions=[0.1, 0.1, 0.1])
+    try:
+        create_asset_placement_editor_model(asset=asset, scale=0)
+        assert False, "expected PlacementEditorError"
+    except PlacementEditorError:
+        assert True
+
+
+def test_missing_pick_place_warnings() -> None:
+    assets = [
+        build_environment_asset(asset_id="table", asset_type="table", xyz=[0.5, 0, 0], rpy=[0, 0, 0], dimensions=[1.2, 0.8, 0.05]),
+        build_environment_asset(asset_id="robot", asset_type="robot_base", xyz=[0, 0, 0], rpy=[0, 0, 0], dimensions=[0.4, 0.4, 0.2]),
+    ]
+    warnings = validate_asset_placements({"assets": assets})
+    assert "pick area missing" in warnings
+    assert "place target missing" in warnings
+
+
+def test_generated_environment_layout_includes_asset_poses() -> None:
+    bin_asset = build_environment_asset(asset_id="bin_a", asset_type="bin", xyz=[0.4, 0.2, -0.1], rpy=[0, 0, 0], dimensions=[0.2, 0.2, 0.2])
+    enriched = {**bin_asset, "role": "visual_only", "scale": 1.0, "visible": True, "collision_enabled": False, "lock_asset": True}
+    layout = export_environment_layout_with_placement("layout_with_placement", [enriched])
+    assert layout["metadata"]["placement_editor"]["enabled"] is True
+    assert "bin_a" in layout["metadata"]["placement_editor"]["asset_poses"]
+    assert any("below floor" in w for w in layout["metadata"]["placement_warnings"])


### PR DESCRIPTION
### Motivation
- Provide a programmatic placement editor model so Workcell Studio can be used as a visual builder for environment assets instead of requiring manual YAML edits. 
- Allow editing of transforms (`xyz`, `rpy`), `scale`, primitive `dimensions`, visibility, collision, lock state and a semantic `role` for each asset. 
- Add quick placement shortcuts and automated layout validations to make building a realistic cell layout faster and less error-prone. 

### Description
- Added placement editor primitives to `scripts/workcell_builder_environment_palette.py`: `ASSET_ROLES`, `PlacementEditorError`, `_as_vec3`, and `create_asset_placement_editor_model` for input validation and model creation. 
- Implemented quick placement helpers in `apply_quick_placement` supporting actions `on_table`, `left_of_robot`, `right_of_robot`, `in_front_of_robot`, `behind_robot`, `align_to_table`, and `duplicate_asset`. 
- Implemented simple AABB helpers `_bbox`, `_overlap` and a validator `validate_asset_placements` that emits warnings for assets below the floor, missing robot base, missing `pick_area`/`place_target`, cameras with missing pose, and simple bin overlap checks against table/robot. 
- Added `export_environment_layout_with_placement` which embeds placement metadata under `metadata.placement_editor` (schema `workcell_asset_placement/v1`) and writes `placement_warnings` into layout metadata. 
- Added unit tests in `tests/test_workcell_builder_asset_placement.py` covering XYZ/RPY serialization, quick placement behavior, invalid scale rejection, missing pick/place warnings, and exported layout placement metadata. 
- No ROS calls were introduced and no RViz is launched by these changes. 

### Testing
- Ran `pytest -q tests/test_workcell_builder_asset_placement.py` and all tests passed (`5 passed`). 
- The new test module exercises `create_asset_placement_editor_model`, `apply_quick_placement`, `validate_asset_placements`, and `export_environment_layout_with_placement` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf93901b4833190e4a597421e7ffc)