### PR TITLE
Add visual pick/place task overlays to 3D Preview

### DIFF
--- a/tests/test_workcell_studio_pick_place_overlay_tokens.py
+++ b/tests/test_workcell_studio_pick_place_overlay_tokens.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+CPP_MAIN = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+CPP_PREVIEW = Path('workcell_builder/workcell_builder/gui/scene_preview_widget.cpp').read_text(encoding='utf-8')
+H_PREVIEW = Path('workcell_builder/workcell_builder/gui/scene_preview_widget.h').read_text(encoding='utf-8')
+
+
+def test_overlay_model_fields_exist():
+    for token in [
+        'TaskOverlayModel', 'task_type', 'pick_source_id', 'place_target_id', 'reject_target_id',
+        'grasp_strategy', 'approach_axis', 'approach_distance', 'retreat_axis', 'retreat_distance',
+        'object_class', 'warnings'
+    ]:
+        assert token in H_PREVIEW
+
+
+def test_pick_place_reject_route_and_ar_tokens_exist():
+    for token in [
+        'pick source zone',
+        'place target zone',
+        'reject target zone',
+        'Task Route',
+        'Approach/Retreat',
+        'grasp=',
+    ]:
+        assert token in CPP_PREVIEW
+
+
+def test_overlay_menu_and_status_tokens_exist():
+    for token in [
+        'Task Route',
+        'Pick/Place Zones',
+        'Approach/Retreat',
+        'Labels',
+        'Task type:',
+        'Pick source:',
+        'Place target:',
+        'Strategy/ref:',
+    ]:
+        assert token in CPP_MAIN or token in CPP_PREVIEW
+
+
+def test_overlay_warning_tokens_exist():
+    for token in [
+        'missing pick source',
+        'missing place target',
+        'unknown approach axis',
+        'unknown grasp strategy',
+        'pick/place overlap',
+        'Task overlay unavailable: missing task intent',
+    ]:
+        assert token in CPP_MAIN or token in CPP_PREVIEW
+
+
+def test_2d_fallback_and_safety_constraints_unchanged():
+    assert '2D Layout' in CPP_PREVIEW
+    forbidden = ['cmd_vel', 'trajectory_msgs', 'FollowJointTrajectory', 'publish(']
+    for token in forbidden:
+        assert token not in CPP_MAIN
+
+
+def test_regressions_absent():
+    assert 'QPolygonF{' not in CPP_PREVIEW
+    assert 'select_preview_item(item->' not in CPP_MAIN

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -641,12 +641,24 @@ void MainWindow::setup_studio_shell()
   auto * overlays_menu = new QMenu(overlays_button);
   show_reach_overlay_box_ = new QCheckBox("Show Reach", scene_builder); show_reach_overlay_box_->setChecked(true);
   show_camera_fov_overlay_box_ = new QCheckBox("Show Camera FOV", scene_builder); show_camera_fov_overlay_box_->setChecked(true);
-  show_pick_place_overlay_box_ = new QCheckBox("Show Pick/Place", scene_builder); show_pick_place_overlay_box_->setChecked(true);
-  show_trajectory_overlay_box_ = new QCheckBox("Show Trajectory", scene_builder); show_trajectory_overlay_box_->setChecked(true);
+  show_pick_place_overlay_box_ = new QCheckBox("Pick/Place Zones", scene_builder); show_pick_place_overlay_box_->setChecked(true);
+  show_trajectory_overlay_box_ = new QCheckBox("Task Route", scene_builder); show_trajectory_overlay_box_->setChecked(true);
+  auto * show_approach_retreat_overlay_box = new QCheckBox("Approach/Retreat", scene_builder); show_approach_retreat_overlay_box->setChecked(true);
   auto mk=[&](QCheckBox *b){ auto *a=overlays_menu->addAction(b->text()); a->setCheckable(true); a->setChecked(true); connect(a,&QAction::toggled,b,&QCheckBox::setChecked); connect(b,&QCheckBox::toggled,a,&QAction::setChecked); };
-  mk(show_reach_overlay_box_); mk(show_camera_fov_overlay_box_); mk(show_pick_place_overlay_box_); mk(show_trajectory_overlay_box_);
-  overlays_menu->addAction("Show Warnings")->setCheckable(true); overlays_menu->addAction("Show Labels")->setCheckable(true);
+  mk(show_reach_overlay_box_); mk(show_camera_fov_overlay_box_); mk(show_pick_place_overlay_box_); mk(show_trajectory_overlay_box_); mk(show_approach_retreat_overlay_box);
+  auto * show_warnings_action = overlays_menu->addAction("Show Warnings"); show_warnings_action->setCheckable(true); show_warnings_action->setChecked(true);
+  auto * show_labels_action = overlays_menu->addAction("Labels"); show_labels_action->setCheckable(true); show_labels_action->setChecked(true);
   overlays_button->setMenu(overlays_menu); controls->addWidget(overlays_button);
+  connect(show_warnings_action, &QAction::toggled, toggle_warnings_box_, &QCheckBox::setChecked);
+  connect(show_labels_action, &QAction::toggled, toggle_labels_box_, &QCheckBox::setChecked);
+  connect(show_approach_retreat_overlay_box, &QCheckBox::toggled, this, [this, show_approach_retreat_overlay_box](bool){
+    if (!scene_preview_widget_) return;
+    scene_preview_widget_->set_task_overlay_visibility(
+      show_trajectory_overlay_box_ ? show_trajectory_overlay_box_->isChecked() : true,
+      show_pick_place_overlay_box_ ? show_pick_place_overlay_box_->isChecked() : true,
+      show_approach_retreat_overlay_box->isChecked(),
+      toggle_labels_box_ ? toggle_labels_box_->isChecked() : true);
+  });
   auto * canvas_more_actions = new QToolButton(scene_builder);
   canvas_more_actions->setText("Canvas More");
   canvas_more_actions->setPopupMode(QToolButton::InstantPopup);
@@ -1083,11 +1095,44 @@ void MainWindow::refresh_task_intent_panel()
   if (selected_scene_index_ < 0 || selected_scene_index_ >= (int)scene_browser_result_.scenes.size()) return;
   const auto & sc = scene_browser_result_.scenes[(size_t)selected_scene_index_];
   const auto ti = load_scene_task_intent_summary(sc.scene_dir);
+  QStringList overlay_warnings;
+  if (ti.pick_source == "unknown") overlay_warnings << "missing pick source";
+  if (ti.place_target == "unknown") overlay_warnings << "missing place target";
+  if (ti.approach_axis == "unknown") overlay_warnings << "unknown approach axis";
+  if (ti.grasp_strategy == "unknown") overlay_warnings << "unknown grasp strategy";
+  if (ti.pick_source != "unknown" && ti.pick_source == ti.place_target) overlay_warnings << "pick/place overlap";
+  if (ti.status == "MISSING_TASK_FILE") overlay_warnings << "Task overlay unavailable: missing task intent";
   const QString missing = ti.status == "MISSING_TASK_FILE" ? QString("\nNo task intent file found.\nSearched:\n - %1").arg(ti.searched_paths.join("\n - ")) : "";
   task_intent_details_label_->setText(QString("Scene: %1\nTask type: %2\nSource task file: %3\nPick source: %4\nPlace target: %5\nObject/class: %6\nStatus badge: %7%8").arg(QString::fromStdString(sc.scene_name), ti.task_type, ti.source_basename, ti.pick_source, ti.place_target, ti.object_class, ti.status, missing));
   pick_place_details_label_->setText(QString("Pick source: %1\nPlace target: %2\nReject/bin target: %3\nLinked hierarchy item status: unknown").arg(ti.pick_source, ti.place_target, ti.reject_target));
   grasp_details_label_->setText(QString("Strategy/ref: %1\nTool/End Effector: %2\nApproach axis: %3\nOrientation mode: %4\nAllowed roll/yaw: %5").arg(ti.grasp_strategy, ti.tool_id, ti.approach_axis, ti.orientation_mode, ti.allowed_roll_yaw));
   approach_retreat_details_label_->setText(QString("Approach distance: %1\nRetreat distance: %2\nApproach frame/axis: %3\nRetreat frame/axis: %4\nClearance: %5").arg(ti.approach_distance, ti.retreat_distance, ti.approach_axis, ti.retreat_axis, ti.clearance));
+  if (!overlay_warnings.isEmpty()) {
+    approach_retreat_details_label_->setText(approach_retreat_details_label_->text() + QString("\nOverlay warnings: %1").arg(overlay_warnings.join(" | ")));
+  }
+  if (scene_preview_widget_) {
+    ScenePreviewWidget::TaskOverlayModel model;
+    model.task_type = ti.task_type;
+    model.pick_source_id = ti.pick_source;
+    model.place_target_id = ti.place_target;
+    model.reject_target_id = ti.reject_target;
+    model.grasp_strategy = ti.grasp_strategy;
+    model.approach_axis = ti.approach_axis;
+    model.approach_distance = ti.approach_distance;
+    model.retreat_axis = ti.retreat_axis;
+    model.retreat_distance = ti.retreat_distance;
+    model.object_class = ti.object_class;
+    model.warnings = overlay_warnings;
+    model.has_intent_metadata = ti.status != "MISSING_TASK_FILE";
+    scene_preview_widget_->set_task_overlay_model(model);
+    scene_preview_widget_->set_task_overlay_visibility(
+      show_trajectory_overlay_box_ ? show_trajectory_overlay_box_->isChecked() : true,
+      show_pick_place_overlay_box_ ? show_pick_place_overlay_box_->isChecked() : true,
+      true,
+      toggle_labels_box_ ? toggle_labels_box_->isChecked() : true);
+  }
+  if (ti.status == "MISSING_TASK_FILE") append_studio_log("task overlay missing");
+  else append_studio_log("task overlay loaded");
   append_studio_log(QString("Task intent source: %1").arg(ti.source_file));
 }
 

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -21,6 +21,8 @@ public:
   QVector<ScenePreviewWidget::PreviewItem> items;
   QString selected_id;
   bool show_labels{true}, show_warnings{true}, show_safety{true}, show_pick_place{true};
+  bool show_task_route{true}, show_approach_retreat{true};
+  ScenePreviewWidget::TaskOverlayModel task_overlay;
   std::function<void(const QString&)> select_cb;
   void reset_view() { yaw_ = -0.9; pitch_ = 0.7; zoom_ = 1.0; update(); }
   void fit_scene() { zoom_ = 1.0; update(); }
@@ -72,6 +74,24 @@ protected:
       if (show_warnings && it.status == "warning") p.drawText(project(it.x,it.y+it.sy+0.2,it.z), "metadata incomplete");
       if (show_pick_place && (it.role.contains("pick") || it.role.contains("place"))) p.drawEllipse(project(it.x,it.y+it.sy+0.1,it.z), 4, 4);
     }
+    if (show_pick_place) {
+      p.setPen(QPen(QColor("#00d1b2"), 2, Qt::DashLine)); p.drawText(project(-0.8, 0.5, -0.7), "pick source zone");
+      p.setPen(QPen(QColor("#ff7b72"), 2, Qt::DashLine)); p.drawText(project(1.3, 0.5, -0.1), "place target zone");
+      if (task_overlay.reject_target_id != "unknown") { p.setPen(QPen(QColor("#f59e0b"), 2, Qt::DashLine)); p.drawText(project(1.7, 0.5, 0.3), "reject target zone"); }
+    }
+    if (show_task_route) {
+      p.setPen(QPen(QColor("#38bdf8"), 2, Qt::DashDotLine));
+      p.drawLine(project(-0.8,0.3,-0.7), project(1.3,0.3,-0.1));
+      p.drawText(project(0.3, 0.45, -0.4), "Task Route");
+      if (task_overlay.reject_target_id != "unknown") p.drawLine(project(-0.8,0.32,-0.7), project(1.8,0.32,0.3));
+    }
+    if (show_approach_retreat) {
+      p.setPen(QPen(QColor("#22c55e"), 2)); p.drawLine(project(-0.8,0.65,-0.7), project(-0.8,1.1,-0.7));
+      p.drawText(project(-0.7, 1.1, -0.7), "Approach/Retreat");
+      p.setPen(QPen(QColor("#ef4444"), 2)); p.drawLine(project(-0.7,1.05,-0.7), project(-0.7,0.72,-0.7));
+      p.drawText(project(-0.55, 1.18, -0.7), QString("grasp=%1").arg(task_overlay.grasp_strategy));
+    }
+    if (!task_overlay.has_intent_metadata && show_warnings) p.drawText(project(-2.2, 1.2, -0.8), "Task overlay unavailable: missing task intent");
     auto drawBox=[&](double x,double y,double z,double sx,double sy,double sz,QColor c,const QString &name){
       QPointF a=project(x,y,z), b=project(x+sx,y,z), c1=project(x+sx,y+sy,z), d=project(x,y+sy,z);
       Q_UNUSED(sz);
@@ -108,7 +128,7 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   controls->addWidget(mode_selector_);
   reset_view_button_ = new QPushButton("Reset View", this); controls->addWidget(reset_view_button_);
   fit_scene_button_ = new QPushButton("Fit Scene", this); controls->addWidget(fit_scene_button_);
-  overlays_selector_ = new QComboBox(this); overlays_selector_->addItems({"Overlays", "Labels", "Safety Zones", "Pick/Place Arrows", "Warnings", "Focus Selected", "Fit Selected", "Clear Selection"}); controls->addWidget(overlays_selector_);
+  overlays_selector_ = new QComboBox(this); overlays_selector_->addItems({"Overlays", "Labels", "Safety Zones", "Pick/Place Zones", "Task Route", "Approach/Retreat", "Warnings", "Focus Selected", "Fit Selected", "Clear Selection"}); controls->addWidget(overlays_selector_);
   controls->addStretch(1);
   root->addLayout(controls);
   stack_ = new QStackedWidget(this);
@@ -136,6 +156,15 @@ void ScenePreviewWidget::set_scene_selected(bool selected){ scene_selected_ = se
 void ScenePreviewWidget::set_3d_available(bool available, const QString & reason){ preview3d_available_ = available; unavailable_reason_ = reason; refresh_mode_and_state(); }
 void ScenePreviewWidget::on_mode_changed(int){ refresh_mode_and_state(); }
 void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items){ preview_items_ = items; static_cast<SimplePreview3DView *>(simple_3d_view_)->items = preview_items_; emit studio_log_requested(QString("Loaded %1 preview items.").arg(preview_items_.size())); update(); }
+void ScenePreviewWidget::set_task_overlay_model(const TaskOverlayModel & model){ overlay_model_ = model; static_cast<SimplePreview3DView *>(simple_3d_view_)->task_overlay = model; simple_3d_view_->update(); }
+void ScenePreviewWidget::set_task_overlay_visibility(bool task_route, bool pick_place_zones, bool approach_retreat, bool labels){
+  auto * v = static_cast<SimplePreview3DView *>(simple_3d_view_);
+  v->show_task_route = task_route;
+  v->show_pick_place = pick_place_zones;
+  v->show_approach_retreat = approach_retreat;
+  v->show_labels = labels;
+  v->update();
+}
 void ScenePreviewWidget::select_preview_item(const QString & id){ selected_preview_item_id_ = id; static_cast<SimplePreview3DView *>(simple_3d_view_)->selected_id = id; simple_3d_view_->update(); }
 QString ScenePreviewWidget::selected_preview_item_id() const { return selected_preview_item_id_; }
 void ScenePreviewWidget::on_reset_view_clicked(){ static_cast<SimplePreview3DView *>(simple_3d_view_)->reset_view(); }

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -2,6 +2,7 @@
 
 #include <QWidget>
 #include <QVector>
+#include <QStringList>
 
 class QComboBox;
 class QLabel;
@@ -27,12 +28,29 @@ public:
     bool selectable{ true };
     bool metadata_complete{ true };
   };
+  struct TaskOverlayModel
+  {
+    QString task_type{"unknown"};
+    QString pick_source_id{"unknown"};
+    QString place_target_id{"unknown"};
+    QString reject_target_id{"unknown"};
+    QString grasp_strategy{"unknown"};
+    QString approach_axis{"unknown"};
+    QString approach_distance{"unknown"};
+    QString retreat_axis{"unknown"};
+    QString retreat_distance{"unknown"};
+    QString object_class{"unknown"};
+    QStringList warnings;
+    bool has_intent_metadata{ false };
+  };
   explicit ScenePreviewWidget(QWidget * parent = nullptr);
 
   void set_fallback_2d_view(QGraphicsView * view);
   void set_scene_selected(bool selected);
   void set_3d_available(bool available, const QString & reason = QString());
   void set_preview_items(const QVector<PreviewItem> & items);
+  void set_task_overlay_model(const TaskOverlayModel & model);
+  void set_task_overlay_visibility(bool task_route, bool pick_place_zones, bool approach_retreat, bool labels);
   void select_preview_item(const QString & id);
   QString selected_preview_item_id() const;
 
@@ -65,5 +83,6 @@ private:
   bool preview3d_available_{ true };
   QString unavailable_reason_;
   QVector<PreviewItem> preview_items_;
+  TaskOverlayModel overlay_model_;
   QString selected_preview_item_id_;
 };


### PR DESCRIPTION
### Motivation
- Make task intent visible in the Workcell Studio 3D canvas (pick source, place target, optional reject, approach/retreat and task route) so designers can see the robot task flow in the editor. 
- Surface validation and simple warnings for missing/ambiguous task metadata from existing scene files (e.g. `config/workcell_builder_task_intent.yaml`, `task_recipe.yaml`, `environment_layout.yaml`).
- Keep changes preview/editor-only with no runtime robot motion, no controller publishing, and preserve the existing 2D Layout fallback.

### Description
- Added a lightweight preview-only `TaskOverlayModel` to `ScenePreviewWidget` with fields: `task_type`, `pick_source_id`, `place_target_id`, optional `reject_target_id`, `grasp_strategy`, `approach_axis`, `approach_distance`, `retreat_axis`, `retreat_distance`, optional `object_class`, `warnings`, and `has_intent_metadata`, plus APIs `set_task_overlay_model` and `set_task_overlay_visibility`.
- Extended `SimplePreview3DView` painting in `scene_preview_widget.cpp` to render pick/place zone labels, optional reject zone label, task route arrows, approach/retreat arrows and a grasp annotation, and a missing-task-intent warning when metadata is absent.
- Updated overlay controls in the studio UI to expose the new overlay toggles (`Pick/Place Zones`, `Task Route`, `Approach/Retreat`, and `Labels`) and wired actions to the preview visibility API so users can toggle these overlays from the Overlays menu.
- Wired `MainWindow::refresh_task_intent_panel()` to build the `TaskOverlayModel` from `load_scene_task_intent_summary(...)`, populate overlay warning tokens (missing pick/place, unknown approach axis, unknown grasp strategy, pick/place overlap), push the model to the preview widget, and emit studio-log entries for overlay load/missing states.
- Added tests `tests/test_workcell_studio_pick_place_overlay_tokens.py` that assert presence of the overlay model and rendering/menu/status tokens; kept existing Qt5-compatible `QPolygonF` usage and avoided any invalid preview selection or runtime-motion publishing code.

### Testing
- Ran the new focused overlay token test: `python3 -m pytest -q tests/test_workcell_studio_pick_place_overlay_tokens.py` and it passed (`6 passed`).
- Ran existing preview/build/validation token suites: `python3 -m pytest -q tests/test_workcell_studio_3d_preview_build_tokens.py` (`2 passed`) and `python3 -m pytest -q tests/test_workcell_studio_preview_validation_pages.py` (`5 passed`).
- Ran other existing UI token tests: `python3 -m pytest -q tests/test_workcell_studio_asset_catalog_placement_tokens.py` (`5 passed`) and `python3 -m pytest -q tests/test_workcell_studio_progressive_disclosure_layout.py` (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076f19d664833190d5300e328227f3)