### PR TITLE
Add deterministic tests for wizard defaults, task intent, perception messaging, and layout metadata

### DIFF
--- a/workcell_builder/workcell_builder/test/new_cell_wizard_test.cpp
+++ b/workcell_builder/workcell_builder/test/new_cell_wizard_test.cpp
@@ -61,8 +61,38 @@ TEST(NewCellWizard, PlaceholderDefaults)
   EXPECT_EQ(NewCellWizard::default_robot_planning_group(family, model).toStdString(), "preview_group");
 }
 
+TEST(NewCellWizard, RobotFamilyModelMappingsAreDeterministic)
+{
+  const QString ur_family = "Universal Robots / UR";
+  const QString panda_family = "Franka / Panda";
+
+  EXPECT_EQ(NewCellWizard::default_robot_base_link(ur_family, "UR10").toStdString(), "base_link");
+  EXPECT_EQ(NewCellWizard::default_robot_tip_link(ur_family, "UR10").toStdString(), "ee_link");
+  EXPECT_EQ(NewCellWizard::default_robot_planning_group(ur_family, "UR10").toStdString(), "manipulator");
+
+  EXPECT_EQ(NewCellWizard::default_robot_base_link(panda_family, "FR3").toStdString(), "panda_link0");
+  EXPECT_EQ(NewCellWizard::default_robot_tip_link(panda_family, "FR3").toStdString(), "panda_hand");
+  EXPECT_EQ(NewCellWizard::default_robot_planning_group(panda_family, "FR3").toStdString(), "panda_arm");
+
+  EXPECT_EQ(NewCellWizard::default_robot_tip_link("Custom / Placeholder", "my_placeholder_robot").toStdString(), "tool0_placeholder");
+  EXPECT_EQ(NewCellWizard::default_robot_planning_group("Custom / Placeholder", "my_placeholder_robot").toStdString(), "preview_group");
+}
+
 TEST(NewCellWizard, RobotiqDefaults)
 {
   EXPECT_EQ(NewCellWizard::default_end_effector_attach_link("robotiq_85").toStdString(), "gripper_base_link");
   EXPECT_EQ(NewCellWizard::default_end_effector_tcp_link("robotiq_85").toStdString(), "ee_palm");
+}
+
+TEST(NewCellWizard, SuctionDefaults)
+{
+  EXPECT_EQ(NewCellWizard::default_end_effector_attach_link("single_suction").toStdString(), "tool_mount_link");
+  EXPECT_EQ(NewCellWizard::default_end_effector_tcp_link("single_suction").toStdString(), "tcp_link");
+  EXPECT_EQ(NewCellWizard::default_end_effector_type("single_suction").toStdString(), "suction");
+}
+
+TEST(NewCellWizard, ScaffoldReadinessClassification)
+{
+  EXPECT_EQ(NewCellWizard::default_end_effector_family_readiness("Custom / Placeholder").toStdString(), "SCAFFOLD");
+  EXPECT_EQ(NewCellWizard::default_end_effector_family_readiness("Robotiq").toStdString(), "READY");
 }

--- a/workcell_builder/workcell_builder/test/task_intent_readiness_test.cpp
+++ b/workcell_builder/workcell_builder/test/task_intent_readiness_test.cpp
@@ -17,3 +17,23 @@ TEST(TaskIntentReadiness, MissingPlaceZone) { TaskIntentPreview p; p.source_dete
 TEST(TaskIntentReadiness, ConveyorNotReadyWarn) { TaskIntentPreview p; p.source_detection="det"; p.pick_zone="p"; p.place_zone="pl"; p.robot="ur5"; p.end_effector="ee"; p.pick_ready=false; auto r=validate_task_intent_preview(p); EXPECT_EQ(r.status,"WARN"); }
 TEST(TaskIntentReadiness, StaticPickReady) { DetectionAdapterResult m; m.detection_id="det"; m.detection_zone="pick_zone_1"; std::vector<WorkZone> z{{"pick_zone_1","robot_pick"},{"place_zone_1","robot_place"}}; auto p=build_task_intent_preview("ur5","ee",z,{},m); EXPECT_TRUE(p.pick_ready); }
 TEST(TaskIntentReadiness, SerializationFields) { TaskIntentPreview p; p.source_detection="det"; p.pick_zone="pz"; p.place_zone="plz"; auto r=validate_task_intent_preview(p,false); auto y=serialize_task_intent_preview_yaml(p,r); EXPECT_NE(y.find("runtime_mode"),std::string::npos); EXPECT_NE(y.find("robot_motion_commanded"),std::string::npos); EXPECT_NE(y.find("moveit_plan_service_called"),std::string::npos); EXPECT_NE(y.find("gripper_command_sent"),std::string::npos); }
+
+TEST(TaskIntentReadiness, GeneratesPlaceTargetFromSemanticRobotPlaceRole) {
+  DetectionAdapterResult m; m.detection_id="det_001"; m.class_label="widget"; m.pick_zone="pick_zone_1";
+  std::vector<WorkZone> z{{"pick_zone_1","robot_pick"},{"place_zone_fixture","robot_place"}};
+  auto p=build_task_intent_preview("ur5","robotiq_2f_85",z,{},m);
+  EXPECT_EQ(p.place_zone,"place_zone_fixture");
+}
+
+TEST(TaskIntentReadiness, DeterministicPreviewWarningsAndInfosExactStrings) {
+  TaskIntentPreview p; p.source_detection="det_001"; p.pick_zone="pick_zone_1"; p.place_zone="place_zone_1"; p.robot="ur5"; p.end_effector="robotiq_2f_85"; p.pick_ready=false;
+  auto r=validate_task_intent_preview(p,true);
+  ASSERT_GE(r.warnings.size(),4u);
+  EXPECT_EQ(r.warnings[0],"WARN: pick_ready is false because object has not reached pick zone yet");
+  EXPECT_EQ(r.warnings[1],"WARN: preview-only, no planning performed");
+  EXPECT_EQ(r.warnings[2],"WARN: no approach/retreat offsets configured");
+  EXPECT_EQ(r.warnings[3],"WARN: no grasp strategy configured");
+  ASSERT_GE(r.infos.size(),5u);
+  EXPECT_EQ(r.infos[0],"INFO: no robot motion commanded");
+  EXPECT_EQ(r.infos[1],"INFO: no MoveIt call");
+}

--- a/workcell_builder/workcell_builder/test/workcell_scene_status_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_scene_status_test.cpp
@@ -70,3 +70,44 @@ TEST(WorkcellSceneStatus, ScalarRobotAndMalformedYamlDoNotCrash)
   EXPECT_TRUE(report.environment_yaml_ok);
   EXPECT_FALSE(report.items.empty());
 }
+
+TEST(WorkcellSceneStatus, SnapshotMissingShowsSingleInfoWithoutContradiction)
+{
+  fs::path root = fs::temp_directory_path() / "wc_status_snapshot_info";
+  fs::remove_all(root);
+  fs::create_directories(root / "scenes" / "demo" / "launch");
+  std::ofstream(root / "scenes" / "demo" / "environment.yaml") << "robot:\n  name: ur5\n";
+  std::ofstream(root / "scenes" / "demo" / "package.xml") << "<package/>\n";
+  std::ofstream(root / "scenes" / "demo" / "CMakeLists.txt") << "cmake_minimum_required(VERSION 3.5)\n";
+  std::ofstream(root / "scenes" / "demo" / "launch" / "demo.launch.py") << "# fake\n";
+
+  const auto report = workcell_builder::inspect_scene_status(root, root / "scenes", root / "assets", "demo");
+  int snapshot_items = 0;
+  for (const auto & item : report.items) {
+    if (item.name == "Detection snapshot available") {
+      snapshot_items++;
+      EXPECT_EQ(item.status, "INFO");
+      EXPECT_EQ(item.message, "EPD-compatible offline metadata");
+    }
+  }
+  EXPECT_EQ(snapshot_items, 1);
+}
+
+TEST(WorkcellSceneStatus, GroupedPerceptionCameraAndPreviewLinesPresent)
+{
+  fs::path root = fs::temp_directory_path() / "wc_status_grouped_lines";
+  fs::remove_all(root);
+  fs::create_directories(root / "scenes" / "demo" / "launch");
+  std::ofstream(root / "scenes" / "demo" / "environment.yaml") << "robot:\n  name: ur5\ncameras:\n  - name: camera_01\n    package: realsense2_description\n";
+  std::ofstream(root / "scenes" / "demo" / "package.xml") << "<package/>\n";
+  std::ofstream(root / "scenes" / "demo" / "CMakeLists.txt") << "cmake_minimum_required(VERSION 3.5)\n";
+  std::ofstream(root / "scenes" / "demo" / "launch" / "demo.launch.py") << "# fake\n";
+
+  const auto report = workcell_builder::inspect_scene_status(root, root / "scenes", root / "assets", "demo");
+  auto has_line = [&](const std::string &name) {
+    return std::any_of(report.items.begin(), report.items.end(), [&](const auto &item) { return item.name == name; });
+  };
+  EXPECT_TRUE(has_line("Detection mapping available"));
+  EXPECT_TRUE(has_line("Camera configured"));
+  EXPECT_TRUE(has_line("Task intent preview"));
+}

--- a/workcell_builder/workcell_builder/test/workcell_studio_layout_editor_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_studio_layout_editor_test.cpp
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+#include <boost/filesystem.hpp>
+#include <fstream>
+
+#include "workcell_studio_layout_editor.hpp"
+
+namespace fs = boost::filesystem;
+
+TEST(WorkcellStudioLayoutEditor, WritesRequiredMetadataFieldsForBackwardCompatibility)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_layout_editor_defaults";
+  fs::remove_all(root);
+
+  const auto r = workcell_builder::persist_workcell_studio_layout(root, "items: []\n");
+  EXPECT_FALSE(r.warnings.empty());
+
+  const fs::path out = root / "layout" / "workcell_studio_layout.yaml";
+  ASSERT_TRUE(fs::exists(out));
+
+  std::ifstream in(out.string());
+  const std::string text((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+  EXPECT_NE(text.find("schema_version: workcell_studio_layout/v1"), std::string::npos);
+  EXPECT_NE(text.find("saved_at_utc: 1970-01-01T00:00:00Z"), std::string::npos);
+  EXPECT_NE(text.find("layout_changed_since_acceptance: true"), std::string::npos);
+  EXPECT_NE(text.find("layout_stale_label: Layout changed since last acceptance"), std::string::npos);
+  EXPECT_NE(text.find("layout_stale_action: Run acceptance again"), std::string::npos);
+}
+
+TEST(WorkcellStudioLayoutEditor, PreservesProvidedSchemaVersionAndSavedAt)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_layout_editor_preserve";
+  fs::remove_all(root);
+
+  const std::string yaml = "schema_version: workcell_studio_layout/v9\nsaved_at_utc: 2026-05-16T00:00:00Z\nitems: []\n";
+  workcell_builder::persist_workcell_studio_layout(root, yaml);
+
+  const fs::path out = root / "layout" / "workcell_studio_layout.yaml";
+  std::ifstream in(out.string());
+  const std::string text((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+  EXPECT_NE(text.find("schema_version: workcell_studio_layout/v9"), std::string::npos);
+  EXPECT_NE(text.find("saved_at_utc: 2026-05-16T00:00:00Z"), std::string::npos);
+}


### PR DESCRIPTION
### Motivation
- Provide deterministic unit coverage for UI defaults and mappings so robot/tool defaults are stable and well-specified.
- Validate perception messaging and scene-status summarization to avoid contradictory or missing user-facing lines.
- Ensure `workcell_studio` layout serialization is backward-compatible by injecting or preserving required metadata fields.

### Description
- Added deterministic wizard default tests in `test/new_cell_wizard_test.cpp` that assert robot family/model mappings and defaults for UR, Panda, placeholder models, plus tool defaults for Robotiq and suction and scaffold readiness classification via `NewCellWizard` helpers.
- Extended `test/task_intent_readiness_test.cpp` with tests that verify place-target selection from semantic `robot_place` roles and assert exact preview warning/info strings produced by `validate_task_intent_preview`.
- Extended `test/workcell_scene_status_test.cpp` with tests asserting that a missing detection snapshot yields a single non-contradictory `Detection snapshot available` info line and that grouped perception/camera/task-preview lines appear in the scene status items from `inspect_scene_status`.
- Added `test/workcell_studio_layout_editor_test.cpp` which verifies `persist_workcell_studio_layout` writes default compatibility fields (`schema_version`, `saved_at_utc`, `layout_changed_since_acceptance`, `layout_stale_label`, `layout_stale_action`) and preserves provided `schema_version` and `saved_at_utc` when present.

### Testing
- Added unit tests described above (files: `new_cell_wizard_test.cpp`, `task_intent_readiness_test.cpp`, `workcell_scene_status_test.cpp`, `workcell_studio_layout_editor_test.cpp`).
- Attempted to run the changed suites via `colcon test --packages-select workcell_builder --ctest-args -R "new_cell_wizard_test|task_intent_readiness_test|workcell_scene_status_test|workcell_studio_layout_editor_test"`, but the run failed due to the test environment missing `colcon` (`/bin/bash: colcon: command not found`).
- No automated test failures from within this environment could be observed because the test runner toolchain was not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088a2088988331a829577e8fcf0f97)