### PR TITLE
Add safe ROS2/RViz dry-run task recipe visualizer and launch integration

### DIFF
--- a/docs/manuals/WORKCELL_TASK_RECIPE_RVIZ_PREVIEW.md
+++ b/docs/manuals/WORKCELL_TASK_RECIPE_RVIZ_PREVIEW.md
@@ -1,0 +1,29 @@
+# Workcell Task Recipe RViz Preview
+
+Offline dry-run preview visualizer for generated task_recipe.yaml.
+
+- Publishes passive markers on `/workcell_studio/task_plan_markers`.
+- Writes `task_plan_preview.json` and `task_plan_preview.md`.
+- **Does not** command robot motion, call MoveIt planning, or enable real hardware.
+
+Launch args: `launch_task_preview`, `task_recipe_path`, `task_preview_output_dir`, `task_preview_markers`, `launch_rviz`, `use_fake_hardware`.
+
+```bash
+cd ~/workcell_ws
+source /opt/ros/humble/setup.bash
+source install/setup.bash
+
+ros2 launch <scene_name> demo.launch.py \
+  use_fake_hardware:=true \
+  launch_rviz:=true \
+  launch_task_preview:=true
+```
+
+Headless:
+
+```bash
+ros2 launch <scene_name> demo.launch.py \
+  use_fake_hardware:=true \
+  launch_rviz:=false \
+  launch_task_preview:=true
+```

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(emd_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(ament_index_cpp REQUIRED)
+find_package(rclpy REQUIRED)
 
 add_executable(demo_node src/demo_node.cpp)
 target_include_directories(demo_node PUBLIC include)
@@ -65,6 +66,11 @@ install(DIRECTORY
 install(DIRECTORY
   config
   DESTINATION share/${PROJECT_NAME}
+)
+
+install(PROGRAMS
+  run_grasp_execution/task_recipe_visualizer_node.py
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/package.xml
@@ -16,6 +16,8 @@
   <depend>emd_waypoint_execution</depend>
 
   <exec_depend>xacro</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
+  <exec_depend>rclpy</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>tf2_ros</exec_depend>

--- a/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/task_recipe_visualizer_node.py
+++ b/easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/task_recipe_visualizer_node.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+from pathlib import Path
+
+import rclpy
+from rclpy.node import Node
+
+from .task_recipe import load_task_recipe, validate_task_recipe, build_offline_task_plan, write_task_plan_report
+
+try:
+    from visualization_msgs.msg import Marker, MarkerArray
+    MARKERS_AVAILABLE = True
+except Exception:
+    MARKERS_AVAILABLE = False
+
+
+class TaskRecipeVisualizerNode(Node):
+    def __init__(self) -> None:
+        super().__init__('task_recipe_visualizer_node')
+        self.declare_parameter('task_recipe_path', '')
+        self.declare_parameter('output_dir', '/tmp/workcell_task_preview')
+        self.declare_parameter('publish_markers', True)
+        self.declare_parameter('dry_run_only', True)
+        self.declare_parameter('keep_alive', False)
+        self.declare_parameter('frame_id', 'world')
+
+        self._publisher = None
+        if MARKERS_AVAILABLE and bool(self.get_parameter('publish_markers').value):
+            self._publisher = self.create_publisher(MarkerArray, '/workcell_studio/task_plan_markers', 10)
+
+        self._run_preview()
+
+    def _run_preview(self) -> None:
+        recipe_path = Path(str(self.get_parameter('task_recipe_path').value))
+        output_dir = Path(str(self.get_parameter('output_dir').value))
+        dry_run_only = bool(self.get_parameter('dry_run_only').value)
+        frame_id = str(self.get_parameter('frame_id').value)
+
+        try:
+            if not dry_run_only:
+                raise RuntimeError('dry_run_only must be true')
+            recipe = load_task_recipe(recipe_path)
+            validation = validate_task_recipe(recipe)
+            plan = build_offline_task_plan(recipe, {'frame_id': frame_id, 'rviz_preview': True})
+            report = write_task_plan_report(plan, output_dir)
+            for idx, step in enumerate(plan.get('steps', []), start=1):
+                self.get_logger().info(f"[{idx:02d}] {step.get('name')} -> {step.get('status')}")
+            self.get_logger().info(f"Task preview reports: {report['json']} | {report['markdown']} (task_plan_preview.json/task_plan_preview.md)")
+            if self._publisher is not None:
+                self._publisher.publish(self._build_markers(recipe, validation, frame_id))
+            if validation.get('valid'):
+                self.get_logger().info('WORKCELL_TASK_RECIPE_RVIZ_PREVIEW: PASS')
+            else:
+                self.get_logger().info('WORKCELL_TASK_RECIPE_RVIZ_PREVIEW: FAIL')
+        except Exception as exc:
+            self.get_logger().error(f'WORKCELL_TASK_RECIPE_RVIZ_PREVIEW: FAIL ({exc})')
+
+    def _build_markers(self, recipe: dict, validation: dict, frame_id: str) -> MarkerArray:
+        arr = MarkerArray()
+        labels = [
+            'pick source','approach pick','grasp','retreat','transfer placeholder',
+            'approach place','release','retreat','complete'
+        ]
+        for i, label in enumerate(labels):
+            m = Marker()
+            m.header.frame_id = frame_id
+            m.id = i
+            m.ns = 'task_plan'
+            m.type = Marker.TEXT_VIEW_FACING if i in (2,6,8) else (Marker.ARROW if i in (1,3,4,5,7) else Marker.SPHERE)
+            m.action = Marker.ADD
+            m.pose.position.x = float(i) * 0.2
+            m.pose.position.y = 0.0
+            m.pose.position.z = 0.3
+            m.scale.x = 0.06
+            m.scale.y = 0.06
+            m.scale.z = 0.06
+            m.color.a = 1.0
+            m.color.r = 0.2
+            m.color.g = 0.8 if validation.get('valid') else 0.8
+            m.color.b = 0.2 if validation.get('valid') else 0.0
+            m.text = label
+            arr.markers.append(m)
+        safety = Marker()
+        safety.header.frame_id = frame_id
+        safety.id = 999
+        safety.ns = 'task_plan_safety'
+        safety.type = Marker.TEXT_VIEW_FACING
+        safety.action = Marker.ADD
+        safety.pose.position.x = 0.0
+        safety.pose.position.y = -0.25
+        safety.pose.position.z = 0.45
+        safety.scale.z = 0.08
+        safety.color.a = 1.0
+        safety.color.r = 1.0
+        safety.color.g = 1.0
+        safety.color.b = 0.0
+        grasp_strategy = recipe.get('grasp', {}).get('strategy', 'unknown')
+        safety.text = f'Offline dry-run preview only — no robot motion | grasp={grasp_strategy}'
+        arr.markers.append(safety)
+        return arr
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = TaskRecipeVisualizerNode()
+    keep_alive = bool(node.get_parameter('keep_alive').value)
+    if keep_alive:
+        rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/validate_workcell_builder_healthcheck.py
+++ b/scripts/validate_workcell_builder_healthcheck.py
@@ -48,6 +48,7 @@ def main() -> int:
     key_files = [
         repo_root / "scripts/preview_task_recipe.py",
         repo_root / "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/task_recipe.py",
+        repo_root / "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/task_recipe_visualizer_node.py",
         repo_root / "workcell_builder/workcell_builder/CMakeLists.txt",
         repo_root / "workcell_builder/workcell_builder/package.xml",
         repo_root / "workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py",
@@ -69,12 +70,13 @@ def main() -> int:
     launch_template = (repo_root / "workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py").read_text(encoding="utf-8")
     for needle in ["use_fake_hardware", "launch_rviz", "launch_rviz:=false", "DeclareLaunchArgument("]:
         _check(needle in launch_template, f"launch template contains {needle}", errors)
-    for marker in ["task_recipe_path", "Task recipe loaded for offline preview"]:
+    for marker in ["task_recipe_path", "launch_task_preview", "task_preview_markers", "task_preview_output_dir", "Task recipe loaded for offline preview"]:
         _check(marker in launch_template, f"launch template contains {marker}", errors)
 
     scene_cpp = (repo_root / "workcell_builder/workcell_builder/gui/scene_select.cpp").read_text(encoding="utf-8")
     _check("demo.launch.py use_fake_hardware:=true" in scene_cpp, "guidance uses fake hardware default", errors)
     _check("demo.launch.py use_fake_hardware:=false" not in scene_cpp, "default guidance does not suggest real hardware", errors)
+    _check("launch_task_preview:=true" in scene_cpp, "guidance includes dry-run task preview launch", errors)
 
     for bad in ["unknown_description", "unknown_moveit_config", "none_moveit_config"]:
         _check(bad not in scene_cpp.lower(), f"forbidden placeholder text absent: {bad}", errors)
@@ -85,12 +87,15 @@ def main() -> int:
     for artifact in ["workcell_studio_summary.json", "workcell_studio_summary.md", "preview/workcell_preview.svg", "preview/workcell_preview.html"]:
         _check(artifact in scene_cpp, f"artifact string present: {artifact}", errors)
     preview_script = (repo_root / "scripts/preview_task_recipe.py").read_text(encoding="utf-8")
+    preview_visualizer = (repo_root / "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/task_recipe_visualizer_node.py").read_text(encoding="utf-8")
     _check("WORKCELL_TASK_RECIPE_PREVIEW: PASS" in preview_script, "preview CLI has PASS marker", errors)
     task_recipe_module = (repo_root / "easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/task_recipe.py").read_text(encoding="utf-8")
     for marker in ["OFFLINE_ONLY", "NO_MOTION_COMMAND", "NO_MOVEIT_PLAN", "NO_REAL_HARDWARE"]:
         _check(marker in task_recipe_module, f"task preview safety marker present: {marker}", errors)
-    for forbidden in ["moveit_msgs/srv/GetMotionPlan", "execute_trajectory", "FollowJointTrajectory"]:
-        _check(forbidden.lower() not in (preview_script + task_recipe_module).lower(), f"dry-run code does not call runtime motion API: {forbidden}", errors)
+    for required in ["WORKCELL_TASK_RECIPE_RVIZ_PREVIEW: PASS", "/workcell_studio/task_plan_markers", "Offline dry-run preview only", "no robot motion", "no MoveIt planning", "no real hardware"]:
+        _check(required in preview_visualizer or required in launch_template, f"task preview marker present: {required}", errors)
+    for forbidden in ["moveit_msgs/srv/GetMotionPlan", "execute_trajectory", "FollowJointTrajectory", "ActionClient", "/plan_kinematic_path"]:
+        _check(forbidden.lower() not in (preview_script + task_recipe_module + preview_visualizer).lower(), f"dry-run code does not call runtime motion API: {forbidden}", errors)
     for needle in [
         "Task & Grasp Strategy",
         "config\" / \"task_recipe.yaml",

--- a/tests/test_task_recipe_rviz_visualizer.py
+++ b/tests/test_task_recipe_rviz_visualizer.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+def test_visualizer_node_and_launch_template_safety_contract():
+    node = Path("easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/task_recipe_visualizer_node.py")
+    assert node.exists()
+    txt = node.read_text(encoding="utf-8")
+    for needle in [
+        "task_recipe_path", "output_dir", "publish_markers", "dry_run_only", "keep_alive",
+        "load_task_recipe", "validate_task_recipe", "build_offline_task_plan",
+        "task_plan_preview.json", "task_plan_preview.md",
+        "WORKCELL_TASK_RECIPE_RVIZ_PREVIEW: PASS",
+        "/workcell_studio/task_plan_markers", "MarkerArray", "Offline dry-run preview only",
+    ]:
+        assert needle in txt
+
+    launch = Path("workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py").read_text(encoding="utf-8")
+    for needle in ["launch_task_preview", "task_preview_markers", "task_preview_output_dir", "task_recipe_visualizer_node", "condition=IfCondition"]:
+        assert needle in launch
+
+    lowered = txt.lower()
+    for forbidden in ["getmotionplan", "execute_trajectory", "followjointtrajectory", "actionclient", "hardware_interface"]:
+        assert forbidden not in lowered

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -977,7 +977,7 @@ void SceneSelect::generate_scene_package(
   append_info("Next commands:");
   append_info("  colcon build --symlink-install --packages-select " + scene_name);
   append_info("  source install/setup.bash");
-  append_info("  ros2 launch " + scene_name + " demo.launch.py use_fake_hardware:=true");
+  append_info("  ros2 launch " + scene_name + " demo.launch.py use_fake_hardware:=true launch_task_preview:=true");
   std::ofstream readme((scene_dir / "README.builder.md").string());
   if (readme.is_open()) {
     readme << "# Builder Scene Metadata\n\n";
@@ -1088,7 +1088,7 @@ void SceneSelect::generate_scene_files(Scene scene)
   append_info("  cd " + workcell_path.string());
   append_info("  colcon build --symlink-install --packages-select " + scene.name);
   append_info("  source install/setup.bash");
-  append_info("  ros2 launch " + scene.name + " demo.launch.py use_fake_hardware:=true");
+  append_info("  ros2 launch " + scene.name + " demo.launch.py use_fake_hardware:=true launch_task_preview:=true");
   append_warning("Real hardware mode requires explicit validation and use_fake_hardware:=false.");
   append_info("Workcell Studio metadata generated/updated.");
   append_info("Validation helper: generated/run_builder_validation.sh");
@@ -1480,7 +1480,7 @@ void SceneSelect::on_generate_files_clicked()
 cd <workspace>
 colcon build --symlink-install --packages-select " + curr_scene.name + "
 source install/setup.bash
-ros2 launch " + curr_scene.name + " demo.launch.py use_fake_hardware:=true");
+ros2 launch " + curr_scene.name + " demo.launch.py use_fake_hardware:=true launch_task_preview:=true");
   } else {
     append_error("No scene selected to generate files from.");
   }
@@ -1998,7 +1998,10 @@ void SceneSelect::write_workcell_studio_summary(const Scene & scene, const fs::p
   mout << "- release strategy: " << task_cfg.release_strategy << "\n";
   mout << "- task_recipe_path: config/task_recipe.yaml\n";
   mout << "- task_plan_preview_path: task_plan_preview.json\n";
-  mout << "- dry_run_preview_status: WARN\n";
+  mout << "- task_preview_node: task_recipe_visualizer_node\n";
+  mout << "- task_preview_topic: /workcell_studio/task_plan_markers\n";
+  mout << "- task_preview_status: WARN\n";
+  mout << "- task_preview_safety: Offline RViz/task recipe preview only. No robot motion, no MoveIt planning, no real hardware.\n";
   mout << "- Task/grasp recipe generated for offline/fake-hardware planning only. No robot motion was commanded.\n";
   mout << "- Task recipe preview is offline only. No MoveIt planning service was called and no robot motion was commanded.\n";
 }
@@ -2120,7 +2123,7 @@ void SceneSelect::on_copy_fake_hardware_launch_command_clicked()
 {
   const fs::path scene_dir = scene_dir_for_current_selection();
   const std::string scene_name = scene_dir.empty() ? std::string("<scene_name>") : scene_dir.filename().string();
-  const QString cmd(QString::fromStdString("ros2 launch " + scene_name + " demo.launch.py use_fake_hardware:=true"));
+  const QString cmd(QString::fromStdString("ros2 launch " + scene_name + " demo.launch.py use_fake_hardware:=true launch_task_preview:=true"));
   QApplication::clipboard()->setText(cmd);
   append_success("Copied fake-hardware launch command to clipboard.");
 }

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -441,6 +441,9 @@ def _launch_setup(context):
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     launch_rviz = LaunchConfiguration("launch_rviz")
     task_recipe_path = LaunchConfiguration("task_recipe_path")
+    launch_task_preview = LaunchConfiguration("launch_task_preview")
+    task_preview_output_dir = LaunchConfiguration("task_preview_output_dir")
+    task_preview_markers = LaunchConfiguration("task_preview_markers")
     # Keep joint states isolated per-scene to avoid global topic collisions.
     joint_states_topic = f"/{scene_pkg}/joint_states"
 
@@ -710,15 +713,34 @@ def _launch_setup(context):
         output="screen",
     )
 
+
+    task_preview_node = Node(
+        condition=IfCondition(PythonExpression([launch_task_preview, " == 'true'"])),
+        package="run_grasp_execution",
+        executable="task_recipe_visualizer_node.py",
+        name="task_recipe_visualizer_node",
+        output="screen",
+        parameters=[{
+            "task_recipe_path": task_recipe_path,
+            "output_dir": task_preview_output_dir,
+            "publish_markers": task_preview_markers,
+            "dry_run_only": True,
+            "keep_alive": True,
+            "frame_id": "world",
+        }],
+    )
+
     controller_status_logs = [LogInfo(msg=f"[workcell_builder] {status}") for status in controller_statuses]
     controller_warning_logs = [LogInfo(msg=f"[workcell_builder] WARNING: {warning}") for warning in controller_filter_warnings]
     fake_hw_ready_log = LogInfo(msg=f"[workcell_builder] fake hardware launch available (use_fake_hardware:={use_fake_hardware.perform(context)} launch_rviz:={launch_rviz.perform(context)}; headless hint launch_rviz:=false)")
     task_recipe_log = LogInfo(msg=f"[workcell_builder] Task recipe loaded for offline preview: {task_recipe_path.perform(context)}")
+    task_preview_log = LogInfo(msg="[workcell_builder] Offline dry-run preview only — no robot motion, no MoveIt planning, no real hardware.")
 
     return [
         octomap_launch_message,
         fake_hw_ready_log,
         task_recipe_log,
+        task_preview_log,
         *controller_status_logs,
         *controller_warning_logs,
         static_tf,
@@ -728,6 +750,7 @@ def _launch_setup(context):
         rviz_node,
         workcell_marker_publisher,
         collision_object_publisher,
+        task_preview_node,
     ]
 
 
@@ -786,6 +809,21 @@ def generate_launch_description():
             "launch_rviz",
             default_value="true",
             description="Launch RViz alongside MoveIt nodes (set false for headless CI/smoke).",
+        ),
+        DeclareLaunchArgument(
+            "launch_task_preview",
+            default_value="true",
+            description="Launch passive task recipe RViz/log preview node (dry-run only).",
+        ),
+        DeclareLaunchArgument(
+            "task_preview_output_dir",
+            default_value="/tmp/workcell_task_preview",
+            description="Output directory for task_plan_preview.json and task_plan_preview.md.",
+        ),
+        DeclareLaunchArgument(
+            "task_preview_markers",
+            default_value="true",
+            description="Publish task preview MarkerArray on /workcell_studio/task_plan_markers.",
         ),
         DeclareLaunchArgument(
             "task_recipe_path",


### PR DESCRIPTION
### Motivation
- Provide a passive, offline-only RViz/ROS visualization of generated `config/task_recipe.yaml` so generated scenes can show task intent without commanding motion or calling planning services.
- Preserve fake-hardware-first safety by ensuring the preview never executes trajectories, calls MoveIt services, enables hardware, or introduces runtime execution APIs.

### Description
- Adds a ROS 2 Python visualizer node `easy_manipulation_deployment/emd_demo_nodes/run_grasp_execution/run_grasp_execution/task_recipe_visualizer_node.py` that declares parameters (`task_recipe_path`, `output_dir`, `publish_markers`, `dry_run_only`, `keep_alive`, `frame_id`), loads and validates the recipe using existing `load_task_recipe`/`validate_task_recipe`/`build_offline_task_plan`, writes `task_plan_preview.json` and `task_plan_preview.md`, logs ordered steps and emits `WORKCELL_TASK_RECIPE_RVIZ_PREVIEW: PASS/FAIL`, and publishes a passive `MarkerArray` on `/workcell_studio/task_plan_markers` when available.
- Integrates optional preview into generated Humble demo launch template by adding launch args `launch_task_preview` (default `true`), `task_preview_output_dir`, and `task_preview_markers`, and conditionally launching the visualizer (`task_recipe_visualizer_node.py`) without affecting MoveIt/controllers/real hardware.
- Updates `run_grasp_execution` packaging (`CMakeLists.txt` and `package.xml`) to install the Python node and add `rclpy` and `visualization_msgs` exec deps, and updates `workcell_builder` generated summary/guidance in `scene_select.cpp` to include preview node/topic/status/safety and `launch_task_preview:=true` in safe launch guidance.
- Extends the healthcheck (`scripts/validate_workcell_builder_healthcheck.py`) to verify the visualizer file, new launch args, marker topic/safety text, and the absence of runtime motion/planning/action APIs in preview code; adds a focused test `tests/test_task_recipe_rviz_visualizer.py` and docs `docs/manuals/WORKCELL_TASK_RECIPE_RVIZ_PREVIEW.md`.

### Testing
- Ran unit/smoke tests: `python3 -m pytest -q tests/test_task_recipe_rviz_visualizer.py tests/test_task_recipe_loader_preview.py tests/test_workcell_builder_healthcheck.py` and `python3 -m pytest -q tests/test_workcell_builder_launch_smoke_acceptance.py tests/test_workcell_builder_package_consistency.py tests/test_workcell_builder_task_grasp_strategy.py`, and all executed tests passed (total tests reported: 11 passed and 8 passed in the runs above).
- Healthcheck script and existing preview/loader tests were executed and passed, confirming the visualizer meets the offline/no-motion safety contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a2b64b1083318c1ab10420e98671)