### PR TITLE
Promote Supported Asset Pack v1 (UR5 + Robotiq 2F golden path)

### DIFF
--- a/catalog/capabilities/end_effectors/ee_airpick_suction.yaml
+++ b/catalog/capabilities/end_effectors/ee_airpick_suction.yaml
@@ -3,21 +3,42 @@ end_effector:
   id: onrobot_airpick_style
   label: OnRobot Airpick Style
   family: suction
-  compatible_robot_families: [serial_6_axis, collaborative_6_axis, delta, gantry]
-  required_frames: [tool0]
-  grasp_frames: [suction_tip]
-  contact_links: [suction_cup]
-  allowed_touch_links: [suction_cup]
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  - delta
+  - gantry
+  required_frames:
+  - tool0
+  grasp_frames:
+  - suction_tip
+  contact_links:
+  - suction_cup
+  allowed_touch_links:
+  - suction_cup
   max_object_mass_kg: 0.6
   suction_area_mm2: 900
-  supported_grasp_strategies: [top_down_suction, side_pick]
-  required_io_signals: [vacuum_on, blowoff]
+  supported_grasp_strategies:
+  - top_down_suction
+  - side_pick
+  required_io_signals:
+  - vacuum_on
+  - blowoff
   release_behaviour: vacuum_off_with_blowoff
   limitations_warnings:
-    - Porous surfaces reduce holding force.
-
-  support_status: supported
-  runtime_status: fake_hardware_only
+  - Porous surfaces reduce holding force.
+  support_status: warn
+  runtime_status: warn_partial
   asset_package: onrobot_airpick4_description
   urdf_or_xacro: assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro
   moveit_config_package: onrobot_airpick4_moveit_config
+  fake_hardware_status: ready
+  real_hardware_status: optional_later
+  driver_status: optional_later
+  category: tool
+  display_name: OnRobot AirPick/AirPick4
+  tcp_frame: suction_tip
+  compatible_grasp_strategies:
+  - suction_top
+  - suction_top_basic
+  - auto

--- a/catalog/capabilities/end_effectors/ee_robotiq_2f.yaml
+++ b/catalog/capabilities/end_effectors/ee_robotiq_2f.yaml
@@ -3,21 +3,43 @@ end_effector:
   id: robotiq_2f_85
   label: Robotiq 2F-85
   family: finger_gripper
-  compatible_robot_families: [serial_6_axis, collaborative_6_axis, scara]
-  required_frames: [tool0]
-  grasp_frames: [tool0]
-  contact_links: [left_inner_finger, right_inner_finger]
-  allowed_touch_links: [left_inner_finger, right_inner_finger]
+  compatible_robot_families:
+  - serial_6_axis
+  - collaborative_6_axis
+  - scara
+  required_frames:
+  - tool0
+  grasp_frames:
+  - tool0
+  contact_links:
+  - left_inner_finger
+  - right_inner_finger
+  allowed_touch_links:
+  - left_inner_finger
+  - right_inner_finger
   max_object_mass_kg: 2.0
   opening_width_mm: 85
-  supported_grasp_strategies: [pinch, side_pick]
-  required_io_signals: [gripper_open_cmd, gripper_close_cmd]
+  supported_grasp_strategies:
+  - pinch
+  - side_pick
+  required_io_signals:
+  - gripper_open_cmd
+  - gripper_close_cmd
   release_behaviour: open_until_clear
   limitations_warnings:
-    - Requires parallel approach for reliable pinch grasps.
-
+  - Requires parallel approach for reliable pinch grasps.
   support_status: supported
-  runtime_status: fake_hardware_only
+  runtime_status: supported
   asset_package: robotiq_85_description
   urdf_or_xacro: assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro
   moveit_config_package: robotiq_85_moveit_config
+  fake_hardware_status: ready
+  real_hardware_status: optional_later
+  driver_status: optional_later
+  category: tool
+  display_name: Robotiq 2F-85
+  tcp_frame: tool0
+  compatible_grasp_strategies:
+  - finger_top
+  - auto
+  - finger_pinch_basic

--- a/catalog/capabilities/environment_assets/asset_bin.yaml
+++ b/catalog/capabilities/environment_assets/asset_bin.yaml
@@ -8,14 +8,25 @@ asset:
     width_m: 0.4
     height_m: 0.35
   frame: world
-  pose: [0.3, -0.6, 0.175, 0.0, 0.0, 0.0]
+  pose:
+  - 0.3
+  - -0.6
+  - 0.175
+  - 0.0
+  - 0.0
+  - 0.0
   collision_behaviour: rigid_container
   mobility: movable
   import_source: internal_catalog
-  mesh_path: assets/environment/bin_blue_large.stl
-  limitations_warnings:
-    - Keep 50 mm clearance around rim for placement.
-
-  support_status: supported
-  runtime_status: fake_hardware_only
   mesh_path: assets/environment/workbench_description/meshes/visual/table.stl
+  limitations_warnings:
+  - Keep 50 mm clearance around rim for placement.
+  support_status: supported
+  runtime_status: supported
+  category: environment
+  display_name: Sorting Bin
+  fake_hardware_status: ready
+  real_hardware_status: n/a
+  driver_status: optional_later
+  mesh_paths:
+  - assets/environment/workbench_description/meshes/visual/table.stl

--- a/catalog/capabilities/environment_assets/asset_table.yaml
+++ b/catalog/capabilities/environment_assets/asset_table.yaml
@@ -8,15 +8,27 @@ asset:
     width_m: 0.8
     height_m: 0.9
   frame: world
-  pose: [0.8, 0.0, 0.45, 0.0, 0.0, 0.0]
+  pose:
+  - 0.8
+  - 0.0
+  - 0.45
+  - 0.0
+  - 0.0
+  - 0.0
   collision_behaviour: static_collision
   mobility: static
   import_source: internal_catalog
   mesh_path: assets/environment/table_standard.stl
   limitations_warnings:
-    - Payload limit depends on selected table model.
-
+  - Payload limit depends on selected table model.
   support_status: supported
-  runtime_status: fake_hardware_only
+  runtime_status: supported
   asset_package: workbench_description
   urdf_or_xacro: assets/environment/workbench_description/urdf/table.urdf.xacro
+  category: environment
+  display_name: Workbench/Table
+  fake_hardware_status: ready
+  real_hardware_status: n/a
+  driver_status: optional_later
+  mesh_paths:
+  - assets/environment/workbench_description/meshes/visual/table.stl

--- a/catalog/capabilities/robots/robot_ur5.yaml
+++ b/catalog/capabilities/robots/robot_ur5.yaml
@@ -5,22 +5,36 @@ robot:
   brand: Universal Robots
   family: serial_6_axis
   mounting: floor
-  planning_groups: [manipulator]
+  planning_groups:
+  - manipulator
   base_frame: base_link
-  tool_frames: [tool0, ee_link]
+  tool_frames:
+  - tool0
+  - ee_link
   default_tool_frame: tool0
-  named_targets: [home, ready, stow]
+  named_targets:
+  - home
+  - ready
+  - stow
   payload_kg: 5.0
   reach_m: 0.85
   workspace_description: Cylindrical workstation envelope
   controller_type: position_trajectory
-  supported_interfaces: [moveit, ros2_control, joint_trajectory_controller, cartesian_path, named_targets]
-  supported_task_families: [pick_place, sort_by_colour, sort_by_shape, machine_tending]
+  supported_interfaces:
+  - moveit
+  - ros2_control
+  - joint_trajectory_controller
+  - cartesian_path
+  - named_targets
+  supported_task_families:
+  - pick_place
+  - sort_by_colour
+  - sort_by_shape
+  - machine_tending
   limitations_warnings:
-    - Demonstration metadata only.
-
+  - Demonstration metadata only.
   support_status: supported
-  runtime_status: fake_hardware_only
+  runtime_status: supported
   runtime_mode_default: fake_hardware
   asset_package: ur5_description
   urdf_or_xacro: assets/robots/universal_robot/ur5_moveit_config/config/ur5.ros2_control.xacro
@@ -36,7 +50,11 @@ robot:
   driver_package: ur_robot_driver
   driver_repo: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver
   driver_status: optional_later
-  real_hardware_status: guarded_later
+  real_hardware_status: optional_later
   real_hardware_guard_required: true
   required_hardware_interface: ros2_control
   real_hardware_notes: Metadata only; no real driver dependencies are enabled by default.
+  fake_hardware_status: ready
+  planning_group: manipulator
+  category: robot
+  display_name: Universal Robots UR5

--- a/catalog/capabilities/sensors/sensor_realsense_d435i.yaml
+++ b/catalog/capabilities/sensors/sensor_realsense_d435i.yaml
@@ -3,16 +3,38 @@ sensor:
   id: intel_realsense_d435i
   label: Intel RealSense D435i
   family: rgbd_camera
-  frames: [camera_link, camera_color_optical_frame, camera_depth_optical_frame]
-  topics: [/camera/color/image_raw, /camera/depth/image_rect_raw, /camera/aligned_depth_to_color/image_raw]
-  detection_outputs: [pose, size, confidence, class]
-  supported_object_attributes: [class, colour, shape, pose, size, confidence]
+  frames:
+  - camera_link
+  - camera_color_optical_frame
+  - camera_depth_optical_frame
+  topics:
+  - /camera/color/image_raw
+  - /camera/depth/image_rect_raw
+  - /camera/aligned_depth_to_color/image_raw
+  detection_outputs:
+  - pose
+  - size
+  - confidence
+  - class
+  supported_object_attributes:
+  - class
+  - colour
+  - shape
+  - pose
+  - size
+  - confidence
   mounting: fixed
-  calibration_requirements: [intrinsics, hand_eye_if_robot_relative]
+  calibration_requirements:
+  - intrinsics
+  - hand_eye_if_robot_relative
   limitations_warnings:
-    - IR interference can reduce depth quality on reflective parts.
-
-  support_status: supported
-  runtime_status: fake_hardware_only
+  - IR interference can reduce depth quality on reflective parts.
+  support_status: warn
+  runtime_status: metadata_only
   asset_package: realsense2_description
   urdf_or_xacro: assets/environment/realsense2_description/urdf/_d435i.urdf.xacro
+  category: sensor
+  display_name: Intel RealSense D435i
+  fake_hardware_status: metadata_only
+  real_hardware_status: optional_later
+  driver_status: optional_later

--- a/catalog/workcell_studio_demos.yaml
+++ b/catalog/workcell_studio_demos.yaml
@@ -1,139 +1,181 @@
 schema_version: workcell_studio_demo_catalog/v1
 demos:
-  - id: ur5_2f_table_pick_place
-    title: UR5 + Robotiq 2F Table Pick/Place
-    description: Supported UR5 fake-hardware starter for table-based pick and place.
-    cell_definition: tests/fixtures/cell_definition_ur5_2f_table_pick_place.yaml
-    runtime_mode: fake_hardware_ready
-    compatibility_status: supported
-    fake_hardware_default: true
-    preview_only: false
-    notes:
-      - Existing UR5 fake-hardware path only; no real robot execution enabled.
-    warnings: []
-    tags: [ur5, robotiq_2f, pick_place, table, supported]
-
-  - id: ur5_2f_sorting_three_bins
-    title: UR5 + Robotiq 2F Sorting (3 bins)
-    description: Supported UR5 fake-hardware starter for sorting into three bins.
-    cell_definition: tests/fixtures/cell_definition_ur5_2f_sorting_three_bins.yaml
-    runtime_mode: fake_hardware_ready
-    compatibility_status: supported
-    fake_hardware_default: true
-    preview_only: false
-    notes:
-      - Uses existing UR5 path and default routing task as a sorting baseline.
-    warnings: []
-    tags: [ur5, robotiq_2f, sorting, bins, supported]
-
-  - id: ur5_suction_table_pick_place
-    title: UR5 + Suction Table Pick/Place
-    description: Supported UR5 fake-hardware starter for suction top-pick and place.
-    cell_definition: tests/fixtures/cell_definition_ur5_suction_table_pick_place.yaml
-    runtime_mode: fake_hardware_ready
-    compatibility_status: supported
-    fake_hardware_default: true
-    preview_only: false
-    notes:
-      - Runtime IO remains disabled; metadata-only suction defaults.
-    warnings:
-      - Vacuum hardware actuation is not executed in this template.
-    tags: [ur5, suction, pick_place, table, supported]
-
-  - id: ur5_suction_conveyor_placeholder
-    title: UR5 + Suction Conveyor Placeholder
-    description: UR5 conveyor-oriented starter with visual conveyor placeholder only.
-    cell_definition: tests/fixtures/cell_definition_ur5_suction_conveyor_placeholder.yaml
-    runtime_mode: fake_hardware_ready
-    compatibility_status: supported
-    fake_hardware_default: true
-    preview_only: false
-    notes:
-      - Conveyor is represented as a static placeholder asset.
-    warnings:
-      - Conveyor tracking/runtime integration is intentionally not enabled.
-    tags: [ur5, suction, conveyor, placeholder, supported]
-
-  - id: generic_delta_suction_preview_sorting
-    title: Generic Delta + Suction Preview Sorting
-    description: Preview-only concept starter for high-speed delta sorting.
-    cell_definition: tests/fixtures/cell_definition_generic_delta_suction_preview_sorting.yaml
-    runtime_mode: preview_only
-    compatibility_status: warn_preview_only
-    fake_hardware_default: true
-    preview_only: true
-    notes:
-      - Concept-only scene for layout/task review.
-    warnings:
-      - Preview-only template; runtime execution remains blocked.
-    tags: [delta, suction, sorting, preview_only]
-
-  - id: generic_cartesian_gantry_suction_preview_pick_place
-    title: Generic Cartesian Gantry + Suction Preview Pick/Place
-    description: Preview-only concept starter for cartesian gantry pick/place.
-    cell_definition: tests/fixtures/cell_definition_generic_cartesian_gantry_suction_preview_pick_place.yaml
-    runtime_mode: preview_only
-    compatibility_status: warn_preview_only
-    fake_hardware_default: true
-    preview_only: true
-    notes:
-      - Concept-only gantry layout with editable assets and poses.
-    warnings:
-      - Preview-only template; runtime execution remains blocked.
-    tags: [cartesian, gantry, suction, pick_place, preview_only]
-
-  - id: inspection_station_preview
-    title: Inspection Station Preview
-    description: Preview-only inspection station starter with camera-first setup.
-    cell_definition: tests/fixtures/cell_definition_inspection_station_preview.yaml
-    runtime_mode: preview_only
-    compatibility_status: warn_preview_only
-    fake_hardware_default: true
-    preview_only: true
-    notes:
-      - Visual validation flow only; no inspection runtime pipeline.
-    warnings:
-      - Preview-only template; runtime execution remains blocked.
-    tags: [inspection, camera, fixture, preview_only]
-
-  - id: machine_tending_preview
-    title: Machine Tending Preview
-    description: Preview-only machine tending starter with machine fixture placeholder.
-    cell_definition: tests/fixtures/cell_definition_machine_tending_preview.yaml
-    runtime_mode: preview_only
-    compatibility_status: warn_preview_only
-    fake_hardware_default: true
-    preview_only: true
-    notes:
-      - Machine door/chuck signals are represented as placeholders.
-    warnings:
-      - Preview-only template; runtime execution remains blocked.
-    tags: [machine_tending, fixture, preview_only]
-
-  - id: palletising_preview
-    title: Palletising Preview
-    description: Preview-only palletising starter with pallet and tray placeholders.
-    cell_definition: tests/fixtures/cell_definition_palletising_preview.yaml
-    runtime_mode: preview_only
-    compatibility_status: warn_preview_only
-    fake_hardware_default: true
-    preview_only: true
-    notes:
-      - Stack logic is illustrative only.
-    warnings:
-      - Preview-only template; runtime execution remains blocked.
-    tags: [palletising, trays, preview_only]
-
-  - id: bin_picking_preview
-    title: Bin Picking Preview
-    description: Preview-only bin picking starter with deep-bin fixture setup.
-    cell_definition: tests/fixtures/cell_definition_bin_picking_preview.yaml
-    runtime_mode: preview_only
-    compatibility_status: warn_preview_only
-    fake_hardware_default: true
-    preview_only: true
-    notes:
-      - Perception-assisted grasping remains concept-only.
-    warnings:
-      - Preview-only template; runtime execution remains blocked.
-    tags: [bin_picking, perception, preview_only]
+- id: ur5_2f_table_pick_place
+  title: UR5 + Robotiq 2F Table Pick/Place
+  description: Supported UR5 fake-hardware starter for table-based pick and place.
+  cell_definition: tests/fixtures/cell_definition_ur5_2f_table_pick_place.yaml
+  runtime_mode: fake_hardware_ready
+  compatibility_status: supported
+  fake_hardware_default: true
+  preview_only: false
+  notes:
+  - Existing UR5 fake-hardware path only; no real robot execution enabled.
+  warnings: []
+  tags:
+  - ur5
+  - robotiq_2f
+  - pick_place
+  - table
+  - supported
+  status: supported
+  readiness_level: fake_hardware_ready
+- id: ur5_2f_sorting_three_bins
+  title: UR5 + Robotiq 2F Sorting (3 bins)
+  description: Supported UR5 fake-hardware starter for sorting into three bins.
+  cell_definition: tests/fixtures/cell_definition_ur5_2f_sorting_three_bins.yaml
+  runtime_mode: fake_hardware_ready
+  compatibility_status: supported
+  fake_hardware_default: true
+  preview_only: false
+  notes:
+  - Uses existing UR5 path and default routing task as a sorting baseline.
+  warnings: []
+  tags:
+  - ur5
+  - robotiq_2f
+  - sorting
+  - bins
+  - supported
+  status: supported
+  readiness_level: fake_hardware_ready
+- id: ur5_suction_table_pick_place
+  title: UR5 + Suction Table Pick/Place
+  description: Supported UR5 fake-hardware starter for suction top-pick and place.
+  cell_definition: tests/fixtures/cell_definition_ur5_suction_table_pick_place.yaml
+  runtime_mode: fake_hardware_ready
+  compatibility_status: warn_partial
+  fake_hardware_default: true
+  preview_only: false
+  notes:
+  - Runtime IO remains disabled; metadata-only suction defaults.
+  warnings:
+  - Vacuum hardware actuation is not executed in this template.
+  tags:
+  - ur5
+  - suction
+  - pick_place
+  - table
+  - supported
+  status: warn
+  readiness_level: warn
+- id: ur5_suction_conveyor_placeholder
+  title: UR5 + Suction Conveyor Placeholder
+  description: UR5 conveyor-oriented starter with visual conveyor placeholder only.
+  cell_definition: tests/fixtures/cell_definition_ur5_suction_conveyor_placeholder.yaml
+  runtime_mode: preview_only
+  compatibility_status: warn_partial
+  fake_hardware_default: true
+  preview_only: true
+  notes:
+  - Conveyor is represented as a static placeholder asset.
+  warnings:
+  - Conveyor tracking/runtime integration is intentionally not enabled.
+  tags:
+  - ur5
+  - suction
+  - conveyor
+  - placeholder
+  - supported
+  status: warn
+  readiness_level: warn
+- id: generic_delta_suction_preview_sorting
+  title: Generic Delta + Suction Preview Sorting
+  description: Preview-only concept starter for high-speed delta sorting.
+  cell_definition: tests/fixtures/cell_definition_generic_delta_suction_preview_sorting.yaml
+  runtime_mode: preview_only
+  compatibility_status: warn_preview_only
+  fake_hardware_default: true
+  preview_only: true
+  notes:
+  - Concept-only scene for layout/task review.
+  warnings:
+  - Preview-only template; runtime execution remains blocked.
+  tags:
+  - delta
+  - suction
+  - sorting
+  - preview_only
+- id: delta_suction_preview_sorting
+  title: Delta Suction Preview Sorting
+  description: Preview-only concept starter for cartesian gantry pick/place.
+  cell_definition: tests/fixtures/cell_definition_generic_cartesian_gantry_suction_preview_pick_place.yaml
+  runtime_mode: preview_only
+  compatibility_status: warn_preview_only
+  fake_hardware_default: true
+  preview_only: true
+  notes:
+  - Concept-only gantry layout with editable assets and poses.
+  warnings:
+  - Preview-only template; runtime execution remains blocked.
+  tags:
+  - cartesian
+  - gantry
+  - suction
+  - pick_place
+  - preview_only
+  status: preview_only
+- id: inspection_station_preview
+  title: Inspection Station Preview
+  description: Preview-only inspection station starter with camera-first setup.
+  cell_definition: tests/fixtures/cell_definition_inspection_station_preview.yaml
+  runtime_mode: preview_only
+  compatibility_status: warn_preview_only
+  fake_hardware_default: true
+  preview_only: true
+  notes:
+  - Visual validation flow only; no inspection runtime pipeline.
+  warnings:
+  - Preview-only template; runtime execution remains blocked.
+  tags:
+  - inspection
+  - camera
+  - fixture
+  - preview_only
+- id: machine_tending_preview
+  title: Machine Tending Preview
+  description: Preview-only machine tending starter with machine fixture placeholder.
+  cell_definition: tests/fixtures/cell_definition_machine_tending_preview.yaml
+  runtime_mode: preview_only
+  compatibility_status: warn_preview_only
+  fake_hardware_default: true
+  preview_only: true
+  notes:
+  - Machine door/chuck signals are represented as placeholders.
+  warnings:
+  - Preview-only template; runtime execution remains blocked.
+  tags:
+  - machine_tending
+  - fixture
+  - preview_only
+- id: palletising_preview
+  title: Palletising Preview
+  description: Preview-only palletising starter with pallet and tray placeholders.
+  cell_definition: tests/fixtures/cell_definition_palletising_preview.yaml
+  runtime_mode: preview_only
+  compatibility_status: warn_preview_only
+  fake_hardware_default: true
+  preview_only: true
+  notes:
+  - Stack logic is illustrative only.
+  warnings:
+  - Preview-only template; runtime execution remains blocked.
+  tags:
+  - palletising
+  - trays
+  - preview_only
+- id: bin_picking_preview
+  title: Bin Picking Preview
+  description: Preview-only bin picking starter with deep-bin fixture setup.
+  cell_definition: tests/fixtures/cell_definition_bin_picking_preview.yaml
+  runtime_mode: preview_only
+  compatibility_status: warn_preview_only
+  fake_hardware_default: true
+  preview_only: true
+  notes:
+  - Perception-assisted grasping remains concept-only.
+  warnings:
+  - Preview-only template; runtime execution remains blocked.
+  tags:
+  - bin_picking
+  - perception
+  - preview_only

--- a/docs/manuals/SUPPORTED_ASSET_PACK_V1.md
+++ b/docs/manuals/SUPPORTED_ASSET_PACK_V1.md
@@ -1,0 +1,15 @@
+# Supported Asset Pack v1
+
+- Golden path: UR5 + Robotiq 2F + table/workbench + bins + cube object, fake hardware first.
+- WARN path: UR5 + AirPick suction (metadata/generation ready; runtime may be partial).
+- Preview only: generic delta/gantry plus placeholder industrial templates (Fanuc/ABB/KUKA/conveyor/CNC/safety).
+- Real drivers remain metadata-only (`driver_status: optional_later`).
+
+## Validation
+
+Run:
+
+```bash
+PYTHONPATH=$PWD:$PYTHONPATH python3 scripts/audit_workcell_assets.py --root . --json
+PYTHONPATH=$PWD:$PYTHONPATH python3 -m pytest -q tests/test_supported_asset_pack_v1.py tests/test_builder_golden_ur5_2f_template.py tests/test_builder_ur5_suction_template.py tests/test_builder_preview_only_templates.py
+```

--- a/tests/fixtures/cell_definition_generic_cartesian_gantry_suction_preview_pick_place.yaml
+++ b/tests/fixtures/cell_definition_generic_cartesian_gantry_suction_preview_pick_place.yaml
@@ -135,6 +135,6 @@ commissioning:
     generated_motion_launch_supported: false
     reason: Placeholder robot family has no approved runtime launch/control stack
       yet.
-  demo_template_id: generic_cartesian_gantry_suction_preview_pick_place
+  demo_template_id: delta_suction_preview_sorting
   fake_hardware_default: true
   preview_only: true

--- a/tests/test_builder_golden_ur5_2f_template.py
+++ b/tests/test_builder_golden_ur5_2f_template.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import yaml
+ROOT=Path(__file__).resolve().parents[1]
+
+def test_golden_template_present():
+    demos=yaml.safe_load((ROOT/"catalog/workcell_studio_demos.yaml").read_text())["demos"]
+    demo=next(d for d in demos if d["id"]=="ur5_2f_table_pick_place")
+    assert demo["runtime_mode"]=="fake_hardware_ready"
+    assert demo.get("status")=="supported"

--- a/tests/test_builder_preview_only_templates.py
+++ b/tests/test_builder_preview_only_templates.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import yaml
+ROOT=Path(__file__).resolve().parents[1]
+
+def test_preview_templates_flagged():
+    demos=yaml.safe_load((ROOT/"catalog/workcell_studio_demos.yaml").read_text())["demos"]
+    preview=[d for d in demos if d.get("preview_only")]
+    assert preview
+    for d in preview:
+        assert d["runtime_mode"]=="preview_only"

--- a/tests/test_builder_ur5_suction_template.py
+++ b/tests/test_builder_ur5_suction_template.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import yaml
+ROOT=Path(__file__).resolve().parents[1]
+
+def test_suction_template_warn_not_false_supported():
+    demos=yaml.safe_load((ROOT/"catalog/workcell_studio_demos.yaml").read_text())["demos"]
+    demo=next(d for d in demos if d["id"]=="ur5_suction_table_pick_place")
+    assert "warn" in str(demo.get("compatibility_status","")).lower()

--- a/tests/test_supported_asset_pack_v1.py
+++ b/tests/test_supported_asset_pack_v1.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import yaml
+
+ROOT=Path(__file__).resolve().parents[1]
+
+def load(path):
+    return yaml.safe_load((ROOT/path).read_text(encoding="utf-8"))
+
+def test_catalog_entries_exist():
+    assert load("catalog/capabilities/robots/robot_ur5.yaml")["robot"]["id"]=="ur5"
+    assert load("catalog/capabilities/end_effectors/ee_robotiq_2f.yaml")["end_effector"]["id"]=="robotiq_2f_85"
+    assert load("catalog/capabilities/environment_assets/asset_table.yaml")["asset"]["id"]
+    assert load("catalog/capabilities/environment_assets/asset_bin.yaml")["asset"]["id"]
+
+def test_ur5_packages_exist():
+    r=load("catalog/capabilities/robots/robot_ur5.yaml")["robot"]
+    assert (ROOT/r["urdf_or_xacro"]).exists()
+    assert r["moveit_config_package"]=="ur5_moveit_config"

--- a/tests/test_workcell_builder_demo_templates.py
+++ b/tests/test_workcell_builder_demo_templates.py
@@ -40,9 +40,10 @@ def test_preview_only_templates_are_honest() -> None:
             assert "warn" in str(demo.get("compatibility_status", "")).lower()
 
 
-def test_ur5_templates_remain_supported_only() -> None:
+def test_ur5_templates_have_honest_status() -> None:
     ur5_demos = [d for d in _load().get("demos", []) if d["id"].startswith("ur5_")]
     assert len(ur5_demos) == 4
-    for demo in ur5_demos:
-        assert demo.get("runtime_mode") == "fake_hardware_ready"
-        assert demo.get("compatibility_status") == "supported"
+    by_id={d["id"]:d for d in ur5_demos}
+    assert by_id["ur5_2f_table_pick_place"].get("compatibility_status") == "supported"
+    assert by_id["ur5_2f_sorting_three_bins"].get("compatibility_status") == "supported"
+    assert "warn" in str(by_id["ur5_suction_table_pick_place"].get("compatibility_status","")).lower()


### PR DESCRIPTION
### Motivation
- Promote a first-class Supported Asset Pack v1 so the Workcell Studio builder can produce honest, usable fake-hardware workcells centered on UR5 + Robotiq 2F. 
- Ensure partial/preview paths (suction, delta, gantry, industrial placeholders) are labeled WARN or preview_only rather than claimed as runtime-ready. 
- Preserve fake-hardware-first behavior and keep real drivers metadata-only to avoid adding runtime driver dependencies.

### Description
- Normalized and enriched catalog capability metadata for core assets including `robot_ur5.yaml`, `ee_robotiq_2f.yaml`, `ee_airpick_suction.yaml`, `asset_table.yaml`, `asset_bin.yaml`, and `sensor_realsense_d435i.yaml` with explicit `support_status`, `runtime_status`, `fake_hardware_status`, `driver_status`, `category`, and display/tcp/planning fields. 
- Updated the Workcell Studio demo catalog `catalog/workcell_studio_demos.yaml` to mark the golden UR5+2F demos as supported/fake-hardware-ready, mark suction templates as WARN/partial, and mark placeholders as `preview_only`. 
- Added documentation `docs/manuals/SUPPORTED_ASSET_PACK_V1.md` summarizing what is supported, WARN, and preview-only, and how to validate. 
- Added focused tests to validate the pack and demo templates: `tests/test_supported_asset_pack_v1.py`, `tests/test_builder_golden_ur5_2f_template.py`, `tests/test_builder_ur5_suction_template.py`, and `tests/test_builder_preview_only_templates.py`, and updated `tests/test_workcell_builder_demo_templates.py` and a fixture id to reflect renamed preview demo. 
- Left real-hardware driver references as metadata-only (`driver_status: optional_later`) and did not add drivers as active dependencies or change runtime launch behavior.

### Testing
- Ran the asset audit: `PYTHONPATH=$PWD:$PYTHONPATH python3 scripts/audit_workcell_assets.py --root . --json` which produced the repository asset/catalog summary JSON. 
- Ran focused pytest verification: `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_supported_asset_pack_v1.py tests/test_builder_golden_ur5_2f_template.py tests/test_builder_ur5_suction_template.py tests/test_builder_preview_only_templates.py tests/test_workcell_builder_demo_templates.py tests/test_workcell_asset_duplicate_guard.py` and all tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda216e72c83318226e546e841500d)