### PR TITLE
Refine 3D preview warning presentation and debug overlay gating

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -6,6 +6,7 @@
 #include <QPainter>
 #include <QVector3D>
 #include <QVector4D>
+#include <QToolTip>
 #include <QtMath>
 
 #include <algorithm>
@@ -88,6 +89,39 @@ void Scene3DViewportWidget::paintGL()
   }
   if (show_camera_fov) draw_frustum(QColor(56, 189, 248, 96), true);
   glDisable(GL_BLEND);
+
+  QPainter painter(this);
+  painter.setRenderHint(QPainter::Antialiasing, true);
+  const auto compact_role = [](const QString & role) {
+    const QString r = role.trimmed().toLower();
+    if (r.contains("pick")) return QStringLiteral("Pick");
+    if (r.contains("place")) return QStringLiteral("Place");
+    if (r.contains("camera")) return QStringLiteral("Cam");
+    if (r.contains("safety")) return QStringLiteral("Safe");
+    if (r.isEmpty()) return QStringLiteral("Item");
+    return role.left(10);
+  };
+  for (const auto & it : items) {
+    const QPointF p = project_to_screen(it.x + (it.sx * 0.5), it.y + (it.sy * 0.5), it.z + it.sz + 0.08);
+    const bool selected = (it.id == selected_id);
+    const bool draw_label = label_mode == ScenePreviewWidget::LabelMode::All || selected;
+    if (show_warning_labels && !it.warnings.isEmpty()) {
+      painter.setPen(Qt::NoPen);
+      painter.setBrush(QColor("#f59e0b"));
+      painter.drawEllipse(QRectF(p.x() - 8.0, p.y() - 20.0, 16.0, 16.0));
+      painter.setPen(QColor("#111827"));
+      painter.drawText(QRectF(p.x() - 8.0, p.y() - 20.0, 16.0, 16.0), Qt::AlignCenter, "!");
+    }
+    if (draw_label) {
+      const QString text = selected ? it.id : compact_role(it.role);
+      painter.setPen(QColor("#e2e8f0"));
+      painter.drawText(QPointF(p.x() + 10.0, p.y() - 8.0), text);
+    }
+    if (debug_overlays_mode && show_warning_labels && !it.warnings.isEmpty()) {
+      painter.setPen(QColor("#fca5a5"));
+      painter.drawText(QPointF(p.x() + 10.0, p.y() + 10.0), it.warnings.join(" | "));
+    }
+  }
 }
 
 void Scene3DViewportWidget::draw_box(double cx, double cy, double cz, double sx, double sy, double sz, const QColor & color, bool translucent)
@@ -203,5 +237,29 @@ void Scene3DViewportWidget::mousePressEvent(QMouseEvent * e) {
   }
   if (!best_id.isEmpty() && select_cb) select_cb(best_id, best_role);
 }
-void Scene3DViewportWidget::mouseMoveEvent(QMouseEvent * e) { auto d = e->pos() - last_; last_ = e->pos(); if (e->buttons() & Qt::LeftButton) { yaw_ += d.x() * 0.01; pitch_ = qBound(-1.4, pitch_ + d.y() * 0.01, 1.4); update(); } }
+void Scene3DViewportWidget::mouseMoveEvent(QMouseEvent * e)
+{
+  auto d = e->pos() - last_;
+  last_ = e->pos();
+  if (e->buttons() & Qt::LeftButton) {
+    yaw_ += d.x() * 0.01;
+    pitch_ = qBound(-1.4, pitch_ + d.y() * 0.01, 1.4);
+    update();
+    return;
+  }
+  const QPointF pos = e->position();
+  QString hovered;
+  for (const auto & it : items) {
+    const QPointF p = project_to_screen(it.x + (it.sx * 0.5), it.y + (it.sy * 0.5), it.z + it.sz + 0.08);
+    if (QLineF(pos, p).length() < 20.0) {
+      hovered = it.id;
+      if (!it.warnings.isEmpty()) {
+        QToolTip::showText(e->globalPosition().toPoint(), it.warnings.join("\n"), this);
+      }
+      break;
+    }
+  }
+  if (hovered.isEmpty()) QToolTip::hideText();
+  hovered_id_ = hovered;
+}
 void Scene3DViewportWidget::wheelEvent(QWheelEvent * e) { zoom_ = qBound(0.4, zoom_ + (e->angleDelta().y() > 0 ? -0.1 : 0.1), 2.2); update(); }

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -22,6 +22,7 @@ public:
   bool show_reachability_heatmap{ true }, show_collision_warnings{ true }, show_work_envelope{ true }, show_warning_labels{ true };
   bool show_task_route{ true }, show_approach_retreat{ true };
   bool show_camera_fov{ true }, show_pick_coverage{ true }, show_epd_detections{ true }, show_detection_labels{ true };
+  bool debug_overlays_mode{ false };
   ScenePreviewWidget::TaskOverlayModel task_overlay;
   ScenePreviewWidget::ReachabilityOverlayModel reach_overlay;
   ScenePreviewWidget::CollisionOverlayModel collision_overlay;
@@ -56,10 +57,12 @@ private:
   void draw_cylinder(double cx, double cy, double cz, double radius, double height, const QColor & color, bool translucent = false);
   void draw_frustum(const QColor & color, bool translucent = true);
   QPoint last_;
+  QString hovered_id_;
   QVector3D orbit_offset_{ 0.0f, 0.0f, 0.0f };
   double yaw_{ -0.9 };
   double pitch_{ 0.7 };
   double distance_{ 6.0 };
+  double zoom_{ 1.0 };
   const double min_distance_{ 0.35 };
   const double max_distance_{ 80.0 };
 };

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -110,6 +110,8 @@ void ScenePreviewWidget::refresh_mode_and_state()
   }
   fallback_banner_label_->setVisible(false);
   bool use3d = mode_selector_->currentText() == "3D View";
+  auto * viewport = static_cast<Scene3DViewportWidget *>(simple_3d_view_);
+  viewport->debug_overlays_mode = (mode_selector_->currentText() == "Debug Overlays");
   if (mode_selector_->currentText() == "Debug Overlays") use3d = false;
   stack_->setCurrentWidget(use3d ? view3d_container_ : view2d_container_);
   const bool has_preview_items = !preview_items_.isEmpty();


### PR DESCRIPTION
### Motivation
- Reduce visual clutter in the 3D viewport by keeping in-scene labels compact (selected item ID or short role labels) while preserving visible warning badges/icons above items.
- Remove long warning prose from the default center-scene draw path so the scene remains readable during normal use.
- Keep full warning text available via interactive surfaces and existing data sources (tooltips on hover/selection and readiness/status panels).
- Allow verbose/debug overlays to be shown only when the dedicated `Debug Overlays` mode is selected.

### Description
- Render changes in the 3D viewport: `paintGL` now draws compact role labels for non-selected items and the full item ID only for the selected item, while still drawing a visible warning badge (`!`) for items with warnings.
- Move long warning prose out of the default draw path and surface full warning text on hover via `QToolTip::showText` from `mouseMoveEvent` so hover/selection reveals detailed warnings without cluttering the scene.
- Gate verbose in-viewport warning text behind a new `debug_overlays_mode` flag so debug prose is only drawn when `Debug Overlays` is active; `ScenePreviewWidget::refresh_mode_and_state` sets this flag from the mode selector.
- Minor viewport state additions: added `debug_overlays_mode`, `hovered_id_`, and `zoom_` members to `Scene3DViewportWidget` to support hover/tooltips and zoom-based camera matrices.
- Files changed: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`, `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h`, and `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`.

### Testing
- Ran the canvas validation test `python -m pytest -q tests/test_workcell_studio_canvas_validation.py`, which passed (1 test, all assertions succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c22308c883318d3876a66bccfc9f)