### PR TITLE
Fix workcell builder UI rescue build

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -345,7 +345,7 @@ SceneSelect::SceneSelect(QWidget * parent)
 {
   ui->setupUi(this);
   templates_path = get_default_templates_directory();
-  ui->setWindowTitle("Workcell Builder");
+  setWindowTitle("Workcell Builder");
   ui->workflow_tabs->setCurrentWidget(ui->start_tab);
 
   ui->asset_browser_group->hide();
@@ -1727,3 +1727,20 @@ void SceneSelect::on_copy_fake_hardware_launch_command_clicked()
 }
 
 // compatibility note: missing one of [package.xml, CMakeLists.txt, urdf/]
+
+void SceneSelect::on_generate_full_scene_package_start_clicked()
+{
+  on_generate_files_clicked();
+}
+
+void SceneSelect::on_open_scene_folder_clicked()
+{
+  const boost::filesystem::path scene_dir = scene_dir_for_current_selection();
+  if (scene_dir.empty()) {
+    append_warning("No scene selected. Select a scene before opening its folder.");
+    return;
+  }
+
+  QDesktopServices::openUrl(
+    QUrl::fromLocalFile(QString::fromStdString(scene_dir.string())));
+}


### PR DESCRIPTION
### Motivation
- The UI rescue PR introduced compile/link errors in `workcell_builder`.
- `SceneSelect` attempted to call `setWindowTitle` on the generated `ui` object instead of the dialog itself.
- Two Qt slots were declared/connected but not defined, causing linker failures.

### Description
- Replace `ui->setWindowTitle("Workcell Builder")` with `setWindowTitle("Workcell Builder")`.
- Add `SceneSelect::on_generate_full_scene_package_start_clicked()` and delegate it to the existing real generation path via `on_generate_files_clicked()`.
- Add `SceneSelect::on_open_scene_folder_clicked()` to open the currently selected scene folder and warn when no scene is selected.
- No runtime execution behaviour changed.
- No EPD, RealSense, MoveIt, or robot execution behaviour changed.
- Fake-hardware-first defaults are preserved.

### Testing
- Built the failed package:
  `colcon build --symlink-install --packages-select workcell_builder --event-handlers console_direct+`
- Ran focused UI rescue tests:
  `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_ui_rescue.py tests/test_workcell_builder_default_scenes_folder.py tests/test_workcell_builder_hide_unwired_studio_tabs.py tests/test_workcell_builder_original_flow_preserved.py tests/test_workcell_builder_real_generation_buttons.py`

### Safety
- Compile/link hotfix only.
- No automatic launch of RViz, MoveIt, EPD, RealSense, or robot motion.
- No weakening of safety gates.
EOF
)"