### PR TITLE
Add RViz pose feedback importer tests and placement UI marker assertions

### DIFF
--- a/tests/test_workcell_builder_object_placement_manager.py
+++ b/tests/test_workcell_builder_object_placement_manager.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 
 def test_object_placement_manager_ui_strings_exist():
-    txt = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8') + Path('workcell_builder/workcell_builder/gui/addobject.cpp').read_text(encoding='utf-8')
+    txt = (
+        Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
+        + Path('workcell_builder/workcell_builder/gui/addobject.cpp').read_text(encoding='utf-8')
+        + Path('workcell_builder/workcell_builder/gui/object_placement_dialog.cpp').read_text(encoding='utf-8')
+    )
     for needle in [
         'Object Placement Manager',
         'Placed Objects',
@@ -15,6 +19,9 @@ def test_object_placement_manager_ui_strings_exist():
         'Open RViz STL Preview',
         'Open Interactive RViz Preview',
         'Import RViz Pose Feedback',
+        'Apply Valid Updates',
+        'Proposed XYZ/RPY',
+        'safe_for_robot_motion',
         'placed_objects_feedback.yaml',
     ]:
         assert needle in txt
@@ -42,3 +49,8 @@ def test_no_new_symlink_policy_or_motion_api_in_object_placement_path_and_fake_h
     assert 'ensure_workspace_alias "assets"' in fix and 'ensure_workspace_alias "scenes"' in fix
     scene = Path('workcell_builder/workcell_builder/gui/scene_select.cpp').read_text(encoding='utf-8')
     assert 'use_fake_hardware:=true' in scene
+
+
+def test_object_placement_unknown_feedback_object_marker_exists():
+    txt = Path('workcell_builder/workcell_builder/gui/object_placement_dialog.cpp').read_text(encoding='utf-8').lower()
+    assert 'unknown object in feedback' in txt

--- a/tests/test_workcell_builder_rviz_pose_feedback_importer.py
+++ b/tests/test_workcell_builder_rviz_pose_feedback_importer.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+
+IMPORTER_CPP = Path('workcell_builder/workcell_builder/gui/rviz_pose_feedback_importer.cpp').read_text(encoding='utf-8')
+DIALOG_CPP = Path('workcell_builder/workcell_builder/gui/object_placement_dialog.cpp').read_text(encoding='utf-8')
+PREVIEW_CPP = Path('workcell_builder/workcell_builder/gui/placed_object_preview_writer.cpp').read_text(encoding='utf-8')
+PREVIEW_NODE = Path('scripts/workcell_builder_interactive_preview_node.py').read_text(encoding='utf-8')
+
+
+def test_valid_feedback_parses_markers_exist():
+    for marker in [
+        'YAML::Load(input)',
+        'root.IsMap()',
+        'out.entries.push_back(entry)',
+        'entry.valid = entry.errors.empty()',
+    ]:
+        assert marker in IMPORTER_CPP
+
+
+def test_safe_for_robot_motion_true_rejected():
+    for marker in [
+        'Rejected feedback: safe_for_robot_motion must be explicitly false.',
+        'Rejected feedback: safe_for_robot_motion must be false.',
+    ]:
+        assert marker in IMPORTER_CPP
+
+
+def test_wrong_source_rejected():
+    assert 'Rejected feedback: source must be rviz_interactive_marker_preview.' in IMPORTER_CPP
+
+
+def test_missing_objects_list_safe_handling():
+    assert 'Missing or invalid objects list.' in IMPORTER_CPP
+
+
+def test_malformed_yaml_safe_handling():
+    for marker in ['Malformed YAML: ', 'Malformed YAML: root is not a map.']:
+        assert marker in IMPORTER_CPP
+
+
+def test_missing_xyz_rpy_safe_handling():
+    for marker in [
+        'Missing or non-finite x.',
+        'Missing or non-finite y.',
+        'Missing or non-finite z.',
+        'Missing or non-finite roll.',
+        'Missing or non-finite pitch.',
+        'Missing or non-finite yaw.',
+    ]:
+        assert marker in IMPORTER_CPP
+
+
+def test_nan_inf_rejected():
+    assert 'std::isfinite(out)' in IMPORTER_CPP
+
+
+def test_unknown_object_warning_behavior():
+    assert 'Unknown object in feedback' in DIALOG_CPP
+
+
+def test_matched_object_updates_pose_only_name_source_mesh_unchanged():
+    for marker in [
+        'if (entry.valid && entry.name == obj.name)',
+        'obj.x = entry.x;',
+        'obj.y = entry.y;',
+        'obj.z = entry.z;',
+        'obj.roll = entry.roll;',
+        'obj.pitch = entry.pitch;',
+        'obj.yaw = entry.yaw;',
+    ]:
+        assert marker in DIALOG_CPP
+    feedback_apply_block = DIALOG_CPP.split('if (entry.valid && entry.name == obj.name)')[1].split('model_ = ObjectPlacementModel();')[0]
+    for forbidden in [
+        'obj.name =',
+        'obj.source_type =',
+        'obj.mesh_path =',
+    ]:
+        assert forbidden not in feedback_apply_block
+
+
+def test_examples_contain_safe_for_robot_motion_false():
+    assert 'safe_for_robot_motion: false' in PREVIEW_CPP
+    assert 'safe_for_robot_motion' in PREVIEW_NODE and 'False' in PREVIEW_NODE


### PR DESCRIPTION
### Motivation
- Add focused unit coverage for the RViz pose feedback importer and ensure the Object Placement Manager UI contains expected review/apply markers and safety messaging to prevent unsafe robot motion.

### Description
- Add `tests/test_workcell_builder_rviz_pose_feedback_importer.py` which asserts parsing logic and safety checks including source validation, `safe_for_robot_motion` handling, malformed YAML handling, missing objects/fields, finite-number checks, unknown-object warnings, and that matched entries only update pose fields.
- Extend `tests/test_workcell_builder_object_placement_manager.py` to include `object_placement_dialog.cpp` in the UI-string scan and assert presence of `Import RViz Pose Feedback`, `Apply Valid Updates`, `Proposed XYZ/RPY`, `safe_for_robot_motion`, and an explicit unknown-feedback-object warning marker.
- Ensure examples/preview artifacts contain `safe_for_robot_motion: false` markers checked against the preview writer and interactive preview node sources.

### Testing
- Ran `python -m pytest -q tests/test_workcell_builder_object_placement_manager.py tests/test_workcell_builder_rviz_pose_feedback_importer.py` and all tests passed with `15 passed`.
- The added tests are text-based assertions against existing C++/Python source and do not modify production code behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0998f8554083318986cdcfe3de42f2)