### PR TITLE
Fix Scene Builder preview selected-state and UI panel polish

### DIFF
--- a/tests/test_workcell_builder_layout_restructure.py
+++ b/tests/test_workcell_builder_layout_restructure.py
@@ -8,7 +8,7 @@ def test_scene_builder_uses_main_splitter_layout():
     for token in [
         'sceneBuilderMainSplitter',
         'QSplitter(Qt::Horizontal, scene_shell)',
-        'setSizes({290, 980, 350})',
+        'setSizes({320, 940, 400})',
     ]:
         assert token in MAIN
 
@@ -23,6 +23,9 @@ def test_left_and_right_tabs_exist():
 def test_scene_tree_headers_include_name_role_status():
     for token in [
         'scene_hierarchy_tree_->setHeaderLabels({"Name", "Role", "Status"})',
+        'header->setSectionResizeMode(0, QHeaderView::Stretch);',
+        'header->setSectionResizeMode(1, QHeaderView::ResizeToContents);',
+        'header->setSectionResizeMode(2, QHeaderView::ResizeToContents);',
     ]:
         assert token in MAIN
 
@@ -47,5 +50,15 @@ def test_inspector_scroll_and_activity_log_toggle_exist():
 
 
 def test_canvas_more_menu_and_safety_text_present():
-    for token in ['Canvas More...', 'Fake Hardware', 'No Robot Motion']:
+    for token in ['Canvas More...', 'Duplicate Selected', 'Remove Selected Layout Item', 'Revert Layout', 'Run Layout Merge', 'Open Merge Report', 'Copy Merge Summary', 'Export Canvas Snapshot', 'Fake Hardware', 'No Robot Motion']:
+        assert token in MAIN
+
+
+def test_scene_preview_selected_state_updates_and_compact_inspector_pose_grid_present():
+    for token in [
+        'scene_preview_widget_->set_scene_selected(true);',
+        'scene_preview_widget_->set_scene_selected(false);',
+        'auto * pose_grid = new QGridLayout();',
+        'scene_builder_log_toggle_button_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);',
+    ]:
         assert token in MAIN

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -709,7 +709,7 @@ void MainWindow::setup_studio_shell()
   scene_splitter->setStretchFactor(0, 1);
   scene_splitter->setStretchFactor(1, 4);
   scene_splitter->setStretchFactor(2, 1);
-  scene_splitter->setSizes({290, 980, 350});
+  scene_splitter->setSizes({320, 940, 400});
   scene_shell_layout->addWidget(scene_splitter, 1);
   sl->addWidget(scene_shell, 1);
 
@@ -897,7 +897,7 @@ void MainWindow::setup_studio_shell()
   canvas_more_menu->addAction("Toggle Warnings")->setCheckable(true);
   canvas_more_actions->setMenu(canvas_more_menu);
   controls->addWidget(canvas_more_actions);
-  auto * export_snapshot = new QPushButton("Export Canvas Snapshot", scene_builder); controls->addWidget(export_snapshot); center_panel_layout->addLayout(controls);
+  auto * export_snapshot = new QPushButton("Export Canvas Snapshot", scene_builder); center_panel_layout->addLayout(controls);
   digital_twin_canvas_ = new QGraphicsView(scene_builder); digital_twin_canvas_->setObjectName("digital_twin_canvas_"); digital_twin_canvas_->setMinimumHeight(420);
   scene_preview_widget_->set_fallback_2d_view(digital_twin_canvas_);
   center_panel_layout->addWidget(scene_preview_widget_, 1);
@@ -905,13 +905,21 @@ void MainWindow::setup_studio_shell()
   auto * layout_controls = new QHBoxLayout();
   undo_layout_button_ = new QPushButton("Undo", scene_builder); layout_controls->addWidget(undo_layout_button_);
   redo_layout_button_ = new QPushButton("Redo", scene_builder); layout_controls->addWidget(redo_layout_button_);
-  duplicate_layout_button_ = new QPushButton("Duplicate Selected", scene_builder); layout_controls->addWidget(duplicate_layout_button_);
-  delete_layout_button_ = new QPushButton("Remove Selected Layout Item", scene_builder); layout_controls->addWidget(delete_layout_button_);
+  duplicate_layout_button_ = new QPushButton("Duplicate Selected", scene_builder);
+  delete_layout_button_ = new QPushButton("Remove Selected Layout Item", scene_builder);
   save_layout_button_ = new QPushButton("Save Layout", scene_builder); layout_controls->addWidget(save_layout_button_);
-  revert_layout_button_ = new QPushButton("Revert Layout", scene_builder); layout_controls->addWidget(revert_layout_button_);
-  auto * run_layout_merge_button = new QPushButton("Run Layout Merge", scene_builder); layout_controls->addWidget(run_layout_merge_button);
-  auto * open_layout_merge_report_button = new QPushButton("Open Merge Report", scene_builder); layout_controls->addWidget(open_layout_merge_report_button);
-  auto * copy_layout_merge_summary_button = new QPushButton("Copy Merge Summary", scene_builder); layout_controls->addWidget(copy_layout_merge_summary_button);
+  revert_layout_button_ = new QPushButton("Revert Layout", scene_builder);
+  auto * run_layout_merge_button = new QPushButton("Run Layout Merge", scene_builder);
+  auto * open_layout_merge_report_button = new QPushButton("Open Merge Report", scene_builder);
+  auto * copy_layout_merge_summary_button = new QPushButton("Copy Merge Summary", scene_builder);
+  canvas_more_menu->addSeparator();
+  canvas_more_menu->addAction("Duplicate Selected", this, [this](){ duplicate_selected_item(); });
+  canvas_more_menu->addAction("Remove Selected Layout Item", this, [this](){ delete_selected_item(); });
+  canvas_more_menu->addAction("Revert Layout", revert_layout_button_, &QPushButton::click);
+  canvas_more_menu->addAction("Run Layout Merge", run_layout_merge_button, &QPushButton::click);
+  canvas_more_menu->addAction("Open Merge Report", open_layout_merge_report_button, &QPushButton::click);
+  canvas_more_menu->addAction("Copy Merge Summary", copy_layout_merge_summary_button, &QPushButton::click);
+  canvas_more_menu->addAction("Export Canvas Snapshot", export_snapshot, &QPushButton::click);
   center_panel_layout->addLayout(layout_controls);
   layout_state_label_ = new QLabel("Unsaved Layout Edits: none", scene_builder); center_panel_layout->addWidget(layout_state_label_);
   canvas_legend_label_ = new QLabel("Legend: robot | Robot Reach | camera | Camera FOV | pick zone | place zone | conveyor | bin | warning"); center_panel_layout->addWidget(canvas_legend_label_);
@@ -996,14 +1004,14 @@ void MainWindow::setup_studio_shell()
   actions_tab_layout->addWidget(preview_actions_card);
   inspector_label_=new QLabel("Inspector selection: none"); inspector_label_->setWordWrap(true); selection_tab_layout->addWidget(inspector_label_);
   live_coordinate_label_ = new QLabel("Selected: none", scene_builder); selection_tab_layout->addWidget(live_coordinate_label_);
-  auto * pose_row = new QHBoxLayout();
-  inspector_x_ = new QDoubleSpinBox(scene_builder); inspector_x_->setPrefix("x "); pose_row->addWidget(inspector_x_);
-  inspector_y_ = new QDoubleSpinBox(scene_builder); inspector_y_->setPrefix("y "); pose_row->addWidget(inspector_y_);
-  inspector_z_ = new QDoubleSpinBox(scene_builder); inspector_z_->setPrefix("z "); pose_row->addWidget(inspector_z_);
-  inspector_roll_ = new QDoubleSpinBox(scene_builder); inspector_roll_->setPrefix("r "); pose_row->addWidget(inspector_roll_);
-  inspector_pitch_ = new QDoubleSpinBox(scene_builder); inspector_pitch_->setPrefix("p "); pose_row->addWidget(inspector_pitch_);
-  inspector_yaw_ = new QDoubleSpinBox(scene_builder); inspector_yaw_->setPrefix("y θ "); pose_row->addWidget(inspector_yaw_);
-  selection_tab_layout->addLayout(pose_row);
+  auto * pose_grid = new QGridLayout();
+  inspector_x_ = new QDoubleSpinBox(scene_builder); inspector_x_->setPrefix("x "); pose_grid->addWidget(inspector_x_, 0, 0);
+  inspector_y_ = new QDoubleSpinBox(scene_builder); inspector_y_->setPrefix("y "); pose_grid->addWidget(inspector_y_, 0, 1);
+  inspector_z_ = new QDoubleSpinBox(scene_builder); inspector_z_->setPrefix("z "); pose_grid->addWidget(inspector_z_, 0, 2);
+  inspector_roll_ = new QDoubleSpinBox(scene_builder); inspector_roll_->setPrefix("r "); pose_grid->addWidget(inspector_roll_, 1, 0);
+  inspector_pitch_ = new QDoubleSpinBox(scene_builder); inspector_pitch_->setPrefix("p "); pose_grid->addWidget(inspector_pitch_, 1, 1);
+  inspector_yaw_ = new QDoubleSpinBox(scene_builder); inspector_yaw_->setPrefix("yaw "); pose_grid->addWidget(inspector_yaw_, 1, 2);
+  selection_tab_layout->addLayout(pose_grid);
   inspector_warning_label_ = new QLabel("Warnings: none\nReachability status: unknown\nCollision status: unknown\nSafety zone status: unknown\nPick source reach: unknown\nPlace target reach: unknown\nWarning count: 0\nPreview-only", scene_builder); selection_tab_layout->addWidget(inspector_warning_label_);
   scene_builder_inspector_tabs_->addTab(selection_tab, "Selection");
   scene_builder_inspector_tabs_->addTab(task_tab, "Task");
@@ -1127,7 +1135,8 @@ void MainWindow::setup_studio_shell()
   auto * log_head = new QHBoxLayout();
   log_head->addWidget(new QLabel("<b>Activity Log</b>", log_card));
   scene_builder_log_toggle_button_ = new QPushButton("Hide Log", log_card);
-  log_head->addWidget(scene_builder_log_toggle_button_);
+  scene_builder_log_toggle_button_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  log_head->addWidget(scene_builder_log_toggle_button_, 0, Qt::AlignRight);
   auto * clear_log = new QPushButton("Clear", log_card);
   log_head->addWidget(clear_log, 0, Qt::AlignRight);
   log_layout->addLayout(log_head);
@@ -2356,6 +2365,7 @@ void MainWindow::refresh_scene_builder_selected_scene_ui()
     if (scene_builder_title_) scene_builder_title_->setText("<h2>Scene Builder</h2>");
     if (canvas_header_label_) canvas_header_label_->setText("No scene selected");
     if (scene_preview_label_) scene_preview_label_->setText("<b>Digital Twin Canvas</b>");
+    if (scene_preview_widget_) scene_preview_widget_->set_scene_selected(false);
     populate_scene_files_tab();
     return;
   }
@@ -2365,6 +2375,7 @@ void MainWindow::refresh_scene_builder_selected_scene_ui()
   if (canvas_header_label_) canvas_header_label_->setText(QString("%1 | status: %2 | source: %3")
     .arg(QString::fromStdString(s.scene_name), QString::fromStdString(s.status), QString::fromStdString(s.scene_dir.string())));
   if (inspector_label_) inspector_label_->setText(QString("Scene name: %1\nScene path: %2\nStatus: %3\nRobot: %4\nEnd effector: %5\nGripper Mount RPY: -1.5708 -1.5708 0\nObjects count: %6\nTask recipe: %7\nSmoke report: %8\nLaunch command: %9").arg(QString::fromStdString(s.scene_name)).arg(QString::fromStdString(s.scene_dir.string())).arg(QString::fromStdString(s.status)).arg(QString::fromStdString(s.robot_summary)).arg(QString::fromStdString(s.gripper_summary)).arg(s.object_count).arg(s.has_task_recipe?"present":"missing").arg(s.has_smoke_report_json?"present":"missing").arg(selected_scene_launch_command()));
+  if (scene_preview_widget_) scene_preview_widget_->set_scene_selected(true);
   populate_scene_files_tab();
 }
 
@@ -2913,7 +2924,7 @@ void MainWindow::populate_scene_hierarchy()
   if (!scene_hierarchy_tree_) return;
   scene_hierarchy_tree_->clear();
 
-  if (selected_scene_index_ < 0 || selected_scene_index_ >= (int)scene_browser_result_.scenes.size()) return;
+  if (selected_scene_index_ < 0 || selected_scene_index_ >= (int)scene_browser_result_.scenes.size()) { if (scene_preview_widget_) scene_preview_widget_->set_scene_selected(false); return; }
   const auto & s = scene_browser_result_.scenes[(size_t)selected_scene_index_];
   const fs::path d = s.scene_dir;
   const auto model = workcell_builder::build_workcell_studio_canvas_model(s.scene_dir, s.scene_name);
@@ -2981,6 +2992,9 @@ void MainWindow::populate_scene_hierarchy()
 
   auto add_tree_node = [&](const ScenePreviewWidget::PreviewItem & p) {
     auto * node = new QTreeWidgetItem(scene_hierarchy_tree_, {p.display_name, p.role, p.status});
+    node->setToolTip(0, p.display_name);
+    node->setToolTip(1, p.role);
+    node->setToolTip(2, p.status);
     node->setData(0, TreeRoleId, p.id);
     node->setData(0, TreeRoleCategory, p.category);
     node->setData(
@@ -3093,7 +3107,7 @@ void MainWindow::populate_scene_hierarchy()
     node->setData(0, TreeRoleRole, "file");
   }
 
-  if (scene_preview_widget_) scene_preview_widget_->set_preview_items(preview_items);
+  if (scene_preview_widget_) { scene_preview_widget_->set_scene_selected(true); scene_preview_widget_->set_preview_items(preview_items); }
 
   auto * header = scene_hierarchy_tree_->header();
   if (header) {

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -3,6 +3,8 @@
 #include <QComboBox>
 #include <QFrame>
 #include <QGraphicsView>
+#include <QGraphicsScene>
+#include <QGraphicsItem>
 #include <QHBoxLayout>
 #include <functional>
 #include <QLabel>
@@ -198,6 +200,10 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   empty_state_label_->setAlignment(Qt::AlignCenter); v3->addWidget(empty_state_label_);
   error_state_label_ = new QLabel("3D preview unavailable", view3d_container_); error_state_label_->setAlignment(Qt::AlignCenter); v3->addWidget(error_state_label_);
   view2d_container_ = new QWidget(this); view2d_container_->setLayout(new QVBoxLayout());
+  fallback_banner_label_ = new QLabel("2D fallback preview active", view2d_container_);
+  fallback_banner_label_->setAlignment(Qt::AlignCenter);
+  fallback_banner_label_->setVisible(false);
+  view2d_container_->layout()->addWidget(fallback_banner_label_);
   stack_->addWidget(view3d_container_); stack_->addWidget(view2d_container_); root->addWidget(stack_, 1);
   connect(mode_selector_, qOverload<int>(&QComboBox::currentIndexChanged), this, &ScenePreviewWidget::on_mode_changed);
   connect(reset_view_button_, &QPushButton::clicked, this, &ScenePreviewWidget::on_reset_view_clicked);
@@ -222,7 +228,7 @@ void ScenePreviewWidget::set_fallback_2d_view(QGraphicsView * view){ fallback_2d
 void ScenePreviewWidget::set_scene_selected(bool selected){ scene_selected_ = selected; refresh_mode_and_state(); }
 void ScenePreviewWidget::set_3d_available(bool available, const QString & reason){ preview3d_available_ = available; unavailable_reason_ = reason; refresh_mode_and_state(); }
 void ScenePreviewWidget::on_mode_changed(int){ refresh_mode_and_state(); }
-void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items){ preview_items_ = items; static_cast<SimplePreview3DView *>(simple_3d_view_)->items = preview_items_; emit studio_log_requested(QString("Loaded %1 preview items.").arg(preview_items_.size())); update(); }
+void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items){ preview_items_ = items; static_cast<SimplePreview3DView *>(simple_3d_view_)->items = preview_items_; emit studio_log_requested(QString("Loaded %1 preview items.").arg(preview_items_.size())); fit_fallback_scene_to_items(); update(); }
 void ScenePreviewWidget::set_task_overlay_model(const TaskOverlayModel & model){ overlay_model_ = model; static_cast<SimplePreview3DView *>(simple_3d_view_)->task_overlay = model; simple_3d_view_->update(); }
 void ScenePreviewWidget::set_task_overlay_visibility(bool task_route, bool pick_place_zones, bool approach_retreat, bool labels){
   auto * v = static_cast<SimplePreview3DView *>(simple_3d_view_);
@@ -234,8 +240,8 @@ void ScenePreviewWidget::set_task_overlay_visibility(bool task_route, bool pick_
 }
 void ScenePreviewWidget::select_preview_item(const QString & id){ selected_preview_item_id_ = id; static_cast<SimplePreview3DView *>(simple_3d_view_)->selected_id = id; simple_3d_view_->update(); }
 QString ScenePreviewWidget::selected_preview_item_id() const { return selected_preview_item_id_; }
-void ScenePreviewWidget::on_reset_view_clicked(){ static_cast<SimplePreview3DView *>(simple_3d_view_)->reset_view(); }
-void ScenePreviewWidget::on_fit_scene_clicked(){ static_cast<SimplePreview3DView *>(simple_3d_view_)->fit_scene(); }
+void ScenePreviewWidget::on_reset_view_clicked(){ static_cast<SimplePreview3DView *>(simple_3d_view_)->reset_view(); reset_fallback_scene_view(); }
+void ScenePreviewWidget::on_fit_scene_clicked(){ static_cast<SimplePreview3DView *>(simple_3d_view_)->fit_scene(); fit_fallback_scene_to_items(); }
 void ScenePreviewWidget::on_focus_selected_clicked(){ static_cast<SimplePreview3DView *>(simple_3d_view_)->focus_selected(); }
 void ScenePreviewWidget::on_clear_selection_clicked(){ selected_preview_item_id_.clear(); static_cast<SimplePreview3DView *>(simple_3d_view_)->selected_id.clear(); simple_3d_view_->update(); emit studio_log_requested("Cleared preview selection."); emit preview_item_selected(QString()); }
 void ScenePreviewWidget::refresh_mode_and_state()
@@ -243,14 +249,42 @@ void ScenePreviewWidget::refresh_mode_and_state()
   if (!preview3d_available_) {
     mode_selector_->setCurrentText("2D Layout");
     stack_->setCurrentWidget(view2d_container_);
+    fallback_banner_label_->setVisible(scene_selected_);
     emit studio_log_requested(QString("3D preview fallback to 2D: %1").arg(unavailable_reason_.isEmpty() ? "initialization failed" : unavailable_reason_));
     return;
   }
+  fallback_banner_label_->setVisible(false);
   bool use3d = mode_selector_->currentText() == "3D Preview";
   stack_->setCurrentWidget(use3d ? view3d_container_ : view2d_container_);
+  const bool has_preview_items = !preview_items_.isEmpty();
   empty_state_label_->setVisible(use3d && !scene_selected_);
   simple_3d_view_->setVisible(use3d && scene_selected_);
-  error_state_label_->setVisible(false);
+  const bool rendering_failed = scene_selected_ && has_preview_items && !simple_3d_view_->isVisible() && !preview3d_available_;
+  error_state_label_->setText(QString("Scene selected but preview rendering failed. Loaded %1 preview items. Check fallback 2D canvas.").arg(preview_items_.size()));
+  error_state_label_->setVisible(rendering_failed);
+}
+QRectF ScenePreviewWidget::rendered_items_bounds_2d() const
+{
+  if (!fallback_2d_view_ || !fallback_2d_view_->scene()) return QRectF();
+  QRectF bounds;
+  const auto items = fallback_2d_view_->scene()->items();
+  for (QGraphicsItem * item : items) {
+    if (!item || !item->isVisible()) continue;
+    bounds = bounds.isNull() ? item->sceneBoundingRect() : bounds.united(item->sceneBoundingRect());
+  }
+  return bounds;
+}
+void ScenePreviewWidget::fit_fallback_scene_to_items()
+{
+  if (!fallback_2d_view_) return;
+  const QRectF bounds = rendered_items_bounds_2d();
+  if (bounds.isValid() && !bounds.isEmpty()) fallback_2d_view_->fitInView(bounds.adjusted(-20, -20, 20, 20), Qt::KeepAspectRatio);
+}
+void ScenePreviewWidget::reset_fallback_scene_view()
+{
+  if (!fallback_2d_view_) return;
+  fallback_2d_view_->resetTransform();
+  fit_fallback_scene_to_items();
 }
 
 void ScenePreviewWidget::set_camera_overlay_model(const CameraOverlayModel & model){ camera_overlay_model_ = model; auto *v=static_cast<SimplePreview3DView *>(simple_3d_view_); v->camera_overlay = model; simple_3d_view_->update(); }

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -9,6 +9,8 @@ class QLabel;
 class QPushButton;
 class QStackedWidget;
 class QGraphicsView;
+class QGraphicsScene;
+class QGraphicsItem;
 
 class ScenePreviewWidget : public QWidget
 {
@@ -123,6 +125,9 @@ private slots:
 
 private:
   void refresh_mode_and_state();
+  QRectF rendered_items_bounds_2d() const;
+  void fit_fallback_scene_to_items();
+  void reset_fallback_scene_view();
 
   QComboBox * mode_selector_{ nullptr };
   QPushButton * reset_view_button_{ nullptr };
@@ -133,6 +138,7 @@ private:
   QWidget * view2d_container_{ nullptr };
   QLabel * empty_state_label_{ nullptr };
   QLabel * error_state_label_{ nullptr };
+  QLabel * fallback_banner_label_{ nullptr };
   QWidget * simple_3d_view_{ nullptr };
   QGraphicsView * fallback_2d_view_{ nullptr };
   bool scene_selected_{ false };


### PR DESCRIPTION
## Summary
This PR applies a focused Scene Builder usability/functionality fix for the remaining issues seen after opening `suction_test`.

### What was fixed
- **Preview selected-state consistency**
  - Ensured selected scene transitions call `scene_preview_widget_->set_scene_selected(true)` and no-scene transitions call `set_scene_selected(false)`.
  - Updated selected-scene refresh/populate paths so preview is not left in empty-state mode.

- **Preview item visibility + fallback behavior**
  - `ScenePreviewWidget::set_preview_items(...)` now triggers fitting to rendered 2D items.
  - Added fallback banner text in 2D view: `2D fallback preview active`.
  - `Reset View` and `Fit Scene` now also reset/fit the fallback 2D view using actual rendered item bounds.

- **Scene tree readability improvements**
  - Added per-column tooltips for Name/Role/Status.
  - Kept readable header sizing with Stretch + ResizeToContents modes.

- **Right inspector usability**
  - Replaced one long horizontal XYZ/RPY pose row with a compact 2-row grid (`QGridLayout`) for better fit.

- **Bottom canvas controls declutter**
  - Kept bottom bar focused on `Undo`, `Redo`, `Save Layout`.
  - Moved duplicate/remove/revert/merge/report/summary/snapshot actions into `Canvas More...` while preserving action availability.

- **Activity Log toggle polish**
  - Kept `Hide Log` as a compact header button (non-expanding size policy), next to log header controls.

## Tests
Ran:
- `PYTHONPATH=$PWD:$PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_workcell_builder_canvas_navigation.py tests/test_workcell_builder_layout_restructure.py tests/test_workcell_builder_existing_scene_editor_real_impl.py`

Result: **12 passed**.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08adea62a48331a9f7a9ad0434345e)