### PR TITLE
Fix Qt5 QProcess::finished overload and silence unused marker warnings in workcell_builder

### DIFF
--- a/workcell_builder/workcell_builder/gui/conveyor_sorting_run_console.cpp
+++ b/workcell_builder/workcell_builder/gui/conveyor_sorting_run_console.cpp
@@ -30,8 +30,16 @@ ConveyorSortingRunConsole::ConveyorSortingRunConsole(const fs::path & scene_path
   connect(build_process_, &QProcess::readyReadStandardError, this, &ConveyorSortingRunConsole::onBuildOutput);
   connect(launch_process_, &QProcess::readyReadStandardOutput, this, &ConveyorSortingRunConsole::onLaunchOutput);
   connect(launch_process_, &QProcess::readyReadStandardError, this, &ConveyorSortingRunConsole::onLaunchOutput);
-  connect(build_process_, &QProcess::finished, this, &ConveyorSortingRunConsole::onBuildFinished);
-  connect(launch_process_, &QProcess::finished, this, &ConveyorSortingRunConsole::onLaunchFinished);
+  connect(
+    build_process_,
+    qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
+    this,
+    &ConveyorSortingRunConsole::onBuildFinished);
+  connect(
+    launch_process_,
+    qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
+    this,
+    &ConveyorSortingRunConsole::onLaunchFinished);
   connect(build_process_, &QProcess::errorOccurred, this, &ConveyorSortingRunConsole::onBuildError);
   connect(launch_process_, &QProcess::errorOccurred, this, &ConveyorSortingRunConsole::onLaunchError);
 

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -2405,23 +2405,23 @@ void SceneSelect::on_open_scene_folder_clicked()
 
 
 // Object Placement Manager markers for generated scene artifacts
-static const char * kObjectPlacementManagerLabel = "Object Placement Manager";
-static const char * kPlacedObjectsLabel = "Placed Objects";
-static const char * kAddAssetObjectLabel = "Add Asset Object";
-static const char * kImportStlToAssetLibraryLabel = "Import STL to Asset Library";
-static const char * kDuplicateObjectLabel = "Duplicate Object";
-static const char * kRemoveObjectLabel = "Remove Object";
-static const char * kEditPoseLabel = "Edit Pose";
-static const char * kExternalStlWarningLabel = "external_stl_warning";
-static const char * kAssetStlLabel = "asset_stl";
-static const char * kGeneratedPrimitiveLabel = "generated_primitive";
-static const char * kManagedCustomMeshFolder = "easy_manipulation_deployment/assets/environment/custom_meshes";
-static const char * kPlacedObjectsSummaryExample = "placed_objects:\n  - name: table_01\n    source: asset_stl\n    mesh: package://easy_manipulation_deployment/assets/environment/custom_meshes/table.stl\n    pose: [0, 0, 0, 0, 0, 0]";
+[[maybe_unused]] static const char * kObjectPlacementManagerLabel = "Object Placement Manager";
+[[maybe_unused]] static const char * kPlacedObjectsLabel = "Placed Objects";
+[[maybe_unused]] static const char * kAddAssetObjectLabel = "Add Asset Object";
+[[maybe_unused]] static const char * kImportStlToAssetLibraryLabel = "Import STL to Asset Library";
+[[maybe_unused]] static const char * kDuplicateObjectLabel = "Duplicate Object";
+[[maybe_unused]] static const char * kRemoveObjectLabel = "Remove Object";
+[[maybe_unused]] static const char * kEditPoseLabel = "Edit Pose";
+[[maybe_unused]] static const char * kExternalStlWarningLabel = "external_stl_warning";
+[[maybe_unused]] static const char * kAssetStlLabel = "asset_stl";
+[[maybe_unused]] static const char * kGeneratedPrimitiveLabel = "generated_primitive";
+[[maybe_unused]] static const char * kManagedCustomMeshFolder = "easy_manipulation_deployment/assets/environment/custom_meshes";
+[[maybe_unused]] static const char * kPlacedObjectsSummaryExample = "placed_objects:\n  - name: table_01\n    source: asset_stl\n    mesh: package://easy_manipulation_deployment/assets/environment/custom_meshes/table.stl\n    pose: [0, 0, 0, 0, 0, 0]";
 
-static const char * kVisualLayoutSummaryJsonMarker = "visual_layout_editor_used placed_object_count placed_object_positions";
-static const char * kVisualLayoutPreviewMarker = "Object table_01 @ x=0.0 y=0.0 | Save Layout to Environment YAML";
+[[maybe_unused]] static const char * kVisualLayoutSummaryJsonMarker = "visual_layout_editor_used placed_object_count placed_object_positions";
+[[maybe_unused]] static const char * kVisualLayoutPreviewMarker = "Object table_01 @ x=0.0 y=0.0 | Save Layout to Environment YAML";
 // readiness overlay markers
-static const char * kReadinessOverlayWarningMarkers = "reach_warnings workspace_warnings overlap_warnings camera_warnings task_target_warnings safety_zone_warnings blocker_count warning_count";
+[[maybe_unused]] static const char * kReadinessOverlayWarningMarkers = "reach_warnings workspace_warnings overlap_warnings camera_warnings task_target_warnings safety_zone_warnings blocker_count warning_count";
 
 // Portable Scene Bundle UI markers
 // Export Scene Bundle


### PR DESCRIPTION
### Motivation
- Resolve a Qt5 compile error where `QProcess::finished` is overloaded and the signal/slot `connect` calls were ambiguous, and silence unused-symbol warnings for retained scene marker strings in `scene_select.cpp` without removing them.

### Description
- Explicitly bind the `QProcess::finished(int, QProcess::ExitStatus)` overload in `ConveyorSortingRunConsole` using `qOverload<int, QProcess::ExitStatus>(&QProcess::finished)` so `connect(...)` selects the correct overload and keep the existing slot signatures unchanged; change applied in `workcell_builder/workcell_builder/gui/conveyor_sorting_run_console.cpp`.
- Mark the retained scene marker constants as intentionally unused with `[[maybe_unused]] static const char * ...` in `workcell_builder/workcell_builder/gui/scene_select.cpp` to suppress warnings while preserving the strings.

### Testing
- Attempted to build and test the package with `colcon` using `cd ~/workcell_ws && source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder --event-handlers console_direct+`, `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder --event-handlers console_direct+`, and `colcon build --symlink-install --packages-select workcell_builder --event-handlers console_direct+`, but all runs could not execute in this environment (`/root/workcell_ws` missing, `/opt/ros/humble/setup.bash` missing, and `colcon` not installed respectively), so automated build/tests were not completed here; the code changes were committed locally with message "Fix Qt5 QProcess finished overload and silence marker warnings".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a049b883ec08331a8b86272dd1e939a)