### PR TITLE
Fix generated scene task preview launch path and fallback behavior

### DIFF
--- a/tests/test_generated_task_preview_launch.py
+++ b/tests/test_generated_task_preview_launch.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+TEMPLATE = Path('workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py')
+
+
+def test_generated_demo_launch_uses_generated_preview_helper():
+    launch = TEMPLATE.read_text(encoding='utf-8')
+    assert 'workcell_visual_scene_publisher.py' in launch
+    assert 'task_recipe_visualizer_node.py' not in launch
+    assert 'Task preview helper not found; continuing without task preview.' in launch
+
+
+def test_generated_demo_launch_supports_task_preview_toggle():
+    launch = TEMPLATE.read_text(encoding='utf-8')
+    assert 'DeclareLaunchArgument(' in launch
+    assert '"launch_task_preview"' in launch
+    assert 'condition=IfCondition(launch_task_preview)' in launch

--- a/tests/test_task_recipe_rviz_visualizer.py
+++ b/tests/test_task_recipe_rviz_visualizer.py
@@ -15,8 +15,17 @@ def test_visualizer_node_and_launch_template_safety_contract():
         assert needle in txt
 
     launch = Path("workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py").read_text(encoding="utf-8")
-    for needle in ["launch_task_preview", "task_preview_markers", "task_preview_output_dir", "task_recipe_visualizer_node", "condition=IfCondition"]:
+    for needle in [
+        "launch_task_preview",
+        "task_preview_markers",
+        "task_preview_output_dir",
+        "workcell_visual_scene_publisher.py",
+        "Task preview helper not found; continuing without task preview.",
+        "condition=IfCondition(launch_task_preview)",
+    ]:
         assert needle in launch
+
+    assert "task_recipe_visualizer_node.py" not in launch
 
     lowered = txt.lower()
     for forbidden in ["getmotionplan", "execute_trajectory", "followjointtrajectory", "actionclient", "hardware_interface"]:

--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -713,20 +713,23 @@ def _launch_setup(context):
     )
 
 
-    task_preview_node = Node(
+    task_preview_helper = os.path.join(
+        get_package_share_directory(scene_pkg), "launch", "workcell_visual_scene_publisher.py"
+    )
+    task_preview_process = ExecuteProcess(
+        cmd=[
+            "python3",
+            task_preview_helper,
+            "--scene-name", scene_pkg,
+            "--show-task-flow", "true",
+            "--show-grasp-markers", task_preview_markers,
+        ],
         condition=IfCondition(launch_task_preview),
-        package="run_grasp_execution",
-        executable="task_recipe_visualizer_node.py",
-        name="task_recipe_visualizer_node",
         output="screen",
-        parameters=[{
-            "task_recipe_path": task_recipe_path,
-            "output_dir": task_preview_output_dir,
-            "publish_markers": task_preview_markers,
-            "dry_run_only": True,
-            "keep_alive": True,
-            "frame_id": "world",
-        }],
+    )
+    task_preview_missing_log = LogInfo(
+        condition=IfCondition(launch_task_preview),
+        msg="[workcell_builder] Task preview helper not found; continuing without task preview.",
     )
 
     controller_status_logs = [LogInfo(msg=f"[workcell_builder] {status}") for status in controller_statuses]
@@ -749,7 +752,7 @@ def _launch_setup(context):
         rviz_node,
         workcell_marker_publisher,
         collision_object_publisher,
-        task_preview_node,
+        task_preview_process if os.path.exists(task_preview_helper) else task_preview_missing_log,
     ]
 
 


### PR DESCRIPTION
### Motivation

- Generated scene launches were failing by default because the template tried to run `run_grasp_execution/task_recipe_visualizer_node.py`, which is not always installed in runtime packages. 
- The goal is to make the optional task preview safe by using a shipped scene helper when available and degrading gracefully when it is not. 
- Preserve the offline dry-run / fake-hardware-first behavior and ensure no real robot motion is introduced by the preview helper.

### Description

- Replace the `Node` that launched `task_recipe_visualizer_node.py` with an `ExecuteProcess` that runs the scene helper `launch/workcell_visual_scene_publisher.py` via `python3` and a `task_preview_helper` path computed with `get_package_share_directory(scene_pkg)`.
- Add a conditional fallback so the returned launch actions include `task_preview_process` when `os.path.exists(task_preview_helper)` else a `LogInfo` with the message `"[workcell_builder] Task preview helper not found; continuing without task preview."` so the launch does not crash when the helper is missing.
- Update template and tests: modify `workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py` accordingly, adjust `tests/test_task_recipe_rviz_visualizer.py` expectations, and add `tests/test_generated_task_preview_launch.py` that asserts the new helper is used and the `launch_task_preview` toggle is present.

### Testing

- Ran `pytest -q tests/test_task_recipe_rviz_visualizer.py tests/test_workcell_builder_generation.py::test_humble_scene_template_preserves_fake_hardware_launch_behavior tests/test_workcell_builder_launch_smoke_acceptance.py` and all tests passed (4 passed). 
- Ran `pytest -q tests/test_generated_task_preview_launch.py tests/test_task_recipe_rviz_visualizer.py` and all tests passed (3 passed). 
- The changes keep the existing offline/fake-hardware log messages and the `launch_task_preview` conditional in the generated `demo.launch.py` template as verified by the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a024814332083319754606ccf99276a)