### PR TITLE
Keep Debug Overlays as a 3D request, tighten 2D fallback and info-chip reporting

### DIFF
--- a/tests/test_workcell_builder_canvas_navigation.py
+++ b/tests/test_workcell_builder_canvas_navigation.py
@@ -109,5 +109,16 @@ def test_fit_scene_excludes_overlay_only_items_tokens_present():
 
 
 def test_fallback_mode_and_banner_tokens_present():
-    for token in ["2D Layout", "2D fallback preview active", "3D View unavailable, using 2D Layout"]:
+    for token in ["2D Layout", "2D fallback preview active", "3D View unavailable, using 2D Layout", "2D Layout (Fallback)"]:
         assert token in PREVIEW
+
+
+def test_debug_overlays_remains_3d_and_fallback_is_unavailable_only():
+    for token in [
+        'viewport->debug_overlays_mode = (mode == "Debug Overlays")',
+        'const bool requested_3d = (mode == "3D View") || (mode == "Debug Overlays")',
+        "const bool use3d = requested_3d && preview3d_available_;",
+        "Mode: %2",
+    ]:
+        assert token in PREVIEW
+    assert 'if (mode_selector_->currentText() == "Debug Overlays") use3d = false;' not in PREVIEW

--- a/tests/test_workcell_studio_16x9_presentation_ui.py
+++ b/tests/test_workcell_studio_16x9_presentation_ui.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MAIN = (ROOT / 'workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+PREVIEW = (ROOT / 'workcell_builder/workcell_builder/gui/scene_preview_widget.cpp').read_text(encoding='utf-8')
 
 
 def test_full_screen_presentation_tokens_present():
@@ -36,3 +37,8 @@ def test_misleading_pseudo3d_default_labels_are_not_present():
     forbidden = ["Pseudo-3D", "Fake 3D", "2.5D"]
     for token in forbidden:
         assert token not in MAIN
+
+
+def test_preview_mode_chip_reports_fallback_state_tokens_present():
+    for token in ["Mode: %2", "2D Layout (Fallback)"]:
+        assert token in PREVIEW

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -101,25 +101,28 @@ void ScenePreviewWidget::on_focus_selected_clicked(){ static_cast<Scene3DViewpor
 void ScenePreviewWidget::on_clear_selection_clicked(){ selected_preview_item_id_.clear(); static_cast<Scene3DViewportWidget *>(simple_3d_view_)->selected_id.clear(); simple_3d_view_->update(); emit studio_log_requested("Cleared preview selection."); emit preview_item_selected(QString(), QStringLiteral("unknown")); }
 void ScenePreviewWidget::refresh_mode_and_state()
 {
+  const QString mode = mode_selector_->currentText();
+  const bool requested_3d = (mode == "3D View") || (mode == "Debug Overlays");
+  const bool use3d = requested_3d && preview3d_available_;
+  auto * viewport = static_cast<Scene3DViewportWidget *>(simple_3d_view_);
+  viewport->debug_overlays_mode = (mode == "Debug Overlays");
+
   if (!preview3d_available_) {
-    mode_selector_->setCurrentText("2D Layout");
     stack_->setCurrentWidget(view2d_container_);
     fallback_banner_label_->setVisible(scene_selected_);
-    emit studio_log_requested(QString("3D View unavailable, using 2D Layout: %1").arg(unavailable_reason_.isEmpty() ? "initialization failed" : unavailable_reason_));
-    return;
+    const QString reason = unavailable_reason_.isEmpty() ? "initialization failed" : unavailable_reason_;
+    emit studio_log_requested(QString("3D View unavailable, using 2D Layout: %1").arg(reason));
+  } else {
+    fallback_banner_label_->setVisible(false);
+    stack_->setCurrentWidget(use3d ? view3d_container_ : view2d_container_);
   }
-  fallback_banner_label_->setVisible(false);
-  bool use3d = mode_selector_->currentText() == "3D View";
-  auto * viewport = static_cast<Scene3DViewportWidget *>(simple_3d_view_);
-  viewport->debug_overlays_mode = (mode_selector_->currentText() == "Debug Overlays");
-  if (mode_selector_->currentText() == "Debug Overlays") use3d = false;
-  stack_->setCurrentWidget(use3d ? view3d_container_ : view2d_container_);
   const bool has_preview_items = !preview_items_.isEmpty();
   empty_state_label_->setVisible(use3d && !scene_selected_);
   simple_3d_view_->setVisible(use3d && scene_selected_);
-  const bool rendering_failed = scene_selected_ && has_preview_items && !simple_3d_view_->isVisible() && !preview3d_available_;
-  error_state_label_->setText(QString("Scene selected but preview rendering failed. Loaded %1 preview items. Check fallback 2D canvas.").arg(preview_items_.size()));
+  const bool rendering_failed = scene_selected_ && has_preview_items && requested_3d && !preview3d_available_;
+  error_state_label_->setText(QString("Scene selected but 3D preview is unavailable. Loaded %1 preview items. Using 2D fallback canvas.").arg(preview_items_.size()));
   error_state_label_->setVisible(rendering_failed);
+  refresh_info_chip();
 }
 QRectF ScenePreviewWidget::rendered_items_bounds_2d() const
 {
@@ -157,4 +160,4 @@ void ScenePreviewWidget::set_label_mode(LabelMode mode){ auto *v=static_cast<Sce
 
 int ScenePreviewWidget::total_warning_count() const { int count = 0; for (const auto & item : preview_items_) count += item.warnings.size(); count += overlay_model_.warnings.size() + reachability_overlay_model_.warnings.size() + collision_overlay_model_.warnings.size() + camera_overlay_model_.warnings.size(); for (const auto & det : epd_detections_) count += det.warnings.size(); return count; }
 bool ScenePreviewWidget::task_is_ready() const { return overlay_model_.has_intent_metadata && overlay_model_.pick_source_id != "unknown" && overlay_model_.place_target_id != "unknown"; }
-void ScenePreviewWidget::refresh_info_chip() { if (!info_chip_label_) return; info_chip_label_->setText(QString("Scene: %1\nItems: %2  Warn: %3  Task: %4").arg(preview_scene_name_).arg(preview_items_.size()).arg(total_warning_count()).arg(task_is_ready() ? "Ready" : "Missing")); info_chip_label_->adjustSize(); if (fallback_info_chip_proxy_) fallback_info_chip_proxy_->setPos(12.0, 12.0); }
+void ScenePreviewWidget::refresh_info_chip() { if (!info_chip_label_) return; const QString mode = mode_selector_ ? mode_selector_->currentText() : QStringLiteral("2D Layout"); const bool requested_3d = (mode == "3D View") || (mode == "Debug Overlays"); const QString render_mode = requested_3d && preview3d_available_ ? mode : QStringLiteral("2D Layout (Fallback)"); info_chip_label_->setText(QString("Scene: %1\nMode: %2\nItems: %3  Warn: %4  Task: %5").arg(preview_scene_name_).arg(render_mode).arg(preview_items_.size()).arg(total_warning_count()).arg(task_is_ready() ? "Ready" : "Missing")); info_chip_label_->adjustSize(); if (fallback_info_chip_proxy_) fallback_info_chip_proxy_->setPos(12.0, 12.0); }


### PR DESCRIPTION
### Motivation
- Debug Overlays should toggle the `Scene3DViewportWidget::debug_overlays_mode` from the mode selector without being forcibly demoted to the 2D fallback when 3D is available.
- The 2D canvas should only be used when 3D initialization is actually unavailable or has failed, and UI labels must accurately reflect when a 2D fallback is active.
- Tests that assert UI token presence need to cover the updated mode and fallback reporting.

### Description
- Changed `ScenePreviewWidget::refresh_mode_and_state()` to compute `mode`, `requested_3d`, and `use3d = requested_3d && preview3d_available_` and to set `viewport->debug_overlays_mode` based on the selector while preserving 3D rendering when available (file `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`).
- Removed the previous line that forced `use3d = false` for the `Debug Overlays` selector and made the 2D fallback path only trigger when `preview3d_available_` is false.
- Updated the fallback/error message to clearly state when 3D preview is unavailable and the 2D canvas is being used, and ensured `refresh_info_chip()` is called after state changes.
- Enhanced `refresh_info_chip()` to include a `Mode:` line that reports either the active mode (e.g. `3D View`, `Debug Overlays`) or `2D Layout (Fallback)` when a requested 3D mode cannot be used.
- Updated token tests in `tests/test_workcell_builder_canvas_navigation.py` and `tests/test_workcell_studio_16x9_presentation_ui.py` to assert the new tokens and to ensure `Debug Overlays` is treated as a 3D request (and no longer forcibly converted to 2D in the source).

### Testing
- Ran `pytest -q tests/test_workcell_builder_canvas_navigation.py tests/test_workcell_studio_16x9_presentation_ui.py` and all tests passed.
- `18 passed` (the two updated test files were exercised and succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cfc33a4483319527192ccfaaee28)