### PR TITLE
Remove duplicated workspace setup panel and add compact Studio header

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -54,6 +54,9 @@
 #include <QMetaObject>
 #include <QPointer>
 #include <QProgressDialog>
+#include <QSettings>
+#include <QLineEdit>
+#include <QHBoxLayout>
 #include <QtConcurrent>
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <boost/filesystem.hpp>
@@ -202,12 +205,21 @@ MainWindow::MainWindow(const QString & startup_workspace, const QString & startu
   setWindowTitle("Workcell Studio - Workcell Builder");
   ui->next->setDisabled(true);
   ui->change_workcell->setDisabled(true);
+  ui->quick_start_label->hide();
+  ui->filepath_label->hide();
+  ui->filepath->hide();
+  ui->label->hide();
+  ui->ros_distro->hide();
+  ui->load_workcell->hide();
+  ui->change_workcell->hide();
+  ui->next->hide();
   success = false;
   ui->error_label->setWordWrap(true);
   ui->error_label->setText("<font color='#C0392B'>Workcell not available</font>");
   ui->filepath->setToolTip("Selected ROS workspace root (contains assets/ and scenes/)");
   ui->ros_distro->setToolTip("Choose the ROS 2 distro that will be used for generated launch/config files");
-  statusBar()->showMessage("Select a workspace directory to begin.");
+  setup_compact_header();
+  statusBar()->showMessage("Initializing Workcell Studio...");
   // Scene Status panel action labels (preview-only contract)
   static const char * kSceneStatusGraspActions[] = {"Check Grasp Strategy", "Generate EMD Grasp Request", "Open EMD Grasp Request", "Open Grasp Visualization Docs"};
   (void)kSceneStatusGraspActions;
@@ -275,6 +287,7 @@ MainWindow::MainWindow(const QString & startup_workspace, const QString & startu
     });
 
   apply_startup_selection();
+  refresh_header_status();
   update_next_button_state();
   setup_studio_shell();
   apply_studio_theme();
@@ -838,18 +851,15 @@ void MainWindow::on_load_workcell_clicked()
           "to continue.</font>");
         statusBar()->showMessage("Workspace loaded. Select a ROS distro.");
       }
-      ui->load_workcell->setDisabled(true);
-      ui->change_workcell->setDisabled(false);
       success = true;
-      ui->filepath->setText(result.workcell_file);
+      selected_workspace_ = result.workcell_file;
+      refresh_header_status();
       update_next_button_state();
     } else {
       const QString error_text = result.cancelled ? "Workcell load cancelled" :
         QString("Failed to load workcell: %1").arg(result.error);
       ui->error_label->setText(QString("<font color='#C0392B'>%1</font>").arg(error_text));
       statusBar()->showMessage(error_text);
-      ui->load_workcell->setDisabled(false);
-      ui->change_workcell->setDisabled(true);
       success = false;
       update_next_button_state();
     }
@@ -885,18 +895,56 @@ void MainWindow::on_next_clicked()
 
 void MainWindow::on_change_workcell_clicked()
 {
-  ui->load_workcell->setDisabled(false);
-  ui->change_workcell->setDisabled(true);
-  ui->filepath->clear();
   success = false;
   ui->error_label->setText("<font color='#C0392B'>Workcell not available</font>");
   statusBar()->showMessage("Select a new workspace directory.");
   apply_startup_selection();
+  refresh_header_status();
   update_next_button_state();
   setup_studio_shell();
   apply_studio_theme();
 }
 
+
+
+void MainWindow::setup_compact_header()
+{
+  QWidget * content = ui->centralwidget;
+  auto * root_layout = qobject_cast<QVBoxLayout *>(content->layout());
+  if (!root_layout || studio_title_label_) return;
+
+  auto * header = new QWidget(content);
+  header->setMaximumHeight(64);
+  auto * hl = new QHBoxLayout(header);
+  hl->setContentsMargins(8, 6, 8, 6);
+  studio_title_label_ = new QLabel("<b>Workcell Studio</b>", header);
+  studio_ros_label_ = new QLabel("ROS 2: not selected", header);
+  studio_workspace_path_ = new QLineEdit(header);
+  studio_workspace_path_->setReadOnly(true);
+  studio_workspace_path_->setMinimumWidth(280);
+  studio_change_workspace_button_ = new QPushButton("Change Workspace", header);
+  connect(studio_change_workspace_button_, &QPushButton::clicked, this, &MainWindow::on_change_workcell_clicked);
+  hl->addWidget(studio_title_label_);
+  hl->addSpacing(12);
+  hl->addWidget(studio_ros_label_);
+  hl->addSpacing(12);
+  hl->addWidget(studio_workspace_path_, 1);
+  hl->addWidget(studio_change_workspace_button_);
+  root_layout->insertWidget(0, header);
+}
+
+void MainWindow::refresh_header_status()
+{
+  if (studio_ros_label_) {
+    const QString ros_text = has_selected_ros_distro() ? ui->ros_distro->currentText() : QString("Humble");
+    studio_ros_label_->setText("ROS 2 " + ros_text);
+  }
+  if (studio_workspace_path_) {
+    const QString ws = detect_workspace_root();
+    studio_workspace_path_->setText(ws);
+    studio_workspace_path_->setToolTip(ws);
+  }
+}
 
 void MainWindow::apply_startup_selection()
 {
@@ -908,11 +956,10 @@ void MainWindow::apply_startup_selection()
   }
 
   if (!startup_workspace_.trimmed().isEmpty()) {
-    if (ui && ui->filepath) {
-      ui->filepath->setPlainText(startup_workspace_.trimmed());
-    }
+    selected_workspace_ = startup_workspace_.trimmed();
     on_load_workcell_clicked();
   }
+  refresh_header_status();
 }
 
 bool MainWindow::has_selected_ros_distro() const
@@ -939,10 +986,12 @@ QString MainWindow::detect_workspace_root() const
   const QString startup_workspace = startup_workspace_.trimmed();
   if (!startup_workspace.isEmpty() && QDir(startup_workspace).exists()) return startup_workspace;
 
-  if (ui && ui->filepath) {
-    const QString configured_workspace = ui->filepath->toPlainText().trimmed();
-    if (!configured_workspace.isEmpty() && QDir(configured_workspace).exists()) return configured_workspace;
-  }
+  const QString selected_workspace = selected_workspace_.trimmed();
+  if (!selected_workspace.isEmpty() && QDir(selected_workspace).exists()) return selected_workspace;
+
+  QSettings settings;
+  const QString saved_workspace = settings.value("startup/last_workspace").toString().trimmed();
+  if (!saved_workspace.isEmpty() && QDir(saved_workspace).exists()) return saved_workspace;
 
   const QString default_workspace = QDir::homePath() + "/workcell_ws";
   if (QDir(default_workspace).exists()) return default_workspace;

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -23,6 +23,7 @@
 #include <QLabel>
 #include <QString>
 #include <QJsonObject>
+#include <QLineEdit>
 #include <atomic>
 #include <QProcess>
 #include <boost/filesystem.hpp>
@@ -100,6 +101,8 @@ private:
   void write_preview_launch_transcript(bool ran_process, const QString & command, const QString & event, int exit_code = -1);
   QString detect_workspace_root() const;
   void apply_startup_selection();
+  void setup_compact_header();
+  void refresh_header_status();
   void set_preview_state(const QString & state);
   void rebuild_digital_twin_canvas();
   void rebuild_canvas_inspector();
@@ -215,5 +218,10 @@ private:
   std::atomic<bool> cancel_requested_{ false };
   QString startup_workspace_;
   QString startup_ros_distro_;
+  QString selected_workspace_;
+  QLabel * studio_title_label_{ nullptr };
+  QLabel * studio_ros_label_{ nullptr };
+  QLineEdit * studio_workspace_path_{ nullptr };
+  QPushButton * studio_change_workspace_button_{ nullptr };
 };
 #endif  // EASY_MANIPULATION_DEPLOYMENT__WORKCELL_BUILDER__WORKCELL_BUILDER__GUI__MAINWINDOW_H_


### PR DESCRIPTION
### Motivation
- The startup dialog already collects workspace and ROS distro, but the full Studio window still showed the same large setup form which clutters the UI. The change aims to remove that visual duplication while keeping startup gating and backend logic intact.
- Keep the studio layout compact so primary content gets more vertical space and the workspace/distro are shown only as a small status/header strip.

### Description
- Hid the legacy top setup widgets in the main Studio UI (`Quick start` text, `filepath` QTextBrowser, ROS distro combobox row, `Select workspace directory`, `Change workspace directory`, and `Next: Scene Setup` button) and replaced them with a compact header/status strip. (files: `mainwindow.ui` usage retained; changes in `mainwindow.cpp` and `mainwindow.h`).
- Added a compact header with `Workcell Studio` title, `ROS 2 <distro>` label, a read-only workspace path field, and a small `Change Workspace` button wired to the existing change-workspace handler. Implemented as `setup_compact_header()` and `refresh_header_status()` in `MainWindow`.
- Kept backend workspace loading logic and scene generation unchanged while switching the UI source-of-truth to startup-selected values; introduced `selected_workspace_` and updated `detect_workspace_root()` to prefer (a) `startup_workspace_`, (b) `selected_workspace_`, (c) saved settings (`startup/last_workspace`), (d) `~/workcell_ws`, then home fallback.
- Removed references to the removed visible widgets where necessary (no broken signal/slot references left) and updated header refresh calls so status and theme messages remain in the `QStatusBar`/log areas.

### Testing
- Attempted build: `colcon build --symlink-install --packages-select workcell_builder --event-handlers console_direct+` and the run failed in this environment with `colcon: command not found` (environment limitation), so an automated package build could not be completed here.
- No package-level automated tests were added or modified in this PR; `colcon test` was not executed due to the same environment limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06256f6dc883318c51ff82e15d639f)