### PR TITLE
Fix generate scene files guidance variable

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -917,9 +917,9 @@ void SceneSelect::generate_scene_files(Scene scene)
   append_success("Scene package generated/updated successfully.");
   append_info("Build before launching so ROS 2 can discover updated package files.");
   append_info("Next commands:");
-  append_info("  colcon build --symlink-install --packages-select " + scene_name);
+  append_info("  colcon build --symlink-install --packages-select " + scene.name);
   append_info("  source install/setup.bash");
-  append_info("  ros2 launch " + scene_name + " demo.launch.py use_fake_hardware:=true");
+  append_info("  ros2 launch " + scene.name + " demo.launch.py use_fake_hardware:=true");
   append_info("Workcell Studio metadata generated/updated.");
   append_info("Validation helper: generated/run_builder_validation.sh");
   append_info("Export helper: generated/export_workcell_studio_sources.sh");


### PR DESCRIPTION
gh pr create \
  --base main \
  --head codex/fix-generate-scene-files-scene-name-build \
  --title "Fix workcell_builder generate_scene_files build" \
  --body "$(cat <<'EOF'
### Motivation
- The latest workcell_builder guidance fix corrected `generate_scene_package(...)` but accidentally used `scene_name` inside `generate_scene_files(Scene scene)`.
- `generate_scene_files(...)` has a `Scene scene` parameter, not a `scene_name` variable, causing a compile failure.

### Description
- Use `scene.name` inside `SceneSelect::generate_scene_files(Scene scene)` guidance messages.
- Keep `scene_name` usage only where the function actually receives a `std::string scene_name` parameter.
- No runtime execution behaviour changed.
- Fake-hardware-first defaults are preserved.

### Testing
- Built the failed package:
  `colcon build --symlink-install --packages-select workcell_builder --event-handlers console_direct+`

### Safety
- Compile-only hotfix.
- No EPD, RealSense, MoveIt, RViz, or robot execution behaviour changed.
- No safety gates changed.
EOF
)"