### PR TITLE
Add Workcell Studio startup/setup dialog (startup gate)

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -145,6 +145,7 @@ add_executable(workcell_builder
     gui/environment_layout_editor.cpp
     gui/external_asset_import_dialog.cpp
     gui/workcell_builder_ui_utils.cpp
+    gui/startup_dialog.cpp
     gui/asset_catalog_model.cpp
     gui/conveyor_sorting_scenario_wizard.cpp
     gui/conveyor_sorting_scenario_wizard.h
@@ -156,7 +157,9 @@ add_executable(workcell_builder
     include/asset_picker_dialog.hpp
     include/object_placement_dialog.hpp
     include/environment_layout_editor.hpp
-    include/external_asset_import_dialog.hpp)
+    include/external_asset_import_dialog.hpp
+    include/workspace_validation.hpp
+    src_workspace_validation.cpp)
 
 ament_target_dependencies(workcell_builder
   rclcpp
@@ -250,6 +253,13 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_robot_tool_compatibility_inference_test
     test/robot_tool_compatibility_inference_test.cpp
     src_robot_tool_compatibility.cpp)
+
+  ament_add_gtest(workcell_workspace_validation_test
+    test/workspace_validation_test.cpp
+    src_workspace_validation.cpp)
+  if(TARGET workcell_workspace_validation_test)
+    target_link_libraries(workcell_workspace_validation_test Qt5::Widgets)
+  endif()
 
   foreach(workcell_builder_yaml_boost_test
       workcell_task_intent_readiness_test

--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -24,7 +24,8 @@
 #include <vector>
 
 #include "gui/mainwindow.h"
- #include "gui/scene_select.h"
+#include "gui/scene_select.h"
+#include "gui/startup_dialog.h"
 #include "workcell_builder_ui_utils.hpp"
 
 namespace
@@ -142,7 +143,12 @@ int main(int argc, char * argv[])
   a.setStyleSheet(workcell_builder::workcellStudioStyleSheet());
 
 
-  MainWindow w;
+  StartupDialog startup;
+  if (startup.exec() != QDialog::Accepted) {
+    return 0;
+  }
+
+  MainWindow w(startup.selected_workspace(), startup.selected_ros_distro());
   w.show();
   return a.exec();
 }

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -191,8 +191,10 @@ QPointF default_xy_for_category(const QString & category){
   return QPointF(60.0, 5.0);
 }
 
-MainWindow::MainWindow(QWidget * parent)
+MainWindow::MainWindow(const QString & startup_workspace, const QString & startup_ros_distro, QWidget * parent)
 : QMainWindow(parent),
+  startup_workspace_(startup_workspace),
+  startup_ros_distro_(startup_ros_distro),
   ui(new Ui::MainWindow)
 {
   ui->setupUi(this);
@@ -272,6 +274,7 @@ MainWindow::MainWindow(QWidget * parent)
       }
     });
 
+  apply_startup_selection();
   update_next_button_state();
   setup_studio_shell();
   apply_studio_theme();
@@ -634,10 +637,14 @@ MainWindow::~MainWindow()
 
 void MainWindow::on_load_workcell_clicked()
 {
-  QString workcell_file = QFileDialog::getExistingDirectory(
-    this,
-    "Target workcell project destination",
-    QDir::homePath());
+  QString workcell_file = startup_workspace_.trimmed();
+  if (workcell_file.isEmpty()) {
+    workcell_file = QFileDialog::getExistingDirectory(
+      this,
+      "Target workcell project destination",
+      QDir::homePath());
+  }
+  startup_workspace_.clear();
   if (workcell_file.isEmpty()) {
     return;
   }
@@ -884,9 +891,25 @@ void MainWindow::on_change_workcell_clicked()
   success = false;
   ui->error_label->setText("<font color='#C0392B'>Workcell not available</font>");
   statusBar()->showMessage("Select a new workspace directory.");
+  apply_startup_selection();
   update_next_button_state();
   setup_studio_shell();
   apply_studio_theme();
+}
+
+
+void MainWindow::apply_startup_selection()
+{
+  if (!startup_ros_distro_.trimmed().isEmpty()) {
+    const int idx = ui->ros_distro->findData(startup_ros_distro_.trimmed().toLower());
+    if (idx >= 0) {
+      ui->ros_distro->setCurrentIndex(idx);
+    }
+  }
+
+  if (!startup_workspace_.trimmed().isEmpty()) {
+    on_load_workcell_clicked();
+  }
 }
 
 bool MainWindow::has_selected_ros_distro() const
@@ -910,6 +933,9 @@ bool MainWindow::is_good_scene(boost::filesystem::path original_path, std::strin
 
 QString MainWindow::detect_workspace_root() const
 {
+  const QString configured_workspace = ui->filepath->text().trimmed();
+  if (!configured_workspace.isEmpty()) return configured_workspace;
+  if (!startup_workspace_.trimmed().isEmpty()) return startup_workspace_.trimmed();
   const fs::path cwd(QDir::currentPath().toStdString());
   if (fs::exists(cwd / "src") && fs::is_directory(cwd / "src")) return QString::fromStdString(cwd.string());
   if (selected_scene_index_ >= 0 && selected_scene_index_ < (int)scene_browser_result_.scenes.size()) {

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -63,7 +63,7 @@ public:
   std::vector<std::string> ros_dist;
   bool is_good_scene(boost::filesystem::path original_path, std::string scene_name);
 
-  explicit MainWindow(QWidget * parent = nullptr);
+  explicit MainWindow(const QString & startup_workspace = QString(), const QString & startup_ros_distro = QString(), QWidget * parent = nullptr);
   ~MainWindow();
 
 private slots:
@@ -99,6 +99,7 @@ private:
   void refresh_preview_launch_ui();
   void write_preview_launch_transcript(bool ran_process, const QString & command, const QString & event, int exit_code = -1);
   QString detect_workspace_root() const;
+  void apply_startup_selection();
   void set_preview_state(const QString & state);
   void rebuild_digital_twin_canvas();
   void rebuild_canvas_inspector();
@@ -212,5 +213,7 @@ private:
   QFutureWatcher<WorkcellLoadResult> * load_watcher_{ nullptr };
   QProgressDialog * progress_dialog_{ nullptr };
   std::atomic<bool> cancel_requested_{ false };
+  QString startup_workspace_;
+  QString startup_ros_distro_;
 };
 #endif  // EASY_MANIPULATION_DEPLOYMENT__WORKCELL_BUILDER__WORKCELL_BUILDER__GUI__MAINWINDOW_H_

--- a/workcell_builder/workcell_builder/gui/startup_dialog.cpp
+++ b/workcell_builder/workcell_builder/gui/startup_dialog.cpp
@@ -1,0 +1,107 @@
+#include "gui/startup_dialog.h"
+#include "include/workspace_validation.hpp"
+
+#include <QComboBox>
+#include <QDir>
+#include <QFileDialog>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSettings>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+
+StartupDialog::StartupDialog(QWidget * parent)
+: QDialog(parent)
+{
+  setWindowTitle("Workcell Studio Setup");
+  setMinimumSize(520, 260);
+
+  auto * root = new QVBoxLayout(this);
+  auto * title = new QLabel("<h2>Workcell Studio Setup</h2>", this);
+  auto * subtitle = new QLabel("Select your ROS 2 distro and workspace to begin.", this);
+  root->addWidget(title);
+  root->addWidget(subtitle);
+
+  ros_distro_combo_ = new QComboBox(this);
+  ros_distro_combo_->addItem("Humble", "humble");
+  ros_distro_combo_->addItem("Foxy (legacy)", "foxy");
+  ros_distro_combo_->setItemData(1, 0, Qt::UserRole - 1);
+  ros_distro_combo_->addItem("Iron (preview)", "iron");
+  ros_distro_combo_->setItemData(2, 0, Qt::UserRole - 1);
+  ros_distro_combo_->addItem("Jazzy (preview)", "jazzy");
+  ros_distro_combo_->setItemData(3, 0, Qt::UserRole - 1);
+  root->addWidget(new QLabel("ROS 2 distro", this));
+  root->addWidget(ros_distro_combo_);
+
+  workspace_edit_ = new QLineEdit(this);
+  auto * workspace_row = new QHBoxLayout();
+  workspace_row->addWidget(workspace_edit_);
+  auto * browse = new QPushButton("Browse...", this);
+  workspace_row->addWidget(browse);
+  root->addWidget(new QLabel("Workspace folder", this));
+  root->addLayout(workspace_row);
+
+  status_label_ = new QLabel(this);
+  status_label_->setWordWrap(true);
+  root->addWidget(status_label_);
+
+  auto * actions = new QHBoxLayout();
+  actions->addStretch();
+  open_studio_button_ = new QPushButton("Open Studio", this);
+  auto * exit_button = new QPushButton("Exit", this);
+  actions->addWidget(open_studio_button_);
+  actions->addWidget(exit_button);
+  root->addLayout(actions);
+
+  QSettings settings("easy_manipulation_deployment", "workcell_builder");
+  const QString saved_workspace = settings.value("startup/last_workspace").toString();
+  const QString saved_distro = settings.value("startup/last_ros_distro", "humble").toString();
+
+  const QString ws = saved_workspace.isEmpty() ? default_workspace() : saved_workspace;
+  workspace_edit_->setText(ws);
+  const int idx = ros_distro_combo_->findData(saved_distro.toLower());
+  ros_distro_combo_->setCurrentIndex(idx >= 0 ? idx : 0);
+
+  connect(browse, &QPushButton::clicked, this, &StartupDialog::on_browse_clicked);
+  connect(open_studio_button_, &QPushButton::clicked, this, &StartupDialog::on_open_studio_clicked);
+  connect(exit_button, &QPushButton::clicked, this, &QDialog::reject);
+
+  update_status("Choose a valid workspace to continue.", false);
+}
+
+QString StartupDialog::selected_workspace() const { return workspace_edit_->text().trimmed(); }
+QString StartupDialog::selected_ros_distro() const { return ros_distro_combo_->currentData().toString(); }
+
+void StartupDialog::on_browse_clicked()
+{
+  const QString selected = QFileDialog::getExistingDirectory(this, "Select workspace folder", workspace_edit_->text());
+  if (!selected.isEmpty()) {
+    workspace_edit_->setText(selected);
+  }
+}
+
+void StartupDialog::on_open_studio_clicked()
+{
+  const QString path = selected_workspace();
+  if (!workcell_builder::is_valid_workcell_workspace(path)) {
+    update_status("Selected folder is not a valid Workcell Studio workspace. Expected a ROS workspace containing src/ and easy_manipulation_deployment, scenes, or assets.", true);
+    return;
+  }
+
+  QSettings settings("easy_manipulation_deployment", "workcell_builder");
+  settings.setValue("startup/last_workspace", path);
+  settings.setValue("startup/last_ros_distro", selected_ros_distro());
+  accept();
+}
+
+void StartupDialog::update_status(const QString & message, bool error)
+{
+  status_label_->setText(QString("<font color='%1'>%2</font>").arg(error ? "#C0392B" : "#2E86C1", message));
+}
+
+QString StartupDialog::default_workspace() const
+{
+  const QString ws = QDir::homePath() + "/workcell_ws";
+  return QDir(ws).exists() ? ws : ws;
+}

--- a/workcell_builder/workcell_builder/gui/startup_dialog.h
+++ b/workcell_builder/workcell_builder/gui/startup_dialog.h
@@ -1,0 +1,34 @@
+#ifndef EASY_MANIPULATION_DEPLOYMENT__WORKCELL_BUILDER__GUI__STARTUP_DIALOG_H_
+#define EASY_MANIPULATION_DEPLOYMENT__WORKCELL_BUILDER__GUI__STARTUP_DIALOG_H_
+
+#include <QDialog>
+
+class QComboBox;
+class QLabel;
+class QLineEdit;
+class QPushButton;
+
+class StartupDialog : public QDialog
+{
+  Q_OBJECT
+
+public:
+  explicit StartupDialog(QWidget * parent = nullptr);
+  QString selected_workspace() const;
+  QString selected_ros_distro() const;
+
+private slots:
+  void on_browse_clicked();
+  void on_open_studio_clicked();
+
+private:
+  void update_status(const QString & message, bool error);
+  QString default_workspace() const;
+
+  QComboBox * ros_distro_combo_;
+  QLineEdit * workspace_edit_;
+  QLabel * status_label_;
+  QPushButton * open_studio_button_;
+};
+
+#endif

--- a/workcell_builder/workcell_builder/include/workspace_validation.hpp
+++ b/workcell_builder/workcell_builder/include/workspace_validation.hpp
@@ -1,0 +1,11 @@
+#ifndef EASY_MANIPULATION_DEPLOYMENT__WORKCELL_BUILDER__WORKSPACE_VALIDATION_HPP_
+#define EASY_MANIPULATION_DEPLOYMENT__WORKCELL_BUILDER__WORKSPACE_VALIDATION_HPP_
+
+#include <QString>
+
+namespace workcell_builder
+{
+bool is_valid_workcell_workspace(const QString & path);
+}
+
+#endif

--- a/workcell_builder/workcell_builder/src_workspace_validation.cpp
+++ b/workcell_builder/workcell_builder/src_workspace_validation.cpp
@@ -1,0 +1,23 @@
+#include "include/workspace_validation.hpp"
+
+#include <QDir>
+#include <QFileInfo>
+
+namespace workcell_builder
+{
+bool is_valid_workcell_workspace(const QString & path)
+{
+  const QFileInfo root_info(path);
+  if (!root_info.exists() || !root_info.isDir()) {
+    return false;
+  }
+
+  const QDir root(path);
+  if (!root.exists("src")) {
+    return false;
+  }
+
+  const QDir src(root.filePath("src"));
+  return src.exists("easy_manipulation_deployment") || src.exists("scenes") || src.exists("assets");
+}
+}  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/test/workspace_validation_test.cpp
+++ b/workcell_builder/workcell_builder/test/workspace_validation_test.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+#include <QDir>
+#include <QTemporaryDir>
+
+#include "include/workspace_validation.hpp"
+
+TEST(WorkspaceValidationTest, MissingFolderInvalid)
+{
+  EXPECT_FALSE(workcell_builder::is_valid_workcell_workspace("/tmp/this_path_should_not_exist_12345"));
+}
+
+TEST(WorkspaceValidationTest, MissingSrcInvalid)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  EXPECT_FALSE(workcell_builder::is_valid_workcell_workspace(dir.path()));
+}
+
+TEST(WorkspaceValidationTest, SrcOnlyInvalid)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  ASSERT_TRUE(QDir(dir.path()).mkpath("src"));
+  EXPECT_FALSE(workcell_builder::is_valid_workcell_workspace(dir.path()));
+}
+
+TEST(WorkspaceValidationTest, EmdFolderValid)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(QDir(dir.path()).mkpath("src/easy_manipulation_deployment"));
+  EXPECT_TRUE(workcell_builder::is_valid_workcell_workspace(dir.path()));
+}
+
+TEST(WorkspaceValidationTest, ScenesFolderValid)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(QDir(dir.path()).mkpath("src/scenes"));
+  EXPECT_TRUE(workcell_builder::is_valid_workcell_workspace(dir.path()));
+}
+
+TEST(WorkspaceValidationTest, AssetsFolderValid)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(QDir(dir.path()).mkpath("src/assets"));
+  EXPECT_TRUE(workcell_builder::is_valid_workcell_workspace(dir.path()));
+}


### PR DESCRIPTION
### Motivation
- Prevent the full, crowded Workcell Studio shell from opening immediately and present a compact, focused setup gate for first-run UX. 
- Force the user to explicitly select a ROS 2 distro and a valid workspace before the Studio loads, with Humble selected by default.
- Persist the last valid workspace/distro so subsequent launches restore the previous selection.

### Description
- Add a lightweight `StartupDialog` UI (`gui/startup_dialog.h` / `gui/startup_dialog.cpp`) that shows first with title/subtitle, ROS distro dropdown (Humble default), workspace path + `Browse...`, `Open Studio` and `Exit` buttons, and an inline status area.
- Implement a small workspace validation helper `workcell_builder::is_valid_workcell_workspace(const QString&)` (`include/workspace_validation.hpp`, `src_workspace_validation.cpp`) that enforces the minimum rules (folder exists, contains `src/`, and `src/` contains `easy_manipulation_deployment` OR `scenes` OR `assets`).
- Wire the startup flow in `gui/main.cpp` so the `StartupDialog` runs before creating `MainWindow`, and add constructor/fields to `MainWindow` (`gui/mainwindow.h` / `gui/mainwindow.cpp`) to accept and apply the startup selections (workspace + distro) via `apply_startup_selection()`; `detect_workspace_root()` now prefers the configured workspace.
- Persist and restore last valid workspace/distro via `QSettings` in the startup dialog and update `CMakeLists.txt` to include the new sources and a new unit test `test/workspace_validation_test.cpp` that exercises the validation helper.

### Testing
- Added unit tests `test/workspace_validation_test.cpp` that cover: missing folder (invalid), missing `src/` (invalid), `src/` only (invalid), `src/easy_manipulation_deployment` (valid), `src/scenes` (valid), and `src/assets` (valid).
- Attempted to run the package build/tests with `colcon build` in this environment, but the build could not be executed because `colcon` is not available (`/bin/bash: colcon: command not found`), so automated tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06102b54988331ba368e022c4ee832)