### PR TITLE
Fix workcell_builder task_intent_readiness_test build failure

### DIFF
--- a/workcell_builder/workcell_builder/test/task_intent_readiness_test.cpp
+++ b/workcell_builder/workcell_builder/test/task_intent_readiness_test.cpp
@@ -5,12 +5,12 @@ using namespace workcell_builder;
 
 namespace {
 WorkZone make_zone(
-  const QString & id, const QString & type,
-  const QString & linked_camera = QString(), const QString & linked_robot = QString(),
-  const QString & destination = QString(), const QString & purpose = QString())
+  const std::string & name, const std::string & type,
+  const std::string & linked_camera = "", const std::string & linked_robot = "",
+  const std::string & destination = "", const std::string & purpose = "")
 {
   WorkZone zone{};
-  zone.id = id;
+  zone.name = name;
   zone.type = type;
   zone.linked_camera = linked_camera;
   zone.linked_robot = linked_robot;


### PR DESCRIPTION
## Summary
- fixed `make_zone` helper in `task_intent_readiness_test.cpp` to match `WorkZone`'s actual field names and types
- replaced incorrect `zone.id` assignment with `zone.name`
- switched helper argument/default types from `QString` to `std::string` to match `WorkZone` members and eliminate missing `QString` type errors
- preserved explicit initialization of warning-related fields (`linked_camera`, `linked_robot`, `destination`, `purpose`)

## Why
The warning-cleanup helper introduced `QString` and a non-existent `WorkZone::id` member in this test, causing compilation errors (`QString does not name a type`, `WorkZone has no member named id`, and conversion errors).

## Validation
- attempted: `colcon build --symlink-install --packages-select workcell_builder`
- result in this environment: `colcon: command not found`

The code change is scoped to test-only helper logic and preserves existing test intent for zone names/types.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088f031c34833184b3e00d5e848c1c)