### PR TITLE
Add once-per-session builder warnings for YAML parse failures and legacy fallback

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -35,6 +35,7 @@
 #include <QDateTime>
 #include "workcell_builder_ui_utils.hpp"
 #include "workcell_yaml_utils.hpp"
+#include "workcell_warning_once.hpp"
 
 
 #include <QDesktopServices>
@@ -2239,10 +2240,12 @@ bool SceneSelect::load_scene_from_yaml(Scene * input_scene)
   } catch (const YAML::Exception & error) {
     append_error(
       "Invalid scene YAML: " + yaml_path.string() + " " + std::string(error.what()));
+    workcell_builder::log_warning_once_per_context_path_reason("scene_select_details_panel", yaml_path, "scene YAML parse failed");
     return false;
   } catch (const std::exception & error) {
     append_error(
       "Invalid scene YAML: " + yaml_path.string() + " " + std::string(error.what()));
+    workcell_builder::log_warning_once_per_context_path_reason("scene_select_details_panel", yaml_path, "scene YAML parse failed");
     return false;
   }
   if (!yaml.IsMap()) {
@@ -2251,6 +2254,7 @@ bool SceneSelect::load_scene_from_yaml(Scene * input_scene)
   }
   const YAML::Node perception = yaml["perception"];
   if (!perception) {
+    workcell_builder::log_warning_once_per_context_path_reason("scene_select_details_panel", yaml_path, "downgraded to legacy mode");
     if (emit_perception_contract_warning_once(scene_dir, "missing 'perception' key (legacy disabled mode)")) {
       append_warning("Perception contract warning: missing 'perception' key (legacy disabled mode).");
     }

--- a/workcell_builder/workcell_builder/include/workcell_warning_once.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_warning_once.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <boost/filesystem.hpp>
+#include <boost/system/error_code.hpp>
+
+#include <iostream>
+#include <mutex>
+#include <set>
+#include <string>
+
+namespace workcell_builder {
+
+inline bool log_warning_once_per_context_path_reason(
+  const std::string & context,
+  const boost::filesystem::path & canonical_path,
+  const std::string & reason)
+{
+  static std::mutex mutex;
+  static std::set<std::string> seen;
+
+  boost::system::error_code ec;
+  const boost::filesystem::path normalized_path =
+    boost::filesystem::weakly_canonical(canonical_path, ec);
+  const std::string path_key = (ec ? canonical_path.lexically_normal() : normalized_path).string();
+  const std::string key = context + "\n" + path_key + "\n" + reason;
+
+  std::lock_guard<std::mutex> lock(mutex);
+  if (!seen.insert(key).second) {
+    return false;
+  }
+
+  std::cerr << "[workcell_builder] warning context=" << context
+            << " path=" << path_key
+            << " reason=" << reason << std::endl;
+  return true;
+}
+
+}  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/src_workcell_perception_snapshot.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_perception_snapshot.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <unordered_map>
 #include "workcell_yaml_utils.hpp"
+#include "workcell_warning_once.hpp"
 
 namespace fs = boost::filesystem;
 namespace workcell_builder {
@@ -25,8 +26,10 @@ PerceptionSnapshot parse_detection_snapshot_yaml(const std::string & path){
     if (const auto n = get_scalar(s, "timestamp_sec")) out.timestamp_sec = n.as<double>();
     if (const auto detections = get_sequence(s, "detections")) for(const auto &d:detections){ if(!d||!d.IsMap()) continue; PerceptionDetection pd; if(const auto n=get_scalar(d,"id")) pd.id=n.as<std::string>(); if(const auto n=get_scalar(d,"class_label")) pd.class_label=n.as<std::string>(); if(const auto n=get_scalar(d,"confidence")) pd.confidence=n.as<double>(); const YAML::Node center=get_sequence(d,"center_px"); if(center&&center.size()>=2&&center[0].IsScalar()&&center[1].IsScalar()){ pd.center_px={{center[0].as<double>(),center[1].as<double>()}}; } const YAML::Node bbox=get_sequence(d,"bbox_px"); if(bbox&&bbox.size()>=4&&bbox[0].IsScalar()&&bbox[1].IsScalar()&&bbox[2].IsScalar()&&bbox[3].IsScalar()){ pd.bbox_px={{bbox[0].as<double>(),bbox[1].as<double>(),bbox[2].as<double>(),bbox[3].as<double>()}}; } pd.estimated_xyz_camera=a3(get_sequence(d,"estimated_xyz_camera")); const YAML::Node world=get_sequence(d,"estimated_xyz_world"); if(world&&world.size()>=3){ pd.estimated_xyz_world=a3(world); pd.has_world_xyz=true; } if(const auto n=get_scalar(d,"zone_hint")) pd.zone_hint=n.as<std::string>(); if(const auto n=get_scalar(d,"tracking_id")) pd.tracking_id=n.as<std::string>(); out.detections.push_back(pd);} 
   } catch (const YAML::Exception &) {
+    log_warning_once_per_context_path_reason("perception_snapshot_reader", path, "scene YAML parse failed");
     return out;
   } catch (const std::exception &) {
+    log_warning_once_per_context_path_reason("perception_snapshot_reader", path, "scene YAML parse failed");
     return out;
   }
   return out;

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -1,12 +1,13 @@
 #include "workcell_studio_canvas_model.hpp"
 #include "workcell_yaml_utils.hpp"
+#include "workcell_warning_once.hpp"
 #include <algorithm>
 #include <yaml-cpp/yaml.h>
 
 namespace fs = boost::filesystem;
 namespace workcell_builder {
 
-static bool read_yaml(const fs::path & p, YAML::Node * out){ try{ if(!fs::exists(p)) return false; *out = YAML::LoadFile(p.string()); return true;}catch(...){return false;} }
+static bool read_yaml(const fs::path & p, YAML::Node * out){ try{ if(!fs::exists(p)) return false; *out = YAML::LoadFile(p.string()); return true;}catch(...){ workcell_builder::log_warning_once_per_context_path_reason("task_metadata_summary_loader", p, "scene YAML parse failed"); return false;} }
 
 WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & scene_dir, const std::string & scene_name)
 {
@@ -18,6 +19,7 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
     if (deterministic_fallback_layout) return;
     deterministic_fallback_layout = true;
     deterministic_fallback_reason = reason;
+    workcell_builder::log_warning_once_per_context_path_reason("task_metadata_summary_loader", scene_dir / "layout" / "workcell_studio_layout.yaml", "downgraded to legacy mode");
   };
   const auto add_warning = [&m](const std::string & context, const std::string & detail) {
     m.warnings.push_back("layout/workcell_studio_layout.yaml [" + context + "]: " + detail);

--- a/workcell_builder/workcell_builder/src_workcell_studio_scene_browser.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_scene_browser.cpp
@@ -1,5 +1,6 @@
 #include "workcell_studio_scene_browser.hpp"
 #include "workcell_yaml_utils.hpp"
+#include "workcell_warning_once.hpp"
 
 #include <yaml-cpp/yaml.h>
 
@@ -72,9 +73,6 @@ void try_parse_env(WorkcellStudioSceneInfo * s)
 {
   if (s == nullptr) return;
   const fs::path environment_yaml = s->scene_dir / "environment.yaml";
-  std::cerr << "[workcell_builder] context=scene_browser/environment_yaml path="
-            << environment_yaml.string() << std::endl;
-
   try {
     YAML::Node n = YAML::LoadFile(environment_yaml.string());
 
@@ -100,6 +98,7 @@ void try_parse_env(WorkcellStudioSceneInfo * s)
   } catch (const std::exception & e) {
     s->parse_warning = std::string("Could not parse environment.yaml: ") + e.what() +
       " (file: " + environment_yaml.string() + ")";
+    log_warning_once_per_context_path_reason("scene_browser_load", environment_yaml, "scene YAML parse failed");
   }
 }
 }


### PR DESCRIPTION
### Motivation
- Provide deterministic, one-time diagnostic logging for YAML parse failures and legacy-mode downgrades during a builder session to reduce noisy repeated logs and aid debugging.
- Ensure warnings are correlated by `(context, canonical_path, reason)` so identical issues across repeated UI interactions are emitted only once per process lifetime.

### Description
- Added a small header `workcell_warning_once.hpp` containing `log_warning_once_per_context_path_reason` which canonicalizes the path with `boost::filesystem::weakly_canonical`, deduplicates by an in-memory `std::set`, and prints the required format: `[workcell_builder] warning context=<context> path=<path> reason=<reason>`.
- Wired the helper into scene YAML parsing failure paths in the scene browser (`src_workcell_studio_scene_browser.cpp`) to log `scene_browser_load` on parse errors.
- Wired the helper into the scene select details panel (`gui/scene_select.cpp`) to log `scene_select_details_panel` on parse failures and to log a `downgraded to legacy mode` reason when perception metadata falls back to legacy behavior.
- Wired the helper into perception snapshot reader (`src_workcell_perception_snapshot.cpp`) and task metadata/summary loader (`src_workcell_studio_canvas_model.cpp`) to log parse failures and layout downgrade-to-legacy events using `task_metadata_summary_loader` and `perception_snapshot_reader` contexts.

### Testing
- Ran targeted tests with `python3 -m pytest -q tests/test_workcell_builder_perception_readiness.py tests/test_workcell_builder_scene_bundles.py` which executed the modified code paths.
- Result: 4 tests passed and 1 test failed (`test_scene_select_ui_has_bundle_actions_and_tooltips`) due to an unrelated UI string assertion for "Export Scene Bundle" (pre-existing UI text mismatch), not caused by the logging changes.
- No runtime crashes or additional test regressions were observed in the exercised tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09909c5a7483319cd829877299f427)