### PR TITLE
Harden scene browser environment.yaml parsing

### DIFF
--- a/workcell_builder/workcell_builder/src_workcell_studio_scene_browser.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_scene_browser.cpp
@@ -5,6 +5,7 @@
 
 #include <set>
 #include <cstdlib>
+#include <iostream>
 
 namespace fs = boost::filesystem;
 
@@ -54,15 +55,36 @@ std::string compute_status(const WorkcellStudioSceneInfo & s)
 
 void try_parse_env(WorkcellStudioSceneInfo * s)
 {
+  if (s == nullptr) return;
+  const fs::path environment_yaml = s->scene_dir / "environment.yaml";
+  std::cerr << "[workcell_builder] context=scene_browser/environment_yaml path="
+            << environment_yaml.string() << std::endl;
+
   try {
-    YAML::Node n = YAML::LoadFile((s->scene_dir / "environment.yaml").string());
-    const std::string robot = yaml_named_or_scalar(n["robot"], "name");
-    const std::string gripper = yaml_named_or_scalar(n["end_effector"], "name");
+    YAML::Node n = YAML::LoadFile(environment_yaml.string());
+
+    const std::string robot = yaml_name_from_node(n["robot"]);
+
+    std::string gripper = yaml_name_from_node(n["end_effector"]);
+    if (gripper.empty()) {
+      // Legacy alias support.
+      gripper = yaml_name_from_node(n["gripper"]);
+    }
+
+    std::size_t object_count = 0U;
+    const YAML::Node object = n["object"];
+    if (object && object.IsSequence()) object_count = object.size();
+    if (object_count == 0U) {
+      const YAML::Node objects = n["objects"];
+      if (objects && objects.IsSequence()) object_count = objects.size();
+    }
+
     if (!robot.empty()) s->robot_summary = robot;
     if (!gripper.empty()) s->gripper_summary = gripper;
-    if (n["object"] && n["object"].IsSequence()) s->object_count = n["object"].size();
-  } catch (const std::exception &) {
-    s->parse_warning = "Could not parse environment.yaml";
+    s->object_count = object_count;
+  } catch (const std::exception & e) {
+    s->parse_warning = std::string("Could not parse environment.yaml: ") + e.what() +
+      " (file: " + environment_yaml.string() + ")";
   }
 }
 }


### PR DESCRIPTION
### Motivation
- Prevent crashes and improve observability when parsing per-scene `environment.yaml` files by making parsing defensive and logging the file being parsed. 
- Support legacy and variant YAML shapes for robot/end-effector/object metadata so scene discovery remains useful even with older or slightly malformed scene metadata.

### Description
- Added pre-parse logging that emits the full `environment.yaml` path with context `scene_browser/environment_yaml` using `std::cerr` in `try_parse_env` in `src_workcell_studio_scene_browser.cpp`.
- Made `try_parse_env` null-safe and computed `environment_yaml` once, then used `YAML::LoadFile(environment_yaml.string())` to load the file.
- Replaced direct scalar reads with safe helpers: read robot via `yaml_name_from_node(n["robot"])`, read end-effector via `yaml_name_from_node(n["end_effector"])` with a legacy fallback to `n["gripper"]`, and compute `object_count` from either `object` or `objects` sequence when present.
- Preserved crash-proof behavior by avoiding unchecked `.as<T>()` calls here and by catching `std::exception` and writing the exception text plus filename into `s->parse_warning` on failure.

### Testing
- Ran `pytest -q tests/test_workcell_studio_scene_browser.py`, which passed (`2 passed`).
- Scene discovery continued to enumerate scenes when a single scene's metadata was malformed during tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0869d1b16c83318e50c33eae923174)