### PR TITLE
Fix workcell_builder ODR/linker failure by inlining header helper functions

### DIFF
--- a/workcell_builder/workcell_builder/include/file_functions.h
+++ b/workcell_builder/workcell_builder/include/file_functions.h
@@ -52,7 +52,7 @@ inline void ensure_parent(const fs::path & p)
   }
 }
 
-void find_replace(
+inline void find_replace(
   std::string example_text, std::string target_text, std::string current_text,
   std::string replaced_text)
 {
@@ -81,7 +81,7 @@ void find_replace(
 // void GenerateCMakeLists(boost::filesystem::path workcell_filepath,
 // boost::filesystem::path package_filepath,
 // std::string package_name,int ros_ver)
-void generate_cmakelists(
+inline void generate_cmakelists(
   fs::path workcell_filepath, std::string package_name,
   int ros_ver, const std::string & ros_distro)
 {
@@ -147,7 +147,7 @@ void generate_cmakelists(
   }
 }
 
-void delete_folder(fs::path scene_filepath, std::string scene_name)
+inline void delete_folder(fs::path scene_filepath, std::string scene_name)
 {
   safe_chdir(scene_filepath);
   try {
@@ -159,7 +159,7 @@ void delete_folder(fs::path scene_filepath, std::string scene_name)
   }
 }
 
-void generate_package_xml(
+inline void generate_package_xml(
   fs::path workcell_filepath, std::string package_name,
   int ros_ver, const std::string & ros_distro)
 {
@@ -231,7 +231,7 @@ void generate_package_xml(
     }
   }
 }
-bool copyDir(fs::path const & source, fs::path const & destination)
+inline bool copyDir(fs::path const & source, fs::path const & destination)
 {
   try {
     if (!fs::exists(source) || !fs::is_directory(source)) {


### PR DESCRIPTION
### Motivation
- The build was failing with multiple-definition linker errors for helpers (`delete_folder`, `copyDir`, `find_replace`, `generate_cmakelists`, `generate_package_xml`) because their definitions were present in a header included by multiple translation units.
- The duplicated symbols are used from both the GUI scene code and the template-instantiator code, so a focused fix was required that preserves existing behavior and ROS 2 Humble compatibility.

### Description
- Made the header-defined helper functions in `workcell_builder/workcell_builder/include/file_functions.h` `inline`: `find_replace`, `generate_cmakelists`, `delete_folder`, `generate_package_xml`, and `copyDir` to resolve ODR violations while keeping the same implementations and APIs.
- Kept all call sites unchanged so scene generation and template instantiation behavior are preserved and no generated package content or safety/fake-hardware defaults were modified.
- Change is limited to the header so no redesign of scene generation or removal of features was performed.

### Testing
- Searched and verified usage sites with `rg` for the symbols: `delete_folder`, `copyDir`, `find_replace`, `generate_cmakelists`, and `generate_package_xml`, confirming they are referenced from both `gui/scene_select.cpp` and `src_workcell_studio_template_instantiator.cpp` (searches succeeded).
- Attempted to run the repository build: `colcon build --symlink-install --packages-select workcell_builder --event-handlers console_direct+` but `colcon` was not available in the execution environment (`colcon: command not found`).
- No automated tests were modified; existing test targets remain unchanged and should pass once run in a proper ROS/colcon environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e7ea879483319016844ee744ad17)