### PR TITLE
Add camera support description packages matching realsense2 style

### DIFF
--- a/assets/environment/flat_plate_camera_bracket_description/CMakeLists.txt
+++ b/assets/environment/flat_plate_camera_bracket_description/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.5)
+project(flat_plate_camera_bracket_description)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_runtime REQUIRED)
+
+install(DIRECTORY launch meshes rviz urdf
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/assets/environment/flat_plate_camera_bracket_description/flat_plate_camera_bracket.yaml
+++ b/assets/environment/flat_plate_camera_bracket_description/flat_plate_camera_bracket.yaml
@@ -1,0 +1,23 @@
+flat_plate_camera_bracket:
+  child_link: flat_plate_camera_bracket_body
+  links:
+    flat_plate_camera_bracket_body:
+      visual:
+        name: flat_plate_camera_bracket_visual
+        geometry:
+          filepath: package://flat_plate_camera_bracket_description/meshes/visual/flat_plate_camera_bracket.stl
+          scale:
+            scale_x: 1.0
+            scale_y: 1.0
+            scale_z: 1.0
+      collision:
+        name: flat_plate_camera_bracket_collision
+        geometry:
+          filepath: package://flat_plate_camera_bracket_description/meshes/collision/flat_plate_camera_bracket.stl
+          scale:
+            scale_x: 1.0
+            scale_y: 1.0
+            scale_z: 1.0
+  flat_plate_camera_bracket_base_joint:
+    ext_joint_type: fixed
+    child_link: flat_plate_camera_bracket_body

--- a/assets/environment/flat_plate_camera_bracket_description/launch/view_flat_plate_camera_bracket.launch.py
+++ b/assets/environment/flat_plate_camera_bracket_description/launch/view_flat_plate_camera_bracket.launch.py
@@ -1,0 +1,18 @@
+from launch import LaunchDescription
+from launch.substitutions import Command, PathJoinSubstitution, FindExecutable
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+from launch_ros.substitutions import FindPackageShare
+
+DESCRIPTION_PACKAGE = "flat_plate_camera_bracket_description"
+
+def generate_launch_description():
+    robot_description = ParameterValue(Command([
+        FindExecutable(name="xacro"), " ",
+        PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "urdf", "test_flat_plate_camera_bracket.urdf.xacro"]),
+    ]), value_type=str)
+
+    return LaunchDescription([
+        Node(package="robot_state_publisher", executable="robot_state_publisher", parameters=[{"robot_description": robot_description}]),
+        Node(package="rviz2", executable="rviz2", output="screen", arguments=["-d", PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "rviz", "view_flat_plate_camera_bracket.rviz"])]),
+    ])

--- a/assets/environment/flat_plate_camera_bracket_description/meshes/collision/flat_plate_camera_bracket.stl
+++ b/assets/environment/flat_plate_camera_bracket_description/meshes/collision/flat_plate_camera_bracket.stl
@@ -1,0 +1,86 @@
+solid flat_plate_camera_bracket_collision
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 0.325 -0.825
+      vertex -0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 0.825
+      vertex 0.425 0.325 0.825
+      vertex 0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 0.825
+      vertex -0.425 0.325 0.825
+      vertex 0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex -0.425 -0.325 0.825
+      vertex 0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 -0.325 0.825
+      vertex 0.425 -0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 -0.325 0.825
+      vertex 0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 0.325 0.825
+      vertex 0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 0.325 -0.825
+      vertex 0.425 0.325 0.825
+      vertex -0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 0.325 -0.825
+      vertex -0.425 0.325 0.825
+      vertex -0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 0.325 -0.825
+      vertex -0.425 0.325 0.825
+      vertex -0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 0.325 -0.825
+      vertex -0.425 -0.325 0.825
+      vertex -0.425 -0.325 -0.825
+    endloop
+  endfacet
+endsolid flat_plate_camera_bracket_collision

--- a/assets/environment/flat_plate_camera_bracket_description/meshes/visual/flat_plate_camera_bracket.stl
+++ b/assets/environment/flat_plate_camera_bracket_description/meshes/visual/flat_plate_camera_bracket.stl
@@ -1,0 +1,86 @@
+solid flat_plate_camera_bracket
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 0.3 -0.8
+      vertex -0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 0.8
+      vertex 0.4 0.3 0.8
+      vertex 0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 0.8
+      vertex -0.4 0.3 0.8
+      vertex 0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex -0.4 -0.3 0.8
+      vertex 0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 -0.3 0.8
+      vertex 0.4 -0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 -0.3 0.8
+      vertex 0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 0.3 0.8
+      vertex 0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 0.3 -0.8
+      vertex 0.4 0.3 0.8
+      vertex -0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 0.3 -0.8
+      vertex -0.4 0.3 0.8
+      vertex -0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 0.3 -0.8
+      vertex -0.4 0.3 0.8
+      vertex -0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 0.3 -0.8
+      vertex -0.4 -0.3 0.8
+      vertex -0.4 -0.3 -0.8
+    endloop
+  endfacet
+endsolid flat_plate_camera_bracket

--- a/assets/environment/flat_plate_camera_bracket_description/package.xml
+++ b/assets/environment/flat_plate_camera_bracket_description/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>flat_plate_camera_bracket_description</name>
+  <version>0.1.0</version>
+  <description>Camera support description package for flat plate camera bracket.</description>
+  <maintainer email="maintainers@easy-manipulator.local">Easy Manipulator Team</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/assets/environment/flat_plate_camera_bracket_description/rviz/view_flat_plate_camera_bracket.rviz
+++ b/assets/environment/flat_plate_camera_bracket_description/rviz/view_flat_plate_camera_bracket.rviz
@@ -1,0 +1,3 @@
+Panels: []
+Visualization Manager:
+  Class: ""

--- a/assets/environment/flat_plate_camera_bracket_description/urdf/flat_plate_camera_bracket.urdf.xacro
+++ b/assets/environment/flat_plate_camera_bracket_description/urdf/flat_plate_camera_bracket.urdf.xacro
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<robot name="flat_plate_camera_bracket" xmlns:xacro="http://ros.org/wiki/xacro">
+  <link name="base_link"/>
+  <link name="flat_plate_camera_bracket_body">
+    <visual><geometry><mesh filename="package://flat_plate_camera_bracket_description/meshes/visual/flat_plate_camera_bracket.stl" scale="1 1 1"/></geometry></visual>
+    <collision><geometry><mesh filename="package://flat_plate_camera_bracket_description/meshes/collision/flat_plate_camera_bracket.stl" scale="1 1 1"/></geometry></collision>
+    <inertial><mass value="5.0"/><origin xyz="0 0 0"/><inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/></inertial>
+  </link>
+  <joint name="flat_plate_camera_bracket_base_joint" type="fixed"><parent link="base_link"/><child link="flat_plate_camera_bracket_body"/></joint>
+  <link name="camera_mount_link"/>
+  <joint name="flat_plate_camera_bracket_camera_mount_joint" type="fixed"><parent link="flat_plate_camera_bracket_body"/><child link="camera_mount_link"/><origin xyz="0 0 0.8" rpy="0 0 0"/></joint>
+</robot>

--- a/assets/environment/flat_plate_camera_bracket_description/urdf/test_flat_plate_camera_bracket.urdf.xacro
+++ b/assets/environment/flat_plate_camera_bracket_description/urdf/test_flat_plate_camera_bracket.urdf.xacro
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<robot name="test_flat_plate_camera_bracket" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find flat_plate_camera_bracket_description)/urdf/flat_plate_camera_bracket.urdf.xacro"/>
+  <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro"/>
+  <link name="world"/>
+  <joint name="world_to_base" type="fixed"><parent link="world"/><child link="base_link"/></joint>
+  <xacro:sensor_d435 parent="camera_mount_link" use_nominal_extrinsics="true"><origin xyz="0 0 0" rpy="0 0 0"/></xacro:sensor_d435>
+</robot>

--- a/assets/environment/overhead_camera_gantry_description/CMakeLists.txt
+++ b/assets/environment/overhead_camera_gantry_description/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.5)
+project(overhead_camera_gantry_description)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_runtime REQUIRED)
+
+install(DIRECTORY launch meshes rviz urdf
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/assets/environment/overhead_camera_gantry_description/launch/view_overhead_camera_gantry.launch.py
+++ b/assets/environment/overhead_camera_gantry_description/launch/view_overhead_camera_gantry.launch.py
@@ -1,0 +1,18 @@
+from launch import LaunchDescription
+from launch.substitutions import Command, PathJoinSubstitution, FindExecutable
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+from launch_ros.substitutions import FindPackageShare
+
+DESCRIPTION_PACKAGE = "overhead_camera_gantry_description"
+
+def generate_launch_description():
+    robot_description = ParameterValue(Command([
+        FindExecutable(name="xacro"), " ",
+        PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "urdf", "test_overhead_camera_gantry.urdf.xacro"]),
+    ]), value_type=str)
+
+    return LaunchDescription([
+        Node(package="robot_state_publisher", executable="robot_state_publisher", parameters=[{"robot_description": robot_description}]),
+        Node(package="rviz2", executable="rviz2", output="screen", arguments=["-d", PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "rviz", "view_overhead_camera_gantry.rviz"])]),
+    ])

--- a/assets/environment/overhead_camera_gantry_description/meshes/collision/overhead_camera_gantry.stl
+++ b/assets/environment/overhead_camera_gantry_description/meshes/collision/overhead_camera_gantry.stl
@@ -1,0 +1,86 @@
+solid overhead_camera_gantry_collision
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 0.325 -0.825
+      vertex -0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 0.825
+      vertex 0.425 0.325 0.825
+      vertex 0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 0.825
+      vertex -0.425 0.325 0.825
+      vertex 0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex -0.425 -0.325 0.825
+      vertex 0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 -0.325 0.825
+      vertex 0.425 -0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 -0.325 0.825
+      vertex 0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 0.325 0.825
+      vertex 0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 0.325 -0.825
+      vertex 0.425 0.325 0.825
+      vertex -0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 0.325 -0.825
+      vertex -0.425 0.325 0.825
+      vertex -0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 0.325 -0.825
+      vertex -0.425 0.325 0.825
+      vertex -0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 0.325 -0.825
+      vertex -0.425 -0.325 0.825
+      vertex -0.425 -0.325 -0.825
+    endloop
+  endfacet
+endsolid overhead_camera_gantry_collision

--- a/assets/environment/overhead_camera_gantry_description/meshes/visual/overhead_camera_gantry.stl
+++ b/assets/environment/overhead_camera_gantry_description/meshes/visual/overhead_camera_gantry.stl
@@ -1,0 +1,86 @@
+solid overhead_camera_gantry
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 0.3 -0.8
+      vertex -0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 0.8
+      vertex 0.4 0.3 0.8
+      vertex 0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 0.8
+      vertex -0.4 0.3 0.8
+      vertex 0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex -0.4 -0.3 0.8
+      vertex 0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 -0.3 0.8
+      vertex 0.4 -0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 -0.3 0.8
+      vertex 0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 0.3 0.8
+      vertex 0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 0.3 -0.8
+      vertex 0.4 0.3 0.8
+      vertex -0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 0.3 -0.8
+      vertex -0.4 0.3 0.8
+      vertex -0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 0.3 -0.8
+      vertex -0.4 0.3 0.8
+      vertex -0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 0.3 -0.8
+      vertex -0.4 -0.3 0.8
+      vertex -0.4 -0.3 -0.8
+    endloop
+  endfacet
+endsolid overhead_camera_gantry

--- a/assets/environment/overhead_camera_gantry_description/overhead_camera_gantry.yaml
+++ b/assets/environment/overhead_camera_gantry_description/overhead_camera_gantry.yaml
@@ -1,0 +1,23 @@
+overhead_camera_gantry:
+  child_link: overhead_camera_gantry_body
+  links:
+    overhead_camera_gantry_body:
+      visual:
+        name: overhead_camera_gantry_visual
+        geometry:
+          filepath: package://overhead_camera_gantry_description/meshes/visual/overhead_camera_gantry.stl
+          scale:
+            scale_x: 1.0
+            scale_y: 1.0
+            scale_z: 1.0
+      collision:
+        name: overhead_camera_gantry_collision
+        geometry:
+          filepath: package://overhead_camera_gantry_description/meshes/collision/overhead_camera_gantry.stl
+          scale:
+            scale_x: 1.0
+            scale_y: 1.0
+            scale_z: 1.0
+  overhead_camera_gantry_base_joint:
+    ext_joint_type: fixed
+    child_link: overhead_camera_gantry_body

--- a/assets/environment/overhead_camera_gantry_description/package.xml
+++ b/assets/environment/overhead_camera_gantry_description/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>overhead_camera_gantry_description</name>
+  <version>0.1.0</version>
+  <description>Camera support description package for overhead camera gantry.</description>
+  <maintainer email="maintainers@easy-manipulator.local">Easy Manipulator Team</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/assets/environment/overhead_camera_gantry_description/rviz/view_overhead_camera_gantry.rviz
+++ b/assets/environment/overhead_camera_gantry_description/rviz/view_overhead_camera_gantry.rviz
@@ -1,0 +1,3 @@
+Panels: []
+Visualization Manager:
+  Class: ""

--- a/assets/environment/overhead_camera_gantry_description/urdf/overhead_camera_gantry.urdf.xacro
+++ b/assets/environment/overhead_camera_gantry_description/urdf/overhead_camera_gantry.urdf.xacro
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<robot name="overhead_camera_gantry" xmlns:xacro="http://ros.org/wiki/xacro">
+  <link name="base_link"/>
+  <link name="overhead_camera_gantry_body">
+    <visual><geometry><mesh filename="package://overhead_camera_gantry_description/meshes/visual/overhead_camera_gantry.stl" scale="1 1 1"/></geometry></visual>
+    <collision><geometry><mesh filename="package://overhead_camera_gantry_description/meshes/collision/overhead_camera_gantry.stl" scale="1 1 1"/></geometry></collision>
+    <inertial><mass value="5.0"/><origin xyz="0 0 0"/><inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/></inertial>
+  </link>
+  <joint name="overhead_camera_gantry_base_joint" type="fixed"><parent link="base_link"/><child link="overhead_camera_gantry_body"/></joint>
+  <link name="camera_mount_link"/>
+  <joint name="overhead_camera_gantry_camera_mount_joint" type="fixed"><parent link="overhead_camera_gantry_body"/><child link="camera_mount_link"/><origin xyz="0 0 0.8" rpy="0 0 0"/></joint>
+</robot>

--- a/assets/environment/overhead_camera_gantry_description/urdf/test_overhead_camera_gantry.urdf.xacro
+++ b/assets/environment/overhead_camera_gantry_description/urdf/test_overhead_camera_gantry.urdf.xacro
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<robot name="test_overhead_camera_gantry" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find overhead_camera_gantry_description)/urdf/overhead_camera_gantry.urdf.xacro"/>
+  <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro"/>
+  <link name="world"/>
+  <joint name="world_to_base" type="fixed"><parent link="world"/><child link="base_link"/></joint>
+  <xacro:sensor_d435 parent="camera_mount_link" use_nominal_extrinsics="true"><origin xyz="0 0 0" rpy="0 0 0"/></xacro:sensor_d435>
+</robot>

--- a/assets/environment/pipe_camera_stand_description/CMakeLists.txt
+++ b/assets/environment/pipe_camera_stand_description/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.5)
+project(pipe_camera_stand_description)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_runtime REQUIRED)
+
+install(DIRECTORY launch meshes rviz urdf
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/assets/environment/pipe_camera_stand_description/launch/view_pipe_camera_stand.launch.py
+++ b/assets/environment/pipe_camera_stand_description/launch/view_pipe_camera_stand.launch.py
@@ -1,0 +1,18 @@
+from launch import LaunchDescription
+from launch.substitutions import Command, PathJoinSubstitution, FindExecutable
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+from launch_ros.substitutions import FindPackageShare
+
+DESCRIPTION_PACKAGE = "pipe_camera_stand_description"
+
+def generate_launch_description():
+    robot_description = ParameterValue(Command([
+        FindExecutable(name="xacro"), " ",
+        PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "urdf", "test_pipe_camera_stand.urdf.xacro"]),
+    ]), value_type=str)
+
+    return LaunchDescription([
+        Node(package="robot_state_publisher", executable="robot_state_publisher", parameters=[{"robot_description": robot_description}]),
+        Node(package="rviz2", executable="rviz2", output="screen", arguments=["-d", PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "rviz", "view_pipe_camera_stand.rviz"])]),
+    ])

--- a/assets/environment/pipe_camera_stand_description/meshes/collision/pipe_camera_stand.stl
+++ b/assets/environment/pipe_camera_stand_description/meshes/collision/pipe_camera_stand.stl
@@ -1,0 +1,86 @@
+solid pipe_camera_stand_collision
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 0.325 -0.825
+      vertex -0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 0.825
+      vertex 0.425 0.325 0.825
+      vertex 0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 0.825
+      vertex -0.425 0.325 0.825
+      vertex 0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex -0.425 -0.325 0.825
+      vertex 0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 -0.325 0.825
+      vertex 0.425 -0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 -0.325 0.825
+      vertex 0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 0.325 0.825
+      vertex 0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 0.325 -0.825
+      vertex 0.425 0.325 0.825
+      vertex -0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 0.325 -0.825
+      vertex -0.425 0.325 0.825
+      vertex -0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 0.325 -0.825
+      vertex -0.425 0.325 0.825
+      vertex -0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 0.325 -0.825
+      vertex -0.425 -0.325 0.825
+      vertex -0.425 -0.325 -0.825
+    endloop
+  endfacet
+endsolid pipe_camera_stand_collision

--- a/assets/environment/pipe_camera_stand_description/meshes/visual/pipe_camera_stand.stl
+++ b/assets/environment/pipe_camera_stand_description/meshes/visual/pipe_camera_stand.stl
@@ -1,0 +1,86 @@
+solid pipe_camera_stand
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 0.3 -0.8
+      vertex -0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 0.8
+      vertex 0.4 0.3 0.8
+      vertex 0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 0.8
+      vertex -0.4 0.3 0.8
+      vertex 0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex -0.4 -0.3 0.8
+      vertex 0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 -0.3 0.8
+      vertex 0.4 -0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 -0.3 0.8
+      vertex 0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 0.3 0.8
+      vertex 0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 0.3 -0.8
+      vertex 0.4 0.3 0.8
+      vertex -0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 0.3 -0.8
+      vertex -0.4 0.3 0.8
+      vertex -0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 0.3 -0.8
+      vertex -0.4 0.3 0.8
+      vertex -0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 0.3 -0.8
+      vertex -0.4 -0.3 0.8
+      vertex -0.4 -0.3 -0.8
+    endloop
+  endfacet
+endsolid pipe_camera_stand

--- a/assets/environment/pipe_camera_stand_description/package.xml
+++ b/assets/environment/pipe_camera_stand_description/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>pipe_camera_stand_description</name>
+  <version>0.1.0</version>
+  <description>Camera support description package for pipe camera stand.</description>
+  <maintainer email="maintainers@easy-manipulator.local">Easy Manipulator Team</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/assets/environment/pipe_camera_stand_description/pipe_camera_stand.yaml
+++ b/assets/environment/pipe_camera_stand_description/pipe_camera_stand.yaml
@@ -1,0 +1,23 @@
+pipe_camera_stand:
+  child_link: pipe_camera_stand_body
+  links:
+    pipe_camera_stand_body:
+      visual:
+        name: pipe_camera_stand_visual
+        geometry:
+          filepath: package://pipe_camera_stand_description/meshes/visual/pipe_camera_stand.stl
+          scale:
+            scale_x: 1.0
+            scale_y: 1.0
+            scale_z: 1.0
+      collision:
+        name: pipe_camera_stand_collision
+        geometry:
+          filepath: package://pipe_camera_stand_description/meshes/collision/pipe_camera_stand.stl
+          scale:
+            scale_x: 1.0
+            scale_y: 1.0
+            scale_z: 1.0
+  pipe_camera_stand_base_joint:
+    ext_joint_type: fixed
+    child_link: pipe_camera_stand_body

--- a/assets/environment/pipe_camera_stand_description/rviz/view_pipe_camera_stand.rviz
+++ b/assets/environment/pipe_camera_stand_description/rviz/view_pipe_camera_stand.rviz
@@ -1,0 +1,3 @@
+Panels: []
+Visualization Manager:
+  Class: ""

--- a/assets/environment/pipe_camera_stand_description/urdf/pipe_camera_stand.urdf.xacro
+++ b/assets/environment/pipe_camera_stand_description/urdf/pipe_camera_stand.urdf.xacro
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<robot name="pipe_camera_stand" xmlns:xacro="http://ros.org/wiki/xacro">
+  <link name="base_link"/>
+  <link name="pipe_camera_stand_body">
+    <visual><geometry><mesh filename="package://pipe_camera_stand_description/meshes/visual/pipe_camera_stand.stl" scale="1 1 1"/></geometry></visual>
+    <collision><geometry><mesh filename="package://pipe_camera_stand_description/meshes/collision/pipe_camera_stand.stl" scale="1 1 1"/></geometry></collision>
+    <inertial><mass value="5.0"/><origin xyz="0 0 0"/><inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/></inertial>
+  </link>
+  <joint name="pipe_camera_stand_base_joint" type="fixed"><parent link="base_link"/><child link="pipe_camera_stand_body"/></joint>
+  <link name="camera_mount_link"/>
+  <joint name="pipe_camera_stand_camera_mount_joint" type="fixed"><parent link="pipe_camera_stand_body"/><child link="camera_mount_link"/><origin xyz="0 0 0.8" rpy="0 0 0"/></joint>
+</robot>

--- a/assets/environment/pipe_camera_stand_description/urdf/test_pipe_camera_stand.urdf.xacro
+++ b/assets/environment/pipe_camera_stand_description/urdf/test_pipe_camera_stand.urdf.xacro
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<robot name="test_pipe_camera_stand" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find pipe_camera_stand_description)/urdf/pipe_camera_stand.urdf.xacro"/>
+  <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro"/>
+  <link name="world"/>
+  <joint name="world_to_base" type="fixed"><parent link="world"/><child link="base_link"/></joint>
+  <xacro:sensor_d435 parent="camera_mount_link" use_nominal_extrinsics="true"><origin xyz="0 0 0" rpy="0 0 0"/></xacro:sensor_d435>
+</robot>

--- a/assets/environment/table_clamp_camera_mount_description/CMakeLists.txt
+++ b/assets/environment/table_clamp_camera_mount_description/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.5)
+project(table_clamp_camera_mount_description)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_runtime REQUIRED)
+
+install(DIRECTORY launch meshes rviz urdf
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/assets/environment/table_clamp_camera_mount_description/launch/view_table_clamp_camera_mount.launch.py
+++ b/assets/environment/table_clamp_camera_mount_description/launch/view_table_clamp_camera_mount.launch.py
@@ -1,0 +1,18 @@
+from launch import LaunchDescription
+from launch.substitutions import Command, PathJoinSubstitution, FindExecutable
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+from launch_ros.substitutions import FindPackageShare
+
+DESCRIPTION_PACKAGE = "table_clamp_camera_mount_description"
+
+def generate_launch_description():
+    robot_description = ParameterValue(Command([
+        FindExecutable(name="xacro"), " ",
+        PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "urdf", "test_table_clamp_camera_mount.urdf.xacro"]),
+    ]), value_type=str)
+
+    return LaunchDescription([
+        Node(package="robot_state_publisher", executable="robot_state_publisher", parameters=[{"robot_description": robot_description}]),
+        Node(package="rviz2", executable="rviz2", output="screen", arguments=["-d", PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "rviz", "view_table_clamp_camera_mount.rviz"])]),
+    ])

--- a/assets/environment/table_clamp_camera_mount_description/meshes/collision/table_clamp_camera_mount.stl
+++ b/assets/environment/table_clamp_camera_mount_description/meshes/collision/table_clamp_camera_mount.stl
@@ -1,0 +1,86 @@
+solid table_clamp_camera_mount_collision
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 0.325 -0.825
+      vertex -0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 0.825
+      vertex 0.425 0.325 0.825
+      vertex 0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 0.825
+      vertex -0.425 0.325 0.825
+      vertex 0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex -0.425 -0.325 0.825
+      vertex 0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 -0.325 0.825
+      vertex 0.425 -0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 -0.325 0.825
+      vertex 0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 0.325 0.825
+      vertex 0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 0.325 -0.825
+      vertex 0.425 0.325 0.825
+      vertex -0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 0.325 -0.825
+      vertex -0.425 0.325 0.825
+      vertex -0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 0.325 -0.825
+      vertex -0.425 0.325 0.825
+      vertex -0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 0.325 -0.825
+      vertex -0.425 -0.325 0.825
+      vertex -0.425 -0.325 -0.825
+    endloop
+  endfacet
+endsolid table_clamp_camera_mount_collision

--- a/assets/environment/table_clamp_camera_mount_description/meshes/visual/table_clamp_camera_mount.stl
+++ b/assets/environment/table_clamp_camera_mount_description/meshes/visual/table_clamp_camera_mount.stl
@@ -1,0 +1,86 @@
+solid table_clamp_camera_mount
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 0.3 -0.8
+      vertex -0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 0.8
+      vertex 0.4 0.3 0.8
+      vertex 0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 0.8
+      vertex -0.4 0.3 0.8
+      vertex 0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex -0.4 -0.3 0.8
+      vertex 0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 -0.3 0.8
+      vertex 0.4 -0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 -0.3 0.8
+      vertex 0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 0.3 0.8
+      vertex 0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 0.3 -0.8
+      vertex 0.4 0.3 0.8
+      vertex -0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 0.3 -0.8
+      vertex -0.4 0.3 0.8
+      vertex -0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 0.3 -0.8
+      vertex -0.4 0.3 0.8
+      vertex -0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 0.3 -0.8
+      vertex -0.4 -0.3 0.8
+      vertex -0.4 -0.3 -0.8
+    endloop
+  endfacet
+endsolid table_clamp_camera_mount

--- a/assets/environment/table_clamp_camera_mount_description/package.xml
+++ b/assets/environment/table_clamp_camera_mount_description/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>table_clamp_camera_mount_description</name>
+  <version>0.1.0</version>
+  <description>Camera support description package for table clamp camera mount.</description>
+  <maintainer email="maintainers@easy-manipulator.local">Easy Manipulator Team</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/assets/environment/table_clamp_camera_mount_description/rviz/view_table_clamp_camera_mount.rviz
+++ b/assets/environment/table_clamp_camera_mount_description/rviz/view_table_clamp_camera_mount.rviz
@@ -1,0 +1,3 @@
+Panels: []
+Visualization Manager:
+  Class: ""

--- a/assets/environment/table_clamp_camera_mount_description/table_clamp_camera_mount.yaml
+++ b/assets/environment/table_clamp_camera_mount_description/table_clamp_camera_mount.yaml
@@ -1,0 +1,23 @@
+table_clamp_camera_mount:
+  child_link: table_clamp_camera_mount_body
+  links:
+    table_clamp_camera_mount_body:
+      visual:
+        name: table_clamp_camera_mount_visual
+        geometry:
+          filepath: package://table_clamp_camera_mount_description/meshes/visual/table_clamp_camera_mount.stl
+          scale:
+            scale_x: 1.0
+            scale_y: 1.0
+            scale_z: 1.0
+      collision:
+        name: table_clamp_camera_mount_collision
+        geometry:
+          filepath: package://table_clamp_camera_mount_description/meshes/collision/table_clamp_camera_mount.stl
+          scale:
+            scale_x: 1.0
+            scale_y: 1.0
+            scale_z: 1.0
+  table_clamp_camera_mount_base_joint:
+    ext_joint_type: fixed
+    child_link: table_clamp_camera_mount_body

--- a/assets/environment/table_clamp_camera_mount_description/urdf/table_clamp_camera_mount.urdf.xacro
+++ b/assets/environment/table_clamp_camera_mount_description/urdf/table_clamp_camera_mount.urdf.xacro
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<robot name="table_clamp_camera_mount" xmlns:xacro="http://ros.org/wiki/xacro">
+  <link name="base_link"/>
+  <link name="table_clamp_camera_mount_body">
+    <visual><geometry><mesh filename="package://table_clamp_camera_mount_description/meshes/visual/table_clamp_camera_mount.stl" scale="1 1 1"/></geometry></visual>
+    <collision><geometry><mesh filename="package://table_clamp_camera_mount_description/meshes/collision/table_clamp_camera_mount.stl" scale="1 1 1"/></geometry></collision>
+    <inertial><mass value="5.0"/><origin xyz="0 0 0"/><inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/></inertial>
+  </link>
+  <joint name="table_clamp_camera_mount_base_joint" type="fixed"><parent link="base_link"/><child link="table_clamp_camera_mount_body"/></joint>
+  <link name="camera_mount_link"/>
+  <joint name="table_clamp_camera_mount_camera_mount_joint" type="fixed"><parent link="table_clamp_camera_mount_body"/><child link="camera_mount_link"/><origin xyz="0 0 0.8" rpy="0 0 0"/></joint>
+</robot>

--- a/assets/environment/table_clamp_camera_mount_description/urdf/test_table_clamp_camera_mount.urdf.xacro
+++ b/assets/environment/table_clamp_camera_mount_description/urdf/test_table_clamp_camera_mount.urdf.xacro
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<robot name="test_table_clamp_camera_mount" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find table_clamp_camera_mount_description)/urdf/table_clamp_camera_mount.urdf.xacro"/>
+  <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro"/>
+  <link name="world"/>
+  <joint name="world_to_base" type="fixed"><parent link="world"/><child link="base_link"/></joint>
+  <xacro:sensor_d435 parent="camera_mount_link" use_nominal_extrinsics="true"><origin xyz="0 0 0" rpy="0 0 0"/></xacro:sensor_d435>
+</robot>

--- a/assets/environment/tslot_camera_frame_description/CMakeLists.txt
+++ b/assets/environment/tslot_camera_frame_description/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.5)
+project(tslot_camera_frame_description)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_runtime REQUIRED)
+
+install(DIRECTORY launch meshes rviz urdf
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/assets/environment/tslot_camera_frame_description/launch/view_tslot_camera_frame.launch.py
+++ b/assets/environment/tslot_camera_frame_description/launch/view_tslot_camera_frame.launch.py
@@ -1,0 +1,18 @@
+from launch import LaunchDescription
+from launch.substitutions import Command, PathJoinSubstitution, FindExecutable
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+from launch_ros.substitutions import FindPackageShare
+
+DESCRIPTION_PACKAGE = "tslot_camera_frame_description"
+
+def generate_launch_description():
+    robot_description = ParameterValue(Command([
+        FindExecutable(name="xacro"), " ",
+        PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "urdf", "test_tslot_camera_frame.urdf.xacro"]),
+    ]), value_type=str)
+
+    return LaunchDescription([
+        Node(package="robot_state_publisher", executable="robot_state_publisher", parameters=[{"robot_description": robot_description}]),
+        Node(package="rviz2", executable="rviz2", output="screen", arguments=["-d", PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "rviz", "view_tslot_camera_frame.rviz"])]),
+    ])

--- a/assets/environment/tslot_camera_frame_description/meshes/collision/tslot_camera_frame.stl
+++ b/assets/environment/tslot_camera_frame_description/meshes/collision/tslot_camera_frame.stl
@@ -1,0 +1,86 @@
+solid tslot_camera_frame_collision
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 0.325 -0.825
+      vertex -0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 0.825
+      vertex 0.425 0.325 0.825
+      vertex 0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 0.825
+      vertex -0.425 0.325 0.825
+      vertex 0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex -0.425 -0.325 0.825
+      vertex 0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 -0.325 0.825
+      vertex 0.425 -0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 -0.325 0.825
+      vertex 0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 0.325 0.825
+      vertex 0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 0.325 -0.825
+      vertex 0.425 0.325 0.825
+      vertex -0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 0.325 -0.825
+      vertex -0.425 0.325 0.825
+      vertex -0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 0.325 -0.825
+      vertex -0.425 0.325 0.825
+      vertex -0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 0.325 -0.825
+      vertex -0.425 -0.325 0.825
+      vertex -0.425 -0.325 -0.825
+    endloop
+  endfacet
+endsolid tslot_camera_frame_collision

--- a/assets/environment/tslot_camera_frame_description/meshes/visual/tslot_camera_frame.stl
+++ b/assets/environment/tslot_camera_frame_description/meshes/visual/tslot_camera_frame.stl
@@ -1,0 +1,86 @@
+solid tslot_camera_frame
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 0.3 -0.8
+      vertex -0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 0.8
+      vertex 0.4 0.3 0.8
+      vertex 0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 0.8
+      vertex -0.4 0.3 0.8
+      vertex 0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex -0.4 -0.3 0.8
+      vertex 0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 -0.3 0.8
+      vertex 0.4 -0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 -0.3 0.8
+      vertex 0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 0.3 0.8
+      vertex 0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 0.3 -0.8
+      vertex 0.4 0.3 0.8
+      vertex -0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 0.3 -0.8
+      vertex -0.4 0.3 0.8
+      vertex -0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 0.3 -0.8
+      vertex -0.4 0.3 0.8
+      vertex -0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 0.3 -0.8
+      vertex -0.4 -0.3 0.8
+      vertex -0.4 -0.3 -0.8
+    endloop
+  endfacet
+endsolid tslot_camera_frame

--- a/assets/environment/tslot_camera_frame_description/package.xml
+++ b/assets/environment/tslot_camera_frame_description/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>tslot_camera_frame_description</name>
+  <version>0.1.0</version>
+  <description>Camera support description package for tslot camera frame.</description>
+  <maintainer email="maintainers@easy-manipulator.local">Easy Manipulator Team</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/assets/environment/tslot_camera_frame_description/rviz/view_tslot_camera_frame.rviz
+++ b/assets/environment/tslot_camera_frame_description/rviz/view_tslot_camera_frame.rviz
@@ -1,0 +1,3 @@
+Panels: []
+Visualization Manager:
+  Class: ""

--- a/assets/environment/tslot_camera_frame_description/tslot_camera_frame.yaml
+++ b/assets/environment/tslot_camera_frame_description/tslot_camera_frame.yaml
@@ -1,0 +1,23 @@
+tslot_camera_frame:
+  child_link: tslot_camera_frame_body
+  links:
+    tslot_camera_frame_body:
+      visual:
+        name: tslot_camera_frame_visual
+        geometry:
+          filepath: package://tslot_camera_frame_description/meshes/visual/tslot_camera_frame.stl
+          scale:
+            scale_x: 1.0
+            scale_y: 1.0
+            scale_z: 1.0
+      collision:
+        name: tslot_camera_frame_collision
+        geometry:
+          filepath: package://tslot_camera_frame_description/meshes/collision/tslot_camera_frame.stl
+          scale:
+            scale_x: 1.0
+            scale_y: 1.0
+            scale_z: 1.0
+  tslot_camera_frame_base_joint:
+    ext_joint_type: fixed
+    child_link: tslot_camera_frame_body

--- a/assets/environment/tslot_camera_frame_description/urdf/test_tslot_camera_frame.urdf.xacro
+++ b/assets/environment/tslot_camera_frame_description/urdf/test_tslot_camera_frame.urdf.xacro
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<robot name="test_tslot_camera_frame" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find tslot_camera_frame_description)/urdf/tslot_camera_frame.urdf.xacro"/>
+  <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro"/>
+  <link name="world"/>
+  <joint name="world_to_base" type="fixed"><parent link="world"/><child link="base_link"/></joint>
+  <xacro:sensor_d435 parent="camera_mount_link" use_nominal_extrinsics="true"><origin xyz="0 0 0" rpy="0 0 0"/></xacro:sensor_d435>
+</robot>

--- a/assets/environment/tslot_camera_frame_description/urdf/tslot_camera_frame.urdf.xacro
+++ b/assets/environment/tslot_camera_frame_description/urdf/tslot_camera_frame.urdf.xacro
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<robot name="tslot_camera_frame" xmlns:xacro="http://ros.org/wiki/xacro">
+  <link name="base_link"/>
+  <link name="tslot_camera_frame_body">
+    <visual><geometry><mesh filename="package://tslot_camera_frame_description/meshes/visual/tslot_camera_frame.stl" scale="1 1 1"/></geometry></visual>
+    <collision><geometry><mesh filename="package://tslot_camera_frame_description/meshes/collision/tslot_camera_frame.stl" scale="1 1 1"/></geometry></collision>
+    <inertial><mass value="5.0"/><origin xyz="0 0 0"/><inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/></inertial>
+  </link>
+  <joint name="tslot_camera_frame_base_joint" type="fixed"><parent link="base_link"/><child link="tslot_camera_frame_body"/></joint>
+  <link name="camera_mount_link"/>
+  <joint name="tslot_camera_frame_camera_mount_joint" type="fixed"><parent link="tslot_camera_frame_body"/><child link="camera_mount_link"/><origin xyz="0 0 0.8" rpy="0 0 0"/></joint>
+</robot>

--- a/assets/environment/vslot_camera_frame_description/CMakeLists.txt
+++ b/assets/environment/vslot_camera_frame_description/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.5)
+project(vslot_camera_frame_description)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_runtime REQUIRED)
+
+install(DIRECTORY launch meshes rviz urdf
+  DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/assets/environment/vslot_camera_frame_description/launch/view_vslot_camera_frame.launch.py
+++ b/assets/environment/vslot_camera_frame_description/launch/view_vslot_camera_frame.launch.py
@@ -1,0 +1,18 @@
+from launch import LaunchDescription
+from launch.substitutions import Command, PathJoinSubstitution, FindExecutable
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+from launch_ros.substitutions import FindPackageShare
+
+DESCRIPTION_PACKAGE = "vslot_camera_frame_description"
+
+def generate_launch_description():
+    robot_description = ParameterValue(Command([
+        FindExecutable(name="xacro"), " ",
+        PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "urdf", "test_vslot_camera_frame.urdf.xacro"]),
+    ]), value_type=str)
+
+    return LaunchDescription([
+        Node(package="robot_state_publisher", executable="robot_state_publisher", parameters=[{"robot_description": robot_description}]),
+        Node(package="rviz2", executable="rviz2", output="screen", arguments=["-d", PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "rviz", "view_vslot_camera_frame.rviz"])]),
+    ])

--- a/assets/environment/vslot_camera_frame_description/meshes/collision/vslot_camera_frame.stl
+++ b/assets/environment/vslot_camera_frame_description/meshes/collision/vslot_camera_frame.stl
@@ -1,0 +1,86 @@
+solid vslot_camera_frame_collision
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 0.325 -0.825
+      vertex -0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 0.825
+      vertex 0.425 0.325 0.825
+      vertex 0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 0.825
+      vertex -0.425 0.325 0.825
+      vertex 0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex -0.425 -0.325 0.825
+      vertex 0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 -0.325 -0.825
+      vertex 0.425 -0.325 0.825
+      vertex 0.425 -0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 -0.325 0.825
+      vertex 0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 -0.325 -0.825
+      vertex 0.425 0.325 0.825
+      vertex 0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 0.325 -0.825
+      vertex 0.425 0.325 0.825
+      vertex -0.425 0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.425 0.325 -0.825
+      vertex -0.425 0.325 0.825
+      vertex -0.425 0.325 -0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 0.325 -0.825
+      vertex -0.425 0.325 0.825
+      vertex -0.425 -0.325 0.825
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.425 0.325 -0.825
+      vertex -0.425 -0.325 0.825
+      vertex -0.425 -0.325 -0.825
+    endloop
+  endfacet
+endsolid vslot_camera_frame_collision

--- a/assets/environment/vslot_camera_frame_description/meshes/visual/vslot_camera_frame.stl
+++ b/assets/environment/vslot_camera_frame_description/meshes/visual/vslot_camera_frame.stl
@@ -1,0 +1,86 @@
+solid vslot_camera_frame
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 0.3 -0.8
+      vertex -0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 0.8
+      vertex 0.4 0.3 0.8
+      vertex 0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 0.8
+      vertex -0.4 0.3 0.8
+      vertex 0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex -0.4 -0.3 0.8
+      vertex 0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 -0.3 -0.8
+      vertex 0.4 -0.3 0.8
+      vertex 0.4 -0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 -0.3 0.8
+      vertex 0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 -0.3 -0.8
+      vertex 0.4 0.3 0.8
+      vertex 0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 0.3 -0.8
+      vertex 0.4 0.3 0.8
+      vertex -0.4 0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 0.4 0.3 -0.8
+      vertex -0.4 0.3 0.8
+      vertex -0.4 0.3 -0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 0.3 -0.8
+      vertex -0.4 0.3 0.8
+      vertex -0.4 -0.3 0.8
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -0.4 0.3 -0.8
+      vertex -0.4 -0.3 0.8
+      vertex -0.4 -0.3 -0.8
+    endloop
+  endfacet
+endsolid vslot_camera_frame

--- a/assets/environment/vslot_camera_frame_description/package.xml
+++ b/assets/environment/vslot_camera_frame_description/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>vslot_camera_frame_description</name>
+  <version>0.1.0</version>
+  <description>Camera support description package for vslot camera frame.</description>
+  <maintainer email="maintainers@easy-manipulator.local">Easy Manipulator Team</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/assets/environment/vslot_camera_frame_description/rviz/view_vslot_camera_frame.rviz
+++ b/assets/environment/vslot_camera_frame_description/rviz/view_vslot_camera_frame.rviz
@@ -1,0 +1,3 @@
+Panels: []
+Visualization Manager:
+  Class: ""

--- a/assets/environment/vslot_camera_frame_description/urdf/test_vslot_camera_frame.urdf.xacro
+++ b/assets/environment/vslot_camera_frame_description/urdf/test_vslot_camera_frame.urdf.xacro
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<robot name="test_vslot_camera_frame" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find vslot_camera_frame_description)/urdf/vslot_camera_frame.urdf.xacro"/>
+  <xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro"/>
+  <link name="world"/>
+  <joint name="world_to_base" type="fixed"><parent link="world"/><child link="base_link"/></joint>
+  <xacro:sensor_d435 parent="camera_mount_link" use_nominal_extrinsics="true"><origin xyz="0 0 0" rpy="0 0 0"/></xacro:sensor_d435>
+</robot>

--- a/assets/environment/vslot_camera_frame_description/urdf/vslot_camera_frame.urdf.xacro
+++ b/assets/environment/vslot_camera_frame_description/urdf/vslot_camera_frame.urdf.xacro
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<robot name="vslot_camera_frame" xmlns:xacro="http://ros.org/wiki/xacro">
+  <link name="base_link"/>
+  <link name="vslot_camera_frame_body">
+    <visual><geometry><mesh filename="package://vslot_camera_frame_description/meshes/visual/vslot_camera_frame.stl" scale="1 1 1"/></geometry></visual>
+    <collision><geometry><mesh filename="package://vslot_camera_frame_description/meshes/collision/vslot_camera_frame.stl" scale="1 1 1"/></geometry></collision>
+    <inertial><mass value="5.0"/><origin xyz="0 0 0"/><inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/></inertial>
+  </link>
+  <joint name="vslot_camera_frame_base_joint" type="fixed"><parent link="base_link"/><child link="vslot_camera_frame_body"/></joint>
+  <link name="camera_mount_link"/>
+  <joint name="vslot_camera_frame_camera_mount_joint" type="fixed"><parent link="vslot_camera_frame_body"/><child link="camera_mount_link"/><origin xyz="0 0 0.8" rpy="0 0 0"/></joint>
+</robot>

--- a/assets/environment/vslot_camera_frame_description/vslot_camera_frame.yaml
+++ b/assets/environment/vslot_camera_frame_description/vslot_camera_frame.yaml
@@ -1,0 +1,23 @@
+vslot_camera_frame:
+  child_link: vslot_camera_frame_body
+  links:
+    vslot_camera_frame_body:
+      visual:
+        name: vslot_camera_frame_visual
+        geometry:
+          filepath: package://vslot_camera_frame_description/meshes/visual/vslot_camera_frame.stl
+          scale:
+            scale_x: 1.0
+            scale_y: 1.0
+            scale_z: 1.0
+      collision:
+        name: vslot_camera_frame_collision
+        geometry:
+          filepath: package://vslot_camera_frame_description/meshes/collision/vslot_camera_frame.stl
+          scale:
+            scale_x: 1.0
+            scale_y: 1.0
+            scale_z: 1.0
+  vslot_camera_frame_base_joint:
+    ext_joint_type: fixed
+    child_link: vslot_camera_frame_body

--- a/docs/manuals/WORKCELL_BUILDER_CAMERA_SUPPORT_ASSETS.md
+++ b/docs/manuals/WORKCELL_BUILDER_CAMERA_SUPPORT_ASSETS.md
@@ -1,0 +1,58 @@
+# Workcell Builder Camera Support Assets
+
+## Summary
+
+The `realsense2_description` package remains the existing camera package used by current projects.
+This change adds reusable **physical camera support / mount** description packages so scenes can represent mounted cameras (instead of floating sensors).
+
+## Added camera support package types
+
+- `tslot_camera_frame_description` (`tslot_camera_frame`)
+- `vslot_camera_frame_description` (`vslot_camera_frame`)
+- `pipe_camera_stand_description` (`pipe_camera_stand`)
+- `flat_plate_camera_bracket_description` (`flat_plate_camera_bracket`)
+- `overhead_camera_gantry_description` (`overhead_camera_gantry`)
+- `table_clamp_camera_mount_description` (`table_clamp_camera_mount`)
+
+Each package follows the same ROS 2 description package structure pattern as existing environment description assets and includes:
+
+- `CMakeLists.txt`, `package.xml`
+- `launch/view_<asset>.launch.py`
+- `meshes/visual/<asset>.stl`
+- `meshes/collision/<asset>.stl`
+- `rviz/view_<asset>.rviz`
+- `urdf/<asset>.urdf.xacro`
+- `urdf/test_<asset>.urdf.xacro`
+- `<asset>.yaml` wrapper for object loading workflows
+
+## View each support package
+
+After building and sourcing:
+
+```bash
+ros2 launch tslot_camera_frame_description view_tslot_camera_frame.launch.py
+ros2 launch vslot_camera_frame_description view_vslot_camera_frame.launch.py
+ros2 launch pipe_camera_stand_description view_pipe_camera_stand.launch.py
+ros2 launch flat_plate_camera_bracket_description view_flat_plate_camera_bracket.launch.py
+ros2 launch overhead_camera_gantry_description view_overhead_camera_gantry.launch.py
+ros2 launch table_clamp_camera_mount_description view_table_clamp_camera_mount.launch.py
+```
+
+## Load into Workcell Builder
+
+1. Start `workcell_builder`.
+2. Open or create a scene.
+3. Click **Load Existing Object**.
+4. Select one of:
+   - `tslot_camera_frame`
+   - `vslot_camera_frame`
+   - `pipe_camera_stand`
+   - `flat_plate_camera_bracket`
+   - `overhead_camera_gantry`
+   - `table_clamp_camera_mount`
+
+These support assets are intended to be used alongside the existing RealSense description package.
+
+## Out of scope for this change
+
+Detection zones, pick/place zones, conveyor tracking, and EPD runtime behavior are intentionally not changed here and should be handled in a follow-up PR.

--- a/tests/test_camera_support_description_packages.py
+++ b/tests/test_camera_support_description_packages.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENV = ROOT / 'assets' / 'environment'
+
+ASSETS = [
+    ('tslot_camera_frame_description', 'tslot_camera_frame'),
+    ('vslot_camera_frame_description', 'vslot_camera_frame'),
+    ('pipe_camera_stand_description', 'pipe_camera_stand'),
+    ('flat_plate_camera_bracket_description', 'flat_plate_camera_bracket'),
+    ('overhead_camera_gantry_description', 'overhead_camera_gantry'),
+    ('table_clamp_camera_mount_description', 'table_clamp_camera_mount'),
+]
+
+
+def test_package_structure():
+    for package_name, asset_name in ASSETS:
+        package_dir = ENV / package_name
+        assert (package_dir / 'CMakeLists.txt').exists()
+        assert (package_dir / 'package.xml').exists()
+        assert (package_dir / 'launch' / f'view_{asset_name}.launch.py').exists()
+        assert (package_dir / 'urdf' / f'{asset_name}.urdf.xacro').exists()
+        assert (package_dir / 'urdf' / f'test_{asset_name}.urdf.xacro').exists()
+        assert (package_dir / 'rviz' / f'view_{asset_name}.rviz').exists()
+        assert (package_dir / 'meshes' / 'visual' / f'{asset_name}.stl').exists()
+        assert (package_dir / 'meshes' / 'collision' / f'{asset_name}.stl').exists()
+
+
+def test_cmake_install_pattern():
+    required = 'install(DIRECTORY launch meshes rviz urdf\n  DESTINATION share/${PROJECT_NAME})'
+    for package_name, _ in ASSETS:
+        content = (ENV / package_name / 'CMakeLists.txt').read_text(encoding='utf-8')
+        assert required in content
+
+
+def test_urdf_mesh_and_camera_mount_references():
+    for package_name, asset_name in ASSETS:
+        urdf = (ENV / package_name / 'urdf' / f'{asset_name}.urdf.xacro').read_text(encoding='utf-8')
+        assert f'package://{package_name}/meshes/visual/' in urdf
+        assert f'package://{package_name}/meshes/collision/' in urdf
+        assert ('camera_mount_link' in urdf) or ('camera_plate_link' in urdf)
+
+
+def test_workcell_builder_yaml_wrappers_exist():
+    for package_name, asset_name in ASSETS:
+        yaml_path = ENV / package_name / f'{asset_name}.yaml'
+        assert yaml_path.exists()
+
+
+def test_bundle_includes_camera_support_package_name():
+    content = (ROOT / 'workcell_builder' / 'workcell_builder' / 'src_workcell_scene_bundle.cpp').read_text(encoding='utf-8')
+    assert 'assets/environment/' in content
+    assert 'object_name + "_description"' in content


### PR DESCRIPTION
### Motivation

- Provide physical camera-support/mount description packages so scenes can show mounted cameras consistent with the existing `realsense2_description` camera models. 
- Ensure these supports are discoverable and usable by Workcell Builder without changing runtime EPD, robot motion, or safety behavior. 
- Follow the exact ROS 2 description package layout and install pattern used by `assets/environment/realsense2_description` so packages build with `colcon` and integrate with existing workflows.

### Description

- Added six new ROS 2 description packages under `assets/environment`: `tslot_camera_frame_description`, `vslot_camera_frame_description`, `pipe_camera_stand_description`, `flat_plate_camera_bracket_description`, `overhead_camera_gantry_description`, and `table_clamp_camera_mount_description`, each with `CMakeLists.txt`, `package.xml`, `launch`, `meshes`, `rviz`, and `urdf` directories. 
- Each package exposes a `camera_mount_link` (or `camera_plate_link` where appropriate) in its URDF/Xacro so existing `realsense2_description` camera models can be attached, and uses `package://<package>/meshes/...` references for visual and collision geometry. 
- Added Workcell Builder YAML wrappers (`<asset>.yaml`) for each asset so the assets appear in the existing "Load Existing Object" discovery flow. 
- Added `tests/test_camera_support_description_packages.py` to validate package layout, CMake install pattern, URDF mesh references and camera mount link, and YAML wrapper presence, and added documentation at `docs/manuals/WORKCELL_BUILDER_CAMERA_SUPPORT_ASSETS.md` describing usage and out-of-scope items.

### Testing

- Ran the new unit tests with `python3 -m pytest -q tests/test_camera_support_description_packages.py`, which completed successfully (`5 passed`).
- Attempted `colcon build` / `colcon test` per the included instructions but `colcon` was not available in the execution environment, so workspace build/test steps were not executed here. 
- Static checks in the repository (the added test) confirm the new packages follow the expected file layout and URDF references required for Workcell Builder discovery.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f7693a988331968ba4a898aa96a3)