### PR TITLE
Fix boolean launch argument handling in generated demo.launch.py

### DIFF
--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -22,7 +22,6 @@ import yaml
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, LogInfo, ExecuteProcess
 from launch.conditions import IfCondition
-from launch.substitutions import PythonExpression
 from launch.actions import OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
@@ -671,7 +670,7 @@ def _launch_setup(context):
         get_package_share_directory(scene_pkg), "launch", "demo.rviz"
     )
     rviz_node = Node(
-        condition=IfCondition(PythonExpression([launch_rviz, " == 'true'"])),
+        condition=IfCondition(launch_rviz),
         package="rviz2",
         executable="rviz2",
         name="rviz2",
@@ -715,7 +714,7 @@ def _launch_setup(context):
 
 
     task_preview_node = Node(
-        condition=IfCondition(PythonExpression([launch_task_preview, " == 'true'"])),
+        condition=IfCondition(launch_task_preview),
         package="run_grasp_execution",
         executable="task_recipe_visualizer_node.py",
         name="task_recipe_visualizer_node",


### PR DESCRIPTION
### Motivation
- Launch-time evaluation of boolean launch arguments could raise a NameError (`name 'true' is not defined`) when using `PythonExpression` to compare `LaunchConfiguration` strings to `'true'` in generated demo launch files. 

### Description
- Replace `IfCondition(PythonExpression([launch_rviz, " == 'true'"]))` with `IfCondition(launch_rviz)` for `rviz_node` in `workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py`. 
- Replace `IfCondition(PythonExpression([launch_task_preview, " == 'true'"]))` with `IfCondition(launch_task_preview)` for the task preview node in the same file. 
- Remove the now-unused `PythonExpression` import from the modified template. 

### Testing
- Ran `python -m py_compile workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py` and the file compiled successfully. 
- Verified the changed template no longer contains `PythonExpression` usages for the two boolean launch conditions via a quick code inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023b4cbaa083318dd677ce8a7dd607)