### PR TITLE
Include NewCellWizard header in mainwindow to fix build error

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -96,6 +96,7 @@
 #include "workcell_studio_canvas_model.hpp"
 #include "scene_preview_widget.h"
 #include "workcell_studio_layout_editor.hpp"
+#include "gui/new_cell_wizard.h"
 
 namespace fs = boost::filesystem;
 


### PR DESCRIPTION
### Motivation
- `MainWindow::open_new_scene_creation_flow()` constructs a `NewCellWizard` but `mainwindow.cpp` did not include its declaration, causing a compile error; the change restores visibility without altering the intended New Cell workflow.

### Description
- Added `#include "gui/new_cell_wizard.h"` to `workcell_builder/workcell_builder/gui/mainwindow.cpp` and left the existing `NewCellWizard` implementation and CMake wiring unchanged.

### Testing
- Verified `workcell_builder/workcell_builder/gui/new_cell_wizard.h` and `.cpp` exist and that `gui/new_cell_wizard.cpp` is listed in `workcell_builder/CMakeLists.txt`, and attempted `colcon build --symlink-install --packages-select workcell_builder` which could not be executed in this environment because `colcon: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084f7b5bfc83318f59df76e09dd9b8)