### PR TITLE
Generate object-placement previews on Apply with launch command guidance

### DIFF
--- a/workcell_builder/workcell_builder/gui/object_placement_dialog.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_dialog.cpp
@@ -180,7 +180,7 @@ ObjectPlacementDialog::ObjectPlacementDialog(QWidget * parent)
 
   auto * buttons = new QDialogButtonBox(QDialogButtonBox::Close | QDialogButtonBox::Apply, this);
   QObject::connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
-  QObject::connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+  QObject::connect(buttons, &QDialogButtonBox::accepted, this, &ObjectPlacementDialog::apply_and_generate_preview);
   outer->addWidget(buttons);
 
   applyCompactDialogDefaults(this);
@@ -390,6 +390,32 @@ void ObjectPlacementDialog::import_rviz_pose_feedback()
     "Import RViz Pose Feedback",
     QString("Applied: %1\nSkipped: %2\nUnknown: %3\nInvalid: %4")
       .arg(applied).arg(skipped).arg(unknown).arg(invalid));
+}
+
+void ObjectPlacementDialog::apply_and_generate_preview()
+{
+  PlacedObjectPreviewWriter writer;
+  std::string out_dir;
+  std::vector<std::string> warns;
+  writer.write_preview("workcell_scene", model_.objects(), &out_dir, &warns);
+
+  const QString stl_cmd = QString::fromStdString("ros2 launch " + out_dir + "/preview_scene.launch.py");
+  const QString interactive_cmd = QString::fromStdString("ros2 launch " + out_dir + "/interactive_preview.launch.py");
+  const QString command_bundle = "STL preview launch command:\n" + stl_cmd +
+    "\n\nInteractive preview launch command:\n" + interactive_cmd;
+
+  QApplication::clipboard()->setText(command_bundle);
+
+  QString message = QString::fromStdString("Preview output directory:\n" + out_dir) +
+    "\n\nBoth launch commands copied to clipboard.\n\n" + command_bundle +
+    "\n\nVisual/offline-only preview. This does not launch MoveIt, controllers, or hardware.";
+  if (!warns.empty()) {
+    message += "\n\nWarnings:\n";
+    for (const auto & warn : warns) message += QString::fromStdString("- " + warn + "\n");
+  }
+
+  QMessageBox::information(this, "Object Placement Applied", message);
+  accept();
 }
 
 }  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/include/object_placement_dialog.hpp
+++ b/workcell_builder/workcell_builder/include/object_placement_dialog.hpp
@@ -22,6 +22,7 @@ private:
   void rebuild_table();
   void add_default_object(const std::string & source_type);
   void import_rviz_pose_feedback();
+  void apply_and_generate_preview();
 
   ObjectPlacementModel model_;
   QTableWidget * table_{nullptr};


### PR DESCRIPTION
### Motivation
- Ensure the dialog Apply/confirm path also generates the placed-object preview artifacts so the final applied placement is represented in the same preview outputs as the preview buttons.
- Make it easy for users to run the visual previews by reporting the output directory and providing both the STL and interactive launch commands, while making clear the preview is visual/offline-only.

### Description
- Added a new handler `apply_and_generate_preview()` and declared it in `object_placement_dialog.hpp` to centralize apply-confirm behavior.
- Wired the dialog `Apply` button to call `apply_and_generate_preview()` instead of calling `accept()` directly.
- In `apply_and_generate_preview()` the code now calls `PlacedObjectPreviewWriter::write_preview("workcell_scene", model_.objects(), &out_dir, &warns)`, builds both preview commands (`preview_scene.launch.py` and `interactive_preview.launch.py`), copies both commands to the clipboard, and shows the preview output directory and commands to the user.
- The confirmation message explicitly states this is a visual/offline-only preview and does not launch MoveIt, controllers, or hardware, and any writer warnings are appended to the message.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0998f6ab50833189d235fd42c74a9d)