### PR TITLE
Fix remaining YAML::BadSubscript path for legacy perception/task metadata

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -222,14 +222,17 @@ struct SceneTaskIntentSummary
 };
 
 static QString ystr(const YAML::Node & n){ return (n && n.IsScalar()) ? QString::fromStdString(n.as<std::string>()) : "unknown"; }
-static QString scalar_path(const YAML::Node & root, std::initializer_list<const char *> keys){ YAML::Node n=root; for(auto *k:keys){ if(!n||!n[k]) return "unknown"; n=n[k]; } return ystr(n); }
+static QString scalar_path(const YAML::Node & root, std::initializer_list<const char *> keys){ YAML::Node n=root; for(auto *k:keys){ if(!n || !n.IsMap() || !n[k]) return "unknown"; n=n[k]; } return ystr(n); }
 static QString normalize_bound_id(QString value){ value=value.trimmed(); if(value.isEmpty()||value=="unknown") return "unknown"; return value; }
 
-static bool read_yaml(const fs::path & p, YAML::Node * out){ try{ if(!fs::exists(p)) return false; *out=YAML::LoadFile(p.string()); return true; }catch(const YAML::Exception&){ return false; } catch(const std::exception&){ return false; } }
+static bool read_yaml(const fs::path & p, YAML::Node * out){ try{ if(!fs::exists(p)) return false; qInfo("[workcell_builder] context=task_metadata_summary_loader path=%s", p.string().c_str()); *out=YAML::LoadFile(p.string()); return true; }catch(const YAML::Exception&){ return false; } catch(const std::exception&){ return false; } }
 static YAML::Node ensure_map_path(YAML::Node root, std::initializer_list<const char *> keys)
 {
   YAML::Node cursor = root;
   for (const auto * key : keys) {
+    if (!cursor.IsMap()) {
+      cursor = YAML::Node(YAML::NodeType::Map);
+    }
     if (!cursor[key] || !cursor[key].IsMap()) {
       cursor[key] = YAML::Node(YAML::NodeType::Map);
     }

--- a/workcell_builder/workcell_builder/test/workcell_yaml_utils_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_yaml_utils_test.cpp
@@ -28,3 +28,25 @@ TEST(WorkcellYamlUtils, LegacyAndNewObjectShapes)
   EXPECT_EQ(workcell_builder::yaml_name_from_node(map_obj), "bin_b");
 }
 
+TEST(WorkcellYamlUtils, ScalarPerceptionNodeDoesNotExposeNestedMapKeys)
+{
+  const YAML::Node root = YAML::Load("perception: disabled");
+  const YAML::Node perception_map = workcell_builder::get_map(root, "perception");
+  EXPECT_FALSE(perception_map.IsDefined());
+  EXPECT_FALSE(workcell_builder::get_scalar(root["perception"], "mode").IsDefined());
+}
+
+TEST(WorkcellYamlUtils, BoolLikeHandlesLegacyDisabledTokens)
+{
+  const YAML::Node disabled = YAML::Load("perception: disabled");
+  const YAML::Node false_scalar = YAML::Load("perception: false");
+  const YAML::Node none_scalar = YAML::Load("perception: none");
+  const YAML::Node empty_map = YAML::Load("perception: {}");
+  const YAML::Node missing = YAML::Load("task: pick_place");
+
+  EXPECT_EQ(workcell_builder::bool_like(disabled["perception"]), std::optional<bool>(false));
+  EXPECT_EQ(workcell_builder::bool_like(false_scalar["perception"]), std::optional<bool>(false));
+  EXPECT_EQ(workcell_builder::bool_like(none_scalar["perception"]), std::nullopt);
+  EXPECT_EQ(workcell_builder::get_map(empty_map, "perception").IsMap(), true);
+  EXPECT_FALSE(workcell_builder::get_map(missing, "perception").IsDefined());
+}


### PR DESCRIPTION
### Motivation
- Prevent the application abort caused by `YAML::BadSubscript` when legacy or scalar `perception` (or other nested legacy) values are present in scene/layout/task YAML such as `scenes/new_scene/layout/workcell_studio_layout.yaml`.

### Description
- Hardened YAML traversal in `workcell_builder/workcell_builder/gui/mainwindow.cpp` by making `scalar_path(...)` require the current node to be a map before indexing child keys, avoiding `operator[]` on scalar nodes.
- Made `ensure_map_path(...)` resilient to non-map intermediates by converting scalar/non-map nodes into an empty map before creating nested keys, preventing unsafe writes into scalar nodes.
- Added a startup breadcrumb log (`qInfo`) in the `task_metadata_summary_loader` YAML loader to record `context=task_metadata_summary_loader path=<path>` before `YAML::LoadFile` is called.
- Added regression tests in `workcell_builder/workcell_builder/test/workcell_yaml_utils_test.cpp` that exercise legacy/edge perception shapes (`perception: disabled`, `perception: false`, `perception: none`, `perception: {}`, and missing `perception`) and assert helper functions return safe defaults and do not expose nested keys.

### Testing
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but it failed in this environment because `colcon` is not installed (build could not be executed here).
- Attempted `ctest --test-dir build/workcell_builder --output-on-failure || true` but it could not run because the build output directory is not present in this environment (no compiled tests to run).
- Unit tests were added (see `workcell_yaml_utils_test.cpp`) and should run as part of the normal CI/build; they were not executed here due to the missing build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09969b29148331a4711401d7d61252)