### PR TITLE
Make workcell_builder scene package regeneration idempotent

### DIFF
--- a/tests/test_workcell_builder_idempotent_regeneration.py
+++ b/tests/test_workcell_builder_idempotent_regeneration.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+def test_copydir_merges_existing_directories_and_preserves_files():
+    header = Path('workcell_builder/workcell_builder/include/file_functions.h').read_text(encoding='utf-8')
+    assert 'Merging into existing directory %s' in header
+    assert 'exists and is not a directory' in header
+    assert 'fs::copy_file(current, dst, fs::copy_option::overwrite_if_exists);' in header
+
+
+def test_generation_success_message_and_build_steps_are_present():
+    cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
+    assert 'Scene package generated/updated successfully.' in cpp
+    assert 'Build before launching so ROS 2 can discover updated package files.' in cpp
+    assert 'colcon build --symlink-install --packages-select ' in cpp
+    assert 'source install/setup.bash' in cpp
+    assert 'ros2 launch ' in cpp and 'demo.launch.py use_fake_hardware:=true' in cpp
+
+
+def test_generate_launch_error_message_is_real_failure_not_existing_directory_false_alarm():
+    cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
+    assert 'Failed to generate/merge launch files. Check filesystem permissions and destination path: ' in cpp
+    assert 'destination already exists or could not be created' not in cpp

--- a/tests/test_workcell_builder_real_generation_buttons.py
+++ b/tests/test_workcell_builder_real_generation_buttons.py
@@ -11,3 +11,11 @@ def test_validate_generate_buttons_are_clear_and_wired():
     assert 'ui->generate_files->hide();' in cpp
     assert 'on_generate_canonical_files_clicked()' in cpp and 'on_generate_yaml_clicked();' in cpp
     assert 'on_generate_workcell_package_clicked()' in cpp and 'on_generate_files_clicked();' in cpp
+
+
+def test_generate_workcell_package_guidance_mentions_build_source_launch():
+    cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
+    assert 'Scene package generated/updated successfully.' in cpp
+    assert 'colcon build --symlink-install --packages-select ' in cpp
+    assert 'source install/setup.bash' in cpp
+    assert 'ros2 launch ' in cpp and 'use_fake_hardware:=true' in cpp

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -804,6 +804,12 @@ void SceneSelect::generate_scene_package(
   generate_cmakelists(workcell_path, scene_name, ros_ver, ros_distro);
   generate_package_xml(workcell_path, scene_name, ros_ver, ros_distro);
   write_builder_validation_helper(scene_dir);
+  append_success("Scene package generated/updated successfully.");
+  append_info("Build before launching so ROS 2 can discover updated package files.");
+  append_info("Next commands:");
+  append_info("  colcon build --symlink-install --packages-select " + scene.name);
+  append_info("  source install/setup.bash");
+  append_info("  ros2 launch " + scene.name + " demo.launch.py use_fake_hardware:=true");
   std::ofstream readme((scene_dir / "README.builder.md").string());
   if (readme.is_open()) {
     readme << "# Builder Scene Metadata\n\n";
@@ -866,7 +872,7 @@ void SceneSelect::generate_scene_files(Scene scene)
   fs::path target_path = scene_dir / "launch";
   if (!copyDir(launch_path, target_path)) {
     append_error(
-      "Failed to generate launch files because destination already exists or could not be created: " +
+      "Failed to generate/merge launch files. Check filesystem permissions and destination path: " +
       target_path.string());
     return;
   }
@@ -908,6 +914,12 @@ void SceneSelect::generate_scene_files(Scene scene)
     }
   }
   write_builder_validation_helper(scene_dir);
+  append_success("Scene package generated/updated successfully.");
+  append_info("Build before launching so ROS 2 can discover updated package files.");
+  append_info("Next commands:");
+  append_info("  colcon build --symlink-install --packages-select " + scene.name);
+  append_info("  source install/setup.bash");
+  append_info("  ros2 launch " + scene.name + " demo.launch.py use_fake_hardware:=true");
   append_info("Workcell Studio metadata generated/updated.");
   append_info("Validation helper: generated/run_builder_validation.sh");
   append_info("Export helper: generated/export_workcell_studio_sources.sh");

--- a/workcell_builder/workcell_builder/include/file_functions.h
+++ b/workcell_builder/workcell_builder/include/file_functions.h
@@ -241,14 +241,19 @@ bool copyDir(fs::path const & source, fs::path const & destination)
       return false;
     }
     if (fs::exists(destination)) {
-      RCLCPP_ERROR(rclcpp::get_logger("workcell_builder"),
-        "Destination directory %s already exists.", destination.string().c_str());
-      return false;
-    }
-    if (!fs::create_directory(destination)) {
-      RCLCPP_ERROR(rclcpp::get_logger("workcell_builder"),
-        "Unable to create destination directory %s", destination.string().c_str());
-      return false;
+      if (!fs::is_directory(destination)) {
+        RCLCPP_ERROR(rclcpp::get_logger("workcell_builder"),
+          "Destination path %s exists and is not a directory.", destination.string().c_str());
+        return false;
+      }
+      RCLCPP_INFO(rclcpp::get_logger("workcell_builder"),
+        "Merging into existing directory %s", destination.string().c_str());
+    } else {
+      if (!fs::create_directories(destination)) {
+        RCLCPP_ERROR(rclcpp::get_logger("workcell_builder"),
+          "Unable to create destination directory %s", destination.string().c_str());
+        return false;
+      }
     }
   } catch(fs::filesystem_error const & e) {
     RCLCPP_ERROR(rclcpp::get_logger("workcell_builder"), "%s", e.what());


### PR DESCRIPTION
### Motivation
- Re-running "Generate Full Scene Package" should be safe and look successful instead of logging false errors when generated folders already exist. 
- Preserve user edits (custom meshes, `environment.yaml`, `scene_manifest.yaml`, and unrelated files) while updating generated `launch/`, `urdf/`, `config/` outputs. 
- Give clearer, actionable UI feedback after generation so users know to build/source before `ros2 launch` can find the new package.

### Description
- Make `copyDir` merge into existing directories rather than treating existence as a fatal error by updating `workcell_builder/workcell_builder/include/file_functions.h` to recursively merge and overwrite files as needed, logging an `INFO` message when merging and failing only if the destination exists as a non-directory path. 
- Change the launch-generation failure text in `workcell_builder/workcell_builder/gui/scene_select.cpp` from a misleading "already exists" error to a real merge/copy failure message. 
- Add explicit success and next-step guidance in the UI log (messages that include `colcon build`, `source install/setup.bash`, and `ros2 launch ... demo.launch.py use_fake_hardware:=true`) in `scene_select.cpp` after generation completes. 
- Add `tests/test_workcell_builder_idempotent_regeneration.py` and extend `tests/test_workcell_builder_real_generation_buttons.py` to assert the new merge intent and user-facing guidance are present; no runtime or auto-launch behavior was changed.

### Testing
- Added and updated unit tests: `tests/test_workcell_builder_idempotent_regeneration.py` and `tests/test_workcell_builder_real_generation_buttons.py`. 
- Ran the focused test command: `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_idempotent_regeneration.py tests/test_workcell_builder_scene_scaffold.py tests/test_workcell_builder_real_generation_buttons.py tests/test_workcell_builder_package_consistency.py tests/test_workcell_builder_launch_smoke_acceptance.py`. 
- Result: all tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0065c6048c83318da16bb39a7627e2)