### PR TITLE
Use browser-level scene_root for safe delete and add fallbacks

### DIFF
--- a/tests/test_workcell_studio_button_wiring_regression.py
+++ b/tests/test_workcell_studio_button_wiring_regression.py
@@ -27,3 +27,17 @@ def test_top_bar_uses_named_page_enum_and_no_invalid_indexes():
     assert "show_studio_page(StudioPage::ExportPage)" in cpp
     assert "setCurrentRow(9)" not in cpp
     assert "setCurrentRow(10)" not in cpp
+
+
+def test_delete_scene_uses_browser_scene_root_with_safe_fallback():
+    cpp = Path("workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+    assert "scene_browser_result_.scene_root" in cpp
+    assert "scene_browser_result_.scene_root;" in cpp
+    assert "scene_path.parent_path()" in cpp
+    assert "scene.scene_dir.parent_path()" in cpp
+    assert ".workcell_studio_trash" in cpp
+
+
+def test_scene_info_scenes_root_field_is_not_referenced():
+    cpp = Path("workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+    assert ".scenes_root" not in cpp

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1379,7 +1379,10 @@ bool MainWindow::is_safe_scene_path_for_trash_move(const fs::path & scene_path, 
     if (reason) *reason = "No scene is selected.";
     return false;
   }
-  const fs::path scenes_root = scene_browser_result_.scenes[static_cast<size_t>(selected_scene_index_)].scenes_root;
+  fs::path scenes_root = scene_browser_result_.scene_root;
+  if (scenes_root.empty()) {
+    scenes_root = scene_path.parent_path();
+  }
   boost::system::error_code ec;
   const fs::path canonical_scene = fs::weakly_canonical(scene_path, ec);
   if (ec) {
@@ -1442,7 +1445,10 @@ void MainWindow::delete_selected_scene()
     return;
   }
   boost::system::error_code ec;
-  const fs::path scenes_root = scene.scenes_root;
+  fs::path scenes_root = scene_browser_result_.scene_root;
+  if (scenes_root.empty()) {
+    scenes_root = scene.scene_dir.parent_path();
+  }
   const fs::path trash_root = scenes_root / ".workcell_studio_trash";
   fs::create_directories(trash_root, ec);
   const QString stamp = QDateTime::currentDateTimeUtc().toString("yyyyMMdd_HHmmss");


### PR DESCRIPTION
### Motivation
- Fix a build failure caused by accessing the non-existent `WorkcellStudioSceneInfo::scenes_root` from the scene manager delete/safety code by using the browser-level scene root instead.

### Description
- Replace the invalid `scene_browser_result_.scenes[...].scenes_root` and `scene.scenes_root` usages with `scene_browser_result_.scene_root` and add a safe fallback to the selected scene path (`scene_path.parent_path()` / `scene.scene_dir.parent_path()`).
- Preserve the original trash destination semantics as `scenes_root / ".workcell_studio_trash" / "<scene_name>_<timestamp>"` and keep existing canonical/safety checks in `MainWindow::is_safe_scene_path_for_trash_move` and `MainWindow::delete_selected_scene`.
- Do not modify the `WorkcellStudioSceneInfo` data model and prefer the existing `WorkcellStudioSceneBrowserResult::scene_root` field.
- Add regression assertions in `tests/test_workcell_studio_button_wiring_regression.py` to verify code references `scene_browser_result_.scene_root`, includes the safe fallbacks, keeps `.workcell_studio_trash`, and does not reference `.scenes_root`.

### Testing
- Ran `grep -R "scenes_root" -n workcell_builder/workcell_builder/gui/mainwindow.cpp` to inspect occurrences and confirmed there are no references to the `.scenes_root` field in `mainwindow.cpp` (only local `scenes_root` variables and the browser-level `scene_root` usage remain).
- Ran the requested pytest suites `tests/test_workcell_studio_button_wiring_regression.py`, `tests/test_workcell_studio_16x9_presentation_ui.py`, and `tests/test_workcell_studio_progressive_disclosure_layout.py`, and all tests passed (the suites returned `4`, `3`, and `10` passing tests respectively).
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but `colcon` is not installed in this environment so package build validation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078223fafc8331a26cff60eed4115b)