### PR TITLE
Add offline perception-to-task replay preview for generated workcells

### DIFF
--- a/docs/manuals/WORKCELL_STUDIO_EPD_PERCEPTION_PROFILE.md
+++ b/docs/manuals/WORKCELL_STUDIO_EPD_PERCEPTION_PROFILE.md
@@ -14,3 +14,26 @@ Generated scenes now include `config/perception_profile.yaml` (config-only), `co
 `ros2 launch easy_perception_deployment run.launch.py`
 - Adapter dry-run:
 `python3 scripts/epd_snapshot_adapter.py --profile <scene>/config/perception_profile.yaml --input <scene>/config/sample_detected_objects.yaml --output /tmp/runtime_bridge_payload.json --summary /tmp/epd_adapter_summary.json`
+
+## Perception Replay Preview (Offline Dry-Run)
+- Uses `config/perception_profile.yaml` and `config/sample_detected_objects.yaml` to map detected_objects/v1 into task pick intent.
+- Generates `selected_target_summary.json`, `runtime_bridge_payload.preview.json`, `perception_replay_markers.json`, and `perception_replay_summary.json`.
+- Launch preview with `publish_perception_replay:=true` to visualize replay markers; live EPD/RealSense are not auto-launched.
+- Safety limits: dry-run only, no robot motion, no MoveIt planning service calls, not a safety certificate.
+
+```bash
+python3 scripts/epd_snapshot_adapter.py \
+  --profile ~/workcell_ws/src/scenes/new_scene/config/perception_profile.yaml \
+  --input ~/workcell_ws/src/scenes/new_scene/config/sample_detected_objects.yaml \
+  --task ~/workcell_ws/src/scenes/new_scene/task_recipe.yaml \
+  --grasp ~/workcell_ws/src/scenes/new_scene/grasp_strategy.yaml \
+  --environment ~/workcell_ws/src/scenes/new_scene/environment_layout.yaml \
+  --output ~/workcell_ws/src/scenes/new_scene/config/runtime_bridge_payload.preview.json \
+  --markers ~/workcell_ws/src/scenes/new_scene/config/perception_replay_markers.json \
+  --summary ~/workcell_ws/src/scenes/new_scene/config/perception_replay_summary.json
+
+ros2 launch new_scene demo.launch.py \
+  use_fake_hardware:=true \
+  publish_workcell_markers:=true \
+  publish_perception_replay:=true
+```

--- a/scripts/epd_snapshot_adapter.py
+++ b/scripts/epd_snapshot_adapter.py
@@ -1,32 +1,106 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import argparse, json
+import argparse, json, math
 from pathlib import Path
+from typing import Any
 
-def _load(path: Path):
-    return json.loads(path.read_text(encoding='utf-8'))
+def _load(path: Path)->dict[str,Any]:
+    return json.loads(path.read_text(encoding='utf-8')) if path and path.exists() else {}
+
+def _dist(a,b):
+    return math.sqrt(sum((float(x)-float(y))**2 for x,y in zip(a,b)))
+
+def _pick_area_position(environment:dict[str,Any], pick_ref:str)->list[float]|None:
+    assets=environment.get('assets') or environment.get('objects') or environment.get('current_cell_assets') or []
+    for a in assets:
+        if a.get('id')==pick_ref or a.get('asset_id')==pick_ref or a.get('name')==pick_ref:
+            p=a.get('pose',{})
+            if 'xyz' in p: return p['xyz']
+            return [p.get('x',0.0),p.get('y',0.0),p.get('z',0.0)]
+    return None
+
+def _approach_vector(grasp:dict[str,Any])->list[float]:
+    axis=(grasp.get('grasp',{}) or grasp).get('approach_axis','z_down')
+    m={'x_plus':[1,0,0],'x_minus':[-1,0,0],'y_plus':[0,1,0],'y_minus':[0,-1,0],'z_up':[0,0,1],'z_down':[0,0,-1]}
+    return m.get(axis,[0,0,-1])
 
 def main() -> int:
     ap=argparse.ArgumentParser()
     ap.add_argument('--profile', required=True)
     ap.add_argument('--input', required=True)
+    ap.add_argument('--task')
+    ap.add_argument('--grasp')
+    ap.add_argument('--environment')
     ap.add_argument('--output', required=True)
+    ap.add_argument('--markers')
     ap.add_argument('--summary', required=True)
+    ap.add_argument('--selected-summary')
     args=ap.parse_args()
+
     profile=_load(Path(args.profile))
     detected=_load(Path(args.input))
+    task=_load(Path(args.task)).get('task',{}) if args.task else {}
+    grasp=_load(Path(args.grasp)) if args.grasp else {}
+    env=_load(Path(args.environment)) if args.environment else {}
+
     if detected.get('schema_version')!='detected_objects/v1':
         raise SystemExit('invalid detected_objects schema')
-    objs=detected.get('objects',[])
-    targets=[]
-    for o in objs:
-        pose=o.get('pose',{})
-        targets.append({'id':o.get('id'),'label':o.get('label'),'confidence':o.get('confidence'),'position':pose.get('xyz',[0,0,0]),'rpy':pose.get('rpy',[0,0,0])})
-    payload={'schema_version':'emd_grasp_bridge_payload/v1','source':'perception_replay','dry_run_only':True,'perception_provider':profile.get('perception',{}).get('provider','epd'),'targets':targets,'runtime_execution':{'auto_execute':False,'moveit_planning_called':False,'robot_motion_called':False}}
+
+    mapping=((profile.get('perception',{}) or {}).get('object_mapping',{}))
+    conf=float(mapping.get('confidence_threshold',0.5))
+    allowed=set(mapping.get('allowed_labels') or [])
+    policy=mapping.get('selection_policy','first_object')
+    pick_area_ref=mapping.get('pick_area_ref') or ((task.get('pick') or {}).get('source_ref'))
+    place_ref=mapping.get('place_target_ref') or ((task.get('place') or {}).get('target_ref'))
+    class_map=mapping.get('class_to_task_target',{})
+
+    objects=detected.get('objects',[])
+    warnings=[]
+    candidates=[]
+    for o in objects:
+        if allowed and o.get('label') not in allowed:
+            warnings.append(f"label_not_allowed:{o.get('label')}")
+            continue
+        if float(o.get('confidence',0.0)) < conf:
+            warnings.append(f"low_confidence:{o.get('id')}")
+        candidates.append(o)
+    if not candidates:
+        candidates=objects[:]
+    selected=candidates[0] if candidates else {}
+    if policy=='nearest_pick_area' and len(candidates)>1:
+        pick_pos=_pick_area_position(env,pick_area_ref) if pick_area_ref else None
+        if pick_pos:
+            selected=min(candidates,key=lambda o:_dist((o.get('pose') or {}).get('xyz',[0,0,0]),pick_pos))
+        else:
+            warnings.append('pick_area_missing_fallback_first_object')
+
+    frame_id=detected.get('frame_id')
+    camera_frame=((profile.get('perception',{}).get('camera',{}) or {}).get('frame_id'))
+    if frame_id and camera_frame and frame_id!=camera_frame:
+        warnings.append('frame_mismatch_review_tf')
+
+    selected_summary={
+        'selected_object': {
+            'id': selected.get('id'), 'label': selected.get('label'), 'tracking_id': selected.get('tracking_id'),
+            'confidence': selected.get('confidence'), 'pose': selected.get('pose',{}), 'dimensions_xyz': selected.get('dimensions_xyz',[]), 'frame_id': frame_id,
+        },
+        'mapping': {'pick_area_ref':pick_area_ref,'place_target_ref':place_ref,'task_target_ref':class_map.get(selected.get('label')) or mapping.get('default_pick_object_ref')},
+        'status':'BLOCKED' if not place_ref else ('WARN' if warnings else 'READY'),
+        'warnings':warnings,
+    }
+
+    payload={'schema_version':'emd_grasp_bridge_payload/v1','source':'perception_replay','dry_run_only':True,'perception_provider':profile.get('perception',{}).get('provider','epd'),'targets':[selected_summary['selected_object']],'task_intent':selected_summary['mapping'],'runtime_execution':{'auto_execute':False,'moveit_planning_called':False,'robot_motion_called':False}}
     Path(args.output).write_text(json.dumps(payload,indent=2)+'\n',encoding='utf-8')
-    summary={'status':'ok','dry_run_only':True,'live_epd_launched':False,'object_count':len(targets),'note':'Config generated. Live EPD not launched automatically.'}
+    if args.selected_summary:
+        Path(args.selected_summary).write_text(json.dumps(selected_summary,indent=2)+'\n',encoding='utf-8')
+
+    markers={'schema_version':'perception_replay_markers/v1','frame_id':frame_id or camera_frame or 'world','detected_objects':[{'id':o.get('id'),'label':o.get('label'),'confidence':o.get('confidence'),'pose':o.get('pose',{}),'dimensions_xyz':o.get('dimensions_xyz',[])} for o in objects],'selected_target_id':selected.get('id'),'pick_area_ref':pick_area_ref,'place_target_ref':place_ref,'pick_to_place_arrow':{'from':(selected.get('pose') or {}).get('xyz',[0,0,0]),'to':[0,0,0],'enabled':bool(place_ref)},'grasp_approach_vector':_approach_vector(grasp),'status':selected_summary['status'],'warnings':warnings}
+    if args.markers:
+        Path(args.markers).write_text(json.dumps(markers,indent=2)+'\n',encoding='utf-8')
+
+    summary={'status':selected_summary['status'],'dry_run_only':True,'live_epd_launched':False,'runtime_execution_called':False,'moveit_planning_called':False,'robot_motion_called':False,'selected_pick_target':selected_summary['selected_object'],'bridge_payload_preview_ready':True,'perception_replay_markers_ready':bool(args.markers),'warnings':warnings,'note':'Offline replay preview only. Not a safety certificate.'}
     Path(args.summary).write_text(json.dumps(summary,indent=2)+'\n',encoding='utf-8')
-    print(json.dumps({'payload':args.output,'summary':args.summary,'count':len(targets)}))
+    print(json.dumps({'payload':args.output,'summary':args.summary,'selected':selected.get('id')}))
     return 0
 
 if __name__=='__main__':

--- a/scripts/workcell_builder_acceptance_check.py
+++ b/scripts/workcell_builder_acceptance_check.py
@@ -74,6 +74,12 @@ def main()->int:
     pc_ok,pc_err=package_consistency(scene_dir); checks.append(('package consistency',pc_ok,pc_err))
     sm_ok,sm_err=launch_smoke(scene_dir); checks.append(('SRDF/controller joints',sm_ok,sm_err))
     prev_ok=all((scene_dir/f).exists() for f in ['generated/preview.txt','generated/readiness_summary.md']); checks.append(('preview artifacts',prev_ok,[] if prev_ok else ['missing preview']))
+    cfg=scene_dir/"config"
+    replay=wf.generate_perception_replay_preview(cfg)
+    replay_ok=all((cfg/f).exists() for f in ['runtime_bridge_payload.preview.json','perception_replay_markers.json','selected_target_summary.json'])
+    checks.append(('perception replay offline preview', replay_ok, [] if replay_ok else ['missing replay artifacts']))
+    launch_text=(scene_dir/'launch'/'demo.launch.py').read_text(encoding='utf-8')
+    checks.append(('no live epd/realsense auto launch', ('easy_perception_deployment' not in launch_text and 'realsense2_camera_node' not in launch_text), []))
     fake_ok='True' in (scene_dir/'launch'/'demo.launch.py').read_text(encoding='utf-8'); checks.append(('fake-hardware default',fake_ok,[] if fake_ok else ['false']))
     for name,ok,errs in checks:
       print(f"{'PASS' if ok else 'FAIL'}: {name}")
@@ -82,7 +88,10 @@ def main()->int:
     print('cd ~/workcell_ws')
     print(f'colcon build --symlink-install --packages-select {args.scene_name}')
     print('source install/setup.bash')
-    print(f'ros2 launch {args.scene_name} demo.launch.py use_fake_hardware:=true')
+    print(f'ros2 launch {args.scene_name} demo.launch.py \\')
+    print('  use_fake_hardware:=true \\')
+    print('  publish_workcell_markers:=true \\')
+    print('  publish_perception_replay:=true')
     return 0 if all(c[1] for c in checks) else 1
 
 if __name__=='__main__':

--- a/scripts/workcell_builder_gui_workflow.py
+++ b/scripts/workcell_builder_gui_workflow.py
@@ -227,13 +227,57 @@ def generate_studio_pack(state:dict[str,Any], output_dir:Path)->dict[str,Any]:
         result=generate_canonical_files(state,output_dir)
     except Exception as exc:
         return {"ok":False,"error":{"code":"generation_failure","message":str(exc)}}
-    (output_dir/"readiness_summary.md").write_text("# Readiness\n- Final readiness: **%s**\n- Safety: offline/fake hardware first\n"%result["validation"]["status"],encoding="utf-8")
+    replay = generate_perception_replay_preview(output_dir)
+    replay_status = replay.get("status","NOT_RUN")
+    selected = (((replay.get("selected_target") or {}).get("selected_object")) or {})
+    (output_dir/"readiness_summary.md").write_text(
+        "# Readiness\n"
+        f"- Final readiness: **{result['validation']['status']}**\n"
+        "- Safety: offline/fake hardware first\n\n"
+        "## Perception Replay\n"
+        "- profile: config/perception_profile.yaml\n"
+        "- input snapshot: config/sample_detected_objects.yaml\n"
+        f"- selected object: {selected.get('label')}/{selected.get('id')}/{selected.get('confidence')}\n"
+        f"- mapped place target: {((replay.get('selected_target') or {}).get('mapping') or {}).get('place_target_ref')}\n"
+        f"- generated bridge payload preview: {replay_status}\n"
+        "- live EPD launched automatically: false\n- runtime execution called: false\n- motion command sent: false\n",
+        encoding="utf-8")
     (output_dir/"readiness_summary.html").write_text("<html><body><h1>Readiness</h1></body></html>",encoding="utf-8")
     (output_dir/"environment_preview.svg").write_text("<svg xmlns='http://www.w3.org/2000/svg'></svg>",encoding="utf-8")
     (output_dir/"environment_preview.html").write_text("<html><body>Preview</body></html>",encoding="utf-8")
     launch=copy_fake_hardware_launch_command(state)
     (output_dir/"generated_launch_commands.md").write_text(launch.get("message",""),encoding="utf-8")
-    return {"ok":True,"output_dir":str(output_dir),"readiness":result["validation"]["status"],"runtime_classification":_runtime_classification(state,result["validation"]) }
+    return {"ok":True,"output_dir":str(output_dir),"readiness":result["validation"]["status"],"runtime_classification":_runtime_classification(state,result["validation"]), "perception_replay": replay }
+
+def generate_perception_replay_preview(scene_dir:Path)->dict[str,Any]:
+    cfg = scene_dir
+    profile = cfg/"perception_profile.yaml"
+    snap = cfg/"sample_detected_objects.yaml"
+    out = cfg/"runtime_bridge_payload.preview.json"
+    markers = cfg/"perception_replay_markers.json"
+    summary = cfg/"perception_replay_summary.json"
+    selected = cfg/"selected_target_summary.json"
+    task = scene_dir.parent/"task_recipe.yaml"
+    grasp = scene_dir.parent/"grasp_strategy.yaml"
+    env = scene_dir.parent/"environment_layout.yaml"
+    if not (profile.exists() and snap.exists()):
+        return {"status":"PERCEPTION_REPLAY_BLOCKED","reason":"missing_profile_or_snapshot"}
+    cmd=[sys.executable, str(repo_root()/ "scripts"/"epd_snapshot_adapter.py"), "--profile", str(profile), "--input", str(snap), "--output", str(out), "--markers", str(markers), "--summary", str(summary), "--selected-summary", str(selected)]
+    if task.exists(): cmd += ["--task", str(task)]
+    if grasp.exists(): cmd += ["--grasp", str(grasp)]
+    if env.exists(): cmd += ["--environment", str(env)]
+    run=_run(cmd, cwd=repo_root())
+    if not run["ok"]:
+        return {"status":"PERCEPTION_REPLAY_BLOCKED","error":run.get("stderr","").strip()}
+    sp = _load_json_safe(summary)
+    st = _load_json_safe(selected)
+    return {"status":"PERCEPTION_REPLAY_READY" if sp.get("status")=="READY" else "PERCEPTION_REPLAY_WARN","summary":sp,"selected_target":st,"bridge_payload_preview_ready":out.exists()}
+
+def _load_json_safe(path:Path)->dict[str,Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
 
 
 def _runtime_classification(state:dict[str,Any], validation:dict[str,Any])->str:

--- a/tests/test_epd_snapshot_adapter_task_preview.py
+++ b/tests/test_epd_snapshot_adapter_task_preview.py
@@ -1,0 +1,8 @@
+import json, subprocess, sys
+
+def test_preview_outputs_generated(tmp_path):
+    profile=tmp_path/'p.json'; det=tmp_path/'d.json'; out=tmp_path/'o.json'; s=tmp_path/'s.json'; ss=tmp_path/'ss.json'; m=tmp_path/'m.json'
+    profile.write_text(json.dumps({'perception':{'object_mapping':{'place_target_ref':'bin_1'}}}))
+    det.write_text(json.dumps({'schema_version':'detected_objects/v1','objects':[{'id':'o1','label':'cube','confidence':0.1,'pose':{'xyz':[0,0,0]},'dimensions_xyz':[1,1,1]}]}))
+    p=subprocess.run([sys.executable,'scripts/epd_snapshot_adapter.py','--profile',str(profile),'--input',str(det),'--output',str(out),'--summary',str(s),'--selected-summary',str(ss),'--markers',str(m)],capture_output=True,text=True)
+    assert p.returncode==0 and out.exists() and s.exists() and ss.exists() and m.exists()

--- a/tests/test_generated_perception_replay_launch_args.py
+++ b/tests/test_generated_perception_replay_launch_args.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+def test_launch_has_publish_perception_replay_default_false():
+    t=Path('workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py').read_text(encoding='utf-8')
+    assert 'publish_perception_replay' in t and 'default_value="false"' in t

--- a/tests/test_perception_replay_markers.py
+++ b/tests/test_perception_replay_markers.py
@@ -1,0 +1,10 @@
+import json, subprocess, sys
+
+def test_markers_include_arrow_and_selected(tmp_path):
+    pth=tmp_path/'p.json'; d=tmp_path/'d.json'; out=tmp_path/'o.json'; s=tmp_path/'s.json'; m=tmp_path/'m.json'; ss=tmp_path/'ss.json'
+    pth.write_text(json.dumps({'perception':{'object_mapping':{'place_target_ref':'bin_1'}}}))
+    d.write_text(json.dumps({'schema_version':'detected_objects/v1','objects':[{'id':'o1','label':'cube','confidence':0.9,'pose':{'xyz':[0,0,0]}}]}))
+    subprocess.check_call([sys.executable,'scripts/epd_snapshot_adapter.py','--profile',str(pth),'--input',str(d),'--output',str(out),'--summary',str(s),'--markers',str(m),'--selected-summary',str(ss)])
+    data=json.loads(m.read_text())
+    assert data['selected_target_id']=='o1'
+    assert 'pick_to_place_arrow' in data

--- a/tests/test_perception_to_task_mapping.py
+++ b/tests/test_perception_to_task_mapping.py
@@ -1,0 +1,11 @@
+import json, subprocess, sys
+
+def test_mapping_nearest_pick_area(tmp_path):
+    profile=tmp_path/'p.json'; det=tmp_path/'d.json'; env=tmp_path/'environment_layout.yaml'
+    profile.write_text(json.dumps({'perception':{'camera':{'frame_id':'camera_color_optical_frame'},'object_mapping':{'selection_policy':'nearest_pick_area','pick_area_ref':'pick_area_1','place_target_ref':'bin_1','confidence_threshold':0.5}}}))
+    env.write_text(json.dumps({'assets':[{'id':'pick_area_1','pose':{'xyz':[0,0,0]}}]}))
+    det.write_text(json.dumps({'schema_version':'detected_objects/v1','frame_id':'camera_color_optical_frame','objects':[{'id':'far','label':'cube','confidence':0.9,'pose':{'xyz':[2,0,0]}},{'id':'near','label':'cube','confidence':0.9,'pose':{'xyz':[0.1,0,0]}}]}))
+    out=tmp_path/'out.json'; s=tmp_path/'s.json'; ss=tmp_path/'sel.json'; m=tmp_path/'m.json'
+    p=subprocess.run([sys.executable,'scripts/epd_snapshot_adapter.py','--profile',str(profile),'--input',str(det),'--environment',str(env),'--output',str(out),'--summary',str(s),'--selected-summary',str(ss),'--markers',str(m)],capture_output=True,text=True)
+    assert p.returncode==0
+    assert json.loads(ss.read_text())['selected_object']['id']=='near'

--- a/tests/test_workcell_builder_acceptance_perception_replay.py
+++ b/tests/test_workcell_builder_acceptance_perception_replay.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+def test_acceptance_script_mentions_publish_perception_replay():
+    t=Path('scripts/workcell_builder_acceptance_check.py').read_text(encoding='utf-8')
+    assert 'publish_perception_replay:=true' in t

--- a/tests/test_workcell_builder_perception_replay_readiness.py
+++ b/tests/test_workcell_builder_perception_replay_readiness.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+from scripts import workcell_builder_gui_workflow as wf
+
+def test_generate_perception_replay_preview(tmp_path):
+    (tmp_path/'perception_profile.yaml').write_text('{"perception": {"object_mapping": {"place_target_ref":"bin_1"}}}')
+    (tmp_path/'sample_detected_objects.yaml').write_text('{"schema_version":"detected_objects/v1","objects":[{"id":"o1","label":"cube","confidence":0.9,"pose":{"xyz":[0,0,0]}}]}')
+    r=wf.generate_perception_replay_preview(tmp_path)
+    assert r['status'] in {'PERCEPTION_REPLAY_READY','PERCEPTION_REPLAY_WARN'}
+    assert (tmp_path/'runtime_bridge_payload.preview.json').exists()

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -406,6 +406,7 @@ def _launch_setup(context):
     publish_collision_objects = LaunchConfiguration("publish_collision_objects")
     show_task_flow = LaunchConfiguration("show_task_flow")
     show_grasp_markers = LaunchConfiguration("show_grasp_markers")
+    publish_perception_replay = LaunchConfiguration("publish_perception_replay")
 
     enable_octomap = LaunchConfiguration("enable_octomap")
     octomap_resolution = LaunchConfiguration("octomap_resolution")
@@ -655,6 +656,8 @@ def _launch_setup(context):
             "--scene-name", scene_pkg,
             "--show-task-flow", show_task_flow,
             "--show-grasp-markers", show_grasp_markers,
+            "--publish-perception-replay", publish_perception_replay,
+            "--perception-replay-path", os.path.join(get_package_share_directory(scene_pkg), "config", "perception_replay_markers.json"),
         ],
         condition=None,
         output="screen",
@@ -726,6 +729,11 @@ def generate_launch_description():
             "show_grasp_markers",
             default_value="true",
             description="Show grasp approach/retreat intent markers.",
+        ),
+        DeclareLaunchArgument(
+            "publish_perception_replay",
+            default_value="false",
+            description="Publish offline perception replay markers from config/perception_replay_markers.json.",
         ),
         DeclareLaunchArgument(
             "use_fake_hardware",

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/workcell_visual_scene_publisher.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/workcell_visual_scene_publisher.py
@@ -8,8 +8,18 @@ def main():
     ap.add_argument('--scene-name',required=True)
     ap.add_argument('--show-task-flow',default='true')
     ap.add_argument('--show-grasp-markers',default='true')
+    ap.add_argument('--publish-perception-replay',default='false')
+    ap.add_argument('--perception-replay-path',default='')
     args=ap.parse_args()
     print(f"[workcell_visual_scene_publisher] scene={args.scene_name} topic=/{args.scene_name}/workcell_markers preview_only=true")
+    if str(args.publish_perception_replay).lower() in {'1','true','yes'}:
+        replay=Path(args.perception_replay_path) if args.perception_replay_path else Path('config/perception_replay_markers.json')
+        if replay.exists():
+            data=json.loads(replay.read_text(encoding='utf-8'))
+            print(f"[workcell_visual_scene_publisher] loaded perception replay markers ({len(data.get('detected_objects',[]))} objects) from {replay}")
+            print("Perception replay markers loaded from offline snapshot. Live EPD not running.")
+        else:
+            print(f"[workcell_visual_scene_publisher] perception replay file missing: {replay}")
     print("[workcell_visual_scene_publisher] publishes table/bin/camera/frustum/pick/place/task/grasp/readiness markers via visualization_msgs/MarkerArray")
 
 if __name__=='__main__':

--- a/workcell_builder/workcell_builder/templates/ros2/launch/workcell_visual_scene_publisher.py
+++ b/workcell_builder/workcell_builder/templates/ros2/launch/workcell_visual_scene_publisher.py
@@ -8,8 +8,18 @@ def main():
     ap.add_argument('--scene-name',required=True)
     ap.add_argument('--show-task-flow',default='true')
     ap.add_argument('--show-grasp-markers',default='true')
+    ap.add_argument('--publish-perception-replay',default='false')
+    ap.add_argument('--perception-replay-path',default='')
     args=ap.parse_args()
     print(f"[workcell_visual_scene_publisher] scene={args.scene_name} topic=/{args.scene_name}/workcell_markers preview_only=true")
+    if str(args.publish_perception_replay).lower() in {'1','true','yes'}:
+        replay=Path(args.perception_replay_path) if args.perception_replay_path else Path('config/perception_replay_markers.json')
+        if replay.exists():
+            data=json.loads(replay.read_text(encoding='utf-8'))
+            print(f"[workcell_visual_scene_publisher] loaded perception replay markers ({len(data.get('detected_objects',[]))} objects) from {replay}")
+            print("Perception replay markers loaded from offline snapshot. Live EPD not running.")
+        else:
+            print(f"[workcell_visual_scene_publisher] perception replay file missing: {replay}")
     print("[workcell_visual_scene_publisher] publishes table/bin/camera/frustum/pick/place/task/grasp/readiness markers via visualization_msgs/MarkerArray")
 
 if __name__=='__main__':


### PR DESCRIPTION
### Motivation
- Make generated perception snapshots from Workcell Studio useful for task selection and preview without launching live EPD/RealSense or executing robot motion. 
- Provide safety-first dry-run artifacts (selected target summary, bridge payload preview, RViz markers, readiness/report entries) so builders can validate perception-to-task mapping offline.

### Description
- Extend `scripts/epd_snapshot_adapter.py` to map `detected_objects/v1` into task intent with label matching, confidence thresholding, `nearest_pick_area` selection, tracking_id/dimensions/pose preservation, frame_id validation, selected-target summary, `runtime_bridge_payload.preview.json`, and `perception_replay_markers.json` generation while keeping `dry_run_only` true. 
- Add `generate_perception_replay_preview(...)` to `scripts/workcell_builder_gui_workflow.py` and include replay status and selected-target details in generated `readiness_summary.md`. 
- Update acceptance harness `scripts/workcell_builder_acceptance_check.py` to validate offline replay artifacts and print the replay-enabled launch command, and add launch template support in `workcell_builder/.../demo.launch.py` for a `publish_perception_replay` argument defaulting to `false`. 
- Update `workcell_visual_scene_publisher.py` templates to optionally load and log offline `config/perception_replay_markers.json`, add docs in `docs/manuals/WORKCELL_STUDIO_EPD_PERCEPTION_PROFILE.md`, and add focused tests under `tests/` to cover mapping, adapter outputs, markers, launch args, readiness helper, and acceptance check coverage. 

### Testing
- Ran the focused pytest suite: `tests/test_perception_to_task_mapping.py`, `tests/test_epd_snapshot_adapter_task_preview.py`, `tests/test_perception_replay_markers.py`, `tests/test_generated_perception_replay_launch_args.py`, `tests/test_workcell_builder_perception_replay_readiness.py`, `tests/test_workcell_builder_acceptance_perception_replay.py`, `tests/test_generated_perception_profile.py`, `tests/test_epd_snapshot_adapter.py`, and `tests/test_workcell_builder_golden_acceptance.py`. 
- All automated tests in that suite passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9b546f188331b087652c81b1f890)