### PR TITLE
Add label modes and compact role labels to scene preview

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -843,6 +843,7 @@ void MainWindow::setup_studio_shell()
   auto * controls = new QHBoxLayout();
   canvas_mode_label_ = new QLabel("Mode: Select", scene_builder); controls->addWidget(canvas_mode_label_);
   scene_preview_widget_ = new ScenePreviewWidget(scene_builder);
+  scene_preview_widget_->set_label_mode(ScenePreviewWidget::LabelMode::SelectedOnly);
   connect(scene_preview_widget_, &ScenePreviewWidget::studio_log_requested, this, [this](const QString &m){ append_studio_log(m); });
   connect(scene_preview_widget_, &ScenePreviewWidget::preview_item_selected, this, [this](const QString &id){
     if (!scene_hierarchy_tree_) return;
@@ -1331,7 +1332,10 @@ connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo
   connect(snap_to_grid_box_, &QCheckBox::toggled, this, [this](bool){ mark_layout_dirty("Snap to Grid"); });
   connect(fine_move_mode_box_, &QCheckBox::toggled, this, [this](bool){ mark_layout_dirty("Fine Move Mode"); });
   connect(unlock_robot_base_box_, &QCheckBox::toggled, this, [this](bool checked){ if (checked) { QMessageBox::warning(this, "Unlock Robot Base", "Robot base is locked by default. Moving robot base may invalidate reach and safety assumptions."); }});
-  connect(toggle_labels_box_, &QCheckBox::toggled, this, [this](bool){ rebuild_digital_twin_canvas(); });
+  connect(toggle_labels_box_, &QCheckBox::toggled, this, [this](bool enabled){
+    if (scene_preview_widget_) scene_preview_widget_->set_label_mode(enabled ? ScenePreviewWidget::LabelMode::All : ScenePreviewWidget::LabelMode::Off);
+    rebuild_digital_twin_canvas();
+  });
   connect(toggle_warnings_box_, &QCheckBox::toggled, this, [this](bool){ rebuild_digital_twin_canvas(); });
   connect(undo_layout_button_, &QPushButton::clicked, this, &MainWindow::undo_layout_edit);
   connect(redo_layout_button_, &QPushButton::clicked, this, &MainWindow::redo_layout_edit);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -23,7 +23,8 @@ public:
   explicit SimplePreview3DView(QWidget * parent=nullptr) : QOpenGLWidget(parent) { setMinimumHeight(420); }
   QVector<ScenePreviewWidget::PreviewItem> items;
   QString selected_id;
-  bool show_labels{true}, show_warnings{true}, show_safety{true}, show_pick_place{true};
+  ScenePreviewWidget::LabelMode label_mode{ScenePreviewWidget::LabelMode::SelectedOnly};
+  bool show_warnings{true}, show_safety{true}, show_pick_place{true};
   bool show_reachability_heatmap{true}, show_collision_warnings{true}, show_work_envelope{true}, show_warning_labels{true};
   bool show_task_route{true}, show_approach_retreat{true};
   bool show_camera_fov{true}, show_pick_coverage{true}, show_epd_detections{true}, show_detection_labels{true};
@@ -211,11 +212,40 @@ protected:
     }
   }
 
+  QString shortRoleLabel(const ScenePreviewWidget::PreviewItem & it) const {
+    const QString category = it.category.toLower();
+    const QString role = it.role.toLower();
+    if (category.contains("robot")) return "Robot";
+    if (category.contains("table")) return "Table";
+    if (category.contains("conveyor")) return "Conveyor";
+    if (category.contains("camera")) return "Camera";
+    if (role.contains("pick") || category.contains("pick")) return "Pick";
+    if (role.contains("place") || category.contains("place")) return "Place";
+    if (category.contains("bin")) return "Bin";
+    return QString();
+  }
+
   void drawCompactLabels(QPainter & p) const {
+    QVector<QRectF> used_label_rects;
     for (const auto & it : items) {
       if (!show_safety && it.category.contains("safety", Qt::CaseInsensitive)) continue;
       const bool selected = (it.id == selected_id);
-      if (show_labels || selected) p.drawText(project(it.x,it.y+it.sy+0.08,it.z), selected ? (it.display_name + " [selected]") : it.display_name);
+      if (label_mode == ScenePreviewWidget::LabelMode::Off) continue;
+      if (label_mode == ScenePreviewWidget::LabelMode::SelectedOnly && !selected) continue;
+      const QString short_label = shortRoleLabel(it);
+      if (short_label.isEmpty()) continue;
+      const QPointF anchor = project(it.x, it.y + it.sy + 0.08, it.z);
+      const QRectF label_rect = QFontMetricsF(p.font()).boundingRect(short_label).translated(anchor);
+      bool intersects_existing = false;
+      for (const QRectF & used : used_label_rects) {
+        if (used.intersects(label_rect)) {
+          intersects_existing = true;
+          break;
+        }
+      }
+      if (intersects_existing) continue;
+      p.drawText(anchor, selected ? (short_label + " [selected]") : short_label);
+      used_label_rects.push_back(label_rect);
     }
     if (show_work_envelope) p.drawText(project(-0.1, 0.25, -2.2), "Work Envelope (preview-only)");
     if (show_reachability_heatmap) p.drawText(project(-0.08, 0.4, -2.2), "Reachability Heatmap (approximate, preview-only)");
@@ -308,7 +338,7 @@ void ScenePreviewWidget::set_task_overlay_visibility(bool task_route, bool pick_
   v->show_task_route = task_route;
   v->show_pick_place = pick_place_zones;
   v->show_approach_retreat = approach_retreat;
-  v->show_labels = labels;
+  v->label_mode = labels ? LabelMode::All : LabelMode::Off;
   v->update();
 }
 void ScenePreviewWidget::select_preview_item(const QString & id){ selected_preview_item_id_ = id; static_cast<SimplePreview3DView *>(simple_3d_view_)->selected_id = id; simple_3d_view_->update(); }
@@ -367,3 +397,5 @@ void ScenePreviewWidget::set_perception_overlay_visibility(bool camera_fov, bool
 
 void ScenePreviewWidget::set_reachability_overlay_model(const ReachabilityOverlayModel & model){ reachability_overlay_model_ = model; auto *v=static_cast<SimplePreview3DView *>(simple_3d_view_); v->reach_overlay = model; emit studio_log_requested(QString("reachability overlay loaded: warning count=%1").arg(model.warnings.size())); simple_3d_view_->update(); }
 void ScenePreviewWidget::set_collision_overlay_model(const CollisionOverlayModel & model){ collision_overlay_model_ = model; auto *v=static_cast<SimplePreview3DView *>(simple_3d_view_); v->collision_overlay = model; emit studio_log_requested(QString("collision preview checks complete: warning count=%1").arg(model.warnings.size())); simple_3d_view_->update(); }
+
+void ScenePreviewWidget::set_label_mode(LabelMode mode){ auto *v=static_cast<SimplePreview3DView *>(simple_3d_view_); v->label_mode = mode; v->update(); }

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -59,6 +59,7 @@ public:
     bool selectable{true};
   };
   enum class ReachStatus { Reachable, NearLimit, OutOfReach, Unknown };
+  enum class LabelMode { Off, SelectedOnly, All };
   struct ReachabilityOverlayModel
   {
     QString robot_base_id{"unknown"};
@@ -109,6 +110,7 @@ public:
   void set_epd_detection_overlays(const QVector<EpdDetectionOverlayModel> & detections);
   void set_perception_overlay_visibility(bool camera_fov, bool pick_coverage, bool epd_detections, bool detection_labels);
   void set_task_overlay_visibility(bool task_route, bool pick_place_zones, bool approach_retreat, bool labels);
+  void set_label_mode(LabelMode mode);
   void select_preview_item(const QString & id);
   QString selected_preview_item_id() const;
 


### PR DESCRIPTION
### Motivation
- Reduce 3D canvas label clutter by showing concise role labels and making label visibility configurable via an explicit mode enum for better readability.
- Preserve full display names in tooltips/inspector while keeping on-canvas text lightweight and focused on role semantics.
- Default to showing only the selected item's label to avoid overwhelming the preview by default.
- Avoid obvious label overlaps by skipping labels whose projected rects intersect previously drawn labels.

### Description
- Added `enum class LabelMode { Off, SelectedOnly, All }` to `ScenePreviewWidget` and a `void set_label_mode(LabelMode)` setter in `scene_preview_widget.h`.
- Wired label mode into the internal `SimplePreview3DView` and set its default to `LabelMode::SelectedOnly` for improved initial readability.
- Replaced full display-name drawing on the 3D canvas with a `shortRoleLabel(...)` helper that returns compact role labels (`Robot`, `Table`, `Conveyor`, `Camera`, `Pick`, `Place`, `Bin`) based on item `category`/`role`, while leaving full names intact in metadata and 2D canvas/inspector.
- Implemented minimal collision avoidance in `drawCompactLabels` by tracking projected label `QRectF`s and skipping labels that intersect previously drawn label rects; mapped legacy boolean label toggles to `LabelMode::All`/`LabelMode::Off` and exposed the new setter for external control.
- Updated `MainWindow` initialization to call `scene_preview_widget_->set_label_mode(ScenePreviewWidget::LabelMode::SelectedOnly)` and changed the `toggle_labels_box_` handler to call `set_label_mode(...)` (All vs Off) to keep UI behavior consistent.

### Testing
- Ran `pytest -q tests/test_workcell_studio_scene_preview_ui.py`, which passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b5c191948331b3befb2135a7793b)