### PR TITLE
Initialize WorkZone in tests and remove unused preview variable

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -2925,7 +2925,6 @@ void SceneSelect::refresh_preview_status()
     {"Bins", true}, {"Conveyors", true}, {"Cameras", true}, {"Pick/place zones", true},
     {"Camera ROI/FOV", true}, {"Warnings/blockers", true}, {"Labels", true}};
   static std::string selected_item_id;
-  static bool unsaved_layout_edits = false;
   const int idx = ui->scene_list->currentIndex();
   if (idx < 0 || idx >= static_cast<int>(workcell.scene_vector.size())) {
     auto * empty_scene = new QGraphicsScene(ui->visual_layout_canvas);
@@ -2972,7 +2971,6 @@ void SceneSelect::refresh_preview_status()
     selected_item_id = i->data(3).toString().toStdString();
     selected_canvas_item_id_ = selected_item_id;
     selected_canvas_item_type_ = i->data(1).toString().toStdString();
-    unsaved_layout_edits = true;
     ui->inspector_help->setText(QString("zone_inspector_token id=%1 name=%2 type=%3 | %4 | layout_unsaved=true | rerun zone validation")
       .arg(i->data(3).toString(), i->data(0).toString(), i->data(1).toString(), i->data(2).toString()));
   });

--- a/workcell_builder/workcell_builder/test/task_intent_readiness_test.cpp
+++ b/workcell_builder/workcell_builder/test/task_intent_readiness_test.cpp
@@ -3,9 +3,29 @@
 
 using namespace workcell_builder;
 
+namespace {
+WorkZone make_zone(
+  const QString & id, const QString & type,
+  const QString & linked_camera = QString(), const QString & linked_robot = QString(),
+  const QString & destination = QString(), const QString & purpose = QString())
+{
+  WorkZone zone{};
+  zone.id = id;
+  zone.type = type;
+  zone.linked_camera = linked_camera;
+  zone.linked_robot = linked_robot;
+  zone.destination = destination;
+  zone.purpose = purpose;
+  return zone;
+}
+}  // namespace
+
 TEST(TaskIntentReadiness, BuildValid) {
   DetectionAdapterResult m; m.detection_id="det_001"; m.class_label="box"; m.detection_zone="detection_zone_1"; m.pick_zone="pick_zone_1"; m.time_to_pick_s=1.0;
-  std::vector<WorkZone> z{{"detection_zone_1","camera_detection"},{"pick_zone_1","robot_pick"},{"place_zone_1","robot_place"}};
+  std::vector<WorkZone> z{
+    make_zone("detection_zone_1", "camera_detection"),
+    make_zone("pick_zone_1", "robot_pick"),
+    make_zone("place_zone_1", "robot_place")};
   auto p=build_task_intent_preview("ur5","robotiq_2f_85",z,{},m);
   auto r=validate_task_intent_preview(p,true);
   EXPECT_EQ(p.task_steps.size(),8);
@@ -15,12 +35,16 @@ TEST(TaskIntentReadiness, BuildValid) {
 TEST(TaskIntentReadiness, MissingRobot) { TaskIntentPreview p; p.source_detection="det"; p.pick_zone="p"; p.place_zone="pl"; auto r=validate_task_intent_preview(p); EXPECT_EQ(r.status,"ERROR"); }
 TEST(TaskIntentReadiness, MissingPlaceZone) { TaskIntentPreview p; p.source_detection="det"; p.pick_zone="p"; p.robot="ur5"; p.end_effector="ee"; auto r=validate_task_intent_preview(p); EXPECT_EQ(r.status,"ERROR"); }
 TEST(TaskIntentReadiness, ConveyorNotReadyWarn) { TaskIntentPreview p; p.source_detection="det"; p.pick_zone="p"; p.place_zone="pl"; p.robot="ur5"; p.end_effector="ee"; p.pick_ready=false; auto r=validate_task_intent_preview(p); EXPECT_EQ(r.status,"WARN"); }
-TEST(TaskIntentReadiness, StaticPickReady) { DetectionAdapterResult m; m.detection_id="det"; m.detection_zone="pick_zone_1"; std::vector<WorkZone> z{{"pick_zone_1","robot_pick"},{"place_zone_1","robot_place"}}; auto p=build_task_intent_preview("ur5","ee",z,{},m); EXPECT_TRUE(p.pick_ready); }
+TEST(TaskIntentReadiness, StaticPickReady) { DetectionAdapterResult m; m.detection_id="det"; m.detection_zone="pick_zone_1"; std::vector<WorkZone> z{
+    make_zone("pick_zone_1", "robot_pick"),
+    make_zone("place_zone_1", "robot_place")}; auto p=build_task_intent_preview("ur5","ee",z,{},m); EXPECT_TRUE(p.pick_ready); }
 TEST(TaskIntentReadiness, SerializationFields) { TaskIntentPreview p; p.source_detection="det"; p.pick_zone="pz"; p.place_zone="plz"; auto r=validate_task_intent_preview(p,false); auto y=serialize_task_intent_preview_yaml(p,r); EXPECT_NE(y.find("runtime_mode"),std::string::npos); EXPECT_NE(y.find("robot_motion_commanded"),std::string::npos); EXPECT_NE(y.find("moveit_plan_service_called"),std::string::npos); EXPECT_NE(y.find("gripper_command_sent"),std::string::npos); }
 
 TEST(TaskIntentReadiness, GeneratesPlaceTargetFromSemanticRobotPlaceRole) {
   DetectionAdapterResult m; m.detection_id="det_001"; m.class_label="widget"; m.pick_zone="pick_zone_1";
-  std::vector<WorkZone> z{{"pick_zone_1","robot_pick"},{"place_zone_fixture","robot_place"}};
+  std::vector<WorkZone> z{
+    make_zone("pick_zone_1", "robot_pick"),
+    make_zone("place_zone_fixture", "robot_place")};
   auto p=build_task_intent_preview("ur5","robotiq_2f_85",z,{},m);
   EXPECT_EQ(p.place_zone,"place_zone_fixture");
 }


### PR DESCRIPTION
### Motivation
- Silence compiler warnings from incomplete `WorkZone` aggregate initializers in tests by providing explicit initialization for all fields. 
- Remove the `variable set but not used` warning emitted from `SceneSelect::refresh_preview_status()` by eliminating the unused `unsaved_layout_edits` state without changing UI behavior.

### Description
- Added a small test-only helper `make_zone(...)` in `workcell_builder/test/task_intent_readiness_test.cpp` that sets `id`, `type`, `linked_camera`, `linked_robot`, `destination`, and `purpose`, and replaced partial aggregate initializers with calls to `make_zone(...)` in the affected tests. 
- Preserved test semantics: `detection_zone_1` remains `camera_detection`, `pick_zone_1` remains `robot_pick`, `place_zone_1` / `place_zone_fixture` remain `robot_place`, and place-target generation assertions are unchanged. 
- Removed the now-unused `static bool unsaved_layout_edits` declaration and its assignment inside `workcell_builder/gui/scene_select.cpp::refresh_preview_status()` while keeping selection and inspector text updates intact. 
- Made no changes to EPD behavior, New Cell design, safety logic, or any runtime robot motion logic.

### Testing
- Attempted automated build: `colcon build --symlink-install --packages-select workcell_builder`, but it could not be run in this environment because `colcon` is not available (`colcon: command not found`). 
- No package test runs were executed in this environment; changes are limited to tests and a preview UI code path and are designed to be behavior-preserving for runtime and test semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088e21e930833197362b873cad0807)