### PR TITLE
Use `scene_name` in scene package guidance messages

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -807,9 +807,9 @@ void SceneSelect::generate_scene_package(
   append_success("Scene package generated/updated successfully.");
   append_info("Build before launching so ROS 2 can discover updated package files.");
   append_info("Next commands:");
-  append_info("  colcon build --symlink-install --packages-select " + scene.name);
+  append_info("  colcon build --symlink-install --packages-select " + scene_name);
   append_info("  source install/setup.bash");
-  append_info("  ros2 launch " + scene.name + " demo.launch.py use_fake_hardware:=true");
+  append_info("  ros2 launch " + scene_name + " demo.launch.py use_fake_hardware:=true");
   std::ofstream readme((scene_dir / "README.builder.md").string());
   if (readme.is_open()) {
     readme << "# Builder Scene Metadata\n\n";
@@ -917,9 +917,9 @@ void SceneSelect::generate_scene_files(Scene scene)
   append_success("Scene package generated/updated successfully.");
   append_info("Build before launching so ROS 2 can discover updated package files.");
   append_info("Next commands:");
-  append_info("  colcon build --symlink-install --packages-select " + scene.name);
+  append_info("  colcon build --symlink-install --packages-select " + scene_name);
   append_info("  source install/setup.bash");
-  append_info("  ros2 launch " + scene.name + " demo.launch.py use_fake_hardware:=true");
+  append_info("  ros2 launch " + scene_name + " demo.launch.py use_fake_hardware:=true");
   append_info("Workcell Studio metadata generated/updated.");
   append_info("Validation helper: generated/run_builder_validation.sh");
   append_info("Export helper: generated/export_workcell_studio_sources.sh");


### PR DESCRIPTION
### Motivation
- Fix a compile error in `SceneSelect::generate_scene_package(...)` caused by referencing an out-of-scope `scene` identifier instead of the local `std::string scene_name` when emitting user guidance.

### Description
- Replaced `scene.name` with `scene_name` in the guidance/log messages that show the `colcon build` and `ros2 launch` commands so messages are constructed from the function parameter `scene_name` and no other behavior was changed.

### Testing
- Attempted to build with `colcon build --symlink-install --packages-select workcell_builder --event-handlers console_direct+`, which failed in this environment with `/bin/bash: colcon: command not found` (no local `colcon` available), and no further automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0067cf8dbc83318fd4fdcee131754e)