### PR TITLE
Limit Scene3DViewportWidget::fit_scene to physical items and exclude overlays

### DIFF
--- a/tests/test_workcell_builder_canvas_navigation.py
+++ b/tests/test_workcell_builder_canvas_navigation.py
@@ -78,6 +78,17 @@ def test_camera_fit_and_view_matrices_tokens_present():
         assert token in VIEW3D_CPP
 
 
+def test_fit_scene_excludes_overlay_only_items_tokens_present():
+    for token in [
+        "FIT_PHYSICAL_ONLY_FILTER",
+        "FIT_EXCLUDE_OVERLAY_ONLY",
+        "if (!include_in_fit_bounds_physical_only(it)) continue;",
+        "FIT_FALLBACK_ISO_IF_NO_PHYSICAL",
+        "if (!has_physical_item) { set_isometric_view(); return; }",
+    ]:
+        assert token in VIEW3D_CPP
+
+
 def test_fallback_mode_and_banner_tokens_present():
     for token in ["2D Layout", "2D fallback preview active", "3D View unavailable, using 2D Layout"]:
         assert token in PREVIEW

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -50,6 +50,28 @@ NormalizedRole classify_item_role(const ScenePreviewWidget::PreviewItem & it)
   return NormalizedRole::Generic;
 }
 
+
+
+bool include_in_fit_bounds_physical_only(const ScenePreviewWidget::PreviewItem & it)
+{
+  // FIT_PHYSICAL_ONLY_FILTER: keep fit_scene() bounds focused on physical geometry.
+  const NormalizedRole role = classify_item_role(it);
+  switch (role) {
+    case NormalizedRole::SafetyZone:
+    case NormalizedRole::WarningAnchor:
+      return false;  // FIT_EXCLUDE_OVERLAY_ONLY: safety envelope + warning markers.
+    case NormalizedRole::RobotBase:
+    case NormalizedRole::Table:
+    case NormalizedRole::Conveyor:
+    case NormalizedRole::Camera:
+    case NormalizedRole::PickZone:
+    case NormalizedRole::PlaceBin:
+    case NormalizedRole::Object:
+    case NormalizedRole::Generic:
+      return true;
+  }
+  return true;
+}
 QColor item_color(const ScenePreviewWidget::PreviewItem & it)
 {
   switch (classify_item_role(it)) {
@@ -86,7 +108,10 @@ void Scene3DViewportWidget::fit_scene() {
   if (items.isEmpty()) { set_isometric_view(); return; }
   QVector3D bmin(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
   QVector3D bmax(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
+  bool has_physical_item = false;
   for (const auto & it : items) {
+    if (!include_in_fit_bounds_physical_only(it)) continue;
+    has_physical_item = true;
     bmin.setX(std::min(bmin.x(), static_cast<float>(it.x)));
     bmin.setY(std::min(bmin.y(), static_cast<float>(it.y)));
     bmin.setZ(std::min(bmin.z(), static_cast<float>(it.z)));
@@ -94,6 +119,7 @@ void Scene3DViewportWidget::fit_scene() {
     bmax.setY(std::max(bmax.y(), static_cast<float>(it.y + it.sy)));
     bmax.setZ(std::max(bmax.z(), static_cast<float>(it.z + it.sz)));
   }
+  if (!has_physical_item) { set_isometric_view(); return; } // FIT_FALLBACK_ISO_IF_NO_PHYSICAL
   orbit_offset_ = (bmin + bmax) * 0.5f;
   const QVector3D ext = bmax - bmin;
   const double radius = qMax(0.25, 0.5 * qSqrt(ext.x() * ext.x() + ext.y() * ext.y() + ext.z() * ext.z()));


### PR DESCRIPTION
### Motivation
- Ensure camera fitting focuses on physical scene geometry rather than overlay-only artifacts like safety envelopes or warning markers.
- Prevent overlay-only items from inflating fit bounds and producing misleading camera framing.
- Provide a predictable fallback to the isometric view when no physical items are present so the viewport remains usable.

### Description
- Added `include_in_fit_bounds_physical_only(const ScenePreviewWidget::PreviewItem &)` to explicitly classify which roles should contribute to fit bounds and included maintenance/test tokens (`FIT_PHYSICAL_ONLY_FILTER`, `FIT_EXCLUDE_OVERLAY_ONLY`).
- Integrated the new inclusion filter into `Scene3DViewportWidget::fit_scene()` so overlay-only roles (e.g. `SafetyZone`, `WarningAnchor`) are skipped when computing `bmin`/`bmax`.
- Added `has_physical_item` tracking and a fallback that calls `set_isometric_view()` when no physical items contribute to bounds (`FIT_FALLBACK_ISO_IF_NO_PHYSICAL`).
- Updated `tests/test_workcell_builder_canvas_navigation.py` to add `test_fit_scene_excludes_overlay_only_items_tokens_present()` which asserts presence of the new tokens/lines to lock the behavior for tests and future maintenance.

### Testing
- Ran `pytest -q tests/test_workcell_builder_canvas_navigation.py` which completed successfully with `9 passed`.
- The modified test file and `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp` were validated by the token-based test suite above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cd8232688331b9d1b2c5aced5114)