### PR TITLE
Add GUI catalog export and make metadata renderer import robust

### DIFF
--- a/docs/manuals/WORKCELL_BUILDER_GUI_CATALOG.md
+++ b/docs/manuals/WORKCELL_BUILDER_GUI_CATALOG.md
@@ -1,0 +1,25 @@
+# Workcell Builder GUI Catalog
+
+- Generate GUI catalog JSON:
+  - `python3 scripts/workcell_builder_gui_catalog.py`
+  - Output: `workcell_studio_catalog/generated/workcell_builder_gui_catalog.json`
+- Renderer metadata command:
+  - `python3 scripts/render_workcell_builder_metadata.py --help`
+
+## How Qt GUI loads it
+Current integration keeps legacy loaders and uses generated catalog as additive source for robot/gripper/object/environment visibility in selection flows.
+If catalog JSON is missing, legacy folder scanning is still used and GUI remains functional.
+
+## Refresh/Rescan
+Run catalog generation command again (no rebuild required), then reopen selection dialogs.
+
+## Add new entries
+1. Add/modify items in `workcell_studio_catalog/catalog.yaml`.
+2. Re-run `scripts/workcell_builder_gui_catalog.py`.
+3. Ensure entries include support/runtime status and tags.
+
+## Preview-only
+`preview_only` entries are visible for planning/manual authoring, but may not be fully runtime-enabled.
+
+## Known limitation
+EPD GUI remains separate and is not merged into workcell_builder.

--- a/scripts/render_workcell_builder_metadata.py
+++ b/scripts/render_workcell_builder_metadata.py
@@ -3,8 +3,16 @@ from __future__ import annotations
 import argparse, json
 from pathlib import Path
 from typing import Any
+import sys
 
-from scripts.workcell_builder_capability_catalog import load_workcell_capability_catalog
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    from scripts.workcell_builder_capability_catalog import load_workcell_capability_catalog
+except ModuleNotFoundError:
+    from scripts.workcell_builder_capability_matrix import load_workcell_capability_catalog
 from scripts.workcell_builder_grasp_strategy import normalize_grasp_strategy
 from scripts.workcell_builder_compatibility_matrix import evaluate_compatibility
 

--- a/scripts/workcell_builder_gui_catalog.py
+++ b/scripts/workcell_builder_gui_catalog.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+import yaml
+
+GROUPS = ["robots", "grippers", "tools", "objects", "tables", "workbenches", "sensors", "cameras", "conveyors", "fixtures", "machines", "safety", "custom"]
+
+def _root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+def _group(item: dict[str, Any]) -> str:
+    c = (item.get("category") or "").lower()
+    i = (item.get("id") or "").lower()
+    if c == "robots": return "robots"
+    if c in {"end_effectors", "grippers"}: return "grippers"
+    if c == "tools": return "tools"
+    if c == "sensors": return "sensors"
+    if "camera" in i: return "cameras"
+    if c == "fixtures": return "fixtures"
+    if c == "machines": return "machines"
+    if c == "safety": return "safety"
+    if "table" in i: return "tables"
+    if "bench" in i: return "workbenches"
+    if "conveyor" in i: return "conveyors"
+    if c in {"environment", "objects"}: return "objects"
+    return "custom"
+
+def generate(root: Path | None = None) -> dict[str, Any]:
+    root = root or _root()
+    data = yaml.safe_load((root / "workcell_studio_catalog" / "catalog.yaml").read_text(encoding="utf-8")) or {}
+    out = {k: [] for k in GROUPS}
+    for item in data.get("items", []):
+        out[_group(item)].append({
+            "id": item.get("id"), "display_name": item.get("display_name"), "category": item.get("category"),
+            "family": item.get("family"), "support_status": item.get("support_status"), "runtime_status": item.get("runtime_status"),
+            "package_name": item.get("urdf_package") or item.get("moveit_config_package") or "",
+            "urdf_or_xacro": item.get("urdf_path") or "", "mesh_path": item.get("mesh_path") or item.get("preview_mesh_path") or "",
+            "thumbnail_path": item.get("thumbnail_path") or "", "notes": item.get("notes") or "", "tags": item.get("tags") or []
+        })
+    for g, i, d in [("objects", "cube_placeholder", "Cube Placeholder"), ("objects", "bin_placeholder", "Bin Placeholder"), ("conveyors", "conveyor_placeholder", "Conveyor Placeholder"), ("fixtures", "camera_mount_placeholder", "Camera Mount Placeholder")]:
+        if not any(x["id"] == i for x in out[g]):
+            out[g].append({"id": i, "display_name": d, "category": g, "family": "placeholder", "support_status": "preview_only", "runtime_status": "preview_only", "package_name": "", "urdf_or_xacro": "", "mesh_path": "", "thumbnail_path": "", "notes": "Primitive placeholder for GUI visibility.", "tags": ["placeholder"]})
+    return out
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", type=Path, default=_root())
+    ap.add_argument("--output", type=Path)
+    a = ap.parse_args()
+    payload = generate(a.root.resolve())
+    out = a.output or (a.root / "workcell_studio_catalog" / "generated" / "workcell_builder_gui_catalog.json")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(out)
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workcell_builder_gui_catalog_entries.py
+++ b/tests/test_workcell_builder_gui_catalog_entries.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from scripts.workcell_builder_gui_catalog import generate
+
+def _names(group):
+    return {x.get('display_name','').lower() for x in group}
+
+def test_expected_entries_present():
+    data=generate(Path('.').resolve())
+    robots=_names(data['robots'])
+    assert any('ur5' in n for n in robots)
+    assert any('ur3' in n for n in robots)
+    assert any('ur10' in n for n in robots)
+    assert any('fanuc' in n for n in robots)
+    assert any('panda' in n for n in robots)
+    grippers=_names(data['grippers'])|_names(data['tools'])
+    assert any('robotiq' in n and ('85' in n or '2f' in n) for n in grippers)
+    assert any('robotiq' in n and '3f' in n for n in grippers)
+    assert any('suction' in n for n in grippers)
+    assert any('airpick' in n for n in grippers)
+    env=_names(data['tables'])|_names(data['workbenches'])|_names(data['objects'])|_names(data['conveyors'])
+    assert any('table' in n for n in env)
+    assert any('bench' in n for n in env)
+    assert any('cube' in n or 'bin' in n for n in env)
+    sensors=_names(data['sensors'])|_names(data['cameras'])
+    assert any('d435' in n or 'realsense' in n for n in sensors)

--- a/tests/test_workcell_builder_gui_catalog_export.py
+++ b/tests/test_workcell_builder_gui_catalog_export.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+from scripts.workcell_builder_gui_catalog import generate
+
+def test_gui_catalog_export(tmp_path: Path):
+    payload = generate(Path('.').resolve())
+    assert 'robots' in payload
+    out = tmp_path / 'workcell_builder_gui_catalog.json'
+    out.write_text(__import__('json').dumps(payload))
+    assert out.exists()

--- a/tests/test_workcell_builder_metadata_renderer.py
+++ b/tests/test_workcell_builder_metadata_renderer.py
@@ -1,0 +1,6 @@
+import subprocess,sys
+
+def test_metadata_renderer_help_runs():
+    cp=subprocess.run([sys.executable,'scripts/render_workcell_builder_metadata.py','--help'],capture_output=True,text=True)
+    assert cp.returncode==0
+    assert 'ModuleNotFoundError' not in (cp.stdout+cp.stderr)

--- a/workcell_studio_catalog/generated/workcell_builder_gui_catalog.json
+++ b/workcell_studio_catalog/generated/workcell_builder_gui_catalog.json
@@ -1,0 +1,2613 @@
+{
+  "robots": [
+    {
+      "id": "ur3",
+      "display_name": "Ur3",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "ur3e",
+      "display_name": "Ur3E",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "ur5",
+      "display_name": "Ur5",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "supported",
+      "runtime_status": "supported",
+      "package_name": "workcell_builder",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "ur5e",
+      "display_name": "Ur5E",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "ur10",
+      "display_name": "Ur10",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "ur10e",
+      "display_name": "Ur10E",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "ur16e",
+      "display_name": "Ur16E",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "ur20",
+      "display_name": "Ur20",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "ur30",
+      "display_name": "Ur30",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "fanuc_lr_mate_200id",
+      "display_name": "Fanuc Lr Mate 200Id",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "fanuc_m10ia",
+      "display_name": "Fanuc M10Ia",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "fanuc_m20ia",
+      "display_name": "Fanuc M20Ia",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "fanuc_crx_10ia",
+      "display_name": "Fanuc Crx 10Ia",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "fanuc_crx_20ia",
+      "display_name": "Fanuc Crx 20Ia",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "abb_irb_120",
+      "display_name": "Abb Irb 120",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "abb_irb_1200",
+      "display_name": "Abb Irb 1200",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "abb_irb_1600",
+      "display_name": "Abb Irb 1600",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "abb_gofa",
+      "display_name": "Abb Gofa",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "abb_yumi",
+      "display_name": "Abb Yumi",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "kuka_kr6",
+      "display_name": "Kuka Kr6",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "kuka_kr10",
+      "display_name": "Kuka Kr10",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "kuka_lbr_iiwa",
+      "display_name": "Kuka Lbr Iiwa",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "kuka_lbr_med",
+      "display_name": "Kuka Lbr Med",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "motoman_gp7",
+      "display_name": "Motoman Gp7",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "motoman_gp12",
+      "display_name": "Motoman Gp12",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "motoman_gp25",
+      "display_name": "Motoman Gp25",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "motoman_hc10",
+      "display_name": "Motoman Hc10",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "franka_panda",
+      "display_name": "Franka Panda",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "kinova_gen3",
+      "display_name": "Kinova Gen3",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "xarm6",
+      "display_name": "Xarm6",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "xarm7",
+      "display_name": "Xarm7",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "dobot_cr5",
+      "display_name": "Dobot Cr5",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "dobot_cr10",
+      "display_name": "Dobot Cr10",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "elephant_my_cobot",
+      "display_name": "Elephant My Cobot",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "elephant_my_arm",
+      "display_name": "Elephant My Arm",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "ufactory_lite6",
+      "display_name": "Ufactory Lite6",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "generic_6dof_aliexpress_arm",
+      "display_name": "Generic 6Dof Aliexpress Arm",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "homemade_3d_printed_6dof_arm",
+      "display_name": "Homemade 3D Printed 6Dof Arm",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "generic_scara",
+      "display_name": "Generic Scara",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "generic_delta_robot",
+      "display_name": "Generic Delta Robot",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "generic_cartesian_gantry",
+      "display_name": "Generic Cartesian Gantry",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "generic_3_axis_cartesian",
+      "display_name": "Generic 3 Axis Cartesian",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    },
+    {
+      "id": "generic_4_axis_palletizer",
+      "display_name": "Generic 4 Axis Palletizer",
+      "category": "robots",
+      "family": "robot_arm",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/robots/robot_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Catalog entry for Workcell Studio.",
+      "tags": [
+        "robot",
+        "arm"
+      ]
+    }
+  ],
+  "grippers": [
+    {
+      "id": "robotiq_2f_85",
+      "display_name": "Robotiq 2F 85",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "supported",
+      "runtime_status": "fake_hardware_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "robotiq_2f_140",
+      "display_name": "Robotiq 2F 140",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "robotiq_3f",
+      "display_name": "Robotiq 3F",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "onrobot_rg2",
+      "display_name": "Onrobot Rg2",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "onrobot_rg6",
+      "display_name": "Onrobot Rg6",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "schunk_egp",
+      "display_name": "Schunk Egp",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "schunk_egk",
+      "display_name": "Schunk Egk",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "schunk_pg",
+      "display_name": "Schunk Pg",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "weiss_wsg_50",
+      "display_name": "Weiss Wsg 50",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "generic_parallel_jaw_small",
+      "display_name": "Generic Parallel Jaw Small",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "generic_parallel_jaw_large",
+      "display_name": "Generic Parallel Jaw Large",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "generic_3_finger_gripper",
+      "display_name": "Generic 3 Finger Gripper",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "generic_servo_gripper",
+      "display_name": "Generic Servo Gripper",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "onrobot_airpick",
+      "display_name": "Onrobot Airpick",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "preview_only",
+      "runtime_status": "fake_hardware_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "onrobot_airpick4",
+      "display_name": "Onrobot Airpick4",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "preview_only",
+      "runtime_status": "fake_hardware_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "onrobot_vgc10",
+      "display_name": "Onrobot Vgc10",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "piab_single_cup",
+      "display_name": "Piab Single Cup",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "piab_multi_cup",
+      "display_name": "Piab Multi Cup",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "generic_single_suction_cup",
+      "display_name": "Generic Single Suction Cup",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "generic_dual_suction_cup",
+      "display_name": "Generic Dual Suction Cup",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "generic_4_cup_vacuum_array",
+      "display_name": "Generic 4 Cup Vacuum Array",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "generic_8_cup_vacuum_array",
+      "display_name": "Generic 8 Cup Vacuum Array",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "generic_foam_vacuum_gripper",
+      "display_name": "Generic Foam Vacuum Gripper",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "generic_vacuum_plate",
+      "display_name": "Generic Vacuum Plate",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "magnetic_gripper_placeholder",
+      "display_name": "Magnetic Gripper Placeholder",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "soft_gripper_placeholder",
+      "display_name": "Soft Gripper Placeholder",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "welding_torch_placeholder",
+      "display_name": "Welding Torch Placeholder",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "glue_dispenser_placeholder",
+      "display_name": "Glue Dispenser Placeholder",
+      "category": "end_effectors",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    }
+  ],
+  "tools": [
+    {
+      "id": "tool_changer_placeholder",
+      "display_name": "Tool Changer Placeholder",
+      "category": "tools",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "screwdriver_tool_placeholder",
+      "display_name": "Screwdriver Tool Placeholder",
+      "category": "tools",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "inspection_camera_tool_placeholder",
+      "display_name": "Inspection Camera Tool Placeholder",
+      "category": "tools",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "barcode_scanner_tool_placeholder",
+      "display_name": "Barcode Scanner Tool Placeholder",
+      "category": "tools",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    },
+    {
+      "id": "spindle_tool_placeholder",
+      "display_name": "Spindle Tool Placeholder",
+      "category": "tools",
+      "family": "gripper",
+      "support_status": "placeholder",
+      "runtime_status": "placeholder",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/grippers/gripper_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Selection metadata only.",
+      "tags": [
+        "gripper"
+      ]
+    }
+  ],
+  "objects": [
+    {
+      "id": "small_bin",
+      "display_name": "Small Bin",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "medium_bin",
+      "display_name": "Medium Bin",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "large_bin",
+      "display_name": "Large Bin",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "euro_box",
+      "display_name": "Euro Box",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "tote_box",
+      "display_name": "Tote Box",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "klt_bin",
+      "display_name": "Klt Bin",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "sorting_bin_red",
+      "display_name": "Sorting Bin Red",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "sorting_bin_green",
+      "display_name": "Sorting Bin Green",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "sorting_bin_blue",
+      "display_name": "Sorting Bin Blue",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "reject_bin",
+      "display_name": "Reject Bin",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "pass_bin",
+      "display_name": "Pass Bin",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "fail_bin",
+      "display_name": "Fail Bin",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "pallet",
+      "display_name": "Pallet",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "pallet_stack",
+      "display_name": "Pallet Stack",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "shelf_rack",
+      "display_name": "Shelf Rack",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "small_parts_rack",
+      "display_name": "Small Parts Rack",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "tray_stack",
+      "display_name": "Tray Stack",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "cardboard_box",
+      "display_name": "Cardboard Box",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "crate",
+      "display_name": "Crate",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "dunnage_tray",
+      "display_name": "Dunnage Tray",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "cube_small",
+      "display_name": "Cube Small",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "cube_large",
+      "display_name": "Cube Large",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "cylinder_small",
+      "display_name": "Cylinder Small",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "cylinder_large",
+      "display_name": "Cylinder Large",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "bottle",
+      "display_name": "Bottle",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "can",
+      "display_name": "Can",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "pouch",
+      "display_name": "Pouch",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "box",
+      "display_name": "Box",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "parcel",
+      "display_name": "Parcel",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "gear_placeholder",
+      "display_name": "Gear Placeholder",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "bracket_placeholder",
+      "display_name": "Bracket Placeholder",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "washer_placeholder",
+      "display_name": "Washer Placeholder",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "bolt_placeholder",
+      "display_name": "Bolt Placeholder",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "plastic_part_placeholder",
+      "display_name": "Plastic Part Placeholder",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "metal_part_placeholder",
+      "display_name": "Metal Part Placeholder",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "food_pack_placeholder",
+      "display_name": "Food Pack Placeholder",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "medical_tray_placeholder",
+      "display_name": "Medical Tray Placeholder",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "electronics_part_placeholder",
+      "display_name": "Electronics Part Placeholder",
+      "category": "objects",
+      "family": "object",
+      "support_status": "placeholder",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/objects/object_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Demo object placeholder.",
+      "tags": [
+        "object"
+      ]
+    },
+    {
+      "id": "cube_placeholder",
+      "display_name": "Cube Placeholder",
+      "category": "objects",
+      "family": "placeholder",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "",
+      "thumbnail_path": "",
+      "notes": "Primitive placeholder for GUI visibility.",
+      "tags": [
+        "placeholder"
+      ]
+    },
+    {
+      "id": "bin_placeholder",
+      "display_name": "Bin Placeholder",
+      "category": "objects",
+      "family": "placeholder",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "",
+      "thumbnail_path": "",
+      "notes": "Primitive placeholder for GUI visibility.",
+      "tags": [
+        "placeholder"
+      ]
+    }
+  ],
+  "tables": [
+    {
+      "id": "basic_table_small",
+      "display_name": "Basic Table Small",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "basic_table_large",
+      "display_name": "Basic Table Large",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "aluminium_profile_table",
+      "display_name": "Aluminium Profile Table",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    }
+  ],
+  "workbenches": [
+    {
+      "id": "workbench",
+      "display_name": "Workbench",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    },
+    {
+      "id": "mobile_workbench",
+      "display_name": "Mobile Workbench",
+      "category": "environment",
+      "family": "environment",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "environment"
+      ]
+    }
+  ],
+  "sensors": [
+    {
+      "id": "realsense_d435i",
+      "display_name": "Realsense D435I",
+      "category": "sensors",
+      "family": "sensors",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "sensors"
+      ]
+    },
+    {
+      "id": "overhead_rgbd_camera_placeholder",
+      "display_name": "Overhead Rgbd Camera Placeholder",
+      "category": "sensors",
+      "family": "sensors",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "sensors"
+      ]
+    },
+    {
+      "id": "area_scan_camera_placeholder",
+      "display_name": "Area Scan Camera Placeholder",
+      "category": "sensors",
+      "family": "sensors",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "sensors"
+      ]
+    },
+    {
+      "id": "line_scan_camera_placeholder",
+      "display_name": "Line Scan Camera Placeholder",
+      "category": "sensors",
+      "family": "sensors",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "sensors"
+      ]
+    },
+    {
+      "id": "barcode_scanner_placeholder",
+      "display_name": "Barcode Scanner Placeholder",
+      "category": "sensors",
+      "family": "sensors",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "sensors"
+      ]
+    }
+  ],
+  "cameras": [],
+  "conveyors": [
+    {
+      "id": "conveyor_1m_placeholder",
+      "display_name": "Conveyor 1M Placeholder",
+      "category": "conveyors",
+      "family": "conveyors",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "conveyors"
+      ]
+    },
+    {
+      "id": "conveyor_2m_placeholder",
+      "display_name": "Conveyor 2M Placeholder",
+      "category": "conveyors",
+      "family": "conveyors",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "conveyors"
+      ]
+    },
+    {
+      "id": "belt_conveyor_placeholder",
+      "display_name": "Belt Conveyor Placeholder",
+      "category": "conveyors",
+      "family": "conveyors",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "conveyors"
+      ]
+    },
+    {
+      "id": "roller_conveyor_placeholder",
+      "display_name": "Roller Conveyor Placeholder",
+      "category": "conveyors",
+      "family": "conveyors",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "conveyors"
+      ]
+    },
+    {
+      "id": "indexing_conveyor_placeholder",
+      "display_name": "Indexing Conveyor Placeholder",
+      "category": "conveyors",
+      "family": "conveyors",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "conveyors"
+      ]
+    },
+    {
+      "id": "outfeed_conveyor_placeholder",
+      "display_name": "Outfeed Conveyor Placeholder",
+      "category": "conveyors",
+      "family": "conveyors",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "conveyors"
+      ]
+    },
+    {
+      "id": "infeed_conveyor_placeholder",
+      "display_name": "Infeed Conveyor Placeholder",
+      "category": "conveyors",
+      "family": "conveyors",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "conveyors"
+      ]
+    },
+    {
+      "id": "conveyor_placeholder",
+      "display_name": "Conveyor Placeholder",
+      "category": "conveyors",
+      "family": "placeholder",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "",
+      "thumbnail_path": "",
+      "notes": "Primitive placeholder for GUI visibility.",
+      "tags": [
+        "placeholder"
+      ]
+    }
+  ],
+  "fixtures": [
+    {
+      "id": "simple_fixture_plate",
+      "display_name": "Simple Fixture Plate",
+      "category": "fixtures",
+      "family": "fixtures",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "fixtures"
+      ]
+    },
+    {
+      "id": "peg_fixture",
+      "display_name": "Peg Fixture",
+      "category": "fixtures",
+      "family": "fixtures",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "fixtures"
+      ]
+    },
+    {
+      "id": "vice_fixture",
+      "display_name": "Vice Fixture",
+      "category": "fixtures",
+      "family": "fixtures",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "fixtures"
+      ]
+    },
+    {
+      "id": "nest_fixture",
+      "display_name": "Nest Fixture",
+      "category": "fixtures",
+      "family": "fixtures",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "fixtures"
+      ]
+    },
+    {
+      "id": "locating_pins_fixture",
+      "display_name": "Locating Pins Fixture",
+      "category": "fixtures",
+      "family": "fixtures",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "fixtures"
+      ]
+    },
+    {
+      "id": "tray_fixture",
+      "display_name": "Tray Fixture",
+      "category": "fixtures",
+      "family": "fixtures",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "fixtures"
+      ]
+    },
+    {
+      "id": "part_holder_fixture",
+      "display_name": "Part Holder Fixture",
+      "category": "fixtures",
+      "family": "fixtures",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "fixtures"
+      ]
+    },
+    {
+      "id": "adjustable_stop_fixture",
+      "display_name": "Adjustable Stop Fixture",
+      "category": "fixtures",
+      "family": "fixtures",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "fixtures"
+      ]
+    },
+    {
+      "id": "emergency_stop_pedestal",
+      "display_name": "Emergency Stop Pedestal",
+      "category": "fixtures",
+      "family": "fixtures",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "fixtures"
+      ]
+    },
+    {
+      "id": "camera_mount_placeholder",
+      "display_name": "Camera Mount Placeholder",
+      "category": "fixtures",
+      "family": "placeholder",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "",
+      "thumbnail_path": "",
+      "notes": "Primitive placeholder for GUI visibility.",
+      "tags": [
+        "placeholder"
+      ]
+    }
+  ],
+  "machines": [
+    {
+      "id": "machine_side_table",
+      "display_name": "Machine Side Table",
+      "category": "machines",
+      "family": "machines",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "machines"
+      ]
+    },
+    {
+      "id": "cnc_machine_placeholder",
+      "display_name": "Cnc Machine Placeholder",
+      "category": "machines",
+      "family": "machines",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "machines"
+      ]
+    },
+    {
+      "id": "lathe_placeholder",
+      "display_name": "Lathe Placeholder",
+      "category": "machines",
+      "family": "machines",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "machines"
+      ]
+    },
+    {
+      "id": "injection_moulding_machine_placeholder",
+      "display_name": "Injection Moulding Machine Placeholder",
+      "category": "machines",
+      "family": "machines",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "machines"
+      ]
+    },
+    {
+      "id": "press_machine_placeholder",
+      "display_name": "Press Machine Placeholder",
+      "category": "machines",
+      "family": "machines",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "machines"
+      ]
+    },
+    {
+      "id": "test_station_placeholder",
+      "display_name": "Test Station Placeholder",
+      "category": "machines",
+      "family": "machines",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "machines"
+      ]
+    },
+    {
+      "id": "inspection_station_placeholder",
+      "display_name": "Inspection Station Placeholder",
+      "category": "machines",
+      "family": "machines",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "machines"
+      ]
+    },
+    {
+      "id": "packaging_machine_placeholder",
+      "display_name": "Packaging Machine Placeholder",
+      "category": "machines",
+      "family": "machines",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "machines"
+      ]
+    }
+  ],
+  "safety": [
+    {
+      "id": "safety_fence_panel",
+      "display_name": "Safety Fence Panel",
+      "category": "safety",
+      "family": "safety",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "safety"
+      ]
+    },
+    {
+      "id": "safety_gate",
+      "display_name": "Safety Gate",
+      "category": "safety",
+      "family": "safety",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "safety"
+      ]
+    },
+    {
+      "id": "light_curtain",
+      "display_name": "Light Curtain",
+      "category": "safety",
+      "family": "safety",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "safety"
+      ]
+    },
+    {
+      "id": "floor_marking_zone",
+      "display_name": "Floor Marking Zone",
+      "category": "safety",
+      "family": "safety",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "safety"
+      ]
+    },
+    {
+      "id": "robot_keepout_zone",
+      "display_name": "Robot Keepout Zone",
+      "category": "safety",
+      "family": "safety",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "safety"
+      ]
+    },
+    {
+      "id": "operator_zone",
+      "display_name": "Operator Zone",
+      "category": "safety",
+      "family": "safety",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "safety"
+      ]
+    },
+    {
+      "id": "safety_scanner_placeholder",
+      "display_name": "Safety Scanner Placeholder",
+      "category": "safety",
+      "family": "safety",
+      "support_status": "preview_only",
+      "runtime_status": "preview_only",
+      "package_name": "",
+      "urdf_or_xacro": "",
+      "mesh_path": "workcell_studio_catalog/meshes/environment/env_placeholder.stl",
+      "thumbnail_path": "",
+      "notes": "Environment asset placeholder.",
+      "tags": [
+        "safety"
+      ]
+    }
+  ],
+  "custom": []
+}


### PR DESCRIPTION
### Motivation
- The workcell builder metadata renderer crashed with `ModuleNotFoundError` when run from the repository root, preventing GUI metadata rendering and manual authoring workflows.  
- The Qt GUI requires a simple, GUI-friendly catalog JSON so selection dialogs can surface many more robots, grippers, environment assets and placeholders without relying only on legacy folder scanning.  

### Description
- Make the metadata renderer import robust by inserting the repository root into `sys.path` and adding a safe fallback import so `scripts/render_workcell_builder_metadata.py` no longer fails with `ModuleNotFoundError`.  
- Add `scripts/workcell_builder_gui_catalog.py`, a small exporter that reads `workcell_studio_catalog/catalog.yaml` and writes a grouped GUI-friendly JSON at `workcell_studio_catalog/generated/workcell_builder_gui_catalog.json` with groups for robots, grippers, tools, objects, tables, workbenches, sensors, cameras, conveyors, fixtures, machines, safety and custom entries.  
- Commit a generated catalog artifact with placeholder entries (cube/bin/conveyor/camera mount etc.) so preview-only items are visible in selection flows even if some meshes/URDFs are not present.  
- Add automated tests that exercise catalog generation and the metadata renderer and add documentation explaining how the GUI catalog is generated and refreshed.  

### Testing
- Ran the exporter: `python3 scripts/workcell_builder_gui_catalog.py`, which produced `workcell_studio_catalog/generated/workcell_builder_gui_catalog.json` successfully.  
- Verified the metadata renderer no longer crashes: `python3 scripts/render_workcell_builder_metadata.py --help` returned successfully with no `ModuleNotFoundError`.  
- Executed the new pytest suite: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_gui_catalog_export.py tests/test_workcell_builder_gui_catalog_entries.py tests/test_workcell_builder_metadata_renderer.py`, and all tests passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb820e55483318f2369a3c25b2e31)