### PR TITLE
Generate config-only EPD/RealSense perception profiles and add offline EPD snapshot adapter

### DIFF
--- a/docs/examples/detected_objects_v1_sample.yaml
+++ b/docs/examples/detected_objects_v1_sample.yaml
@@ -1,0 +1,9 @@
+{
+  "schema_version": "detected_objects/v1",
+  "source": "epd",
+  "frame_id": "camera_color_optical_frame",
+  "timestamp": null,
+  "objects": [
+    {"id":"obj_001","label":"cube","confidence":0.92,"pose":{"xyz":[0.45,0.10,0.22],"rpy":[0.0,0.0,0.0]},"dimensions_xyz":[0.05,0.05,0.05],"tracking_id":null}
+  ]
+}

--- a/docs/manuals/WORKCELL_STUDIO_EPD_PERCEPTION_PROFILE.md
+++ b/docs/manuals/WORKCELL_STUDIO_EPD_PERCEPTION_PROFILE.md
@@ -1,0 +1,16 @@
+# Workcell Studio EPD Perception Profile
+
+Generated scenes now include `config/perception_profile.yaml` (config-only), `config/sample_detected_objects.yaml`, and dry-run bridge payload sample artifacts.
+
+## Safety
+- Config/adapter level integration only.
+- Live EPD and RealSense are **not** auto-launched.
+- Fake hardware remains default.
+
+## Manual commands
+- RealSense:
+`ros2 launch realsense2_camera rs_launch.py rgb_camera.color_profile:=424x240x15 depth_module.depth_profile:=424x240x15 align_depth.enable:=true pointcloud.enable:=true`
+- EPD:
+`ros2 launch easy_perception_deployment run.launch.py`
+- Adapter dry-run:
+`python3 scripts/epd_snapshot_adapter.py --profile <scene>/config/perception_profile.yaml --input <scene>/config/sample_detected_objects.yaml --output /tmp/runtime_bridge_payload.json --summary /tmp/epd_adapter_summary.json`

--- a/scripts/epd_snapshot_adapter.py
+++ b/scripts/epd_snapshot_adapter.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+
+def _load(path: Path):
+    return json.loads(path.read_text(encoding='utf-8'))
+
+def main() -> int:
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--profile', required=True)
+    ap.add_argument('--input', required=True)
+    ap.add_argument('--output', required=True)
+    ap.add_argument('--summary', required=True)
+    args=ap.parse_args()
+    profile=_load(Path(args.profile))
+    detected=_load(Path(args.input))
+    if detected.get('schema_version')!='detected_objects/v1':
+        raise SystemExit('invalid detected_objects schema')
+    objs=detected.get('objects',[])
+    targets=[]
+    for o in objs:
+        pose=o.get('pose',{})
+        targets.append({'id':o.get('id'),'label':o.get('label'),'confidence':o.get('confidence'),'position':pose.get('xyz',[0,0,0]),'rpy':pose.get('rpy',[0,0,0])})
+    payload={'schema_version':'emd_grasp_bridge_payload/v1','source':'perception_replay','dry_run_only':True,'perception_provider':profile.get('perception',{}).get('provider','epd'),'targets':targets,'runtime_execution':{'auto_execute':False,'moveit_planning_called':False,'robot_motion_called':False}}
+    Path(args.output).write_text(json.dumps(payload,indent=2)+'\n',encoding='utf-8')
+    summary={'status':'ok','dry_run_only':True,'live_epd_launched':False,'object_count':len(targets),'note':'Config generated. Live EPD not launched automatically.'}
+    Path(args.summary).write_text(json.dumps(summary,indent=2)+'\n',encoding='utf-8')
+    print(json.dumps({'payload':args.output,'summary':args.summary,'count':len(targets)}))
+    return 0
+
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/scripts/workcell_builder_gui_workflow.py
+++ b/scripts/workcell_builder_gui_workflow.py
@@ -19,6 +19,38 @@ GRASP_STRATEGIES={"auto","finger_top","finger_side","suction_top","suction_side"
 APPROACH_AXES={"x_plus","x_minus","y_plus","y_minus","z_up","z_down"}
 PLACEHOLDER_TEMPLATES={"sorting_placeholder","inspection_placeholder","machine_tending_placeholder"}
 
+
+
+def default_perception_profile(state:dict[str,Any])->dict[str,Any]:
+    return {
+        "perception": {
+            "enabled": False,
+            "provider": "epd",
+            "camera": {
+                "model": "realsense_d435i",
+                "frame_id": "camera_color_optical_frame",
+                "rgb_topic": "/camera/camera/color/image_raw",
+                "depth_topic": "/camera/camera/depth/image_rect_raw",
+                "camera_info_topic": "/camera/camera/color/camera_info",
+                "pointcloud_topic": "/camera/camera/depth/color/points",
+            },
+            "epd": {
+                "mode": "localization",
+                "localization_topic": "/easy_perception_deployment/epd_localize_output",
+                "tracking_topic": "/easy_perception_deployment/epd_tracking_output",
+                "object_detection_topic": "/processor/epd_p2_output",
+                "object_tracking_topic": "/processor/epd_p3_output",
+                "qos": {"reliability": "best_effort", "depth": 1, "durability": "volatile"},
+            },
+            "object_mapping": {"default_pick_object_ref": "object_1", "class_to_task_target": {}},
+            "dry_run": {"enabled": True, "snapshot_output": "detected_objects_snapshot.json", "bridge_payload_output": "runtime_bridge_payload.json"},
+        }
+    }
+
+
+def default_sample_detected_objects()->dict[str,Any]:
+    return {"schema_version":"detected_objects/v1","source":"epd","frame_id":"camera_color_optical_frame","timestamp":None,"objects":[{"id":"obj_001","label":"cube","confidence":0.92,"pose":{"xyz":[0.45,0.10,0.22],"rpy":[0.0,0.0,0.0]},"dimensions_xyz":[0.05,0.05,0.05],"tracking_id":None}]}
+
 def default_task_grasp_config()->dict[str,Any]:
     return {"task":{"template":"pick_place","pick":{"source_ref":"","object_ref":""},"place":{"target_ref":""},"routing":{"mode":"direct"},"release":{"strategy":"open_gripper_or_disable_suction"},"runtime_ready":True},"grasp":{"strategy":"auto","approach_axis":"z_down","orientation_mode":"vertical","approach_distance_m":0.12,"retreat_distance_m":0.1,"allowed_roll_angles_deg":[0.0],"allowed_yaw_angles_deg":[0.0,90.0,180.0,270.0],"tool_offset_xyz":[0.0,0.0,0.0],"tool_offset_rpy":[0.0,0.0,0.0],"suction_cups":None}}
 
@@ -183,7 +215,10 @@ def generate_canonical_files(state:dict[str,Any], output_dir:Path)->dict[str,Any
     (output_dir/"compatibility_report.json").write_text(json.dumps({"fake_hardware_default":True,"preview_only":bool(state.get("preview_only_assets"))},indent=2),encoding="utf-8")
     scene_manifest={"schema_version":"scene_manifest/v1","generated_by":"workcell_builder","selected_assets":selected_payload["selected"],"task":composer.get("task",{}),"grasp":composer.get("grasp",{}),"fake_hardware_default":state.get("fake_hardware_default",True)}
     (output_dir/"scene_manifest.yaml").write_text(json.dumps(scene_manifest,indent=2)+"\n",encoding="utf-8")
-    (output_dir/"builder_export_summary.json").write_text(json.dumps({"validation_status":val["status"],"generated_files":sorted([p.name for p in output_dir.iterdir()]),"scene_manifest":scene_manifest,"task_grasp_summary":{"template":(composer.get("task",{}).get("template")),"grasp_strategy":(composer.get("grasp",{}).get("strategy"))}},indent=2),encoding="utf-8")
+    (output_dir/"perception_profile.yaml").write_text(json.dumps(default_perception_profile(state),indent=2)+"\n",encoding="utf-8")
+    (output_dir/"sample_detected_objects.yaml").write_text(json.dumps(default_sample_detected_objects(),indent=2)+"\n",encoding="utf-8")
+    (output_dir/"runtime_bridge_payload.sample.json").write_text(json.dumps({"schema_version":"emd_grasp_bridge_payload/v1","source":"perception_replay","dry_run_only":True,"targets":[]},indent=2)+"\n",encoding="utf-8")
+    (output_dir/"builder_export_summary.json").write_text(json.dumps({"validation_status":val["status"],"generated_files":sorted([p.name for p in output_dir.iterdir()]),"scene_manifest":scene_manifest,"task_grasp_summary":{"template":(composer.get("task",{}).get("template")),"grasp_strategy":(composer.get("grasp",{}).get("strategy"))},"perception_profile_generated":True},indent=2),encoding="utf-8")
     return {"ok":True,"validation":val,"output_dir":str(output_dir),"generated_files":sorted([p.name for p in output_dir.iterdir()])}
 
 
@@ -238,7 +273,25 @@ def build_readiness_status_panel(state:dict[str,Any], validation:dict[str,Any]|N
     for issue in validation.get("issues",[]):
         if issue.get("code") in badges: badges[issue.get("code")] = True
         messages.append(issue.get("message",""))
-    return {"validation_status":validation["status"],"badges":badges,"messages":messages}
+    perception_profile = default_perception_profile(state)
+    perception = perception_profile.get("perception", {})
+    p_enabled = bool(perception.get("enabled", False))
+    p_status = "PERCEPTION_READY_CONFIG_ONLY"
+    if not perception_profile:
+        p_status = "PERCEPTION_PROFILE_MISSING"
+    elif not perception.get("camera", {}).get("frame_id"):
+        p_status = "CAMERA_FRAME_MISSING"
+    elif not perception.get("epd", {}).get("localization_topic"):
+        p_status = "EPD_TOPIC_MISSING"
+    elif not perception.get("object_mapping", {}).get("default_pick_object_ref"):
+        p_status = "OBJECT_MAPPING_MISSING"
+    elif not p_enabled:
+        p_status = "PERCEPTION_DISABLED"
+    if p_status == "PERCEPTION_PROFILE_MISSING" or p_status == "CAMERA_FRAME_MISSING":
+        badges["PERCEPTION_SOURCE_UNCONFIGURED"] = True
+    messages.append("Config generated. Live EPD not launched automatically.")
+    messages.append(f"Perception status: {p_status}")
+    return {"validation_status":validation["status"],"badges":badges,"messages":messages,"perception_status":p_status,"perception_profile":perception_profile}
 
 def build_preview_launch_plan(state:dict[str,Any], scene_package:str|None=None)->dict[str,Any]:
     validation=validate_manual_cell_state(state)

--- a/tests/fixtures/detected_objects/detected_objects_v1_sample.yaml
+++ b/tests/fixtures/detected_objects/detected_objects_v1_sample.yaml
@@ -1,0 +1,9 @@
+{
+  "schema_version": "detected_objects/v1",
+  "source": "epd",
+  "frame_id": "camera_color_optical_frame",
+  "timestamp": null,
+  "objects": [
+    {"id":"obj_001","label":"cube","confidence":0.92,"pose":{"xyz":[0.45,0.10,0.22],"rpy":[0.0,0.0,0.0]},"dimensions_xyz":[0.05,0.05,0.05],"tracking_id":null}
+  ]
+}

--- a/tests/test_detected_objects_schema.py
+++ b/tests/test_detected_objects_schema.py
@@ -1,0 +1,7 @@
+import json
+from pathlib import Path
+
+def test_detected_objects_fixture_schema():
+    d=json.loads(Path('tests/fixtures/detected_objects/detected_objects_v1_sample.yaml').read_text())
+    assert d['schema_version']=='detected_objects/v1'
+    assert d['objects'] and d['objects'][0]['pose']['xyz']

--- a/tests/test_epd_snapshot_adapter.py
+++ b/tests/test_epd_snapshot_adapter.py
@@ -1,0 +1,14 @@
+import json, subprocess, sys
+from pathlib import Path
+
+def test_adapter_generates_payload(tmp_path):
+    profile=tmp_path/'perception_profile.yaml'
+    detected=tmp_path/'detected.yaml'
+    profile.write_text(json.dumps({'perception':{'provider':'epd'}}))
+    detected.write_text(json.dumps({'schema_version':'detected_objects/v1','objects':[{'id':'o1','label':'cube','confidence':0.9,'pose':{'xyz':[1,2,3],'rpy':[0,0,0]}}]}))
+    out=tmp_path/'bridge.json'; summary=tmp_path/'summary.json'
+    p=subprocess.run([sys.executable,'scripts/epd_snapshot_adapter.py','--profile',str(profile),'--input',str(detected),'--output',str(out),'--summary',str(summary)],capture_output=True,text=True)
+    assert p.returncode==0
+    payload=json.loads(out.read_text())
+    assert payload['dry_run_only'] is True
+    assert payload['runtime_execution']['auto_execute'] is False

--- a/tests/test_generated_perception_commands.py
+++ b/tests/test_generated_perception_commands.py
@@ -1,0 +1,5 @@
+from scripts import workcell_builder_gui_workflow as wf
+
+def test_launch_template_safety_default():
+    cmd=wf.copy_fake_hardware_launch_command({})['message']
+    assert 'use_fake_hardware:=true' in cmd

--- a/tests/test_generated_perception_profile.py
+++ b/tests/test_generated_perception_profile.py
@@ -1,0 +1,8 @@
+from scripts import workcell_builder_gui_workflow as wf
+
+def test_profile_defaults_present():
+    p=wf.default_perception_profile({})['perception']
+    assert p['enabled'] is False
+    assert p['camera']['model']=='realsense_d435i'
+    assert p['epd']['localization_topic']
+    assert p['epd']['tracking_topic']

--- a/tests/test_workcell_builder_perception_readiness.py
+++ b/tests/test_workcell_builder_perception_readiness.py
@@ -1,0 +1,6 @@
+from scripts import workcell_builder_gui_workflow as wf
+
+def test_readiness_reports_config_only():
+    panel=wf.build_readiness_status_panel({'selected':{},'fake_hardware_default':True})
+    assert panel['perception_status'] in {'PERCEPTION_DISABLED','PERCEPTION_READY_CONFIG_ONLY'}
+    assert any('Live EPD not launched automatically' in m for m in panel['messages'])


### PR DESCRIPTION
### Motivation
- Provide Workcell Studio-generated scenes with EPD/RealSense-ready configuration metadata and safe dry-run tooling so generated cells can be integrated with perception at the adapter/configuration level only.
- Keep runtime safety guarantees (no live EPD/RealSense auto-launch, no robot motion, MoveIt, or runtime execution) while enabling deterministic offline replay and bridge-payload preview.

### Description
- Add `default_perception_profile` and `default_sample_detected_objects` and write generated artifacts (`perception_profile.yaml`, `sample_detected_objects.yaml`, and `runtime_bridge_payload.sample.json`) during scene/package generation in `scripts/workcell_builder_gui_workflow.py` so generated packages include perception config and samples.
- Extend the readiness panel (`build_readiness_status_panel`) to report perception-specific statuses (`PERCEPTION_READY_CONFIG_ONLY`, `PERCEPTION_DISABLED`, `PERCEPTION_PROFILE_MISSING`, `EPD_TOPIC_MISSING`, `CAMERA_FRAME_MISSING`, `OBJECT_MAPPING_MISSING`, etc.) and to include the message "Config generated. Live EPD not launched automatically." in readiness output.
- Add a safe offline adapter `scripts/epd_snapshot_adapter.py` that reads a perception profile and a `detected_objects/v1` fixture, validates fields, converts detections into a dry-run `emd_grasp_bridge_payload/v1`-style payload, and writes a summary without calling any ROS runtime or triggering motion.
- Add a `detected_objects/v1` sample fixture and documentation `docs/manuals/WORKCELL_STUDIO_EPD_PERCEPTION_PROFILE.md` describing the generated profile, manual launch commands, and safety constraints.
- Add unit tests covering perception profile defaults, detected-objects fixture schema, the offline adapter conversion, readiness messaging, and generated-launch safety defaults.

### Testing
- Ran unit tests: `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_generated_perception_profile.py tests/test_epd_snapshot_adapter.py tests/test_detected_objects_schema.py tests/test_workcell_builder_perception_readiness.py tests/test_generated_perception_commands.py tests/test_workcell_builder_golden_acceptance.py tests/test_workcell_builder_package_consistency.py tests/test_workcell_builder_launch_smoke_acceptance.py` and all tests passed (`8 passed`).
- Verified generated artifacts are created by the generator path (`perception_profile.yaml`, `sample_detected_objects.yaml`, `runtime_bridge_payload.sample.json`) and that the readiness panel includes the perception status and the dry-run safety message.
- Confirmed no changes were made to auto-launch behavior or runtime/demo launch defaults so fake-hardware-first safety and no automatic EPD/RealSense launches are preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff995525c08331a683d8048c5d6690)