### PR TITLE
Add pose update and object lookup helpers to ObjectPlacementModel

### DIFF
--- a/workcell_builder/workcell_builder/include/object_placement_model.hpp
+++ b/workcell_builder/workcell_builder/include/object_placement_model.hpp
@@ -35,9 +35,14 @@ public:
   void add_object(const PlacedObject & object);
   bool duplicate_object(const std::string & name);
   bool remove_object(const std::string & name);
+  bool update_object_pose_by_name(
+    const std::string & name, double x, double y, double z, double roll, double pitch, double yaw,
+    std::string * warning = nullptr);
+  const PlacedObject * find_object_by_name(const std::string & name) const;
   std::vector<PlacedObject> objects() const;
 
 private:
+  PlacedObject * find_object_by_name(const std::string & name);
   std::vector<PlacedObject> objects_;
 };
 

--- a/workcell_builder/workcell_builder/src_object_placement_model.cpp
+++ b/workcell_builder/workcell_builder/src_object_placement_model.cpp
@@ -104,6 +104,56 @@ bool ObjectPlacementModel::remove_object(const std::string & name)
   return false;
 }
 
+PlacedObject * ObjectPlacementModel::find_object_by_name(const std::string & name)
+{
+  for (auto & object : objects_) {
+    if (object.name == name) {
+      return &object;
+    }
+  }
+  return nullptr;
+}
+
+const PlacedObject * ObjectPlacementModel::find_object_by_name(const std::string & name) const
+{
+  for (const auto & object : objects_) {
+    if (object.name == name) {
+      return &object;
+    }
+  }
+  return nullptr;
+}
+
+bool ObjectPlacementModel::update_object_pose_by_name(
+  const std::string & name, double x, double y, double z, double roll, double pitch, double yaw, std::string * warning)
+{
+  const bool finite_pose = std::isfinite(x) && std::isfinite(y) && std::isfinite(z) &&
+    std::isfinite(roll) && std::isfinite(pitch) && std::isfinite(yaw);
+  if (!finite_pose) {
+    if (warning) {
+      *warning = "pose values must be finite";
+    }
+    return false;
+  }
+
+  PlacedObject * object = find_object_by_name(name);
+  if (object == nullptr) {
+    return false;
+  }
+
+  object->x = x;
+  object->y = y;
+  object->z = z;
+  object->roll = roll;
+  object->pitch = pitch;
+  object->yaw = yaw;
+
+  if (warning && (std::fabs(x) > 100.0 || std::fabs(y) > 100.0 || std::fabs(z) > 100.0)) {
+    *warning = "suspicious object coordinate magnitude";
+  }
+  return true;
+}
+
 std::vector<PlacedObject> ObjectPlacementModel::objects() const { return objects_; }
 
 std::string serialize_placed_objects_to_environment_yaml(const std::vector<PlacedObject> & objects)


### PR DESCRIPTION
### Motivation

- Provide a stable API to locate placed objects by name and to update an object's pose without touching identity or mesh metadata.
- Ensure pose updates are validated for finite values and can surface warnings for suspicious coordinates.

### Description

- Added `bool update_object_pose_by_name(const std::string&, double x, double y, double z, double roll, double pitch, double yaw, std::string* warning = nullptr)` declaration in `ObjectPlacementModel` and implemented it to update only `x/y/z/roll/pitch/yaw` fields and to leave `name`, `source_type`, and `mesh_path` unchanged.
- Added `find_object_by_name` helpers with a private non-const overload and a public `const` overload that return `nullptr` when the named object is not present.
- The update implementation validates all pose components with `std::isfinite` before mutating state, returns `false` for invalid inputs or when the object is not found, and optionally sets a warning for large coordinate magnitudes (threshold |value| > 100).
- No other object fields are modified and behavior mirrors existing coordinate-magnitude warning semantics used elsewhere in the module.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0996eae6008331addd5b5ee6fcd5f5)