### PR TITLE
Fix Qt5 build breakages in Scene3D viewport widget

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -216,8 +216,8 @@ void Scene3DViewportWidget::mousePressEvent(QMouseEvent * e) {
   QMatrix4x4 proj, view;
   camera_matrices(proj, view);
   const QMatrix4x4 inv = (proj * view).inverted();
-  const float ndc_x = (2.0f * static_cast<float>(e->position().x()) / qMax(1, width())) - 1.0f;
-  const float ndc_y = 1.0f - (2.0f * static_cast<float>(e->position().y()) / qMax(1, height()));
+  const float ndc_x = (2.0f * static_cast<float>(e->pos().x()) / qMax(1, width())) - 1.0f;
+  const float ndc_y = 1.0f - (2.0f * static_cast<float>(e->pos().y()) / qMax(1, height()));
   QVector4D near_h = inv * QVector4D(ndc_x, ndc_y, -1.0f, 1.0f);
   QVector4D far_h = inv * QVector4D(ndc_x, ndc_y, 1.0f, 1.0f);
   if (qFuzzyIsNull(near_h.w()) || qFuzzyIsNull(far_h.w())) return;
@@ -247,14 +247,14 @@ void Scene3DViewportWidget::mouseMoveEvent(QMouseEvent * e)
     update();
     return;
   }
-  const QPointF pos = e->position();
+  const QPointF pos = e->pos();
   QString hovered;
   for (const auto & it : items) {
     const QPointF p = project_to_screen(it.x + (it.sx * 0.5), it.y + (it.sy * 0.5), it.z + it.sz + 0.08);
     if (QLineF(pos, p).length() < 20.0) {
       hovered = it.id;
       if (!it.warnings.isEmpty()) {
-        QToolTip::showText(e->globalPosition().toPoint(), it.warnings.join("\n"), this);
+        QToolTip::showText(e->globalPos(), it.warnings.join("\n"), this);
       }
       break;
     }

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -4,10 +4,10 @@
 
 #include <QOpenGLFunctions>
 #include <QOpenGLWidget>
+#include <QVector3D>
 
 #include <functional>
 
-class QVector3D;
 
 class Scene3DViewportWidget : public QOpenGLWidget, protected QOpenGLFunctions
 {


### PR DESCRIPTION
## Summary
- Added `#include <QVector3D>` to `scene3d_viewport_widget.h` so the by-value `orbit_offset_` member has a complete type at declaration.
- Replaced Qt6-only mouse APIs in `scene3d_viewport_widget.cpp` with Qt5-compatible calls:
  - `e->position().x()/y()` -> `e->pos().x()/y()`
  - `const QPointF pos = e->position();` -> `const QPointF pos = e->pos();`
  - `e->globalPosition().toPoint()` -> `e->globalPos()`
- Searched the new 3D viewport GUI files for other Qt6-only event-position APIs and confirmed no remaining matches in that path.

## Validation
- Static inspection only (no build/test execution requested).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c78932e4833194e2ace7aaddca93)