### PR TITLE
Add forward declarations for scene helper functions in scene_select

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -312,6 +312,9 @@ fs::path select_scene_root(const fs::path & cwd)
 
 }  // namespace
 
+bool ensure_minimal_environment_yaml(const fs::path & scene_dir, const std::string & scene_name);
+void refresh_scene_manifest_if_missing(const fs::path & scene_dir, const std::string & scene_name);
+
 
 SceneSelect::SceneSelect(QWidget * parent)
 : QDialog(parent),


### PR DESCRIPTION
### Motivation
- Fix a compile-time error caused by `SceneSelect::discover_scene_packages_on_startup()` calling helper functions that are defined later in the same translation unit and therefore not visible at the call site.

### Description
- Add forward declarations for `bool ensure_minimal_environment_yaml(const fs::path & scene_dir, const std::string & scene_name);` and `void refresh_scene_manifest_if_missing(const fs::path & scene_dir, const std::string & scene_name);` immediately after the anonymous namespace and before `SceneSelect::SceneSelect(...)` in `workcell_builder/workcell_builder/gui/scene_select.cpp`, without moving or changing any function bodies or runtime behavior.

### Testing
- Attempted to run `source /opt/ros/humble/setup.bash && cd ~/workcell_ws && colcon build --symlink-install --packages-select workcell_builder --event-handlers console_direct+`, which could not run in this environment because `/opt/ros/humble/setup.bash` was not present.
- Attempted to run `cd ~/workcell_ws && colcon build --symlink-install --packages-skip tesseract_rviz --allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils`, which could not run because `~/workcell_ws` is not present in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffa80b48b483319383819f4ce3e20b)