### PR TITLE
Fix workcell_builder Camera FOV build by including QVector3D

### DIFF
--- a/tests/test_workcell_studio_camera_fov_build_tokens.py
+++ b/tests/test_workcell_studio_camera_fov_build_tokens.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+CPP_MAIN = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+CPP_PREVIEW = Path('workcell_builder/workcell_builder/gui/scene_preview_widget.cpp').read_text(encoding='utf-8')
+
+
+def test_scene_preview_widget_includes_qvector3d_and_uses_it():
+    assert '#include <QVector3D>' in CPP_PREVIEW
+    assert 'QVector3D' in CPP_PREVIEW
+
+
+def test_qt5_compatible_polygon_construction_and_selection_regression_guards():
+    assert 'QPolygonF{' not in CPP_PREVIEW
+    assert 'select_preview_item(item->' not in CPP_MAIN
+
+
+def test_no_live_perception_or_motion_runtime_tokens_introduced():
+    forbidden = [
+        'realsense2_camera',
+        'easy_perception_deployment',
+        'trajectory_msgs',
+        'FollowJointTrajectory',
+        'publish(',
+        'move_group',
+        'moveit::',
+    ]
+    for token in forbidden:
+        assert token not in CPP_MAIN

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -11,6 +11,7 @@
 #include <QPainter>
 #include <QPushButton>
 #include <QStackedWidget>
+#include <QVector3D>
 #include <QVBoxLayout>
 #include <QtMath>
 


### PR DESCRIPTION
### Motivation
- Fix compile failures in the Camera FOV/frustum rendering in `scene_preview_widget.cpp` caused by use of `QVector3D` without including its full definition.

### Description
- Add `#include <QVector3D>` next to the other Qt includes in `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp` to provide the complete `QVector3D` type.
- Add a focused regression test `tests/test_workcell_studio_camera_fov_build_tokens.py` that asserts the include and `QVector3D` usage exist and that Qt5-safe `QPolygonF` construction and selection/regression/safety tokens are preserved; no runtime or feature changes were made.
- Confirmed no CMake linkage change was necessary since `QVector3D` is provided by the existing QtGui/Widgets linkage already in use.

### Testing
- Ran `python3 -m pytest -q tests/test_workcell_studio_camera_fov_build_tokens.py` and related preview tests; the test suite for the affected tokens passed (`pytest` runs completed successfully).
- Attempted `colcon build --symlink-install --packages-select workcell_builder` in this environment but `colcon` is not available here (build should be validated in the target development environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0779acc0fc833182b994369bbe27c1)