### PR TITLE
Expand test coverage for 3D viewport, fallback behavior, and OpenGL/Qt linkage

### DIFF
--- a/tests/test_workcell_builder_canvas_navigation.py
+++ b/tests/test_workcell_builder_canvas_navigation.py
@@ -3,6 +3,9 @@ from pathlib import Path
 CPP = Path("workcell_builder/workcell_builder/gui/scene_select.cpp").read_text(encoding="utf-8")
 MAIN = Path("workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
 UI = Path("workcell_builder/workcell_builder/gui/scene_select.ui").read_text(encoding="utf-8")
+PREVIEW = Path("workcell_builder/workcell_builder/gui/scene_preview_widget.cpp").read_text(encoding="utf-8")
+VIEW3D_CPP = Path("workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp").read_text(encoding="utf-8")
+VIEW3D_H = Path("workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h").read_text(encoding="utf-8")
 
 
 def test_navigation_tokens_present():
@@ -44,3 +47,18 @@ def test_fit_scene_and_minimap_viewport_behavior_tokens_present():
         "minimap_scene_->addRect(visible_rect",
     ]:
         assert token in MAIN
+
+
+def test_real_3d_viewport_and_camera_depth_tokens_present():
+    for token in ["class Scene3DViewportWidget : public QOpenGLWidget", "glEnable(GL_DEPTH_TEST)", "out_proj.perspective(50.0f", "set_isometric_view()"]:
+        assert token in VIEW3D_H or token in VIEW3D_CPP
+
+
+def test_orbit_pan_zoom_interaction_tokens_present():
+    for token in ["mouseMoveEvent", "yaw_ += d.x() * 0.01", "pitch_ = qBound", "wheelEvent", "zoom_ = qBound"]:
+        assert token in VIEW3D_CPP
+
+
+def test_fallback_mode_and_banner_tokens_present():
+    for token in ["2D Layout", "2D fallback preview active", "3D View unavailable, using 2D Layout"]:
+        assert token in PREVIEW

--- a/tests/test_workcell_builder_layout_restructure.py
+++ b/tests/test_workcell_builder_layout_restructure.py
@@ -26,6 +26,9 @@ def test_scene_tree_headers_include_name_role_status():
         'header->setSectionResizeMode(0, QHeaderView::Interactive);',
         'header->setSectionResizeMode(1, QHeaderView::Interactive);',
         'header->setSectionResizeMode(2, QHeaderView::Interactive);',
+        'header->setStretchLastSection(false);',
+        'scene_hierarchy_tree_->setColumnWidth(0, 200);',
+        'scene_hierarchy_tree_->setColumnWidth(1, 120);',
     ]:
         assert token in MAIN
 
@@ -80,5 +83,13 @@ def test_scene_tree_excludes_file_artifact_rows_but_files_tab_keeps_required_art
         '{"Demo Launch", "launch/demo.launch.py"}',
         '{"Environment YAML", "environment.yaml"}',
         '{"Scene Manifest", "scene_manifest.yaml"}',
+    ]:
+        assert token in MAIN
+
+
+def test_selection_sync_invokes_apply_scene_selection_from_preview_signal():
+    for token in [
+        "connect(scene_preview_widget_, &ScenePreviewWidget::preview_item_selected, this, [this](const QString &id, const QString &role){",
+        "apply_scene_selection(id, role, id.trimmed().isEmpty(), false);",
     ]:
         assert token in MAIN

--- a/tests/test_workcell_studio_16x9_presentation_ui.py
+++ b/tests/test_workcell_studio_16x9_presentation_ui.py
@@ -25,3 +25,14 @@ def test_dashboard_action_and_fullscreen_controls_are_explicit():
         'Exit Full Screen',
     ]:
         assert token in MAIN
+
+
+def test_camera_view_menu_uses_explicit_3d_camera_tokens():
+    for token in ["Camera / View", "Perspective", "Top", "Left", "Right", "Front"]:
+        assert token in MAIN
+
+
+def test_misleading_pseudo3d_default_labels_are_not_present():
+    forbidden = ["Pseudo-3D", "Fake 3D", "2.5D"]
+    for token in forbidden:
+        assert token not in MAIN

--- a/tests/test_workcell_studio_canvas_model.py
+++ b/tests/test_workcell_studio_canvas_model.py
@@ -7,6 +7,15 @@ def test_canvas_model_files_and_tokens():
     cm = ROOT / 'workcell_builder/workcell_builder/CMakeLists.txt'
     assert h.exists() and c.exists()
     text = c.read_text()
-    for t in ['robot','reach','table','conveyor','camera','pick_zone','place_zone','bin','object','warning','Malformed or missing environment.yaml']:
+    for t in ['robot','reach','table','conveyor','camera','pick_zone','place_zone','bin','object','warning','Malformed or missing environment.yaml',
+              'deterministic_fallback_layout', 'Using deterministic 3D fallback layout because']:
         assert t in text
-    assert 'src_workcell_studio_canvas_model.cpp' in cm.read_text()
+    cm_text = cm.read_text()
+    for token in ['src_workcell_studio_canvas_model.cpp', 'find_package(OpenGL REQUIRED)', 'OpenGL::GL', 'Qt5::Widgets']:
+        assert token in cm_text
+
+
+def test_canvas_model_depth_and_fallback_schema_tokens_present():
+    c = (ROOT / "workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp").read_text(encoding="utf-8")
+    for token in ["items[].size.depth", "size.depth", "has invalid or missing schema_version", "layout/workcell_studio_layout.yaml is missing"]:
+        assert token in c


### PR DESCRIPTION
### Motivation
- Improve static test assertions to ensure a real 3D viewport (GL-backed) and explicit 3D camera/depth setup are present rather than pseudo-3D labels.
- Make fallback behavior observable to tests by asserting `2D Layout` fallback UI/banners and deterministic-fallback log tokens so layout failures are deterministic and debuggable.
- Ensure selection sync and hierarchy readability behaviors are covered and that required CMake OpenGL/Qt linkage tokens are present for build-time validation.

### Description
- Updated tests in `tests/test_workcell_builder_canvas_navigation.py`, `tests/test_workcell_builder_layout_restructure.py`, `tests/test_workcell_studio_16x9_presentation_ui.py`, and `tests/test_workcell_studio_canvas_model.py` to add assertions for GL-backed 3D viewport tokens (`QOpenGLWidget`, `glEnable(GL_DEPTH_TEST)`, perspective matrix), orbit/pan/zoom handlers, and isometric reset.
- Added assertions to guard misleading pseudo-3D labels and to verify camera/view menu labels and fallback UI tokens (`"2D Layout"`, fallback banner text, and the fallback log message token).
- Added selection-sync assertion that the preview signal path invokes `apply_scene_selection(...)`, explicit hierarchy header resize/column-width tokens for readability, deterministic 3D fallback tokens and messages in the canvas model, and required CMake linkage tokens (`find_package(OpenGL REQUIRED`, `OpenGL::GL`, `Qt5::Widgets`).

### Testing
- Ran `pytest -q tests/test_workcell_builder_canvas_navigation.py tests/test_workcell_builder_layout_restructure.py tests/test_workcell_studio_16x9_presentation_ui.py tests/test_workcell_studio_canvas_model.py` and all tests passed.
- Test result: `23 passed in 1.44s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c24d2ebc83319a0864f2a335a43b)