### PR TITLE
Standardize environment assets to realsense2_description style and add checker

### DIFF
--- a/assets/asset_manifest.yaml
+++ b/assets/asset_manifest.yaml
@@ -36,3 +36,16 @@ assets:
       - sensor_realsense_d435i
     notes:
       - Existing asset reused. No files moved.
+
+  - asset_id: overhead_camera_gantry_support
+    display_name: Overhead camera gantry
+    asset_type: support
+    source:
+      path: assets/environment/overhead_camera_gantry_description
+      package: overhead_camera_gantry_description
+    geometry:
+      preferred_mesh: package://overhead_camera_gantry_description/meshes/visual/overhead_camera_gantry.stl
+    capabilities:
+      - asset_environment_support
+    notes:
+      - Standardized to realsense-style package layout.

--- a/assets/environment/table_description/CMakeLists.txt
+++ b/assets/environment/table_description/CMakeLists.txt
@@ -13,11 +13,6 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_runtime REQUIRED)
-install(DIRECTORY meshes
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(DIRECTORY urdf
-  DESTINATION share/${PROJECT_NAME}
-)
+install(DIRECTORY launch meshes rviz urdf
+  DESTINATION share/${PROJECT_NAME})
 ament_package()

--- a/assets/environment/table_description/launch/view_table.launch.py
+++ b/assets/environment/table_description/launch/view_table.launch.py
@@ -1,0 +1,18 @@
+from launch import LaunchDescription
+from launch.substitutions import Command, PathJoinSubstitution, FindExecutable
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+from launch_ros.substitutions import FindPackageShare
+
+DESCRIPTION_PACKAGE = "table_description"
+
+def generate_launch_description():
+    robot_description = ParameterValue(Command([
+        FindExecutable(name="xacro"), " ",
+        PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "urdf", "test_table.urdf.xacro"]),
+    ]), value_type=str)
+
+    return LaunchDescription([
+        Node(package="robot_state_publisher", executable="robot_state_publisher", parameters=[{"robot_description": robot_description}]),
+        Node(package="rviz2", executable="rviz2", output="screen", arguments=["-d", PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "rviz", "view_table.rviz"])]),
+    ])

--- a/assets/environment/table_description/rviz/view_table.rviz
+++ b/assets/environment/table_description/rviz/view_table.rviz
@@ -1,0 +1,9 @@
+Panels:
+  - Class: rviz_common/Displays
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Class: rviz_default_plugins/RobotModel
+      Name: RobotModel
+  Global Options:
+    Fixed Frame: world

--- a/assets/environment/table_description/urdf/test_table.urdf.xacro
+++ b/assets/environment/table_description/urdf/test_table.urdf.xacro
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="test_table">
+  <link name="world"/>
+  <xacro:include filename="$(find table_description)/urdf/table.urdf.xacro"/>
+  <xacro:table parent="world" prefix="preview">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </xacro:table>
+</robot>

--- a/assets/environment/workbench_description/CMakeLists.txt
+++ b/assets/environment/workbench_description/CMakeLists.txt
@@ -13,11 +13,6 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_runtime REQUIRED)
-install(DIRECTORY meshes
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(DIRECTORY urdf
-  DESTINATION share/${PROJECT_NAME}
-)
+install(DIRECTORY launch meshes rviz urdf
+  DESTINATION share/${PROJECT_NAME})
 ament_package()

--- a/assets/environment/workbench_description/launch/view_workbench.launch.py
+++ b/assets/environment/workbench_description/launch/view_workbench.launch.py
@@ -1,0 +1,18 @@
+from launch import LaunchDescription
+from launch.substitutions import Command, PathJoinSubstitution, FindExecutable
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+from launch_ros.substitutions import FindPackageShare
+
+DESCRIPTION_PACKAGE = "workbench_description"
+
+def generate_launch_description():
+    robot_description = ParameterValue(Command([
+        FindExecutable(name="xacro"), " ",
+        PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "urdf", "test_workbench.urdf.xacro"]),
+    ]), value_type=str)
+
+    return LaunchDescription([
+        Node(package="robot_state_publisher", executable="robot_state_publisher", parameters=[{"robot_description": robot_description}]),
+        Node(package="rviz2", executable="rviz2", output="screen", arguments=["-d", PathJoinSubstitution([FindPackageShare(DESCRIPTION_PACKAGE), "rviz", "view_workbench.rviz"])]),
+    ])

--- a/assets/environment/workbench_description/rviz/view_workbench.rviz
+++ b/assets/environment/workbench_description/rviz/view_workbench.rviz
@@ -1,0 +1,9 @@
+Panels:
+  - Class: rviz_common/Displays
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Class: rviz_default_plugins/RobotModel
+      Name: RobotModel
+  Global Options:
+    Fixed Frame: world

--- a/assets/environment/workbench_description/urdf/test_workbench.urdf.xacro
+++ b/assets/environment/workbench_description/urdf/test_workbench.urdf.xacro
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="test_workbench">
+  <link name="world"/>
+  <xacro:include filename="$(find workbench_description)/urdf/table.urdf.xacro"/>
+  <xacro:table parent="world" prefix="preview">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </xacro:table>
+</robot>

--- a/assets/environment/workbench_description/workbench.yaml
+++ b/assets/environment/workbench_description/workbench.yaml
@@ -1,0 +1,29 @@
+table:
+  child_link: table
+  links:
+    table:
+      visual:
+        name: None
+        geometry:
+          filepath: package://workbench_description/meshes/visual/table.stl
+          scale:
+            scale_x: 0.001
+            scale_y: 0.001
+            scale_z: 0.001
+        material:
+          name: aluminum
+          r: 0.549
+          g: 0.557
+          b: 0.529
+          a: 1
+      collision:
+        name: None
+        geometry:
+          filepath: package://workbench_description/meshes/collision/table.stl
+          scale:
+            scale_x: 0.001
+            scale_y: 0.001
+            scale_z: 0.001
+  table_base_joint:
+    ext_joint_type: fixed
+    child_link: table

--- a/docs/manuals/WORKCELL_BUILDER_ENVIRONMENT_ASSET_STYLE.md
+++ b/docs/manuals/WORKCELL_BUILDER_ENVIRONMENT_ASSET_STYLE.md
@@ -1,0 +1,34 @@
+# Workcell Builder Environment Asset Style
+
+Environment asset packages under `assets/environment` should follow the same style as `realsense2_description`:
+
+- `CMakeLists.txt`
+- `package.xml`
+- `launch/`
+- `meshes/` (prefer `meshes/visual` and `meshes/collision`)
+- `rviz/`
+- `urdf/`
+
+## Why this style
+This layout is proven to be discoverable, buildable, and previewable with ROS 2 tooling and Workcell Builder.
+
+## Environment vs robot/gripper assets
+This convention is for **environment assets only**. Robot and end-effector MoveIt packages are intentionally out-of-scope.
+
+## Add a new environment asset
+1. Create `assets/environment/<asset_name>_description`.
+2. Add package files (`package.xml`, `CMakeLists.txt`) with `ament_cmake`.
+3. Add `urdf/<asset>.urdf.xacro` and `urdf/test_<asset>.urdf.xacro`.
+4. Add `meshes/visual` and `meshes/collision`.
+5. Add `launch/view_<asset>.launch.py` and `rviz/view_<asset>.rviz`.
+6. If it should show in **Load Existing Object**, add `<asset>.yaml` wrapper with link/joint/visual/collision references.
+
+## Checker
+Run:
+
+```bash
+python3 scripts/check_environment_asset_style.py --root assets/environment --strict
+python3 scripts/check_environment_asset_style.py --root assets/environment --json-out /tmp/environment_asset_style_report.json
+```
+
+The checker prints PASS/WARN/FAIL per environment folder and returns non-zero in strict mode when required layout checks fail.

--- a/scripts/check_environment_asset_style.py
+++ b/scripts/check_environment_asset_style.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import argparse, json, re
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+REQ_DIRS=("launch","meshes","rviz","urdf")
+INSTALL_RE=re.compile(r"install\s*\(\s*DIRECTORY\s+launch\s+meshes\s+rviz\s+urdf",re.I|re.S)
+
+def classify(p:Path):
+    if p.name.endswith('_description') and (p/'package.xml').exists():
+        if 'camera' in p.name or 'realsense' in p.name: return 'camera/sensor description package'
+        if any(k in p.name for k in ['mount','stand','frame','gantry','bracket']): return 'support/mount package'
+        return 'ROS 2 description package'
+    if (p/'package.xml').exists(): return 'generated asset package'
+    return 'legacy/non-package asset'
+
+def has_valid_object_yaml(pkg:Path):
+    ys=list(pkg.glob('*.yaml'))
+    for y in ys:
+        t=y.read_text(errors='ignore')
+        if all(k in t for k in ['link','joint','visual','collision']):
+            return True,y.name
+    return False, ys[0].name if ys else None
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--root',default='assets/environment')
+    ap.add_argument('--strict',action='store_true')
+    ap.add_argument('--json-out')
+    args=ap.parse_args()
+    root=Path(args.root)
+    report=[]; fails=0
+    for p in sorted([x for x in root.iterdir() if x.is_dir()]):
+        row={'name':p.name,'path':str(p),'classification':classify(p),'warnings':[],'errors':[]}
+        if (p/'package.xml').exists() or (p/'CMakeLists.txt').exists():
+            for d in REQ_DIRS:
+                if not (p/d).exists(): row['errors'].append(f'missing {d}')
+            if not (p/'CMakeLists.txt').exists(): row['errors'].append('missing CMakeLists.txt')
+            else:
+                cm=(p/'CMakeLists.txt').read_text(errors='ignore')
+                if not INSTALL_RE.search(cm): row['errors'].append('CMakeLists missing install(DIRECTORY launch meshes rviz urdf ...) pattern')
+            if (p/'package.xml').exists():
+                try:
+                    n=ET.parse(p/'package.xml').getroot().findtext('name','').strip()
+                    if n!=p.name: row['errors'].append(f'package.xml name mismatch ({n})')
+                except Exception as e:
+                    row['errors'].append(f'package.xml parse error: {e}')
+            else: row['errors'].append('missing package.xml')
+            valid_yaml,y=has_valid_object_yaml(p)
+            if list(p.glob('*.yaml')) and not valid_yaml:
+                row['warnings'].append('yaml wrapper present but failed simple LoadObjects field check')
+            if not list(p.glob('*.yaml')) and p.name not in ['realsense2_description']:
+                row['warnings'].append('no top-level object yaml wrapper')
+        else:
+            row['warnings'].append('legacy/non-package folder kept as-is')
+        fails += len(row['errors'])
+        report.append(row)
+    for r in report:
+        status='FAIL' if r['errors'] else ('WARN' if r['warnings'] else 'PASS')
+        print(f"[{status}] {r['name']} :: {r['classification']}")
+        for e in r['errors']: print('  - ERROR:',e)
+        for w in r['warnings']: print('  - WARN :',w)
+    if args.json_out: Path(args.json_out).write_text(json.dumps({'root':str(root),'results':report},indent=2))
+    return 1 if (args.strict and fails) else 0
+
+if __name__=='__main__': raise SystemExit(main())

--- a/tests/test_environment_asset_style.py
+++ b/tests/test_environment_asset_style.py
@@ -1,0 +1,31 @@
+import json, subprocess, tempfile
+from pathlib import Path
+
+ROOT=Path(__file__).resolve().parents[1]
+
+def run_checker(strict=True):
+    with tempfile.NamedTemporaryFile(suffix='.json',delete=False) as f:
+        out=f.name
+    cmd=['python3','scripts/check_environment_asset_style.py','--root','assets/environment','--json-out',out]
+    if strict: cmd.append('--strict')
+    cp=subprocess.run(cmd,cwd=ROOT,check=not strict and False)
+    data=json.loads(Path(out).read_text())
+    return cp.returncode,data
+
+def _row(data,name):
+    return next(r for r in data['results'] if r['name']==name)
+
+def test_realsense_passes():
+    code,data=run_checker(strict=False)
+    row=_row(data,'realsense2_description')
+    assert not row['errors']
+
+def test_camera_support_packages_pass():
+    _,data=run_checker(strict=False)
+    for n in ['tslot_camera_frame_description','vslot_camera_frame_description','pipe_camera_stand_description','flat_plate_camera_bracket_description','overhead_camera_gantry_description','table_clamp_camera_mount_description']:
+        assert not _row(data,n)['errors']
+
+def test_standardized_environment_assets_have_required_layout():
+    _,data=run_checker(strict=False)
+    for n in ['table_description','workbench_description']:
+        assert not _row(data,n)['errors']


### PR DESCRIPTION
### Motivation
- Make all environment asset packages under `assets/environment` follow the proven `realsense2_description` layout so they are discoverable, buildable, previewable, and usable from Workcell Builder.
- Provide an automated, repeatable audit that reports PASS/WARN/FAIL for each environment folder and helps keep future assets consistent.

### Description
- Updated `assets/environment/table_description` and `assets/environment/workbench_description` to the canonical package layout by updating `CMakeLists.txt` to install `launch meshes rviz urdf` and adding minimal viewer/test scaffolding (`launch/view_*.launch.py`, `rviz/view_*.rviz`, `urdf/test_*.urdf.xacro`).
- Added a Workcell Builder YAML wrapper `assets/environment/workbench_description/workbench.yaml` to improve object discoverability without removing existing files.
- Added an audit/checker script `scripts/check_environment_asset_style.py` with CLI options `--root`, `--strict`, and `--json-out` that classifies folders, validates required dirs/files, checks the CMake install pattern and `package.xml` name, and validates simple Workcell Builder YAML wrappers.
- Added automated tests `tests/test_environment_asset_style.py`, documentation `docs/manuals/WORKCELL_BUILDER_ENVIRONMENT_ASSET_STYLE.md`, and a manifest entry in `assets/asset_manifest.yaml` for the overhead camera gantry support.

### Testing
- Ran the checker: `python3 scripts/check_environment_asset_style.py --root assets/environment --strict` and it completed successfully (reported PASS/WARN/FAIL per-folder; legacy non-package folders are reported as warnings).
- Ran unit tests: `python3 -m pytest -q tests/test_environment_asset_style.py` and all tests passed (`3 passed`).
- Attempted representative package build `colcon build --symlink-install --packages-select realsense2_description` in the container, but `colcon` is not installed in this environment so the attempt failed; this is an environment/tooling limitation and not a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02fa2b2fc48331842360f970ebb05a)