### PR TITLE
Expand workcell builder UI token coverage tests

### DIFF
--- a/tests/test_workcell_builder_asset_picker.py
+++ b/tests/test_workcell_builder_asset_picker.py
@@ -9,6 +9,24 @@ def test_asset_discovery_helper_paths_and_statuses_present():
     assert 'READY' in text
     assert 'MISSING_MOVEIT_CONFIG' in text
     assert 'MISSING_DESCRIPTION' in text
+    assert 'easy_manipulation_deployment/assets/environment' in text
+    assert 'easy_manipulation_deployment/assets/environment_objects' in text
+    assert '/src/assets/environment' in text
+    assert '/src/assets/environment_objects' in text
+
+
+def test_empty_asset_catalog_diagnostic_includes_searched_paths():
+    main = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+    assert 'No assets found. Searched paths:' in main
+    assert '{"No assets found", "Info", "Searched paths", "Unavailable"}' in main
+
+
+def test_add_to_canvas_button_is_disabled_then_enabled_via_selection_signal():
+    main = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+    assert 'add_to_canvas_button_->setEnabled(false);' in main
+    assert 'connect(asset_catalog_tree_, &QTreeWidget::currentItemChanged, this, [this](QTreeWidgetItem *, QTreeWidgetItem *){ validate_asset_catalog_selection(); });' in main
+    assert 'validate_asset_catalog_selection();' in main
+    assert 'add_to_canvas_button_->setEnabled(can_add);' in main
 
 
 def test_end_effector_type_inference_keywords():

--- a/tests/test_workcell_builder_existing_scene_editor_real_impl.py
+++ b/tests/test_workcell_builder_existing_scene_editor_real_impl.py
@@ -25,3 +25,10 @@ def test_save_scene_creates_timestamped_backup_and_canvas_refresh():
     assert 'environment.yaml.' in CPP and '.bak' in CPP
     assert 'QDateTime::currentDateTimeUtc().toString("yyyyMMddhhmmss")' in CPP
     assert 'refresh_canvas_from_scene(scene_window.scene);' in CPP
+
+
+def test_scene_selection_hook_updates_inspector_and_canvas_selection():
+    main = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+    assert 'connect(scene_hierarchy_tree_, &QTreeWidget::itemClicked, this, [this](QTreeWidgetItem *item, int column){ Q_UNUSED(column); on_hierarchy_item_selected(item); });' in main
+    assert 'inspector_label_->setText(QString("Selected: %1\\nCategory: %2\\nPose: %3\\nSource: %4")' in main
+    assert 'digital_twin_scene_->clearSelection(); gi->setSelected(true); digital_twin_canvas_->centerOn(gi); select_canvas_item(gi);' in main

--- a/tests/test_workcell_builder_layout_restructure.py
+++ b/tests/test_workcell_builder_layout_restructure.py
@@ -20,6 +20,27 @@ def test_left_and_right_tabs_exist():
         assert token in MAIN
 
 
+def test_scene_tree_headers_include_name_role_status():
+    for token in [
+        'scene_hierarchy_tree_->setHeaderLabels({"Name", "Role", "Status"})',
+    ]:
+        assert token in MAIN
+
+
+def test_scene_population_role_taxonomy_tokens_present():
+    for token in [
+        'return QString("robot")',
+        'return QString("end_effector/tool")',
+        'return QString("camera")',
+        'return QString("support_surface/table")',
+        'return QString("pick_source/pick_zone")',
+        'return QString("place_target/bin")',
+        'return QString("safety_zone")',
+        'return QString("unknown")',
+    ]:
+        assert token in MAIN
+
+
 def test_inspector_scroll_and_activity_log_toggle_exist():
     for token in ['QScrollArea(right_panel)', 'setWidgetResizable(true)', 'Show Log', 'Hide Log', '<b>Activity Log</b>']:
         assert token in MAIN


### PR DESCRIPTION
### Motivation
- Increase regression coverage for the Workcell Builder UI by asserting presence of UI construction tokens and runtime wiring used by scene population, asset picker, and selection syncing logic.
- Ensure asset discovery roots and diagnostics are explicitly surfaced so empty-catalog diagnostics and asset-path discovery remain verifiable.

### Description
- Added/updated tests in `tests/test_workcell_builder_layout_restructure.py`, `tests/test_workcell_builder_asset_picker.py`, and `tests/test_workcell_builder_existing_scene_editor_real_impl.py` to assert Scene/Assets/Files tab tokens and that the scene hierarchy header includes `Name/Role/Status`.
- Added assertions that the scene population role taxonomy returns tokens for `robot`, `end_effector/tool`, `camera`, `support_surface/table`, `pick_source/pick_zone`, `place_target/bin`, `safety_zone`, and `unknown`.
- Expanded asset discovery assertions to require explicit environment asset roots and added checks that the empty asset-catalog diagnostic includes the searched paths text.
- Added checks that the `Add to Canvas` button is initialized disabled and that selection-change wiring (`currentItemChanged` → `validate_asset_catalog_selection`) enables it as appropriate, and added assertions that scene-hierarchy selection hooks update the inspector and perform canvas selection/centering calls.

### Testing
- Ran `pytest -q tests/test_workcell_builder_layout_restructure.py tests/test_workcell_builder_asset_picker.py tests/test_workcell_builder_existing_scene_editor_real_impl.py tests/test_workcell_builder_canvas_navigation.py` and all tests passed (`17 passed`).
- The added assertions are read-only checks against existing source files and succeeded in the CI-local test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a845866c8331a065a05fb83fc16b)