### PR TITLE
Add Golden Demo Cell generator and acceptance pack

### DIFF
--- a/docs/manuals/WORKCELL_GOLDEN_DEMO_ACCEPTANCE_PACK.md
+++ b/docs/manuals/WORKCELL_GOLDEN_DEMO_ACCEPTANCE_PACK.md
@@ -1,0 +1,59 @@
+# Workcell Golden Demo Acceptance Pack
+
+This artifact is for **developer/test/reference** use. It is **not** a normal operator-first main-page button.
+
+## Generate
+
+```bash
+python3 scripts/generate_golden_workcell_demo.py \
+  --output-dir /tmp/workcell_golden_demo \
+  --scene-name ur5_2f_golden_demo \
+  --validate \
+  --print-summary
+```
+
+Default output is safe:
+- `/tmp/workcell_golden_demo/ur5_2f_golden_demo`
+
+To write into repo scenes, opt in explicitly with `--install-into-scenes`.
+
+## Validate
+
+```bash
+python3 scripts/validate_golden_workcell_demo.py \
+  --scene-dir /tmp/workcell_golden_demo/ur5_2f_golden_demo
+```
+
+## Produced files
+
+- `environment.yaml` (`schema_version: workcell_scene/v1`)
+- `config/task_recipe.yaml` (`schema_version: workcell_task/v1`)
+- `config/perception_metadata.json`
+- `config/compatibility_metadata.json`
+- `config/readiness_overlay_metadata.json`
+- `config/visual_layout_metadata.json`
+- `preview/workcell_preview.svg`
+- `preview/workcell_preview.html`
+- `workcell_studio_summary.json`
+- `workcell_studio_summary.md`
+- `readiness_report.json`
+
+## Fake-hardware-first launch only
+
+```bash
+colcon build --symlink-install --packages-select ur5_2f_golden_demo
+source install/setup.bash
+ros2 launch ur5_2f_golden_demo demo.launch.py use_fake_hardware:=true launch_rviz:=true
+```
+
+Real hardware is intentionally not enabled in this pack.
+
+## Safety proof flags
+
+- `fake_hardware_first: true`
+- `motion_command_sent: false`
+- `runtime_execution_enabled: false`
+- `real_hardware_enabled: false`
+- `moveit_plan_service_called: false`
+
+This pack supports deterministic regression testing and reference demos for the full Workcell Studio pipeline while remaining offline-safe.

--- a/scripts/generate_golden_workcell_demo.py
+++ b/scripts/generate_golden_workcell_demo.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _scene_yaml(scene_name: str) -> str:
+    return f"""schema_version: workcell_scene/v1
+scene:
+  name: {scene_name}
+robot:
+  id: ur5
+tool:
+  id: robotiq_2f85
+compatibility:
+  status: COMPATIBLE
+  profile_pair: ur5__robotiq_2f85
+  tcp_frame: tool0
+  tool_mount_link: ee_link
+placed_objects:
+  - name: table_01
+    asset_id: table_01
+    pose: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  - name: pick_object_01
+    asset_id: pick_object_01
+    pose: [0.45, 0.0, 0.78, 0.0, 0.0, 0.0]
+  - name: bin_left
+    asset_id: bin_left
+    pose: [0.55, 0.25, 0.75, 0.0, 0.0, 0.0]
+  - name: bin_right
+    asset_id: bin_right
+    pose: [0.55, -0.25, 0.75, 0.0, 0.0, 0.0]
+  - name: fixture_01
+    asset_id: fixture_01
+    optional: true
+    pose: [0.3, -0.3, 0.75, 0.0, 0.0, 0.0]
+camera:
+  enabled: true
+  camera_id: realsense_d435i
+  frame_id: camera_link
+  pose: [0.25, -0.45, 1.25, -2.6, 0.0, -1.57]
+  rgb_topic: /camera/color/image_raw
+  depth_topic: /camera/depth/image_rect_raw
+  pointcloud_topic: /camera/depth/color/points
+task:
+  schema_version: workcell_task/v1
+  pick_source: pick_object_01
+  place_target: bin_left
+  grasp_strategy: finger_top
+  release_strategy: open_gripper
+workspace:
+  bounds:
+    x_min: 0.10
+    x_max: 0.80
+    y_min: -0.50
+    y_max: 0.50
+    z_min: 0.65
+    z_max: 1.20
+  zones:
+    - name: robot_base_exclusion
+      type: exclusion
+      shape: circle
+      center: [0.0, 0.0]
+      radius: 0.22
+    - name: operator_warning_zone
+      type: warning
+      shape: rectangle
+      min: [0.0, -0.65]
+      max: [0.95, 0.65]
+safety:
+  fake_hardware_first: true
+  motion_command_sent: false
+  runtime_execution_enabled: false
+  real_hardware_enabled: false
+  moveit_plan_service_called: false
+metadata:
+  golden_demo: true
+  generated_by: generate_golden_workcell_demo.py
+  object_placement_metadata: present
+  visual_layout_metadata: present
+  camera_metadata_status: present
+  compatibility_status: COMPATIBLE
+  readiness_overlay_status: present
+"""
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Generate deterministic golden Workcell Studio demo pack")
+    p.add_argument("--output-dir", default="/tmp/workcell_golden_demo")
+    p.add_argument("--scene-name", default="ur5_2f_golden_demo")
+    p.add_argument("--validate", action="store_true")
+    p.add_argument("--strict", action="store_true")
+    p.add_argument("--overwrite", action="store_true")
+    p.add_argument("--print-summary", action="store_true")
+    p.add_argument("--no-rviz", action="store_true")
+    p.add_argument("--install-into-scenes", action="store_true")
+    a = p.parse_args()
+
+    root = Path(__file__).resolve().parents[1]
+    output_base = (root / "scenes") if a.install_into_scenes else Path(a.output_dir)
+    scene_dir = output_base / a.scene_name
+    if scene_dir.exists() and not a.overwrite:
+        print(f"Refusing to overwrite existing scene: {scene_dir}")
+        print("Use --overwrite to replace it.")
+        return 1
+    if scene_dir.exists():
+        shutil.rmtree(scene_dir)
+
+    _write(scene_dir / "environment.yaml", _scene_yaml(a.scene_name))
+    _write(scene_dir / "config/task_recipe.yaml", """schema_version: workcell_task/v1
+pick:
+  source: pick_object_01
+place:
+  target: bin_left
+grasp_strategy: finger_top
+release_strategy: open_gripper
+tool_type: robotiq_2f85
+tcp_frame: tool0
+safety:
+  fake_hardware_first: true
+  motion_command_sent: false
+  runtime_execution_enabled: false
+  real_hardware_enabled: false
+  moveit_plan_service_called: false
+""")
+    _write(scene_dir / "config/perception_metadata.json", json.dumps({"camera_id": "realsense_d435i", "metadata_only": True}, indent=2) + "\n")
+    _write(scene_dir / "config/compatibility_metadata.json", json.dumps({"status": "COMPATIBLE", "robot": "ur5", "tool": "robotiq_2f85"}, indent=2) + "\n")
+    _write(scene_dir / "config/readiness_overlay_metadata.json", json.dumps({"status": "ready_for_offline_preview", "runtime_execution_enabled": False}, indent=2) + "\n")
+    _write(scene_dir / "config/visual_layout_metadata.json", json.dumps({"layout": "top_down", "grid_enabled": True}, indent=2) + "\n")
+    _write(scene_dir / "preview/workcell_preview.svg", '<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360"><text x="20" y="40">ur5_2f_golden_demo preview</text></svg>\n')
+    _write(scene_dir / "preview/workcell_preview.html", "<html><body><h1>Golden Demo Preview</h1><p>Offline-only reference pack.</p></body></html>\n")
+
+    fake_launch = f"ros2 launch {a.scene_name} demo.launch.py use_fake_hardware:=true launch_rviz:={'false' if a.no_rviz else 'true'}"
+    summary = {
+        "golden_demo": True,
+        "generated_by": "generate_golden_workcell_demo.py",
+        "scene_name": a.scene_name,
+        "scene_schema_validation_status": "pending",
+        "compatibility_status": "COMPATIBLE",
+        "readiness_overlay_status": "present",
+        "camera_metadata_status": "present",
+        "fake_hardware_launch_command": fake_launch,
+        "safety": {
+            "fake_hardware_first": True,
+            "motion_command_sent": False,
+            "runtime_execution_enabled": False,
+            "real_hardware_enabled": False,
+            "moveit_plan_service_called": False,
+        },
+    }
+    _write(scene_dir / "workcell_studio_summary.json", json.dumps(summary, indent=2) + "\n")
+    _write(scene_dir / "workcell_studio_summary.md", f"""# Workcell Studio Golden Demo Summary
+
+golden_demo: true
+
+generated_by: generate_golden_workcell_demo.py
+
+scene_schema_validation_status: pending
+compatibility_status: COMPATIBLE
+readiness_overlay_status: present
+camera_metadata_status: present
+
+fake_hardware_launch_command: `{fake_launch}`
+
+Safety flags:
+- fake_hardware_first: true
+- motion_command_sent: false
+- runtime_execution_enabled: false
+- real_hardware_enabled: false
+- moveit_plan_service_called: false
+
+Build/launch (fake hardware only):
+- colcon build --symlink-install --packages-select {a.scene_name}
+- source install/setup.bash
+- {fake_launch}
+""")
+    _write(scene_dir / "readiness_report.json", json.dumps({"status": "PASS", "offline_only": True}, indent=2) + "\n")
+
+    if a.validate:
+        cmd = [sys.executable, str(root / "scripts/validate_workcell_scene.py"), "--scene-dir", str(scene_dir)]
+        if a.strict:
+            cmd.append("--strict")
+        rc = subprocess.run(cmd, check=False).returncode
+        summary["scene_schema_validation_status"] = "PASS" if rc == 0 else "FAIL"
+        _write(scene_dir / "workcell_studio_summary.json", json.dumps(summary, indent=2) + "\n")
+        if rc != 0:
+            return rc
+
+    if a.print_summary:
+        print(json.dumps(summary, indent=2))
+    print(f"Generated golden demo pack at: {scene_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_golden_workcell_demo.py
+++ b/scripts/validate_golden_workcell_demo.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import json
+from pathlib import Path
+
+PASS='WORKCELL_GOLDEN_DEMO: PASS'
+WARN='WORKCELL_GOLDEN_DEMO: WARN'
+FAIL='WORKCELL_GOLDEN_DEMO: FAIL'
+
+
+def main()->int:
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--scene-dir', required=True)
+    a=ap.parse_args()
+    d=Path(a.scene_dir)
+    blocks=[]; warns=[]
+    required=[
+        'environment.yaml','config/task_recipe.yaml','workcell_studio_summary.json','workcell_studio_summary.md',
+        'preview/workcell_preview.svg','preview/workcell_preview.html','config/perception_metadata.json',
+        'config/compatibility_metadata.json','config/readiness_overlay_metadata.json'
+    ]
+    for r in required:
+        if not (d/r).exists(): blocks.append(f'missing required file: {r}')
+    env=(d/'environment.yaml').read_text(encoding='utf-8') if (d/'environment.yaml').exists() else ''
+    task=(d/'config/task_recipe.yaml').read_text(encoding='utf-8') if (d/'config/task_recipe.yaml').exists() else ''
+    summaryj={}
+    if (d/'workcell_studio_summary.json').exists():
+        try: summaryj=json.loads((d/'workcell_studio_summary.json').read_text(encoding='utf-8'))
+        except Exception: blocks.append('summary json invalid')
+
+    for tok in ['schema_version: workcell_scene/v1','schema_version: workcell_task/v1','realsense_d435i','robotiq','fake_hardware_first: true','real_hardware_enabled: false','motion_command_sent: false','runtime_execution_enabled: false','moveit_plan_service_called: false']:
+        if tok not in (env+'\n'+task): blocks.append(f'missing token: {tok}')
+
+    launch_cmd=str(summaryj.get('fake_hardware_launch_command',''))
+    if 'use_fake_hardware:=true' not in launch_cmd: blocks.append('missing fake-hardware launch command')
+    if 'use_fake_hardware:=false' in launch_cmd: blocks.append('real hardware launch must not be default')
+    if summaryj.get('golden_demo') is not True: warns.append('golden_demo flag not true in summary json')
+
+    if blocks: print(FAIL)
+    elif warns: print(WARN)
+    else: print(PASS)
+    for b in blocks: print('BLOCKER:',b)
+    for w in warns: print('WARNING:',w)
+    return 1 if blocks else 0
+
+
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/scripts/validate_workcell_builder_healthcheck.py
+++ b/scripts/validate_workcell_builder_healthcheck.py
@@ -151,6 +151,23 @@ def main() -> int:
         _check(needle in scene_cpp or needle in (repo_root / "workcell_builder/workcell_builder/gui/scene_select.ui").read_text(encoding="utf-8"), f"task/grasp marker present: {needle}", errors)
 
     
+
+    golden_gen = repo_root / "scripts/generate_golden_workcell_demo.py"
+    golden_val = repo_root / "scripts/validate_golden_workcell_demo.py"
+    _check(golden_gen.exists(), "golden demo generator script exists", errors)
+    _check(golden_val.exists(), "golden demo validator script exists", errors)
+    if golden_gen.exists():
+        gtxt = golden_gen.read_text(encoding="utf-8").lower()
+        for marker in ["fake_hardware_first: true", "real_hardware_enabled: false", "motion_command_sent: false", "runtime_execution_enabled: false", "--install-into-scenes"]:
+            _check(marker in gtxt, f"golden generator marker present: {marker}", errors)
+        for forbidden in ["import yaml", "pyyaml", "getmotionplan", "execute_trajectory", "/plan_kinematic_path"]:
+            _check(forbidden not in gtxt, f"golden generator excludes forbidden marker: {forbidden}", errors)
+    if golden_val.exists():
+        vtxt = golden_val.read_text(encoding="utf-8").lower()
+        for marker in ["workcell_golden_demo: pass", "workcell_golden_demo: warn", "workcell_golden_demo: fail"]:
+            _check(marker in vtxt, f"golden validator marker present: {marker}", errors)
+        _check("pyyaml" not in vtxt and "import yaml" not in vtxt, "golden validator uses stdlib only", errors)
+
     compat_root = repo_root / "workcell_builder/workcell_builder/config/compatibility_profiles"
     _check((compat_root / "robots").exists() and (compat_root / "tools").exists() and (compat_root / "pairs").exists(), "compatibility profile catalog exists", errors)
     compat_cpp = (repo_root / "workcell_builder/workcell_builder/src_robot_tool_compatibility.cpp").read_text(encoding="utf-8")

--- a/tests/test_workcell_golden_demo_acceptance_pack.py
+++ b/tests/test_workcell_golden_demo_acceptance_pack.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+
+def test_golden_scripts_exist_and_markers_present():
+    gen = Path('scripts/generate_golden_workcell_demo.py')
+    val = Path('scripts/validate_golden_workcell_demo.py')
+    assert gen.exists()
+    assert val.exists()
+    vtxt = val.read_text(encoding='utf-8')
+    assert 'WORKCELL_GOLDEN_DEMO: PASS' in vtxt
+    assert 'WORKCELL_GOLDEN_DEMO: WARN' in vtxt
+    assert 'WORKCELL_GOLDEN_DEMO: FAIL' in vtxt
+
+
+def test_golden_generator_tokens_and_safety_markers():
+    txt = Path('scripts/generate_golden_workcell_demo.py').read_text(encoding='utf-8')
+    for needle in [
+        'ur5_2f_golden_demo',
+        'schema_version: workcell_scene/v1',
+        'schema_version: workcell_task/v1',
+        'realsense_d435i',
+        'robotiq',
+        'fake_hardware_first: true',
+        'real_hardware_enabled: false',
+        'motion_command_sent: false',
+        'runtime_execution_enabled: false',
+        'placed_objects',
+        'visual_layout_metadata',
+        'perception_metadata.json',
+        'compatibility_metadata.json',
+        'readiness_overlay_metadata.json',
+        '--install-into-scenes',
+    ]:
+        assert needle in txt
+
+
+def test_no_forbidden_runtime_or_deps_or_main_button_tokens():
+    txt = Path('scripts/generate_golden_workcell_demo.py').read_text(encoding='utf-8').lower()
+    for forbidden in ['import yaml', 'pyyaml', 'getmotionplan', 'execute_trajectory', '/plan_kinematic_path', 'streamlit']:
+        assert forbidden not in txt
+    scene_cpp = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8').lower()
+    assert 'golden demo pack' not in scene_cpp
+
+
+def test_workspace_alias_policy_files_untouched_markers_present():
+    fix = Path('scripts/fix_workspace_layout.sh').read_text(encoding='utf-8')
+    verify = Path('scripts/verify_workspace_discovery.sh').read_text(encoding='utf-8')
+    assert 'ensure_workspace_alias "assets"' in fix
+    assert 'ensure_workspace_alias "scenes"' in fix
+    assert 'for alias in assets scenes' in verify


### PR DESCRIPTION
### Motivation
- Provide a deterministic, offline-safe golden demo scene and acceptance pack to exercise the full Workcell Studio pipeline end-to-end as a developer/test artifact.
- Keep the golden demo out of normal operator workflows and avoid adding prominent UI surfaces, while enabling CI/healthcheck and local validation.

### Description
- Added CLI generator `scripts/generate_golden_workcell_demo.py` that creates a deterministic `ur5_2f_golden_demo` pack (default output `/tmp/workcell_golden_demo/ur5_2f_golden_demo`) with `environment.yaml` (`schema_version: workcell_scene/v1`), `config/task_recipe.yaml` (`schema_version: workcell_task/v1`), placed objects, camera/perception metadata, compatibility metadata, visual layout metadata, readiness metadata, preview artifacts, and `workcell_studio_summary.{json,md}`; supports flags `--output-dir`, `--scene-name`, `--validate`, `--strict`, `--overwrite`, `--print-summary`, `--no-rviz`, and opt-in `--install-into-scenes`.
- Added acceptance validator `scripts/validate_golden_workcell_demo.py` that checks for required artifacts and tokens and emits `WORKCELL_GOLDEN_DEMO: PASS/WARN/FAIL` markers and enforces fake-hardware-first launch guidance and safety flags.
- Updated `scripts/validate_workcell_builder_healthcheck.py` to check the presence and constraints of the golden generator/validator, verify stdlib-only usage (no PyYAML), and assert forbidden runtime/planning API markers are absent in new tooling.
- Added tests `tests/test_workcell_golden_demo_acceptance_pack.py` and documentation `docs/manuals/WORKCELL_GOLDEN_DEMO_ACCEPTANCE_PACK.md` describing CLI usage, produced files, fake-hardware-only launch guidance, and safety flags.

### Testing
- Ran targeted pytest suite: `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_golden_demo_acceptance_pack.py tests/test_workcell_builder_offline_readiness_overlay.py tests/test_workcell_builder_camera_perception_metadata.py tests/test_workcell_scene_schema_v1_validator.py tests/test_workcell_builder_robot_tool_compatibility_profiles.py tests/test_workcell_builder_healthcheck.py tests/test_workspace_layout_assets_scenes_aliases.py` and all tests passed (`25 passed`).
- Executed generator smoke run with validation and summary: `python3 scripts/generate_golden_workcell_demo.py --output-dir /tmp/workcell_golden_demo --scene-name ur5_2f_golden_demo --validate --print-summary` which produced `WORKCELL_SCENE_SCHEMA: PASS` and printed the generated summary JSON.
- Executed validator and schema/health checks: `python3 scripts/validate_golden_workcell_demo.py --scene-dir /tmp/workcell_golden_demo/ur5_2f_golden_demo`, `python3 scripts/validate_workcell_scene.py --scene-dir /tmp/workcell_golden_demo/ur5_2f_golden_demo`, and `python3 scripts/validate_workcell_builder_healthcheck.py --repo-root . --workspace ~/workcell_ws --skip-colcon --skip-launch`, each of which reported PASS for the relevant validations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c939a5b88331804e2e0cf395e003)