### PR TITLE
Replace New Cell UI with stable guided wizard form

### DIFF
--- a/workcell_builder/workcell_builder/gui/new_cell_wizard.cpp
+++ b/workcell_builder/workcell_builder/gui/new_cell_wizard.cpp
@@ -1,54 +1,362 @@
 #include "gui/new_cell_wizard.h"
-#include <QVBoxLayout>
-#include <QHBoxLayout>
-#include <QFormLayout>
-#include <QListWidget>
-#include <QStackedWidget>
-#include <QLineEdit>
-#include <QTextEdit>
-#include <QComboBox>
-#include <QLabel>
-#include <QPushButton>
+
 #include <QCheckBox>
+#include <QComboBox>
 #include <QDoubleSpinBox>
+#include <QFormLayout>
 #include <QFrame>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QPushButton>
+#include <QStackedWidget>
+#include <QTextEdit>
+#include <QVBoxLayout>
+
 #include <fstream>
 #include <regex>
 
 namespace fs = boost::filesystem;
 
-NewCellWizard::NewCellWizard(const QString &workspace_root, QWidget *parent): QDialog(parent), workspace_root_(workspace_root) { build_ui(); refresh_validation(); }
-
-bool NewCellWizard::is_valid_package_name(const QString &name){ static const std::regex re("^[a-z][a-z0-9_]*$"); return std::regex_match(name.toStdString(), re); }
-QString NewCellWizard::default_gripper_rpy_text(){ return "-1.5708, -1.5708, 0"; }
-QStringList NewCellWizard::recommended_environment_assets(){ return {"Work table", "Source bin", "Place fixture", "RealSense D435i", "Safety zone"}; }
-
-void NewCellWizard::build_ui(){ setWindowTitle("New Cell Wizard"); resize(1000,700); auto *root=new QVBoxLayout(this); root->addWidget(new QLabel("<h2>New Cell</h2><p>Create a new robotic workcell in a guided setup flow.</p><p><b>Safety:</b> Fake hardware default / Real robot locked</p>"));
- auto *body=new QHBoxLayout(); root->addLayout(body,1); steps_=new QListWidget(this); steps_->addItems({"Basics","Robot","End Effector","Environment","Task Intent","Review & Create"}); steps_->setFixedWidth(220); body->addWidget(steps_);
- stack_=new QStackedWidget(this); body->addWidget(stack_,1);
- auto mk=[&](QWidget *w){ auto *c=new QWidget(this); auto *l=new QVBoxLayout(c); l->addWidget(w); l->addStretch(1); stack_->addWidget(c); };
- auto *s1=new QWidget(this); auto *f1=new QFormLayout(s1); display_name_=new QLineEdit; scene_name_=new QLineEdit; description_=new QTextEdit; template_=new QComboBox; template_->addItems({"Pick & Place","Sorting","Inspection","Machine Tending","Conveyor Picking","Blank Cell"}); output_path_=new QLineEdit(QString::fromStdString(scenes_root_path().string())); scene_error_=new QLabel; scene_error_->setStyleSheet("color:#b00020"); f1->addRow("Cell display name",display_name_); f1->addRow("Scene/package name",scene_name_); f1->addRow("",scene_error_); f1->addRow("Description",description_); f1->addRow("Template",template_); f1->addRow("Scenes output path",output_path_); mk(s1);
- auto *s2=new QWidget(this); auto *f2=new QFormLayout(s2); robot_=new QComboBox; robot_->addItems({"UR5","UR10","UR3","Generic Cartesian Placeholder","Generic Delta Placeholder"}); robot_warning_=new QLabel("Placeholders are scaffold only."); f2->addRow("Robot",robot_); f2->addRow("",robot_warning_); mk(s2);
- auto *s3=new QWidget(this); auto *f3=new QFormLayout(s3); ee_=new QComboBox; ee_->addItems({"robotiq_85 / Robotiq 2F","single_suction","parallel gripper","vacuum placeholder"}); ee_roll_=new QDoubleSpinBox; ee_pitch_=new QDoubleSpinBox; ee_yaw_=new QDoubleSpinBox; for (auto *b:{ee_roll_,ee_pitch_,ee_yaw_}){b->setDecimals(4);b->setRange(-6.2832,6.2832);} ee_roll_->setValue(-1.5708); ee_pitch_->setValue(-1.5708); ee_yaw_->setValue(0.0); f3->addRow("End effector",ee_); f3->addRow("Roll",ee_roll_); f3->addRow("Pitch",ee_pitch_); f3->addRow("Yaw",ee_yaw_); mk(s3);
- auto *s4=new QWidget(this); auto *v4=new QVBoxLayout(s4); env_table_=new QCheckBox("Work table / workbench"); env_source_=new QCheckBox("Source bin"); env_place_=new QCheckBox("Place fixture / target table"); env_reject_=new QCheckBox("Reject bin"); env_conveyor_=new QCheckBox("Conveyor placeholder"); env_camera_=new QCheckBox("RealSense D435i / camera"); env_safety_=new QCheckBox("Safety zone"); for(auto*c:{env_table_,env_source_,env_place_,env_reject_,env_conveyor_,env_camera_,env_safety_}) v4->addWidget(c); auto *r=new QHBoxLayout(); auto *rec=new QPushButton("Use recommended layout"); auto *clr=new QPushButton("Clear layout"); auto *pv=new QPushButton("Preview layout summary"); r->addWidget(rec);r->addWidget(clr);r->addWidget(pv); v4->addLayout(r); env_preview_=new QLabel; v4->addWidget(env_preview_); mk(s4);
- auto *s5=new QWidget(this); auto *f5=new QFormLayout(s5); task_family_=new QComboBox; task_family_->addItems({"pick_place","sorting","inspection","machine_tending","conveyor_picking"}); pick_source_=new QLineEdit; place_target_=new QLineEdit; task_warning_=new QLabel; task_warning_->setStyleSheet("color:#b36b00"); f5->addRow("Task family",task_family_); f5->addRow("Pick source",pick_source_); f5->addRow("Place target",place_target_); f5->addRow("",task_warning_); mk(s5);
- auto *s6=new QWidget(this); auto *v6=new QVBoxLayout(s6); summary_=new QLabel; summary_->setWordWrap(true); summary_->setFrameShape(QFrame::StyledPanel); v6->addWidget(summary_); mk(s6);
- auto *nav=new QHBoxLayout(); root->addLayout(nav); back_=new QPushButton("Back"); next_=new QPushButton("Next"); create_=new QPushButton("Create Cell"); create_open_=new QPushButton("Create and Open in Scene Builder"); auto *cancel=new QPushButton("Cancel"); nav->addWidget(back_); nav->addWidget(next_); nav->addStretch(1); nav->addWidget(create_); nav->addWidget(create_open_); nav->addWidget(cancel);
- connect(steps_, &QListWidget::currentRowChanged, stack_, &QStackedWidget::setCurrentIndex); connect(steps_, &QListWidget::currentRowChanged, this, &NewCellWizard::refresh_validation); steps_->setCurrentRow(0);
- connect(back_, &QPushButton::clicked, this, [this]{ steps_->setCurrentRow(std::max(0, steps_->currentRow()-1));}); connect(next_, &QPushButton::clicked, this, [this]{ steps_->setCurrentRow(std::min(5, steps_->currentRow()+1));});
- connect(cancel,&QPushButton::clicked,this,&QDialog::reject);
- auto refresh_all=[this]{refresh_validation(); refresh_summary();}; connect(scene_name_, &QLineEdit::textChanged, this, refresh_all); connect(task_family_, &QComboBox::currentTextChanged, this, refresh_all); connect(pick_source_, &QLineEdit::textChanged, this, refresh_all); connect(place_target_, &QLineEdit::textChanged, this, refresh_all);
- connect(rec,&QPushButton::clicked,this,[this]{env_table_->setChecked(true);env_source_->setChecked(true);env_place_->setChecked(true);env_reject_->setChecked(false);env_conveyor_->setChecked(false);env_camera_->setChecked(true);env_safety_->setChecked(true);refresh_summary();});
- connect(clr,&QPushButton::clicked,this,[this]{for(auto*c:{env_table_,env_source_,env_place_,env_reject_,env_conveyor_,env_camera_,env_safety_}) c->setChecked(false);refresh_summary();});
- connect(pv,&QPushButton::clicked,this,[this]{refresh_summary();});
- connect(create_, &QPushButton::clicked, this, [this]{ if(create_scene_scaffold(false)) accept(); });
- connect(create_open_, &QPushButton::clicked, this, [this]{ if(create_scene_scaffold(true)) accept(); });
+NewCellWizard::NewCellWizard(const QString &workspace_root, QWidget *parent)
+: QDialog(parent), workspace_root_(workspace_root)
+{
+  build_ui();
+  refresh_validation();
 }
 
-boost::filesystem::path NewCellWizard::scenes_root_path() const { return fs::path(workspace_root_.toStdString()) / "src" / "scenes"; }
-QString NewCellWizard::scene_name_error() const { const QString n=scene_name_->text().trimmed(); if(n.isEmpty()) return "Scene/package name is required."; if(!is_valid_package_name(n)) return "Use lowercase letters, digits, underscores; start with a letter."; const fs::path p=scenes_root_path()/n.toStdString(); if(fs::exists(p)) return "A scene with this name already exists."; return ""; }
-void NewCellWizard::refresh_validation(){ const int row=steps_->currentRow(); back_->setEnabled(row>0); next_->setEnabled(row<5 && (row!=0 || scene_name_error().isEmpty())); scene_error_->setText(scene_name_error()); const bool valid=scene_name_error().isEmpty(); create_->setEnabled(valid); create_open_->setEnabled(valid); const bool needs_pick_place=task_family_->currentText().contains("pick")||task_family_->currentText().contains("sort"); task_warning_->setText((needs_pick_place && (pick_source_->text().trimmed().isEmpty()||place_target_->text().trimmed().isEmpty()))?"Warning: incomplete pick/place bindings; scaffold allowed.":""); refresh_summary(); }
-void NewCellWizard::refresh_summary(){ QStringList env; if(env_table_->isChecked()) env<<"table"; if(env_source_->isChecked()) env<<"source_bin"; if(env_place_->isChecked()) env<<"place_fixture"; if(env_reject_->isChecked()) env<<"reject_bin"; if(env_conveyor_->isChecked()) env<<"conveyor"; if(env_camera_->isChecked()) env<<"realsense_d435i"; if(env_safety_->isChecked()) env<<"safety_zone"; env_preview_->setText("Enabled: "+env.join(", "));
- summary_->setText(QString("<b>scene name</b>: %1<br/><b>template</b>: %2<br/><b>robot</b>: %3<br/><b>end effector</b>: %4<br/><b>gripper mount RPY</b>: %5, %6, %7<br/><b>enabled environment assets</b>: %8<br/><b>task</b>: %9 (%10 → %11)<br/><b>fake hardware</b>: default / real robot locked<br/><b>output path</b>: %12")
- .arg(scene_name_->text(),template_->currentText(),robot_->currentText(),ee_->currentText()).arg(ee_roll_->text(),ee_pitch_->text(),ee_yaw_->text(),env.join(", "),task_family_->currentText(),pick_source_->text(),place_target_->text(),output_path_->text())); }
-bool NewCellWizard::create_scene_scaffold(bool open_in_builder){ const QString err=scene_name_error(); if(!err.isEmpty()) return false; const fs::path scene_dir=scenes_root_path()/scene_name_->text().trimmed().toStdString(); boost::system::error_code ec; fs::create_directories(scene_dir/"config", ec); if(ec) return false; std::ofstream env((scene_dir/"environment.yaml").string()); env<<"scene_name: "<<scene_name_->text().trimmed().toStdString()<<"\n"; env<<"template: "<<template_->currentText().toStdString()<<"\n"; env<<"robot: "<<robot_->currentText().toStdString()<<"\n"; env<<"end_effector: "<<ee_->currentText().toStdString()<<"\n"; env<<"gripper_mount_rpy: ["<<ee_roll_->value()<<", "<<ee_pitch_->value()<<", "<<ee_yaw_->value()<<"]\n"; env<<"fake_hardware_first: true\n"; env<<"runtime_execution_enabled: false\n"; env.close(); result_.created=true; result_.open_in_scene_builder=open_in_builder; result_.scene_name=scene_name_->text().trimmed(); result_.scene_dir=scene_dir; return true; }
+bool NewCellWizard::is_valid_package_name(const QString &name)
+{
+  static const std::regex re("^[a-z][a-z0-9_]*$");
+  return std::regex_match(name.toStdString(), re);
+}
+
+QString NewCellWizard::default_gripper_rpy_text() { return "-1.5708, -1.5708, 0"; }
+
+QStringList NewCellWizard::recommended_environment_assets()
+{
+  return {"Work table", "Source bin", "Place fixture", "RealSense D435i camera", "Safety zone"};
+}
+
+void NewCellWizard::build_ui()
+{
+  setWindowTitle("New Cell");
+  resize(1040, 720);
+
+  auto *root = new QVBoxLayout(this);
+  root->addWidget(new QLabel(
+    "<h2>New Cell</h2>"
+    "<p>Create a new robotic workcell from a guided setup.</p>"
+    "<p><b>Safety badge:</b> Fake hardware default / Real robot locked</p>"));
+
+  auto *body = new QHBoxLayout();
+  root->addLayout(body, 1);
+
+  steps_ = new QListWidget(this);
+  steps_->addItems({"1 Basics", "2 Robot", "3 End Effector", "4 Environment", "5 Task Intent", "6 Review"});
+  steps_->setFixedWidth(220);
+  body->addWidget(steps_);
+
+  stack_ = new QStackedWidget(this);
+  body->addWidget(stack_, 1);
+
+  auto mk_page = [&](QWidget *w) {
+    auto *c = new QWidget(this);
+    auto *l = new QVBoxLayout(c);
+    l->addWidget(w);
+    l->addStretch(1);
+    stack_->addWidget(c);
+  };
+
+  auto mk_pose_spin = []() {
+    auto *s = new QDoubleSpinBox();
+    s->setDecimals(4);
+    s->setRange(-1000.0, 1000.0);
+    s->setSingleStep(0.01);
+    return s;
+  };
+
+  // Step 1
+  auto *s1 = new QWidget(this);
+  auto *f1 = new QFormLayout(s1);
+  display_name_ = new QLineEdit();
+  scene_name_ = new QLineEdit();
+  description_ = new QTextEdit();
+  template_ = new QComboBox();
+  template_->addItems({"Pick & Place", "Sorting", "Inspection", "Machine Tending", "Conveyor Picking", "Blank Cell"});
+  output_path_ = new QLineEdit(QString::fromStdString(scenes_root_path().string()));
+  scene_error_ = new QLabel();
+  scene_error_->setStyleSheet("color:#b00020");
+  scene_warning_ = new QLabel();
+  scene_warning_->setStyleSheet("color:#8a6d00");
+  f1->addRow("Cell display name", display_name_);
+  f1->addRow("Scene/package name", scene_name_);
+  f1->addRow("", scene_error_);
+  f1->addRow("", scene_warning_);
+  f1->addRow("Description", description_);
+  f1->addRow("Template", template_);
+  f1->addRow("Output scenes path", output_path_);
+  mk_page(s1);
+
+  // Step 2
+  auto *s2 = new QWidget(this);
+  auto *f2 = new QFormLayout(s2);
+  robot_ = new QComboBox();
+  robot_->addItems({"UR5", "UR10", "UR3", "Generic Cartesian Placeholder", "Generic Delta Placeholder"});
+  auto *robot_pose = new QWidget(this);
+  auto *grid2 = new QGridLayout(robot_pose);
+  robot_x_ = mk_pose_spin(); robot_y_ = mk_pose_spin(); robot_z_ = mk_pose_spin();
+  robot_roll_ = mk_pose_spin(); robot_pitch_ = mk_pose_spin(); robot_yaw_ = mk_pose_spin();
+  grid2->addWidget(new QLabel("x"),0,0); grid2->addWidget(robot_x_,0,1);
+  grid2->addWidget(new QLabel("y"),0,2); grid2->addWidget(robot_y_,0,3);
+  grid2->addWidget(new QLabel("z"),0,4); grid2->addWidget(robot_z_,0,5);
+  grid2->addWidget(new QLabel("roll"),1,0); grid2->addWidget(robot_roll_,1,1);
+  grid2->addWidget(new QLabel("pitch"),1,2); grid2->addWidget(robot_pitch_,1,3);
+  grid2->addWidget(new QLabel("yaw"),1,4); grid2->addWidget(robot_yaw_,1,5);
+  robot_warning_ = new QLabel();
+  robot_warning_->setWordWrap(true);
+  robot_warning_->setStyleSheet("color:#8a6d00");
+  f2->addRow("Robot", robot_);
+  f2->addRow("Robot base pose", robot_pose);
+  f2->addRow("Hardware mode", new QLabel("Fake hardware default / Real robot locked"));
+  f2->addRow("", robot_warning_);
+  mk_page(s2);
+
+  // Step 3
+  auto *s3 = new QWidget(this);
+  auto *f3 = new QFormLayout(s3);
+  ee_ = new QComboBox();
+  ee_->addItems({"robotiq_85", "single_suction", "parallel_gripper", "vacuum_array_placeholder"});
+  auto *ee_pose = new QWidget(this);
+  auto *grid3 = new QGridLayout(ee_pose);
+  ee_x_ = mk_pose_spin(); ee_y_ = mk_pose_spin(); ee_z_ = mk_pose_spin();
+  ee_roll_ = mk_pose_spin(); ee_pitch_ = mk_pose_spin(); ee_yaw_ = mk_pose_spin();
+  ee_roll_->setValue(-1.5708); ee_pitch_->setValue(-1.5708); ee_yaw_->setValue(0.0);
+  grid3->addWidget(new QLabel("x"),0,0); grid3->addWidget(ee_x_,0,1);
+  grid3->addWidget(new QLabel("y"),0,2); grid3->addWidget(ee_y_,0,3);
+  grid3->addWidget(new QLabel("z"),0,4); grid3->addWidget(ee_z_,0,5);
+  grid3->addWidget(new QLabel("roll"),1,0); grid3->addWidget(ee_roll_,1,1);
+  grid3->addWidget(new QLabel("pitch"),1,2); grid3->addWidget(ee_pitch_,1,3);
+  grid3->addWidget(new QLabel("yaw"),1,4); grid3->addWidget(ee_yaw_,1,5);
+  f3->addRow("End effector", ee_);
+  f3->addRow("End effector mount pose", ee_pose);
+  f3->addRow("", new QLabel("Default gripper orientation uses known working generated-scene orientation."));
+  mk_page(s3);
+
+  // Step 4
+  auto *s4 = new QWidget(this);
+  auto *v4 = new QVBoxLayout(s4);
+  env_table_ = new QCheckBox("Work table / workbench");
+  env_source_ = new QCheckBox("Source bin");
+  env_place_ = new QCheckBox("Place fixture");
+  env_reject_ = new QCheckBox("Reject bin");
+  env_conveyor_ = new QCheckBox("Conveyor placeholder");
+  env_camera_ = new QCheckBox("RealSense D435i camera");
+  env_safety_ = new QCheckBox("Safety zone");
+  for (auto *c : {env_table_, env_source_, env_place_, env_reject_, env_conveyor_, env_camera_, env_safety_}) v4->addWidget(c);
+  auto *btns = new QHBoxLayout();
+  auto *rec = new QPushButton("Use Recommended Layout");
+  auto *clr = new QPushButton("Clear Layout");
+  auto *pv = new QPushButton("Preview Layout Summary");
+  btns->addWidget(rec); btns->addWidget(clr); btns->addWidget(pv);
+  v4->addLayout(btns);
+  env_preview_ = new QLabel();
+  env_preview_->setWordWrap(true);
+  v4->addWidget(env_preview_);
+  mk_page(s4);
+
+  // Step 5
+  auto *s5 = new QWidget(this);
+  auto *f5 = new QFormLayout(s5);
+  task_family_ = new QComboBox();
+  task_family_->addItems({"pick_place", "sorting", "inspection", "machine_tending", "conveyor_picking", "blank"});
+  pick_source_ = new QLineEdit();
+  place_target_ = new QLineEdit();
+  grasp_strategy_ = new QComboBox();
+  grasp_strategy_->addItems({"auto", "top_down_2f", "suction_top", "side_grasp_placeholder"});
+  approach_distance_ = mk_pose_spin();
+  retreat_distance_ = mk_pose_spin();
+  approach_distance_->setValue(0.10);
+  retreat_distance_->setValue(0.10);
+  task_intent_text_ = new QTextEdit();
+  task_warning_ = new QLabel();
+  task_warning_->setWordWrap(true);
+  task_warning_->setStyleSheet("color:#8a6d00");
+  f5->addRow("Task family", task_family_);
+  f5->addRow("Pick source", pick_source_);
+  f5->addRow("Place target", place_target_);
+  f5->addRow("Grasp strategy", grasp_strategy_);
+  f5->addRow("Approach distance", approach_distance_);
+  f5->addRow("Retreat distance", retreat_distance_);
+  f5->addRow("Natural language task intent", task_intent_text_);
+  f5->addRow("", task_warning_);
+  mk_page(s5);
+
+  // Step 6
+  auto *s6 = new QWidget(this);
+  auto *v6 = new QVBoxLayout(s6);
+  summary_ = new QLabel();
+  summary_->setWordWrap(true);
+  summary_->setFrameShape(QFrame::StyledPanel);
+  v6->addWidget(summary_);
+  mk_page(s6);
+
+  auto *nav = new QHBoxLayout();
+  back_ = new QPushButton("Back");
+  next_ = new QPushButton("Next");
+  create_ = new QPushButton("Create Cell");
+  create_open_ = new QPushButton("Create and Open");
+  auto *cancel = new QPushButton("Cancel");
+  nav->addWidget(back_);
+  nav->addWidget(next_);
+  nav->addStretch(1);
+  nav->addWidget(create_);
+  nav->addWidget(create_open_);
+  nav->addWidget(cancel);
+  root->addLayout(nav);
+
+  connect(steps_, &QListWidget::currentRowChanged, stack_, &QStackedWidget::setCurrentIndex);
+  connect(steps_, &QListWidget::currentRowChanged, this, &NewCellWizard::refresh_validation);
+  steps_->setCurrentRow(0);
+
+  connect(back_, &QPushButton::clicked, this, [this] { steps_->setCurrentRow(std::max(0, steps_->currentRow() - 1)); });
+  connect(next_, &QPushButton::clicked, this, [this] { steps_->setCurrentRow(std::min(5, steps_->currentRow() + 1)); });
+  connect(cancel, &QPushButton::clicked, this, &QDialog::reject);
+  connect(create_, &QPushButton::clicked, this, [this] { if (create_scene_scaffold(false)) accept(); });
+  connect(create_open_, &QPushButton::clicked, this, [this] { if (create_scene_scaffold(true)) accept(); });
+
+  auto refresh_all = [this] { refresh_validation(); refresh_summary(); };
+  connect(scene_name_, &QLineEdit::textChanged, this, refresh_all);
+  connect(template_, &QComboBox::currentTextChanged, this, refresh_all);
+  connect(robot_, &QComboBox::currentTextChanged, this, refresh_all);
+  connect(task_family_, &QComboBox::currentTextChanged, this, refresh_all);
+  connect(pick_source_, &QLineEdit::textChanged, this, refresh_all);
+  connect(place_target_, &QLineEdit::textChanged, this, refresh_all);
+  for (auto *c : {env_table_, env_source_, env_place_, env_reject_, env_conveyor_, env_camera_, env_safety_}) connect(c, &QCheckBox::toggled, this, refresh_all);
+
+  connect(rec, &QPushButton::clicked, this, [this] {
+    env_table_->setChecked(true); env_source_->setChecked(true); env_place_->setChecked(true);
+    env_reject_->setChecked(false); env_conveyor_->setChecked(false); env_camera_->setChecked(true); env_safety_->setChecked(true);
+    refresh_summary();
+  });
+  connect(clr, &QPushButton::clicked, this, [this] {
+    for (auto *c : {env_table_, env_source_, env_place_, env_reject_, env_conveyor_, env_camera_, env_safety_}) c->setChecked(false);
+    refresh_summary();
+  });
+  connect(pv, &QPushButton::clicked, this, &NewCellWizard::refresh_summary);
+}
+
+fs::path NewCellWizard::scenes_root_path() const { return fs::path(workspace_root_.toStdString()) / "src" / "scenes"; }
+
+QString NewCellWizard::scene_name_error() const
+{
+  const QString n = scene_name_->text().trimmed();
+  if (n.isEmpty()) return "Scene/package name is required.";
+  if (!is_valid_package_name(n)) return "Use lowercase letters, numbers, underscores only; must start with a letter.";
+  return "";
+}
+
+QString NewCellWizard::scene_name_warning() const
+{
+  const QString n = scene_name_->text().trimmed();
+  if (n.isEmpty()) return "";
+  const fs::path p = scenes_root_path() / n.toStdString();
+  if (fs::exists(p)) return "Warning: output folder already exists. Creation is blocked to avoid overwrite.";
+  return "";
+}
+
+void NewCellWizard::refresh_validation()
+{
+  const int row = steps_->currentRow();
+  const QString err = scene_name_error();
+  const QString warn = scene_name_warning();
+  scene_error_->setText(err);
+  scene_warning_->setText(warn);
+
+  const bool name_valid = err.isEmpty() && warn.isEmpty();
+  back_->setEnabled(row > 0);
+  next_->setEnabled(row < 5 && (row != 0 || name_valid));
+  create_->setEnabled(name_valid);
+  create_open_->setEnabled(name_valid);
+
+  const QString robot_txt = robot_->currentText().toLower();
+  if (robot_txt.contains("placeholder")) {
+    robot_warning_->setText("Preview/scaffold only: placeholder robot metadata may be incomplete.");
+  } else {
+    robot_warning_->setText("Known robot selected. Unknown robot metadata/config should be reviewed before runtime.");
+  }
+
+  const bool needs_pick_place = template_->currentText().contains("Pick") || template_->currentText().contains("Sorting");
+  const bool missing_bindings = pick_source_->text().trimmed().isEmpty() || place_target_->text().trimmed().isEmpty();
+  task_warning_->setText((needs_pick_place && missing_bindings)
+    ? "Warning: pick/place template is incomplete (missing pick source or place target). Scaffold creation allowed with warning."
+    : "");
+
+  refresh_summary();
+}
+
+void NewCellWizard::refresh_summary()
+{
+  QStringList env;
+  if (env_table_->isChecked()) env << "work_table";
+  if (env_source_->isChecked()) env << "source_bin";
+  if (env_place_->isChecked()) env << "place_fixture";
+  if (env_reject_->isChecked()) env << "reject_bin";
+  if (env_conveyor_->isChecked()) env << "conveyor_placeholder";
+  if (env_camera_->isChecked()) env << "realsense_d435i_camera";
+  if (env_safety_->isChecked()) env << "safety_zone";
+  env_preview_->setText("Layout summary: " + (env.isEmpty() ? QString("(none)") : env.join(", ")));
+
+  const bool has_warnings = !scene_name_warning().isEmpty() || !task_warning_->text().isEmpty() || robot_->currentText().contains("Placeholder");
+  const QString readiness = scene_name_error().isEmpty() ? (has_warnings ? "scaffold / warnings" : "ready") : "invalid";
+
+  summary_->setText(QString(
+    "<b>Scene/package name:</b> %1<br/>"
+    "<b>Template:</b> %2<br/>"
+    "<b>Robot:</b> %3<br/>"
+    "<b>End effector:</b> %4<br/>"
+    "<b>End effector RPY:</b> %5, %6, %7<br/>"
+    "<b>Environment assets:</b> %8<br/>"
+    "<b>Task intent:</b> %9 | %10 -> %11 | %12<br/>"
+    "<b>Output path:</b> %13<br/>"
+    "<b>Safety mode:</b> Fake hardware default / Real robot locked<br/>"
+    "<b>Expected readiness:</b> %14")
+    .arg(scene_name_->text().trimmed(), template_->currentText(), robot_->currentText(), ee_->currentText(),
+      ee_roll_->text(), ee_pitch_->text(), ee_yaw_->text(),
+      env.isEmpty() ? QString("(none)") : env.join(", "),
+      task_family_->currentText(), pick_source_->text().trimmed(), place_target_->text().trimmed(),
+      task_intent_text_->toPlainText().trimmed(), output_path_->text().trimmed(), readiness));
+}
+
+bool NewCellWizard::create_scene_scaffold(bool open_in_builder)
+{
+  const QString err = scene_name_error();
+  if (!err.isEmpty() || !scene_name_warning().isEmpty()) return false;
+
+  const fs::path scene_dir = scenes_root_path() / scene_name_->text().trimmed().toStdString();
+  boost::system::error_code ec;
+  fs::create_directories(scene_dir / "config", ec);
+  if (ec) return false;
+
+  std::ofstream out((scene_dir / "environment.yaml").string());
+  out << "scene_name: " << scene_name_->text().trimmed().toStdString() << "\n";
+  out << "display_name: \"" << display_name_->text().trimmed().toStdString() << "\"\n";
+  out << "description: \"" << description_->toPlainText().trimmed().toStdString() << "\"\n";
+  out << "template: " << template_->currentText().toStdString() << "\n";
+  out << "robot: " << robot_->currentText().toStdString() << "\n";
+  out << "end_effector: " << ee_->currentText().toStdString() << "\n";
+  out << "gripper_mount_rpy: [" << ee_roll_->value() << ", " << ee_pitch_->value() << ", " << ee_yaw_->value() << "]\n";
+  out << "fake_hardware_first: true\n";
+  out << "real_robot_locked: true\n";
+  out << "runtime_execution_enabled: false\n";
+  out << "scaffold_only: true\n";
+  out.close();
+
+  result_.created = true;
+  result_.open_in_scene_builder = open_in_builder;
+  result_.scene_name = scene_name_->text().trimmed();
+  result_.scene_dir = scene_dir;
+  return true;
+}

--- a/workcell_builder/workcell_builder/gui/new_cell_wizard.h
+++ b/workcell_builder/workcell_builder/gui/new_cell_wizard.h
@@ -1,8 +1,18 @@
 #pragma once
+
 #include <QDialog>
 #include <QStringList>
 #include <boost/filesystem.hpp>
-class QListWidget; class QStackedWidget; class QLineEdit; class QTextEdit; class QComboBox; class QLabel; class QPushButton; class QCheckBox; class QDoubleSpinBox;
+
+class QListWidget;
+class QStackedWidget;
+class QLineEdit;
+class QTextEdit;
+class QComboBox;
+class QLabel;
+class QPushButton;
+class QCheckBox;
+class QDoubleSpinBox;
 
 struct NewCellWizardResult {
   bool created{false};
@@ -16,24 +26,73 @@ class NewCellWizard : public QDialog {
 public:
   explicit NewCellWizard(const QString &workspace_root, QWidget *parent = nullptr);
   NewCellWizardResult result() const { return result_; }
+
   static bool is_valid_package_name(const QString &name);
   static QString default_gripper_rpy_text();
   static QStringList recommended_environment_assets();
+
 private:
   void build_ui();
   void refresh_validation();
   void refresh_summary();
   bool create_scene_scaffold(bool open_in_builder);
   QString scene_name_error() const;
+  QString scene_name_warning() const;
   boost::filesystem::path scenes_root_path() const;
+
   NewCellWizardResult result_;
   QString workspace_root_;
-  QListWidget *steps_{nullptr}; QStackedWidget *stack_{nullptr};
-  QLineEdit *display_name_{nullptr}; QLineEdit *scene_name_{nullptr}; QTextEdit *description_{nullptr}; QComboBox *template_{nullptr}; QLineEdit *output_path_{nullptr}; QLabel *scene_error_{nullptr};
-  QComboBox *robot_{nullptr}; QLabel *robot_warning_{nullptr};
-  QComboBox *ee_{nullptr}; QDoubleSpinBox *ee_roll_{nullptr}; QDoubleSpinBox *ee_pitch_{nullptr}; QDoubleSpinBox *ee_yaw_{nullptr};
-  QCheckBox *env_table_{nullptr}; QCheckBox *env_source_{nullptr}; QCheckBox *env_place_{nullptr}; QCheckBox *env_reject_{nullptr}; QCheckBox *env_conveyor_{nullptr}; QCheckBox *env_camera_{nullptr}; QCheckBox *env_safety_{nullptr}; QLabel *env_preview_{nullptr};
-  QComboBox *task_family_{nullptr}; QLineEdit *pick_source_{nullptr}; QLineEdit *place_target_{nullptr};
-  QLabel *summary_{nullptr}; QLabel *task_warning_{nullptr};
-  QPushButton *back_{nullptr}; QPushButton *next_{nullptr}; QPushButton *create_{nullptr}; QPushButton *create_open_{nullptr};
+
+  QListWidget *steps_{nullptr};
+  QStackedWidget *stack_{nullptr};
+
+  QLineEdit *display_name_{nullptr};
+  QLineEdit *scene_name_{nullptr};
+  QTextEdit *description_{nullptr};
+  QComboBox *template_{nullptr};
+  QLineEdit *output_path_{nullptr};
+  QLabel *scene_error_{nullptr};
+  QLabel *scene_warning_{nullptr};
+
+  QComboBox *robot_{nullptr};
+  QDoubleSpinBox *robot_x_{nullptr};
+  QDoubleSpinBox *robot_y_{nullptr};
+  QDoubleSpinBox *robot_z_{nullptr};
+  QDoubleSpinBox *robot_roll_{nullptr};
+  QDoubleSpinBox *robot_pitch_{nullptr};
+  QDoubleSpinBox *robot_yaw_{nullptr};
+  QLabel *robot_warning_{nullptr};
+
+  QComboBox *ee_{nullptr};
+  QDoubleSpinBox *ee_x_{nullptr};
+  QDoubleSpinBox *ee_y_{nullptr};
+  QDoubleSpinBox *ee_z_{nullptr};
+  QDoubleSpinBox *ee_roll_{nullptr};
+  QDoubleSpinBox *ee_pitch_{nullptr};
+  QDoubleSpinBox *ee_yaw_{nullptr};
+
+  QCheckBox *env_table_{nullptr};
+  QCheckBox *env_source_{nullptr};
+  QCheckBox *env_place_{nullptr};
+  QCheckBox *env_reject_{nullptr};
+  QCheckBox *env_conveyor_{nullptr};
+  QCheckBox *env_camera_{nullptr};
+  QCheckBox *env_safety_{nullptr};
+  QLabel *env_preview_{nullptr};
+
+  QComboBox *task_family_{nullptr};
+  QLineEdit *pick_source_{nullptr};
+  QLineEdit *place_target_{nullptr};
+  QComboBox *grasp_strategy_{nullptr};
+  QDoubleSpinBox *approach_distance_{nullptr};
+  QDoubleSpinBox *retreat_distance_{nullptr};
+  QTextEdit *task_intent_text_{nullptr};
+  QLabel *task_warning_{nullptr};
+
+  QLabel *summary_{nullptr};
+
+  QPushButton *back_{nullptr};
+  QPushButton *next_{nullptr};
+  QPushButton *create_{nullptr};
+  QPushButton *create_open_{nullptr};
 };

--- a/workcell_builder/workcell_builder/test/new_cell_wizard_test.cpp
+++ b/workcell_builder/workcell_builder/test/new_cell_wizard_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include "gui/new_cell_wizard.h"
 
 TEST(NewCellWizard, ScenePackageNameValidation)
@@ -6,6 +7,7 @@ TEST(NewCellWizard, ScenePackageNameValidation)
   EXPECT_TRUE(NewCellWizard::is_valid_package_name("ur5_pick_place"));
   EXPECT_FALSE(NewCellWizard::is_valid_package_name("UR5_bad"));
   EXPECT_FALSE(NewCellWizard::is_valid_package_name("bad-name"));
+  EXPECT_FALSE(NewCellWizard::is_valid_package_name("1bad"));
 }
 
 TEST(NewCellWizard, DefaultGripperRpy)
@@ -19,5 +21,6 @@ TEST(NewCellWizard, RecommendedLayoutDefaults)
   EXPECT_TRUE(items.contains("Work table"));
   EXPECT_TRUE(items.contains("Source bin"));
   EXPECT_TRUE(items.contains("Place fixture"));
-  EXPECT_TRUE(items.contains("RealSense D435i"));
+  EXPECT_TRUE(items.contains("RealSense D435i camera"));
+  EXPECT_TRUE(items.contains("Safety zone"));
 }


### PR DESCRIPTION
### Motivation
- The previous New Cell tab embedded editor-like UI and a broken canvas, making creation unusable and mixing creation with editing responsibilities.  
- The intent is to provide a stable, scaffold-first workflow that is separated from the Scene Builder/editor and enforces safety and validation.  
- Deliver a light-themed Qt-only wizard that guides users through creating a minimal, safe scene scaffold and then optionally opens the Scene Builder for layout editing.

### Description
- Added a simplified six-step Qt dialog `NewCellWizard` and supporting result type, implemented in `workcell_builder/workcell_builder/gui/new_cell_wizard.h` and `workcell_builder/workcell_builder/gui/new_cell_wizard.cpp`, with UI pages: Basics, Robot, End Effector, Environment, Task Intent, and Review.  
- Implemented form fields and validation per requirements including package name regex validation (`^[a-z][a-z0-9_]*$`), inline error/warning for existing output folders, default end-effector RPY `-1.5708, -1.5708, 0`, robot placeholder warnings, and task-bindings warnings for pick/place templates.  
- Replaced heavy editor controls inside the New Cell flow by supplying only checkboxes for environment layout, recommended/clear/preview layout buttons (text summary only), and bottom navigation (`Back`, `Next`, `Create Cell`, `Create and Open`, `Cancel`).  
- Create action produces a minimal safe scaffold (creates `config` dir and `environment.yaml`) with explicit safety metadata (`fake_hardware_first: true`, `real_robot_locked: true`, `runtime_execution_enabled: false`, `scaffold_only: true`) and integrates with the existing `MainWindow::open_new_scene_creation_flow()` handoff to refresh the scene list and optionally open the Scene Builder.

### Testing
- Unit tests were updated/added at `workcell_builder/workcell_builder/test/new_cell_wizard_test.cpp` to cover `is_valid_package_name()`, `default_gripper_rpy_text()`, and `recommended_environment_assets()` behaviors.  
- An attempted build with `colcon build --symlink-install --packages-select workcell_builder` was run in the rollout environment but failed because `colcon` is not available (`colcon: command not found`), so automated tests were not executed here.  
- Manual verification checklist is unchanged and should be run locally (see PR notes), including confirming UI layout, validation behavior, scaffold file creation, and that `Create and Open` hands off to Scene Builder without triggering any robot motion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a085b0360a48331b006fa4661312a56)