### PR TITLE
Rescue Workcell Builder UI: hide unfinished Studio shell and restore original builder flow

### DIFF
--- a/tests/test_workcell_builder_default_scenes_folder.py
+++ b/tests/test_workcell_builder_default_scenes_folder.py
@@ -1,6 +1,12 @@
 from pathlib import Path
 
-def test_repo_has_default_scenes_and_assets():
-    root = Path(__file__).resolve().parents[1]
-    assert (root / 'scenes').is_dir()
-    assert (root / 'assets').is_dir()
+
+def test_default_scene_root_prefers_workspace_src_for_symlinked_scenes():
+    cpp = Path('workcell_builder/workcell_builder/src_scene_select_paths.cpp').read_text(encoding='utf-8')
+    assert 'candidates.push_back(fs::path(home) / "workcell_ws" / "src");' in cpp
+
+
+def test_scene_root_display_supports_tilde_path_label():
+    cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
+    assert 'std::string display_path_with_home_tilde' in cpp
+    assert 'return "~/" +' in cpp

--- a/tests/test_workcell_builder_hide_unwired_studio_tabs.py
+++ b/tests/test_workcell_builder_hide_unwired_studio_tabs.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_unwired_tabs_are_removed_from_default_visible_workflow():
+    cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
+    for tab in ['ingredients_tab', 'layout_tab', 'task_tab', 'perception_roi_tab', 'grasp_tab']:
+        assert f'ui->workflow_tabs->removeTab(ui->workflow_tabs->indexOf(ui->{tab}));' in cpp
+
+
+def test_generate_tab_remains_for_real_actions():
+    cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
+    assert 'ui->workflow_tabs->setTabText(' in cpp
+    assert '"Generate"' in cpp

--- a/tests/test_workcell_builder_original_flow_preserved.py
+++ b/tests/test_workcell_builder_original_flow_preserved.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+def test_original_scene_flow_actions_still_exist():
+    ui = Path('workcell_builder/workcell_builder/gui/scene_select.ui').read_text(encoding='utf-8')
+    for label in [
+        'New Cell',
+        'Open Cell',
+        'Refresh Scenes',
+        'Open Scene Folder',
+        'Save / Generate environment.yaml',
+        'Generate Full Scene Package',
+        'Copy Fake-Hardware Launch Command',
+    ]:
+        assert label in ui
+
+
+def test_real_generation_buttons_remain_wired_to_existing_handlers():
+    cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
+    assert 'on_generate_canonical_files_clicked()' in cpp
+    assert 'on_generate_yaml_clicked();' in cpp
+    assert 'on_generate_workcell_package_clicked()' in cpp
+    assert 'on_generate_files_clicked();' in cpp

--- a/tests/test_workcell_builder_ui_rescue.py
+++ b/tests/test_workcell_builder_ui_rescue.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+def test_main_workflow_hides_unwired_shell_controls_and_focuses_actions():
+    cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
+    for snippet in [
+        'ui->asset_browser_group->hide();',
+        'ui->inspector_group->hide();',
+        'ui->cell_name->hide();',
+        'ui->output_folder->hide();',
+        'ui->browse_output_folder->hide();',
+        'ui->delete_scene->hide();',
+        'ui->generate_studio_pack->hide();',
+        'ui->open_preview->hide();',
+        'ui->show_readiness_report->hide();',
+    ]:
+        assert snippet in cpp
+
+
+def test_scene_folder_status_is_compact_and_user_facing():
+    cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
+    assert 'Scenes folder: %1\\nScenes found: %2\\nLast refresh: %3' in cpp
+    assert 'display_path_with_home_tilde(scenes_path)' in cpp

--- a/tests/test_workcell_builder_ui_workflow.py
+++ b/tests/test_workcell_builder_ui_workflow.py
@@ -9,8 +9,7 @@ def test_start_tab_workflow_and_primary_actions_present():
     assert 'Copy Fake-Hardware Launch Command' in ui
 
 
-def test_placeholder_buttons_marked_coming_soon_or_disabled():
+def test_unwired_workcell_studio_shell_controls_are_hidden_in_rescue_mode():
     cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
-    assert 'placeholder_buttons' in cpp
-    assert '(coming soon)' in cpp
-    assert 'button->setDisabled(true);' in cpp
+    assert 'ui->asset_browser_group->hide();' in cpp
+    assert 'ui->inspector_group->hide();' in cpp

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -131,6 +131,29 @@ std::string path_or_placeholder(const fs::path & path)
   return path.empty() ? std::string("<none>") : path.string();
 }
 
+std::string display_path_with_home_tilde(const fs::path & path)
+{
+  if (path.empty()) {
+    return "<none>";
+  }
+  const char * home = std::getenv("HOME");
+  if (home == nullptr || std::strlen(home) == 0) {
+    return path.string();
+  }
+  const fs::path home_path(home);
+  const fs::path normalized = path.lexically_normal();
+  const std::string home_str = home_path.string();
+  const std::string normalized_str = normalized.string();
+  if (normalized_str == home_str) {
+    return "~";
+  }
+  const std::string prefix = home_str + "/";
+  if (normalized_str.rfind(prefix, 0) == 0) {
+    return "~/" + normalized_str.substr(prefix.size());
+  }
+  return normalized_str;
+}
+
 std::string parse_cli_scene_root_override()
 {
   const QStringList args = QCoreApplication::arguments();
@@ -322,25 +345,31 @@ SceneSelect::SceneSelect(QWidget * parent)
 {
   ui->setupUi(this);
   templates_path = get_default_templates_directory();
+  ui->setWindowTitle("Workcell Builder");
+  ui->workflow_tabs->setCurrentWidget(ui->start_tab);
 
-  ui->asset_category_tree->setHeaderLabel("Asset Categories");
-  const std::vector<QString> categories = {
-    "Robots", "Grippers & Tools", "Cameras & Sensors", "Tables & Workbenches",
-    "Bins & Totes", "Conveyors", "Fixtures & Jigs", "Machines", "Safety",
-    "Objects", "Custom STL", "Preview-only Robots", "Preview-only Assets"};
-  for (const auto & category : categories) {
-    auto * item = new QTreeWidgetItem(ui->asset_category_tree);
-    item->setText(0, category);
-  }
-
-  ui->recommended_starter_list->addItems({
-    "UR5", "Robotiq 2F", "Workbench/Table", "Cube Small", "Small Bin", "RealSense D435i visual asset"});
+  ui->asset_browser_group->hide();
+  ui->inspector_group->hide();
+  ui->cell_name->hide();
+  ui->output_folder->hide();
+  ui->browse_output_folder->hide();
+  ui->golden_demo_cell->hide();
+  ui->delete_scene->hide();
+  ui->generate_studio_pack->hide();
+  ui->open_preview->hide();
+  ui->show_readiness_report->hide();
+  ui->validate_cell->hide();
+  ui->workflow_tabs->removeTab(ui->workflow_tabs->indexOf(ui->ingredients_tab));
+  ui->workflow_tabs->removeTab(ui->workflow_tabs->indexOf(ui->layout_tab));
+  ui->workflow_tabs->removeTab(ui->workflow_tabs->indexOf(ui->task_tab));
+  ui->workflow_tabs->removeTab(ui->workflow_tabs->indexOf(ui->perception_roi_tab));
+  ui->workflow_tabs->removeTab(ui->workflow_tabs->indexOf(ui->grasp_tab));
+  ui->workflow_tabs->setTabText(
+    ui->workflow_tabs->indexOf(ui->validate_generate_tab), "Generate");
+  ui->browse_scenes_folder->setText("Open Folder");
 
   ui->fake_hardware_default_label->setToolTip(
     "Fake hardware is the safe default. Real hardware launch is intentionally not default.");
-  ui->asset_search_filter->setToolTip("Filter assets by id, display name, or tag.");
-  ui->perception_roi_tab->setToolTip("Pointcloud ROI crop filters for pick-area metadata.");
-  ui->layout_help->setToolTip("Collision mode options: visual-only, bounding-box collision, mesh collision.");
   ui->generate_files->hide();
   connect(ui->generate_full_scene_package_start, &QPushButton::clicked, this, &SceneSelect::on_generate_full_scene_package_start_clicked);
   connect(ui->open_scene_folder, &QPushButton::clicked, this, &SceneSelect::on_open_scene_folder_clicked);
@@ -351,19 +380,6 @@ SceneSelect::SceneSelect(QWidget * parent)
     button->setDisabled(true);
   }
 
-  connect(ui->asset_search_filter, &QLineEdit::textChanged, this, [this](const QString & text) {
-    const QString needle = text.trimmed();
-    for (int i = 0; i < ui->asset_category_tree->topLevelItemCount(); ++i) {
-      QTreeWidgetItem * item = ui->asset_category_tree->topLevelItem(i);
-      const bool visible = needle.isEmpty() || item->text(0).contains(needle, Qt::CaseInsensitive);
-      item->setHidden(!visible);
-    }
-    for (int i = 0; i < ui->recommended_starter_list->count(); ++i) {
-      QListWidgetItem * item = ui->recommended_starter_list->item(i);
-      const bool visible = needle.isEmpty() || item->text().contains(needle, Qt::CaseInsensitive);
-      item->setHidden(!visible);
-    }
-  });
 }
 
 SceneSelect::~SceneSelect()
@@ -489,9 +505,8 @@ void SceneSelect::update_scene_browser_status(const std::string & note)
 {
   const int count = static_cast<int>(workcell.scene_vector.size());
   const QString stamp = QDateTime::currentDateTime().toString(Qt::ISODate);
-  QString text = QString("Scenes folder: %1\nAssets folder: %2\nNumber of scenes found: %3\nLast refresh: %4")
-    .arg(QString::fromStdString(path_or_placeholder(scenes_path)))
-    .arg(QString::fromStdString(path_or_placeholder(assets_path)))
+  QString text = QString("Scenes folder: %1\nScenes found: %2\nLast refresh: %3")
+    .arg(QString::fromStdString(display_path_with_home_tilde(scenes_path)))
     .arg(count)
     .arg(stamp);
   if (!note.empty()) {

--- a/workcell_builder/workcell_builder/src_scene_select_paths.cpp
+++ b/workcell_builder/workcell_builder/src_scene_select_paths.cpp
@@ -65,6 +65,7 @@ SceneSelectPathResolution resolve_scene_select_paths(
   if (repo_env != nullptr) candidates.emplace_back(repo_env);
   const char * home = std::getenv("HOME");
   if (home != nullptr) {
+    candidates.push_back(fs::path(home) / "workcell_ws" / "src");
     candidates.push_back(fs::path(home) / "workcell_ws" / "src" / "easy_manipulation_deployment");
   }
 


### PR DESCRIPTION
### Motivation
- The Workcell Studio shell exposed many tabs and buttons that were not wired and made the UI feel broken, so the default experience should present the original, working builder flow instead.
- The scenes root should be user-friendly and default to the workspace layout users expect (~/workcell_ws/src/scenes), including when that path is a symlink, and UI path text should be compact and readable.
- Unfinished inspector/asset-shell controls and large editable workspace fields should not be visible as active features until they are fully implemented.

### Description
- Hid non-functional studio surfaces at runtime by hiding `asset_browser_group`, `inspector_group`, `cell_name`, `output_folder`, `browse_output_folder`, `golden_demo_cell`, `delete_scene`, `generate_studio_pack`, `open_preview`, `show_readiness_report`, and `validate_cell` in `SceneSelect` so only the practical scene/workflow actions remain visible. (see `scene_select.cpp`).
- Removed unwired tabs from the default visible workflow by calling `removeTab(...)` for `ingredients_tab`, `layout_tab`, `task_tab`, `perception_roi_tab`, and `grasp_tab`, and renamed the remaining validate/generate tab to a clear `Generate` label. (see `scene_select.cpp`).
- Added `display_path_with_home_tilde()` to render `HOME`-rooted paths with `~` and simplified the scene browser status text to a compact, user-facing format (`Scenes folder: ...\nScenes found: ...\nLast refresh: ...`). (see `scene_select.cpp`).
- Favoured `~/workcell_ws/src` as a candidate repo root so `~/workcell_ws/src/scenes` is naturally selected (including symlinked workflows) by adding that candidate to the resolution list. (see `src_scene_select_paths.cpp`).
- Kept existing generation handlers and wired actions intact (generate YAML, generate full scene package, open scene folder, copy fake-hardware launch command) and left placeholder controls visibly marked as "(coming soon)" and disabled in code so they do not appear active. (see `scene_select.cpp`).
- Added and updated tests to assert the rescue behavior and preservation of the original flow: `tests/test_workcell_builder_ui_rescue.py`, `tests/test_workcell_builder_default_scenes_folder.py`, `tests/test_workcell_builder_hide_unwired_studio_tabs.py`, `tests/test_workcell_builder_original_flow_preserved.py`, and adjusted `tests/test_workcell_builder_ui_workflow.py`.

### Testing
- Ran the focused pytest suite with `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_ui_rescue.py tests/test_workcell_builder_default_scenes_folder.py tests/test_workcell_builder_hide_unwired_studio_tabs.py tests/test_workcell_builder_original_flow_preserved.py tests/test_workcell_builder_real_generation_buttons.py tests/test_workcell_builder_ui_workflow.py tests/test_workcell_builder_scene_scaffold.py tests/test_workcell_builder_symlink_scene_root.py` and all tests passed. 
- Test summary: `14 passed`.
- The tests verify that non-working Studio tabs/buttons are hidden or disabled, the scenes folder label is compact and home-tilde-aware, the default scene-root resolution prefers `~/workcell_ws/src`, and the original builder generation/actions remain present and wired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0058a3301c8331b86ecf21cb8af896)