### PR TITLE
Fix yaml-cpp linkage for workcell_yaml_utils_test

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -328,6 +328,20 @@ if(BUILD_TESTING)
     target_include_directories(workcell_conveyor_pick_preview_test PRIVATE ${Boost_INCLUDE_DIRS} include)
   endif()
 
+  if(TARGET workcell_yaml_utils_test)
+    target_link_libraries(workcell_yaml_utils_test
+      yaml-cpp
+      ${Boost_LIBRARIES}
+    )
+    target_include_directories(workcell_yaml_utils_test
+      PRIVATE
+        ${Boost_INCLUDE_DIRS}
+        include
+        include/attributes
+        include/yaml_parser
+    )
+  endif()
+
   if(TARGET workcell_scene_status_test)
     target_link_libraries(workcell_scene_status_test
       yaml-cpp


### PR DESCRIPTION
### Motivation
- The new `workcell_yaml_utils_test` target compiles `src_workcell_yaml_utils.cpp` which uses YAML APIs, but the test executable was not linked against `yaml-cpp`, causing undefined references to symbols such as `YAML::Load`, `YAML::Exception`, `YAML::BadSubscript`, and `YAML::Node` at link time.
- The change aims to ensure any target that uses YAML types or functions is properly linked to the YAML library and has the correct include paths.

### Description
- Added an `if(TARGET workcell_yaml_utils_test)` block to `workcell_builder/workcell_builder/CMakeLists.txt` that links `workcell_yaml_utils_test` against `yaml-cpp` and `${Boost_LIBRARIES}` using `target_link_libraries`.
- Added `target_include_directories` for `workcell_yaml_utils_test` to include `${Boost_INCLUDE_DIRS}`, `include`, `include/attributes`, and `include/yaml_parser` so the test has the same include layout as other YAML-using tests.
- Confirmed `find_package(yaml-cpp REQUIRED)` is already present at the top of the CMake file, so no additional package discovery changes were required.

### Testing
- Attempted to run `colcon build --symlink-install --packages-select workcell_builder`, but the environment lacks `colcon` (`colcon: command not found`), so the build and test suite could not be executed here and no automated tests were run.
- No automated tests were executed in this environment; linking should succeed in a normal dev environment where `colcon` and dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0852b14874833188ddf45c0267bf20)