### PR TITLE
Centralize scene selection sync and preserve selection on canvas rebuild

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -2673,6 +2673,7 @@ void MainWindow::open_diagnostics_folder()
 
 void MainWindow::rebuild_digital_twin_canvas()
 {
+  const QString preserved_selected_id = current_selected_scene_item_id_;
   if (!digital_twin_canvas_) return;
   if (!digital_twin_scene_) {
     digital_twin_scene_ = new QGraphicsScene(digital_twin_canvas_);
@@ -2762,6 +2763,9 @@ void MainWindow::rebuild_digital_twin_canvas()
     if (task.tool_id == "unknown") issues << "missing robot/gripper metadata";
     if (!issues.isEmpty()) digital_twin_scene_->addSimpleText("Safety Warning Overlay: " + issues.join(" | "))->setPos(-380, -280);
   }
+  if (!preserved_selected_id.isEmpty()) {
+    apply_scene_selection(preserved_selected_id, QStringLiteral("unknown"), false, false);
+  }
   if (digital_twin_canvas_ && digital_twin_canvas_->scene()) {
     const QRectF bounds = digital_twin_canvas_->scene()->itemsBoundingRect();
     if (!bounds.isNull()) digital_twin_canvas_->fitInView(bounds.adjusted(-24, -24, 24, 24), Qt::KeepAspectRatio);
@@ -2823,6 +2827,68 @@ void MainWindow::select_canvas_item(QGraphicsItem * item)
   append_studio_log("selected item collision status: preview-only");
   if (pick_place_details_label_) pick_place_details_label_->setText(pick_place_details_label_->text() + QStringLiteral("\nLinked hierarchy item: %1").arg(item->data(RoleId).toString()));
   inspector_update_guard_ = false;
+}
+
+void MainWindow::apply_scene_selection(const QString & id, const QString & role, bool intentional_clear, bool center_canvas)
+{
+  const QString selected_id = id.trimmed();
+  const QString selected_role = role.trimmed().isEmpty() ? QStringLiteral("unknown") : role.trimmed();
+
+  if (selected_id.isEmpty()) {
+    if (!intentional_clear) return;
+    current_selected_scene_item_id_.clear();
+    selection_update_guard_ = true;
+    if (scene_hierarchy_tree_) scene_hierarchy_tree_->clearSelection();
+    if (digital_twin_scene_) digital_twin_scene_->clearSelection();
+    if (scene_preview_widget_) scene_preview_widget_->select_preview_item(QString());
+    selection_update_guard_ = false;
+    refresh_selected_scene_item_labels(current_selected_scene_item());
+    append_studio_log("Selected item: <none> (unknown)");
+    return;
+  }
+
+  current_selected_scene_item_id_ = selected_id;
+  selection_update_guard_ = true;
+
+  if (scene_hierarchy_tree_) {
+    QTreeWidgetItem * matched = nullptr;
+    for (int row = 0; row < scene_hierarchy_tree_->topLevelItemCount(); ++row) {
+      auto * tree_item = scene_hierarchy_tree_->topLevelItem(row);
+      if (tree_item && tree_item->data(0, TreeRoleId).toString().trimmed() == selected_id) {
+        matched = tree_item;
+        break;
+      }
+    }
+    if (matched) scene_hierarchy_tree_->setCurrentItem(matched);
+  }
+
+  QGraphicsItem * matched_canvas_item = nullptr;
+  if (digital_twin_scene_) {
+    for (auto * gi : digital_twin_scene_->items()) {
+      if (gi->data(RoleId).toString().trimmed() == selected_id) {
+        matched_canvas_item = gi;
+        break;
+      }
+    }
+    if (matched_canvas_item) {
+      digital_twin_scene_->clearSelection();
+      matched_canvas_item->setSelected(true);
+      if (center_canvas && digital_twin_canvas_) digital_twin_canvas_->centerOn(matched_canvas_item);
+      if (auto * rect = qgraphicsitem_cast<QGraphicsRectItem *>(matched_canvas_item)) {
+        rect->setPen(QPen(QColor("#f8fafc"), 3));
+      }
+    }
+  }
+
+  if (scene_preview_widget_) scene_preview_widget_->select_preview_item(selected_id);
+  selection_update_guard_ = false;
+
+  if (matched_canvas_item) {
+    select_canvas_item(matched_canvas_item);
+  } else {
+    refresh_selected_scene_item_labels(current_selected_scene_item());
+  }
+  append_studio_log(QString("Selected item: %1 (%2)").arg(selected_id, selected_role));
 }
 
 void MainWindow::mark_layout_dirty(const QString & reason)
@@ -2942,7 +3008,20 @@ void MainWindow::revert_layout_changes()
   append_studio_log("Revert Layout requested");
 }
 
-void MainWindow::on_canvas_selection_changed(){ if (!digital_twin_scene_) return; if (digital_twin_scene_->selectedItems().isEmpty()) { refresh_selected_scene_item_labels(current_selected_scene_item()); return; } auto * sel=digital_twin_scene_->selectedItems().front(); if (auto * rect=qgraphicsitem_cast<QGraphicsRectItem*>(sel)) { rect->setPen(QPen(QColor("#f8fafc"),3)); auto b=rect->sceneBoundingRect(); digital_twin_scene_->addRect(QRectF(b.topLeft()-QPointF(4,4), QSizeF(8,8)), QPen(QColor("#93c5fd")), QBrush(QColor("#93c5fd"))); } select_canvas_item(sel); }
+void MainWindow::on_canvas_selection_changed()
+{
+  if (!digital_twin_scene_ || selection_update_guard_) return;
+  if (digital_twin_scene_->selectedItems().isEmpty()) {
+    if (current_selected_scene_item_id_.isEmpty()) {
+      refresh_selected_scene_item_labels(current_selected_scene_item());
+    }
+    return;
+  }
+  auto * sel = digital_twin_scene_->selectedItems().front();
+  const QString selected_id = sel->data(RoleId).toString().trimmed();
+  const QString selected_role = sel->data(RoleRole).toString().trimmed();
+  apply_scene_selection(selected_id, selected_role, false, false);
+}
 void MainWindow::on_canvas_item_moved(QGraphicsItem * item, const QPointF &, const QPointF &, const QString & reason){ if(item) select_canvas_item(item); mark_layout_dirty(reason); }
 void MainWindow::apply_inspector_pose_to_item(){ if(inspector_update_guard_ || !digital_twin_scene_ || digital_twin_scene_->selectedItems().isEmpty()) return; auto *i=digital_twin_scene_->selectedItems().front(); QPointF old=i->pos(); i->setPos(inspector_x_->value()*100.0, inspector_y_->value()*100.0); i->setData(RolePoseZ, inspector_z_->value()); i->setData(RoleRoll, inspector_roll_->value()); i->setData(RolePitch, inspector_pitch_->value()); i->setData(RoleYaw, inspector_yaw_->value()); undo_stack_.push_back({"pose_edit", i->data(RoleId).toString(), old, i->pos(), false, false}); redo_stack_.clear(); mark_layout_dirty("Inspector Pose Edit"); }
 void MainWindow::undo_layout_edit(){ if(undo_stack_.empty() || !digital_twin_scene_) return; auto c=undo_stack_.back(); undo_stack_.pop_back(); for(auto *i:digital_twin_scene_->items()) if(i->data(RoleId).toString()==c.item_id){ i->setPos(c.old_pos); break;} redo_stack_.push_back(c); mark_layout_dirty("Undo"); }
@@ -3051,47 +3130,10 @@ void MainWindow::on_asset_filter_changed(int)
 
 void MainWindow::on_hierarchy_item_selected(QTreeWidgetItem * item)
 {
-  if (!item) return;
-  const QString source = item->data(0, TreeRoleSource).toString();
+  if (!item || selection_update_guard_) return;
   const QString selected_id = item->data(0, TreeRoleId).toString().trimmed();
   const QString selected_role = item->data(0, TreeRoleRole).toString().trimmed();
-  const bool pose_available = item->data(0, TreeRolePoseAvailable).toBool();
-  refresh_selected_scene_item_labels(current_selected_scene_item());
-  if (scene_preview_widget_) scene_preview_widget_->select_preview_item(selected_id);
-  if (!digital_twin_scene_) {
-    append_studio_log(QString("Studio selection: id=%1 role=%2 source=%3 pose_available=%4")
-      .arg(selected_id.isEmpty() ? QStringLiteral("<none>") : selected_id,
-        selected_role.isEmpty() ? QStringLiteral("unknown") : selected_role,
-        source.isEmpty() ? QStringLiteral("unknown") : source,
-        pose_available ? QStringLiteral("true") : QStringLiteral("false")));
-    return;
-  }
-  for (auto * gi : digital_twin_scene_->items()) {
-    if (gi->data(RoleId).toString().trimmed() == selected_id) {
-      digital_twin_scene_->clearSelection(); gi->setSelected(true); digital_twin_canvas_->centerOn(gi); select_canvas_item(gi);
-      if (pose_available) {
-        inspector_update_guard_ = true;
-        inspector_x_->setValue(item->data(0, TreeRolePoseX).toDouble());
-        inspector_y_->setValue(item->data(0, TreeRolePoseY).toDouble());
-        inspector_z_->setValue(item->data(0, TreeRolePoseZ).toDouble());
-        inspector_roll_->setValue(item->data(0, TreeRoleRoll).toDouble());
-        inspector_pitch_->setValue(item->data(0, TreeRolePitch).toDouble());
-        inspector_yaw_->setValue(item->data(0, TreeRoleYaw).toDouble());
-        inspector_update_guard_ = false;
-      }
-      append_studio_log(QString("Studio selection: id=%1 role=%2 source=%3 pose_available=%4")
-        .arg(selected_id.isEmpty() ? QStringLiteral("<none>") : selected_id,
-          selected_role.isEmpty() ? QStringLiteral("unknown") : selected_role,
-          source.isEmpty() ? QStringLiteral("unknown") : source,
-          pose_available ? QStringLiteral("true") : QStringLiteral("false")));
-      return;
-    }
-  }
-  append_studio_log(QString("Studio selection: id=%1 role=%2 source=%3 pose_available=%4")
-    .arg(selected_id.isEmpty() ? QStringLiteral("<none>") : selected_id,
-      selected_role.isEmpty() ? QStringLiteral("unknown") : selected_role,
-      source.isEmpty() ? QStringLiteral("unknown") : source,
-      pose_available ? QStringLiteral("true") : QStringLiteral("false")));
+  apply_scene_selection(selected_id, selected_role, false, true);
 }
 
 void MainWindow::populate_scene_hierarchy()

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -178,6 +178,7 @@ private:
   QPointF snap_canvas_position(const QPointF & pos) const;
   void refresh_minimap_card();
   void select_canvas_item(QGraphicsItem * item);
+  void apply_scene_selection(const QString & id, const QString & role, bool intentional_clear = false, bool center_canvas = true);
   void mark_layout_dirty(const QString & reason);
   void save_layout_changes();
   void revert_layout_changes();
@@ -310,6 +311,8 @@ private:
   double snap_step_m_{ 0.05 };
   bool layout_dirty_{ false };
   bool inspector_update_guard_{ false };
+  bool selection_update_guard_{ false };
+  QString current_selected_scene_item_id_;
   struct CanvasEditCommand { QString kind; QString item_id; QPointF old_pos; QPointF new_pos; bool created{false}; bool deleted{false}; };
   std::vector<CanvasEditCommand> undo_stack_;
   std::vector<CanvasEditCommand> redo_stack_;

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -1,5 +1,6 @@
 #include "scene_preview_widget.h"
 
+#include <algorithm>
 #include <QComboBox>
 #include <QFrame>
 #include <QGraphicsView>
@@ -350,7 +351,7 @@ void ScenePreviewWidget::set_fallback_2d_view(QGraphicsView * view){ fallback_2d
 void ScenePreviewWidget::set_scene_selected(bool selected){ scene_selected_ = selected; refresh_mode_and_state(); }
 void ScenePreviewWidget::set_3d_available(bool available, const QString & reason){ preview3d_available_ = available; unavailable_reason_ = reason; refresh_mode_and_state(); }
 void ScenePreviewWidget::on_mode_changed(int){ refresh_mode_and_state(); }
-void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items){ preview_items_ = items; static_cast<SimplePreview3DView *>(simple_3d_view_)->items = preview_items_; emit studio_log_requested(QString("Loaded %1 preview items.").arg(preview_items_.size())); fit_fallback_scene_to_items(); update(); }
+void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items){ preview_items_ = items; static_cast<SimplePreview3DView *>(simple_3d_view_)->items = preview_items_; const bool has_selected = std::any_of(preview_items_.cbegin(), preview_items_.cend(), [this](const PreviewItem & it){ return it.id == selected_preview_item_id_; }); if (!has_selected && !selected_preview_item_id_.isEmpty()) { emit studio_log_requested(QString("Preview selection id no longer present: %1").arg(selected_preview_item_id_)); } else { static_cast<SimplePreview3DView *>(simple_3d_view_)->selected_id = selected_preview_item_id_; } emit studio_log_requested(QString("Loaded %1 preview items.").arg(preview_items_.size())); fit_fallback_scene_to_items(); update(); }
 void ScenePreviewWidget::set_task_overlay_model(const TaskOverlayModel & model){ overlay_model_ = model; static_cast<SimplePreview3DView *>(simple_3d_view_)->task_overlay = model; simple_3d_view_->update(); }
 void ScenePreviewWidget::set_task_overlay_visibility(bool task_route, bool pick_place_zones, bool approach_retreat, bool labels){
   auto * v = static_cast<SimplePreview3DView *>(simple_3d_view_);


### PR DESCRIPTION
### Motivation
- Reduce duplicated selection-handling logic and prevent accidental clearing of selection during refresh/rebuild operations by centralizing selection updates in one place.
- Ensure all UI sinks (scene tree, canvas, preview widget, and inspector) stay in sync and selection changes are logged in a consistent, requested format.

### Description
- Added a centralized `MainWindow::apply_scene_selection(const QString &id, const QString &role, bool intentional_clear = false, bool center_canvas = true)` to set the current selected id, update the scene tree row selection, highlight/select the canvas item, update the preview widget selected id, and refresh inspector labels.
- Introduced guards and state: added `selection_update_guard_` and `current_selected_scene_item_id_` to prevent recursive churn while syncing selection across widgets and to remember selection across rebuilds (`mainwindow.h`).
- Reworked handlers to use the central API: `on_hierarchy_item_selected` and `on_canvas_selection_changed` now call `apply_scene_selection` instead of doing ad-hoc syncing.
- Preserve selection across canvas rebuilds by capturing `current_selected_scene_item_id_` at the start of `rebuild_digital_twin_canvas()` and re-applying it afterward if present, avoiding implicit clears on refresh.
- Updated preview refresh in `ScenePreviewWidget::set_preview_items` to retain the preview `selected_preview_item_id_` when still present and emit a log only if the previously selected preview id no longer exists.
- Standardized selection logging to the exact format `Selected item: <id> (<role>)` and `Selected item: <none> (unknown)` for intentional clears.

### Testing
- Ran `git diff --check` to ensure no whitespace/style conflicts and it passed (no issues reported).
- Searched for the new selection log via `rg -n "Selected item:"` to verify the updated log strings were present and the grep returned expected occurrences (succeeded).
- Confirmed modified files are staged/committed (`git commit`) as part of the change (commit completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b68c1da08331860f0b245955696f)