### PR TITLE
Improve scene manager UX: scene-root discovery, status labels, and generation guidance

### DIFF
--- a/tests/test_workcell_builder_scene_manager_ux.py
+++ b/tests/test_workcell_builder_scene_manager_ux.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+def test_scene_root_discovery_prefers_emd_scenes_folder():
+    cpp = Path('workcell_builder/workcell_builder/src_scene_select_paths.cpp').read_text(encoding='utf-8')
+    assert 'cwd / "src" / "easy_manipulation_deployment" / "scenes"' in cpp
+    assert 'candidates.push_back(cwd / "src" / "easy_manipulation_deployment")' in cpp
+
+
+def test_scene_status_labels_are_exposed_in_ui_listing():
+    cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
+    for label in [
+        'VALID', 'INCOMPLETE', 'SCAFFOLD_ONLY',
+        'MISSING_ENVIRONMENT_YAML', 'MISSING_ROBOT', 'MISSING_MOVEIT_CONFIG'
+    ]:
+        assert f'"{label}"' in cpp
+    assert 'name + " [" + scene_status_label(status) + "]"' in cpp
+
+
+def test_generate_guidance_includes_fake_hardware_launch_and_warning():
+    cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
+    assert 'colcon build --symlink-install --packages-select' in cpp
+    assert 'ros2 launch ' in cpp
+    assert 'use_fake_hardware:=true' in cpp
+    assert 'Real hardware mode requires explicit validation and use_fake_hardware:=false.' in cpp
+
+
+def test_unknown_description_lookup_text_not_reintroduced():
+    cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
+    assert 'unknown_description' not in cpp
+    assert 'unknown_moveit_config' not in cpp

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -231,6 +231,51 @@ bool scene_has_valid_end_effector(const Scene & scene)
 {
   return scene_requires_end_effector(scene) && !is_placeholder_value(scene.ee_vector[0].name);
 }
+
+
+enum class SceneUiStatus
+{
+  VALID,
+  INCOMPLETE,
+  SCAFFOLD_ONLY,
+  MISSING_ENVIRONMENT_YAML,
+  MISSING_ROBOT,
+  MISSING_MOVEIT_CONFIG
+};
+
+std::string scene_status_label(SceneUiStatus status)
+{
+  switch (status) {
+    case SceneUiStatus::VALID: return "VALID";
+    case SceneUiStatus::INCOMPLETE: return "INCOMPLETE";
+    case SceneUiStatus::SCAFFOLD_ONLY: return "SCAFFOLD_ONLY";
+    case SceneUiStatus::MISSING_ENVIRONMENT_YAML: return "MISSING_ENVIRONMENT_YAML";
+    case SceneUiStatus::MISSING_ROBOT: return "MISSING_ROBOT";
+    case SceneUiStatus::MISSING_MOVEIT_CONFIG: return "MISSING_MOVEIT_CONFIG";
+  }
+  return "INCOMPLETE";
+}
+
+SceneUiStatus compute_scene_status_label(const Scene & scene, const fs::path & scene_dir)
+{
+  const bool has_yaml = fs::exists(scene_dir / "environment.yaml");
+  const bool has_launch = fs::exists(scene_dir / "launch" / "demo.launch.py");
+  const bool has_srdf = fs::exists(scene_dir / "urdf" / "arm_hand.srdf.xacro");
+
+  if (!has_yaml) {
+    return SceneUiStatus::MISSING_ENVIRONMENT_YAML;
+  }
+  if (!scene_has_valid_robot(scene)) {
+    return SceneUiStatus::MISSING_ROBOT;
+  }
+  if (scene_requires_end_effector(scene) && !scene_has_valid_end_effector(scene)) {
+    return SceneUiStatus::INCOMPLETE;
+  }
+  if (!has_srdf) {
+    return has_launch ? SceneUiStatus::MISSING_MOVEIT_CONFIG : SceneUiStatus::SCAFFOLD_ONLY;
+  }
+  return SceneUiStatus::VALID;
+}
 fs::path root_from_override(const std::string & override_value)
 {
   fs::path override_path(override_value);
@@ -287,12 +332,12 @@ fs::path select_scene_root(const fs::path & cwd)
       std::string("environment ") + kSceneRootEnvVar + "=" + env_override));
   }
 
+  candidates.push_back(build_candidate(cwd / "src" / "easy_manipulation_deployment", "workspace src/easy_manipulation_deployment"));
+  candidates.push_back(build_candidate(cwd / "src", "workspace src"));
   candidates.push_back(build_candidate(cwd, "current working directory"));
   candidates.push_back(build_candidate(cwd.parent_path(), "parent directory"));
-  candidates.push_back(build_candidate(
-    cwd / "src" / "easy_manipulation_deployment",
-    "cwd/src/easy_manipulation_deployment"));
-  candidates.push_back(build_candidate(cwd / "src", "cwd/src"));
+  const fs::path repo_root = cwd.parent_path() / "easy_manipulation_deployment";
+  candidates.push_back(build_candidate(repo_root, "repo root easy_manipulation_deployment"));
 
   SceneRootCandidate selected;
   bool has_selected = false;
@@ -955,9 +1000,11 @@ void SceneSelect::generate_scene_files(Scene scene)
   append_success("Scene package generated/updated successfully.");
   append_info("Build before launching so ROS 2 can discover updated package files.");
   append_info("Next commands:");
+  append_info("  cd " + workcell_path.string());
   append_info("  colcon build --symlink-install --packages-select " + scene.name);
   append_info("  source install/setup.bash");
   append_info("  ros2 launch " + scene.name + " demo.launch.py use_fake_hardware:=true");
+  append_warning("Real hardware mode requires explicit validation and use_fake_hardware:=false.");
   append_info("Workcell Studio metadata generated/updated.");
   append_info("Validation helper: generated/run_builder_validation.sh");
   append_info("Export helper: generated/export_workcell_studio_sources.sh");
@@ -973,7 +1020,13 @@ void SceneSelect::refresh_scenes(int latest_scene, bool scaffold_only_status)
   if (workcell.scene_vector.size() > 0) {  // There are scenes in the workcell
     ui->scene_list->setDisabled(false);     // Enable the dropdown menu
     for (int scene = 0; scene < static_cast<int>(workcell.scene_vector.size()); scene++) {
-      ui->scene_list->addItem(QString::fromStdString(workcell.scene_vector[scene].name));
+      Scene scene_value = workcell.scene_vector[scene];
+      if (!scene_value.loaded) {
+        load_scene_from_yaml(&scene_value);
+      }
+      const SceneUiStatus status = compute_scene_status_label(scene_value, scenes_path / workcell.scene_vector[scene].name);
+      const std::string label = workcell.scene_vector[scene].name + " [" + scene_status_label(status) + "]";
+      ui->scene_list->addItem(QString::fromStdString(label));
     }
     ui->scene_list->setCurrentIndex(latest_scene);     // Display the latest scene the user created
     on_scene_list_currentIndexChanged(latest_scene);
@@ -1290,6 +1343,18 @@ bool SceneSelect::check_files(bool strict)
 }
 void SceneSelect::on_scene_list_currentIndexChanged(int index)
 {
+  if (index >= 0 && index < static_cast<int>(workcell.scene_vector.size())) {
+    Scene curr_scene = workcell.scene_vector[index];
+    if (!curr_scene.loaded) {
+      load_scene_from_yaml(&curr_scene);
+    }
+    const SceneUiStatus status = compute_scene_status_label(curr_scene, scenes_path / curr_scene.name);
+    const bool can_generate_files = status == SceneUiStatus::VALID || status == SceneUiStatus::MISSING_MOVEIT_CONFIG || status == SceneUiStatus::SCAFFOLD_ONLY;
+    ui->generate_full_scene_package_start->setDisabled(!can_generate_files);
+    if (!can_generate_files) {
+      append_warning("Generate Files blocked: scene status is " + scene_status_label(status) + ".");
+    }
+  }
   refresh_scene_status(index != scaffold_scene_index_, "Scene Selection Changed");
 }
 void SceneSelect::on_generate_files_clicked()

--- a/workcell_builder/workcell_builder/src_scene_select_paths.cpp
+++ b/workcell_builder/workcell_builder/src_scene_select_paths.cpp
@@ -58,6 +58,10 @@ SceneSelectPathResolution resolve_scene_select_paths(
     if (has_dir(loaded)) candidates.push_back(loaded);
   }
   const fs::path cwd = fs::current_path();
+  if (has_dir(cwd / "src" / "easy_manipulation_deployment" / "scenes")) {
+    candidates.push_back(cwd / "src" / "easy_manipulation_deployment");
+  }
+  if (has_dir(cwd / "src" / "scenes")) candidates.push_back(cwd / "src");
   if (has_dir(cwd / "scenes")) candidates.push_back(cwd);
   const fs::path parent_found = find_repo_from_cwd(cwd);
   if (!parent_found.empty()) candidates.push_back(parent_found);
@@ -65,8 +69,8 @@ SceneSelectPathResolution resolve_scene_select_paths(
   if (repo_env != nullptr) candidates.emplace_back(repo_env);
   const char * home = std::getenv("HOME");
   if (home != nullptr) {
-    candidates.push_back(fs::path(home) / "workcell_ws" / "src");
     candidates.push_back(fs::path(home) / "workcell_ws" / "src" / "easy_manipulation_deployment");
+    candidates.push_back(fs::path(home) / "workcell_ws" / "src");
   }
 
   fs::path workcell_path;


### PR DESCRIPTION
### Motivation
- Make existing scenes immediately visible and clearly classified so users can tell valid vs scaffold/incomplete scenes at a glance.
- Prefer a sensible default scenes root aligned with typical workspace layouts to avoid confusing empty/default folders.
- Prevent deep failures from incomplete scene data and provide clear next-step generation guidance while preserving fake-hardware-first safety.

### Description
- Added deterministic scene-root discovery priority to prefer `<workspace>/src/easy_manipulation_deployment/scenes`, then `<workspace>/src/scenes`, then other fallbacks, without copying or creating duplicate package locations (`workcell_builder/workcell_builder/src_scene_select_paths.cpp`).
- Introduced `SceneUiStatus`, `scene_status_label`, and `compute_scene_status_label` to classify scenes as `VALID`, `INCOMPLETE`, `SCAFFOLD_ONLY`, `MISSING_ENVIRONMENT_YAML`, `MISSING_ROBOT`, or `MISSING_MOVEIT_CONFIG`, and surfaced these labels inline in the scene dropdown so discovered scenes are visible with status (`workcell_builder/workcell_builder/gui/scene_select.cpp`).
- Blocked or disabled generation actions for scenes that are incomplete and emit clear user-facing messages explaining why generation is blocked, and preserved scaffold-only safety logic to avoid invalid package lookups (`workcell_builder/workcell_builder/gui/scene_select.cpp`).
- Improved post-generation guidance to display the exact next commands including `cd <workspace>`, `colcon build --symlink-install --packages-select <scene_name>`, `source install/setup.bash`, and `ros2 launch <scene_name> demo.launch.py use_fake_hardware:=true`, plus an explicit real-hardware warning to keep fake-hardware-first behavior (`workcell_builder/workcell_builder/gui/scene_select.cpp`).
- Added a focused unit test file `tests/test_workcell_builder_scene_manager_ux.py` validating scene-root preference, status label strings in UI, generation guidance wording, and ensuring no reintroduction of prior unknown lookup text.

### Testing
- Added `tests/test_workcell_builder_scene_manager_ux.py` and ran the requested focused test suite with `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_scene_manager_ux.py tests/test_workcell_builder_placeholder_scene_validation.py tests/test_workcell_builder_scene_scaffold.py tests/test_workcell_builder_real_generation_buttons.py tests/test_workcell_builder_package_consistency.py tests/test_workcell_builder_launch_smoke_acceptance.py tests/test_workcell_builder_idempotent_regeneration.py`.
- Result: all targeted tests passed (`19 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a018457690c8331b02212ea23697bf3)