### PR TITLE
Refactor task-intent binding updates to run a unified post-bind refresh

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1597,8 +1597,20 @@ bool MainWindow::update_selected_scene_task_intent_binding(
   out.close();
   append_studio_log(QString("%1 updated to '%2' in %3 (Preview Only | Fake Hardware | No Robot Motion)")
     .arg(binding_label, selected_id, QString::fromStdString(task_intent_path.string())));
-  refresh_task_intent_panel();
+  refresh_after_task_binding_change(binding_label, selected_id);
   return true;
+}
+
+void MainWindow::refresh_after_task_binding_change(const QString & binding_label, const QString & selected_id)
+{
+  append_studio_log(QString("Task binding refresh started: %1 -> %2").arg(binding_label, selected_id));
+  refresh_task_intent_panel();
+  refresh_new_cell_checklist();
+  populate_scene_hierarchy();
+  populate_scene_files_tab();
+  rebuild_digital_twin_canvas();
+  refresh_selected_scene_item_labels(current_selected_scene_item());
+  append_studio_log(QString("Task binding refresh completed: %1 -> %2").arg(binding_label, selected_id));
 }
 
 void MainWindow::bind_selected_item_as_pick_zone()

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -155,6 +155,7 @@ private:
     const QString & binding_label,
     const std::vector<std::string> & key_path,
     const QString & selected_id);
+  void refresh_after_task_binding_change(const QString & binding_label, const QString & selected_id);
   QString selected_scene_launch_command() const;
   QString selected_scene_build_command() const;
   QString selected_scene_source_command() const;


### PR DESCRIPTION
### Motivation
- Ensure all UI surfaces and related state are consistently refreshed after a task-intent binding (pick/place/camera) is written to disk by centralizing post-bind refresh work into a single routine.
- Record the binding outcome and the refresh lifecycle in the activity log so operators can trace binding events and resulting UI updates.

### Description
- Added a declaration for `refresh_after_task_binding_change(const QString & binding_label, const QString & selected_id)` to `mainwindow.h` to expose the new helper.
- Replaced the direct `refresh_task_intent_panel()` call in `update_selected_scene_task_intent_binding()` with a call to `refresh_after_task_binding_change(binding_label, selected_id)` in `mainwindow.cpp` so the binding writer triggers the unified refresh pipeline.
- Implemented `refresh_after_task_binding_change()` to call `refresh_task_intent_panel()`, `refresh_new_cell_checklist()`, `populate_scene_hierarchy()`, `populate_scene_files_tab()`, `rebuild_digital_twin_canvas()`, and `refresh_selected_scene_item_labels(current_selected_scene_item())`, and to emit start/completion messages via `append_studio_log()`.

### Testing
- No automated test suite was executed as part of this change; the patch is a small GUI refresh wiring update limited to two files and does not introduce business-logic changes.
- The modified source files were inspected to confirm the new helper is declared and defined and that `update_selected_scene_task_intent_binding()` now invokes the helper.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b0ca2c788331a9a93ffaf3cc0ac6)