### PR TITLE
Add safe headless fake-hardware smoke acceptance gate

### DIFF
--- a/docs/manuals/WORKCELL_FAKE_HARDWARE_SMOKE_ACCEPTANCE.md
+++ b/docs/manuals/WORKCELL_FAKE_HARDWARE_SMOKE_ACCEPTANCE.md
@@ -1,0 +1,44 @@
+# WORKCELL Fake-Hardware Smoke Acceptance
+
+## Purpose
+Provide one repeatable acceptance gate for Workcell Studio generated scenes that validates safe fake-hardware launch readiness in headless mode.
+
+## Safe default behavior
+`run_workcell_fake_hardware_smoke.py` defaults to static checks only. It does **not** launch ROS unless `--run-launch` is explicitly passed.
+
+## Static-only mode (default)
+Checks include schema validation, catalog validation, scene artifacts, safety flags, and fake-hardware launch guidance (`use_fake_hardware:=true`, `launch_rviz:=false`).
+
+## Optional launch mode
+Optional local ROS smoke can be enabled with `--run-launch`. Launch command is headless and fake hardware only:
+
+`ros2 launch <scene_package> demo.launch.py use_fake_hardware:=true launch_rviz:=false`
+
+## Golden demo smoke command
+```bash
+python3 scripts/run_workcell_fake_hardware_smoke.py \
+  --generate-golden-demo \
+  --skip-launch \
+  --print-summary
+```
+
+## Generated scene smoke command
+```bash
+python3 scripts/run_workcell_fake_hardware_smoke.py \
+  --scene-dir /tmp/workcell_golden_demo/ur5_2f_golden_demo \
+  --skip-launch \
+  --print-summary
+```
+
+## Optional local ROS smoke only
+```bash
+python3 scripts/run_workcell_fake_hardware_smoke.py \
+  --scene-dir /tmp/workcell_golden_demo/ur5_2f_golden_demo \
+  --workspace ~/workcell_ws \
+  --run-launch \
+  --headless \
+  --timeout-seconds 30
+```
+
+## Safety note
+This acceptance gate is fake-hardware-first and offline-safe. It does **not** prove real robot readiness.

--- a/scripts/run_workcell_fake_hardware_smoke.py
+++ b/scripts/run_workcell_fake_hardware_smoke.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+PASS = "WORKCELL_FAKE_HARDWARE_SMOKE: PASS"
+WARN = "WORKCELL_FAKE_HARDWARE_SMOKE: WARN"
+FAIL = "WORKCELL_FAKE_HARDWARE_SMOKE: FAIL"
+SKIP = "WORKCELL_FAKE_HARDWARE_SMOKE: SKIP"
+
+FORBIDDEN_LOG_MARKERS = ["use_fake_hardware:=false", "real_hardware_enabled: true", "move_group_action"]
+
+
+def _run(cmd: list[str], cwd: Path | None = None, timeout: int = 120) -> tuple[int, str]:
+    proc = subprocess.run(cmd, cwd=str(cwd) if cwd else None, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout, check=False)
+    return proc.returncode, proc.stdout
+
+
+def _has(text: str, needle: str) -> bool:
+    return needle.lower() in text.lower()
+
+
+def _status(errors: list[str], warnings: list[str], skipped: bool) -> str:
+    if errors:
+        return "FAIL"
+    if skipped:
+        return "SKIP"
+    if warnings:
+        return "WARN"
+    return "PASS"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Safe headless fake-hardware smoke acceptance gate")
+    p.add_argument("--scene-dir")
+    p.add_argument("--workspace", default="~/workcell_ws")
+    p.add_argument("--generate-golden-demo", action="store_true")
+    p.add_argument("--use-golden-demo", action="store_true")
+    p.add_argument("--skip-colcon", action="store_true")
+    p.add_argument("--skip-launch", action="store_true")
+    p.add_argument("--run-colcon", action="store_true")
+    p.add_argument("--run-launch", action="store_true")
+    p.add_argument("--timeout-seconds", type=int, default=30)
+    p.add_argument("--headless", action="store_true")
+    p.add_argument("--strict", action="store_true")
+    p.add_argument("--print-summary", action="store_true")
+    args = p.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    workspace = Path(args.workspace).expanduser().resolve()
+    warnings: list[str] = []
+    errors: list[str] = []
+    skipped = False
+
+    if args.generate_golden_demo:
+        out_dir = Path("/tmp/workcell_golden_demo")
+        if out_dir.exists():
+            shutil.rmtree(out_dir)
+        rc, out = _run([sys.executable, str(repo_root / "scripts/generate_golden_workcell_demo.py"), "--output-dir", str(out_dir), "--scene-name", "ur5_2f_golden_demo", "--validate", "--overwrite", "--no-rviz"], timeout=120)
+        if rc != 0:
+            errors.append(f"golden demo generation failed: {out}")
+        args.scene_dir = str(out_dir / "ur5_2f_golden_demo")
+
+    if args.use_golden_demo and not args.scene_dir:
+        args.scene_dir = "/tmp/workcell_golden_demo/ur5_2f_golden_demo"
+
+    if not args.scene_dir:
+        errors.append("--scene-dir required unless --generate-golden-demo is used")
+        scene_dir = Path(".")
+    else:
+        scene_dir = Path(args.scene_dir).expanduser().resolve()
+
+    env_file = scene_dir / "environment.yaml"
+    task_recipe = scene_dir / "config/task_recipe.yaml"
+    summary_json = scene_dir / "workcell_studio_summary.json"
+    summary_md = scene_dir / "workcell_studio_summary.md"
+    preview_svg = scene_dir / "preview/workcell_preview.svg"
+    preview_html = scene_dir / "preview/workcell_preview.html"
+
+    if not scene_dir.exists():
+        errors.append(f"scene directory missing: {scene_dir}")
+    if not env_file.exists():
+        errors.append("environment.yaml missing")
+
+    env_text = env_file.read_text(encoding="utf-8") if env_file.exists() else ""
+    for required in [
+        "schema_version: workcell_scene/v1",
+        "real_hardware_enabled: false",
+        "runtime_execution_enabled: false",
+        "motion_command_sent: false",
+        "moveit_plan_service_called: false",
+    ]:
+        if required not in env_text:
+            errors.append(f"missing required safety/schema marker: {required}")
+
+    if not task_recipe.exists():
+        warnings.append("task_recipe.yaml missing")
+    for f in [summary_json, summary_md, preview_svg, preview_html]:
+        if not f.exists():
+            warnings.append(f"artifact missing: {f.name}")
+
+    rc, out = _run([sys.executable, str(repo_root / "scripts/validate_workcell_scene.py"), "--scene-dir", str(scene_dir)] + (["--strict"] if args.strict else []), timeout=60)
+    if rc != 0:
+        errors.append("scene schema validator failed")
+    if "WORKCELL_SCENE_SCHEMA:" not in out:
+        warnings.append("scene schema marker missing")
+
+    rc, out = _run([sys.executable, str(repo_root / "scripts/validate_workcell_asset_catalog.py"), "--repo-root", str(repo_root)] + (["--strict"] if args.strict else []), timeout=60)
+    if rc != 0:
+        (errors if args.strict else warnings).append("asset catalog validator reported issues")
+
+    launch_text = (summary_md.read_text(encoding="utf-8") if summary_md.exists() else "") + "\n" + (summary_json.read_text(encoding="utf-8") if summary_json.exists() else "")
+    if "demo.launch.py" not in launch_text:
+        warnings.append("fake-hardware launch command not found in summary artifacts")
+    if "launch_rviz" not in launch_text:
+        warnings.append("launch_rviz guidance not found")
+    if "use_fake_hardware:=true" not in launch_text:
+        warnings.append("use_fake_hardware:=true guidance not found")
+
+    if args.run_colcon and not args.skip_colcon:
+        if not workspace.exists():
+            (errors if args.strict else warnings).append(f"workspace missing for colcon check: {workspace}")
+        else:
+            rc, out = _run(["bash", "-lc", "source /opt/ros/humble/setup.bash && colcon build --event-handlers console_direct+ --packages-up-to ur5_2f_golden_demo"], cwd=workspace, timeout=1800)
+            if rc != 0:
+                (errors if args.strict else warnings).append("colcon build unavailable/failed")
+
+    if args.run_launch and not args.skip_launch:
+        if not workspace.exists():
+            (errors if args.strict else warnings).append(f"workspace missing for launch check: {workspace}")
+        else:
+            pkg = scene_dir.name
+            launch_cmd = f"source /opt/ros/humble/setup.bash && [ -f install/setup.bash ] && source install/setup.bash && timeout {args.timeout_seconds} ros2 launch {pkg} demo.launch.py use_fake_hardware:=true launch_rviz:=false"
+            rc, out = _run(["bash", "-lc", launch_cmd], cwd=workspace, timeout=max(args.timeout_seconds + 20, 60))
+            low = out.lower()
+            for marker in FORBIDDEN_LOG_MARKERS:
+                if marker in low:
+                    errors.append(f"forbidden runtime marker seen in launch logs: {marker}")
+            if rc not in (0, 124):
+                (errors if args.strict else warnings).append(f"launch failed with exit code {rc}")
+    else:
+        skipped = True
+
+    status = _status(errors, warnings, skipped)
+    marker = {"PASS": PASS, "WARN": WARN, "FAIL": FAIL, "SKIP": SKIP}[status]
+    report = {
+        "schema": "workcell_fake_hardware_smoke/v1",
+        "scene_dir": str(scene_dir),
+        "status": status,
+        "headless": True if args.headless or not args.run_launch else args.headless,
+        "run_launch": bool(args.run_launch and not args.skip_launch),
+        "safety": {
+            "real_hardware_enabled": False,
+            "runtime_execution_enabled": False,
+            "motion_command_sent": False,
+            "moveit_plan_service_called": False,
+        },
+        "warnings": warnings,
+        "errors": errors,
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    (scene_dir / "fake_hardware_smoke_report.json").write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    (scene_dir / "fake_hardware_smoke_report.md").write_text(f"# Fake Hardware Smoke Report\n\n- Status: **{status}**\n- Marker: `{marker}`\n- Scene: `{scene_dir}`\n", encoding="utf-8")
+
+    print(marker)
+    if args.print_summary:
+        print(json.dumps(report, indent=2))
+    return 1 if status == "FAIL" or (args.strict and status in {"WARN"}) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_workcell_builder_healthcheck.py
+++ b/scripts/validate_workcell_builder_healthcheck.py
@@ -205,6 +205,16 @@ def main() -> int:
     for forbidden in ["GetMotionPlan", "execute_trajectory", "FollowJointTrajectory", "/plan_kinematic_path"]:
         _check(forbidden.lower() not in compat_cpp.lower(), f"compatibility layer excludes runtime motion API: {forbidden}", errors)
 
+
+    smoke_script = repo_root / "scripts/run_workcell_fake_hardware_smoke.py"
+    _check(smoke_script.exists(), "fake hardware smoke acceptance script exists", errors)
+    if smoke_script.exists():
+        stxt = smoke_script.read_text(encoding="utf-8")
+        for marker in ["WORKCELL_FAKE_HARDWARE_SMOKE: PASS", "WORKCELL_FAKE_HARDWARE_SMOKE: WARN", "WORKCELL_FAKE_HARDWARE_SMOKE: FAIL", "WORKCELL_FAKE_HARDWARE_SMOKE: SKIP", "--run-launch", "--skip-launch", "--generate-golden-demo", "--headless", "launch_rviz:=false", "use_fake_hardware:=true", "real_hardware_enabled: false", "runtime_execution_enabled: false", "motion_command_sent: false", "moveit_plan_service_called: false"]:
+            _check(marker in stxt, f"smoke script marker present: {marker}", errors)
+        for forbidden in ["import yaml", "pyyaml", "GetMotionPlan", "execute_trajectory", "/plan_kinematic_path", "streamlit", "epd"]:
+            _check(forbidden.lower() not in stxt.lower(), f"smoke script excludes forbidden marker: {forbidden}", errors)
+
     schema_validator = (repo_root / "scripts/validate_workcell_scene.py").read_text(encoding="utf-8")
     for marker in ["WORKCELL_SCENE_SCHEMA: PASS", "WORKCELL_SCENE_SCHEMA: WARN", "WORKCELL_SCENE_SCHEMA: FAIL", "workcell_scene/v1"]:
         _check(marker in schema_validator, f"scene schema validator marker present: {marker}", errors)

--- a/tests/test_workcell_fake_hardware_smoke_acceptance.py
+++ b/tests/test_workcell_fake_hardware_smoke_acceptance.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+
+def test_script_exists_and_markers_exist():
+    p = Path('scripts/run_workcell_fake_hardware_smoke.py')
+    assert p.exists()
+    txt = p.read_text(encoding='utf-8')
+    for marker in [
+        'WORKCELL_FAKE_HARDWARE_SMOKE: PASS',
+        'WORKCELL_FAKE_HARDWARE_SMOKE: WARN',
+        'WORKCELL_FAKE_HARDWARE_SMOKE: FAIL',
+        'WORKCELL_FAKE_HARDWARE_SMOKE: SKIP',
+    ]:
+        assert marker in txt
+
+
+def test_default_mode_safe_static_and_opt_in_launch_flags():
+    txt = Path('scripts/run_workcell_fake_hardware_smoke.py').read_text(encoding='utf-8')
+    for flag in ['--run-launch', '--skip-launch', '--generate-golden-demo', '--use-golden-demo', '--headless', '--timeout-seconds']:
+        assert flag in txt
+    assert 'if args.run_launch and not args.skip_launch:' in txt
+
+
+def test_fake_hardware_safety_checks_and_launch_guidance_markers():
+    txt = Path('scripts/run_workcell_fake_hardware_smoke.py').read_text(encoding='utf-8')
+    for marker in [
+        'schema_version: workcell_scene/v1',
+        'use_fake_hardware:=true',
+        'launch_rviz:=false',
+        'real_hardware_enabled: false',
+        'runtime_execution_enabled: false',
+        'motion_command_sent: false',
+        'moveit_plan_service_called: false',
+        'validate_workcell_scene.py',
+        'validate_workcell_asset_catalog.py',
+        'generate_golden_workcell_demo.py',
+    ]:
+        assert marker in txt
+
+
+def test_no_pyyaml_epd_or_forbidden_planning_motion_apis():
+    txt = Path('scripts/run_workcell_fake_hardware_smoke.py').read_text(encoding='utf-8').lower()
+    for forbidden in ['import yaml', 'pyyaml', 'getmotionplan', 'execute_trajectory', '/plan_kinematic_path', 'streamlit', 'easy_manipulation_deployment/emd_demo_nodes']:
+        assert forbidden not in txt


### PR DESCRIPTION
### Motivation
- Provide one repeatable, safe-by-default acceptance gate that proves generated Workcell Studio scenes are ready for fake-hardware launch without RViz or real robot motion.
- Prefer static/dry-run validation by default and require explicit opt-in for any runtime/ROS launch to avoid accidental hardware activation.

### Description
- Added `scripts/run_workcell_fake_hardware_smoke.py`, a headless smoke acceptance script that performs static checks by default and offers an explicit `--run-launch` opt-in for optional local ROS launch; it supports `--generate-golden-demo`, `--use-golden-demo`, `--skip-colcon`, `--run-colcon`, `--skip-launch`, `--timeout-seconds`, `--headless`, `--strict`, and `--print-summary` flags.
- Static validations include presence of `environment.yaml`, `schema_version: workcell_scene/v1`, required safety flags (`real_hardware_enabled: false`, `runtime_execution_enabled: false`, `motion_command_sent: false`, `moveit_plan_service_called: false`), summary/preview artifacts, schema validator and asset catalog validator invocation, and guidance that `demo.launch.py` supports `use_fake_hardware:=true` and `launch_rviz:=false`.
- Runtime launch (only when `--run-launch` and not `--skip-launch`) runs a headless `ros2 launch <scene_package> demo.launch.py use_fake_hardware:=true launch_rviz:=false` under a timeout, captures logs, and fails if forbidden runtime markers appear; it will not execute trajectories or call planning services by design.
- Produces reports in the scene directory: `fake_hardware_smoke_report.json` and `fake_hardware_smoke_report.md` and prints one of the markers `WORKCELL_FAKE_HARDWARE_SMOKE: PASS|WARN|FAIL|SKIP`.
- Integrated healthcheck: updated `scripts/validate_workcell_builder_healthcheck.py` to assert the smoke script exists, required markers/flags are present, and forbidden tokens (PyYAML, Streamlit, EPD coupling, planning/execution APIs) are absent.
- Tests and docs: added `tests/test_workcell_fake_hardware_smoke_acceptance.py` and `docs/manuals/WORKCELL_FAKE_HARDWARE_SMOKE_ACCEPTANCE.md` with usage examples and safety notes.

### Testing
- Ran targeted pytest suite: `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_fake_hardware_smoke_acceptance.py tests/test_workcell_golden_demo_acceptance_pack.py tests/test_workcell_asset_profile_catalog_validator.py tests/test_workcell_builder_generated_scene_schema_compliance.py tests/test_workcell_builder_healthcheck.py tests/test_workspace_layout_assets_scenes_aliases.py`, which passed (`22 passed`).
- Executed the smoke command in static/golden-demo generation mode: `python3 scripts/run_workcell_fake_hardware_smoke.py --generate-golden-demo --skip-launch --print-summary`, which produced `WORKCELL_FAKE_HARDWARE_SMOKE: SKIP` and printed the JSON summary report.
- Ran the updated healthcheck: `python3 scripts/validate_workcell_builder_healthcheck.py --repo-root . --workspace ~/workcell_ws --skip-colcon --skip-launch`, which passed and reported expected checks.
- Performed shell syntax checks on workspace scripts with `bash -n` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d0e7ed4483319cfe98e07d162cf8)