### PR TITLE
Add crash guards for perception parsing and command builders

### DIFF
--- a/scripts/workcell_builder_gui_workflow.py
+++ b/scripts/workcell_builder_gui_workflow.py
@@ -276,6 +276,49 @@ def generate_perception_replay_preview(scene_dir:Path)->dict[str,Any]:
     st = _load_json_safe(selected)
     return {"status":"PERCEPTION_REPLAY_READY" if sp.get("status")=="READY" else "PERCEPTION_REPLAY_WARN","summary":sp,"selected_target":st,"bridge_payload_preview_ready":out.exists()}
 
+
+def normalize_perception_config_from_environment(environment_payload:dict[str,Any]|None)->dict[str,Any]:
+    """Normalize legacy/partial environment.yaml perception payloads safely."""
+    payload = environment_payload if isinstance(environment_payload, dict) else {}
+    raw = payload.get("perception")
+    if raw is None:
+        return {"status": "MISSING_PERCEPTION", "enabled": False, "config": {}}
+    if isinstance(raw, str):
+        token = raw.strip().lower()
+        if token in {"disabled", "none", "false", "off", ""}:
+            return {"status": "PERCEPTION_DISABLED", "enabled": False, "config": {"enabled": False}}
+        return {"status": "PERCEPTION_LEGACY_SCALAR", "enabled": False, "config": {"enabled": False}}
+    if isinstance(raw, bool):
+        return {"status": "PERCEPTION_DISABLED" if raw is False else "PERCEPTION_ENABLED_NO_DETAILS", "enabled": bool(raw), "config": {"enabled": bool(raw)}}
+    if not isinstance(raw, dict):
+        return {"status": "PERCEPTION_LEGACY_SCALAR", "enabled": False, "config": {"enabled": False}}
+    if not raw:
+        return {"status": "PERCEPTION_EMPTY_CONFIG", "enabled": False, "config": {}}
+    enabled = bool(raw.get("enabled", True))
+    return {"status": "PERCEPTION_ENABLED" if enabled else "PERCEPTION_DISABLED", "enabled": enabled, "config": raw}
+
+
+def parse_environment_yaml_safely(environment_yaml_text:str)->dict[str,Any]:
+    try:
+        loaded = yaml.safe_load(environment_yaml_text) or {}
+    except Exception as exc:
+        return {"ok": False, "error": f"malformed_environment_yaml: {exc}", "environment": {}}
+    if not isinstance(loaded, dict):
+        return {"ok": False, "error": "malformed_environment_yaml: root must be mapping", "environment": {}}
+    return {"ok": True, "environment": loaded}
+
+
+def build_epd_snapshot_adapter_command(*, profile:Path|None, input_snapshot:Path|None, output_payload:Path|None)->dict[str,Any]:
+    if not profile or not input_snapshot or not output_payload:
+        return {"ok": False, "error": "missing required args for epd_snapshot_adapter.py", "command": []}
+    return {"ok": True, "command": [sys.executable, str(repo_root()/ "scripts"/"epd_snapshot_adapter.py"), "--profile", str(profile), "--input", str(input_snapshot), "--output", str(output_payload)]}
+
+
+def build_perception_bridge_preview_command(*, perception_profile:Path|None, detected_objects:Path|None, task_intent:Path|None, output_payload:Path|None, output_report:Path|None)->dict[str,Any]:
+    if not perception_profile or not detected_objects or not task_intent or not output_payload or not output_report:
+        return {"ok": False, "error": "missing required args for generate_perception_bridge_preview.py", "command": []}
+    return {"ok": True, "command": [sys.executable, str(repo_root()/ "scripts"/"generate_perception_bridge_preview.py"), "--perception-profile", str(perception_profile), "--detected-objects", str(detected_objects), "--task-intent", str(task_intent), "--output-payload", str(output_payload), "--output-report", str(output_report)]}
+
 def _load_json_safe(path:Path)->dict[str,Any]:
     try:
         return json.loads(path.read_text(encoding="utf-8"))

--- a/tests/test_workcell_builder_crash_guards.py
+++ b/tests/test_workcell_builder_crash_guards.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import importlib.util
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / 'scripts' / 'workcell_builder_gui_workflow.py'
+spec = importlib.util.spec_from_file_location('workflow', MODULE_PATH)
+workflow = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(workflow)
+
+
+def test_missing_perception_normalizes_safely():
+    out = workflow.normalize_perception_config_from_environment({})
+    assert out['status'] == 'MISSING_PERCEPTION'
+    assert out['enabled'] is False
+
+
+def test_scalar_perception_normalizes_to_disabled():
+    for token in ['disabled', 'none', 'false']:
+        out = workflow.normalize_perception_config_from_environment({'perception': token})
+        assert out['status'] == 'PERCEPTION_DISABLED'
+        assert out['enabled'] is False
+
+
+def test_empty_perception_mapping_guarded():
+    out = workflow.normalize_perception_config_from_environment({'perception': {}})
+    assert out['status'] == 'PERCEPTION_EMPTY_CONFIG'
+
+
+def test_partial_or_malformed_legacy_environment_yaml_is_guarded():
+    malformed = workflow.parse_environment_yaml_safely('robot: [bad')
+    assert malformed['ok'] is False
+    assert malformed['environment'] == {}
+
+    partial = workflow.parse_environment_yaml_safely('robot: {name: ur5}\nend_effector: {name: rg2}\n')
+    assert partial['ok'] is True
+    normalized = workflow.normalize_perception_config_from_environment(partial['environment'])
+    assert normalized['status'] == 'MISSING_PERCEPTION'
+
+
+def test_command_generation_refuses_when_required_args_absent_for_targeted_scripts(tmp_path):
+    epd = workflow.build_epd_snapshot_adapter_command(profile=None, input_snapshot=tmp_path/'snap.yaml', output_payload=tmp_path/'out.json')
+    assert epd['ok'] is False
+    assert 'missing required args' in epd['error']
+
+    bridge = workflow.build_perception_bridge_preview_command(
+        perception_profile=tmp_path/'profile.yaml',
+        detected_objects=None,
+        task_intent=tmp_path/'intent.yaml',
+        output_payload=tmp_path/'payload.json',
+        output_report=tmp_path/'report.json',
+    )
+    assert bridge['ok'] is False
+    assert 'missing required args' in bridge['error']


### PR DESCRIPTION
### Motivation
- Prevent crashes and hard-to-debug failures when older or partial `environment.yaml` files provide missing, scalar, empty, or malformed `perception` values. 
- Ensure helper APIs refuse to build external tool commands when required arguments are absent so higher-level UI code can present clear errors instead of invoking scripts with bad arguments. 

### Description
- Added `normalize_perception_config_from_environment(...)` to `scripts/workcell_builder_gui_workflow.py` to safely normalize legacy/partial `perception` payloads including missing, scalar, boolean, empty mapping, and full-mapping cases. 
- Added `parse_environment_yaml_safely(...)` to safely parse `environment.yaml` text and return a guarded structure on malformed or non-mapping roots. 
- Added command-builder guards `build_epd_snapshot_adapter_command(...)` and `build_perception_bridge_preview_command(...)` that return an error when required arguments are missing and otherwise return the intended command list. 
- Added tests in `tests/test_workcell_builder_crash_guards.py` that exercise missing `perception`, scalar `perception` values (`disabled`, `none`, `false`), `perception: {}`, malformed and partial legacy `environment.yaml`, and refusal behavior when required command args are absent. 

### Testing
- Ran `pytest -q tests/test_workcell_builder_crash_guards.py` and all tests passed (`5 passed`). 
- Tests are pure parser/helper tests and do not depend on the Qt harness to keep validation lightweight and reliable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09909ed83c8331a7421f5458c277f5)