### PR TITLE
Remove legacy Workcell Studio header rows and fix dark-theme contrast

### DIFF
--- a/tests/test_workcell_studio_progressive_disclosure_layout.py
+++ b/tests/test_workcell_studio_progressive_disclosure_layout.py
@@ -72,3 +72,30 @@ def test_secondary_controls_moved_to_menus_and_theme_tokens_present():
 def test_redundant_workspace_change_controls_removed_from_studio_pages():
     assert 'Change Workspace' not in CPP
     assert 'Workcell Studio change workspace' not in CPP
+
+
+def test_legacy_startup_header_rows_removed_from_studio_shell():
+    banned = [
+        'Mode: Design | Runtime: Disabled | Hardware: Fake by default | Safety: Guarded',
+        'Workcell loaded (using selected path/src as workcell root)',
+        'studio_workspace_path_ = new QLineEdit',
+    ]
+    for token in banned:
+        assert token not in CPP
+    assert 'Workspace: ' in CPP
+
+
+def test_dark_qss_has_readable_explicit_foreground_rules_and_no_banned_dark_text_colors():
+    qss = Path('workcell_builder/workcell_builder/gui/resources/workcell_studio_dark.qss').read_text(encoding='utf-8')
+    for token in [
+        'QLabel { color: #f8fafc;',
+        'QPushButton',
+        'QLineEdit, QComboBox, QSpinBox, QDoubleSpinBox',
+        'QTreeWidget, QTableWidget',
+        'QTextEdit, QPlainTextEdit',
+        ':disabled',
+    ]:
+        assert token in qss
+    lowered_color_lines = [line.strip().lower() for line in qss.splitlines() if line.strip().lower().startswith('color:')]
+    for banned in ['color: #111827', 'color: #0f172a', 'color: black', 'color: #000']:
+        assert banned not in lowered_color_lines

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -386,7 +386,8 @@ MainWindow::MainWindow(const QString & startup_workspace, const QString & startu
   ui->next->hide();
   success = false;
   ui->error_label->setWordWrap(true);
-  ui->error_label->setText("<font color='#C0392B'>Workcell not available</font>");
+  ui->error_label->setProperty("status", "error");
+  ui->error_label->setText("Workcell not available");
   ui->filepath->setToolTip("Selected ROS workspace root (contains assets/ and scenes/)");
   ui->ros_distro->setToolTip("Choose the ROS 2 distro that will be used for generated launch/config files");
   setup_compact_header();
@@ -426,8 +427,8 @@ MainWindow::MainWindow(const QString & startup_workspace, const QString & startu
   } else {
     ui->ros_distro->setDisabled(true);
     ui->error_label->setText(
-      "<font color='#C0392B'>No ROS 2 installation detected. Install ROS 2 under /opt/ros, then reopen "
-      "Workcell Builder.</font>");
+      "No ROS 2 installation detected. Install ROS 2 under /opt/ros, then reopen Workcell Builder.");
+    ui->error_label->setProperty("status", "error");
     statusBar()->showMessage("ROS 2 not detected in /opt/ros.");
   }
 
@@ -449,10 +450,12 @@ MainWindow::MainWindow(const QString & startup_workspace, const QString & startu
       update_next_button_state();
       if (success && !has_selected_ros_distro()) {
         ui->error_label->setText(
-          "<font color='#C0392B'>Workcell loaded. Please select a ROS distro to continue.</font>");
+          "Workcell loaded. Please select a ROS distro to continue.");
+        ui->error_label->setProperty("status", "error");
         statusBar()->showMessage("Select a ROS distro to enable the Next step.");
       } else if (success) {
-        ui->error_label->setText("<font color='#27AE60'>Workcell loaded</font>");
+        ui->error_label->setProperty("status", "success");
+        ui->error_label->setText("Workcell loaded");
         statusBar()->showMessage("Ready: open scene setup.");
       }
     });
@@ -570,6 +573,25 @@ void MainWindow::setup_studio_shell()
     return;
   }
 
+  auto detach_widget = [root_layout](QWidget * widget) {
+      if (!widget) {
+        return;
+      }
+      root_layout->removeWidget(widget);
+      widget->setVisible(false);
+      widget->setMaximumHeight(0);
+      widget->setMinimumHeight(0);
+    };
+  detach_widget(ui->quick_start_label);
+  detach_widget(ui->filepath_label);
+  detach_widget(ui->filepath);
+  detach_widget(ui->label);
+  detach_widget(ui->ros_distro);
+  detach_widget(ui->load_workcell);
+  detach_widget(ui->change_workcell);
+  detach_widget(ui->next);
+  detach_widget(ui->error_label);
+
   // status badge | safety banner | scene overview | digital twin preview | command console
   studio_nav_ = new QListWidget(content);
   studio_nav_->addItems({"🏠 Dashboard","🛠 Scene Builder","📚 Existing Scenes","🎬 Demo Mode","🚀 Preview Launch","🩺 Diagnostics","✅ Validation","📤 Export"});
@@ -597,8 +619,7 @@ void MainWindow::setup_studio_shell()
   auto * dash_preview = new QPushButton("Preview Launch", dashboard); dashboard_actions->addWidget(dash_preview);
   auto * dash_export = new QPushButton("Export", dashboard); dashboard_actions->addWidget(dash_export);
   dl->addLayout(dashboard_actions);
-  auto * dash_safety = new QLabel("Mode: Design | Runtime: Disabled | Hardware: Fake by default | Safety: Guarded", dashboard); dl->addWidget(dash_safety);
-
+  
   auto * scene_builder = new QWidget(studio_pages_); auto * sl=new QVBoxLayout(scene_builder);
   scene_builder_title_=new QLabel("<h2>Scene Builder</h2>"); scene_builder_title_->setProperty("studioTitle", true); sl->addWidget(scene_builder_title_);
   auto * scene_shell = new QWidget(scene_builder); scene_shell->setObjectName("sceneBuilderWorkspace");
@@ -798,7 +819,7 @@ void MainWindow::setup_studio_shell()
   auto * grasp_card = new QFrame(right_panel); grasp_card->setObjectName("studioCard"); auto * grasp_layout = new QVBoxLayout(grasp_card);
   grasp_layout->addWidget(new QLabel("<b>Grasp Strategy</b>"));
   grasp_details_label_ = new QLabel("Strategy/ref: unknown\nTool/End Effector: unknown\nApproach axis: unknown\nOrientation mode: unknown\nAllowed roll/yaw: unknown"); grasp_details_label_->setWordWrap(true); grasp_layout->addWidget(grasp_details_label_);
-  readiness_label_=new QLabel("Mode: Design | Runtime: Disabled | Hardware: Fake by default | Safety: Guarded<br/>No uncontrolled robot motion."); readiness_label_->setWordWrap(true); grasp_layout->addWidget(readiness_label_);
+  readiness_label_=new QLabel("Safety posture: guarded (fake hardware default, no uncontrolled robot motion)."); readiness_label_->setWordWrap(true); grasp_layout->addWidget(readiness_label_);
   right_layout->addWidget(grasp_card);
   auto * ar_card = new QFrame(right_panel); ar_card->setObjectName("studioCard"); auto * ar_layout = new QVBoxLayout(ar_card);
   ar_layout->addWidget(new QLabel("<b>Perception Status</b>"));
@@ -1523,7 +1544,8 @@ void MainWindow::on_load_workcell_clicked()
   ui->next->setDisabled(true);
   ui->load_workcell->setDisabled(true);
   ui->change_workcell->setDisabled(true);
-  ui->error_label->setText("<font color='#2E86C1'>Loading workcell...</font>");
+  ui->error_label->setProperty("status", "info");
+  ui->error_label->setText("Loading workcell...");
   statusBar()->showMessage("Loading workspace. Please wait...");
 
   if (progress_dialog_) {
@@ -1698,12 +1720,13 @@ void MainWindow::on_load_workcell_clicked()
       workcell_path = result.workcell_path;
       if (has_selected_ros_distro()) {
         ui->error_label->setText(
-          QString("<font color='#27AE60'>Workcell loaded%1</font>").arg(result.workcell_root_label));
+          QString("Workcell loaded%1").arg(result.workcell_root_label));
+        ui->error_label->setProperty("status", "success");
         statusBar()->showMessage("Ready: open scene setup.");
       } else {
         ui->error_label->setText(
-          "<font color='#C0392B'>Workcell loaded, but no ROS distro is selected. Select a ROS distro "
-          "to continue.</font>");
+          "Workcell loaded, but no ROS distro is selected. Select a ROS distro to continue.");
+        ui->error_label->setProperty("status", "error");
         statusBar()->showMessage("Workspace loaded. Select a ROS distro.");
       }
       success = true;
@@ -1713,7 +1736,8 @@ void MainWindow::on_load_workcell_clicked()
     } else {
       const QString error_text = result.cancelled ? "Workcell load cancelled" :
         QString("Failed to load workcell: %1").arg(result.error);
-      ui->error_label->setText(QString("<font color='#C0392B'>%1</font>").arg(error_text));
+      ui->error_label->setProperty("status", "error");
+      ui->error_label->setText(error_text);
       statusBar()->showMessage(error_text);
       success = false;
       update_next_button_state();
@@ -1726,13 +1750,15 @@ void MainWindow::on_load_workcell_clicked()
 void MainWindow::on_next_clicked()
 {
   if (!success) {
-    ui->error_label->setText("<font color='#C0392B'>Please load a workcell before continuing.</font>");
+    ui->error_label->setProperty("status", "error");
+    ui->error_label->setText("Please load a workcell before continuing.");
     statusBar()->showMessage("Load a workspace before continuing.");
     return;
   }
   if (!has_selected_ros_distro()) {
     ui->error_label->setText(
-      "<font color='#C0392B'>Please select a ROS distro before continuing.</font>");
+      "Please select a ROS distro before continuing.");
+    ui->error_label->setProperty("status", "error");
     statusBar()->showMessage("Select a ROS distro before continuing.");
     update_next_button_state();
     return;
@@ -1751,7 +1777,8 @@ void MainWindow::on_next_clicked()
 void MainWindow::on_change_workcell_clicked()
 {
   success = false;
-  ui->error_label->setText("<font color='#C0392B'>Workcell not available</font>");
+  ui->error_label->setProperty("status", "error");
+  ui->error_label->setText("Workcell not available");
   statusBar()->showMessage("Select a new workspace directory.");
   apply_startup_selection();
   refresh_header_status();
@@ -1769,19 +1796,19 @@ void MainWindow::setup_compact_header()
   if (!root_layout || studio_title_label_) return;
 
   auto * header = new QWidget(content);
-  header->setMaximumHeight(64);
   auto * hl = new QHBoxLayout(header);
   hl->setContentsMargins(8, 6, 8, 6);
   studio_title_label_ = new QLabel("<b>Workcell Studio</b>", header);
   studio_ros_label_ = new QLabel("ROS 2: not selected", header);
-  studio_workspace_path_ = new QLineEdit(header);
-  studio_workspace_path_->setReadOnly(true);
-  studio_workspace_path_->setMinimumWidth(280);
+  studio_workspace_chip_ = new QLabel("Workspace: unknown", header);
+  studio_workspace_chip_->setObjectName("workspaceChip");
+  studio_workspace_chip_->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
   hl->addWidget(studio_title_label_);
   hl->addSpacing(12);
   hl->addWidget(studio_ros_label_);
   hl->addSpacing(12);
-  hl->addWidget(studio_workspace_path_, 1);
+  hl->addWidget(studio_workspace_chip_);
+  hl->addStretch(1);
   root_layout->insertWidget(0, header);
 }
 
@@ -1791,10 +1818,10 @@ void MainWindow::refresh_header_status()
     const QString ros_text = has_selected_ros_distro() ? ui->ros_distro->currentText() : QString("Humble");
     studio_ros_label_->setText("ROS 2 " + ros_text);
   }
-  if (studio_workspace_path_) {
+  if (studio_workspace_chip_) {
     const QString ws = detect_workspace_root();
-    studio_workspace_path_->setText(ws);
-    studio_workspace_path_->setToolTip(ws);
+    studio_workspace_chip_->setText(QString("Workspace: %1").arg(ws.isEmpty() ? QString("unknown") : ws));
+    studio_workspace_chip_->setToolTip(ws);
   }
 }
 

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -315,6 +315,6 @@ private:
   QString selected_workspace_;
   QLabel * studio_title_label_{ nullptr };
   QLabel * studio_ros_label_{ nullptr };
-  QLineEdit * studio_workspace_path_{ nullptr };
+  QLabel * studio_workspace_chip_{ nullptr };
 };
 #endif  // EASY_MANIPULATION_DEPLOYMENT__WORKCELL_BUILDER__WORKCELL_BUILDER__GUI__MAINWINDOW_H_

--- a/workcell_builder/workcell_builder/gui/resources/workcell_studio_dark.qss
+++ b/workcell_builder/workcell_builder/gui/resources/workcell_studio_dark.qss
@@ -1,136 +1,103 @@
 QMainWindow, QDialog, QWidget {
-  background-color: #0d131b;
-  color: #e8f1fb;
+  background-color: #0b1118;
+  color: #f8fafc;
   font-size: 13px;
 }
 QFrame#studioCard, QFrame#statusCard {
-  background-color: #141d28;
-  border: 1px solid #254661;
+  background-color: #111827;
+  border: 1px solid #334155;
   border-radius: 12px;
 }
 QFrame#studioPanel {
-  background-color: #101923;
-  border: 1px solid #22384d;
+  background-color: #162131;
+  border: 1px solid #334155;
   border-radius: 12px;
 }
-QLabel[studioTitle="true"] { color: #dff2ff; font-weight: 700; }
-QPushButton#studioPrimaryButton, QPushButton[studioPrimaryButton="true"] {
-  background-color: #0f5f8f;
-  border: 1px solid #71c9ff;
-  color: #f3fbff;
-}
-QLabel[safetyLabel="true"] {
-  color: #7dd8ff;
-  font-weight: 700;
-}
-QToolBar {
-  background-color: #131c27;
-  border: 1px solid #285173;
-  border-radius: 10px;
-  spacing: 8px;
-  padding: 8px;
-}
-QLabel#safetyPill {
-  background-color: #0e2636;
-  border: 1px solid #2f5f7d;
+QLabel { color: #f8fafc; }
+QLabel[studioTitle="true"] { color: #f8fafc; font-weight: 700; }
+QLabel[status="error"], QLabel[badge="blocked"] { color: #f87171; }
+QLabel[status="success"], QLabel[badge="ready"], QLabel[badge="pass"], QLabel[badge="accepted"] { color: #22c55e; }
+QLabel[status="info"], QLabel[badge="safety"] { color: #38bdf8; }
+QLabel[badge="warning"] { color: #f59e0b; }
+QLabel#safetyPill, QLabel#workspaceChip {
+  background-color: #162131;
+  border: 1px solid #334155;
   border-radius: 10px;
   padding: 4px 10px;
-  color: #d8ecff;
+  color: #cbd5e1;
+}
+QLabel:disabled, QCheckBox:disabled, QGroupBox:disabled, QPushButton:disabled, QToolButton:disabled,
+QLineEdit:disabled, QComboBox:disabled, QTextEdit:disabled, QPlainTextEdit:disabled {
+  color: #94a3b8;
 }
 QPushButton {
-  background-color: #1b2837;
-  border: 1px solid #2f78a4;
+  background-color: #162131;
+  border: 1px solid #334155;
   border-radius: 8px;
   padding: 8px 14px;
   font-weight: 600;
+  color: #f8fafc;
 }
-QPushButton:hover { background-color: #233447; border-color: #4ea6d8; }
-QPushButton:pressed { background-color: #1a3b57; }
-QPushButton:disabled {
-  background-color: #1a1f26;
-  color: #718399;
-  border: 1px solid #2b3642;
+QPushButton:hover { background-color: #1f2e42; border-color: #38bdf8; }
+QPushButton:pressed { background-color: #22364f; }
+QPushButton[role="primary"], QPushButton#studioPrimaryButton, QPushButton[studioPrimaryButton="true"] {
+  background-color: #0e7490;
+  border: 1px solid #38bdf8;
+  color: #f8fafc;
 }
-QPushButton[role="primary"] { background-color: #0f5f8f; border: 1px solid #71c9ff; color: #f3fbff; }
-QPushButton[role="secondary"] { background-color: #1a2230; border: 1px solid #445c73; }
 QToolButton {
-  background-color: #172536;
-  border: 1px solid #44647f;
+  background-color: #162131;
+  border: 1px solid #334155;
   border-radius: 8px;
   padding: 7px 12px;
-  color: #dcecff;
+  color: #f8fafc;
 }
 QToolButton::menu-indicator { image: none; width: 0px; }
-QMenu {
-  background-color: #111b28;
-  color: #dcecff;
-  border: 1px solid #35516a;
-}
-QMenu::item:selected { background-color: #1f4561; }
-QLabel { color: #e8f1fb; }
-QLabel:disabled, QCheckBox:disabled, QGroupBox:disabled {
-  color: #b7c3d1;
-}
 QLineEdit, QComboBox, QSpinBox, QDoubleSpinBox {
-  background-color: #111b28;
-  color: #e8f1fb;
-  border: 1px solid #35516a;
+  background-color: #0f172a;
+  color: #f8fafc;
+  border: 1px solid #334155;
   border-radius: 6px;
   padding: 4px 8px;
 }
-QTreeWidget {
-  background-color: #121b26;
-  color: #e6f0fb;
-  alternate-background-color: #101722;
-  border: 1px solid #29435b;
-}
-QTableWidget::item:selected, QTreeWidget::item:selected {
-  background-color: #1f4561;
-  color: #f6fbff;
-}
-QListWidget {
-  background-color: #111925;
-  border: 1px solid #2d4d66;
-  border-radius: 10px;
-  padding: 8px;
-}
-QListWidget::item { padding: 8px 10px; border-radius: 7px; margin: 2px 0; }
-QListWidget::item:hover { background: #1a2a3c; }
-QListWidget::item:selected { background: #15557b; border: 1px solid #69caff; }
-QTabWidget::pane {
-  background-color: #111923;
-  border: 1px solid #2a465f;
+QTextEdit, QPlainTextEdit {
+  background-color: #0f172a;
+  color: #f8fafc;
+  border: 1px solid #334155;
   border-radius: 8px;
-  padding: 8px;
+  selection-background-color: #38bdf8;
 }
-QTabBar::tab { background: #172230; color: #afc6dd; padding: 8px 14px; border-top-left-radius: 8px; border-top-right-radius: 8px; }
-QTabBar::tab:selected { background: #1f3850; color: #f1f8ff; }
-QTableWidget {
-  background-color: #121b26;
-  color: #e6f0fb;
-  gridline-color: #29435b;
-  alternate-background-color: #101722;
-  border: 1px solid #29435b;
-  border-radius: 8px;
+QListWidget, QTreeWidget, QTableWidget {
+  background-color: #111827;
+  color: #f8fafc;
+  border: 1px solid #334155;
+}
+QTreeWidget, QTableWidget { alternate-background-color: #162131; }
+QListWidget::item { color: #cbd5e1; padding: 8px 10px; border-radius: 7px; margin: 2px 0; }
+QListWidget::item:hover { background: #1f2e42; color: #f8fafc; }
+QListWidget::item:selected, QTableWidget::item:selected, QTreeWidget::item:selected {
+  background-color: #0e7490;
+  color: #f8fafc;
 }
 QHeaderView::section {
-  background-color: #1d2c3d;
-  color: #dcecfb;
+  background-color: #162131;
+  color: #cbd5e1;
   border: none;
-  border-right: 1px solid #2b445d;
+  border-right: 1px solid #334155;
   padding: 8px;
   font-weight: 700;
 }
-QPlainTextEdit, QTextEdit {
-  background-color: #0f1822;
-  color: #d7e8fb;
-  border: 1px solid #29435b;
+QGroupBox {
+  color: #cbd5e1;
+  border: 1px solid #334155;
   border-radius: 8px;
-  selection-background-color: #22689a;
-  font-family: "JetBrains Mono", "Consolas", monospace;
+  margin-top: 8px;
+  padding-top: 8px;
 }
-QLabel[badge="ready"], QLabel[badge="pass"], QLabel[badge="accepted"] { color: #8ce0a8; }
-QLabel[badge="warning"] { color: #ffd380; }
-QLabel[badge="blocked"] { color: #ff8f8f; }
-QLabel[badge="safety"] { color: #7dd8ff; font-weight: 700; }
-QStatusBar { background: #0b1118; color: #8fd7f9; }
+QMenu {
+  background-color: #111827;
+  color: #f8fafc;
+  border: 1px solid #334155;
+}
+QMenu::item:selected { background-color: #0e7490; color: #f8fafc; }
+QStatusBar { background: #0b1118; color: #cbd5e1; }


### PR DESCRIPTION
### Motivation
- Remove leftover legacy startup/header UI that consumed vertical space and used unreadable inline HTML colours, so the main Studio shell begins with the modern top command bar/dashboard content.
- Provide a compact, non-editable workspace status chip instead of a full editable filepath row.
- Standardise dark-theme colours to a readable palette and ensure disabled/readability states are explicit across common widgets.

### Description
- Detached and collapsed legacy startup widgets in `setup_studio_shell()` so they do not occupy space after startup by removing them from the root layout and using `setVisible(false)` plus zero height adjustments. (`mainwindow.cpp`)
- Replaced the editable `QLineEdit` header field with a non-editable `QLabel` workspace chip `studio_workspace_chip_` and updated `setup_compact_header()` and `refresh_header_status()` accordingly. (`mainwindow.h`, `mainwindow.cpp`)
- Removed inline HTML font colour strings used for status/error messages and replaced them with plain text and theme-driven `status` properties (`error`, `success`, `info`) on the `QLabel` so the stylesheet controls colours. (`mainwindow.cpp`)
- Simplified and replaced the dark stylesheet with explicit readable foreground/background/border/disabled rules and the requested palette for core widgets (`QLabel`, `QPushButton`, `QToolButton`, `QLineEdit`, `QComboBox`, `QTextEdit`, `QPlainTextEdit`, `QListWidget`, `QTreeWidget`, `QTableWidget`, `QHeaderView`, `QGroupBox`, `QFrame#studioCard`, `QFrame#studioPanel`, `QStatusBar`, `QMenu`). (`workcell_studio_dark.qss`)
- Reworded internal readiness/safety labels to avoid duplicative legacy banner strings while preserving the safety posture and fake-hardware defaults. (`mainwindow.cpp`)
- Added regression tests to assert legacy banner strings and editable workspace row are no longer present and to verify the QSS contains explicit readable text rules and avoids banned dark-on-dark foreground colours. (`tests/test_workcell_studio_progressive_disclosure_layout.py`)

### Testing
- Ran unit tests: `python3 -m pytest -q tests/test_workcell_studio_button_wiring_regression.py` — passed (`2 passed`).
- Ran unit tests: `python3 -m pytest -q tests/test_workcell_studio_new_cell_button_audit.py` — passed (`6 passed`).
- Ran unit tests: `python3 -m pytest -q tests/test_workcell_studio_16x9_presentation_ui.py` — passed (`3 passed`).
- Ran unit tests: `python3 -m pytest -q tests/test_workcell_studio_progressive_disclosure_layout.py` — passed after adjustments (`8 passed`).
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but the command failed in the CI environment due to `colcon` not being available (`/bin/bash: colcon: command not found`).

No functional runtime, hardware, or workspace selection behaviour was changed; the change only removes legacy header UI elements and fixes theme/contrast for readability.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077dd56fa8833197260d8ce1f04f18)