### PR TITLE
Fix workcell_builder linker regressions for sanitize helper and Qt MOC headers

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -129,7 +129,12 @@ add_executable(workcell_builder
     gui/asset_picker_dialog.cpp
     gui/object_placement_dialog.cpp
     gui/environment_layout_editor.cpp
-    gui/external_asset_import_dialog.cpp)
+    gui/external_asset_import_dialog.cpp
+
+    include/asset_picker_dialog.hpp
+    include/object_placement_dialog.hpp
+    include/environment_layout_editor.hpp
+    include/external_asset_import_dialog.hpp)
 
 ament_target_dependencies(workcell_builder
   rclcpp

--- a/workcell_builder/workcell_builder/src_generated_stl_writer.cpp
+++ b/workcell_builder/workcell_builder/src_generated_stl_writer.cpp
@@ -1,8 +1,8 @@
 #include "generated_stl_writer.hpp"
+#include "object_placement_model.hpp"
 
 #include <algorithm>
 #include <cmath>
-#include <cctype>
 #include <fstream>
 #include <sstream>
 #include <tuple>
@@ -40,15 +40,6 @@ bool write_mesh(const PrimitiveSpec & spec, const std::string & out_path, const 
   return true;
 }
 }
-std::string sanitize_object_name(const std::string & input)
-{
-  std::string out;
-  for (char c : input) out.push_back(std::isalnum(static_cast<unsigned char>(c)) ? static_cast<char>(std::tolower(c)) : '_');
-  while (!out.empty() && out.front() == '_') out.erase(out.begin());
-  while (!out.empty() && out.back() == '_') out.pop_back();
-  return out.empty() ? "custom_object" : out;
-}
-
 bool validate_primitive_spec(const PrimitiveSpec & spec, std::string * reason)
 {
   if (sanitize_object_name(spec.object_name).empty()) { if (reason) *reason = "invalid object name"; return false; }


### PR DESCRIPTION
### Motivation
- Recent UI additions introduced linker regressions: a duplicate definition of `workcell_builder::sanitize_object_name()` and undefined Qt vtable references for new `Q_OBJECT` dialog/editor classes.
- The goal is to keep `workcell_builder` as the canonical Workcell Studio UI and restore a clean link on ROS 2 Humble without changing runtime safety or behavior.

### Description
- Remove the duplicated `sanitize_object_name()` implementation from `src_generated_stl_writer.cpp` and rely on the single shared declaration/implementation in `src_object_placement_model.cpp` by including `object_placement_model.hpp` in the STL writer translation unit.
- Add the new dialog/editor headers to the `workcell_builder` target source list in `CMakeLists.txt` so `CMAKE_AUTOMOC` will generate and link moc code for `AssetPickerDialog`, `ObjectPlacementDialog`, `EnvironmentLayoutEditor`, and `ExternalAssetImportDialog`.
- Preserve existing STL writer behavior and error reporting while cleaning up the helper implementation duplication and removing an unnecessary `#include <cctype>`.
- Keep changes minimal and focused to avoid touching runtime fake-hardware defaults, scene generation behavior, or other UI features.

### Testing
- Ran source-tree checks with `rg` to confirm `sanitize_object_name` occurrences and to locate `Q_OBJECT` headers, which verified the duplicate symbol location and the new headers requiring moc.
- Committed changes locally (`git commit`) to branch `codex/fix-workcell-builder-link-errors` (commit made successfully).
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but the environment lacks `/opt/ros/humble/setup.bash`, so a full automated build could not be executed in this environment (build could not be run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0219967b7c83318281e4dcc160dbcf)