### PR TITLE
Deduplicate scene discovery using canonical directory paths

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -42,6 +42,7 @@
 #include <QClipboard>
 #include <QLineEdit>
 #include <QFileDialog>
+#include <QFileInfo>
 #include <QListWidgetItem>
 #include <QInputDialog>
 #include <QDir>
@@ -1143,8 +1144,15 @@ void SceneSelect::discover_scene_packages_on_startup()
   }
 
   std::unordered_set<std::string> known_scenes;
+  std::unordered_set<std::string> known_scene_dirs;
   for (const auto & known_scene : workcell.scene_vector) {
     known_scenes.insert(known_scene.name);
+    const fs::path known_dir = scenes_path / known_scene.name;
+    QString canonical_qt = QFileInfo(QString::fromStdString(known_dir.string())).canonicalFilePath();
+    fs::path canonical_path = canonical_qt.isEmpty() ? fs::canonical(known_dir, path_ec) : fs::path(canonical_qt.toStdString());
+    if (!canonical_path.empty()) {
+      known_scene_dirs.insert(canonical_path.string());
+    }
   }
 
   int discovered_count = 0;
@@ -1152,12 +1160,29 @@ void SceneSelect::discover_scene_packages_on_startup()
     if (!fs::is_directory(entry.path())) {
       continue;
     }
-    const std::string scene_name = entry.path().filename().string();
-    const fs::path package_xml = entry.path() / "package.xml";
-    const fs::path scene_manifest = entry.path() / "scene_manifest.yaml";
-    const fs::path environment_yaml = entry.path() / "environment.yaml";
-    const fs::path urdf_xacro = entry.path() / "urdf" / "scene.urdf.xacro";
-    const fs::path demo_launch = entry.path() / "launch" / "demo.launch.py";
+    const fs::path scene_dir = entry.path();
+    const std::string scene_name = scene_dir.filename().string();
+    QString canonical_qt = QFileInfo(QString::fromStdString(scene_dir.string())).canonicalFilePath();
+    fs::path canonical_scene_dir;
+    if (!canonical_qt.isEmpty()) {
+      canonical_scene_dir = fs::path(canonical_qt.toStdString());
+    } else {
+      boost::system::error_code canonical_ec;
+      canonical_scene_dir = fs::canonical(scene_dir, canonical_ec);
+      if (canonical_ec || canonical_scene_dir.empty()) {
+        canonical_scene_dir = fs::absolute(scene_dir);
+      }
+    }
+    const std::string canonical_scene_key = canonical_scene_dir.string();
+    if (!known_scene_dirs.insert(canonical_scene_key).second) {
+      append_info("Skipped scene directory '" + scene_name + "': canonical path already loaded (" + canonical_scene_key + ").");
+      continue;
+    }
+    const fs::path package_xml = scene_dir / "package.xml";
+    const fs::path scene_manifest = scene_dir / "scene_manifest.yaml";
+    const fs::path environment_yaml = scene_dir / "environment.yaml";
+    const fs::path urdf_xacro = scene_dir / "urdf" / "scene.urdf.xacro";
+    const fs::path demo_launch = scene_dir / "launch" / "demo.launch.py";
 
     const bool has_markers = fs::exists(package_xml) || fs::exists(scene_manifest) ||
       fs::exists(environment_yaml) || fs::exists(urdf_xacro) || fs::exists(demo_launch);
@@ -1185,12 +1210,12 @@ void SceneSelect::discover_scene_packages_on_startup()
       append_warning(
         "Discovered scaffold scene package '" + scene_name +
         "' without environment.yaml; scene can launch but cannot be fully edited until YAML exists.");
-      if (ensure_minimal_environment_yaml(entry.path(), scene_name)) {
+      if (ensure_minimal_environment_yaml(scene_dir, scene_name)) {
         append_warning(
           "Repair Missing environment.yaml applied at: " +
-          (entry.path() / "environment.yaml").string());
+          (scene_dir / "environment.yaml").string());
       }
-      refresh_scene_manifest_if_missing(entry.path(), scene_name);
+      refresh_scene_manifest_if_missing(scene_dir, scene_name);
     }
     workcell.scene_vector.push_back(discovered_scene);
     known_scenes.insert(scene_name);

--- a/workcell_builder/workcell_builder/include/workcell_studio_scene_browser.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_studio_scene_browser.hpp
@@ -11,6 +11,7 @@ struct WorkcellStudioSceneInfo
 {
   std::string scene_name;
   boost::filesystem::path scene_dir;
+  boost::filesystem::path canonical_scene_dir;
   bool has_environment_yaml{false};
   bool has_package_xml{false};
   bool has_launch_demo{false};

--- a/workcell_builder/workcell_builder/src_workcell_studio_scene_browser.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_scene_browser.cpp
@@ -14,6 +14,21 @@ namespace workcell_builder {
 namespace {
 bool exists_file(const fs::path & p){ boost::system::error_code ec; return fs::exists(p, ec) && !ec; }
 
+fs::path canonical_or_absolute(const fs::path & p)
+{
+  boost::system::error_code ec;
+  const fs::path canonical_path = fs::canonical(p, ec);
+  if (!ec) {
+    return canonical_path;
+  }
+  ec.clear();
+  const fs::path weak = fs::weakly_canonical(p, ec);
+  if (!ec) {
+    return weak;
+  }
+  return fs::absolute(p);
+}
+
 bool is_valid_scene_package(const WorkcellStudioSceneInfo & s)
 {
   return s.has_environment_yaml || s.has_scene_manifest_yaml ||
@@ -35,7 +50,7 @@ std::vector<fs::path> candidate_scene_roots(const fs::path & workspace_root)
   std::set<std::string> seen;
   std::vector<fs::path> uniq;
   for (const auto & r : roots) {
-    std::string k = r.lexically_normal().string();
+    std::string k = canonical_or_absolute(r).string();
     if (seen.insert(k).second) uniq.push_back(r);
   }
   return uniq;
@@ -97,6 +112,7 @@ WorkcellStudioSceneBrowserResult discover_workcell_studio_scenes(const fs::path 
   out.searched_roots = roots;
 
   boost::system::error_code ec;
+  std::set<std::string> discovered_scene_dirs;
   for (const auto & scene_root : roots) {
     const bool exists = fs::exists(scene_root, ec) && !ec && fs::is_directory(scene_root, ec) && !ec;
     if (!exists) {
@@ -110,6 +126,11 @@ WorkcellStudioSceneBrowserResult discover_workcell_studio_scenes(const fs::path 
       if (!fs::is_directory(it->path(), ec) || ec) continue;
       WorkcellStudioSceneInfo s;
       s.scene_dir = it->path();
+      s.canonical_scene_dir = canonical_or_absolute(s.scene_dir);
+      const std::string scene_key = s.canonical_scene_dir.string();
+      if (!discovered_scene_dirs.insert(scene_key).second) {
+        continue;
+      }
       s.scene_name = s.scene_dir.filename().string();
       s.has_environment_yaml = exists_file(s.scene_dir / "environment.yaml");
       s.has_package_xml = exists_file(s.scene_dir / "package.xml");


### PR DESCRIPTION
### Motivation
- Prevent duplicate scene entries when the same scene directory is discovered via symlinks or alternate path spellings while keeping the UI display name stable.
- Improve diagnostics by retaining canonical absolute paths for scene directories for downstream use.

### Description
- Resolve candidate scene directories in the UI discovery using `QFileInfo(path).canonicalFilePath()` and fall back to Boost `canonical`/`absolute` when needed, then deduplicate by the canonical absolute path in `SceneSelect::discover_scene_packages_on_startup` (file `gui/scene_select.cpp`).
- Add canonicalization helper `canonical_or_absolute` and canonicalize candidate roots in `candidate_scene_roots`, then deduplicate emitted scenes by canonical directory in `discover_workcell_studio_scenes` (file `src_workcell_studio_scene_browser.cpp`).
- Store the canonical directory on the scene info by adding `canonical_scene_dir` to `WorkcellStudioSceneInfo` (header `include/workcell_studio_scene_browser.hpp`).
- Keep displayed scene name stable using the directory basename (`scene_name`) while using canonical paths only for deduplication and diagnostics.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a098ef114108331ae7b61b68c38b967)