### PR TITLE
Add compact scene status chip to preview canvases

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -3168,7 +3168,7 @@ void MainWindow::populate_scene_hierarchy()
   if (!scene_hierarchy_tree_) return;
   scene_hierarchy_tree_->clear();
 
-  if (selected_scene_index_ < 0 || selected_scene_index_ >= (int)scene_browser_result_.scenes.size()) { if (scene_preview_widget_) scene_preview_widget_->set_scene_selected(false); return; }
+  if (selected_scene_index_ < 0 || selected_scene_index_ >= (int)scene_browser_result_.scenes.size()) { if (scene_preview_widget_) { scene_preview_widget_->set_scene_selected(false); scene_preview_widget_->set_preview_scene_name("No scene"); } return; }
   const auto & s = scene_browser_result_.scenes[(size_t)selected_scene_index_];
   const fs::path d = s.scene_dir;
   const auto model = workcell_builder::build_workcell_studio_canvas_model(s.scene_dir, s.scene_name);
@@ -3430,7 +3430,7 @@ void MainWindow::populate_scene_hierarchy()
     }
   }
 
-  if (scene_preview_widget_) { scene_preview_widget_->set_scene_selected(true); scene_preview_widget_->set_preview_items(preview_items); }
+  if (scene_preview_widget_) { scene_preview_widget_->set_scene_selected(true); scene_preview_widget_->set_preview_scene_name(QString::fromStdString(s.scene_name)); scene_preview_widget_->set_preview_items(preview_items); }
   preview_warning_details_ = preview_warning_details;
 
   const bool snapshot_available = fs::exists(d / "preview" / "epd_detection_snapshot.png");

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -6,6 +6,7 @@
 #include <QGraphicsView>
 #include <QGraphicsScene>
 #include <QGraphicsItem>
+#include <QGraphicsProxyWidget>
 #include <QHBoxLayout>
 #include <functional>
 #include <QLabel>
@@ -32,6 +33,7 @@ public:
   ScenePreviewWidget::TaskOverlayModel task_overlay;
   ScenePreviewWidget::ReachabilityOverlayModel reach_overlay;
   ScenePreviewWidget::CollisionOverlayModel collision_overlay;
+  QString scene_name{"No scene"};
   ScenePreviewWidget::CameraOverlayModel camera_overlay;
   QVector<ScenePreviewWidget::EpdDetectionOverlayModel> epd_detections;
   std::function<void(const QString&)> select_cb;
@@ -110,6 +112,7 @@ protected:
     drawSelectionHighlight(p);
     drawCompactLabels(p);
     drawWarningBadges(p);
+    drawInfoChip(p);
   }
 
   QColor itemColor(const ScenePreviewWidget::PreviewItem & it) const {
@@ -297,6 +300,21 @@ protected:
       p.drawText(QRectF(badge_center.x() - 8, badge_center.y() - 8, 16, 16), Qt::AlignCenter, it.warnings.size() > 1 ? QString::number(it.warnings.size()) : "!");
     }
   }
+  void drawInfoChip(QPainter & p) const {
+    int warning_count = 0;
+    for (const auto & it : items) warning_count += it.warnings.size();
+    warning_count += task_overlay.warnings.size() + reach_overlay.warnings.size() + collision_overlay.warnings.size() + camera_overlay.warnings.size();
+    for (const auto & det : epd_detections) warning_count += det.warnings.size();
+    const bool task_ready = task_overlay.has_intent_metadata && task_overlay.pick_source_id != "unknown" && task_overlay.place_target_id != "unknown";
+    const QString chip_text = QString("Scene: %1\nItems: %2  Warn: %3  Task: %4").arg(scene_name, QString::number(items.size()), QString::number(warning_count), task_ready ? "Ready" : "Missing");
+    const QRectF text_rect = QFontMetricsF(p.font()).boundingRect(QRectF(0, 0, width() * 0.6, 100), Qt::TextWordWrap, chip_text);
+    const QRectF chip_rect(12, height() - text_rect.height() - 16, text_rect.width() + 16, text_rect.height() + 10);
+    p.setPen(Qt::NoPen);
+    p.setBrush(QColor(15, 23, 42, 210));
+    p.drawRoundedRect(chip_rect, 6, 6);
+    p.setPen(QColor("#e2e8f0"));
+    p.drawText(chip_rect.adjusted(8, 5, -8, -5), Qt::AlignLeft | Qt::AlignVCenter | Qt::TextWordWrap, chip_text);
+  }
 private:
   QPoint last_;
   double yaw_{-0.9}, pitch_{0.7}, zoom_{1.0};
@@ -327,6 +345,11 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   fallback_banner_label_->setAlignment(Qt::AlignCenter);
   fallback_banner_label_->setVisible(false);
   view2d_container_->layout()->addWidget(fallback_banner_label_);
+  info_chip_label_ = new QLabel(view2d_container_);
+  info_chip_label_->setObjectName("previewInfoChip");
+  info_chip_label_->setStyleSheet("QLabel#previewInfoChip { background-color: rgba(15,23,42,210); color: #e2e8f0; border-radius: 6px; padding: 5px 8px; }");
+  info_chip_label_->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+  info_chip_label_->setWordWrap(true);
   stack_->addWidget(view3d_container_); stack_->addWidget(view2d_container_); root->addWidget(stack_, 1);
   connect(mode_selector_, qOverload<int>(&QComboBox::currentIndexChanged), this, &ScenePreviewWidget::on_mode_changed);
   connect(reset_view_button_, &QPushButton::clicked, this, &ScenePreviewWidget::on_reset_view_clicked);
@@ -345,14 +368,16 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
     v->update();
   });
   static_cast<SimplePreview3DView *>(simple_3d_view_)->select_cb = [this](const QString & id){ select_preview_item(id); emit preview_item_selected(id); emit studio_log_requested(QString("Selected preview item: %1").arg(id)); };
+  refresh_info_chip();
   refresh_mode_and_state();
 }
-void ScenePreviewWidget::set_fallback_2d_view(QGraphicsView * view){ fallback_2d_view_ = view; if (!view2d_container_->layout()) view2d_container_->setLayout(new QVBoxLayout()); view2d_container_->layout()->addWidget(view); }
+void ScenePreviewWidget::set_fallback_2d_view(QGraphicsView * view){ fallback_2d_view_ = view; if (!view2d_container_->layout()) view2d_container_->setLayout(new QVBoxLayout()); view2d_container_->layout()->addWidget(view); if (fallback_2d_view_ && fallback_2d_view_->scene() && info_chip_label_ && !fallback_info_chip_proxy_) { fallback_info_chip_proxy_ = fallback_2d_view_->scene()->addWidget(info_chip_label_); fallback_info_chip_proxy_->setZValue(10000.0); fallback_info_chip_proxy_->setPos(12.0, 12.0); } refresh_info_chip(); }
 void ScenePreviewWidget::set_scene_selected(bool selected){ scene_selected_ = selected; refresh_mode_and_state(); }
 void ScenePreviewWidget::set_3d_available(bool available, const QString & reason){ preview3d_available_ = available; unavailable_reason_ = reason; refresh_mode_and_state(); }
 void ScenePreviewWidget::on_mode_changed(int){ refresh_mode_and_state(); }
-void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items){ preview_items_ = items; static_cast<SimplePreview3DView *>(simple_3d_view_)->items = preview_items_; const bool has_selected = std::any_of(preview_items_.cbegin(), preview_items_.cend(), [this](const PreviewItem & it){ return it.id == selected_preview_item_id_; }); if (!has_selected && !selected_preview_item_id_.isEmpty()) { emit studio_log_requested(QString("Preview selection id no longer present: %1").arg(selected_preview_item_id_)); } else { static_cast<SimplePreview3DView *>(simple_3d_view_)->selected_id = selected_preview_item_id_; } emit studio_log_requested(QString("Loaded %1 preview items.").arg(preview_items_.size())); fit_fallback_scene_to_items(); update(); }
-void ScenePreviewWidget::set_task_overlay_model(const TaskOverlayModel & model){ overlay_model_ = model; static_cast<SimplePreview3DView *>(simple_3d_view_)->task_overlay = model; simple_3d_view_->update(); }
+void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items){ preview_items_ = items; static_cast<SimplePreview3DView *>(simple_3d_view_)->items = preview_items_; const bool has_selected = std::any_of(preview_items_.cbegin(), preview_items_.cend(), [this](const PreviewItem & it){ return it.id == selected_preview_item_id_; }); if (!has_selected && !selected_preview_item_id_.isEmpty()) { emit studio_log_requested(QString("Preview selection id no longer present: %1").arg(selected_preview_item_id_)); } else { static_cast<SimplePreview3DView *>(simple_3d_view_)->selected_id = selected_preview_item_id_; } emit studio_log_requested(QString("Loaded %1 preview items.").arg(preview_items_.size())); fit_fallback_scene_to_items(); refresh_info_chip(); update(); }
+void ScenePreviewWidget::set_preview_scene_name(const QString & scene_name){ preview_scene_name_ = scene_name.trimmed().isEmpty() ? "No scene" : scene_name.trimmed(); auto * v = static_cast<SimplePreview3DView *>(simple_3d_view_); v->scene_name = preview_scene_name_; refresh_info_chip(); v->update(); }
+void ScenePreviewWidget::set_task_overlay_model(const TaskOverlayModel & model){ overlay_model_ = model; static_cast<SimplePreview3DView *>(simple_3d_view_)->task_overlay = model; refresh_info_chip(); simple_3d_view_->update(); }
 void ScenePreviewWidget::set_task_overlay_visibility(bool task_route, bool pick_place_zones, bool approach_retreat, bool labels){
   auto * v = static_cast<SimplePreview3DView *>(simple_3d_view_);
   v->show_task_route = task_route;
@@ -410,12 +435,16 @@ void ScenePreviewWidget::reset_fallback_scene_view()
   fit_fallback_scene_to_items();
 }
 
-void ScenePreviewWidget::set_camera_overlay_model(const CameraOverlayModel & model){ camera_overlay_model_ = model; auto *v=static_cast<SimplePreview3DView *>(simple_3d_view_); v->camera_overlay = model; simple_3d_view_->update(); }
-void ScenePreviewWidget::set_epd_detection_overlays(const QVector<EpdDetectionOverlayModel> & detections){ epd_detections_ = detections; auto *v=static_cast<SimplePreview3DView *>(simple_3d_view_); v->epd_detections = detections; simple_3d_view_->update(); }
+void ScenePreviewWidget::set_camera_overlay_model(const CameraOverlayModel & model){ camera_overlay_model_ = model; auto *v=static_cast<SimplePreview3DView *>(simple_3d_view_); v->camera_overlay = model; refresh_info_chip(); simple_3d_view_->update(); }
+void ScenePreviewWidget::set_epd_detection_overlays(const QVector<EpdDetectionOverlayModel> & detections){ epd_detections_ = detections; auto *v=static_cast<SimplePreview3DView *>(simple_3d_view_); v->epd_detections = detections; refresh_info_chip(); simple_3d_view_->update(); }
 void ScenePreviewWidget::set_perception_overlay_visibility(bool camera_fov, bool pick_coverage, bool epd_detections, bool detection_labels){ auto *v=static_cast<SimplePreview3DView *>(simple_3d_view_); v->show_camera_fov=camera_fov; v->show_pick_coverage=pick_coverage; v->show_epd_detections=epd_detections; v->show_detection_labels=detection_labels; v->update(); }
 
 
-void ScenePreviewWidget::set_reachability_overlay_model(const ReachabilityOverlayModel & model){ reachability_overlay_model_ = model; auto *v=static_cast<SimplePreview3DView *>(simple_3d_view_); v->reach_overlay = model; emit studio_log_requested(QString("reachability overlay loaded: warning count=%1").arg(model.warnings.size())); simple_3d_view_->update(); }
-void ScenePreviewWidget::set_collision_overlay_model(const CollisionOverlayModel & model){ collision_overlay_model_ = model; auto *v=static_cast<SimplePreview3DView *>(simple_3d_view_); v->collision_overlay = model; emit studio_log_requested(QString("collision preview checks complete: warning count=%1").arg(model.warnings.size())); simple_3d_view_->update(); }
+void ScenePreviewWidget::set_reachability_overlay_model(const ReachabilityOverlayModel & model){ reachability_overlay_model_ = model; auto *v=static_cast<SimplePreview3DView *>(simple_3d_view_); v->reach_overlay = model; emit studio_log_requested(QString("reachability overlay loaded: warning count=%1").arg(model.warnings.size())); refresh_info_chip(); simple_3d_view_->update(); }
+void ScenePreviewWidget::set_collision_overlay_model(const CollisionOverlayModel & model){ collision_overlay_model_ = model; auto *v=static_cast<SimplePreview3DView *>(simple_3d_view_); v->collision_overlay = model; emit studio_log_requested(QString("collision preview checks complete: warning count=%1").arg(model.warnings.size())); refresh_info_chip(); simple_3d_view_->update(); }
 
 void ScenePreviewWidget::set_label_mode(LabelMode mode){ auto *v=static_cast<SimplePreview3DView *>(simple_3d_view_); v->label_mode = mode; v->update(); }
+
+int ScenePreviewWidget::total_warning_count() const { int count = 0; for (const auto & item : preview_items_) count += item.warnings.size(); count += overlay_model_.warnings.size() + reachability_overlay_model_.warnings.size() + collision_overlay_model_.warnings.size() + camera_overlay_model_.warnings.size(); for (const auto & det : epd_detections_) count += det.warnings.size(); return count; }
+bool ScenePreviewWidget::task_is_ready() const { return overlay_model_.has_intent_metadata && overlay_model_.pick_source_id != "unknown" && overlay_model_.place_target_id != "unknown"; }
+void ScenePreviewWidget::refresh_info_chip() { if (!info_chip_label_) return; info_chip_label_->setText(QString("Scene: %1\nItems: %2  Warn: %3  Task: %4").arg(preview_scene_name_).arg(preview_items_.size()).arg(total_warning_count()).arg(task_is_ready() ? "Ready" : "Missing")); info_chip_label_->adjustSize(); if (fallback_info_chip_proxy_) fallback_info_chip_proxy_->setPos(12.0, 12.0); }

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -11,6 +11,7 @@ class QStackedWidget;
 class QGraphicsView;
 class QGraphicsScene;
 class QGraphicsItem;
+class QGraphicsProxyWidget;
 
 class ScenePreviewWidget : public QWidget
 {
@@ -104,6 +105,7 @@ public:
   void set_scene_selected(bool selected);
   void set_3d_available(bool available, const QString & reason = QString());
   void set_preview_items(const QVector<PreviewItem> & items);
+  void set_preview_scene_name(const QString & scene_name);
   void set_task_overlay_model(const TaskOverlayModel & model);
   void set_reachability_overlay_model(const ReachabilityOverlayModel & model);
   void set_collision_overlay_model(const CollisionOverlayModel & model);
@@ -131,6 +133,9 @@ private:
   QRectF rendered_items_bounds_2d() const;
   void fit_fallback_scene_to_items();
   void reset_fallback_scene_view();
+  void refresh_info_chip();
+  int total_warning_count() const;
+  bool task_is_ready() const;
 
   QComboBox * mode_selector_{ nullptr };
   QPushButton * reset_view_button_{ nullptr };
@@ -144,6 +149,9 @@ private:
   QLabel * fallback_banner_label_{ nullptr };
   QWidget * simple_3d_view_{ nullptr };
   QGraphicsView * fallback_2d_view_{ nullptr };
+  QLabel * info_chip_label_{ nullptr };
+  QGraphicsProxyWidget * fallback_info_chip_proxy_{ nullptr };
+  QString preview_scene_name_{"No scene"};
   bool scene_selected_{ false };
   bool preview3d_available_{ true };
   QString unavailable_reason_;


### PR DESCRIPTION
### Motivation
- Provide a minimal, always-visible status indicator in scene previews to surface scene name, item count, warnings count, and task readiness without blocking the central workcell view.
- Mirror the same concise information in the 2D fallback canvas so users see consistent preview/readiness state regardless of rendering mode.
- Populate the chip exclusively from existing preview/readiness model data to avoid changing runtime execution or task logic.

### Description
- Render a compact chip in the 3D preview by adding `drawInfoChip` to `SimplePreview3DView` that paints scene name, items count, aggregated warnings count, and task readiness (`Missing`/`Ready`).
- Add a mirrored 2D overlay by creating a styled `QLabel` and attaching it to the fallback `QGraphicsScene` as a `QGraphicsProxyWidget` so it appears at fixed position on the 2D canvas.
- Extend `ScenePreviewWidget` with `set_preview_scene_name`, `refresh_info_chip`, `total_warning_count`, and `task_is_ready` helpers and wire updates from existing setters (`set_preview_items`, `set_task_overlay_model`, `set_reachability_overlay_model`, `set_collision_overlay_model`, `set_camera_overlay_model`, `set_epd_detection_overlays`).
- Pass the selected scene name from `MainWindow::populate_scene_hierarchy()` into the preview widget and ensure the chip updates on data changes; no changes to runtime execution flow were made.

### Testing
- Inspected diffs and file contents with `git diff` and `nl` to verify the new declarations and implementations were added to `scene_preview_widget.h`, `scene_preview_widget.cpp`, and `mainwindow.cpp`, and these commands completed successfully.
- Ran repository searches (`rg`) to confirm relevant symbols and call sites were updated and the commands completed successfully.
- No unit tests were added; manual code inspection of the modified files was performed and showed expected wiring and rendering code added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b7c3db34833191c3b84144ad179a)