### PR TITLE
Link yaml-cpp in emd_grasp_planner to fix undefined YAML symbols

### DIFF
--- a/easy_manipulation_deployment/emd_grasp_planner/CMakeLists.txt
+++ b/easy_manipulation_deployment/emd_grasp_planner/CMakeLists.txt
@@ -81,6 +81,7 @@ if(NOT _emd_octomap_targets_valid AND NOT (_emd_octomap_library_octomap AND _emd
 endif()
 
 find_package(sensor_msgs REQUIRED)
+find_package(yaml-cpp REQUIRED)
 find_package(emd_msgs REQUIRED)
 find_package(epd_msgs QUIET)
 find_package(geometry_msgs REQUIRED)
@@ -208,6 +209,7 @@ target_link_libraries(grasp_planning_interface
   ${PCL_LIBRARIES}
   ${FCL_LIBRARIES}
   ${EMD_OCTOMAP_LINK_LIBS}
+  yaml-cpp
 )
 if(OpenMP_CXX_FOUND)
   target_link_libraries(grasp_planning_interface OpenMP::OpenMP_CXX)
@@ -285,6 +287,7 @@ if(epd_msgs_FOUND)
     tf2_geometry_msgs
     PCL
     octomap
+    yaml-cpp
   )
 else()
   ament_export_dependencies(
@@ -298,6 +301,7 @@ else()
     tf2_geometry_msgs
     PCL
     octomap
+    yaml-cpp
   )
 endif()
 


### PR DESCRIPTION
### Motivation
- The build was failing with undefined `YAML::*` symbols when linking `libgrasp_planning_interface.so`, indicating `yaml-cpp` was not being linked or exported by the package.
- Ensuring `yaml-cpp` is a declared find and link dependency prevents runtime/link-time symbol resolution issues for downstream consumers.

### Description
- Added `find_package(yaml-cpp REQUIRED)` to `easy_manipulation_deployment/emd_grasp_planner/CMakeLists.txt` to declare the dependency.
- Linked `grasp_planning_interface` against `yaml-cpp` by adding `yaml-cpp` to `target_link_libraries` so YAML symbols are resolved at link time.
- Exported `yaml-cpp` in `ament_export_dependencies` for both `epd_msgs` and non-`epd_msgs` branches so downstream packages receive the dependency.

### Testing
- Ran an initial workspace build (`colcon build`) which failed with linker errors referencing `YAML::*` from `emd_grasp_planner`, motivating this change. (failure)
- Attempted to build the single package after the patch with `colcon build --packages-select emd_grasp_planner`, but `colcon` is not installed in the current environment so validation could not be completed. (not run)
- The change was committed to the branch successfully with the message `Fix emd_grasp_planner yaml-cpp link errors`. (N/A)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0497a071dc833189bf70a90c0b91ab)