### PR TITLE
Add Qt5 OpenGL linkage for workcell_builder (QOpenGLWidget support)

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -41,7 +41,7 @@ find_package(pluginlib REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem)
-find_package(Qt5 COMPONENTS Widgets Concurrent Svg REQUIRED)
+find_package(Qt5 COMPONENTS Widgets Concurrent Svg OpenGL REQUIRED)
 find_package(OpenGL REQUIRED)
 
 include_directories(include)
@@ -190,6 +190,7 @@ target_link_libraries(workcell_builder
   Qt5::Widgets
   Qt5::Concurrent
   Qt5::Svg
+  Qt5::OpenGL
   OpenGL::GL
   yaml-cpp
   ${Boost_LIBRARIES}

--- a/workcell_builder/workcell_builder/package.xml
+++ b/workcell_builder/workcell_builder/package.xml
@@ -29,9 +29,11 @@
 
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>libqt5svg5-dev</build_depend>
+  <build_depend>libqt5opengl5-dev</build_depend>
   <build_depend>qt5-qmake</build_depend>
   <exec_depend>qtbase5-dev</exec_depend>
   <exec_depend>libqt5svg5-dev</exec_depend>
+  <exec_depend>libqt5opengl5-dev</exec_depend>
   <exec_depend>qt5-qmake</exec_depend>
   <!--test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend-->


### PR DESCRIPTION
### Motivation
- The package's GUI uses `QOpenGLWidget` and therefore needs the Qt5 OpenGL component to be discovered and linked at build time.
- Ensure linkage remains on Qt5 APIs compatible with ROS 2 Humble and do not introduce any Qt6-only requirements.

### Description
- Updated `workcell_builder/workcell_builder/CMakeLists.txt` to add `OpenGL` to `find_package(Qt5 COMPONENTS ...)` so the Qt5 OpenGL component is required.
- Linked the `workcell_builder` target against `Qt5::OpenGL` in addition to existing `Qt5::Widgets`, `Qt5::Concurrent`, and `Qt5::Svg`, while keeping the system `OpenGL::GL` linkage.
- Updated `workcell_builder/workcell_builder/package.xml` to add `libqt5opengl5-dev` as both a `build_depend` and an `exec_depend` to ensure the Qt5 OpenGL development package is available at build and runtime.
- Verified the target usage by locating the `QOpenGLWidget` usage in `gui/scene3d_viewport_widget.h` before making changes.

### Testing
- Ran source discovery checks with `rg --files | rg 'workcell_builder/.*/(CMakeLists.txt|package.xml)|workcell_builder/(CMakeLists.txt|package.xml)'` which located the package-level files successfully.
- Verified `QOpenGLWidget` usage with `rg -n "QOpenGLWidget|QGL|OpenGLWidget" workcell_builder/workcell_builder` which returned the widget usage in `gui/scene3d_viewport_widget.h` successfully.
- Inspected diffs with `git diff` and committed the changes with `git commit`, and both operations completed successfully.
- No CMake configure, build, or package unit tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c23f0a9483319d4c38b983a5c6bd)