### PR TITLE
Harden Workcell Studio local build/runtime flow (Qt/CMake/scripts/QProcess)

### DIFF
--- a/docs/manuals/WORKCELL_STUDIO_GOLDEN_FLOW_QA.md
+++ b/docs/manuals/WORKCELL_STUDIO_GOLDEN_FLOW_QA.md
@@ -49,3 +49,11 @@ GUI flow:
 - Run Build if dependencies are ready
 - Do not run real hardware
 - Confirm no robot motion was commanded
+
+## Local Build and Runtime Troubleshooting
+- If `colcon build --packages-select workcell_builder` fails, verify Qt5 SVG dev package is installed (`libqt5svg5-dev`) and rerun from a sourced ROS 2 Humble shell.
+- If Workcell Studio opens without the dark theme, verify `share/workcell_builder/gui/resources/workcell_studio_dark.qss` exists in your install space.
+- If merge/acceptance/demo/preview actions fail, collect GUI console output and `preview_launch/latest_console.log` under the selected scene directory.
+- If helper scripts cannot be found, confirm scripts are present under either:
+  - `install/workcell_builder/share/workcell_builder/scripts`, or
+  - repository `scripts/` in the workspace source tree.

--- a/docs/manuals/WORKCELL_STUDIO_QT_UI_QA.md
+++ b/docs/manuals/WORKCELL_STUDIO_QT_UI_QA.md
@@ -26,3 +26,9 @@
 - Verify critical buttons are wired or explicitly show safe fallback (no silent button failures).
 - Validate stale layout gating blocks preview launch until merge/regeneration is rerun.
 - Confirm preview command remains fake-hardware-only and no motion command is sent.
+
+## Startup / Process Troubleshooting
+- If `workcell_builder` fails to open, run from terminal and capture stdout/stderr.
+- If preview launch/build appears stuck, use **Stop Preview** and check `preview_launch/latest_console.log`.
+- If helper script lookup fails, UI should display `Could not find Workcell Studio helper script`; verify installed `share/workcell_builder/scripts` and source checkout `scripts/` paths.
+- If scene save/merge actions are disabled or blocked, verify a scene is selected and layout has been saved to `layout/workcell_studio_layout.yaml`.

--- a/scripts/workcell_studio_layout_merge.py
+++ b/scripts/workcell_studio_layout_merge.py
@@ -24,6 +24,17 @@ def _index(items: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     return out
 
 def merge(scene_dir: Path) -> dict[str, Any]:
+    if not scene_dir.exists() or not scene_dir.is_dir():
+        return {
+            'status': 'BLOCKED',
+            'layout_applied': False,
+            'generated_from_saved_layout': False,
+            'merge_warnings': [],
+            'merge_blockers': [f"scene_dir not found: {scene_dir}"],
+            'layout_saved_at_utc': None,
+            'merged_at_utc': datetime.now(timezone.utc).isoformat(),
+            'safety_flags': {'fake_hardware_first': True, 'runtime_execution_enabled': False, 'motion_command_sent': False},
+        }
     env = _load(scene_dir/'environment.yaml')
     manifest = _load(scene_dir/'scene_manifest.yaml')
     layout = _load(scene_dir/'layout'/'workcell_studio_layout.yaml')
@@ -88,9 +99,11 @@ def merge(scene_dir: Path) -> dict[str, Any]:
     }
     (generated/'workcell_studio_layout_merge_report.json').write_text(json.dumps(report, indent=2)+'\n', encoding='utf-8')
     (generated/'workcell_studio_layout_merge_summary.txt').write_text(f"layout_applied={report['layout_applied']}\ngenerated_from_saved_layout={report['generated_from_saved_layout']}\n", encoding='utf-8')
+    report['status'] = 'READY' if not blockers else 'BLOCKED'
     return report
 
 if __name__ == '__main__':
     ap = argparse.ArgumentParser(); ap.add_argument('scene_dir', type=Path); ap.add_argument('--json', action='store_true')
     a = ap.parse_args(); rep = merge(a.scene_dir)
     if a.json: print(json.dumps(rep, indent=2))
+    raise SystemExit(0 if rep.get('status') == 'READY' else 2)

--- a/tests/test_workcell_studio_canvas_runtime_guards.py
+++ b/tests/test_workcell_studio_canvas_runtime_guards.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+MAIN = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+
+
+def test_canvas_and_layout_guard_strings_present():
+    for needle in [
+        'No scene selected',
+        'Layout has unsaved edits. Save Layout first.',
+        'No saved layout found (layout/workcell_studio_layout.yaml).',
+    ]:
+        assert needle in MAIN

--- a/tests/test_workcell_studio_helper_script_install_lookup.py
+++ b/tests/test_workcell_studio_helper_script_install_lookup.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+CMAKE = Path('workcell_builder/workcell_builder/CMakeLists.txt').read_text(encoding='utf-8')
+MAIN = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+
+
+def test_helper_scripts_installed_to_share_scripts():
+    for script in [
+        'workcell_studio_layout_merge.py',
+        'validate_workcell_studio_generated_scene.py',
+        'workcell_studio_demo_mode.py',
+        'workcell_studio_preview_launch.py',
+        'run_workcell_studio_golden_flow.py',
+    ]:
+        assert script in CMAKE
+    assert 'DESTINATION share/${PROJECT_NAME}/scripts' in CMAKE
+
+
+def test_missing_helper_script_message_is_clear():
+    assert 'Could not find Workcell Studio helper script' in MAIN

--- a/tests/test_workcell_studio_local_build_contract.py
+++ b/tests/test_workcell_studio_local_build_contract.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+CMAKE = Path('workcell_builder/workcell_builder/CMakeLists.txt').read_text(encoding='utf-8')
+PKG = Path('workcell_builder/workcell_builder/package.xml').read_text(encoding='utf-8')
+
+
+def test_workcell_studio_sources_in_cmake_once():
+    for src in [
+        'src_workcell_studio_canvas_model.cpp',
+        'src_workcell_studio_layout_editor.cpp',
+        'src_workcell_studio_layout_merge.cpp',
+    ]:
+        assert CMAKE.count(src) >= 1
+
+
+def test_qt_svg_wiring_present_for_svg_usage():
+    assert 'find_package(Qt5 COMPONENTS Widgets Concurrent Svg REQUIRED)' in CMAKE
+    assert 'Qt5::Svg' in CMAKE
+    assert 'libqt5svg5-dev' in PKG

--- a/tests/test_workcell_studio_qprocess_hardening.py
+++ b/tests/test_workcell_studio_qprocess_hardening.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+MAIN = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+
+
+def test_qprocess_stdout_stderr_and_finished_hooks():
+    for needle in ['readyReadStandardOutput', 'readyReadStandardError', 'QProcess::finished']:
+        assert needle in MAIN
+
+
+def test_qprocess_stop_path_uses_terminate_and_kill():
+    assert 'terminate()' in MAIN
+    assert 'kill()' in MAIN
+    assert 'waitForFinished(2000)' in MAIN

--- a/tests/test_workcell_studio_script_failure_modes.py
+++ b/tests/test_workcell_studio_script_failure_modes.py
@@ -1,0 +1,18 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_layout_merge_missing_scene_reports_blocked_json(tmp_path):
+    missing = tmp_path / 'missing_scene'
+    script = Path('scripts/workcell_studio_layout_merge.py')
+    run = subprocess.run([sys.executable, str(script), str(missing), '--json'], capture_output=True, text=True, check=False)
+    assert run.returncode != 0
+    payload = json.loads(run.stdout)
+    assert payload.get('status') in {'BLOCKED', 'ERROR'}
+
+
+def test_preview_launch_script_keeps_fake_hardware_guard_tokens():
+    text = Path('scripts/workcell_studio_preview_launch.py').read_text(encoding='utf-8')
+    assert 'use_fake_hardware:=true' in text

--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -41,7 +41,7 @@ find_package(pluginlib REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem)
-find_package(Qt5 COMPONENTS Widgets Concurrent REQUIRED)
+find_package(Qt5 COMPONENTS Widgets Concurrent Svg REQUIRED)
 
 include_directories(include)
 include_directories(include/attributes)
@@ -178,6 +178,7 @@ ament_target_dependencies(workcell_builder
 target_link_libraries(workcell_builder
   Qt5::Widgets
   Qt5::Concurrent
+  Qt5::Svg
   yaml-cpp
   ${Boost_LIBRARIES}
 )
@@ -393,6 +394,14 @@ install(PROGRAMS
   scripts/publish_sample_epd_snapshot.py
   scripts/epd_to_workcell_snapshot_node.py
   DESTINATION lib/${PROJECT_NAME})
+
+install(PROGRAMS
+  ../../scripts/workcell_studio_layout_merge.py
+  ../../scripts/validate_workcell_studio_generated_scene.py
+  ../../scripts/workcell_studio_demo_mode.py
+  ../../scripts/workcell_studio_preview_launch.py
+  ../../scripts/run_workcell_studio_golden_flow.py
+  DESTINATION share/${PROJECT_NAME}/scripts)
 
 install(DIRECTORY ${WORKCELL_BUILDER_SECONDARY_ASSETS_DIR}/
   DESTINATION share/${PROJECT_NAME}/legacy_assets)

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -613,6 +613,7 @@ Could not find Workcell Studio helper script");
 
 MainWindow::~MainWindow()
 {
+  stop_preview_process();
   delete ui;
 }
 

--- a/workcell_builder/workcell_builder/package.xml
+++ b/workcell_builder/workcell_builder/package.xml
@@ -28,8 +28,10 @@
   <depend>boost</depend>
 
   <build_depend>qtbase5-dev</build_depend>
+  <build_depend>libqt5svg5-dev</build_depend>
   <build_depend>qt5-qmake</build_depend>
   <exec_depend>qtbase5-dev</exec_depend>
+  <exec_depend>libqt5svg5-dev</exec_depend>
   <exec_depend>qt5-qmake</exec_depend>
   <!--test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend-->


### PR DESCRIPTION
### Motivation
- Stabilize Workcell Studio build and runtime after recent UI/canvas/layout/merge/demo/preview additions by fixing compile/runtime hazards and improving failure modes.
- Ensure installed GUI can find helper scripts, safely run preview processes, and produce deterministic, machine-readable reports on failure.

### Description
- Added Qt SVG support in `CMakeLists.txt` and `package.xml` (`find_package(Qt5 ... Svg)`, link `Qt5::Svg`, and `libqt5svg5-dev` deps) to match uses of `QSvgGenerator`/SVG APIs.
- Install Workcell Studio helper scripts into the package share path (`share/workcell_builder/scripts`) so installed binaries can locate runtime helpers without relying on source-relative paths.
- Stop any running preview `QProcess` during `MainWindow` teardown to avoid dangling processes and made `QProcess` wiring robust (stdout/stderr handlers, terminate/kill/timeouts preserved). 
- Hardened `scripts/workcell_studio_layout_merge.py` to return a structured `BLOCKED` JSON payload when the `scene_dir` is missing, preserve fake-hardware safety flags, and exit non-zero on blocked/error paths (zero only for `READY`).
- Added focused regression tests covering CMake contract, helper-script install/lookup, `QProcess` wiring, canvas/layout guards, and layout-merge failure modes, and updated QA docs with local build/runtime troubleshooting guidance.

### Testing
- Added and executed unit/regression tests with: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_studio_local_build_contract.py tests/test_workcell_studio_helper_script_install_lookup.py tests/test_workcell_studio_qprocess_hardening.py tests/test_workcell_studio_canvas_runtime_guards.py tests/test_workcell_studio_script_failure_modes.py`.
- Test result: all tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05c2e2242083318ace3c1dde1aefdc)