### PR TITLE
Add YAML-safe accessors and harden scene YAML parsing

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -75,6 +75,7 @@
 #include <QHBoxLayout>
 #include <QtConcurrent>
 #include <yaml-cpp/yaml.h>
+#include "workcell_yaml_utils.hpp"
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <boost/filesystem.hpp>
 #include <stdio.h>
@@ -223,7 +224,7 @@ static QString ystr(const YAML::Node & n){ return (n && n.IsScalar()) ? QString:
 static QString scalar_path(const YAML::Node & root, std::initializer_list<const char *> keys){ YAML::Node n=root; for(auto *k:keys){ if(!n||!n[k]) return "unknown"; n=n[k]; } return ystr(n); }
 static QString normalize_bound_id(QString value){ value=value.trimmed(); if(value.isEmpty()||value=="unknown") return "unknown"; return value; }
 
-static bool read_yaml(const fs::path & p, YAML::Node * out){ try{ if(!fs::exists(p)) return false; *out=YAML::LoadFile(p.string()); return true; }catch(...){return false;} }
+static bool read_yaml(const fs::path & p, YAML::Node * out){ try{ if(!fs::exists(p)) return false; *out=YAML::LoadFile(p.string()); return true; }catch(const YAML::Exception&){ return false; } catch(const std::exception&){ return false; } }
 static YAML::Node ensure_map_path(YAML::Node root, std::initializer_list<const char *> keys)
 {
   YAML::Node cursor = root;
@@ -1650,6 +1651,18 @@ bool MainWindow::update_selected_scene_task_intent_binding(
   if (has_existing) {
     try {
       root = YAML::LoadFile(task_intent_path.string());
+    } catch (const YAML::Exception & ex) {
+      const fs::path backup = task_intent_path.string() + ".malformed." + std::to_string(std::time(nullptr)) + ".bak";
+      boost::system::error_code ec;
+      fs::copy_file(task_intent_path, backup, fs::copy_option::overwrite_if_exists, ec);
+      if (ec) {
+        append_studio_log(QString("Task binding blocked: malformed YAML at %1 and backup failed (%2)")
+          .arg(QString::fromStdString(task_intent_path.string()), QString::fromStdString(ec.message())));
+        return false;
+      }
+      append_studio_log(QString("Malformed task intent YAML detected; backup created at %1 before rewrite.")
+        .arg(QString::fromStdString(backup.string())));
+      root = YAML::Node(YAML::NodeType::Map);
     } catch (const std::exception & ex) {
       const fs::path backup = task_intent_path.string() + ".malformed." + std::to_string(std::time(nullptr)) + ".bak";
       boost::system::error_code ec;
@@ -3000,7 +3013,9 @@ void MainWindow::save_layout_changes()
   if (fs::exists(layout_path)) {
     try {
       root = YAML::LoadFile(layout_path.string());
-    } catch (...) {
+    } catch (const YAML::Exception &) {
+      malformed_existing = true;
+    } catch (const std::exception &) {
       malformed_existing = true;
     }
   }
@@ -3256,8 +3271,8 @@ void MainWindow::populate_scene_hierarchy()
         QString status = ystr(node["status"]);
         if (status == "unknown") {
           bool enabled = true;
-          if (node["enabled"] && node["enabled"].IsScalar()) {
-            enabled = node["enabled"].as<bool>();
+          if (const auto enabled_like = get_bool_like(node, "enabled")) {
+            enabled = *enabled_like;
           }
           status = enabled ? "ready" : "disabled";
         }

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -34,6 +34,7 @@
 #include <QCoreApplication>
 #include <QDateTime>
 #include "workcell_builder_ui_utils.hpp"
+#include "workcell_yaml_utils.hpp"
 
 
 #include <QDesktopServices>
@@ -1471,7 +1472,10 @@ bool repair_scene_yaml_file(const fs::path & scene_dir, std::string * summary)
     return false;
   }
   YAML::Node root;
-  try { root = YAML::LoadFile(environment_file.string()); } catch (const std::exception & e) {
+  try { root = YAML::LoadFile(environment_file.string()); } catch (const YAML::Exception & e) {
+    if (summary) *summary = std::string("YAML parse failure: ") + e.what();
+    return false;
+  } catch (const std::exception & e) {
     if (summary) *summary = std::string("YAML parse failure: ") + e.what();
     return false;
   }
@@ -2196,6 +2200,10 @@ bool SceneSelect::load_scene_from_yaml(Scene * input_scene)
     append_error(
       "Invalid scene YAML: " + yaml_path.string() + " " + std::string(error.what()));
     return false;
+  } catch (const std::exception & error) {
+    append_error(
+      "Invalid scene YAML: " + yaml_path.string() + " " + std::string(error.what()));
+    return false;
   }
   if (!yaml.IsMap()) {
     append_error("Invalid scene YAML: " + yaml_path.string() + " root must be a map.");
@@ -2392,6 +2400,10 @@ bool SceneSelect::load_scene_from_yaml(Scene * input_scene)
     }
   }
   } catch (const YAML::Exception & error) {
+    append_error(
+      "Invalid scene YAML: " + yaml_path.string() + " " + std::string(error.what()));
+    return false;
+  } catch (const std::exception & error) {
     append_error(
       "Invalid scene YAML: " + yaml_path.string() + " " + std::string(error.what()));
     return false;
@@ -3288,7 +3300,8 @@ static void write_conveyor_pick_preview_artifacts(const boost::filesystem::path 
     boost::filesystem::create_directories(preview_dir);
     std::ofstream(preview_dir.string() + "/conveyor_pick_preview.yaml") << workcell_builder::serialize_preview_to_yaml(preview);
     std::ofstream(preview_dir.string() + "/conveyor_pick_preview.json") << workcell_builder::serialize_preview_to_json(preview);
-  } catch (...) {}
+  } catch (const YAML::Exception &) {
+  } catch (const std::exception &) {}
 }
 
 void SceneSelect::on_refresh_status_button_clicked()

--- a/workcell_builder/workcell_builder/include/workcell_yaml_utils.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_yaml_utils.hpp
@@ -2,6 +2,7 @@
 
 #include <yaml-cpp/yaml.h>
 #include <string>
+#include <optional>
 
 namespace workcell_builder
 {
@@ -16,4 +17,10 @@ bool yaml_read_bool(const YAML::Node & node, bool * out);
 
 YAML::Node yaml_map_key(const YAML::Node & node, const char * key);
 YAML::Node yaml_seq_index(const YAML::Node & node, std::size_t index);
+
+YAML::Node get_map(const YAML::Node & node, const char * key);
+YAML::Node get_scalar(const YAML::Node & node, const char * key);
+YAML::Node get_sequence(const YAML::Node & node, const char * key);
+std::optional<bool> get_bool_like(const YAML::Node & node, const char * key);
+std::optional<bool> bool_like(const YAML::Node & node);
 }

--- a/workcell_builder/workcell_builder/src_workcell_perception_snapshot.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_perception_snapshot.cpp
@@ -3,13 +3,33 @@
 #include <fstream>
 #include <sstream>
 #include <unordered_map>
+#include "workcell_yaml_utils.hpp"
 
 namespace fs = boost::filesystem;
 namespace workcell_builder {
 namespace {
-std::array<double,3> a3(const YAML::Node&n){ if(!n||!n.IsSequence()||n.size()<3) return {{0,0,0}}; return {{n[0].as<double>(),n[1].as<double>(),n[2].as<double>()}}; }
+std::array<double,3> a3(const YAML::Node&n){ if(!n||!n.IsSequence()||n.size()<3||!n[0].IsScalar()||!n[1].IsScalar()||!n[2].IsScalar()) return {{0,0,0}}; return {{n[0].as<double>(),n[1].as<double>(),n[2].as<double>()}}; }
 }
-PerceptionSnapshot parse_detection_snapshot_yaml(const std::string & path){ YAML::Node root=YAML::LoadFile(path); auto s=root["detection_snapshot"]; PerceptionSnapshot out; if(s["schema_version"]) out.schema_version=s["schema_version"].as<int>(); if(s["source"]) out.source=s["source"].as<std::string>(); if(s["runtime_mode"]) out.runtime_mode=s["runtime_mode"].as<std::string>(); if(s["camera"]) out.camera=s["camera"].as<std::string>(); if(s["camera_frame"]) out.camera_frame=s["camera_frame"].as<std::string>(); if(s["timestamp_sec"]) out.timestamp_sec=s["timestamp_sec"].as<double>(); if(s["detections"]) for(const auto &d:s["detections"]){ PerceptionDetection pd; if(d["id"]) pd.id=d["id"].as<std::string>(); if(d["class_label"]) pd.class_label=d["class_label"].as<std::string>(); if(d["confidence"]) pd.confidence=d["confidence"].as<double>(); if(d["center_px"]&&d["center_px"].size()>=2){ pd.center_px={{d["center_px"][0].as<double>(),d["center_px"][1].as<double>()}}; } if(d["bbox_px"]&&d["bbox_px"].size()>=4){ pd.bbox_px={{d["bbox_px"][0].as<double>(),d["bbox_px"][1].as<double>(),d["bbox_px"][2].as<double>(),d["bbox_px"][3].as<double>()}}; } pd.estimated_xyz_camera=a3(d["estimated_xyz_camera"]); if(d["estimated_xyz_world"]&&d["estimated_xyz_world"].IsSequence()&&d["estimated_xyz_world"].size()>=3){ pd.estimated_xyz_world=a3(d["estimated_xyz_world"]); pd.has_world_xyz=true; } if(d["zone_hint"]) pd.zone_hint=d["zone_hint"].as<std::string>(); if(d["tracking_id"]) pd.tracking_id=d["tracking_id"].as<std::string>(); out.detections.push_back(pd);} return out; }
+PerceptionSnapshot parse_detection_snapshot_yaml(const std::string & path){
+  PerceptionSnapshot out;
+  try {
+    const YAML::Node root = YAML::LoadFile(path);
+    const YAML::Node s = get_map(root, "detection_snapshot");
+    if (!s) return out;
+    if (const auto n = get_scalar(s, "schema_version")) out.schema_version = n.as<int>();
+    if (const auto n = get_scalar(s, "source")) out.source = n.as<std::string>();
+    if (const auto n = get_scalar(s, "runtime_mode")) out.runtime_mode = n.as<std::string>();
+    if (const auto n = get_scalar(s, "camera")) out.camera = n.as<std::string>();
+    if (const auto n = get_scalar(s, "camera_frame")) out.camera_frame = n.as<std::string>();
+    if (const auto n = get_scalar(s, "timestamp_sec")) out.timestamp_sec = n.as<double>();
+    if (const auto detections = get_sequence(s, "detections")) for(const auto &d:detections){ if(!d||!d.IsMap()) continue; PerceptionDetection pd; if(const auto n=get_scalar(d,"id")) pd.id=n.as<std::string>(); if(const auto n=get_scalar(d,"class_label")) pd.class_label=n.as<std::string>(); if(const auto n=get_scalar(d,"confidence")) pd.confidence=n.as<double>(); const YAML::Node center=get_sequence(d,"center_px"); if(center&&center.size()>=2&&center[0].IsScalar()&&center[1].IsScalar()){ pd.center_px={{center[0].as<double>(),center[1].as<double>()}}; } const YAML::Node bbox=get_sequence(d,"bbox_px"); if(bbox&&bbox.size()>=4&&bbox[0].IsScalar()&&bbox[1].IsScalar()&&bbox[2].IsScalar()&&bbox[3].IsScalar()){ pd.bbox_px={{bbox[0].as<double>(),bbox[1].as<double>(),bbox[2].as<double>(),bbox[3].as<double>()}}; } pd.estimated_xyz_camera=a3(get_sequence(d,"estimated_xyz_camera")); const YAML::Node world=get_sequence(d,"estimated_xyz_world"); if(world&&world.size()>=3){ pd.estimated_xyz_world=a3(world); pd.has_world_xyz=true; } if(const auto n=get_scalar(d,"zone_hint")) pd.zone_hint=n.as<std::string>(); if(const auto n=get_scalar(d,"tracking_id")) pd.tracking_id=n.as<std::string>(); out.detections.push_back(pd);} 
+  } catch (const YAML::Exception &) {
+    return out;
+  } catch (const std::exception &) {
+    return out;
+  }
+  return out;
+}
 PerceptionSnapshot parse_detection_snapshot_json(const std::string & path){ return parse_detection_snapshot_yaml(path); }
 std::string serialize_detection_snapshot_yaml(const PerceptionSnapshot & s){ YAML::Emitter out; out<<YAML::BeginMap<<YAML::Key<<"detection_snapshot"<<YAML::Value<<YAML::BeginMap<<YAML::Key<<"schema_version"<<YAML::Value<<s.schema_version<<YAML::Key<<"source"<<YAML::Value<<s.source<<YAML::Key<<"runtime_mode"<<YAML::Value<<s.runtime_mode<<YAML::Key<<"camera"<<YAML::Value<<s.camera<<YAML::Key<<"camera_frame"<<YAML::Value<<s.camera_frame<<YAML::Key<<"timestamp_sec"<<YAML::Value<<s.timestamp_sec<<YAML::Key<<"detections"<<YAML::Value<<YAML::BeginSeq; for(const auto&d:s.detections){ out<<YAML::BeginMap<<YAML::Key<<"id"<<YAML::Value<<d.id<<YAML::Key<<"class_label"<<YAML::Value<<d.class_label<<YAML::Key<<"confidence"<<YAML::Value<<d.confidence<<YAML::Key<<"center_px"<<YAML::Value<<YAML::Flow<<std::vector<double>{d.center_px[0],d.center_px[1]}<<YAML::Key<<"bbox_px"<<YAML::Value<<YAML::Flow<<std::vector<double>{d.bbox_px[0],d.bbox_px[1],d.bbox_px[2],d.bbox_px[3]}<<YAML::Key<<"estimated_xyz_camera"<<YAML::Value<<YAML::Flow<<std::vector<double>{d.estimated_xyz_camera[0],d.estimated_xyz_camera[1],d.estimated_xyz_camera[2]}; if(d.has_world_xyz) out<<YAML::Key<<"estimated_xyz_world"<<YAML::Value<<YAML::Flow<<std::vector<double>{d.estimated_xyz_world[0],d.estimated_xyz_world[1],d.estimated_xyz_world[2]}; out<<YAML::Key<<"zone_hint"<<YAML::Value<<d.zone_hint<<YAML::Key<<"tracking_id"<<YAML::Value<<d.tracking_id<<YAML::EndMap;} out<<YAML::EndSeq<<YAML::EndMap<<YAML::EndMap; return out.c_str(); }
 std::string serialize_detection_snapshot_json(const PerceptionSnapshot & s){ std::ostringstream ss; ss<<"{\n  \"detection_snapshot\": {\n    \"schema_version\": "<<s.schema_version<<",\n    \"source\": \""<<s.source<<"\",\n    \"runtime_mode\": \""<<s.runtime_mode<<"\",\n    \"camera\": \""<<s.camera<<"\",\n    \"camera_frame\": \""<<s.camera_frame<<"\",\n    \"timestamp_sec\": "<<s.timestamp_sec<<",\n    \"detections\": []\n  }\n}"; return ss.str(); }

--- a/workcell_builder/workcell_builder/src_workcell_yaml_utils.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_yaml_utils.cpp
@@ -1,4 +1,5 @@
 #include "workcell_yaml_utils.hpp"
+#include <algorithm>
 
 namespace workcell_builder
 {
@@ -63,5 +64,46 @@ YAML::Node yaml_seq_index(const YAML::Node & node, std::size_t index)
 {
   if (!node.IsDefined() || !node.IsSequence() || index >= node.size()) return YAML::Node();
   return node[index];
+}
+
+YAML::Node get_map(const YAML::Node & node, const char * key)
+{
+  if (!node.IsDefined() || !node.IsMap() || key == nullptr) return YAML::Node();
+  const YAML::Node child = node[key];
+  return (child && child.IsMap()) ? child : YAML::Node();
+}
+
+YAML::Node get_scalar(const YAML::Node & node, const char * key)
+{
+  if (!node.IsDefined() || !node.IsMap() || key == nullptr) return YAML::Node();
+  const YAML::Node child = node[key];
+  return (child && child.IsScalar()) ? child : YAML::Node();
+}
+
+YAML::Node get_sequence(const YAML::Node & node, const char * key)
+{
+  if (!node.IsDefined() || !node.IsMap() || key == nullptr) return YAML::Node();
+  const YAML::Node child = node[key];
+  return (child && child.IsSequence()) ? child : YAML::Node();
+}
+
+std::optional<bool> bool_like(const YAML::Node & node)
+{
+  if (!node || !node.IsScalar()) return std::nullopt;
+  try {
+    return node.as<bool>();
+  } catch (...) {}
+  try {
+    std::string value = node.as<std::string>();
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c){ return static_cast<char>(std::tolower(c)); });
+    if (value == "1" || value == "true" || value == "yes" || value == "on" || value == "enabled") return true;
+    if (value == "0" || value == "false" || value == "no" || value == "off" || value == "disabled") return false;
+  } catch (...) {}
+  return std::nullopt;
+}
+
+std::optional<bool> get_bool_like(const YAML::Node & node, const char * key)
+{
+  return bool_like(get_scalar(node, key));
 }
 }


### PR DESCRIPTION
### Motivation
- Centralize and standardize safe YAML access patterns to avoid unsafe `node["a"]["b"]` chaining and unchecked `.as<T>()` conversions that can crash or throw on malformed scene files.
- Support flexible boolean-like values used in scene/status YAML (e.g., `enabled`/`disabled`, `on`/`off`, `yes`/`no`, `1`/`0`) while keeping parsing non-fatal.

### Description
- Added YAML-safe accessors in `workcell_yaml_utils`: `get_map`, `get_scalar`, `get_sequence`, `bool_like`, and `get_bool_like`, and exported them in the header `include/workcell_yaml_utils.hpp` and implemented in `src_workcell_yaml_utils.cpp`.
- Rewrote `parse_detection_snapshot_yaml` in `src_workcell_perception_snapshot.cpp` to use the new accessors, perform element type checks before calls to `.as<T>()`, and return a default `PerceptionSnapshot` on parse/load failures.
- Hardened GUI YAML flows by including `workcell_yaml_utils.hpp`, replacing unsafe scalar bool casts with `get_bool_like(node, "enabled")` in `gui/mainwindow.cpp`, adding stricter checks (`a3`), and adding explicit `catch (const YAML::Exception&)` and `catch (const std::exception&)` handlers around `YAML::LoadFile`/parse sites in `gui/mainwindow.cpp` and `gui/scene_select.cpp` to make failures non-fatal.
- Files changed: `include/workcell_yaml_utils.hpp`, `src_workcell_yaml_utils.cpp`, `src_workcell_perception_snapshot.cpp`, `gui/mainwindow.cpp`, and `gui/scene_select.cpp`.

### Testing
- No automated build or test commands were executed in this edit cycle; changes were implemented, staged, and committed but not compiled or run in CI in this pass.
- The change set is intentionally defensive and aims to be behavior-preserving for valid YAML while returning safe defaults on malformed inputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a098eed0f4483319ce502b501175636)