### PR TITLE
Add robust RViz pose-feedback importer and review-before-apply UI flow

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -147,6 +147,7 @@ add_executable(workcell_builder
     src_external_asset_importer.cpp
     gui/asset_picker_dialog.cpp
     gui/object_placement_dialog.cpp
+    gui/rviz_pose_feedback_importer.cpp
     gui/environment_layout_editor.cpp
     gui/placed_object_preview_writer.cpp
     gui/external_asset_import_dialog.cpp
@@ -164,6 +165,7 @@ add_executable(workcell_builder
 
     include/asset_picker_dialog.hpp
     include/object_placement_dialog.hpp
+    include/rviz_pose_feedback_importer.hpp
     include/environment_layout_editor.hpp
     include/placed_object_preview_writer.hpp
     include/external_asset_import_dialog.hpp

--- a/workcell_builder/workcell_builder/gui/object_placement_dialog.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_dialog.cpp
@@ -1,5 +1,6 @@
 #include "workcell_builder_ui_utils.hpp"
 #include "object_placement_dialog.hpp"
+#include "rviz_pose_feedback_importer.hpp"
 
 #include <QDialogButtonBox>
 #include <QHeaderView>
@@ -10,8 +11,8 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 #include <array>
-#include <fstream>
 #include <sstream>
+#include <set>
 #include "environment_layout_editor.hpp"
 #include "placed_object_preview_writer.hpp"
 #include <QApplication>
@@ -81,20 +82,64 @@ ObjectPlacementDialog::ObjectPlacementDialog(QWidget * parent)
     QMessageBox::information(this, "Open Interactive RViz Preview", QString::fromStdString("Interactive preview generated at: " + out_dir + "\n\nCommand copied to clipboard:\n") + cmd + "\n\nVisual-only/offline-only preview.");
   });
   mk("Import RViz Pose Feedback", [this]() {
-    const std::string feedback_path = PlacedObjectPreviewWriter::default_preview_root() + std::string("/") + PlacedObjectPreviewWriter::sanitize_scene_name("workcell_scene") + "/placed_objects_feedback.yaml";
-    std::ifstream feedback(feedback_path);
-    if (!feedback.good()) {
-      QMessageBox::information(this, "Import RViz Pose Feedback", "No placed_objects_feedback.yaml found yet. Generate interactive preview and edit in RViz first.");
-      return;
+    const std::string scene_name = "workcell_scene";
+    const std::string feedback_path = PlacedObjectPreviewWriter::default_preview_root() + std::string("/") + PlacedObjectPreviewWriter::sanitize_scene_name(scene_name) + "/placed_objects_feedback.yaml";
+    const auto parsed = parse_rviz_pose_feedback_file(scene_name, feedback_path);
+
+    std::set<std::string> known_names;
+    for (const auto & obj : model_.objects()) known_names.insert(obj.name);
+
+    std::vector<std::string> unknown_names;
+    for (const auto & entry : parsed.entries) {
+      if (!entry.name.empty() && known_names.find(entry.name) == known_names.end()) {
+        unknown_names.push_back(entry.name);
+      }
     }
-    std::stringstream ss; ss << feedback.rdbuf();
-    QMessageBox::information(
-      this,
-      "Import RViz Pose Feedback",
-      QString::fromStdString(
-        "Found feedback file:\n" + feedback_path +
-        "\n\nPreview-only import placeholder for next PR.\n\n" +
-        ss.str()));
+
+    std::stringstream review;
+    review << "Feedback file: " << feedback_path << "\n";
+    review << "Scene: " << parsed.scene_name << "\n";
+    review << "Source: " << parsed.source << "\n";
+    review << "safe_for_robot_motion: " << (parsed.safe_for_robot_motion ? "true" : "false") << "\n\n";
+    for (const auto & err : parsed.errors) review << "ERROR: " << err << "\n";
+    for (const auto & warn : parsed.warnings) review << "WARNING: " << warn << "\n";
+    for (const auto & name : unknown_names) review << "WARNING: Unknown object in feedback (not auto-added): " << name << "\n";
+    review << "\nEntries: " << parsed.entries.size() << "\n";
+    for (const auto & entry : parsed.entries) {
+      review << " - " << (entry.name.empty() ? "<unnamed>" : entry.name)
+             << " [" << (entry.valid ? "valid" : "invalid") << "]"
+             << " xyz=(" << entry.x << ", " << entry.y << ", " << entry.z << ")"
+             << " rpy=(" << entry.roll << ", " << entry.pitch << ", " << entry.yaw << ")\n";
+      for (const auto & err : entry.errors) review << "    ERROR: " << err << "\n";
+      for (const auto & warn : entry.warnings) review << "    WARNING: " << warn << "\n";
+    }
+
+    QMessageBox review_box(this);
+    review_box.setWindowTitle("Review RViz Pose Feedback");
+    review_box.setIcon(parsed.has_fatal_error() ? QMessageBox::Warning : QMessageBox::Information);
+    review_box.setText(parsed.has_fatal_error() ? "Feedback import rejected. Review errors below." : "Review imported feedback before apply.");
+    review_box.setDetailedText(QString::fromStdString(review.str()));
+    review_box.setStandardButtons(parsed.has_fatal_error() ? QMessageBox::Ok : (QMessageBox::Apply | QMessageBox::Cancel));
+    const auto clicked = review_box.exec();
+    if (parsed.has_fatal_error() || clicked != QMessageBox::Apply) return;
+
+    auto objects = model_.objects();
+    for (auto & obj : objects) {
+      for (const auto & entry : parsed.entries) {
+        if (entry.valid && entry.name == obj.name) {
+          obj.x = entry.x;
+          obj.y = entry.y;
+          obj.z = entry.z;
+          obj.roll = entry.roll;
+          obj.pitch = entry.pitch;
+          obj.yaw = entry.yaw;
+          if (!entry.status.empty()) obj.status = entry.status;
+        }
+      }
+    }
+    model_ = ObjectPlacementModel();
+    for (const auto & obj : objects) model_.add_object(obj);
+    rebuild_table();
   });
   mk("Open Visual Layout Editor", [this]() {
     EnvironmentLayoutEditor editor(this);

--- a/workcell_builder/workcell_builder/gui/rviz_pose_feedback_importer.cpp
+++ b/workcell_builder/workcell_builder/gui/rviz_pose_feedback_importer.cpp
@@ -1,0 +1,153 @@
+#include "rviz_pose_feedback_importer.hpp"
+
+#include <cmath>
+#include <fstream>
+#include <limits>
+
+#include <yaml-cpp/yaml.h>
+
+namespace workcell_builder
+{
+
+namespace
+{
+bool parse_finite_double(const YAML::Node & node, const char * key, double & out)
+{
+  if (!node[key]) {
+    return false;
+  }
+  try {
+    out = node[key].as<double>();
+  } catch (const YAML::Exception &) {
+    return false;
+  }
+  return std::isfinite(out);
+}
+
+void add_large_coord_warnings(RvizPoseFeedbackObjectEntry & entry)
+{
+  if (std::abs(entry.x) > 100.0) entry.warnings.push_back("X coordinate magnitude exceeds 100.");
+  if (std::abs(entry.y) > 100.0) entry.warnings.push_back("Y coordinate magnitude exceeds 100.");
+  if (std::abs(entry.z) > 100.0) entry.warnings.push_back("Z coordinate magnitude exceeds 100.");
+}
+}  // namespace
+
+bool RvizPoseFeedbackImportSummary::has_fatal_error() const
+{
+  return !errors.empty();
+}
+
+RvizPoseFeedbackImportSummary parse_rviz_pose_feedback_file(
+  const std::string & scene_name,
+  const std::string & feedback_yaml_path) noexcept
+{
+  RvizPoseFeedbackImportSummary out;
+  out.scene_name = scene_name;
+
+  std::ifstream input(feedback_yaml_path);
+  if (!input.good()) {
+    out.errors.push_back("Feedback file missing: " + feedback_yaml_path);
+    return out;
+  }
+
+  YAML::Node root;
+  try {
+    root = YAML::Load(input);
+  } catch (const YAML::Exception & ex) {
+    out.errors.push_back(std::string("Malformed YAML: ") + ex.what());
+    return out;
+  }
+
+  if (!root || !root.IsMap()) {
+    out.errors.push_back("Malformed YAML: root is not a map.");
+    return out;
+  }
+
+  if (root["scene_name"]) {
+    try {
+      out.scene_name = root["scene_name"].as<std::string>();
+    } catch (const YAML::Exception &) {
+      out.warnings.push_back("scene_name field is not a string; using provided scene name.");
+    }
+  }
+
+  if (root["source"]) {
+    try {
+      out.source = root["source"].as<std::string>();
+    } catch (const YAML::Exception &) {
+      out.errors.push_back("source field exists but is not a string.");
+    }
+  }
+
+  if (out.source != "rviz_interactive_marker_preview") {
+    out.errors.push_back("Rejected feedback: source must be rviz_interactive_marker_preview.");
+  }
+
+  bool safe_flag = true;
+  if (!root["safe_for_robot_motion"]) {
+    out.errors.push_back("Rejected feedback: safe_for_robot_motion must be explicitly false.");
+  } else {
+    try {
+      safe_flag = root["safe_for_robot_motion"].as<bool>();
+    } catch (const YAML::Exception &) {
+      out.errors.push_back("Rejected feedback: safe_for_robot_motion is not a boolean false.");
+    }
+  }
+  out.safe_for_robot_motion = safe_flag;
+  if (safe_flag) {
+    out.errors.push_back("Rejected feedback: safe_for_robot_motion must be false.");
+  }
+
+  const YAML::Node objects = root["objects"];
+  if (!objects || !objects.IsSequence()) {
+    out.errors.push_back("Missing or invalid objects list.");
+    return out;
+  }
+
+  for (std::size_t i = 0; i < objects.size(); ++i) {
+    RvizPoseFeedbackObjectEntry entry;
+    const YAML::Node object = objects[i];
+    if (!object || !object.IsMap()) {
+      entry.errors.push_back("Object entry is not a map.");
+      out.entries.push_back(entry);
+      continue;
+    }
+
+    try {
+      entry.name = object["name"].as<std::string>();
+    } catch (const YAML::Exception &) {
+      entry.errors.push_back("Missing or invalid name.");
+    }
+
+    if (object["status"]) {
+      try {
+        entry.status = object["status"].as<std::string>();
+      } catch (const YAML::Exception &) {
+        entry.errors.push_back("Invalid status field.");
+      }
+    }
+
+    if (object["original_mesh"]) {
+      try {
+        entry.original_mesh = object["original_mesh"].as<std::string>();
+      } catch (const YAML::Exception &) {
+        entry.errors.push_back("Invalid original_mesh field.");
+      }
+    }
+
+    if (!parse_finite_double(object, "x", entry.x)) entry.errors.push_back("Missing or non-finite x.");
+    if (!parse_finite_double(object, "y", entry.y)) entry.errors.push_back("Missing or non-finite y.");
+    if (!parse_finite_double(object, "z", entry.z)) entry.errors.push_back("Missing or non-finite z.");
+    if (!parse_finite_double(object, "roll", entry.roll)) entry.errors.push_back("Missing or non-finite roll.");
+    if (!parse_finite_double(object, "pitch", entry.pitch)) entry.errors.push_back("Missing or non-finite pitch.");
+    if (!parse_finite_double(object, "yaw", entry.yaw)) entry.errors.push_back("Missing or non-finite yaw.");
+
+    add_large_coord_warnings(entry);
+    entry.valid = entry.errors.empty();
+    out.entries.push_back(entry);
+  }
+
+  return out;
+}
+
+}  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/include/rviz_pose_feedback_importer.hpp
+++ b/workcell_builder/workcell_builder/include/rviz_pose_feedback_importer.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace workcell_builder
+{
+
+struct RvizPoseFeedbackObjectEntry
+{
+  std::string name;
+  double x{0.0};
+  double y{0.0};
+  double z{0.0};
+  double roll{0.0};
+  double pitch{0.0};
+  double yaw{0.0};
+  std::string status;
+  std::string original_mesh;
+  std::vector<std::string> warnings;
+  std::vector<std::string> errors;
+  bool valid{false};
+};
+
+struct RvizPoseFeedbackImportSummary
+{
+  std::string scene_name;
+  std::string source;
+  bool safe_for_robot_motion{true};
+  std::vector<std::string> errors;
+  std::vector<std::string> warnings;
+  std::vector<RvizPoseFeedbackObjectEntry> entries;
+
+  bool has_fatal_error() const;
+};
+
+RvizPoseFeedbackImportSummary parse_rviz_pose_feedback_file(
+  const std::string & scene_name,
+  const std::string & feedback_yaml_path) noexcept;
+
+}  // namespace workcell_builder


### PR DESCRIPTION
### Motivation
- Provide a safe, no-throw API to consume RViz interactive-preview pose feedback and avoid crashing on malformed or unexpected feedback files. 
- Give users a chance to review imported poses and warnings before they are applied to the current `ObjectPlacementModel` to prevent accidental model corruption.

### Description
- Added `include/rviz_pose_feedback_importer.hpp` which defines `RvizPoseFeedbackObjectEntry` and `RvizPoseFeedbackImportSummary` result types and the noexcept API `parse_rviz_pose_feedback_file`.
- Implemented defensive parsing in `gui/rviz_pose_feedback_importer.cpp` that records structured errors/warnings instead of throwing and enforces rules: missing file → non-fatal error, malformed YAML → recorded error, `source` must equal `rviz_interactive_marker_preview`, `safe_for_robot_motion` must be explicitly `false`, reject non-finite `x/y/z/roll/pitch/yaw`, and warn when `|x|/|y|/|z| > 100`.
- Updated `ObjectPlacementDialog` import callback (in `gui/object_placement_dialog.cpp`) to locate the preview feedback under the preview root path, call the new importer, compare feedback object names to current model names, surface unknown objects as warnings (do not auto-add), present a detailed review dialog, and apply only valid matching entries to existing objects after explicit user confirmation.
- Registered the new header and implementation in `CMakeLists.txt` so the importer is compiled and linked into the `workcell_builder` target.

### Testing
- Attempted an in-tree CMake build with `cmake -S workcell_builder/workcell_builder -B /tmp/wb_build && cmake --build /tmp/wb_build -j2`, which failed in this environment because `ament_cmake` is not available in `CMAKE_PREFIX_PATH` (no full build/test environment provided).
- No unit tests were added in this change and no automated tests completed successfully in the current environment due to the missing ROS/ament dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0996e564148331b41c0dcd14e4c4d0)