### PR TITLE
Harden Workcell Studio canvas YAML parsing and fallback behavior

### DIFF
--- a/workcell_builder/workcell_builder/include/workcell_yaml_utils.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_yaml_utils.hpp
@@ -9,5 +9,11 @@ std::string yaml_scalar_or_empty(const YAML::Node & node);
 std::string yaml_map_value_or_empty(const YAML::Node & node, const char * key);
 std::string yaml_name_from_node(const YAML::Node & node);
 std::string yaml_named_or_scalar(const YAML::Node & node, const char * key);
-}
 
+bool yaml_read_string(const YAML::Node & node, std::string * out);
+bool yaml_read_double(const YAML::Node & node, double * out);
+bool yaml_read_bool(const YAML::Node & node, bool * out);
+
+YAML::Node yaml_map_key(const YAML::Node & node, const char * key);
+YAML::Node yaml_seq_index(const YAML::Node & node, std::size_t index);
+}

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -10,6 +10,23 @@ static bool read_yaml(const fs::path & p, YAML::Node * out){ try{ if(!fs::exists
 WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & scene_dir, const std::string & scene_name)
 {
   WorkcellStudioCanvasModel m; m.scene_name = scene_name; m.status = "WARNINGS";
+  const auto add_warning = [&m](const std::string & context, const std::string & detail) {
+    m.warnings.push_back("layout/workcell_studio_layout.yaml [" + context + "]: " + detail);
+    m.has_warnings = true;
+  };
+  const auto read_string_or_warn = [&add_warning](const YAML::Node & node, const std::string & context, const std::string & fallback) {
+    std::string out;
+    if (yaml_read_string(node, &out)) return out;
+    if (node.IsDefined()) add_warning(context, "expected scalar string; using default");
+    return fallback;
+  };
+  const auto read_double_or_warn = [&add_warning](const YAML::Node & node, const std::string & context, double fallback) {
+    double out = fallback;
+    if (yaml_read_double(node, &out)) return out;
+    if (node.IsDefined()) add_warning(context, "expected scalar number; using default");
+    return fallback;
+  };
+
   YAML::Node env, manifest, task, layout;
   const bool env_ok = read_yaml(scene_dir / "environment.yaml", &env);
   const bool manifest_ok = read_yaml(scene_dir / "scene_manifest.yaml", &manifest);
@@ -26,10 +43,10 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   if (m.robot_summary.empty()) m.robot_summary = "Robot";
   m.tool_summary = env_ok ? yaml_named_or_scalar(env["end_effector"], "name") : "";
   if (m.tool_summary.empty()) m.tool_summary = "Tool";
-  m.pick_source = task_ok && task["pick_source"] ? task["pick_source"].as<std::string>() : "Task intent missing";
-  m.grasp_strategy = task_ok && task["grasp_strategy"] ? task["grasp_strategy"].as<std::string>() : "Generate task recipe to populate this panel";
-  m.place_target = task_ok && task["place_target"] ? task["place_target"].as<std::string>() : "Task intent missing";
-  m.release_strategy = task_ok && task["release_strategy"] ? task["release_strategy"].as<std::string>() : "Generate task recipe to populate this panel";
+  m.pick_source = task_ok ? read_string_or_warn(yaml_map_key(task, "pick_source"), "task_recipe.pick_source", "Task intent missing") : "Task intent missing";
+  m.grasp_strategy = task_ok ? read_string_or_warn(yaml_map_key(task, "grasp_strategy"), "task_recipe.grasp_strategy", "Generate task recipe to populate this panel") : "Generate task recipe to populate this panel";
+  m.place_target = task_ok ? read_string_or_warn(yaml_map_key(task, "place_target"), "task_recipe.place_target", "Task intent missing") : "Task intent missing";
+  m.release_strategy = task_ok ? read_string_or_warn(yaml_map_key(task, "release_strategy"), "task_recipe.release_strategy", "Generate task recipe to populate this panel") : "Generate task recipe to populate this panel";
 
   m.items.push_back({"robot_base","robot_base","robot","Robot Base","environment.yaml",0,0,0,0,0,0,0.35,0.35,0.35,0,true,{}});
   m.items.push_back({"robot_reach","reach","reach","Robot Reach","environment.yaml",0,0,0,0,0,0,0,0,0,1.2,true,{}});
@@ -42,47 +59,83 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   m.items.push_back({"object_a","object","object","Object","environment.yaml",0.6,0.1,0,0,0,0,0.08,0.08,0.08,0,false,{}});
   m.items.push_back({"home_pose","safety","safety/home","config/workcell_builder_task_intent.yaml","config/workcell_builder_task_intent.yaml",-0.4,0.5,0,0,0,0,0.14,0.14,0.14,0,true,{}});
 
-  if (layout_ok && layout["schema_version"] && layout["schema_version"].as<std::string>() == "workcell_studio_layout/v1" && layout["items"] && layout["items"].IsSequence()) {
-    for (const auto & node : layout["items"]) {
-      if (!node["id"]) continue;
-      const auto id = node["id"].as<std::string>();
+  const std::string schema_version = read_string_or_warn(yaml_map_key(layout, "schema_version"), "schema_version", "");
+  YAML::Node layout_items = yaml_map_key(layout, "items");
+  if (layout_ok && schema_version == "workcell_studio_layout/v1") {
+    if (!layout_items.IsDefined() || !layout_items.IsSequence()) {
+      if (layout_items.IsDefined()) add_warning("items", "expected sequence; skipping malformed items");
+    } else {
+    for (const auto & node : layout_items) {
+      if (!node.IsMap()) { add_warning("items[]", "expected map item; skipping"); continue; }
+      const auto id = read_string_or_warn(yaml_map_key(node, "id"), "items[].id", "");
+      if (id.empty()) continue;
       bool matched_existing = false;
       for (auto & item : m.items) {
         if (item.id == id) {
           matched_existing = true;
-          if (node["pose"]) {
-            auto p = node["pose"];
-            if (p["xyz"] && p["xyz"].IsSequence() && p["xyz"].size() >= 3) { item.x = p["xyz"][0].as<double>(); item.y = p["xyz"][1].as<double>(); item.z = p["xyz"][2].as<double>(); }
-            if (p["rpy"] && p["rpy"].IsSequence() && p["rpy"].size() >= 3) { item.roll = p["rpy"][0].as<double>(); item.pitch = p["rpy"][1].as<double>(); item.yaw = p["rpy"][2].as<double>(); }
+          YAML::Node pose = yaml_map_key(node, "pose");
+          if (pose.IsDefined() && pose.IsMap()) {
+            YAML::Node xyz = yaml_map_key(pose, "xyz");
+            if (xyz.IsDefined() && xyz.IsSequence()) {
+              item.x = read_double_or_warn(yaml_seq_index(xyz, 0), "items[].pose.xyz[0]", item.x);
+              item.y = read_double_or_warn(yaml_seq_index(xyz, 1), "items[].pose.xyz[1]", item.y);
+              item.z = read_double_or_warn(yaml_seq_index(xyz, 2), "items[].pose.xyz[2]", item.z);
+            } else if (xyz.IsDefined()) add_warning("items[].pose.xyz", "expected sequence; using defaults");
+            YAML::Node rpy = yaml_map_key(pose, "rpy");
+            if (rpy.IsDefined() && rpy.IsSequence()) {
+              item.roll = read_double_or_warn(yaml_seq_index(rpy, 0), "items[].pose.rpy[0]", item.roll);
+              item.pitch = read_double_or_warn(yaml_seq_index(rpy, 1), "items[].pose.rpy[1]", item.pitch);
+              item.yaw = read_double_or_warn(yaml_seq_index(rpy, 2), "items[].pose.rpy[2]", item.yaw);
+            } else if (rpy.IsDefined()) add_warning("items[].pose.rpy", "expected sequence; using defaults");
+          } else if (pose.IsDefined()) {
+            add_warning("items[].pose", "expected map; using defaults");
           }
         }
       }
       if (!matched_existing) {
         WorkcellStudioCanvasItem extra;
         extra.id = id;
-        extra.type = node["type"] ? node["type"].as<std::string>() : "object";
-        extra.role = node["role"] ? node["role"].as<std::string>() : "preview";
-        const auto category = node["category"] ? node["category"].as<std::string>() : "Custom / Imported";
+        extra.type = read_string_or_warn(yaml_map_key(node, "type"), "items[].type", "object");
+        extra.role = read_string_or_warn(yaml_map_key(node, "role"), "items[].role", "preview");
+        const auto category = read_string_or_warn(yaml_map_key(node, "category"), "items[].category", "Custom / Imported");
         if (category == "Pick/Place Zones") extra.type = "zone";
-        extra.label = node["display_name"] ? node["display_name"].as<std::string>() : id;
-        extra.source_file = node["source_path"] ? node["source_path"].as<std::string>() : "layout/workcell_studio_layout.yaml";
-        if (node["pose"]) {
-          auto p = node["pose"];
-          if (p["xyz"] && p["xyz"].IsSequence() && p["xyz"].size() >= 3) { extra.x = p["xyz"][0].as<double>(); extra.y = p["xyz"][1].as<double>(); extra.z = p["xyz"][2].as<double>(); }
-          if (p["rpy"] && p["rpy"].IsSequence() && p["rpy"].size() >= 3) { extra.roll = p["rpy"][0].as<double>(); extra.pitch = p["rpy"][1].as<double>(); extra.yaw = p["rpy"][2].as<double>(); }
-        }
-        if (node["size"]) {
-          if (node["size"].IsMap()) {
-            if (node["size"]["width"]) extra.width = node["size"]["width"].as<double>();
-            if (node["size"]["depth"]) extra.depth = node["size"]["depth"].as<double>();
-            if (node["size"]["height"]) extra.height = node["size"]["height"].as<double>();
-          } else if (node["size"].IsSequence() && node["size"].size() >= 3) {
-            extra.width = node["size"][0].as<double>(); extra.depth = node["size"][1].as<double>(); extra.height = node["size"][2].as<double>();
+        extra.label = read_string_or_warn(yaml_map_key(node, "display_name"), "items[].display_name", id);
+        extra.source_file = read_string_or_warn(yaml_map_key(node, "source_path"), "items[].source_path", "layout/workcell_studio_layout.yaml");
+        YAML::Node pose = yaml_map_key(node, "pose");
+        if (pose.IsDefined() && pose.IsMap()) {
+          YAML::Node xyz = yaml_map_key(pose, "xyz");
+          if (xyz.IsDefined() && xyz.IsSequence()) {
+            extra.x = read_double_or_warn(yaml_seq_index(xyz, 0), "items[].pose.xyz[0]", extra.x);
+            extra.y = read_double_or_warn(yaml_seq_index(xyz, 1), "items[].pose.xyz[1]", extra.y);
+            extra.z = read_double_or_warn(yaml_seq_index(xyz, 2), "items[].pose.xyz[2]", extra.z);
+          } else if (xyz.IsDefined()) add_warning("items[].pose.xyz", "expected sequence; using defaults");
+          YAML::Node rpy = yaml_map_key(pose, "rpy");
+          if (rpy.IsDefined() && rpy.IsSequence()) {
+            extra.roll = read_double_or_warn(yaml_seq_index(rpy, 0), "items[].pose.rpy[0]", extra.roll);
+            extra.pitch = read_double_or_warn(yaml_seq_index(rpy, 1), "items[].pose.rpy[1]", extra.pitch);
+            extra.yaw = read_double_or_warn(yaml_seq_index(rpy, 2), "items[].pose.rpy[2]", extra.yaw);
+          } else if (rpy.IsDefined()) add_warning("items[].pose.rpy", "expected sequence; using defaults");
+        } else if (pose.IsDefined()) add_warning("items[].pose", "expected map; using defaults");
+        YAML::Node size = yaml_map_key(node, "size");
+        if (size.IsDefined()) {
+          if (size.IsMap()) {
+            extra.width = read_double_or_warn(yaml_map_key(size, "width"), "items[].size.width", extra.width);
+            extra.depth = read_double_or_warn(yaml_map_key(size, "depth"), "items[].size.depth", extra.depth);
+            extra.height = read_double_or_warn(yaml_map_key(size, "height"), "items[].size.height", extra.height);
+          } else if (size.IsSequence()) {
+            extra.width = read_double_or_warn(yaml_seq_index(size, 0), "items[].size[0]", extra.width);
+            extra.depth = read_double_or_warn(yaml_seq_index(size, 1), "items[].size[1]", extra.depth);
+            extra.height = read_double_or_warn(yaml_seq_index(size, 2), "items[].size[2]", extra.height);
+          } else {
+            add_warning("items[].size", "expected map or sequence; using defaults");
           }
         }
-        extra.locked = node["locked"] ? node["locked"].as<bool>() : false;
+        bool locked = false;
+        if (yaml_read_bool(yaml_map_key(node, "locked"), &locked)) extra.locked = locked;
+        else if (yaml_map_key(node, "locked").IsDefined()) add_warning("items[].locked", "expected scalar bool; using default");
         m.items.push_back(extra);
       }
+    }
     }
   }
   if (!m.warnings.empty()) { m.has_warnings = true; m.status = "WARNINGS"; { WorkcellStudioCanvasItem w; w.id="warning"; w.type="warning"; w.role="warning"; w.label="warning"; w.source_file="environment.yaml"; w.x=-1.2; w.y=1.2; w.width=0.1; w.depth=0.1; w.height=0.0; w.warnings=m.warnings; m.items.push_back(w); } }

--- a/workcell_builder/workcell_builder/src_workcell_yaml_utils.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_yaml_utils.cpp
@@ -34,5 +34,34 @@ std::string yaml_named_or_scalar(const YAML::Node & node, const char * key)
   }
   return "";
 }
+
+bool yaml_read_string(const YAML::Node & node, std::string * out)
+{
+  if (out == nullptr || !node.IsDefined() || !node.IsScalar()) return false;
+  try { *out = node.as<std::string>(); return true; } catch (...) { return false; }
 }
 
+bool yaml_read_double(const YAML::Node & node, double * out)
+{
+  if (out == nullptr || !node.IsDefined() || !node.IsScalar()) return false;
+  try { *out = node.as<double>(); return true; } catch (...) { return false; }
+}
+
+bool yaml_read_bool(const YAML::Node & node, bool * out)
+{
+  if (out == nullptr || !node.IsDefined() || !node.IsScalar()) return false;
+  try { *out = node.as<bool>(); return true; } catch (...) { return false; }
+}
+
+YAML::Node yaml_map_key(const YAML::Node & node, const char * key)
+{
+  if (!node.IsDefined() || !node.IsMap() || key == nullptr) return YAML::Node();
+  return node[key];
+}
+
+YAML::Node yaml_seq_index(const YAML::Node & node, std::size_t index)
+{
+  if (!node.IsDefined() || !node.IsSequence() || index >= node.size()) return YAML::Node();
+  return node[index];
+}
+}


### PR DESCRIPTION
### Motivation
- Prevent exceptions and crashes when reading layout/task YAML by avoiding unchecked `Node::as<...>()` and direct indexing. 
- Support both legacy and new metadata shapes (scalar, map, sequence) and continue building a usable model when input is malformed. 
- Surface actionable warnings that include file and parsing context so issues can be diagnosed without aborting model construction.

### Description
- Add safe YAML helpers in `workcell_yaml_utils`: `yaml_read_string`, `yaml_read_double`, `yaml_read_bool`, `yaml_map_key`, and `yaml_seq_index` for guarded scalar/map/sequence access. 
- Refactor `build_workcell_studio_canvas_model(...)` to use those helpers for task fields (`pick_source`, `grasp_strategy`, `place_target`, `release_strategy`) and layout parsing (`schema_version`, `items`, `items[]`).
- Harden nested parsing for `pose.xyz`/`pose.rpy`, `size` (map `width/depth/height` or sequence form), and `locked` bool with shape checks, bounds checks, numeric compatibility checks, and non-throwing fallbacks to defaults. 
- Emit warnings that include `layout/workcell_studio_layout.yaml` and a parse-context key (e.g., `items[].pose.xyz`, `task_recipe.pick_source`, `items[].size.width`) and ensure `m.has_warnings = true` while continuing model construction.

### Testing
- Performed a local syntax-only compile attempt with `g++ -fsyntax-only -std=c++17 -Iworkcell_builder/workcell_builder/include -I/usr/include/yaml-cpp workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp workcell_builder/workcell_builder/src_workcell_yaml_utils.cpp`, which failed in this container due to missing system headers/libraries (Boost/YAML-CPP include paths). 
- No unit tests were executed in this environment; the changes were committed (`Harden canvas model YAML parsing with safe helpers and warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0869a13940833184769757122fda54)