### PR TITLE
Fix AddScene slot definitions to restore workcell_builder build

### DIFF
--- a/workcell_builder/workcell_builder/gui/addscene.cpp
+++ b/workcell_builder/workcell_builder/gui/addscene.cpp
@@ -425,7 +425,7 @@ void AddScene::on_remove_ee_clicked()
   ui->add_ee->setText(QString::fromStdString("Add End Effector"));
 }
 
-void AddScene::handle_accept
+void AddScene::handle_accept()
 {
   ui->scene_errors->clear();
   if (CheckRobot() && CheckEE() && CheckExtJoint() && CheckSceneName()) {
@@ -438,7 +438,7 @@ void AddScene::handle_accept
   }
 }
 
-void AddScene::handle_reject
+void AddScene::handle_reject()
 {
   success = false;
   this->close();


### PR DESCRIPTION
### Motivation
- Fix a C++ compile error in `workcell_builder` caused by method definitions missing parentheses for `AddScene::handle_accept` and `AddScene::handle_reject`.

### Description
- Add the missing `()` to the definitions in `workcell_builder/workcell_builder/gui/addscene.cpp` so they are `void AddScene::handle_accept()` and `void AddScene::handle_reject()`, and confirm that `workcell_builder/workcell_builder/gui/addscene.h` already declares `void handle_accept();` and `void handle_reject();`.

### Testing
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but the environment does not have `colcon` installed (`/bin/bash: colcon: command not found`), so a full package build could not be run here; the change is syntactic and resolves the parser errors in `addscene.cpp`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a6623d8c833181a95c47039d4114)