### PR TITLE
Fix workcell_builder build failure from invalid multiline dashboard string literal

### DIFF
--- a/tests/test_workcell_studio_scene_discovery.py
+++ b/tests/test_workcell_studio_scene_discovery.py
@@ -22,3 +22,9 @@ def test_dashboard_safety_and_non_plain_table_ui_tokens_present():
 def test_scene_validation_tokens_present():
     for token in ['environment.yaml', 'scene_manifest.yaml', 'launch" / "demo.launch.py', 'environment.urdf.xacro']:
         assert token in SRC_BROWSER
+
+
+def test_dashboard_no_scenes_warning_uses_escaped_newlines_in_qstring():
+    assert 'Searched:\\n - %1' in MAIN_CPP
+    assert 'searched.join("\\\\n - ")' in MAIN_CPP
+    assert 'searched.join("\n - ")' not in MAIN_CPP

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -623,10 +623,10 @@ void MainWindow::refresh_scene_browser_ui()
   QString summary = QString("Total scenes: %1 | Ready: %2 | Warnings: %3 | Blocked/Scaffold: %4 | Workspace: %5 | Loaded from: %6")
     .arg(scene_browser_result_.scenes.size()).arg(ready).arg(warn).arg(blocked).arg(QString::fromStdString(workspace_root.string())).arg(root_used);
   if (!scene_browser_result_.root_exists) {
-    summary += " | Warning: no scene folders found. Searched:
- - " + searched.join("
- - ") + "
-Check selected workspace or symlink ~/workcell_ws/src/scenes";
+    summary += QString(
+      " | Warning: no scene folders found. Searched:\\n - %1\\n"
+      "Check selected workspace or symlink ~/workcell_ws/src/scenes")
+      .arg(searched.join("\\n - "));
     append_studio_log("No scenes found. Searched paths: " + searched.join(" | "));
   } else {
     append_studio_log(QString("Loaded %1 scenes from %2").arg(scene_browser_result_.scenes.size()).arg(root_used));


### PR DESCRIPTION
### Motivation
- A recent change introduced an invalid multi-line C++ string literal in `MainWindow::refresh_scene_browser_ui()` that produced a compiler error (`missing terminating " character`) for the dashboard no-scenes warning.
- The intent is to perform a focused build fix that preserves dashboard text and behavior without changing scene discovery, runtime launch, or safety wording.

### Description
- Replace the broken quoted literal with a `QString` expression using escaped newlines and `.arg(searched.join("\\n - "))` in `workcell_builder/workcell_builder/gui/mainwindow.cpp` so the message compiles correctly.
- Update `tests/test_workcell_studio_scene_discovery.py` to add a regression test that asserts the escaped newline format is present, the escaped `searched.join("\\n - ")` token exists, and the raw-broken `searched.join("\n - ")` pattern is absent.
- The change preserves the original no-scenes text including the `Check selected workspace or symlink ~/workcell_ws/src/scenes` hint and the safety wording `Fake Hardware | No Robot Motion`.

### Testing
- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_studio_scene_discovery.py`, which passed (`5 passed`).
- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_studio_qt_shell_hardening.py tests/test_workcell_studio_command_bar_wiring.py`, which passed (`8 passed`).
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but `colcon` was not available in the execution environment, so a full package build was not performed here; this build step should succeed in a normal ROS workspace CI with `colcon` installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a062b510b2083319687bd61a84f417d)