### PR TITLE
Fix Humble CI dependency install failure in rosdep override script

### DIFF
--- a/scripts/ensure_rosdep_overrides.sh
+++ b/scripts/ensure_rosdep_overrides.sh
@@ -36,6 +36,7 @@ fi
 
 if [[ $needs_update -eq 1 ]]; then
   echo "Registering rosdep overrides from $OVERRIDES_FILE"
+  run_as_root mkdir -p "$(dirname "$ROSDEP_SOURCE_LIST")"
   printf '%s\n' "$ROSDEP_SOURCE_ENTRY" | run_as_root tee "$ROSDEP_SOURCE_LIST" >/dev/null
 else
   echo "Rosdep overrides already registered in $ROSDEP_SOURCE_LIST"


### PR DESCRIPTION
### Motivation
- The Humble CI `Install dependencies` step was failing because `ensure_rosdep_overrides.sh` attempted to write `/etc/ros/rosdep/sources.list.d/10-easy-manipulator-overrides.list` without ensuring the parent directory existed, causing the job to exit early; this is a minimal CI/test-focused fix to restore the install step.

### Description
- Inserted a single directory-creation guard: `run_as_root mkdir -p "$(dirname \"$ROSDEP_SOURCE_LIST\")"` immediately before writing the override file in `scripts/ensure_rosdep_overrides.sh` so the `/etc/ros/rosdep/sources.list.d` directory is created if missing.

### Testing
- Ran `python3 -m pytest -q tests/workcell_studio/test_workcell_ci_smoke.py`, which passed locally, and reproduced the CI install path to confirm the missing-directory error is resolved (the script then advances until it stops later in the local environment due to `rosdep` not being installed, which is expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b05da26483319eae85a58e1b0843)