### PR TITLE
Harden generated scene launch/controller defaults for Workcell Builder

### DIFF
--- a/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/launch/demo.launch.py
@@ -253,13 +253,19 @@ def _extract_controller_joints(robot_description_semantic_config, robot_descript
     groups_with_chain = []
     preferred_group_names = ["manipulator", "arm", "ur_manipulator"]
 
+    movable_joints, _ = _collect_movable_urdf_joints(urdf_root)
+    movable_joint_set = set(movable_joints)
+
     for group in srdf_root.findall(".//group"):
         group_name = group.get("name") or "arm"
         group_names.append(group_name)
         joints = [joint.get("name") for joint in group.findall("joint") if joint.get("name")]
         if joints:
-            groups_with_explicit.append((group_name, joints))
+            movable_explicit_joints = [joint for joint in joints if joint in movable_joint_set]
+            groups_with_explicit.append((group_name, joints, movable_explicit_joints))
             if group_name in preferred_group_names:
+                if movable_explicit_joints:
+                    return group_name, movable_explicit_joints
                 return group_name, joints
         for chain in group.findall("chain"):
             base_link = chain.get("base_link")
@@ -268,9 +274,13 @@ def _extract_controller_joints(robot_description_semantic_config, robot_descript
                 groups_with_chain.append((group_name, base_link, tip_link))
 
     if groups_with_explicit:
-        return groups_with_explicit[0]
-
-    movable_joints, _ = _collect_movable_urdf_joints(urdf_root)
+        best_group_name, original_joints, movable_explicit_joints = max(
+            groups_with_explicit,
+            key=lambda entry: len(entry[2]),
+        )
+        if movable_explicit_joints:
+            return best_group_name, movable_explicit_joints
+        return best_group_name, original_joints
     if all(joint in set(movable_joints) for joint in UR_ARM_JOINTS):
         return "manipulator", UR_ARM_JOINTS
 

--- a/workcell_builder/workcell_builder/templates/ros2/humble/test_load_yaml.py
+++ b/workcell_builder/workcell_builder/templates/ros2/humble/test_load_yaml.py
@@ -110,3 +110,37 @@ def test_extract_end_effector_metadata_prefers_normalized_keys():
     assert metadata["tcp_link"] == "vacuum_tip"
     assert metadata["spawn_gripper_controller"] is False
     assert metadata["finger_count"] == 0
+
+
+def test_extract_controller_joints_prefers_movable_srdf_group():
+    srdf = """
+<robot name="test_robot">
+  <group name="gripper">
+    <joint name="gripper_base_joint"/>
+    <joint name="gripper_finger1_finger_joint"/>
+  </group>
+  <group name="manipulator">
+    <joint name="shoulder_pan_joint"/>
+    <joint name="shoulder_lift_joint"/>
+    <joint name="elbow_joint"/>
+    <joint name="wrist_1_joint"/>
+    <joint name="wrist_2_joint"/>
+    <joint name="wrist_3_joint"/>
+  </group>
+</robot>
+"""
+    urdf = """
+<robot name="test_robot">
+  <joint name="shoulder_pan_joint" type="revolute"/>
+  <joint name="shoulder_lift_joint" type="revolute"/>
+  <joint name="elbow_joint" type="revolute"/>
+  <joint name="wrist_1_joint" type="revolute"/>
+  <joint name="wrist_2_joint" type="revolute"/>
+  <joint name="wrist_3_joint" type="revolute"/>
+  <joint name="gripper_base_joint" type="fixed"/>
+  <joint name="gripper_finger1_finger_joint" type="fixed"/>
+</robot>
+"""
+    group_name, joints = demo._extract_controller_joints(srdf, urdf)
+    assert group_name == "manipulator"
+    assert joints == demo.UR_ARM_JOINTS

--- a/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
+++ b/workcell_builder/workcell_builder/templates/ros2/launch/demo.launch.py
@@ -252,13 +252,19 @@ def _extract_controller_joints(robot_description_semantic_config, robot_descript
     groups_with_chain = []
     preferred_group_names = ["manipulator", "arm", "ur_manipulator"]
 
+    movable_joints, _ = _collect_movable_urdf_joints(urdf_root)
+    movable_joint_set = set(movable_joints)
+
     for group in srdf_root.findall(".//group"):
         group_name = group.get("name") or "arm"
         group_names.append(group_name)
         joints = [joint.get("name") for joint in group.findall("joint") if joint.get("name")]
         if joints:
-            groups_with_explicit.append((group_name, joints))
+            movable_explicit_joints = [joint for joint in joints if joint in movable_joint_set]
+            groups_with_explicit.append((group_name, joints, movable_explicit_joints))
             if group_name in preferred_group_names:
+                if movable_explicit_joints:
+                    return group_name, movable_explicit_joints
                 return group_name, joints
         for chain in group.findall("chain"):
             base_link = chain.get("base_link")
@@ -267,9 +273,13 @@ def _extract_controller_joints(robot_description_semantic_config, robot_descript
                 groups_with_chain.append((group_name, base_link, tip_link))
 
     if groups_with_explicit:
-        return groups_with_explicit[0]
-
-    movable_joints, _ = _collect_movable_urdf_joints(urdf_root)
+        best_group_name, original_joints, movable_explicit_joints = max(
+            groups_with_explicit,
+            key=lambda entry: len(entry[2]),
+        )
+        if movable_explicit_joints:
+            return best_group_name, movable_explicit_joints
+        return best_group_name, original_joints
     if all(joint in set(movable_joints) for joint in UR_ARM_JOINTS):
         return "manipulator", UR_ARM_JOINTS
 

--- a/workcell_builder/workcell_builder/templates/ros2/test_load_yaml.py
+++ b/workcell_builder/workcell_builder/templates/ros2/test_load_yaml.py
@@ -72,3 +72,37 @@ def test_load_yaml_returns_none_on_parse_error(tmp_path, monkeypatch):
     bad_yaml.write_text('list: [1, 2')
     monkeypatch.setattr(demo, 'get_package_share_directory', lambda pkg: str(pkg_dir))
     assert demo.load_yaml('pkg', bad_yaml.name) is None
+
+
+def test_extract_controller_joints_prefers_movable_srdf_group():
+    srdf = """
+<robot name="test_robot">
+  <group name="gripper">
+    <joint name="gripper_base_joint"/>
+    <joint name="gripper_finger1_finger_joint"/>
+  </group>
+  <group name="manipulator">
+    <joint name="shoulder_pan_joint"/>
+    <joint name="shoulder_lift_joint"/>
+    <joint name="elbow_joint"/>
+    <joint name="wrist_1_joint"/>
+    <joint name="wrist_2_joint"/>
+    <joint name="wrist_3_joint"/>
+  </group>
+</robot>
+"""
+    urdf = """
+<robot name="test_robot">
+  <joint name="shoulder_pan_joint" type="revolute"/>
+  <joint name="shoulder_lift_joint" type="revolute"/>
+  <joint name="elbow_joint" type="revolute"/>
+  <joint name="wrist_1_joint" type="revolute"/>
+  <joint name="wrist_2_joint" type="revolute"/>
+  <joint name="wrist_3_joint" type="revolute"/>
+  <joint name="gripper_base_joint" type="fixed"/>
+  <joint name="gripper_finger1_finger_joint" type="fixed"/>
+</robot>
+"""
+    group_name, joints = demo._extract_controller_joints(srdf, urdf)
+    assert group_name == "manipulator"
+    assert joints == demo.UR_ARM_JOINTS


### PR DESCRIPTION
### Motivation
- Generated scenes could select SRDF groups that contain fixed gripper joints, producing broken controller configs and warnings like "Controller joints are not present in robot_description" at launch. 
- The launch template should prefer movable URDF joints when deriving controllers so fake-hardware previews start cleanly by default. 

### Description
- Updated the generated launch templates (`workcell_builder/.../templates/ros2/launch/demo.launch.py` and `.../ros2/humble/launch/demo.launch.py`) to filter SRDF explicit group joints against movable URDF joints and prefer movable joints when deriving controller joint lists. 
- When multiple SRDF groups contain explicit joints, the templates now choose the group with the largest set of movable joints rather than accepting fixed-only groups. 
- Added template-level regression tests (`test_load_yaml.py`) in both `ros2` and `ros2/humble` template folders to verify that an SRDF with fixed gripper joints does not override a manipulator group of movable arm joints. 

### Testing
- Ran the template unit tests with `pytest` for the modified template test files, which were gated by `pytest.importorskip` and reported as skipped in this environment (no failing assertions observed). 
- The new template tests exercise `_extract_controller_joints` and assert selection of `UR_ARM_JOINTS` for the representative SRDF/URDF case. 
- No runtime/launch integration tests were run in this patch; generated scene/regeneration and full-launch smoke tests are expected to be performed in CI or locally following scene generation per the repo validation guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a024a63e5f88331a1965683d705fd2b)