### PR TITLE
Fix workcell_builder compile regressions in studio UI/template flow

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -29,6 +29,7 @@
 #include <QStackedWidget>
 #include <QTabWidget>
 #include <QTextEdit>
+#include <QPlainTextEdit>
 #include <QToolBar>
 #include <QApplication>
 #include <QClipboard>
@@ -80,7 +81,6 @@ namespace fs = boost::filesystem;
 namespace {
 [[maybe_unused]] static const char * kStudioShellCompatLabels[] = {
   "New Cell", "Open Existing Scene", "Validate", "Preview", "Generate Scene", "Export",
-  "if (label == "Open Existing Scene")"
 };
 bool is_good_scene_path(const fs::path & scene_path)
 {
@@ -557,24 +557,9 @@ void MainWindow::select_scene_by_row(int row)
   if (row < 0 || row >= (int)scene_browser_result_.scenes.size()) return;
   selected_scene_index_ = row; const auto & s = scene_browser_result_.scenes[(size_t)row];
   scene_builder_title_->setText(QString("<h2>Scene Builder: %1</h2>").arg(QString::fromStdString(s.scene_name)));
-  scene_preview_label_->setText((s.has_static_preview_svg?"Preview SVG available":"Generate preview/readiness pack to populate this panel") + QString("
-Status: %1").arg(QString::fromStdString(s.status)));
-  inspector_label_->setText(QString("Scene name: %1
-Scene path: %2
-Status: %3
-Robot: %4
-End effector: %5
-Gripper Mount RPY: -1.5708 -1.5708 0
-Objects count: %6
-Task recipe: %7
-Smoke report: %8
-Launch command: %9").arg(QString::fromStdString(s.scene_name)).arg(QString::fromStdString(s.scene_dir.string())).arg(QString::fromStdString(s.status)).arg(QString::fromStdString(s.robot_summary)).arg(QString::fromStdString(s.gripper_summary)).arg(s.object_count).arg(s.has_task_recipe?"present":"missing").arg(s.has_smoke_report_json?"present":"missing").arg(selected_scene_launch_command()));
-  readiness_label_->setText("Preview/offline validation only
-No robot motion commanded
-Runtime execution remains disabled unless explicitly enabled elsewhere
-colcon build --symlink-install --packages-select "+QString::fromStdString(s.scene_name)+"
-source install/setup.bash
-"+selected_scene_launch_command());
+  scene_preview_label_->setText((s.has_static_preview_svg?"Preview SVG available":"Generate preview/readiness pack to populate this panel") + QString("\nStatus: %1").arg(QString::fromStdString(s.status)));
+  inspector_label_->setText(QString("Scene name: %1\nScene path: %2\nStatus: %3\nRobot: %4\nEnd effector: %5\nGripper Mount RPY: -1.5708 -1.5708 0\nObjects count: %6\nTask recipe: %7\nSmoke report: %8\nLaunch command: %9").arg(QString::fromStdString(s.scene_name)).arg(QString::fromStdString(s.scene_dir.string())).arg(QString::fromStdString(s.status)).arg(QString::fromStdString(s.robot_summary)).arg(QString::fromStdString(s.gripper_summary)).arg(s.object_count).arg(s.has_task_recipe?"present":"missing").arg(s.has_smoke_report_json?"present":"missing").arg(selected_scene_launch_command()));
+  readiness_label_->setText("Preview/offline validation only\nNo robot motion commanded\nRuntime execution remains disabled unless explicitly enabled elsewhere\ncolcon build --symlink-install --packages-select "+QString::fromStdString(s.scene_name)+"\nsource install/setup.bash\n"+selected_scene_launch_command());
   refresh_preview_launch_ui();
   rebuild_digital_twin_canvas();
 }
@@ -635,9 +620,7 @@ void MainWindow::show_not_wired_message(const QString & action_label)
   QMessageBox::information(
     this,
     "Workcell Studio",
-    "This Workcell Studio action is not wired yet. No files changed and no robot motion was commanded.
-
-Could not find Workcell Studio helper script");
+    "This Workcell Studio action is not wired yet. No files changed and no robot motion was commanded.\n\nCould not find Workcell Studio helper script");
 }
 
 MainWindow::~MainWindow()
@@ -1062,9 +1045,7 @@ void MainWindow::run_diagnostics_self_test()
   add("no robot motion safety flags", true, true, "no_robot_motion_commanded: true", "Diagnostics is offline-only", "diagnostics report");
   const QString st=diagnostics_status_from_counts(blocked,warn); if(diagnostics_status_label_) diagnostics_status_label_->setText("Status: "+st); if(diagnostics_indicator_label_) diagnostics_indicator_label_->setText("Diagnostics: "+st); if(diagnostics_summary_label_) diagnostics_summary_label_->setText(QString("PASS rows: %1 | WARN rows: %2 | BLOCKED rows: %3").arg(diagnostics_table_?diagnostics_table_->rowCount()-warn-blocked:0).arg(warn).arg(blocked));
   QJsonObject report{{"timestamp", QDateTime::currentDateTimeUtc().toString(Qt::ISODate)}, {"workspace_root", ws}, {"scenes_root", ws+"/scenes"}, {"assets_root", ws+"/assets"}, {"golden_flow_status", "NOT CHECKED"}, {"safety_status", st}, {"no_robot_motion_commanded", true}};
-  write_diagnostics_report(report, QString("Diagnostics status: %1
-no_robot_motion_commanded=true
-").arg(st), QString("<html><body><h1>Diagnostics: %1</h1><p>No robot motion commanded.</p></body></html>").arg(st)); }
+  write_diagnostics_report(report, QString("Diagnostics status: %1\nno_robot_motion_commanded=true\n").arg(st), QString("<html><body><h1>Diagnostics: %1</h1><p>No robot motion commanded.</p></body></html>").arg(st)); }
 
 void MainWindow::run_diagnostics_golden_flow_dry_run()
 { const QString cmd = "python3 scripts/run_workcell_studio_golden_flow.py --scene-dir /tmp/workcell_studio_diag_scene --json"; QProcess p; p.start("/bin/bash", {"-lc", cmd}); p.waitForFinished(60000); append_studio_log("Run Golden Flow Dry Run"); append_studio_log("Command: " + cmd); append_studio_log("Report path: /tmp/workcell_studio_diag_scene/golden_flow/workcell_studio_golden_flow_report.json"); append_studio_log("Summary path: /tmp/workcell_studio_diag_scene/golden_flow/workcell_studio_golden_flow_summary.txt"); append_studio_log("Dashboard path: /tmp/workcell_studio_diag_scene/golden_flow/workcell_studio_golden_flow_dashboard.html"); }

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -62,6 +62,7 @@
 #include <QPainter>
 #include <QWheelEvent>
 #include <QMouseEvent>
+#include "workcell_studio_template_instantiator.hpp"
 #include <boost/filesystem.hpp>
 #include <filesystem>
 #include <boost/system/error_code.hpp>
@@ -122,7 +123,7 @@ protected:
   {
     if (event->button() == Qt::MiddleButton || event->button() == Qt::RightButton) {
       setDragMode(QGraphicsView::ScrollHandDrag);
-      QMouseEvent fake(QEvent::MouseButtonPress, event->position(), Qt::LeftButton, Qt::LeftButton, event->modifiers());
+      QMouseEvent fake(QEvent::MouseButtonPress, event->localPos(), Qt::LeftButton, Qt::LeftButton, event->modifiers());
       QGraphicsView::mousePressEvent(&fake);
       return;
     }
@@ -131,7 +132,7 @@ protected:
   void mouseReleaseEvent(QMouseEvent * event) override
   {
     if (dragMode() == QGraphicsView::ScrollHandDrag) {
-      QMouseEvent fake(QEvent::MouseButtonRelease, event->position(), Qt::LeftButton, Qt::NoButton, event->modifiers());
+      QMouseEvent fake(QEvent::MouseButtonRelease, event->localPos(), Qt::LeftButton, Qt::NoButton, event->modifiers());
       QGraphicsView::mouseReleaseEvent(&fake);
       setDragMode(QGraphicsView::RubberBandDrag);
       return;
@@ -1465,7 +1466,8 @@ bool repair_scene_yaml_file(const fs::path & scene_dir, std::string * summary)
     YAML::Node map(YAML::NodeType::Map);
     for (const auto & obj : root["objects"]) {
       if (!obj["name"]) continue;
-      map[obj["name"].as<std::string>()] = obj;
+      const std::string key = obj["name"].as<std::string>();
+      map[key] = YAML::Clone(obj);
     }
     root["objects"] = map;
     changed = true;

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -81,7 +81,7 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
       }
     }
   }
-  if (!m.warnings.empty()) { m.has_warnings = true; m.status = "WARNINGS"; m.items.push_back({"warning","warning","warning","warning","environment.yaml",-1.2,1.2,0,0,0,0,0.1,0.1,0,m.warnings}); }
+  if (!m.warnings.empty()) { m.has_warnings = true; m.status = "WARNINGS"; { WorkcellStudioCanvasItem w; w.id="warning"; w.type="warning"; w.role="warning"; w.label="warning"; w.source_file="environment.yaml"; w.x=-1.2; w.y=1.2; w.width=0.1; w.depth=0.1; w.height=0.0; w.warnings=m.warnings; m.items.push_back(w); } }
   else { m.status = "READY"; }
   return m;
 }

--- a/workcell_builder/workcell_builder/src_workcell_studio_template_instantiator.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_template_instantiator.cpp
@@ -45,8 +45,8 @@ WorkcellStudioTemplateInstantiationResult instantiate_workcell_studio_template(c
   if (scene_dir.filename().string() != scene_name) r.warnings.push_back("scene existed; created suffixed scene: " + scene_dir.filename().string());
   r.scene_dir = scene_dir;
 
-  generate_package_xml(scene_dir, scene_dir.filename().string(), "humble");
-  generate_cmake(scene_dir, scene_dir.filename().string(), "humble");
+  generate_package_xml(scene_dir, scene_dir.filename().string(), 0, "humble");
+  generate_cmakelists(scene_dir, scene_dir.filename().string(), 0, "humble");
   r.created_files.push_back((scene_dir / "package.xml").string());
   r.created_files.push_back((scene_dir / "CMakeLists.txt").string());
 


### PR DESCRIPTION
### Motivation
- Restore a previously broken `workcell_builder` build by repairing several compile-time regressions introduced in the studio UI and template instantiation code. 
- Ensure Qt5 API compatibility for mouse events and correct usage of preview console widgets.
- Prevent YAML and template-instantiator mismatches that caused type/conversion errors during scene/template operations.

### Description
- Fixed malformed multi-line string literals and removed an accidental stray token from `kStudioShellCompatLabels` in `gui/mainwindow.cpp`, and added the missing `#include <QPlainTextEdit>` to match preview-log usage.
- Replaced `QMouseEvent::position()` with `QMouseEvent::localPos()` and added `workcell_studio_template_instantiator.hpp` include in `gui/scene_select.cpp` to restore Qt5 and symbol visibility compatibility.
- Changed legacy YAML normalization to clone nodes before inserting into a map (`map[key] = YAML::Clone(obj)`) to avoid `YAML::iterator_value` conversion errors in `gui/scene_select.cpp`.
- Updated `instantiate_workcell_studio_template` calls to current `generate_package_xml`/`generate_cmakelists` signatures in `src_workcell_studio_template_instantiator.cpp` and replaced an invalid aggregate initializer with explicit `WorkcellStudioCanvasItem` field assignments for the warning item in `src_workcell_studio_canvas_model.cpp`.

### Testing
- Attempted to build the package with `colcon build --packages-select workcell_builder --event-handlers console_direct+`, but the build could not be executed in this environment because `colcon` is not installed (failure: `colcon: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e54127b88331a1abf7d30af9eb00)