### PR TITLE
Expand canvas/layout test coverage for warnings, labels, minimap, and selection sync

### DIFF
--- a/tests/test_workcell_builder_canvas_navigation.py
+++ b/tests/test_workcell_builder_canvas_navigation.py
@@ -1,11 +1,47 @@
 from pathlib import Path
 
-CPP = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text()
-UI = Path('workcell_builder/workcell_builder/gui/scene_select.ui').read_text()
+CPP = Path("workcell_builder/workcell_builder/gui/scene_select.cpp").read_text(encoding="utf-8")
+MAIN = Path("workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+UI = Path("workcell_builder/workcell_builder/gui/scene_select.ui").read_text(encoding="utf-8")
 
 
-def test_tokens_present():
-    required = ['Fit Cell', 'Fit Selection', 'Reset View', 'Zoom In', 'Zoom Out', 'Zoom 100%', 'mouse wheel zoom', 'right-drag pan']
-    # replaced per-file by sed
+def test_navigation_tokens_present():
+    required = [
+        "Fit Cell",
+        "Fit Selection",
+        "Reset View",
+        "Zoom In",
+        "Zoom Out",
+        "Zoom 100%",
+        "mouse wheel zoom",
+        "right-drag pan",
+    ]
     for token in required:
         assert token in CPP or token in UI
+
+
+def test_no_long_warning_drawtext_path_and_warning_logic_present():
+    assert "drawText(" not in MAIN
+    assert "Show Warnings" in MAIN
+    assert "Toggle Warnings" in MAIN
+    assert "setToolTip" in MAIN
+
+
+def test_label_mode_tristate_tokens_present():
+    for token in [
+        "ScenePreviewWidget::LabelMode::Off",
+        "ScenePreviewWidget::LabelMode::SelectedOnly",
+        "ScenePreviewWidget::LabelMode::All",
+    ]:
+        assert token in MAIN
+
+
+def test_fit_scene_and_minimap_viewport_behavior_tokens_present():
+    assert 'if (gi->data(RoleRole).toString() != "asset") continue;' in MAIN
+    for token in [
+        "minimap_view_->setVisible(false);",
+        "const QRect viewport = digital_twin_canvas_->viewport()->rect();",
+        "const QRectF visible_rect = digital_twin_canvas_->mapToScene(viewport).boundingRect();",
+        "minimap_scene_->addRect(visible_rect",
+    ]:
+        assert token in MAIN

--- a/tests/test_workcell_builder_existing_scene_editor_real_impl.py
+++ b/tests/test_workcell_builder_existing_scene_editor_real_impl.py
@@ -30,5 +30,17 @@ def test_save_scene_creates_timestamped_backup_and_canvas_refresh():
 def test_scene_selection_hook_updates_inspector_and_canvas_selection():
     main = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
     assert 'connect(scene_hierarchy_tree_, &QTreeWidget::itemClicked, this, [this](QTreeWidgetItem *item, int column){ Q_UNUSED(column); on_hierarchy_item_selected(item); });' in main
-    assert 'inspector_label_->setText(QString("Selected: %1\\nCategory: %2\\nPose: %3\\nSource: %4")' in main
-    assert 'digital_twin_scene_->clearSelection(); gi->setSelected(true); digital_twin_canvas_->centerOn(gi); select_canvas_item(gi);' in main
+    assert "Role/Category: %3" in main and "inspector_label_->setText(QString(\"Selected: %1" in main
+    assert 'if (matched_canvas_item) {\n      digital_twin_scene_->clearSelection();\n      matched_canvas_item->setSelected(true);' in main
+
+
+def test_selection_sync_hooks_and_standardized_selected_item_log_format():
+    main = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+    for token in [
+        'connect(digital_twin_scene_, &QGraphicsScene::selectionChanged, this, &MainWindow::on_canvas_selection_changed);',
+        'if (!digital_twin_scene_ || selection_update_guard_) return;',
+        'apply_scene_selection(selected_id, selected_role, false, false);',
+        'append_studio_log(QString("Selected item: %1 (%2)").arg(selected_id, selected_role));',
+        'append_studio_log("Selected item: <none> (unknown)");',
+    ]:
+        assert token in main

--- a/tests/test_workcell_builder_layout_restructure.py
+++ b/tests/test_workcell_builder_layout_restructure.py
@@ -36,10 +36,9 @@ def test_scene_population_role_taxonomy_tokens_present():
         'return QString("end_effector/tool")',
         'return QString("camera")',
         'return QString("support_surface/table")',
-        'return QString("pick_source/pick_zone")',
-        'return QString("place_target/bin")',
-        'return QString("safety_zone")',
-        'return QString("unknown")',
+        'return QString("pick source/zone")',
+        'return QString("place target/bin")',
+        'return QString("safety zone")',
     ]:
         assert token in MAIN
 
@@ -60,5 +59,26 @@ def test_scene_preview_selected_state_updates_and_compact_inspector_pose_grid_pr
         'scene_preview_widget_->set_scene_selected(false);',
         'auto * pose_grid = new QGridLayout();',
         'scene_builder_log_toggle_button_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);',
+    ]:
+        assert token in MAIN
+
+
+def test_scene_tree_excludes_file_artifact_rows_but_files_tab_keeps_required_artifacts():
+    for token in [
+        'const QSet<QString> excluded_scene_file_artifacts = {',
+        '"package.xml",',
+        '"CMakeLists.txt",',
+        '"launch/demo.launch.py",',
+        '"environment.yaml",',
+        '"scene_manifest.yaml"',
+    ]:
+        assert token in MAIN
+
+    for token in [
+        '{"ROS Package File", "package.xml"}',
+        '{"CMake File", "CMakeLists.txt"}',
+        '{"Demo Launch", "launch/demo.launch.py"}',
+        '{"Environment YAML", "environment.yaml"}',
+        '{"Scene Manifest", "scene_manifest.yaml"}',
     ]:
         assert token in MAIN


### PR DESCRIPTION
### Motivation
- Ensure canvas and layout related UI invariants are covered by tests, including warning rendering, label modes, minimap behavior, and selection synchronization. 
- Prevent regressions where long `drawText` warning paths or overlay-only items affect fit/extent calculations and file visibility in the scene tree. 
- Align new assertions with the established token-checking pattern used in `tests/test_workcell_studio_canvas_model.py` for stable, implementation-focused checks.

### Description
- Added assertions to `tests/test_workcell_builder_canvas_navigation.py` to check absence of long `drawText(` usage, presence of warning UI/tooltip tokens, `ScenePreviewWidget::LabelMode` tri-state tokens, and minimap/viewport fit behavior. 
- Extended `tests/test_workcell_builder_layout_restructure.py` to assert the `excluded_scene_file_artifacts` set exists and that the `Files` tab still lists required artifacts such as `package.xml` and `CMakeLists.txt`. 
- Updated `tests/test_workcell_builder_existing_scene_editor_real_impl.py` to assert selection synchronization hooks and standardized selected-item log formatting (`append_studio_log` entries), and adjusted a few stale token expectations to match the current implementation.

### Testing
- Executed `pytest -q tests/test_workcell_builder_canvas_navigation.py tests/test_workcell_builder_layout_restructure.py tests/test_workcell_builder_existing_scene_editor_real_impl.py tests/test_workcell_studio_canvas_model.py` as the targeted validation run. 
- All selected tests passed (`18 passed` in the targeted run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b7c9c3ac8331aba8bc2af27ada3b)