### PR TITLE
Align canonical task-intent YAML handling across GUI and script

### DIFF
--- a/scripts/create_or_update_builder_task_intent.py
+++ b/scripts/create_or_update_builder_task_intent.py
@@ -75,7 +75,30 @@ def _resolve_scene_label(scene_package: Path, target_id: str) -> tuple[str, bool
     return _readable_label(target_id), False
 
 def _default(scene_package: str) -> dict[str, Any]:
-    return {"schema":"workcell_builder_task_intent/v1","scene_package":scene_package,"task":{"id":"default_builder_task","type":"pick_place","mode":"offline_preview","template":"pick_place"},"task_template":{"id":"pick_place","scenario":"pick_place","runtime_status":"supported","notes":"Template metadata only; runtime remains existing pick/place and sorting flows."},"pick":{"source":{"type":"zone","id":"pick_zone_main"},"object_filter":{"class_id":"any","color":"any"}},"grasp":{"strategy_ref":"finger_pinch_basic","approach_axis":"z_down","approach_distance_m":0.1,"retreat_axis":"z_up","retreat_distance_m":0.1},"place":{"target":{"type":"bin","id":"bin_red"},"release_strategy":"tool_release","retreat_axis":"z_up","retreat_distance_m":0.1,"place_clearance_m":0.05},"routing":{"rules":[]},"safety":{"metadata_only":True,"runtime_io_applied":False,"motion_started":False,"ros_launch_started":False}}
+    return {"schema":"workcell_builder_task_intent/v1","scene_package":scene_package,"task":{"id":"default_builder_task","type":"pick_place","family":"pick_place","mode":"offline_preview","template":"pick_place","pick":{"source":{"type":"zone","id":"pick_zone_main"}},"grasp":{"strategy":"finger_top","approach_axis":"z_down","approach_distance_m":0.1,"retreat_axis":"z_up","retreat_distance_m":0.1},"place":{"target":{"type":"bin","id":"bin_red"},"release_strategy":"tool_release","retreat_axis":"z_up","retreat_distance_m":0.1,"place_clearance_m":0.05},"perception":{"camera":{"id":"camera_main"}}},"task_template":{"id":"pick_place","scenario":"pick_place","runtime_status":"supported","notes":"Template metadata only; runtime remains existing pick/place and sorting flows."},"pick":{"source":{"type":"zone","id":"pick_zone_main"},"object_filter":{"class_id":"any","color":"any"}},"grasp":{"strategy":"finger_top","approach_axis":"z_down","approach_distance_m":0.1,"retreat_axis":"z_up","retreat_distance_m":0.1},"place":{"target":{"type":"bin","id":"bin_red"},"release_strategy":"tool_release","retreat_axis":"z_up","retreat_distance_m":0.1,"place_clearance_m":0.05},"routing":{"rules":[]},"safety":{"preview_only":True,"use_fake_hardware":True,"no_robot_motion":True}}
+
+def _ensure_map(parent: dict[str, Any], key: str) -> dict[str, Any]:
+    value = parent.get(key)
+    if not isinstance(value, dict):
+        value = {}
+        parent[key] = value
+    return value
+
+def _default_grasp_strategy(payload: dict[str, Any]) -> str:
+    task = payload.get("task") if isinstance(payload.get("task"), dict) else {}
+    tool_id = ""
+    if isinstance(task.get("tool"), dict):
+        tool_id = str(task["tool"].get("id") or "")
+    if not tool_id and isinstance(payload.get("tool"), dict):
+        tool_id = str(payload["tool"].get("id") or "")
+    if not tool_id:
+        tool_id = str(task.get("end_effector") or payload.get("end_effector") or "")
+    lowered = tool_id.lower()
+    if "suction" in lowered:
+        return "suction_top"
+    if "finger" in lowered or "gripper" in lowered or "robotiq" in lowered:
+        return "finger_top"
+    return "tool_profile_default"
 
 def _seed(scene_package: Path, output: Path | None) -> tuple[dict[str, Any], Path | None]:
     cands = [output] if output else []
@@ -112,7 +135,8 @@ def main() -> int:
     payload, _ = _seed(a.scene_package, a.output)
     out = a.output or (a.scene_package/'generated'/'workcell_builder_task_intent.yaml')
     payload['schema']='workcell_builder_task_intent/v1'; payload['scene_package']=a.scene_package.as_posix()
-    payload.setdefault('task',{}).update({'id':a.task_id,'type':a.task_type, 'template': a.task_template})
+    task = _ensure_map(payload, 'task')
+    task.update({'id':a.task_id,'type':a.task_type,'family':a.task_type,'template': a.task_template})
     template_meta: dict[str, Any] = {
         'id': a.task_template,
         'scenario': a.task_template,
@@ -151,23 +175,36 @@ def main() -> int:
         template_meta['conveyor_picking'] = {'source_area': a.pick_source, 'drop_target': a.place_target}
     payload['task_template'] = template_meta
     source_type = {'epd_detected_object':'perception','epd_replay':'replay_object'}.get(a.pick_source_type, a.pick_source_type)
-    payload.setdefault('pick',{}).setdefault('source',{}).update({'id':a.pick_source, 'type': source_type})
+    pick = _ensure_map(payload, 'pick')
+    pick_source = _ensure_map(pick, 'source')
+    pick_source.update({'id':a.pick_source, 'type': source_type})
     pick_label, pick_resolved = _resolve_scene_label(a.scene_package, a.pick_source)
-    payload['pick']['source']['label'] = pick_label
-    payload['pick'].setdefault('object_filter',{}).update({'class_id':a.object_class,'color':a.object_color})
-    payload.setdefault('grasp',{}).update({'strategy_ref':a.grasp_strategy,'approach_axis':a.approach_axis,'approach_distance_m':a.approach_distance_m,'retreat_axis':a.retreat_axis,'retreat_distance_m':a.retreat_distance_m})
+    pick_source['label'] = pick_label
+    _ensure_map(pick, 'object_filter').update({'class_id':a.object_class,'color':a.object_color})
+    grasp = _ensure_map(payload, 'grasp')
+    grasp.update({'strategy':a.grasp_strategy,'approach_axis':a.approach_axis,'approach_distance_m':a.approach_distance_m,'retreat_axis':a.retreat_axis,'retreat_distance_m':a.retreat_distance_m})
     
-    payload.setdefault('place',{}).setdefault('target',{}).update({'id':a.place_target})
-    payload['place'].setdefault('target',{}).setdefault('type', 'place_target')
+    place = _ensure_map(payload, 'place')
+    place_target = _ensure_map(place, 'target')
+    place_target.update({'id':a.place_target})
+    place_target.setdefault('type', 'place_target')
     place_label, place_resolved = _resolve_scene_label(a.scene_package, a.place_target)
-    payload['place']['target']['label'] = place_label
-    payload['place'].update({'release_strategy':a.release_strategy,'retreat_axis':a.retreat_axis,'retreat_distance_m':a.retreat_distance_m, 'place_clearance_m': 0.05})
+    place_target['label'] = place_label
+    place.update({'release_strategy':a.release_strategy,'retreat_axis':a.retreat_axis,'retreat_distance_m':a.retreat_distance_m, 'place_clearance_m': 0.05})
+    _ensure_map(_ensure_map(task, 'pick'), 'source').update({'id':a.pick_source, 'type': source_type})
+    _ensure_map(_ensure_map(task, 'place'), 'target').update({'id':a.place_target})
+    task_grasp = _ensure_map(task, 'grasp')
+    if not isinstance(task_grasp.get('strategy'), str) or not task_grasp.get('strategy'):
+        task_grasp['strategy'] = _default_grasp_strategy(payload)
+    task_grasp.update({'strategy':a.grasp_strategy,'approach_axis':a.approach_axis,'approach_distance_m':a.approach_distance_m,'retreat_axis':a.retreat_axis,'retreat_distance_m':a.retreat_distance_m})
+    _ensure_map(_ensure_map(task, 'perception'), 'camera').setdefault('id', 'camera_main')
     payload.setdefault('routing', {})['rules'] = [{
         'id': 'route_any_to_selected_place',
         'when': {'object_class': a.object_class, 'object_color': a.object_color},
         'place_target': a.place_target,
     }]
-    payload['safety']={'metadata_only':True,'runtime_io_applied':False,'motion_started':False,'ros_launch_started':False,'fake_hardware_first':True,'runtime_execution_enabled':False,'motion_command_sent':False}
+    payload['safety'] = _ensure_map(payload, 'safety')
+    payload['safety'].update({'preview_only':True,'use_fake_hardware':True,'no_robot_motion':True})
     _dump(out, payload)
     val={'status':'SKIP'}
     if a.validate:

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -220,6 +220,27 @@ struct SceneTaskIntentSummary
 static QString ystr(const YAML::Node & n){ return (n && n.IsScalar()) ? QString::fromStdString(n.as<std::string>()) : "unknown"; }
 static QString scalar_path(const YAML::Node & root, std::initializer_list<const char *> keys){ YAML::Node n=root; for(auto *k:keys){ if(!n||!n[k]) return "unknown"; n=n[k]; } return ystr(n); }
 static bool read_yaml(const fs::path & p, YAML::Node * out){ try{ if(!fs::exists(p)) return false; *out=YAML::LoadFile(p.string()); return true; }catch(...){return false;} }
+static YAML::Node ensure_map_path(YAML::Node root, std::initializer_list<const char *> keys)
+{
+  YAML::Node cursor = root;
+  for (const auto * key : keys) {
+    if (!cursor[key] || !cursor[key].IsMap()) {
+      cursor[key] = YAML::Node(YAML::NodeType::Map);
+    }
+    cursor = cursor[key];
+  }
+  return cursor;
+}
+static std::string infer_default_grasp_strategy(const YAML::Node & root)
+{
+  const QString tool_id = scalar_path(root, {"task", "tool", "id"}) != "unknown" ?
+    scalar_path(root, {"task", "tool", "id"}) :
+    (scalar_path(root, {"tool", "id"}) != "unknown" ? scalar_path(root, {"tool", "id"}) : scalar_path(root, {"task", "end_effector"}));
+  const QString lower = tool_id.toLower();
+  if (lower.contains("suction")) return "suction_top";
+  if (lower.contains("finger") || lower.contains("gripper") || lower.contains("robotiq")) return "finger_top";
+  return "tool_profile_default";
+}
 static SceneTaskIntentSummary load_scene_task_intent_summary(const fs::path & scene_dir)
 {
   SceneTaskIntentSummary s;
@@ -233,15 +254,18 @@ static SceneTaskIntentSummary load_scene_task_intent_summary(const fs::path & sc
   const YAML::Node task = root["task"] ? root["task"] : root;
   s.task_type = scalar_path(task, {"type"});
   if (s.task_type == "unknown") s.task_type = scalar_path(task, {"family"});
-  s.pick_source = scalar_path(task, {"pick","source"});
+  s.pick_source = scalar_path(task, {"pick","source","id"});
+  if (s.pick_source == "unknown") s.pick_source = scalar_path(task, {"pick","source"});
   if (s.pick_source == "unknown") s.pick_source = scalar_path(task, {"pick_source"});
-  s.place_target = scalar_path(task, {"place","target"});
+  s.place_target = scalar_path(task, {"place","target","id"});
+  if (s.place_target == "unknown") s.place_target = scalar_path(task, {"place","target"});
   if (s.place_target == "unknown") s.place_target = scalar_path(task, {"place_target"});
   s.reject_target = scalar_path(task, {"reject","target"});
   if (s.reject_target == "unknown") s.reject_target = scalar_path(task, {"reject_target"});
   s.object_class = scalar_path(task, {"object","class"});
   if (s.object_class == "unknown") s.object_class = scalar_path(task, {"object_class"});
   s.grasp_strategy = scalar_path(task, {"grasp","strategy"});
+  if (s.grasp_strategy == "unknown") s.grasp_strategy = scalar_path(task, {"grasp","strategy_ref"});
   if (s.grasp_strategy == "unknown") s.grasp_strategy = scalar_path(task, {"grasp_strategy"});
   s.approach_axis = scalar_path(task, {"approach","axis"});
   s.approach_distance = scalar_path(task, {"approach","distance"});
@@ -1577,18 +1601,23 @@ bool MainWindow::update_selected_scene_task_intent_binding(
     }
   }
   if (!root || !root.IsMap()) root = YAML::Node(YAML::NodeType::Map);
-  if (!root["task"]) root["task"] = YAML::Node(YAML::NodeType::Map);
-  if (!root["task"]["type"]) root["task"]["type"] = "pick_place";
-  if (!root["task"]["family"]) root["task"]["family"] = "pick_place";
-  if (!root["grasp"]) root["grasp"] = YAML::Node(YAML::NodeType::Map);
-  if (!root["grasp"]["strategy"]) root["grasp"]["strategy"] = "auto";
-  if (!root["safety"]) root["safety"] = YAML::Node(YAML::NodeType::Map);
-  root["safety"]["preview_only"] = true;
-  root["safety"]["use_fake_hardware"] = true;
-  root["safety"]["no_robot_motion"] = true;
-  YAML::Node cursor = root;
+  YAML::Node task = ensure_map_path(root, {"task"});
+  if (!task["type"] || !task["type"].IsScalar()) task["type"] = "pick_place";
+  if (!task["family"] || !task["family"].IsScalar()) task["family"] = task["type"];
+  YAML::Node grasp = ensure_map_path(task, {"grasp"});
+  if (!grasp["strategy"] || !grasp["strategy"].IsScalar()) {
+    grasp["strategy"] = infer_default_grasp_strategy(root);
+  }
+  YAML::Node safety = ensure_map_path(root, {"safety"});
+  (void)ensure_map_path(task, {"pick", "source"});
+  (void)ensure_map_path(task, {"place", "target"});
+  (void)ensure_map_path(task, {"perception", "camera"});
+  safety["preview_only"] = true;
+  safety["use_fake_hardware"] = true;
+  safety["no_robot_motion"] = true;
+  YAML::Node cursor = task;
   for (size_t i = 0; i + 1 < key_path.size(); ++i) {
-    if (!cursor[key_path[i]]) cursor[key_path[i]] = YAML::Node(YAML::NodeType::Map);
+    if (!cursor[key_path[i]] || !cursor[key_path[i]].IsMap()) cursor[key_path[i]] = YAML::Node(YAML::NodeType::Map);
     cursor = cursor[key_path[i]];
   }
   cursor[key_path.back()] = selected_id.toStdString();


### PR DESCRIPTION
### Motivation
- Unify how task-intent YAML is read and written so both the GUI and the task-intent creation script use the same canonical keys (`task.type`, `task.family`, `task.pick.source.id`, `task.place.target.id`, `task.grasp.strategy`) while remaining backward-compatible with legacy fields.
- Ensure safety-first behavior by always preserving or writing safety flags and creating/repairing nested maps when the YAML is missing or malformed.
- Provide a predictable default grasp strategy derived from the configured tool when a strategy is not present.

### Description
- Updated `load_scene_task_intent_summary` in the GUI to prefer canonical `task.*` paths and fall back to legacy keys (e.g. `pick_source`, `place_target`, `grasp.strategy_ref`) for compatibility, and to read `...source.id` / `...target.id` when present.
- Added `ensure_map_path` and `infer_default_grasp_strategy` helpers in `mainwindow.cpp`, and updated the GUI binding writer to always create safe parent maps, write canonical `task.*` entries, and set `safety.preview_only`, `safety.use_fake_hardware`, and `safety.no_robot_motion` to `true`.
- Updated `scripts/create_or_update_builder_task_intent.py` to emit a canonical `task` subtree in the payload, added `_ensure_map` and `_default_grasp_strategy` helpers, write canonical fields under `task.*` while preserving existing unrelated fields and legacy top-level `pick`/`place`/`grasp` sections for compatibility, and always set the three safety flags to `true`.
- Added a more canonical default payload shape in the script and applied the default-grasp mapping: suction -> `suction_top`, finger/gripper/robotiq -> `finger_top`, otherwise -> `tool_profile_default`.

### Testing
- Ran `python3 -m py_compile scripts/create_or_update_builder_task_intent.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b13da658833189f6679b652b2ad1)