### PR TITLE
Update NewCellWizard tests to family/model robot API

### DIFF
--- a/workcell_builder/workcell_builder/test/new_cell_wizard_test.cpp
+++ b/workcell_builder/workcell_builder/test/new_cell_wizard_test.cpp
@@ -27,9 +27,38 @@ TEST(NewCellWizard, RecommendedLayoutDefaults)
 
 TEST(NewCellWizard, UrDefaults)
 {
-  EXPECT_EQ(NewCellWizard::default_robot_base_link("UR5").toStdString(), "base_link");
-  EXPECT_EQ(NewCellWizard::default_robot_tip_link("UR5").toStdString(), "ee_link");
-  EXPECT_EQ(NewCellWizard::default_robot_planning_group("UR5").toStdString(), "manipulator");
+  const QString family = "Universal Robots / UR";
+
+  EXPECT_EQ(NewCellWizard::default_robot_base_link(family, "UR5").toStdString(), "base_link");
+  EXPECT_EQ(NewCellWizard::default_robot_tip_link(family, "UR5").toStdString(), "ee_link");
+  EXPECT_EQ(NewCellWizard::default_robot_planning_group(family, "UR5").toStdString(), "manipulator");
+
+  EXPECT_EQ(NewCellWizard::default_robot_base_link(family, "UR3").toStdString(), "base_link");
+  EXPECT_EQ(NewCellWizard::default_robot_tip_link(family, "UR3").toStdString(), "ee_link");
+  EXPECT_EQ(NewCellWizard::default_robot_planning_group(family, "UR3").toStdString(), "manipulator");
+
+  EXPECT_EQ(NewCellWizard::default_robot_base_link(family, "UR10").toStdString(), "base_link");
+  EXPECT_EQ(NewCellWizard::default_robot_tip_link(family, "UR10").toStdString(), "ee_link");
+  EXPECT_EQ(NewCellWizard::default_robot_planning_group(family, "UR10").toStdString(), "manipulator");
+}
+
+TEST(NewCellWizard, FrankaDefaults)
+{
+  const QString family = "Franka / Panda";
+
+  EXPECT_EQ(NewCellWizard::default_robot_base_link(family, "Panda").toStdString(), "panda_link0");
+  EXPECT_EQ(NewCellWizard::default_robot_tip_link(family, "Panda").toStdString(), "panda_hand");
+  EXPECT_EQ(NewCellWizard::default_robot_planning_group(family, "Panda").toStdString(), "panda_arm");
+}
+
+TEST(NewCellWizard, PlaceholderDefaults)
+{
+  const QString family = "Delta";
+  const QString model = "delta_placeholder";
+
+  EXPECT_EQ(NewCellWizard::default_robot_base_link(family, model).toStdString(), "base_link");
+  EXPECT_EQ(NewCellWizard::default_robot_tip_link(family, model).toStdString(), "tool0_placeholder");
+  EXPECT_EQ(NewCellWizard::default_robot_planning_group(family, model).toStdString(), "preview_group");
 }
 
 TEST(NewCellWizard, RobotiqDefaults)


### PR DESCRIPTION
### Motivation
- The NewCellWizard API changed to require both `robot_family` and `robot_model` parameters for robot defaults, which broke existing one-argument tests and needs test updates to reflect the new selection model.

### Description
- Updated `workcell_builder/workcell_builder/test/new_cell_wizard_test.cpp` to replace legacy one-argument calls with two-argument calls for `default_robot_base_link`, `default_robot_tip_link`, and `default_robot_planning_group`.
- Switched UR tests to use `const QString family = "Universal Robots / UR"` and added checks for `UR5`, `UR3`, and `UR10` models to keep coverage of UR defaults.
- Added explicit family/model tests for `Franka / Panda` + `Panda` and `Delta` + `delta_placeholder` to validate panda defaults and scaffold-safe placeholder defaults.
- No production code behavior was modified; these are test-only changes to match the current wizard API.

### Testing
- Attempted `colcon build --symlink-install --packages-select workcell_builder`, but the build could not be run in this environment because `colcon` is not installed (`colcon: command not found`).
- Verified that `new_cell_wizard.h` exposes the new two-argument signatures and that `new_cell_wizard.cpp` contains the family/model logic used by the updated tests, and confirmed the test source file was updated at `workcell_builder/workcell_builder/test/new_cell_wizard_test.cpp`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0888203f308331bc3baaeb5619a693)