### PR TITLE
Improve Workcell Builder default scene root discovery and scene browser UX

### DIFF
--- a/docs/manuals/WORKCELL_BUILDER_SCENE_MANAGEMENT.md
+++ b/docs/manuals/WORKCELL_BUILDER_SCENE_MANAGEMENT.md
@@ -1,0 +1,11 @@
+# Workcell Builder Scene Management
+
+- Default scenes folder: `<repo_root>/scenes`.
+- Default assets folder: `<repo_root>/assets`.
+- Existing scenes are discovered by scanning subfolders under `scenes/` and accepting any folder containing at least one marker: `package.xml`, `scene_manifest.yaml`, `environment.yaml`, `urdf/scene.urdf.xacro`, or `launch/demo.launch.py`.
+- Use **Browse Scenes Folder** to switch scene roots for this session.
+- Use **Refresh Scenes** to rescan without restarting.
+- New scene output defaults to `scenes/<safe_scene_name>`.
+- `/tmp` remains for temporary export/demo usage, not default package generation.
+- Existing scene names are checked; collisions are blocked and user must rename or cancel.
+- Safe package names are lowercased, spaces become `_`, only `[a-z0-9_]` kept, and leading digits are prefixed with `scene_`.

--- a/docs/manuals/WORKCELL_BUILDER_USER_FRIENDLY_GUI.md
+++ b/docs/manuals/WORKCELL_BUILDER_USER_FRIENDLY_GUI.md
@@ -28,3 +28,10 @@ EPD controls are intentionally not part of workcell_builder. EPD remains a separ
 
 ## Fake-Hardware First
 Default launch command guidance is safe simulation (fake hardware). Real hardware launch is not default.
+
+
+## Scene browser defaults
+- The GUI now resolves repo/workspace roots and shows scenes from `scenes/` by default.
+- Status text shows scenes folder path, assets folder path, count, and last refresh.
+- Actions: **Browse Scenes Folder** and **Refresh Scenes**.
+- New cells default to `scenes/<safe_name>` and do not silently overwrite existing packages.

--- a/tests/test_workcell_builder_default_scenes_folder.py
+++ b/tests/test_workcell_builder_default_scenes_folder.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+def test_repo_has_default_scenes_and_assets():
+    root = Path(__file__).resolve().parents[1]
+    assert (root / 'scenes').is_dir()
+    assert (root / 'assets').is_dir()

--- a/tests/test_workcell_builder_scene_discovery.py
+++ b/tests/test_workcell_builder_scene_discovery.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import re
+
+def _sanitize(name: str) -> str:
+    out = ''.join('_' if c.isspace() else c.lower() for c in name)
+    out = ''.join(c for c in out if c.isalnum() or c == '_')
+    while '__' in out:
+        out = out.replace('__','_')
+    if out and out[0].isdigit():
+        out = 'scene_' + out
+    return out
+
+def test_scene_sanitize_example():
+    assert _sanitize('My First UR5 Cell') == 'my_first_ur5_cell'
+
+def test_scenes_have_discovery_markers():
+    root = Path(__file__).resolve().parents[1] / 'scenes'
+    markers = ['package.xml', 'scene_manifest.yaml', 'environment.yaml', 'urdf/scene.urdf.xacro', 'launch/demo.launch.py']
+    scene_dirs = [p for p in root.iterdir() if p.is_dir()]
+    assert scene_dirs, 'expected scene directories'
+    assert any(any((d / m).exists() for m in markers) for d in scene_dirs)

--- a/workcell_builder/workcell_builder/gui/addscene.cpp
+++ b/workcell_builder/workcell_builder/gui/addscene.cpp
@@ -20,6 +20,8 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <regex>
+#include <cctype>
 
 #include "gui/addscene.h"
 #include "gui/ui_addscene.h"
@@ -501,13 +503,25 @@ bool AddScene::CheckSceneName()
   std::string initial_name = ui->scene_name->text().toStdString();
   std::string final_name;
   if (initial_name.find_first_not_of(' ') != std::string::npos) {
-    for(int i = 0 ; i < static_cast<int>(initial_name.length()); i++){
-        if(isspace(initial_name[i])){
-            final_name += "_";
+    for (char c : initial_name) {
+      if (isspace(c)) {
+        final_name += "_";
+      } else {
+        const char lc = static_cast<char>(std::tolower(c));
+        if ((lc >= 'a' && lc <= 'z') || (lc >= '0' && lc <= '9') || lc == '_') {
+          final_name += lc;
         }
-        else{
-            final_name += std::tolower(initial_name[i]);
-        }
+      }
+    }
+    while (final_name.find("__") != std::string::npos) {
+      final_name = std::regex_replace(final_name, std::regex("__"), "_");
+    }
+    if (!final_name.empty() && std::isdigit(final_name.front())) {
+      final_name = "scene_" + final_name;
+    }
+    if (final_name.empty()) {
+      ui->scene_errors->append("<font color='red'> Scene name must contain letters/numbers/underscore. </font>");
+      return false;
     }
     ui->scene_name->setText(QString::fromStdString(final_name));
     const boost::filesystem::path target_scene_dir = scenes_path / final_name;

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -22,6 +22,7 @@
 #include <QApplication>
 #include <QClipboard>
 #include <QLineEdit>
+#include <QFileDialog>
 #include <QListWidgetItem>
 #include <QTreeWidgetItem>
 #include <boost/filesystem.hpp>
@@ -454,12 +455,10 @@ void SceneSelect::load_workcell(Workcell workcell_input)
 {
   workcell = workcell_input;
 
-  const auto resolution = workcell_builder::resolve_scene_select_paths(workcell);
+  const auto resolution = workcell_builder::resolve_scene_select_paths(workcell, workcell_path);
   templates_path = resolution.paths.templates_path;
   if (!resolution.success) {
-    workcell_path.clear();
-    scenes_path.clear();
-    assets_path.clear();
+    configure_startup_fallback_paths();
     show_invalid_workcell_error(resolution.error);
     return;
   }
@@ -472,6 +471,21 @@ void SceneSelect::load_workcell(Workcell workcell_input)
   }
   discover_scene_packages_on_startup();
   refresh_scenes(0, false);
+}
+
+void SceneSelect::update_scene_browser_status(const std::string & note)
+{
+  const int count = static_cast<int>(workcell.scene_vector.size());
+  const QString stamp = QDateTime::currentDateTime().toString(Qt::ISODate);
+  QString text = QString("Scenes folder: %1\nAssets folder: %2\nNumber of scenes found: %3\nLast refresh: %4")
+    .arg(QString::fromStdString(path_or_placeholder(scenes_path)))
+    .arg(QString::fromStdString(path_or_placeholder(assets_path)))
+    .arg(count)
+    .arg(stamp);
+  if (!note.empty()) {
+    text += "\n" + QString::fromStdString(note);
+  }
+  ui->scene_browser_status->setText(text);
 }
 
 void SceneSelect::discover_scene_packages_on_startup()
@@ -499,14 +513,15 @@ void SceneSelect::discover_scene_packages_on_startup()
     }
     const std::string scene_name = entry.path().filename().string();
     const fs::path package_xml = entry.path() / "package.xml";
-    const fs::path cmake_lists = entry.path() / "CMakeLists.txt";
-    const fs::path urdf_dir = entry.path() / "urdf";
+    const fs::path scene_manifest = entry.path() / "scene_manifest.yaml";
     const fs::path environment_yaml = entry.path() / "environment.yaml";
+    const fs::path urdf_xacro = entry.path() / "urdf" / "scene.urdf.xacro";
+    const fs::path demo_launch = entry.path() / "launch" / "demo.launch.py";
 
-    if (!fs::exists(package_xml) || !fs::exists(cmake_lists) || !fs::is_directory(urdf_dir)) {
-      append_info(
-        "Skipped scene directory '" + scene_name +
-        "': missing one of [package.xml, CMakeLists.txt, urdf/].");
+    const bool has_markers = fs::exists(package_xml) || fs::exists(scene_manifest) ||
+      fs::exists(environment_yaml) || fs::exists(urdf_xacro) || fs::exists(demo_launch);
+    if (!has_markers) {
+      append_info("Skipped scene directory '" + scene_name + "': no scene package markers found.");
       continue;
     }
     if (known_scenes.find(scene_name) != known_scenes.end()) {
@@ -535,6 +550,11 @@ void SceneSelect::discover_scene_packages_on_startup()
     ++discovered_count;
   }
   append_info("Discovered scene packages: " + std::to_string(discovered_count));
+  if (discovered_count == 0 && workcell.scene_vector.empty()) {
+    append_warning("No scene packages found. Expected scenes under " + scenes_path.string() +
+      ". Use Browse Scenes Folder or create a new cell.");
+  }
+  update_scene_browser_status();
 }
 void SceneSelect::on_add_scene_clicked()
 {
@@ -552,7 +572,28 @@ void SceneSelect::on_add_scene_clicked()
     generate_scene_package(
       scenes_path, scene_window.scene.name, workcell.ros_ver, workcell.ros_distro);
     refresh_scenes(workcell.scene_vector.size() - 1, true);
+    update_scene_browser_status("Created new scene at: " + (scenes_path / scene_window.scene.name).string());
   }
+}
+
+void SceneSelect::on_browse_scenes_folder_clicked()
+{
+  const QString selected = QFileDialog::getExistingDirectory(
+    this, "Select Scenes Folder", QString::fromStdString(path_or_placeholder(scenes_path)));
+  if (selected.isEmpty()) return;
+  scenes_path = fs::path(selected.toStdString());
+  workcell_path = scenes_path.parent_path();
+  assets_path = workcell_path / "assets";
+  workcell.scene_vector.clear();
+  discover_scene_packages_on_startup();
+  refresh_scenes(0, false);
+}
+
+void SceneSelect::on_refresh_scenes_button_clicked()
+{
+  workcell.scene_vector.clear();
+  discover_scene_packages_on_startup();
+  refresh_scenes(0, false);
 }
 
 

--- a/workcell_builder/workcell_builder/gui/scene_select.h
+++ b/workcell_builder/workcell_builder/gui/scene_select.h
@@ -85,6 +85,8 @@ private slots:
   void on_open_output_folder_clicked();
   void on_show_readiness_report_clicked();
   void on_copy_fake_hardware_launch_command_clicked();
+  void on_browse_scenes_folder_clicked();
+  void on_refresh_scenes_button_clicked();
 
 private:
   enum class MessageLevel
@@ -109,6 +111,7 @@ private:
   void configure_startup_fallback_paths();
   void show_invalid_workcell_error(const std::string & error_message);
   void discover_scene_packages_on_startup();
+  void update_scene_browser_status(const std::string & note = "");
 
   int scaffold_scene_index_ = -1;
 };

--- a/workcell_builder/workcell_builder/gui/scene_select.ui
+++ b/workcell_builder/workcell_builder/gui/scene_select.ui
@@ -26,6 +26,8 @@
         <item><widget class="QLineEdit" name="output_folder"><property name="placeholderText"><string>Output Folder</string></property></widget></item>
         <item><widget class="QPushButton" name="add_scene"><property name="text"><string>New Cell</string></property></widget></item>
         <item><widget class="QComboBox" name="scene_list"/></item>
+        <item><layout class="QHBoxLayout" name="sceneActionsLayout"><item><widget class="QPushButton" name="browse_scenes_folder"><property name="text"><string>Browse Scenes Folder</string></property></widget></item><item><widget class="QPushButton" name="refresh_scenes_button"><property name="text"><string>Refresh Scenes</string></property></widget></item></layout></item>
+        <item><widget class="QLabel" name="scene_browser_status"><property name="text"><string>Scenes folder: &lt;none&gt;</string></property><property name="wordWrap"><bool>true</bool></property></widget></item>
         <item><widget class="QPushButton" name="edit_scene"><property name="text"><string>Open Cell</string></property></widget></item>
         <item><widget class="QPushButton" name="generate_yaml"><property name="text"><string>Save Cell</string></property></widget></item>
        </layout></widget>

--- a/workcell_builder/workcell_builder/include/scene_select_paths.h
+++ b/workcell_builder/workcell_builder/include/scene_select_paths.h
@@ -24,6 +24,9 @@ struct SceneSelectPathResolution
 };
 
 SceneSelectPathResolution resolve_scene_select_paths(const Workcell & workcell);
+SceneSelectPathResolution resolve_scene_select_paths(
+  const Workcell & workcell,
+  const boost::filesystem::path & preferred_root);
 
 }  // namespace workcell_builder
 

--- a/workcell_builder/workcell_builder/src_scene_select_paths.cpp
+++ b/workcell_builder/workcell_builder/src_scene_select_paths.cpp
@@ -1,6 +1,8 @@
 #include "scene_select_paths.h"
 
 #include <boost/system/error_code.hpp>
+#include <vector>
+#include <cstdlib>
 
 #include "default_asset_paths.h"
 
@@ -8,24 +10,73 @@ namespace fs = boost::filesystem;
 
 namespace workcell_builder
 {
+namespace
+{
+bool has_dir(const fs::path & p)
+{
+  boost::system::error_code ec;
+  return !p.empty() && fs::exists(p, ec) && !ec && fs::is_directory(p, ec) && !ec;
+}
+
+bool is_repo_root(const fs::path & root)
+{
+  return has_dir(root / "scenes") && has_dir(root / "assets");
+}
+
+fs::path find_repo_from_cwd(fs::path cwd)
+{
+  while (!cwd.empty()) {
+    if (is_repo_root(cwd)) {
+      return cwd;
+    }
+    const fs::path parent = cwd.parent_path();
+    if (parent == cwd) {
+      break;
+    }
+    cwd = parent;
+  }
+  return fs::path();
+}
+}
+
 SceneSelectPathResolution resolve_scene_select_paths(const Workcell & workcell)
+{
+  return resolve_scene_select_paths(workcell, fs::path());
+}
+
+SceneSelectPathResolution resolve_scene_select_paths(
+  const Workcell & workcell,
+  const fs::path & preferred_root)
 {
   SceneSelectPathResolution resolution;
   resolution.paths.templates_path = get_default_templates_directory();
 
-  if (workcell.workcell_filepath.empty()) {
-    resolution.error = "Loaded workcell is missing workcell_filepath; unable to locate scenes directory.";
-    return resolution;
+  std::vector<fs::path> candidates;
+  if (has_dir(preferred_root)) candidates.push_back(preferred_root);
+  if (!workcell.workcell_filepath.empty()) {
+    const fs::path loaded(workcell.workcell_filepath);
+    if (has_dir(loaded)) candidates.push_back(loaded);
+  }
+  const fs::path cwd = fs::current_path();
+  if (has_dir(cwd / "scenes")) candidates.push_back(cwd);
+  const fs::path parent_found = find_repo_from_cwd(cwd);
+  if (!parent_found.empty()) candidates.push_back(parent_found);
+  const char * repo_env = std::getenv("WORKCELL_STUDIO_REPO_ROOT");
+  if (repo_env != nullptr) candidates.emplace_back(repo_env);
+  const char * home = std::getenv("HOME");
+  if (home != nullptr) {
+    candidates.push_back(fs::path(home) / "workcell_ws" / "src" / "easy_manipulation_deployment");
   }
 
-  const fs::path workcell_path(workcell.workcell_filepath);
-  boost::system::error_code ec;
-  if (!fs::exists(workcell_path, ec) || ec) {
-    resolution.error = "Loaded workcell path does not exist: " + workcell_path.string();
-    return resolution;
+  fs::path workcell_path;
+  for (const auto & c : candidates) {
+    if (has_dir(c / "scenes")) {
+      workcell_path = c;
+      break;
+    }
   }
-  if (!fs::is_directory(workcell_path, ec) || ec) {
-    resolution.error = "Loaded workcell path is not a directory: " + workcell_path.string();
+  if (workcell_path.empty()) {
+    resolution.error = "No scene packages found. Expected scenes under a repo root with scenes/ and assets/.";
     return resolution;
   }
 


### PR DESCRIPTION
### Motivation
- The GUI felt empty when `workcell.workcell_filepath` was empty or invalid because scene discovery only derived `scenes/` from a loaded workcell path. 
- The builder should immediately show existing scene packages under the repository `scenes/` folder and allow users to change or refresh that folder without manual filesystem browsing. 
- New scene creation needs safe, ROS-compatible package names and must not default to `/tmp` for authored packages. 

### Description
- Added robust fallback scene root resolution in `resolve_scene_select_paths` with candidate order including a preferred root override, loaded `workcell_filepath`, current working directory if it contains `scenes/`, upward parent search for a repo root containing `scenes/` and `assets/`, `WORKCELL_STUDIO_REPO_ROOT` env override, and `~/workcell_ws/src/easy_manipulation_deployment` as a final candidate; the resolved defaults are `<repo_root>/scenes` and `<repo_root>/assets` (files: `scene_select_paths.h`, `src_scene_select_paths.cpp`).
- Made startup discovery scan the resolved `scenes/` folder by marker files (any of `package.xml`, `scene_manifest.yaml`, `environment.yaml`, `urdf/scene.urdf.xacro`, or `launch/demo.launch.py`) and append discovered scaffold/info messages so existing scene packages are visible in the GUI (file: `gui/scene_select.cpp`).
- Added user-facing scene browser UX: a `Browse Scenes Folder` button, `Refresh Scenes` button, and a status label that displays `Scenes folder`, `Assets folder`, `Number of scenes found`, and `Last refresh` (file: `gui/scene_select.ui` and `gui/scene_select.cpp`).
- Hardened new-scene naming in the Add Scene dialog to sanitize names to lowercase, convert spaces to underscores, strip any non `[a-z0-9_]` characters, and prefix names beginning with digits with `scene_`, while preserving collision detection so existing scenes are not silently overwritten (file: `gui/addscene.cpp`).
- Added simple pytest checks and documentation: `tests/test_workcell_builder_default_scenes_folder.py`, `tests/test_workcell_builder_scene_discovery.py`, and `docs/manuals/WORKCELL_BUILDER_SCENE_MANAGEMENT.md` / `WORKCELL_BUILDER_USER_FRIENDLY_GUI.md` describing defaults and usage. 

### Testing
- Ran the added pytest checks with `python3 -m pytest -q tests/test_workcell_builder_default_scenes_folder.py tests/test_workcell_builder_scene_discovery.py` and the suite completed successfully (`3 passed`).
- No GUI integration or colcon build was executed as part of these automated tests; manual QA guidance is included in the docs for the acceptance flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc226c82c83318aa197fb82dca846)