### PR TITLE
Fix workcell_builder build breaks after crash-guard changes

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -266,7 +266,8 @@ if(BUILD_TESTING)
     src_planning_readiness.cpp
     src_conveyor_pick_preview.cpp
     src_workcell_camera_model.cpp
-    src_workcell_zone_model.cpp)
+    src_workcell_zone_model.cpp
+    src_workcell_yaml_utils.cpp)
   ament_add_gtest(workcell_robot_tool_compatibility_inference_test
     test/robot_tool_compatibility_inference_test.cpp
     src_robot_tool_compatibility.cpp)
@@ -284,6 +285,10 @@ if(BUILD_TESTING)
     src_workcell_builder_command_builders.cpp)
   if(TARGET workcell_workspace_validation_test)
     target_link_libraries(workcell_workspace_validation_test Qt5::Widgets)
+  endif()
+
+  if(TARGET workcell_command_builders_test)
+    target_link_libraries(workcell_command_builders_test Qt5::Core)
   endif()
 
   if(TARGET workcell_new_cell_wizard_test)

--- a/workcell_builder/workcell_builder/gui/addobject.cpp
+++ b/workcell_builder/workcell_builder/gui/addobject.cpp
@@ -136,12 +136,13 @@ AddObject::AddObject(QWidget * parent)
       writer.write_preview("workcell_scene", dlg.objects(), &out_dir, &warns);
       const QString cmd = QString::fromStdString("ros2 launch " + out_dir + "/preview_scene.launch.py");
       QApplication::clipboard()->setText(cmd);
-      QMessageBox::information(this, "Open RViz STL Preview", QString::fromStdString("Preview generated at: " + out_dir + "
-
-Command copied to clipboard:
-") + cmd + "
-
-Visual-only/offline-only preview.");
+      QMessageBox::information(
+        this,
+        "Open RViz STL Preview",
+        QString::fromStdString(
+          "Preview generated at: " + out_dir +
+          "\n\nCommand copied to clipboard:\n" + cmd.toStdString() +
+          "\n\nVisual-only/offline-only preview."));
     }
   });
   (void)QString("Object Placement Manager");
@@ -472,6 +473,6 @@ void AddObject::keyPressEvent(QKeyEvent * e)
     QDialog::keyPressEvent(e);
   } else { /* minimize */}
 }
-Create Custom STL / Create Primitive Object
+// Create Custom STL / Create Primitive Object
 
 // Object Placement Manager markers: Open Interactive RViz Preview | Import RViz Pose Feedback | placed_objects_feedback.yaml

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -3332,7 +3332,7 @@ void MainWindow::populate_scene_hierarchy()
         QString status = ystr(node["status"]);
         if (status == "unknown") {
           bool enabled = true;
-          if (const auto enabled_like = get_bool_like(node, "enabled")) {
+          if (const auto enabled_like = workcell_builder::get_bool_like(node, "enabled")) {
             enabled = *enabled_like;
           }
           status = enabled ? "ready" : "disabled";


### PR DESCRIPTION
## Summary
This PR is a focused build repair for `workcell_builder` after the YAML crash-guard work.

## Fixes included
- Repaired broken multiline string literal in `gui/addobject.cpp` (RViz STL preview info message) by using a valid `QString::fromStdString(...)` message with explicit `\n` escapes.
- Removed stray raw plain text in `gui/addobject.cpp` by converting it into a C++ comment:
  - `// Create Custom STL / Create Primitive Object`
- Fixed namespace qualification in `gui/mainwindow.cpp`:
  - `get_bool_like(...)` -> `workcell_builder::get_bool_like(...)`
- Updated test linkage in `CMakeLists.txt` for Qt Core on `workcell_command_builders_test` because the command builder headers use `QString`.
- Fixed YAML utility linkage for perception snapshot test by adding `src_workcell_yaml_utils.cpp` to `workcell_perception_snapshot_test` sources.

## Behavioral impact
- No UI redesign.
- No scene generation behavior changes.
- No robot motion or planning behavior changes.
- No safety gate weakening.
- YAML crash guards were not removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0994bbe0448331adff46c49e36fe8e)