### PR TITLE
Add Workcell Studio generated-scene acceptance preflight and reports

### DIFF
--- a/docs/manuals/WORKCELL_STUDIO_GENERATED_SCENE_ACCEPTANCE.md
+++ b/docs/manuals/WORKCELL_STUDIO_GENERATED_SCENE_ACCEPTANCE.md
@@ -1,0 +1,38 @@
+# Workcell Studio Generated Scene Acceptance
+
+This preflight validates template-generated scene packages before local build/launch preflight. It is offline/static and **does not execute ROS launch** and **does not command robot motion**.
+
+## Checks
+- Required files: `package.xml`, `CMakeLists.txt`, `environment.yaml`, `scene_manifest.yaml`, `config/task_recipe.yaml`, `config/workcell_builder_task_intent.yaml`
+- Preview/smoke artifacts and generated summary
+- ROS package name validity (scene directory)
+- Safety flags: `fake_hardware_first=true`, `runtime_execution_enabled=false`, `motion_command_sent=false`
+- Launch contract checks for `launch/demo.launch.py`
+- Static xacro/URDF markers where available, including gripper mount RPY `-1.5708 -1.5708 0`
+
+## Statuses
+- `PASS`: complete and consistent.
+- `WARNINGS`: usable, but non-blocking issues exist.
+- `BLOCKED`: critical acceptance failures.
+- `PREVIEW_ONLY`: preview artifacts exist but launch/runtime package is intentionally incomplete.
+
+## Outputs
+- `acceptance/generated_scene_acceptance.json`
+- `acceptance/generated_scene_acceptance.html`
+- `acceptance/generated_scene_acceptance_summary.txt`
+
+## Run
+```bash
+python3 scripts/validate_workcell_studio_generated_scene.py <scene_dir> --json
+```
+
+## Manual preflight commands (emitted only; not executed)
+```bash
+colcon build --symlink-install --packages-select <scene_name>
+source install/setup.bash
+ros2 launch <scene_name> demo.launch.py use_fake_hardware:=true
+```
+
+## Relation to offline smoke check
+- Offline smoke check confirms smoke/readiness artifacts from generation.
+- Generated-scene acceptance focuses on package completeness + launch/safety contract compliance.

--- a/scripts/validate_workcell_studio_generated_scene.py
+++ b/scripts/validate_workcell_studio_generated_scene.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, re
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except Exception:
+    yaml = None
+
+STATUS_PASS="PASS"; STATUS_WARN="WARNINGS"; STATUS_BLOCKED="BLOCKED"; STATUS_PREVIEW="PREVIEW_ONLY"
+ROS_NAME_RE=re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def _load_yaml(path: Path)->dict[str, Any]:
+    if not path.is_file(): return {}
+    text=path.read_text(encoding='utf-8')
+    if yaml is not None:
+        out=yaml.safe_load(text)
+        return out if isinstance(out, dict) else {}
+    return {}
+
+def _has(scene:Path, rel:str)->bool: return (scene/rel).is_file()
+
+def validate(scene:Path)->dict[str,Any]:
+    checks=[]; blockers=[]; warnings=[]
+    req=["package.xml","CMakeLists.txt","environment.yaml","scene_manifest.yaml","config/task_recipe.yaml","config/workcell_builder_task_intent.yaml"]
+    for r in req:
+        ok=_has(scene,r); checks.append({"name":f"{r} exists","ok":ok});
+        if not ok: blockers.append(f"Missing required file: {r}")
+
+    preview_ok=_has(scene,"preview/static_preview.html") or _has(scene,"preview/static_preview.svg")
+    checks.append({"name":"preview/static_preview.html or static_preview.svg exists","ok":preview_ok})
+    if not preview_ok: warnings.append("Preview artifact missing")
+
+    smoke_ok=_has(scene,"smoke/offline_smoke_summary.txt")
+    checks.append({"name":"smoke/offline_smoke_summary.txt exists","ok":smoke_ok})
+    if not smoke_ok: warnings.append("Offline smoke summary missing")
+
+    summary_ok=_has(scene,"workcell_studio_summary.json") or _has(scene,"workcell_template_summary.json")
+    checks.append({"name":"generated summary exists","ok":summary_ok})
+    if not summary_ok: warnings.append("Generated summary missing")
+
+    name_ok=bool(ROS_NAME_RE.match(scene.name))
+    checks.append({"name":"scene name is valid ROS package name","ok":name_ok})
+    if not name_ok: blockers.append("Scene directory name is not a valid ROS package name")
+
+    env=_load_yaml(scene/"environment.yaml")
+    intent=_load_yaml(scene/"config/workcell_builder_task_intent.yaml")
+    recipe=_load_yaml(scene/"config/task_recipe.yaml")
+    safety=((intent.get("safety") if isinstance(intent.get("safety"),dict) else {}) or (recipe.get("safety") if isinstance(recipe.get("safety"),dict) else {}))
+    for key, expected in [("fake_hardware_first",True),("runtime_execution_enabled",False),("motion_command_sent",False)]:
+        ok=safety.get(key)==expected
+        checks.append({"name":f"{key} == {expected}","ok":ok})
+        if not ok: blockers.append(f"Safety flag {key} expected {expected} got {safety.get(key)!r}")
+
+    launch=scene/"launch/demo.launch.py"
+    launch_ready=launch.is_file()
+    checks.append({"name":"launch/demo.launch.py exists for launch-ready scene","ok":launch_ready,"optional":True})
+    launch_text=launch.read_text(encoding='utf-8') if launch_ready else ""
+    if launch_ready:
+        fake_arg_ok=("use_fake_hardware" in launch_text)
+        checks.append({"name":"launch file contains use_fake_hardware argument","ok":fake_arg_ok})
+        if not fake_arg_ok: blockers.append("Launch file missing use_fake_hardware argument")
+        no_real_default=("use_fake_hardware:=false" not in launch_text and "real_hardware:=true" not in launch_text)
+        checks.append({"name":"launch file does not default to real hardware","ok":no_real_default})
+        if not no_real_default: blockers.append("Launch file appears to default to real hardware")
+        no_runtime_default=("runtime_execution_enabled:=true" not in launch_text)
+        checks.append({"name":"launch file does not enable runtime execution by default","ok":no_runtime_default})
+        if not no_runtime_default: blockers.append("Launch file enables runtime execution by default")
+    else:
+        warnings.append("Launch file missing; preview-only or scaffold scene")
+
+    urdf_scene=(scene/"urdf/scene.urdf.xacro").is_file() or (scene/"urdf/environment.urdf.xacro").is_file()
+    srdf_ok=(scene/"urdf/arm_hand.srdf.xacro").is_file()
+    checks.append({"name":"scene.urdf.xacro or environment.urdf.xacro exists","ok":urdf_scene,"optional":True})
+    checks.append({"name":"arm_hand.srdf.xacro exists","ok":srdf_ok,"optional":True})
+
+    xacro_text=""
+    for p in [scene/"urdf/scene.urdf.xacro", scene/"urdf/environment.urdf.xacro", scene/"environment.yaml"]:
+        if p.is_file(): xacro_text += p.read_text(encoding='utf-8')+"\n"
+    if "robotiq" in xacro_text.lower() or "2f" in xacro_text.lower() or "gripper" in xacro_text.lower():
+        rpy_ok="-1.5708 -1.5708 0" in xacro_text
+        checks.append({"name":"generated gripper mount RPY is -1.5708 -1.5708 0","ok":rpy_ok})
+        if not rpy_ok: warnings.append("Expected gripper mount RPY not found")
+
+    cmd=f"ros2 launch {scene.name} demo.launch.py use_fake_hardware:=true"
+    checks.append({"name":"launch command contains use_fake_hardware:=true","ok":True})
+
+    # mirror browser high-level statuses
+    has_env=_has(scene,"environment.yaml"); has_launch=launch_ready
+    if not has_env: status="MISSING_ENVIRONMENT_YAML"
+    elif not has_launch and preview_ok: status=STATUS_PREVIEW
+    elif blockers: status=STATUS_BLOCKED
+    elif warnings: status=STATUS_WARN
+    else: status=STATUS_PASS
+
+    acceptance={
+        "scene_name":scene.name,"scene_path":str(scene),"status":status,"checks":checks,
+        "blockers":blockers,"warnings":warnings,
+        "safety_flags":{"fake_hardware_first":safety.get("fake_hardware_first"),"runtime_execution_enabled":safety.get("runtime_execution_enabled"),"motion_command_sent":safety.get("motion_command_sent")},
+        "next_commands":[f"colcon build --symlink-install --packages-select {scene.name}","source install/setup.bash",cmd],
+        "notes":["Command not executed by validator","No robot motion commanded"],
+    }
+    out_dir=scene/"acceptance"; out_dir.mkdir(exist_ok=True)
+    (out_dir/"generated_scene_acceptance.json").write_text(json.dumps(acceptance,indent=2)+"\n",encoding='utf-8')
+    html=f"<html><body><h1>Generated Scene Acceptance</h1><p>scene={scene.name}</p><p>status={status}</p><p>no robot motion commanded</p><h2>blockers</h2><pre>{json.dumps(blockers,indent=2)}</pre><h2>warnings</h2><pre>{json.dumps(warnings,indent=2)}</pre><h2>next commands</h2><pre>{'\\n'.join(acceptance['next_commands'])}</pre></body></html>"
+    (out_dir/"generated_scene_acceptance.html").write_text(html,encoding='utf-8')
+    summary='\n'.join([f"scene={scene.name}",f"status={status}","no_robot_motion_commanded=true",f"launch_command={cmd}"])
+    (out_dir/"generated_scene_acceptance_summary.txt").write_text(summary+"\n",encoding='utf-8')
+    return acceptance
+
+
+def main()->int:
+    ap=argparse.ArgumentParser(); ap.add_argument('scene_dir',type=Path); ap.add_argument('--json',action='store_true')
+    a=ap.parse_args(); report=validate(a.scene_dir)
+    if a.json: print(json.dumps(report,indent=2))
+    else: print(f"{report['status']}: {report['scene_name']}")
+    return 0 if report['status'] in {STATUS_PASS, STATUS_WARN, STATUS_PREVIEW} else 1
+
+if __name__=='__main__': raise SystemExit(main())

--- a/tests/test_workcell_studio_generated_scene_acceptance.py
+++ b/tests/test_workcell_studio_generated_scene_acceptance.py
@@ -1,0 +1,29 @@
+import json, shutil, subprocess, sys
+from pathlib import Path
+
+ROOT=Path(__file__).resolve().parents[1]
+SCRIPT=ROOT/'scripts/validate_workcell_studio_generated_scene.py'
+
+def _run(scene:Path):
+    p=subprocess.run([sys.executable,str(SCRIPT),str(scene),'--json'],capture_output=True,text=True,check=False)
+    return p, json.loads(p.stdout)
+
+def test_acceptance_on_existing_scene(tmp_path: Path):
+    src=next((ROOT/'scenes').iterdir())
+    scene=tmp_path/src.name
+    shutil.copytree(src,scene)
+    p, out=_run(scene)
+    assert p.returncode in (0,1)
+    assert out['status'] in {'PASS','WARNINGS','PREVIEW_ONLY','BLOCKED'}
+    a=scene/'acceptance'
+    assert (a/'generated_scene_acceptance.json').is_file()
+    assert (a/'generated_scene_acceptance.html').is_file()
+    assert (a/'generated_scene_acceptance_summary.txt').is_file()
+
+
+def test_missing_environment_blocked(tmp_path: Path):
+    scene=tmp_path/'ur5_demo'
+    scene.mkdir(); (scene/'package.xml').write_text('x'); (scene/'CMakeLists.txt').write_text('x')
+    p,out=_run(scene)
+    assert out['status'] in {'MISSING_ENVIRONMENT_YAML','BLOCKED'}
+    assert p.returncode==1

--- a/tests/test_workcell_studio_generated_scene_acceptance_reports.py
+++ b/tests/test_workcell_studio_generated_scene_acceptance_reports.py
@@ -1,0 +1,24 @@
+import json, subprocess, sys
+from pathlib import Path
+
+ROOT=Path(__file__).resolve().parents[1]
+SCRIPT=ROOT/'scripts/validate_workcell_studio_generated_scene.py'
+
+def test_report_content(tmp_path: Path):
+    scene=tmp_path/'ur5_robotiq_demo'
+    (scene/'config').mkdir(parents=True)
+    (scene/'launch').mkdir(); (scene/'preview').mkdir(); (scene/'smoke').mkdir(); (scene/'urdf').mkdir()
+    (scene/'package.xml').write_text('x'); (scene/'CMakeLists.txt').write_text('x')
+    (scene/'environment.yaml').write_text('robot: {name: ur5}\nend_effector: {name: robotiq}\nmount_rpy: "-1.5708 -1.5708 0"\n')
+    (scene/'scene_manifest.yaml').write_text('x')
+    (scene/'config/task_recipe.yaml').write_text('safety:\n  fake_hardware_first: true\n  runtime_execution_enabled: false\n  motion_command_sent: false\n')
+    (scene/'config/workcell_builder_task_intent.yaml').write_text('safety:\n  fake_hardware_first: true\n  runtime_execution_enabled: false\n  motion_command_sent: false\n')
+    (scene/'launch/demo.launch.py').write_text('use_fake_hardware')
+    (scene/'preview/static_preview.html').write_text('<html/>')
+    (scene/'smoke/offline_smoke_summary.txt').write_text('ok')
+    (scene/'workcell_studio_summary.json').write_text('{}')
+    p=subprocess.run([sys.executable,str(SCRIPT),str(scene),'--json'],capture_output=True,text=True,check=False)
+    out=json.loads(p.stdout)
+    assert 'use_fake_hardware:=true' in '\n'.join(out['next_commands'])
+    assert out['safety_flags']['fake_hardware_first'] is True
+    assert (scene/'acceptance/generated_scene_acceptance.html').read_text().lower().find('no robot motion commanded')!=-1

--- a/tests/test_workcell_studio_generated_scene_launch_contract.py
+++ b/tests/test_workcell_studio_generated_scene_launch_contract.py
@@ -1,0 +1,15 @@
+import json, subprocess, sys
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+SCRIPT=ROOT/'scripts/validate_workcell_studio_generated_scene.py'
+
+def test_placeholder_preview_only(tmp_path: Path):
+    s=tmp_path/'placeholder_scene'
+    (s/'config').mkdir(parents=True); (s/'preview').mkdir()
+    for f in ['package.xml','CMakeLists.txt','environment.yaml','scene_manifest.yaml']:
+        (s/f).write_text('x')
+    (s/'config/task_recipe.yaml').write_text('safety:\n  fake_hardware_first: true\n  runtime_execution_enabled: false\n  motion_command_sent: false\n')
+    (s/'config/workcell_builder_task_intent.yaml').write_text('safety:\n  fake_hardware_first: true\n  runtime_execution_enabled: false\n  motion_command_sent: false\n')
+    (s/'preview/static_preview.html').write_text('x')
+    out=json.loads(subprocess.run([sys.executable,str(SCRIPT),str(s),'--json'],capture_output=True,text=True).stdout)
+    assert out['status']=='PREVIEW_ONLY'

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -4,7 +4,8 @@
   "Create Scene From Template", "Scene Template Library", "Template Category",
   "Pick and Place Cell", "Sorting Cell", "Camera Inspection Cell",
   "Conveyor Pick Cell", "Palletizing Cell", "Instantiate Template",
-  "Template Validation Status"
+  "Template Validation Status",
+  "Run Generated Scene Acceptance", "Open Acceptance Report", "Copy Acceptance Summary"
 };
 
 // Scene round-trip UI labels:


### PR DESCRIPTION
### Motivation
- Make template-generated Workcell Studio scenes verifiable as complete, buildable, and safe for demos without launching ROS or commanding robot motion.
- Ensure generated scenes adhere to existing Workcell Builder conventions and mirror the Scene Browser readiness statuses to avoid duplicated logic and surprise blockers.
- Provide a clear, offline preflight that emits (but does not run) local build/launch commands and produces human-readable acceptance artifacts for operator/QA workflows.

### Description
- Add offline validator `scripts/validate_workcell_studio_generated_scene.py` that checks required files (`package.xml`, `CMakeLists.txt`, `environment.yaml`, `scene_manifest.yaml`, `config/task_recipe.yaml`, `config/workcell_builder_task_intent.yaml`), preview/smoke artifacts, generated summaries, ROS package name validity, safety flags (`fake_hardware_first: true`, `runtime_execution_enabled: false`, `motion_command_sent: false`), launch-file contract (presence of `use_fake_hardware` and no real-hardware defaults), and static xacro/URDF markers including expected gripper mount RPY `-1.5708 -1.5708 0` when applicable, and writes `acceptance/generated_scene_acceptance.json`, `.html`, and `_summary.txt`.
- Mirror Scene Browser high-level statuses (`PASS`/`WARNINGS`/`BLOCKED`/`PREVIEW_ONLY`) to remain consistent with UI expectations and avoid divergent readiness logic.
- Add UI discoverability strings in `workcell_builder/workcell_builder/gui/scene_select.cpp` for actions: `Run Generated Scene Acceptance`, `Open Acceptance Report`, and `Copy Acceptance Summary`.
- Add documentation `docs/manuals/WORKCELL_STUDIO_GENERATED_SCENE_ACCEPTANCE.md` describing checks, outputs, safe usage, and emitted preflight commands (not executed): `colcon build --symlink-install --packages-select <scene_name>`, `source install/setup.bash`, `ros2 launch <scene_name> demo.launch.py use_fake_hardware:=true`.
- Add automated tests: `tests/test_workcell_studio_generated_scene_acceptance.py`, `tests/test_workcell_studio_generated_scene_acceptance_reports.py`, and `tests/test_workcell_studio_generated_scene_launch_contract.py` that exercise validator behavior on real and synthetic scenes and assert artifacts and safety/launch contract detection.

### Testing
- Ran the new acceptance tests together with related suite checks using:
  - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_studio_generated_scene_acceptance.py tests/test_workcell_studio_generated_scene_acceptance_reports.py tests/test_workcell_studio_generated_scene_launch_contract.py tests/test_workcell_studio_template_instantiator_e2e.py tests/test_workcell_studio_scene_browser.py`.
- Result: all tests passed (`7 passed`).
- The validator writes the three acceptance artifacts under each scene `acceptance/` directory and returns non-zero exit codes for `BLOCKED` conditions while never executing ROS launch or commanding motion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a059fc18a5c83318d6a93c14a947bc0)