### PR TITLE
Stabilization: add Workcell Builder CI healthcheck acceptance gate

### DIFF
--- a/docs/manuals/WORKCELL_BUILDER_HEALTHCHECK.md
+++ b/docs/manuals/WORKCELL_BUILDER_HEALTHCHECK.md
@@ -1,0 +1,64 @@
+# Workcell Builder Healthcheck (Stabilization/Acceptance)
+
+This manual validates the post-Qt Workcell Builder stack in a safe, fake-hardware-first mode.
+
+## 1) Targeted pytest acceptance suite
+
+```bash
+cd ~/workcell_ws/src/easy_manipulation_deployment
+
+PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q \
+  tests/test_workcell_builder_healthcheck.py \
+  tests/test_workcell_builder_layout_preview_readiness.py \
+  tests/test_workcell_builder_asset_picker_dialogs.py \
+  tests/test_workcell_builder_functional_asset_selection.py \
+  tests/test_workcell_builder_asset_picker.py \
+  tests/test_workcell_builder_scene_manager_ux.py \
+  tests/test_workcell_builder_placeholder_scene_validation.py \
+  tests/test_workcell_builder_scene_scaffold.py \
+  tests/test_workcell_builder_real_generation_buttons.py \
+  tests/test_workcell_builder_package_consistency.py \
+  tests/test_workcell_builder_launch_smoke_acceptance.py \
+  tests/test_workcell_builder_idempotent_regeneration.py
+```
+
+## 2) Build validation
+
+```bash
+cd ~/workcell_ws
+source /opt/ros/humble/setup.bash
+colcon build --symlink-install --packages-select workcell_builder --event-handlers console_direct+
+```
+
+```bash
+source install/setup.bash
+cd ~/workcell_ws/src/easy_manipulation_deployment
+```
+
+## 3) Healthcheck validation (safe default: skip launch)
+
+```bash
+python3 scripts/validate_workcell_builder_healthcheck.py \
+  --repo-root . \
+  --workspace ~/workcell_ws \
+  --run-colcon \
+  --skip-launch
+```
+
+## 4) Optional smoke launch (headless fake hardware only)
+
+```bash
+python3 scripts/validate_workcell_builder_healthcheck.py \
+  --repo-root . \
+  --workspace ~/workcell_ws \
+  --run-colcon \
+  --smoke-launch
+```
+
+The smoke mode launches:
+
+```bash
+ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=false
+```
+
+No motion commands or runtime execution are issued by this workflow.

--- a/scripts/validate_workcell_builder_healthcheck.py
+++ b/scripts/validate_workcell_builder_healthcheck.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _check(cond: bool, msg: str, errors: list[str]) -> None:
+    if cond:
+        print(f"[PASS] {msg}")
+    else:
+        print(f"[FAIL] {msg}")
+        errors.append(msg)
+
+
+def _run(cmd: list[str], cwd: Path | None = None, timeout: int = 600) -> tuple[int, str]:
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    return proc.returncode, proc.stdout
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Validate Workcell Builder CI/healthcheck acceptance gate.")
+    p.add_argument("--repo-root", default=".", help="Repository root path")
+    p.add_argument("--workspace", default="~/workcell_ws", help="ROS workspace path")
+    p.add_argument("--skip-colcon", action="store_true", help="Skip colcon build validation")
+    p.add_argument("--run-colcon", action="store_true", help="Run colcon build validation")
+    p.add_argument("--skip-launch", action="store_true", help="Skip launch smoke check")
+    p.add_argument("--smoke-launch", action="store_true", help="Run fake-hardware headless launch smoke check")
+    args = p.parse_args()
+
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    workspace = Path(args.workspace).expanduser().resolve()
+    errors: list[str] = []
+
+    # Safe default: skip launch unless explicitly enabled.
+    run_launch = args.smoke_launch
+
+    key_files = [
+        repo_root / "workcell_builder/workcell_builder/CMakeLists.txt",
+        repo_root / "workcell_builder/workcell_builder/package.xml",
+        repo_root / "workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py",
+        repo_root / "workcell_builder/workcell_builder/gui/asset_picker_dialog.cpp",
+        repo_root / "workcell_builder/workcell_builder/src_asset_discovery_helper.cpp",
+        repo_root / "workcell_builder/workcell_builder/gui/scene_select.cpp",
+    ]
+    for f in key_files:
+        _check(f.exists(), f"required file exists: {f.relative_to(repo_root)}", errors)
+
+    cmake_text = (repo_root / "workcell_builder/workcell_builder/CMakeLists.txt").read_text(encoding="utf-8")
+    for needle in ["gui/asset_picker_dialog.cpp", "src_asset_discovery_helper.cpp", "gui/scene_select.cpp"]:
+        _check(needle in cmake_text, f"CMake references {needle}", errors)
+
+    pkg_text = (repo_root / "workcell_builder/workcell_builder/package.xml").read_text(encoding="utf-8")
+    for dep in ["ament_cmake", "rclcpp", "qtbase5-dev", "yaml-cpp"]:
+        _check(dep in pkg_text, f"package.xml includes dependency marker: {dep}", errors)
+
+    launch_template = (repo_root / "workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py").read_text(encoding="utf-8")
+    for needle in ["use_fake_hardware", "launch_rviz", "launch_rviz:=false", "DeclareLaunchArgument("]:
+        _check(needle in launch_template, f"launch template contains {needle}", errors)
+
+    scene_cpp = (repo_root / "workcell_builder/workcell_builder/gui/scene_select.cpp").read_text(encoding="utf-8")
+    _check("demo.launch.py use_fake_hardware:=true" in scene_cpp, "guidance uses fake hardware default", errors)
+    _check("demo.launch.py use_fake_hardware:=false" not in scene_cpp, "default guidance does not suggest real hardware", errors)
+
+    for bad in ["unknown_description", "unknown_moveit_config", "none_moveit_config"]:
+        _check(bad not in scene_cpp.lower(), f"forbidden placeholder text absent: {bad}", errors)
+
+    for ui in ["Select Robot Asset", "Select End Effector Asset", "Select Existing STL"]:
+        _check(ui in scene_cpp or ui in (repo_root / "workcell_builder/workcell_builder/gui/asset_picker_dialog.cpp").read_text(encoding="utf-8"), f"asset picker string present: {ui}", errors)
+
+    for artifact in ["workcell_studio_summary.json", "workcell_studio_summary.md", "preview/workcell_preview.svg", "preview/workcell_preview.html"]:
+        _check(artifact in scene_cpp, f"artifact string present: {artifact}", errors)
+
+    if args.run_colcon and not args.skip_colcon:
+        code, out = _run([
+            "bash", "-lc",
+            "source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder --event-handlers console_direct+",
+        ], cwd=workspace, timeout=1800)
+        print(out)
+        _check(code == 0, "colcon build passed", errors)
+
+    if run_launch and not args.skip_launch:
+        code, out = _run([
+            "bash", "-lc",
+            "source /opt/ros/humble/setup.bash && source install/setup.bash && timeout 45 ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=false",
+        ], cwd=workspace, timeout=120)
+        print(out)
+        _check(code in (0, 124), "smoke launch did not fail immediately", errors)
+
+    if errors:
+        print("WORKCELL_BUILDER_HEALTHCHECK: FAIL")
+        return 1
+    print("WORKCELL_BUILDER_HEALTHCHECK: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_workcell_builder_healthcheck.py
+++ b/tests/test_workcell_builder_healthcheck.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+def test_healthcheck_script_exists_and_has_pass_fail_markers():
+    path = Path("scripts/validate_workcell_builder_healthcheck.py")
+    assert path.exists()
+    txt = path.read_text(encoding="utf-8")
+    assert "WORKCELL_BUILDER_HEALTHCHECK: PASS" in txt
+    assert "WORKCELL_BUILDER_HEALTHCHECK: FAIL" in txt
+
+
+def test_healthcheck_cli_defaults_safe_and_optional_flags_present():
+    txt = Path("scripts/validate_workcell_builder_healthcheck.py").read_text(encoding="utf-8")
+    assert "--run-colcon" in txt
+    assert "--smoke-launch" in txt
+    assert "run_launch = args.smoke_launch" in txt
+
+
+def test_healthcheck_checks_build_integration_and_launch_safety():
+    txt = Path("scripts/validate_workcell_builder_healthcheck.py").read_text(encoding="utf-8")
+    assert "gui/asset_picker_dialog.cpp" in txt
+    assert "src_asset_discovery_helper.cpp" in txt
+    assert "gui/scene_select.cpp" in txt
+    assert "demo.launch.py use_fake_hardware:=true" in txt
+    assert "use_fake_hardware:=false" in txt
+    assert "launch_rviz" in txt
+    assert "launch_rviz:=false" in txt or "launch_rviz:=false\"" in txt
+
+
+def test_healthcheck_checks_artifacts_strings_and_placeholders_and_asset_ui():
+    txt = Path("scripts/validate_workcell_builder_healthcheck.py").read_text(encoding="utf-8")
+    assert "workcell_studio_summary.json" in txt
+    assert "workcell_studio_summary.md" in txt
+    assert "preview/workcell_preview.svg" in txt
+    assert "preview/workcell_preview.html" in txt
+    assert "Select Robot Asset" in txt
+    assert "Select End Effector Asset" in txt
+    assert "Select Existing STL" in txt
+    assert "unknown_description" in txt
+    assert "unknown_moveit_config" in txt
+    assert "none_moveit_config" in txt

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -21,6 +21,8 @@ import yaml
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, LogInfo, ExecuteProcess
+from launch.conditions import IfCondition
+from launch.substitutions import PythonExpression
 from launch.actions import OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
@@ -437,6 +439,7 @@ def _launch_setup(context):
     octomap_pointcloud_topic = LaunchConfiguration("octomap_pointcloud_topic")
     octomap_max_range = LaunchConfiguration("octomap_max_range")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    launch_rviz = LaunchConfiguration("launch_rviz")
     # Keep joint states isolated per-scene to avoid global topic collisions.
     joint_states_topic = f"/{scene_pkg}/joint_states"
 
@@ -664,6 +667,7 @@ def _launch_setup(context):
         get_package_share_directory(scene_pkg), "launch", "demo.rviz"
     )
     rviz_node = Node(
+        condition=IfCondition(PythonExpression([launch_rviz, " == 'true'"])),
         package="rviz2",
         executable="rviz2",
         name="rviz2",
@@ -707,7 +711,7 @@ def _launch_setup(context):
 
     controller_status_logs = [LogInfo(msg=f"[workcell_builder] {status}") for status in controller_statuses]
     controller_warning_logs = [LogInfo(msg=f"[workcell_builder] WARNING: {warning}") for warning in controller_filter_warnings]
-    fake_hw_ready_log = LogInfo(msg=f"[workcell_builder] fake hardware launch available (use_fake_hardware:={use_fake_hardware.perform(context)})")
+    fake_hw_ready_log = LogInfo(msg=f"[workcell_builder] fake hardware launch available (use_fake_hardware:={use_fake_hardware.perform(context)} launch_rviz:={launch_rviz.perform(context)}; headless hint launch_rviz:=false)")
 
     return [
         octomap_launch_message,
@@ -774,6 +778,11 @@ def generate_launch_description():
             "publish_perception_replay",
             default_value="false",
             description="Publish offline perception replay markers from config/perception_replay_markers.json.",
+        ),
+        DeclareLaunchArgument(
+            "launch_rviz",
+            default_value="true",
+            description="Launch RViz alongside MoveIt nodes (set false for headless CI/smoke).",
         ),
         DeclareLaunchArgument(
             "use_fake_hardware",


### PR DESCRIPTION
### Motivation
- Stabilize recent Workcell Builder Qt/asset-picker/readiness/preview/summary changes by adding a repeatable CI/acceptance gate to catch regressions early.
- Ensure the builder still builds, tests, generates preview/summary artifacts, and supports safe headless fake-hardware smoke launches without enabling real hardware or motion by default.

### Description
- Add `scripts/validate_workcell_builder_healthcheck.py`, a healthcheck script with flags `--repo-root`, `--workspace`, `--skip-colcon`, `--run-colcon`, `--skip-launch`, and `--smoke-launch` that verifies key files, CMake/source wiring, `package.xml` markers, launch template knobs, forbidden placeholder strings, asset-picker UI strings, and preview/summary artifact names, and emits `WORKCELL_BUILDER_HEALTHCHECK: PASS|FAIL`.
- Add `tests/test_workcell_builder_healthcheck.py` to assert the healthcheck script exists, contains PASS/FAIL markers, defaults to skipping launch, exposes optional flags, and checks the same safety/artifact strings.
- Add operator runbook `docs/manuals/WORKCELL_BUILDER_HEALTHCHECK.md` with exact commands for running the targeted pytest suite, `colcon` build, the healthcheck, and the optional headless fake-hardware smoke launch using `launch_rviz:=false`.
- Update `workcell_builder/.../templates/ros2/humble/launch/demo.launch.py` to introduce a `launch_rviz` `DeclareLaunchArgument`, gate the `rviz_node` with an `IfCondition(PythonExpression(...))`, and augment the fake-hardware ready log with a headless hint, while preserving `use_fake_hardware` default semantics.

### Testing
- Ran the targeted pytest acceptance suite with `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q ...` and observed `38 passed` across the relevant tests.
- Executed the healthcheck in safe default mode with `python3 scripts/validate_workcell_builder_healthcheck.py --repo-root . --workspace ~/workcell_ws --skip-colcon --skip-launch` and observed `WORKCELL_BUILDER_HEALTHCHECK: PASS`.
- Verified the updated `demo.launch.py` contains `launch_rviz` and conditional `rviz_node`, and that `scene_select.cpp` guidance still prefers `use_fake_hardware:=true` and does not suggest `use_fake_hardware:=false` by default.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0195ab37d48331a8e109e000fb7290)