### PR TITLE
Remove duplicate manipulator SRDF injection and add generated-scene quality tests

### DIFF
--- a/tests/test_workcell_builder_generated_scene_quality.py
+++ b/tests/test_workcell_builder_generated_scene_quality.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import re
+import xml.etree.ElementTree as ET
+
+
+def test_demo_launch_does_not_emit_world_with_trailing_space():
+    launch_template = Path(
+        'workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py'
+    ).read_text(encoding='utf-8')
+    assert "'world '" not in launch_template
+    assert '"world "' not in launch_template
+
+
+def test_generated_srdf_template_avoids_duplicate_manipulator_group_definition():
+    parser = Path('workcell_builder/workcell_builder/include/armhand_xacro_parser.h').read_text(encoding='utf-8')
+    assert '<group name=\"manipulator\">' not in parser
+
+
+def test_robotiq_gripper_base_link_has_collision_geometry():
+    gripper_xacro = Path(
+        'assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro'
+    ).read_text(encoding='utf-8')
+
+    link_start = gripper_xacro.find('<link name="${prefix}gripper_base_link">')
+    assert link_start >= 0, 'gripper_base_link link block not found'
+    link_end = gripper_xacro.find('</link>', link_start)
+    assert link_end > link_start, 'gripper_base_link link block not closed'
+    link_xml = f'<root>{gripper_xacro[link_start:link_end + len("</link>")]}</root>'
+    root = ET.fromstring(link_xml)
+    link = root.find('link')
+    assert link is not None
+    collision = link.find('collision')
+    assert collision is not None, 'gripper_base_link is missing collision geometry'
+    assert collision.find('geometry/mesh') is not None

--- a/workcell_builder/workcell_builder/include/armhand_xacro_parser.h
+++ b/workcell_builder/workcell_builder/include/armhand_xacro_parser.h
@@ -38,17 +38,6 @@ void generate_armhand_xacro(
     "_gripper.srdf.xacro\" />\n\n";
   MyFile << "  <xacro:" + robot.name + "/>\n\n";
   MyFile << "  <xacro:" + ee.name + "_gripper/>\n\n";
-  if (robot.name == "ur5") {
-    MyFile << "  <group name=\"manipulator\">\n";
-    MyFile << "    <joint name=\"shoulder_pan_joint\"/>\n";
-    MyFile << "    <joint name=\"shoulder_lift_joint\"/>\n";
-    MyFile << "    <joint name=\"elbow_joint\"/>\n";
-    MyFile << "    <joint name=\"wrist_1_joint\"/>\n";
-    MyFile << "    <joint name=\"wrist_2_joint\"/>\n";
-    MyFile << "    <joint name=\"wrist_3_joint\"/>\n";
-    MyFile << "  </group>\n\n";
-  }
-
   // For now we will only disable the base link of the  gripepr with all links of the robot.
   // Will change in the future if collisions with other links of the ee happens
   for (int i = 0; i < static_cast < int > (robot.robot_links.size()); i++) {
@@ -68,16 +57,6 @@ void generate_armhand_xacro(
     "_moveit_config)/config/" +
     robot.name + ".srdf.xacro\" />\n\n";
   MyFile << "  <xacro:" + robot.name + "/>\n\n";
-  if (robot.name == "ur5") {
-    MyFile << "  <group name=\"manipulator\">\n";
-    MyFile << "    <joint name=\"shoulder_pan_joint\"/>\n";
-    MyFile << "    <joint name=\"shoulder_lift_joint\"/>\n";
-    MyFile << "    <joint name=\"elbow_joint\"/>\n";
-    MyFile << "    <joint name=\"wrist_1_joint\"/>\n";
-    MyFile << "    <joint name=\"wrist_2_joint\"/>\n";
-    MyFile << "    <joint name=\"wrist_3_joint\"/>\n";
-    MyFile << "  </group>\n\n";
-  }
   MyFile << "\n\n</robot>";
 }
 


### PR DESCRIPTION
### Motivation
- Generated Workcell Studio scenes produced cosmetic MoveIt/RViz warnings (duplicate `manipulator` SRDF group, `gripper_base_link` visual-without-collision, and an octomap frame with trailing whitespace) that make a successful fake-hardware launch look rough. 
- The change aims to eliminate those warning sources in generated artifacts while preserving runtime, safety gates, and fake-hardware defaults. 
- Add regression tests to prevent reintroducing these quality issues during future refactors.

### Description
- Removed the hardcoded UR5 `<group name="manipulator">` emission paths from `workcell_builder/workcell_builder/include/armhand_xacro_parser.h` so generated SRDF relies on included MoveIt config definitions instead of injecting a duplicate group. 
- Added `tests/test_workcell_builder_generated_scene_quality.py` which asserts that the demo launch template does not contain a trailing-space frame literal (`'world '`), that the parser no longer contains a hardcoded `manipulator` group, and that the baseline Robotiq gripper `gripper_base_link` xacro contains a `<collision>`/mesh element. 
- No runtime behavior changes, no auto-launch, no fake-hardware default changes, and no safety/EPD weakening were made.

### Testing
- Ran the focused test suite with `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_generated_scene_quality.py tests/test_workcell_builder_launch_smoke_acceptance.py tests/test_workcell_builder_package_consistency.py tests/test_workcell_builder_scene_scaffold.py tests/test_workcell_builder_idempotent_regeneration.py`. 
- All tests passed: `10 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006c5eb2e4833181ce5fe9c8659178)