### PR TITLE
Fix remaining workcell_builder linker break in SceneSelect

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -2524,3 +2524,16 @@ void SceneSelect::on_copy_launch_command_button_clicked()
   if (latest_scene_status_report_.next_commands.size() < 3) return;
   QApplication::clipboard()->setText(QString::fromStdString(latest_scene_status_report_.next_commands[2]));
 }
+
+void SceneSelect::on_open_conveyor_sorting_run_console_clicked()
+{
+  const fs::path scene_dir = scene_dir_for_current_selection();
+  if (scene_dir.empty()) {
+    append_warning("No scene selected. Select a scene before opening the run console.");
+    return;
+  }
+
+  const QString scenario_name = ui->scene_list->itemText(ui->scene_list->currentIndex());
+  ConveyorSortingRunConsole dialog(std::filesystem::path(scene_dir.string()), scenario_name, this);
+  dialog.exec();
+}


### PR DESCRIPTION
### Motivation
- A previously-declared slot in `SceneSelect` lacked an implementation, causing a linker/build failure for `workcell_builder`; this PR provides the missing definition as a build-stabilisation fix only. 

### Description
- Implemented `SceneSelect::on_open_conveyor_sorting_run_console_clicked()` in `workcell_builder/workcell_builder/gui/scene_select.cpp`. 
- The new slot validates the selected scene via `scene_dir_for_current_selection()`, emits a warning if none is selected, constructs a `ConveyorSortingRunConsole` with the selected scene and scenario name, and shows it with `exec()`. 
- Change is minimal and limited to restoring parity between the header and implementation without adding new features or changing defaults. 

### Testing
- Confirmed the new symbol is present with a code search: `rg "void SceneSelect::on_open_conveyor_sorting_run_console_clicked"` which found the implementation. 
- Attempted to run the package build with `colcon build --symlink-install --packages-select workcell_builder --event-handlers console_direct+`, and `source /opt/ros/humble/setup.bash && colcon build ...`, but both could not run in this environment because `/opt/ros/humble/setup.bash` and `colcon` are not available (build could not be executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0494f974b08331bcacbff51d90b73f)