### PR TITLE
Harden Workcell Studio Qt shell wiring, fallbacks, and regression checks

### DIFF
--- a/docs/manuals/WORKCELL_STUDIO_QT_UI_QA.md
+++ b/docs/manuals/WORKCELL_STUDIO_QT_UI_QA.md
@@ -1,0 +1,54 @@
+# Workcell Studio Qt UI Manual QA Checklist
+
+This checklist validates the hardened Workcell Studio Qt shell wiring without changing generation/runtime semantics.
+
+## Build and Run
+
+```bash
+cd ~/workcell_ws
+source /opt/ros/humble/setup.bash
+colcon build --symlink-install --packages-select workcell_builder
+source install/setup.bash
+workcell_builder
+```
+
+## Click-through checklist
+
+- App opens to **Workcell Studio** shell.
+- Dark theme loads; if missing, app stays usable and reports fallback in status/log.
+- Dashboard and left navigation appear.
+- Open **Full Screen** and confirm **Escape** returns to normal mode.
+- Click each visible action and verify behavior:
+  - **New Cell**: clear placeholder message appears.
+  - **Open Existing Scene**: transitions into existing scene workflow.
+  - **Scene Builder**: transitions into existing scene workflow.
+  - **Asset Browser**: placeholder message appears.
+  - **Scenario Templates**: placeholder message appears.
+  - **Validate**: request is logged and no crash.
+  - **Preview**: placeholder message appears.
+  - **Generate Scene**: request is logged and no crash.
+  - **Export**: placeholder message appears.
+- Verify placeholder text includes:
+  - "This Workcell Studio action is not wired yet. No files changed and no robot motion was commanded."
+
+## Existing workflow preservation checks
+
+After opening Scene Builder workflow:
+
+- Existing scenes are discovered from default scenes folder.
+- **Add New Scene** still works.
+- **Edit Scene** still works.
+- **Generate YAML** still works.
+- **Generate Files From YAML** still works.
+- Scene generation outputs remain unchanged in intent (URDF/Xacro/launch semantics unchanged).
+
+## Safety checks
+
+- Bottom action/status log updates for user actions (navigation + button clicks).
+- Confirm logs include concise action messages and explicit safety note for placeholders.
+- Confirm no runtime execution is auto-triggered and no robot motion is commanded.
+
+## Scope note
+
+- Workcell Builder remains the primary Workcell Studio product UI.
+- EPD GUI remains separate and is not merged into this shell in this change.

--- a/tests/test_workcell_studio_qt_shell_hardening.py
+++ b/tests/test_workcell_studio_qt_shell_hardening.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+CMAKE = Path('workcell_builder/workcell_builder/CMakeLists.txt').read_text(encoding='utf-8')
+MAIN_CPP = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+
+REQUIRED_LABELS = [
+    'Workcell Studio',
+    'New Cell',
+    'Open Existing Scene',
+    'Scene Builder',
+    'Asset Browser',
+    'Scenario Templates',
+    'Validate',
+    'Preview',
+    'Generate Scene',
+    'Export',
+    'Full Screen',
+    'No robot motion commanded',
+]
+
+
+def test_cmake_keeps_qt5_widgets_wiring():
+    assert 'find_package(Qt5 COMPONENTS Widgets Concurrent REQUIRED)' in CMAKE
+    assert 'Qt5::Widgets' in CMAKE
+    assert 'Qt5::Concurrent' in CMAKE
+
+
+def test_dark_qss_file_exists_and_installed():
+    qss = Path('workcell_builder/workcell_builder/gui/resources/workcell_studio_dark.qss')
+    assert qss.exists(), 'Expected dark theme stylesheet to exist'
+    assert 'install(DIRECTORY gui/resources' in CMAKE
+
+
+def test_required_studio_labels_present_in_source():
+    for label in REQUIRED_LABELS:
+        assert label in MAIN_CPP, f'Missing required label: {label}'
+
+
+def test_required_actions_have_wiring_or_safe_fallback():
+    assert 'if (label == "Open Existing Scene")' in MAIN_CPP
+    assert 'if (title == "Open Existing Scene" || title == "Scene Builder")' in MAIN_CPP
+    assert 'label == "Validate" || label == "Generate Scene"' in MAIN_CPP
+    assert 'title == "Validate" || title == "Generate Scene"' in MAIN_CPP
+    assert 'show_not_wired_message' in MAIN_CPP
+    assert 'This Workcell Studio action is not wired yet. No files changed and no robot motion was commanded.' in MAIN_CPP

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -35,6 +35,7 @@
 #include <QPointer>
 #include <QProgressDialog>
 #include <QtConcurrent>
+#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <boost/filesystem.hpp>
 #include <stdio.h>
 #include <algorithm>
@@ -207,15 +208,30 @@ MainWindow::MainWindow(QWidget * parent)
 
 void MainWindow::apply_studio_theme()
 {
-  QString style_path = QCoreApplication::applicationDirPath() + "/../share/workcell_builder/gui/resources/workcell_studio_dark.qss";
-  QFile external_style(style_path);
-  if (!external_style.open(QIODevice::ReadOnly | QIODevice::Text)) {
-    external_style.setFileName("workcell_builder/workcell_builder/gui/resources/workcell_studio_dark.qss");
-    if (!external_style.open(QIODevice::ReadOnly | QIODevice::Text)) {
+  QStringList style_candidates;
+  try {
+    const auto share_dir = ament_index_cpp::get_package_share_directory("workcell_builder");
+    style_candidates << QString::fromStdString(share_dir + "/gui/resources/workcell_studio_dark.qss");
+  } catch (const std::exception &) {
+    // Intentionally continue with fallback candidate paths.
+  }
+  style_candidates
+    << (QCoreApplication::applicationDirPath() + "/../share/workcell_builder/gui/resources/workcell_studio_dark.qss")
+    << "workcell_builder/workcell_builder/gui/resources/workcell_studio_dark.qss";
+
+  QFile external_style;
+  for (const auto & candidate : style_candidates) {
+    external_style.setFileName(candidate);
+    if (external_style.open(QIODevice::ReadOnly | QIODevice::Text)) {
+      setStyleSheet(QString::fromUtf8(external_style.readAll()));
+      append_studio_log("Loaded Workcell Studio dark theme.");
+      statusBar()->showMessage("Workcell Studio dark theme loaded.");
       return;
     }
   }
-  setStyleSheet(QString::fromUtf8(external_style.readAll()));
+
+  append_studio_log("Warning: dark theme missing. Using default Qt theme.");
+  statusBar()->showMessage("Dark theme not found. Using default Qt theme.");
 }
 
 void MainWindow::toggle_full_screen()
@@ -246,15 +262,19 @@ void MainWindow::setup_studio_shell()
   auto * top_layout = new QHBoxLayout(top_bar);
   top_layout->setContentsMargins(10, 6, 10, 6);
   const QStringList actions = {
-    "New Cell", "Open Scene", "Validate", "Preview", "Generate Scene", "Export"
+    "New Cell", "Open Existing Scene", "Validate", "Preview", "Generate Scene", "Export"
   };
   for (const QString & label : actions) {
     auto * button = new QPushButton(label, top_bar);
     button->setObjectName("commandBarButton");
     connect(button, &QPushButton::clicked, this, [this, label]() {
-      statusBar()->showMessage(label + " action selected.");
-      if (label == "Validate" || label == "Generate Scene") {
+      append_studio_log(label + " requested");
+      if (label == "Open Existing Scene") {
+        on_next_clicked();
+      } else if (label == "Validate" || label == "Generate Scene") {
         ui->error_label->setText("<font color='#2E86C1'>" + label + " action opened from Workcell Studio shell.</font>");
+      } else {
+        show_not_wired_message(label);
       }
     });
     top_layout->addWidget(button);
@@ -265,7 +285,7 @@ void MainWindow::setup_studio_shell()
   top_layout->addStretch(1);
 
   studio_nav_ = new QListWidget(content);
-  studio_nav_->addItems({"Dashboard", "Scene Builder", "Assets", "Templates", "Existing Scenes", "Validation", "Export"});
+  studio_nav_->addItems({"Dashboard", "Scene Builder", "Asset Browser", "Scenario Templates", "Existing Scenes", "Validation", "Export"});
   studio_nav_->setCurrentRow(0);
   studio_nav_->setMaximumWidth(190);
 
@@ -275,21 +295,28 @@ void MainWindow::setup_studio_shell()
   auto make_card = [this, dashboard_page](const QString & title, const QString & msg) {
     auto * card = new QPushButton(title, dashboard_page);
     card->setObjectName("studioCardButton");
-    connect(card, &QPushButton::clicked, this, [this, msg]() {
-      statusBar()->showMessage(msg);
-      if (msg.contains("soon")) {
-        QMessageBox::information(this, "Workcell Studio", msg);
+    connect(card, &QPushButton::clicked, this, [this, title, msg]() {
+      append_studio_log(msg);
+      if (title == "Open Existing Scene" || title == "Scene Builder") {
+        on_next_clicked();
+      } else if (title == "Validate" || title == "Generate Scene") {
+        ui->error_label->setText("<font color='#2E86C1'>" + title + " action opened from Workcell Studio shell.</font>");
+      } else {
+        show_not_wired_message(title);
       }
     });
     return card;
   };
   dashboard_layout->addWidget(new QLabel("<h2>Workcell Studio</h2><p>Dashboard</p>", dashboard_page));
-  dashboard_layout->addWidget(make_card("New Workcell", "Use 'Select workspace directory' to start a new workcell."));
+  dashboard_layout->addWidget(make_card("New Cell", "Use 'Select workspace directory' to start a new workcell."));
   dashboard_layout->addWidget(make_card("Open Existing Scene", "Open Existing Scene from Scene Builder controls."));
+  dashboard_layout->addWidget(make_card("Scene Builder", "Opened Scene Builder page"));
   dashboard_layout->addWidget(make_card("Scenario Templates", "Scenario Templates coming soon / not wired yet."));
   dashboard_layout->addWidget(make_card("Asset Browser", "Asset Browser coming soon / not wired yet."));
-  dashboard_layout->addWidget(make_card("Validate Current Cell", "Validate action selected."));
-  dashboard_layout->addWidget(make_card("Export Demo Bundle", "Export demo bundle coming soon / not wired yet."));
+  dashboard_layout->addWidget(make_card("Validate", "Validate requested"));
+  dashboard_layout->addWidget(make_card("Preview", "Preview requested"));
+  dashboard_layout->addWidget(make_card("Generate Scene", "Generate Scene requested"));
+  dashboard_layout->addWidget(make_card("Export", "Export requested"));
   dashboard_layout->addWidget(new QLabel("Recent / Existing Scenes
 - Loaded from selected workspace scenes/", dashboard_page));
   dashboard_layout->addLayout(ui->verticalLayout);
@@ -330,10 +357,28 @@ EPD adapter metadata", scene_builder));
 
   root_layout->insertWidget(0, top_bar);
   root_layout->insertLayout(1, body, 1);
+  studio_log_ = new QTextEdit(content);
+  studio_log_->setReadOnly(true);
+  studio_log_->setObjectName("studioActionLog");
+  studio_log_->setPlaceholderText("Workcell Studio action/status log");
+  studio_log_->setMaximumHeight(110);
+  root_layout->addWidget(studio_log_);
 
   connect(studio_nav_, &QListWidget::currentRowChanged, this, [this](int idx) {
     if (idx >= 0 && idx < studio_pages_->count()) {
       studio_pages_->setCurrentIndex(idx);
+      const QStringList nav_messages = {
+        "Opened Dashboard page",
+        "Opened Scene Builder page",
+        "Opened Asset Browser page",
+        "Opened Scenario Templates page",
+        "Opened Existing Scenes page",
+        "Opened Validation page",
+        "Opened Export page"
+      };
+      if (idx >= 0 && idx < nav_messages.size()) {
+        append_studio_log(nav_messages[idx]);
+      }
     }
   });
 
@@ -343,6 +388,24 @@ EPD adapter metadata", scene_builder));
       toggle_full_screen();
     }
   });
+}
+
+void MainWindow::append_studio_log(const QString & message)
+{
+  if (studio_log_) {
+    studio_log_->append(message);
+  }
+  statusBar()->showMessage(message);
+}
+
+void MainWindow::show_not_wired_message(const QString & action_label)
+{
+  append_studio_log(action_label + ": Action not wired yet");
+  append_studio_log("No robot motion commanded");
+  QMessageBox::information(
+    this,
+    "Workcell Studio",
+    "This Workcell Studio action is not wired yet. No files changed and no robot motion was commanded.");
 }
 
 MainWindow::~MainWindow()

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -33,6 +33,7 @@ QT_END_NAMESPACE
 class QProgressDialog;
 class QListWidget;
 class QPushButton;
+class QTextEdit;
 
 class MainWindow: public QMainWindow
 {
@@ -63,10 +64,13 @@ private:
   void toggle_full_screen();
   void setup_studio_shell();
   void apply_studio_theme();
+  void append_studio_log(const QString & message);
+  void show_not_wired_message(const QString & action_label);
   Ui::MainWindow * ui;
   QStackedWidget * studio_pages_{ nullptr };
   QListWidget * studio_nav_{ nullptr };
   QPushButton * full_screen_button_{ nullptr };
+  QTextEdit * studio_log_{ nullptr };
   struct WorkcellLoadResult
   {
     bool success{ false };


### PR DESCRIPTION
### Motivation
- Make the new Workcell Studio Qt shell build-safe and reliable by preventing silent/dead buttons, handling missing theme resources gracefully, and adding visible status/logging for user actions.
- Wire visible dashboard and toolbar actions to existing `workcell_builder` entry points where possible and provide explicit, non-blocking placeholders when features are not implemented.
- Add lightweight, CI-friendly checks and a manual QA checklist so regressions such as missing labels, resources, or Qt wiring are caught early.

### Description
- Improve theme loading in `MainWindow::apply_studio_theme()` to attempt the installed share path via `ament_index_cpp::get_package_share_directory()` first, then fall back to runtime/dev paths, and log a clear warning instead of crashing when the QSS is missing (file: `workcell_builder/workcell_builder/gui/mainwindow.cpp`).
- Wire top toolbar and dashboard cards so `Open Existing Scene` and `Scene Builder` route into the existing scene workflow (`on_next_clicked()`), `Validate` and `Generate Scene` update the UI status, and all other unimplemented actions show a safe placeholder via `show_not_wired_message()` with the explicit text `"This Workcell Studio action is not wired yet. No files changed and no robot motion was commanded."` (file: `mainwindow.cpp`).
- Add a bottom, read-only `QTextEdit` action/status log and helper `append_studio_log()` to record navigation and action requests, and add `append_studio_log`/`show_not_wired_message` declarations and `studio_log_` to `MainWindow` (file: `workcell_builder/workcell_builder/gui/mainwindow.h` and `.cpp`).
- Normalize dashboard/nav labels (e.g. `New Cell`, `Open Existing Scene`, `Scene Builder`, `Asset Browser`, `Scenario Templates`, `Validate`, `Preview`, `Generate Scene`, `Export`, `Full Screen`) to match required UI expectations.
- Add a CI-friendly source-inspection test `tests/test_workcell_studio_qt_shell_hardening.py` that verifies `CMakeLists.txt` still references `Qt5::Widgets`/`Qt5::Concurrent`, the dark QSS path/install stanza, required UI labels exist, and action wiring/fallback strings are present.
- Add a manual QA checklist `docs/manuals/WORKCELL_STUDIO_QT_UI_QA.md` documenting build/run steps, click-path expectations, and safety checks.

### Testing
- Ran the new source-inspection test with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_studio_qt_shell_hardening.py`, and the test suite passed (`4 passed`).
- The new tests validate presence of `find_package(Qt5 COMPONENTS Widgets Concurrent REQUIRED)` and `Qt5::Widgets` in `CMakeLists.txt`, the dark QSS file path and install stanza, required UI labels in `mainwindow.cpp`, and the presence of the safe fallback messaging strings.
- No interactive GUI automation was run in CI as part of this change; the manual QA checklist documents click-through validation steps to verify runtime behavior on an installed build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05950a191c833194ef467c35803e10)