### PR TITLE
Filter invalid generated controllers against robot_description

### DIFF
--- a/tests/test_workcell_builder_controller_joint_filtering.py
+++ b/tests/test_workcell_builder_controller_joint_filtering.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def test_humble_demo_launch_has_controller_joint_filtering_and_skip_warning():
+    launch_text = Path('workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py').read_text(encoding='utf-8')
+    assert '_filter_controller_configs' in launch_text
+    assert 'Skipping controller {controller_name}: joints missing from robot_description:' in launch_text
+    assert 'controller_configs, controller_filter_warnings, controller_statuses = _filter_controller_configs(' in launch_text
+
+
+def test_humble_demo_launch_reports_arm_ready_and_fake_hardware_status():
+    launch_text = Path('workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py').read_text(encoding='utf-8')
+    assert 'arm controller ready' in launch_text
+    assert 'fake hardware launch available' in launch_text
+    assert 'default_value="true"' in launch_text

--- a/tests/test_workcell_builder_launch_smoke_acceptance.py
+++ b/tests/test_workcell_builder_launch_smoke_acceptance.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from scripts.workcell_builder_acceptance_check import build_golden_scene, launch_smoke
 
 
@@ -5,3 +6,9 @@ def test_generated_scene_launch_smoke_acceptance(tmp_path):
     scene = build_golden_scene('golden_ur5_2f_cell', tmp_path / 'scenes', tmp_path / 'assets')
     ok, errs = launch_smoke(scene)
     assert ok, errs
+
+
+def test_launch_template_skips_invalid_gripper_controller_without_failing():
+    content = Path('workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py').read_text(encoding='utf-8')
+    assert "gripper controller skipped" in content
+    assert "Skipping controller {controller_name}: joints missing from robot_description:" in content

--- a/tests/test_workcell_builder_package_consistency.py
+++ b/tests/test_workcell_builder_package_consistency.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from scripts.workcell_builder_acceptance_check import build_golden_scene, package_consistency
 
 
@@ -5,3 +7,10 @@ def test_generated_package_consistency(tmp_path):
     scene = build_golden_scene('golden_ur5_2f_cell', tmp_path / 'scenes', tmp_path / 'assets')
     ok, errs = package_consistency(scene)
     assert ok, errs
+
+
+def test_generated_template_package_artifacts_are_present():
+    root = Path('workcell_builder/workcell_builder/templates/ros2/humble')
+    assert (root / 'launch/demo.launch.py').exists()
+    launch_text = (root / 'launch/demo.launch.py').read_text(encoding='utf-8')
+    assert 'load_yaml(robot_moveit_pkg, "config/kinematics.yaml")' in launch_text

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -312,15 +312,39 @@ def _validate_joint_state_configuration(robot_description_config, controller_joi
     if len(movable_joint_names) != len(set(movable_joint_names)):
         raise RuntimeError("Duplicate movable joint names were found in robot_description")
 
-    missing = [joint for joint in controller_joints if joint not in set(movable_joint_names)]
-    if missing:
-        raise RuntimeError(
-            "Controller joints are not present in robot_description: "
-            + ", ".join(missing)
-        )
+    movable_joint_set = set(movable_joint_names)
+    missing = [joint for joint in controller_joints if joint not in movable_joint_set]
+    return movable_joint_set, missing
 
 
+def _filter_controller_configs(controller_configs, movable_joint_set):
+    filtered = {"controller_names": []}
+    warnings = []
+    statuses = []
 
+    for controller_name in controller_configs.get("controller_names", []):
+        cfg = controller_configs.get(controller_name) or {}
+        joints = list(cfg.get("joints") or [])
+        missing = [joint for joint in joints if joint not in movable_joint_set]
+        if missing:
+            warnings.append(
+                f"Skipping controller {controller_name}: joints missing from robot_description: "
+                + ", ".join(missing)
+            )
+            if "gripper" in controller_name:
+                statuses.append(f"gripper controller skipped ({controller_name})")
+            continue
+        filtered["controller_names"].append(controller_name)
+        filtered[controller_name] = cfg
+        if "arm" in controller_name:
+            statuses.append(f"arm controller ready ({controller_name})")
+        elif "gripper" in controller_name:
+            statuses.append(f"gripper controller ready ({controller_name})")
+
+    if not filtered["controller_names"]:
+        raise RuntimeError("No valid controllers remain after filtering against robot_description joints")
+
+    return filtered, warnings, statuses
 
 
 
@@ -469,7 +493,7 @@ def _launch_setup(context):
             "No joints were found in the selected SRDF group. "
             "The generated fake controller cannot be created with an empty joints list."
         )
-    _validate_joint_state_configuration(robot_description_config, controller_joints)
+    movable_joint_set, missing_controller_joints = _validate_joint_state_configuration(robot_description_config, controller_joints)
     environment_config = load_yaml(scene_pkg, "environment.yaml")
     end_effector_metadata = extract_end_effector_metadata(environment_config)
     controller_configs = _derive_controller_configs(
@@ -479,6 +503,15 @@ def _launch_setup(context):
         robot_description_config,
         end_effector_metadata,
     )
+
+    controller_configs, controller_filter_warnings, controller_statuses = _filter_controller_configs(
+        controller_configs,
+        movable_joint_set,
+    )
+    if missing_controller_joints:
+        controller_filter_warnings.append(
+            "Controller joints are not present in robot_description: " + ", ".join(missing_controller_joints)
+        )
 
     moveit_controller_manager = {
         "moveit_controller_manager": "moveit_simple_controller_manager/MoveItSimpleControllerManager"
@@ -672,8 +705,15 @@ def _launch_setup(context):
         output="screen",
     )
 
+    controller_status_logs = [LogInfo(msg=f"[workcell_builder] {status}") for status in controller_statuses]
+    controller_warning_logs = [LogInfo(msg=f"[workcell_builder] WARNING: {warning}") for warning in controller_filter_warnings]
+    fake_hw_ready_log = LogInfo(msg=f"[workcell_builder] fake hardware launch available (use_fake_hardware:={use_fake_hardware.perform(context)})")
+
     return [
         octomap_launch_message,
+        fake_hw_ready_log,
+        *controller_status_logs,
+        *controller_warning_logs,
         static_tf,
         robot_state_publisher,
         joint_state_publisher,


### PR DESCRIPTION
### Motivation
- Generated demo launches could crash when controller configs (typically gripper controllers) reference joints that are not present in the generated `robot_description`, so the launch must degrade gracefully instead of failing.
- The generated fake-hardware demo must preserve arm planning availability and the fake-hardware-first default while clearly reporting when gripper controllers are skipped.

### Description
- Change `workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py` to return movable joint set from `_validate_joint_state_configuration` and add `_filter_controller_configs` to drop controllers whose joints are missing from `robot_description` and collect warnings/statuses.
- Apply filtering in the launch setup: controller configs are filtered before being passed to the MoveIt controller manager, and any missing semantic/controller joints are appended as non-fatal warnings instead of raising an exception.
- Emit readiness/log messages via `LogInfo` for arm controller ready, gripper controller skipped (when applicable), and fake-hardware launch availability, so the generated launch shows clear status in logs.
- Tests added/updated to assert the filtering and logging are present: new `tests/test_workcell_builder_controller_joint_filtering.py` and updates to `tests/test_workcell_builder_launch_smoke_acceptance.py` and `tests/test_workcell_builder_package_consistency.py` to reflect the new behavior and template artifacts.

### Testing
- Ran the targeted pytest set with: `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_controller_joint_filtering.py tests/test_workcell_builder_launch_smoke_acceptance.py tests/test_workcell_builder_package_consistency.py tests/test_workcell_builder_scene_scaffold.py tests/test_workcell_builder_idempotent_regeneration.py`.
- Result: all tests passed (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006f0c3bc883319da36d759a3ef010)