### PR TITLE
Fix object_placement_dialog.cpp build break from malformed strings/includes

### DIFF
--- a/workcell_builder/workcell_builder/gui/object_placement_dialog.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_dialog.cpp
@@ -10,6 +10,8 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 #include <array>
+#include <fstream>
+#include <sstream>
 #include "environment_layout_editor.hpp"
 #include "placed_object_preview_writer.hpp"
 #include <QApplication>
@@ -60,12 +62,13 @@ ObjectPlacementDialog::ObjectPlacementDialog(QWidget * parent)
     writer.write_preview("workcell_scene", model_.objects(), &out_dir, &warns);
     const QString cmd = QString::fromStdString("ros2 launch " + out_dir + "/preview_scene.launch.py");
     QApplication::clipboard()->setText(cmd);
-    QMessageBox::information(this, "Open RViz STL Preview", QString::fromStdString("Preview generated at: " + out_dir + "
-
-Command copied to clipboard:
-") + cmd + "
-
-Visual-only/offline-only preview.");
+    QMessageBox::information(
+      this,
+      "Open RViz STL Preview",
+      QString::fromStdString(
+        "Preview generated at: " + out_dir +
+        "\n\nCommand copied to clipboard:\n" + cmd.toStdString() +
+        "\n\nVisual-only/offline-only preview."));
   });
 
   mk("Open Interactive RViz Preview", [this]() {
@@ -85,12 +88,13 @@ Visual-only/offline-only preview.");
       return;
     }
     std::stringstream ss; ss << feedback.rdbuf();
-    QMessageBox::information(this, "Import RViz Pose Feedback", QString::fromStdString("Found feedback file:
-" + feedback_path + "
-
-Preview-only import placeholder for next PR.
-
-" + ss.str()));
+    QMessageBox::information(
+      this,
+      "Import RViz Pose Feedback",
+      QString::fromStdString(
+        "Found feedback file:\n" + feedback_path +
+        "\n\nPreview-only import placeholder for next PR.\n\n" +
+        ss.str()));
   });
   mk("Open Visual Layout Editor", [this]() {
     EnvironmentLayoutEditor editor(this);


### PR DESCRIPTION
## Summary
This PR fixes `workcell_builder` compilation errors in `gui/object_placement_dialog.cpp` caused by malformed multiline C++ string literals and missing standard headers.

### What was fixed
- Replaced broken multiline `QMessageBox::information(...)` text in:
  - **Open RViz STL Preview** action
  - **Import RViz Pose Feedback** action
- Converted message text to valid C++ string concatenation with explicit `\n` escapes.
- Ensured no raw standalone human text remains inside those lambdas.
- Added missing headers used by the file:
  - `#include <fstream>`
  - `#include <sstream>`

## Scope / Non-goals
- No dialog redesign.
- No changes to scene generation behavior.
- No changes to robot motion/planning behavior.
- No safety gate/default changes.

## Validation
- Attempted:
  - `colcon build --symlink-install --packages-select workcell_builder`
- Result in this environment: build setup is incomplete because ROS 2 `ament_cmake` is unavailable (`ament_cmakeConfig.cmake` not found), so full package build could not be completed here.

The compile-breaking string/header issues in `object_placement_dialog.cpp` are addressed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099580fb388331ace4bda0d38b4e9c)