### PR TITLE
Add GUI placement/ROI validation, export preview metadata, and tests

### DIFF
--- a/docs/manuals/WORKCELL_BUILDER_GUI_AUTHORING.md
+++ b/docs/manuals/WORKCELL_BUILDER_GUI_AUTHORING.md
@@ -1,0 +1,55 @@
+# Workcell Builder GUI Manual Authoring
+
+This guide covers manual cell authoring workflows in the Workcell Builder GUI metadata path.
+
+## Select assets
+Pick robot, end-effector, tables/workbenches, bins/objects, cameras, and custom STL assets from catalog, then assign role and collision mode.
+
+## Place assets
+Edit XYZ/RPY/scale and asset notes/visibility/lock metadata in the placement inspector.
+
+## Import/customize STL
+Custom STL assets should be marked `custom_stl`, and can remain `visual_only` or use `bounding_box` collision for safe preview-first use.
+
+## Define pick ROI
+Use `camera_pointcloud_roi` with:
+- camera asset id
+- pointcloud topic (`/camera/depth/color/points` or `/camera/camera/depth/color/points`)
+- frame (`base_link`, `world`, `camera_link`, `camera_depth_optical_frame`)
+- crop box x/y/z min/max
+
+## Pointcloud filters
+Configure:
+- remove_table_plane / remove_floor
+- min/max_height_above_table
+- voxel_leaf_size
+- min/max_cluster_size
+
+Plain-English intent:
+- Do not pick below this height
+- Left/right/forward/back crop limits
+- Ignore table/floor points
+- Downsample pointcloud
+
+## Define place target
+Set target id, target type (`pose`, `bin`, `grid`, `reject_bin`, `pass_bin`, `fail_bin`), pose XYZ/RPY, orientation mode, optional class/colour/shape mapping.
+
+## Validate live authoring
+Validation reports Ingredients / Cell / Runtime readiness and flags missing robot, tool, support surface, pick ROI, place target, invalid ROI bounds, and preview-only runtime limitations.
+
+## Export canonical files
+Export produces:
+- `cell_definition.yaml`
+- `environment_layout.yaml`
+- `task_recipe.yaml`
+- `selected_assets.json`
+- `compatibility_report.json`
+- `builder_export_summary.json`
+
+Includes placements, roles, collision modes, pick ROI + filters, place targets, grasp metadata, and `fake_hardware_default: true`.
+
+## preview_only meaning
+`preview_only` means usable for metadata/visual planning but not runtime-ready hardware execution.
+
+## EPD separation
+EPD GUI/runtime controls remain separate; workcell_builder stores passive camera/ROI metadata only.

--- a/tests/test_workcell_builder_gui_authoring_validation.py
+++ b/tests/test_workcell_builder_gui_authoring_validation.py
@@ -1,0 +1,15 @@
+from tools.workcell_studio_streamlit import backend
+
+
+def test_gui_invalid_roi_fails_validation():
+    state = backend.default_manual_authoring_state("gui_validate")
+    state["selected_assets"] = [
+        {"id": "ur5", "role": "robot_base"},
+        {"id": "rg2", "role": "end_effector"},
+        {"id": "table", "role": "support_surface"},
+    ]
+    state["pick_sources"][0]["crop_box"]["x_min"] = 1.0
+    state["pick_sources"][0]["crop_box"]["x_max"] = 0.2
+    report = backend.authoring_validation_report(state)
+    assert report["status"] == "FAIL"
+    assert any(i["code"] == "invalid_crop_box" for i in report["issues"])

--- a/tests/test_workcell_builder_gui_pick_roi_export.py
+++ b/tests/test_workcell_builder_gui_pick_roi_export.py
@@ -1,0 +1,19 @@
+from tools.workcell_studio_streamlit import backend
+
+
+def test_gui_pick_roi_and_filters_export(tmp_path):
+    state = backend.default_manual_authoring_state("gui_roi")
+    state["selected_assets"] = [
+        {"id": "ur5", "role": "robot_base"},
+        {"id": "rg2", "role": "end_effector"},
+        {"id": "table", "role": "support_surface"},
+        {"id": "cam", "role": "camera"},
+    ]
+    state["pick_sources"][0]["pointcloud_topic"] = "/camera/camera/depth/color/points"
+    state["pick_sources"][0]["filters"]["voxel_leaf_size"] = 0.01
+    out = backend.export_manual_authoring_bundle(state, tmp_path)
+    cell = backend.load_environment_layout(out["cell_definition.yaml"])
+    roi = cell["pick_sources"][0]
+    assert roi["type"] == "camera_pointcloud_roi"
+    assert roi["pointcloud_topic"] == "/camera/camera/depth/color/points"
+    assert roi["filters"]["voxel_leaf_size"] == 0.01

--- a/tests/test_workcell_builder_gui_placement_export.py
+++ b/tests/test_workcell_builder_gui_placement_export.py
@@ -1,0 +1,25 @@
+from tools.workcell_studio_streamlit import backend
+
+
+def test_gui_placement_role_collision_export(tmp_path):
+    state = backend.default_manual_authoring_state("gui_place")
+    state["selected_assets"] = [
+        {"id": "ur5", "role": "robot_base"},
+        {"id": "rg2", "role": "end_effector"},
+        {"id": "table", "role": "support_surface"},
+        {"id": "cam", "role": "camera"},
+    ]
+    state["placements"] = [
+        {
+            "id": "bin_a",
+            "asset_ref": "bin_standard",
+            "role": "bin",
+            "collision_mode": "bounding_box",
+            "pose": {"frame": "world", "xyz": [0.6, -0.2, 0.8], "rpy": [0.0, 0.0, 0.0]},
+            "scale": 1.0,
+        }
+    ]
+    out = backend.export_manual_authoring_bundle(state, tmp_path)
+    env = backend.load_environment_layout(out["environment_layout.yaml"])
+    assert env["assets"][0]["role"] == "bin"
+    assert env["assets"][0]["collision_mode"] == "bounding_box"

--- a/tools/workcell_studio_streamlit/backend.py
+++ b/tools/workcell_studio_streamlit/backend.py
@@ -721,7 +721,16 @@ def default_manual_authoring_state(cell_id: str = "manual_cell") -> dict[str, An
         "pick_sources": [default_pick_roi()],
         "place_targets": [{"id": "bin_main", "role": "bin", "pose": {"frame": "world", "xyz": [0.70, -0.2, 0.8], "rpy": [0, 0, 0]}, "allowed_orientation_mode": "upright"}],
         "task": {"type": "pick_place", "supported": True, "preview_only": False},
-        "grasp": {"strategy": "auto", "approach_distance": 0.10, "retreat_distance": 0.10, "approach_axis": "z_down", "orientation_mode": "free"},
+        "grasp": {
+            "strategy": "auto",
+            "approach_distance": 0.10,
+            "retreat_distance": 0.10,
+            "approach_axis": "z_down",
+            "orientation_mode": "free",
+            "allowed_roll_angles": [0.0],
+            "allowed_yaw_angles": [0.0, 180.0],
+            "tcp_offset": {"xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
+        },
     }
 
 
@@ -738,6 +747,17 @@ def validate_pick_roi(roi: dict[str, Any]) -> list[dict[str, str]]:
             issues.append({"level": "FAIL", "code": "invalid_crop_box", "message": f"{axis}_min must be less than {axis}_max."})
     if not roi.get("frame_id"):
         issues.append({"level": "FAIL", "code": "missing_pick_roi_frame", "message": "Pick ROI frame is required."})
+    if not str(roi.get("camera_asset_id", "")).strip():
+        issues.append({"level": "FAIL", "code": "missing_camera_asset", "message": "Camera asset id is required for camera ROI."})
+    if not str(roi.get("pointcloud_topic", "")).strip():
+        issues.append({"level": "FAIL", "code": "missing_pointcloud_topic", "message": "Pointcloud topic is required."})
+    filters = roi.get("filters", {}) if isinstance(roi.get("filters"), dict) else {}
+    if float(filters.get("voxel_leaf_size", 0.0)) < 0:
+        issues.append({"level": "FAIL", "code": "negative_voxel_size", "message": "voxel_leaf_size cannot be negative."})
+    min_cluster = int(filters.get("min_cluster_size", 0))
+    max_cluster = int(filters.get("max_cluster_size", 0))
+    if min_cluster <= 0 or max_cluster < min_cluster:
+        issues.append({"level": "FAIL", "code": "invalid_cluster_limits", "message": "Cluster limits are invalid."})
     return issues
 
 
@@ -747,7 +767,7 @@ def authoring_validation_report(state: dict[str, Any]) -> dict[str, Any]:
     roles = {str(a.get("role")) for a in assets if isinstance(a, dict)}
     if "robot_base" not in roles:
         issues.append({"level": "FAIL", "code": "missing_robot", "message": "Missing robot."})
-    if not ({"gripper", "tool"} & roles):
+    if not ({"gripper", "tool", "end_effector"} & roles):
         issues.append({"level": "FAIL", "code": "missing_tool", "message": "Missing gripper/tool."})
     if "support_surface" not in roles:
         issues.append({"level": "FAIL", "code": "missing_support_surface", "message": "Missing table/support surface."})
@@ -757,6 +777,8 @@ def authoring_validation_report(state: dict[str, Any]) -> dict[str, Any]:
     for src in pick_sources:
         if isinstance(src, dict) and src.get("type") == "camera_pointcloud_roi":
             issues.extend(validate_pick_roi(src))
+            if "camera" not in roles:
+                issues.append({"level": "WARN", "code": "camera_roi_no_camera_asset", "message": "Camera ROI selected but no camera role asset found."})
     if not (state.get("place_targets") or []):
         issues.append({"level": "FAIL", "code": "missing_place_target", "message": "Missing place target."})
     if any(bool(a.get("preview_only")) for a in assets if isinstance(a, dict)):
@@ -782,7 +804,22 @@ def export_manual_authoring_bundle(state: dict[str, Any], output_dir: str | Path
     env = {"schema_version": "environment_layout/v1", "layout_id": f"{cell_id}_layout", "assets": placements}
     recipe = {"schema_version": "task_recipe/v1", "task": task, "pick_source_refs": [s.get("id") for s in pick_sources if isinstance(s, dict)], "place_target_refs": [p.get("id") for p in place_targets if isinstance(p, dict)], "grasp": grasp}
     compat = authoring_validation_report(state)
-    summary = {"mode": state.get("mode"), "fake_hardware_default": bool(state.get("fake_hardware_default", True)), "runtime_generation_allowed": compat.get("runtime_ready", False), "preview_only": not compat.get("runtime_ready", False)}
+    preview_metadata = {
+        "asset_boxes": [
+            {
+                "id": a.get("id"),
+                "role": a.get("role"),
+                "pose": (a.get("pose") if isinstance(a.get("pose"), dict) else {}),
+                "scale": a.get("scale", 1.0),
+                "collision_mode": a.get("collision_mode", "bounding_box"),
+            }
+            for a in placements if isinstance(a, dict)
+        ],
+        "pick_roi_box": [s for s in pick_sources if isinstance(s, dict) and s.get("type") == "camera_pointcloud_roi"],
+        "place_target_markers": [p for p in place_targets if isinstance(p, dict)],
+        "warnings": [i.get("message") for i in compat.get("issues", []) if i.get("level") == "WARN"],
+    }
+    summary = {"mode": state.get("mode"), "fake_hardware_default": bool(state.get("fake_hardware_default", True)), "runtime_generation_allowed": compat.get("runtime_ready", False), "preview_only": not compat.get("runtime_ready", False), "preview_metadata": preview_metadata}
     files = {
         "cell_definition.yaml": cell_def,
         "environment_layout.yaml": env,


### PR DESCRIPTION
### Motivation
- Make the Workcell Builder GUI manual-authoring workflow produce richer, validated metadata so the UI can let users place assets and author camera pointcloud ROIs safely and export canonical files for offline preview and generation.

### Description
- Extended `default_manual_authoring_state` in `tools/workcell_studio_streamlit/backend.py` to include richer grasp metadata (`allowed_roll_angles`, `allowed_yaw_angles`, `tcp_offset`).
- Hardened ROI validation in `validate_pick_roi` to check for missing `camera_asset_id`/`pointcloud_topic`, negative `voxel_leaf_size`, and invalid cluster limits, and added a camera-ROI/no-camera-role warning in `authoring_validation_report`.
- Broadened role detection to accept `end_effector` as a valid tool role and preserved `fake_hardware_default` behavior.
- Added preview metadata to the export (`builder_export_summary.json`) including `asset_boxes`, `pick_roi_box`, `place_target_markers`, and collected warnings, while keeping existing canonical outputs (`cell_definition.yaml`, `environment_layout.yaml`, `task_recipe.yaml`, `selected_assets.json`, `compatibility_report.json`).
- Added focused unit tests `tests/test_workcell_builder_gui_placement_export.py`, `tests/test_workcell_builder_gui_pick_roi_export.py`, and `tests/test_workcell_builder_gui_authoring_validation.py` and a new GUI authoring manual `docs/manuals/WORKCELL_BUILDER_GUI_AUTHORING.md`.

### Testing
- Added and ran the new tests together with existing manual-authoring validation tests using `pytest`; the test run `python3 -m pytest -q tests/test_workcell_builder_gui_placement_export.py tests/test_workcell_builder_gui_pick_roi_export.py tests/test_workcell_builder_gui_authoring_validation.py tests/test_workcell_builder_manual_authoring.py tests/test_workcell_builder_authoring_validation.py` passed with `7 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdba6082b483318833491b68386819)