### PR TITLE
Fix compile failure in workcell_builder::populate_scene_hierarchy

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -2994,10 +2994,6 @@ void MainWindow::populate_scene_hierarchy()
     node->setData(0, TreeRolePoseAvailable, false);
     node->setData(0, TreeRoleRole, "file");
   }
-      ++preview_warning_count;
-      append_studio_log(QString("Preview warning: %1").arg(QString::fromStdString(item.warnings.front())));
-    }
-  }
 
   if (scene_preview_widget_) scene_preview_widget_->set_preview_items(preview_items);
 


### PR DESCRIPTION
### Motivation
- Remove an accidentally duplicated warning/logging block in `MainWindow::populate_scene_hierarchy()` that prematurely closed the function scope and caused compiler errors such as `item`/`d` undeclared and `expected declaration before '}' token`.

### Description
- Deleted the stray duplicated lines that incremented `preview_warning_count` and called `append_studio_log(...)`, restoring the correct brace structure so the remainder of the function remains in scope.

### Testing
- Attempted to run `colcon build --symlink-install --packages-select workcell_builder` but `colcon` is not available in this environment so the build could not be executed; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a9de8f2083319d0836346fda0397)