### PR TITLE
Fix Workcell Studio CI smoke test to avoid PyYAML dependency

### DIFF
--- a/tests/fixtures/grasp_strategies/finger_parallel_fixture.yaml
+++ b/tests/fixtures/grasp_strategies/finger_parallel_fixture.yaml
@@ -1,0 +1,4 @@
+# Smoke fixture for finger strategy
+schema_version: grasp_strategy/v1
+id: finger_parallel_fixture
+family: finger

--- a/tests/fixtures/grasp_strategies/suction_top_fixture.yaml
+++ b/tests/fixtures/grasp_strategies/suction_top_fixture.yaml
@@ -1,0 +1,4 @@
+# Smoke fixture for suction strategy
+schema_version: grasp_strategy/v1
+id: suction_top_fixture
+family: suction

--- a/tests/workcell_studio/test_workcell_ci_smoke.py
+++ b/tests/workcell_studio/test_workcell_ci_smoke.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+def test_grasp_strategy_fixtures_smoke() -> None:
+    # Intentionally dependency-free CI smoke test (no PyYAML). Full schema
+    # validation can be added later when scripts/validate_grasp_strategy.py exists.
+    fixture_dir = Path(__file__).resolve().parents[1] / "fixtures" / "grasp_strategies"
+    assert fixture_dir.is_dir(), "Missing tests/fixtures/grasp_strategies directory"
+
+    yaml_files = sorted(fixture_dir.glob("*.yaml"))
+    assert yaml_files, "Expected at least one .yaml grasp strategy fixture"
+
+    fixture_names = [p.name.lower() for p in yaml_files]
+    assert any("suction" in name for name in fixture_names), "Expected a suction-related fixture"
+    assert any("finger" in name or "parallel" in name for name in fixture_names), (
+        "Expected a finger/parallel-gripper-related fixture"
+    )
+
+    for fixture in yaml_files:
+        text = fixture.read_text(encoding="utf-8")
+        assert text.strip(), f"Fixture is empty: {fixture.name}"
+
+        non_comment_lines = [
+            line for line in text.splitlines() if line.strip() and not line.lstrip().startswith("#")
+        ]
+        assert any(":" in line for line in non_comment_lines), (
+            f"Fixture does not look YAML-like (no key:value line): {fixture.name}"
+        )


### PR DESCRIPTION
### Motivation
- The Workcell Studio CI smoke test was failing with `ModuleNotFoundError: No module named 'yaml'` because the test imported PyYAML which is not installed in the CI environment. 
- The smoke test only needs to assert fixture presence and basic YAML-like shape, so it should be dependency-free to avoid brittle CI failures. 
- The change must be test-only and must not modify any runtime, launch, ROS/MoveIt, or safety-related behavior. 

### Description
- Add a dependency-free smoke test at `tests/workcell_studio/test_workcell_ci_smoke.py` that avoids `import yaml` and instead uses stdlib text checks and `pathlib` to validate fixtures. 
- The smoke test verifies that `tests/fixtures/grasp_strategies/` exists, at least one `*.yaml` fixture exists, a suction-related filename exists, a finger/parallel-gripper-related filename exists, each fixture file is non-empty, and each fixture contains at least one non-comment line with a colon to prove YAML-like shape. 
- Add minimal smoke fixtures `tests/fixtures/grasp_strategies/suction_top_fixture.yaml` and `tests/fixtures/grasp_strategies/finger_parallel_fixture.yaml` so the guard meaningfully protects against accidental deletion/regression. 
- Include an in-test comment explaining this is intentionally a dependency-free CI smoke test and that full schema validation can be added later when `scripts/validate_grasp_strategy.py` exists. 

### Testing
- Ran `python3 -m pytest -q tests/workcell_studio/test_workcell_ci_smoke.py` which passed (`1 passed`).
- Ran `grep -R "import yaml" tests/workcell_studio/test_workcell_ci_smoke.py` which produced no matches, confirming the test does not import PyYAML.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01aab352b0833189ad1361a5d4314b)