### PR TITLE
Fix unresolved symbols in workcell_generated_environment_asset_writer_test

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -205,6 +205,8 @@ if(BUILD_TESTING)
     test/generated_environment_asset_writer_test.cpp
     src_generated_stl_writer.cpp
     src_generated_environment_asset_writer.cpp
+    src_object_placement_model.cpp
+    gui/workcell_builder_ui_utils.cpp
     gui/loadobjects.cpp)
   ament_add_gtest(workcell_generate_yaml_end_effector_metadata_test
     test/generate_yaml_end_effector_metadata_test.cpp)


### PR DESCRIPTION
### Motivation
- Resolve link errors in `workcell_generated_environment_asset_writer_test` caused by missing translation units that provide `workcell_builder::sanitize_object_name` and `workcell_builder::applyCompactDialogDefaults`.

### Description
- Add `src_object_placement_model.cpp` and `gui/workcell_builder_ui_utils.cpp` to the `workcell_generated_environment_asset_writer_test` source list in `workcell_builder/workcell_builder/CMakeLists.txt` so the missing symbols are provided at link time.

### Testing
- Attempted to run `colcon test --packages-select workcell_builder --ctest-args -R workcell_generated_environment_asset_writer_test` but the command failed because `colcon` is not installed in the environment, so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0492e028288331a4db74afff32a5ba)