### PR TITLE
Enable fake-hardware MoveIt/RViz motion in generated Scene Builder safety YAML

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1666,9 +1666,13 @@ bool MainWindow::update_selected_scene_task_intent_binding(
   (void)ensure_map_path(task, {"pick", "source"});
   (void)ensure_map_path(task, {"place", "target"});
   (void)ensure_map_path(task, {"perception", "camera"});
-  safety["preview_only"] = true;
+  safety["preview_only"] = false;
   safety["use_fake_hardware"] = true;
-  safety["no_robot_motion"] = true;
+  safety["allow_simulated_motion"] = true;
+  safety["allow_moveit_execution"] = true;
+  safety["allow_rviz_motion"] = true;
+  safety["allow_real_hardware_motion"] = false;
+  safety["real_robot_locked"] = true;
   YAML::Node cursor = task;
   for (size_t i = 0; i + 1 < key_path.size(); ++i) {
     if (!cursor[key_path[i]] || !cursor[key_path[i]].IsMap()) cursor[key_path[i]] = YAML::Node(YAML::NodeType::Map);
@@ -1679,7 +1683,7 @@ bool MainWindow::update_selected_scene_task_intent_binding(
   out << root;
   out.close();
   append_studio_log(QString("%1 updated to '%2'").arg(binding_label, selected_id));
-  append_studio_log(QString("Task intent updated at %1 (Preview Only | Fake Hardware | No Robot Motion)")
+  append_studio_log(QString("Task intent updated at %1 (Fake Hardware | Simulated Motion Enabled | Real Robot Locked)")
     .arg(QString::fromStdString(task_intent_path.string())));
   refresh_after_task_binding_change(binding_label, selected_id);
   return true;

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -672,8 +672,10 @@ void write_task_recipe_yaml(const fs::path & scene_dir, const TaskGraspConfig & 
   out << "place:\n  clearance_m: " << config.place_clearance_m <<
     "\n  orientation_mode: preserve_object_orientation\n";
   out << "release:\n  strategy: " << config.release_strategy << "\n";
-  out << "safety:\n  fake_hardware_first: true\n  motion_command_sent: false\n";
-  out << "  runtime_execution_enabled: false\n";
+  out << "safety:\n  preview_only: false\n  use_fake_hardware: true\n";
+  out << "  allow_simulated_motion: true\n  allow_moveit_execution: true\n";
+  out << "  allow_rviz_motion: true\n  allow_real_hardware_motion: false\n";
+  out << "  real_robot_locked: true\n";
 }
 
 
@@ -1244,7 +1246,9 @@ bool SceneSelect::apply_recommended_layout_to_scene(const boost::filesystem::pat
   std::ofstream out((scene_dir / "config" / "recommended_layout.yaml").string());
   out << "layout_profile: canonical_new_scene_layout\n";
   out << "template_id: " << template_id << "\n";
-  out << "safety:\n  fake_hardware_first: true\n  runtime_execution_enabled: false\n  motion_command_sent: false\n";
+  out << "safety:\n  preview_only: false\n  use_fake_hardware: true\n  allow_simulated_motion: true\n";
+  out << "  allow_moveit_execution: true\n  allow_rviz_motion: true\n";
+  out << "  allow_real_hardware_motion: false\n  real_robot_locked: true\n";
   out << "objects:\n  map_format: true\n";
   return out.good();
 }
@@ -2139,7 +2143,9 @@ void SceneSelect::on_generate_files_clicked()
     intent << "place:\n  target:\n    id: " << cfg.place_target << "\n    type: " << task_editor_state_.place_target_type << "\n";
     intent << "grasp:\n  strategy_ref: " << cfg.grasp_strategy << "\n  orientation_mode: " << cfg.orientation_mode << "\n";
     intent << "release:\n  strategy: " << cfg.release_strategy << "\n";
-    intent << "safety:\n  fake_hardware_first: true\n  runtime_execution_enabled: false\n  motion_command_sent: false\n";
+    intent << "safety:\n  preview_only: false\n  use_fake_hardware: true\n  allow_simulated_motion: true\n";
+    intent << "  allow_moveit_execution: true\n  allow_rviz_motion: true\n";
+    intent << "  allow_real_hardware_motion: false\n  real_robot_locked: true\n";
     task_editor_state_.unsaved_task_edits = false;
     rerun_task_validation();
     bool blocked = false;

--- a/workcell_builder/workcell_builder/src_workcell_studio_template_instantiator.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_template_instantiator.cpp
@@ -96,13 +96,13 @@ WorkcellStudioTemplateInstantiationResult instantiate_workcell_studio_template(c
     "    - real robot locked\n"
     "    - no runtime motion commands\n"
     "task:\n  type: " + task_type + "\n  preview_only: " + std::string(preview_only ? "true" : "false") +
-    "\nsafety:\n  fake_hardware_first: true\n  runtime_execution_enabled: false\n  motion_command_sent: false\n"
+    "\nsafety:\n  preview_only: false\n  use_fake_hardware: true\n  allow_simulated_motion: true\n  allow_moveit_execution: true\n  allow_rviz_motion: true\n  allow_real_hardware_motion: false\n  real_robot_locked: true\n"
     "layout:\n  preset: " + request.layout_preset_id + "\n  include_camera: " + std::string(request.include_camera ? "true" : "false") + "\n  include_conveyor: " + std::string(request.include_conveyor ? "true" : "false") + "\n",
     r);
   write_file(scene_dir / "scene_manifest.yaml", "schema: workcell_scene_manifest/v1\nscene_name: " + scene_dir.filename().string() + "\ntemplate_id: " + request.template_id + "\n", r);
   write_file(scene_dir / "config" / "task_recipe.yaml", "task:\n  type: " + task_type + "\n  grasp_strategy: " + grasp + "\n", r);
   write_file(scene_dir / "config" / "workcell_builder_task_intent.yaml",
-    "schema: workcell_builder_task_intent/v1\nsafety:\n  fake_hardware_first: true\n  runtime_execution_enabled: false\n  motion_command_sent: false\n",
+    "schema: workcell_builder_task_intent/v1\nsafety:\n  preview_only: false\n  use_fake_hardware: true\n  allow_simulated_motion: true\n  allow_moveit_execution: true\n  allow_rviz_motion: true\n  allow_real_hardware_motion: false\n  real_robot_locked: true\n",
     r);
   write_file(scene_dir / "launch" / "demo.launch.py", "# generated launch placeholder\n# always use fake hardware\n", r);
   write_file(scene_dir / "GENERATED_SCENE_SUMMARY.md", "# Generated Scene\n\nNo robot motion commanded.\n", r);


### PR DESCRIPTION
## Summary
- Updated Scene Builder-generated safety blocks to support simulated execution in MoveIt/RViz with fake hardware.
- Replaced no-motion style safety flags with explicit policy fields:
  - `preview_only: false`
  - `use_fake_hardware: true`
  - `allow_simulated_motion: true`
  - `allow_moveit_execution: true`
  - `allow_rviz_motion: true`
  - `allow_real_hardware_motion: false`
  - `real_robot_locked: true`
- Applied this policy in generated task intent / recipe / layout YAML paths and template-instantiated artifacts.
- Updated task-binding log messaging to reflect simulated-motion-enabled + real-robot-locked behavior.

## Files changed
- `workcell_builder/workcell_builder/gui/mainwindow.cpp`
- `workcell_builder/workcell_builder/gui/scene_select.cpp`
- `workcell_builder/workcell_builder/src_workcell_studio_template_instantiator.cpp`

## Why
This aligns generated backend files with the required safety model so selected scenes can proceed through MoveIt planning, grasp planning, and fake-hardware/RViz execution, while continuing to block real hardware motion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d56e2e508331b2d64b61aab342e3)