### PR TITLE
Fix workcell_builder compile regression in tool compatibility inference

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -186,6 +186,9 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_scene_select_paths_test test/scene_select_paths_test.cpp src_scene_select_paths.cpp)
   ament_add_gtest(workcell_generate_yaml_end_effector_metadata_test
     test/generate_yaml_end_effector_metadata_test.cpp)
+  ament_add_gtest(workcell_robot_tool_compatibility_inference_test
+    test/robot_tool_compatibility_inference_test.cpp
+    src_robot_tool_compatibility.cpp)
   if(TARGET workcell_directory_inspection_test)
     target_link_libraries(workcell_directory_inspection_test
       ${Boost_LIBRARIES}
@@ -210,6 +213,23 @@ if(BUILD_TESTING)
         include
         include/attributes
         include/yaml_parser
+    )
+  endif()
+
+  if(TARGET workcell_robot_tool_compatibility_inference_test)
+    ament_target_dependencies(workcell_robot_tool_compatibility_inference_test
+      rclcpp
+    )
+    target_link_libraries(workcell_robot_tool_compatibility_inference_test
+      Qt5::Widgets
+      yaml-cpp
+      ${Boost_LIBRARIES}
+    )
+    target_include_directories(workcell_robot_tool_compatibility_inference_test
+      PRIVATE
+        ${Boost_INCLUDE_DIRS}
+        include
+        include/attributes
     )
   endif()
 

--- a/workcell_builder/workcell_builder/src_generated_stl_writer.cpp
+++ b/workcell_builder/workcell_builder/src_generated_stl_writer.cpp
@@ -79,6 +79,9 @@ bool write_ascii_stl(const PrimitiveSpec & spec, const std::string & out_path, s
     case PrimitiveType::kConveyorPlaceholder: return write_conveyor_placeholder_mesh(spec, out_path, error);
     case PrimitiveType::kFixturePlate: return write_fixture_plate_mesh(spec, out_path, error);
   }
-  if (error) *error = "unsupported primitive"; return false;
+  if (error) {
+    *error = "unsupported primitive";
+  }
+  return false;
 }
 }

--- a/workcell_builder/workcell_builder/src_robot_tool_compatibility.cpp
+++ b/workcell_builder/workcell_builder/src_robot_tool_compatibility.cpp
@@ -27,9 +27,33 @@ std::string infer_robot_id(const Scene & scene)
 std::string infer_tool_id(const Scene & scene)
 {
   if (!scene.ee_loaded || scene.ee_vector.empty()) { return "generic_unknown_tool"; }
-  const std::string key = normalize(scene.ee_vector[0].name + " " + scene.ee_vector[0].type);
-  if (key.find("robotiq") != std::string::npos || key.find("2f") != std::string::npos) { return "robotiq_2f85"; }
-  if (key.find("airpick") != std::string::npos || key.find("suction") != std::string::npos || key.find("vacuum") != std::string::npos) { return "onrobot_airpick"; }
+
+  const EndEffector & ee = scene.ee_vector[0];
+  std::string key = ee.name;
+  key += " " + ee.brand;
+  key += " " + ee.ee_type;
+  key += " " + ee.gripper_type;
+  key += " " + ee.planner_id;
+  key += " " + ee.base_link;
+  key += " " + ee.robot_link;
+  key += " " + ee.grasp_frame;
+  key += " " + ee.tcp_link;
+  key = normalize(key);
+
+  if (key.find("robotiq") != std::string::npos ||
+    key.find("2f") != std::string::npos ||
+    key.find("finger") != std::string::npos ||
+    key.find("85") != std::string::npos)
+  {
+    return "robotiq_2f85";
+  }
+  if (key.find("airpick") != std::string::npos ||
+    key.find("suction") != std::string::npos ||
+    key.find("vacuum") != std::string::npos ||
+    key.find("cup") != std::string::npos)
+  {
+    return "onrobot_airpick";
+  }
   return "generic_unknown_tool";
 }
 

--- a/workcell_builder/workcell_builder/test/robot_tool_compatibility_inference_test.cpp
+++ b/workcell_builder/workcell_builder/test/robot_tool_compatibility_inference_test.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+
+#include "robot_tool_compatibility.hpp"
+
+namespace {
+
+Scene make_scene(const std::string & ee_name)
+{
+  Scene scene;
+  scene.robot_loaded = true;
+  Robot robot;
+  robot.name = "ur5";
+  scene.robot_vector.push_back(robot);
+
+  scene.ee_loaded = true;
+  EndEffector ee;
+  ee.name = ee_name;
+  scene.ee_vector.push_back(ee);
+  return scene;
+}
+
+}  // namespace
+
+TEST(RobotToolCompatibilityInferenceTest, InfersRobotiqFromNameVariants)
+{
+  const std::string config_root = "./assets/compatibility";
+
+  auto result = evaluate_robot_tool_compatibility(make_scene("robotiq_85"), config_root);
+  EXPECT_EQ(result.tool_id, "robotiq_2f85");
+
+  result = evaluate_robot_tool_compatibility(make_scene("robotiq_2f"), config_root);
+  EXPECT_EQ(result.tool_id, "robotiq_2f85");
+}
+
+TEST(RobotToolCompatibilityInferenceTest, InfersSuctionFromNameVariants)
+{
+  const std::string config_root = "./assets/compatibility";
+
+  auto result = evaluate_robot_tool_compatibility(make_scene("onrobot_airpick4"), config_root);
+  EXPECT_EQ(result.tool_id, "onrobot_airpick");
+
+  result = evaluate_robot_tool_compatibility(make_scene("single_suction"), config_root);
+  EXPECT_EQ(result.tool_id, "onrobot_airpick");
+}
+
+TEST(RobotToolCompatibilityInferenceTest, FallsBackToUnknown)
+{
+  const std::string config_root = "./assets/compatibility";
+  const auto result = evaluate_robot_tool_compatibility(make_scene("unknown"), config_root);
+  EXPECT_EQ(result.tool_id, "generic_unknown_tool");
+}


### PR DESCRIPTION
### Motivation
- A recent helper used a non-existent `EndEffector::type` field which broke compilation of `workcell_builder`; the change restores compatibility with the existing legacy `EndEffector` model. 

### Description
- Replaced the invalid `scene.ee_vector[0].type` access in `src_robot_tool_compatibility.cpp` with an inference key built from actual fields (`name`, `brand`, `ee_type`, `gripper_type`, `planner_id`, `base_link`, `robot_link`, `grasp_frame`, `tcp_link`) and normalized before pattern matching. 
- Updated inference rules to detect Robotiq/finger and suction/airpick patterns and otherwise return the safe fallback `generic_unknown_tool`. 
- Added a lightweight unit test `test/robot_tool_compatibility_inference_test.cpp` exercising inference via the public API and registered it in `CMakeLists.txt`. 
- Applied low-risk cleanup in `src_generated_stl_writer.cpp` to fix a misleading-indentation warning in the unsupported-primitive path. 

### Testing
- Attempted to build the package with `colcon build --symlink-install --packages-select workcell_builder`, but the command could not run in this environment because `/opt/ros/humble/setup.bash` was not present (build not executed here). 
- Verified the invalid `.type` reference was removed via source inspection and `rg` searches, and added a gtest that will validate inference behavior when tests are run in a ROS/Humble environment. 
- All changes were committed on branch `codex/fix-workcell-builder-tool-compat-build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02175dabbc8331af47c215241d867b)