### PR TITLE
Add task_recipe loader/validator and offline dry-run task-plan preview

### DIFF
--- a/docs/manuals/WORKCELL_TASK_RECIPE_PREVIEW.md
+++ b/docs/manuals/WORKCELL_TASK_RECIPE_PREVIEW.md
@@ -1,0 +1,51 @@
+# WORKCELL Task Recipe Preview
+
+`task_recipe.yaml` is the generated task/grasp intent artifact from Workcell Studio (`schema_version: workcell_task/v1`).
+
+## What the dry-run preview does
+- Loads and validates the recipe.
+- Builds an **offline-only** ordered task plan preview.
+- Writes `task_plan_preview.json` and `task_plan_preview.md`.
+
+## What it does NOT do
+- No robot motion commands.
+- No MoveIt planning service calls.
+- No trajectory execution.
+- No real hardware enablement.
+
+## Manual preview command
+```bash
+cd ~/workcell_ws/src/easy_manipulation_deployment
+python3 scripts/preview_task_recipe.py \
+  --recipe scenes/<scene_name>/config/task_recipe.yaml \
+  --output-dir /tmp/workcell_task_preview \
+  --print-plan
+```
+
+## Tests
+```bash
+PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q \
+  tests/test_task_recipe_loader_preview.py \
+  tests/test_workcell_builder_task_grasp_strategy.py \
+  tests/test_workcell_builder_healthcheck.py \
+  tests/test_workcell_builder_layout_preview_readiness.py \
+  tests/test_workcell_builder_launch_smoke_acceptance.py \
+  tests/test_workcell_builder_package_consistency.py
+```
+
+## Build
+```bash
+cd ~/workcell_ws
+source /opt/ros/humble/setup.bash
+colcon build --symlink-install --packages-select workcell_builder run_grasp_execution --event-handlers console_direct+
+```
+
+## Healthcheck
+```bash
+cd ~/workcell_ws/src/easy_manipulation_deployment
+python3 scripts/validate_workcell_builder_healthcheck.py \
+  --repo-root . \
+  --workspace ~/workcell_ws \
+  --skip-colcon \
+  --skip-launch
+```

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/__init__.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/__init__.py
@@ -1,0 +1,1 @@
+"""Offline task recipe preview helpers."""

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/task_recipe.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/task_recipe.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except Exception as exc:  # pragma: no cover
+    raise RuntimeError("PyYAML is required for task recipe preview") from exc
+
+SAFETY_MARKERS = ["OFFLINE_ONLY", "NO_MOTION_COMMAND", "NO_MOVEIT_PLAN", "NO_REAL_HARDWARE"]
+SUPPORTED_TASK_TYPES = {"pick_place", "sorting", "inspection_only"}
+
+
+def load_task_recipe(path: str | Path) -> dict[str, Any]:
+    return yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+
+
+def normalize_task_recipe(recipe: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(recipe)
+    normalized.setdefault("task", {})
+    normalized.setdefault("grasp", {})
+    normalized.setdefault("place", {})
+    normalized.setdefault("release", {})
+    normalized.setdefault("safety", {})
+    normalized.setdefault("warnings", [])
+    return normalized
+
+
+def validate_task_recipe(recipe: dict[str, Any]) -> dict[str, Any]:
+    rec = normalize_task_recipe(recipe)
+    errors: list[str] = []
+    warnings: list[str] = []
+    if rec.get("schema_version") != "workcell_task/v1":
+        errors.append("schema_version must equal workcell_task/v1")
+    task = rec["task"]
+    task_type = task.get("type")
+    if task_type not in SUPPORTED_TASK_TYPES:
+        errors.append("task.type is unknown")
+    if task_type in {"pick_place", "sorting"} and not task.get("pick_source"):
+        errors.append("task.pick_source is required for pick_place/sorting")
+    if task_type in {"pick_place", "sorting"} and not task.get("place_target"):
+        errors.append("task.place_target is required for pick_place/sorting")
+    if task_type != "inspection_only" and not rec["grasp"].get("strategy"):
+        errors.append("grasp.strategy is required unless task.type is inspection_only")
+    if float(rec["grasp"].get("approach_distance_m", 0.0)) < 0:
+        errors.append("approach_distance_m must be >= 0")
+    if float(rec["grasp"].get("retreat_distance_m", 0.0)) < 0:
+        errors.append("retreat_distance_m must be >= 0")
+    if float(rec["place"].get("clearance_m", 0.0)) < 0:
+        errors.append("place.clearance_m must be >= 0")
+
+    safety = rec["safety"]
+    if safety.get("fake_hardware_first") is not True:
+        errors.append("safety.fake_hardware_first must be true")
+    if safety.get("motion_command_sent") is not False:
+        errors.append("safety.motion_command_sent must be false")
+    if safety.get("runtime_execution_enabled") is not False:
+        errors.append("safety.runtime_execution_enabled must be false")
+
+    if task.get("pick_source") == "perception_detection" and not rec.get("epd_adapter"):
+        warnings.append("perception_detection selected but no EPD adapter configured")
+    warnings.append("conveyor_placeholder is visual/metadata only")
+    if task.get("place_target") == "custom_pose_placeholder":
+        warnings.append("custom_pose_placeholder selected")
+    if not rec.get("tool_compatibility_known", False):
+        warnings.append("unknown end-effector/tool compatibility")
+    if task_type == "inspection_only":
+        warnings.append("inspection_only skips grasp/release execution")
+
+    return {"valid": not errors, "errors": errors, "warnings": warnings, "recipe": rec}
+
+
+def build_offline_task_plan(recipe: dict[str, Any], environment_context: dict[str, Any] | None = None) -> dict[str, Any]:
+    result = validate_task_recipe(recipe)
+    rec = result["recipe"]
+    status = "READY" if result["valid"] else "BLOCKED"
+    task_type = rec["task"].get("type")
+    names = ["validate_recipe", "resolve_pick_source", "resolve_place_target", "approach_pick", "apply_grasp_strategy", "retreat_from_pick", "transfer_placeholder", "approach_place", "release_object", "retreat_from_place", "complete"]
+    steps = []
+    for name in names:
+        step_status = status
+        desc = name.replace("_", " ")
+        if task_type == "inspection_only" and name in {"apply_grasp_strategy", "release_object"}:
+            step_status = "NOT_REQUIRED"
+            desc += " (inspection-only no manipulation)"
+        steps.append({"name": name, "description": desc, "source_fields": ["task", "grasp", "place", "release", "safety"], "safety_classification": SAFETY_MARKERS, "status": step_status})
+
+    return {"result": "PASS" if result["valid"] else "FAIL", "warnings": result["warnings"], "errors": result["errors"], "environment_context": environment_context or {}, "steps": steps}
+
+
+def write_task_plan_json(plan: dict[str, Any], output_dir: str | Path) -> Path:
+    out = Path(output_dir); out.mkdir(parents=True, exist_ok=True)
+    path = out / "task_plan_preview.json"
+    path.write_text(json.dumps(plan, indent=2), encoding="utf-8")
+    return path
+
+
+def write_task_plan_markdown(plan: dict[str, Any], output_dir: str | Path) -> Path:
+    out = Path(output_dir); out.mkdir(parents=True, exist_ok=True)
+    path = out / "task_plan_preview.md"
+    lines = ["# Task Plan Preview", f"Result: {plan['result']}", "", "## Safety", "- OFFLINE_ONLY", "- NO_MOTION_COMMAND", "- NO_MOVEIT_PLAN", "- NO_REAL_HARDWARE", "", "## Steps"]
+    for step in plan["steps"]:
+        lines.append(f"- **{step['name']}** ({step['status']}): {step['description']}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def write_task_plan_report(plan: dict[str, Any], output_dir: str | Path) -> dict[str, Path]:
+    return {"json": write_task_plan_json(plan, output_dir), "markdown": write_task_plan_markdown(plan, output_dir)}

--- a/scripts/preview_task_recipe.py
+++ b/scripts/preview_task_recipe.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_ROOT = REPO_ROOT / "easy_manipulation_deployment" / "emd_demo_nodes" / "run_grasp_execution"
+if str(MODULE_ROOT) not in sys.path:
+    sys.path.insert(0, str(MODULE_ROOT))
+
+from run_grasp_execution.task_recipe import (  # noqa: E402
+    build_offline_task_plan,
+    load_task_recipe,
+    validate_task_recipe,
+    write_task_plan_report,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Offline dry-run task recipe preview")
+    parser.add_argument("--recipe", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--print-plan", action="store_true")
+    args = parser.parse_args(argv)
+
+    recipe = load_task_recipe(args.recipe)
+    validation = validate_task_recipe(recipe)
+    if args.strict and validation["warnings"]:
+        validation["errors"].append("strict mode: warnings present")
+        validation["valid"] = False
+    plan = build_offline_task_plan(validation["recipe"])
+    reports = write_task_plan_report(plan, args.output_dir)
+
+    if args.print_plan:
+        for step in plan["steps"]:
+            print(f"- {step['name']}: {step['status']}")
+
+    print(f"recipe={args.recipe}")
+    print(f"json={reports['json']}")
+    print(f"markdown={reports['markdown']}")
+    for warning in validation["warnings"]:
+        print(f"WARN: {warning}")
+    for error in validation["errors"]:
+        print(f"ERROR: {error}")
+
+    if validation["valid"]:
+        print("WORKCELL_TASK_RECIPE_PREVIEW: PASS")
+        return 0
+    print("WORKCELL_TASK_RECIPE_PREVIEW: FAIL")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_workcell_builder_healthcheck.py
+++ b/scripts/validate_workcell_builder_healthcheck.py
@@ -46,6 +46,8 @@ def main() -> int:
     run_launch = args.smoke_launch
 
     key_files = [
+        repo_root / "scripts/preview_task_recipe.py",
+        repo_root / "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/task_recipe.py",
         repo_root / "workcell_builder/workcell_builder/CMakeLists.txt",
         repo_root / "workcell_builder/workcell_builder/package.xml",
         repo_root / "workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py",
@@ -67,6 +69,8 @@ def main() -> int:
     launch_template = (repo_root / "workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py").read_text(encoding="utf-8")
     for needle in ["use_fake_hardware", "launch_rviz", "launch_rviz:=false", "DeclareLaunchArgument("]:
         _check(needle in launch_template, f"launch template contains {needle}", errors)
+    for marker in ["task_recipe_path", "Task recipe loaded for offline preview"]:
+        _check(marker in launch_template, f"launch template contains {marker}", errors)
 
     scene_cpp = (repo_root / "workcell_builder/workcell_builder/gui/scene_select.cpp").read_text(encoding="utf-8")
     _check("demo.launch.py use_fake_hardware:=true" in scene_cpp, "guidance uses fake hardware default", errors)
@@ -80,6 +84,13 @@ def main() -> int:
 
     for artifact in ["workcell_studio_summary.json", "workcell_studio_summary.md", "preview/workcell_preview.svg", "preview/workcell_preview.html"]:
         _check(artifact in scene_cpp, f"artifact string present: {artifact}", errors)
+    preview_script = (repo_root / "scripts/preview_task_recipe.py").read_text(encoding="utf-8")
+    _check("WORKCELL_TASK_RECIPE_PREVIEW: PASS" in preview_script, "preview CLI has PASS marker", errors)
+    task_recipe_module = (repo_root / "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/task_recipe.py").read_text(encoding="utf-8")
+    for marker in ["OFFLINE_ONLY", "NO_MOTION_COMMAND", "NO_MOVEIT_PLAN", "NO_REAL_HARDWARE"]:
+        _check(marker in task_recipe_module, f"task preview safety marker present: {marker}", errors)
+    for forbidden in ["moveit_msgs/srv/GetMotionPlan", "execute_trajectory", "FollowJointTrajectory"]:
+        _check(forbidden.lower() not in (preview_script + task_recipe_module).lower(), f"dry-run code does not call runtime motion API: {forbidden}", errors)
     for needle in [
         "Task & Grasp Strategy",
         "config\" / \"task_recipe.yaml",

--- a/tests/test_task_recipe_loader_preview.py
+++ b/tests/test_task_recipe_loader_preview.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+import importlib.util
+
+MODULE_PATH = Path('easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/task_recipe.py')
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location('task_recipe', MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _valid_recipe():
+    return {
+        'schema_version': 'workcell_task/v1',
+        'task': {'type': 'pick_place', 'pick_source': 'bin_a', 'place_target': 'bin_b'},
+        'grasp': {'strategy': 'finger_top', 'approach_distance_m': 0.1, 'retreat_distance_m': 0.1},
+        'place': {'clearance_m': 0.02},
+        'release': {'strategy': 'open_gripper'},
+        'safety': {'fake_hardware_first': True, 'motion_command_sent': False, 'runtime_execution_enabled': False},
+    }
+
+
+def test_loader_module_and_functions_exist():
+    assert MODULE_PATH.exists()
+    mod = _load_module()
+    for name in ['load_task_recipe', 'validate_task_recipe', 'normalize_task_recipe', 'build_offline_task_plan', 'write_task_plan_report', 'write_task_plan_markdown', 'write_task_plan_json']:
+        assert hasattr(mod, name)
+
+
+def test_schema_required_and_validation_blocks_invalid_values():
+    mod = _load_module()
+    r = _valid_recipe(); r['schema_version'] = 'bad'
+    assert not mod.validate_task_recipe(r)['valid']
+    r = _valid_recipe(); r['grasp']['approach_distance_m'] = -0.1
+    assert not mod.validate_task_recipe(r)['valid']
+    r = _valid_recipe(); del r['task']['pick_source']
+    assert not mod.validate_task_recipe(r)['valid']
+    r = _valid_recipe(); del r['task']['place_target']
+    assert not mod.validate_task_recipe(r)['valid']
+
+
+def test_safety_markers_required():
+    mod = _load_module()
+    r = _valid_recipe(); r['safety']['fake_hardware_first'] = False
+    assert not mod.validate_task_recipe(r)['valid']
+    r = _valid_recipe(); r['safety']['motion_command_sent'] = True
+    assert not mod.validate_task_recipe(r)['valid']
+    r = _valid_recipe(); r['safety']['runtime_execution_enabled'] = True
+    assert not mod.validate_task_recipe(r)['valid']
+
+
+def test_plan_order_and_safety_markers_present():
+    mod = _load_module()
+    plan = mod.build_offline_task_plan(_valid_recipe())
+    assert [s['name'] for s in plan['steps']] == [
+      'validate_recipe','resolve_pick_source','resolve_place_target','approach_pick','apply_grasp_strategy','retreat_from_pick','transfer_placeholder','approach_place','release_object','retreat_from_place','complete'
+    ]
+    txt = str(plan)
+    for marker in ['OFFLINE_ONLY', 'NO_MOTION_COMMAND', 'NO_MOVEIT_PLAN', 'NO_REAL_HARDWARE']:
+        assert marker in txt
+
+
+def test_cli_and_launch_template_passive_and_safe_strings():
+    cli = Path('scripts/preview_task_recipe.py').read_text(encoding='utf-8')
+    assert 'WORKCELL_TASK_RECIPE_PREVIEW: PASS' in cli
+    launch = Path('workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py').read_text(encoding='utf-8')
+    assert 'task_recipe_path' in launch
+    assert 'Task recipe loaded for offline preview' in launch
+    lowered = (cli + launch).lower()
+    assert 'moveit_msgs/srv/getmotionplan' not in lowered
+    assert 'execute_trajectory' not in lowered

--- a/tests/test_workcell_builder_healthcheck.py
+++ b/tests/test_workcell_builder_healthcheck.py
@@ -39,3 +39,9 @@ def test_healthcheck_checks_artifacts_strings_and_placeholders_and_asset_ui():
     assert "unknown_description" in txt
     assert "unknown_moveit_config" in txt
     assert "none_moveit_config" in txt
+
+
+def test_healthcheck_includes_task_recipe_preview_checks():
+    txt = Path("scripts/validate_workcell_builder_healthcheck.py").read_text(encoding="utf-8")
+    for needle in ["preview_task_recipe.py", "task_recipe.py", "WORKCELL_TASK_RECIPE_PREVIEW: PASS", "task_recipe_path", "OFFLINE_ONLY", "NO_MOTION_COMMAND", "NO_MOVEIT_PLAN", "NO_REAL_HARDWARE"]:
+        assert needle in txt

--- a/tests/test_workcell_builder_task_grasp_strategy.py
+++ b/tests/test_workcell_builder_task_grasp_strategy.py
@@ -27,3 +27,9 @@ def test_no_runtime_execution_or_moveit_service_calls_added():
     cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8').lower()
     assert 'moveit_msgs/srv/getmotionplan' not in cpp
     assert 'motion_plan' not in cpp or 'preview' in cpp
+
+
+def test_readiness_and_summary_task_preview_strings_exist():
+    cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
+    for needle in ['task_recipe.yaml', 'Task recipe generated: OK', 'Task plan dry-run preview:', 'workcell_studio_summary.json', 'workcell_studio_summary.md']:
+        assert needle in cpp

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -1931,7 +1931,7 @@ std::string SceneSelect::build_workcell_readiness_report(
   out << "selected environment objects/STLs: " << scene.object_vector.size() << "\n";
   out << "selected output package path: " << scene_dir.string() << "\n";
   out << "fake hardware default status: use_fake_hardware:=true\n";
-  out << "Task recipe: OK\nGrasp strategy: OK\nPick source: OK\nPlace target: OK\n";
+  out << "Task recipe: OK\nTask recipe generated: OK\nTask plan dry-run preview: WARN (run scripts/preview_task_recipe.py)\nGrasp strategy: OK\nPick source: OK\nPlace target: OK\n";
   out << "Tool compatibility: " << (warnings.empty() ? "OK" : "WARN") << "\n";
   for (const auto & b : blockers) { out << "BLOCKER: " << b << "\n"; }
   for (const auto & w : warnings) { out << "WARNING: " << w << "\n"; }
@@ -1977,7 +1977,10 @@ void SceneSelect::write_workcell_studio_summary(const Scene & scene, const fs::p
        << "  \"approach_distance_m\": " << task_cfg.approach_distance_m << ",\n"
        << "  \"retreat_distance_m\": " << task_cfg.retreat_distance_m << ",\n"
        << "  \"release_strategy\": \"" << task_cfg.release_strategy << "\",\n"
-       << "  \"safety_statement\": \"Task/grasp recipe generated for offline/fake-hardware planning only. No robot motion was commanded.\"\n"
+       << "  \"task_recipe_path\": \"config/task_recipe.yaml\",\n"
+       << "  \"task_plan_preview_path\": \"task_plan_preview.json\",\n"
+       << "  \"dry_run_preview_status\": \"WARN\",\n"
+       << "  \"safety_statement\": \"Task recipe preview is offline only. No MoveIt planning service was called and no robot motion was commanded.\"\n"
        << "}\n";
   std::ofstream mout(md_file.string());
   mout << "# Workcell Studio Summary\n\n";
@@ -1993,7 +1996,11 @@ void SceneSelect::write_workcell_studio_summary(const Scene & scene, const fs::p
   mout << "- orientation mode: " << task_cfg.orientation_mode << "\n";
   mout << "- approach/retreat distances (m): " << task_cfg.approach_distance_m << "/" << task_cfg.retreat_distance_m << "\n";
   mout << "- release strategy: " << task_cfg.release_strategy << "\n";
+  mout << "- task_recipe_path: config/task_recipe.yaml\n";
+  mout << "- task_plan_preview_path: task_plan_preview.json\n";
+  mout << "- dry_run_preview_status: WARN\n";
   mout << "- Task/grasp recipe generated for offline/fake-hardware planning only. No robot motion was commanded.\n";
+  mout << "- Task recipe preview is offline only. No MoveIt planning service was called and no robot motion was commanded.\n";
 }
 
 void SceneSelect::on_back_clicked()

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -440,6 +440,7 @@ def _launch_setup(context):
     octomap_max_range = LaunchConfiguration("octomap_max_range")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     launch_rviz = LaunchConfiguration("launch_rviz")
+    task_recipe_path = LaunchConfiguration("task_recipe_path")
     # Keep joint states isolated per-scene to avoid global topic collisions.
     joint_states_topic = f"/{scene_pkg}/joint_states"
 
@@ -712,10 +713,12 @@ def _launch_setup(context):
     controller_status_logs = [LogInfo(msg=f"[workcell_builder] {status}") for status in controller_statuses]
     controller_warning_logs = [LogInfo(msg=f"[workcell_builder] WARNING: {warning}") for warning in controller_filter_warnings]
     fake_hw_ready_log = LogInfo(msg=f"[workcell_builder] fake hardware launch available (use_fake_hardware:={use_fake_hardware.perform(context)} launch_rviz:={launch_rviz.perform(context)}; headless hint launch_rviz:=false)")
+    task_recipe_log = LogInfo(msg=f"[workcell_builder] Task recipe loaded for offline preview: {task_recipe_path.perform(context)}")
 
     return [
         octomap_launch_message,
         fake_hw_ready_log,
+        task_recipe_log,
         *controller_status_logs,
         *controller_warning_logs,
         static_tf,
@@ -783,6 +786,11 @@ def generate_launch_description():
             "launch_rviz",
             default_value="true",
             description="Launch RViz alongside MoveIt nodes (set false for headless CI/smoke).",
+        ),
+        DeclareLaunchArgument(
+            "task_recipe_path",
+            default_value=os.path.join(get_package_share_directory(scene_pkg), "config", "task_recipe.yaml"),
+            description="Passive metadata path to the generated offline task recipe.",
         ),
         DeclareLaunchArgument(
             "use_fake_hardware",


### PR DESCRIPTION
### Motivation
- Make the generated `config/task_recipe.yaml` usable as a safe offline artifact by validating schema and producing a non-executing, human/machine-readable dry-run task plan preview. 
- Preserve fake-hardware-first safety guarantees and ensure no robot motion, MoveIt planning, or real-hardware activation is introduced by preview tooling.

### Description
- Adds a reusable preview module `run_grasp_execution/task_recipe.py` exposing `load_task_recipe`, `validate_task_recipe`, `normalize_task_recipe`, `build_offline_task_plan`, `write_task_plan_report`, `write_task_plan_markdown`, and `write_task_plan_json`, with checks for `schema_version: workcell_task/v1` and required safety fields. 
- Adds CLI `scripts/preview_task_recipe.py` with flags `--recipe`, `--output-dir`, `--strict`, and `--print-plan` that writes `task_plan_preview.json` and `task_plan_preview.md` and prints `WORKCELL_TASK_RECIPE_PREVIEW: PASS|FAIL`. 
- Integrates passive metadata only into generation outputs and templates by adding a `task_recipe_path` launch argument and an offline-only log message to the Humble `demo.launch.py`, and updates `SceneSelect` summaries to reference `task_recipe_path`, `task_plan_preview_path`, `dry_run_preview_status` and an explicit offline safety statement. 
- Extends `scripts/validate_workcell_builder_healthcheck.py` and tests to check for the preview CLI/module presence, safety markers (`OFFLINE_ONLY`, `NO_MOTION_COMMAND`, `NO_MOVEIT_PLAN`, `NO_REAL_HARDWARE`), and absence of runtime motion/MoveIt API calls in the dry-run code paths, and adds focused unit tests and documentation (`docs/manuals/WORKCELL_TASK_RECIPE_PREVIEW.md`).

### Testing
- Added `tests/test_task_recipe_loader_preview.py` and updated `tests/test_workcell_builder_task_grasp_strategy.py` and `tests/test_workcell_builder_healthcheck.py` to validate loader functions, schema enforcement, safety flags, plan step ordering, passive launch metadata, and healthcheck coverage. 
- Ran the focused test subset: `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_task_recipe_loader_preview.py tests/test_workcell_builder_task_grasp_strategy.py tests/test_workcell_builder_healthcheck.py` which completed with `14 passed`.
- Healthcheck and source-string checks confirm no calls or signatures for MoveIt planning or trajectory execution were introduced in the dry-run code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a06ab0248331bb961c4f52335c0b)