### PR TITLE
Fix mainwindow compile regressions after UI/docs consolidation

### DIFF
--- a/tests/test_workcell_studio_mainwindow_build_tokens.py
+++ b/tests/test_workcell_studio_mainwindow_build_tokens.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+def test_mainwindow_build_regression_tokens():
+    text = Path("workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+
+    # Avoid broken QString literal form in linked hierarchy label update.
+    assert 'QString("\nLinked hierarchy item: %1")' not in text
+    assert 'QStringLiteral("\\nLinked hierarchy item: %1")' in text
+
+    assert "Q_UNUSED(int)" not in text
+
+    stale_buttons = [
+        "open_asset_folder_button",
+        "copy_asset_path_button",
+        "import_asset_button",
+        "add_existing_stl_button",
+        "placeholder_button",
+    ]
+    for token in stale_buttons:
+        assert token not in text
+
+    for action in [
+        "open_asset_folder_action",
+        "copy_asset_path_action",
+        "import_asset_action",
+        "add_existing_stl_action",
+        "placeholder_action",
+    ]:
+        assert f"connect({action}, &QAction::triggered" in text
+
+    assert "has_package_files" not in text
+    assert "has_launch_file" not in text
+    assert "entry.warning)" not in text
+    assert "entry.warning;" not in text
+    assert "entry.warnings" in text

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -969,14 +969,14 @@ connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo
   connect(open_layout_merge_report_button, &QPushButton::clicked, this, &MainWindow::open_layout_merge_report);
   connect(copy_layout_merge_summary_button, &QPushButton::clicked, this, &MainWindow::copy_layout_merge_summary);
   connect(revert_layout_button_, &QPushButton::clicked, this, &MainWindow::revert_layout_changes);
-  connect(scene_hierarchy_tree_, &QTreeWidget::itemClicked, this, [this](QTreeWidgetItem *item, int){ Q_UNUSED(int); on_hierarchy_item_selected(item); });
+  connect(scene_hierarchy_tree_, &QTreeWidget::itemClicked, this, [this](QTreeWidgetItem *item, int column){ Q_UNUSED(column); on_hierarchy_item_selected(item); });
   connect(asset_filter_combo_, qOverload<int>(&QComboBox::currentIndexChanged), this, &MainWindow::on_asset_filter_changed);
-  connect(open_asset_folder_button, &QPushButton::clicked, this, [this](){ const QString p = selected_catalog_item_path(); if (p.isEmpty()) { QMessageBox::information(this, "Asset Catalog", "Select an asset first."); return; } QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(p).isDir() ? p : QFileInfo(p).absolutePath())); });
-  connect(copy_asset_path_button, &QPushButton::clicked, this, [this](){ const QString p = selected_catalog_item_path(); if (p.isEmpty()) { QMessageBox::information(this, "Asset Catalog", "Select an asset first."); return; } QApplication::clipboard()->setText(p); append_studio_log("Copy Asset Path: " + p); });
+  connect(open_asset_folder_action, &QAction::triggered, this, [this](){ const QString p = selected_catalog_item_path(); if (p.isEmpty()) { QMessageBox::information(this, "Asset Catalog", "Select an asset first."); return; } QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(p).isDir() ? p : QFileInfo(p).absolutePath())); });
+  connect(copy_asset_path_action, &QAction::triggered, this, [this](){ const QString p = selected_catalog_item_path(); if (p.isEmpty()) { QMessageBox::information(this, "Asset Catalog", "Select an asset first."); return; } QApplication::clipboard()->setText(p); append_studio_log("Copy Asset Path: " + p); });
   connect(add_to_canvas_button, &QPushButton::clicked, this, [this](){ if (!asset_catalog_tree_ || !asset_catalog_tree_->currentItem()) { QMessageBox::information(this, "Asset Catalog", "Select an asset to add to canvas."); return; } auto *it = asset_catalog_tree_->currentItem(); add_asset_to_canvas_from_catalog(it->text(1), it->text(0), it->data(0, Qt::UserRole).toString()); });
-  connect(import_asset_button, &QPushButton::clicked, this, [this](){ QMessageBox::information(this, "Asset Catalog", "Import STL / URDF keeps existing behavior via filesystem import workflows."); });
-  connect(add_existing_stl_button, &QPushButton::clicked, this, [this](){ QMessageBox::information(this, "Asset Catalog", "Add Existing STL to Canvas keeps existing behavior for scene assets."); });
-  connect(placeholder_button, &QPushButton::clicked, this, [this](){ add_asset_to_canvas_from_catalog("Custom", "Generated Placeholder", "placeholder://generated"); });
+  connect(import_asset_action, &QAction::triggered, this, [this](){ QMessageBox::information(this, "Asset Catalog", "Import STL / URDF keeps existing behavior via filesystem import workflows."); });
+  connect(add_existing_stl_action, &QAction::triggered, this, [this](){ QMessageBox::information(this, "Asset Catalog", "Add Existing STL to Canvas keeps existing behavior for scene assets."); });
+  connect(placeholder_action, &QAction::triggered, this, [this](){ add_asset_to_canvas_from_catalog("Custom", "Generated Placeholder", "placeholder://generated"); });
   connect(export_snapshot, &QPushButton::clicked, this, [this](){ if (!digital_twin_canvas_ || !digital_twin_canvas_->scene()) return; fs::path out; if (selected_scene_index_ >= 0 && selected_scene_index_ < (int)scene_browser_result_.scenes.size()) { const auto & s = scene_browser_result_.scenes[(size_t)selected_scene_index_]; out = s.scene_dir / "preview" / "workcell_studio_canvas_snapshot.png"; } else { out = fs::path(diagnostics_output_root().toStdString()) / "preview" / "workcell_studio_canvas_snapshot.png"; } fs::create_directories(out.parent_path()); QImage image(1280, 800, QImage::Format_ARGB32_Premultiplied); image.fill(QColor("#0f131a")); QPainter painter(&image); digital_twin_canvas_->scene()->render(&painter); painter.end(); image.save(QString::fromStdString(out.string())); append_studio_log("Export Canvas Snapshot: " + QString::fromStdString(out.string())); });
   connect(preview_process_, &QProcess::readyReadStandardOutput, this, &MainWindow::handle_preview_stdout);
   connect(preview_process_, &QProcess::readyReadStandardError, this, &MainWindow::handle_preview_stderr);
@@ -1687,7 +1687,7 @@ void MainWindow::refresh_preview_launch_ui()
     else readiness = "READY_FOR_FAKE_HARDWARE_PREVIEW";
     if (preview_scene_label_) preview_scene_label_->setText(QString("<b>Selected Scene</b><br/>scene name: %1<br/>scene path: %2<br/>robot summary: %3<br/>gripper/tool summary: %4<br/>task file status: %5<br/>launch/demo.launch.py status: %6<br/>package.xml/CMakeLists status: %7<br/>preview snapshot path: %8")
       .arg(QString::fromStdString(s.scene_name), QString::fromStdString(s.scene_dir.string()), QString::fromStdString(s.robot_summary), QString::fromStdString(s.gripper_summary),
-      s.has_task_recipe ? "present" : "missing", s.has_launch_demo ? "present" : "missing", s.has_package_files ? "present" : "missing",
+      s.has_task_recipe ? "present" : "missing", s.has_launch_demo ? "present" : "missing", (s.has_package_xml && s.has_launch_demo) ? "present" : "missing",
       QString::fromStdString((s.scene_dir / "preview" / "workcell_studio_canvas_snapshot.png").string())));
     if (validation_summary_label_) validation_summary_label_->setText(QString("<b>Validation Summary</b><br/>Scene: %1<br/>Readiness Gate: %2").arg(QString::fromStdString(s.scene_name), readiness));
   }
@@ -1923,7 +1923,7 @@ void MainWindow::rebuild_digital_twin_canvas()
     item->setData(RoleSourcePackage, QString(""));
     item->setData(RoleWidth, entry.width); item->setData(RoleDepth, entry.depth); item->setData(RoleHeight, entry.height);
     item->setData(RoleImported, false); item->setData(RoleGeneratedPlaceholder, false);
-    item->setData(RoleWarning, QString::fromStdString(entry.warning));
+    item->setData(RoleWarning, QString::fromStdString(entry.warnings.empty() ? std::string() : entry.warnings.front()));
     item->setData(RolePoseText, QString("x=%1 y=%2 z=%3 r=%4 p=%5 y=%6").arg(entry.x).arg(entry.y).arg(entry.z).arg(entry.roll).arg(entry.pitch).arg(entry.yaw));
     item->setFlags(QGraphicsItem::ItemIsSelectable | QGraphicsItem::ItemSendsGeometryChanges | (entry.locked ? QGraphicsItem::GraphicsItemFlag(0) : QGraphicsItem::ItemIsMovable));
     item->position_filter = [this](const QPointF & p){ return snap_canvas_position(p); };
@@ -1952,7 +1952,7 @@ void MainWindow::rebuild_digital_twin_canvas()
     QStringList issues;
     if (!s.has_environment_yaml) issues << "missing environment.yaml";
     if (!s.has_package_xml) issues << "missing package.xml";
-    if (!s.has_launch_file) issues << "missing launch/demo.launch.py";
+    if (!s.has_launch_demo) issues << "missing launch/demo.launch.py";
     auto task = load_scene_task_intent_summary(s.scene_dir);
     if (task.status != "READY") issues << "missing task intent";
     if (task.tool_id == "unknown") issues << "missing robot/gripper metadata";
@@ -2003,8 +2003,7 @@ void MainWindow::select_canvas_item(QGraphicsItem * item)
   inspector_roll_->setValue(item->data(RoleRoll).toDouble()); inspector_pitch_->setValue(item->data(RolePitch).toDouble()); inspector_yaw_->setValue(item->data(RoleYaw).toDouble());
   live_coordinate_label_->setText(QString("Live coordinates: x=%1 y=%2 | %3").arg(inspector_x_->value()).arg(inspector_y_->value()).arg(item->data(RolePoseText).toString()));
   inspector_warning_label_->setText("Warnings: " + (item->data(RoleWarning).toString().isEmpty() ? QString("none") : item->data(RoleWarning).toString()));
-  if (pick_place_details_label_) pick_place_details_label_->setText(pick_place_details_label_->text() + QString("
-Linked hierarchy item: %1").arg(item->data(RoleId).toString()));
+  if (pick_place_details_label_) pick_place_details_label_->setText(pick_place_details_label_->text() + QStringLiteral("\nLinked hierarchy item: %1").arg(item->data(RoleId).toString()));
   inspector_update_guard_ = false;
 }
 


### PR DESCRIPTION
### Motivation
- Recent UI/docs consolidation left C++ syntax and stale UI references in `mainwindow.cpp` that break compilation and reintroduce invalid tokens.
- The changes are build-only and should not modify runtime behavior, UI design, or enable real hardware execution while keeping ROS 2 Humble compatibility.

### Description
- Fix the broken linked-hierarchy string literal by using a properly escaped literal via `QStringLiteral("\nLinked hierarchy item: %1")` in `mainwindow.cpp`.
- Name the unused lambda parameter for the hierarchy `itemClicked` handler as `int column` and use `Q_UNUSED(column)` to remove the invalid `Q_UNUSED(int)` usage.
- Replace stale `QPushButton` connect calls for asset actions with the existing `QAction` variables wired to `QAction::triggered` (`open_asset_folder_action`, `copy_asset_path_action`, `import_asset_action`, `add_existing_stl_action`, `placeholder_action`).
- Correct struct/member usage to real fields: replace `s.has_package_files` with a derived expression `(s.has_package_xml && s.has_launch_demo)`, replace `s.has_launch_file` with `s.has_launch_demo`, and replace `entry.warning` uses with `entry.warnings` handling (use first warning when present).
- Add a focused regression test `tests/test_workcell_studio_mainwindow_build_tokens.py` that asserts the absence/presence of the specific tokens to prevent reintroduction of these compile-breaking patterns.

### Testing
- Added and ran the focused pytest group: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_studio_mainwindow_build_tokens.py tests/test_workcell_studio_docs_consolidation.py tests/test_workcell_studio_acceptance_gate.py tests/test_workcell_studio_new_cell_regression_audit.py` and observed `23 passed`.
- The new regression test `tests/test_workcell_studio_mainwindow_build_tokens.py` passes and verifies the corrected tokens and connects in `mainwindow.cpp`.
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but `colcon` is not available in the execution environment, so an actual local `colcon` build was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073c2a6da483318c2a9425a9375cc5)