### PR TITLE
Add Apply RViz pose feedback docs and healthcheck coverage

### DIFF
--- a/docs/manuals/WORKCELL_BUILDER_OBJECT_PLACEMENT_MANAGER.md
+++ b/docs/manuals/WORKCELL_BUILDER_OBJECT_PLACEMENT_MANAGER.md
@@ -59,11 +59,12 @@ This is generation-time/offline-only workflow. No MoveIt planning call, no traje
 - Full generated scene flow still requires **Generate YAML** and **Generate Files** in Workcell Studio.
 
 
-## Interactive RViz pose editing
+## Apply RViz pose feedback
 
-- Visual STL preview shows placed meshes only.
-- **Open Interactive RViz Preview** generates interactive marker preview artifacts under `/tmp/workcell_builder_preview/<scene_name>/`.
-- Interactive RViz edits write suggestion feedback to `placed_objects_feedback.yaml`.
-- Feedback is not automatically applied to real scene files (`environment.yaml`, `scene_manifest.yaml`) in this PR.
-- No MoveIt/controllers/robot execution are started.
-- This is offline preview/editing only and fake-hardware-first safe.
+- Interactive RViz edits produce `placed_objects_feedback.yaml` in `/tmp/workcell_builder_preview/<scene_name>/`.
+- The Object Placement Manager can import this feedback for operator review before any pose update is applied.
+- Only feedback entries that match existing placed object names are pose-updated.
+- Unknown object names, malformed pose rows, and other invalid entries are warned and skipped.
+- There is no automatic overwrite of `environment.yaml`, `scene_manifest.yaml`, `cell_definition.yaml`, or generated package files.
+- **Save/Generate remains an explicit user action** after review and optional apply.
+- No MoveIt planning, no controller execution, and no real hardware execution are performed by this workflow.

--- a/scripts/validate_workcell_builder_healthcheck.py
+++ b/scripts/validate_workcell_builder_healthcheck.py
@@ -276,6 +276,24 @@ def main() -> int:
         print(out)
         _check(code in (0, 124), "smoke launch did not fail immediately", errors)
 
+    rviz_importer_files = [
+        repo_root / "workcell_builder/workcell_builder/include/rviz_pose_feedback_importer.hpp",
+        repo_root / "workcell_builder/workcell_builder/gui/rviz_pose_feedback_importer.cpp",
+    ]
+    for f in rviz_importer_files:
+        _check(f.exists(), f"RViz pose feedback importer file exists: {f.relative_to(repo_root)}", errors)
+
+    docs_obj = (repo_root / "docs/manuals/WORKCELL_BUILDER_OBJECT_PLACEMENT_MANAGER.md").read_text(encoding="utf-8")
+    _check("Apply RViz pose feedback" in docs_obj, "docs include Apply RViz pose feedback section", errors)
+
+    opd_cpp = (repo_root / "workcell_builder/workcell_builder/gui/object_placement_dialog.cpp").read_text(encoding="utf-8")
+    for marker in ["Import RViz Pose Feedback", "Apply Valid Updates"]:
+        _check(marker in opd_cpp, f"Object Placement Manager UI includes: {marker}", errors)
+
+    itest_path = repo_root / "tests/test_workcell_builder_interactive_preview.py"
+    itest = itest_path.read_text(encoding="utf-8") if itest_path.exists() else ""
+    _check("safe_for_robot_motion" in itest and "Rejected feedback" in itest, "tests include safe_for_robot_motion rejection coverage", errors)
+
     if errors:
         print("WORKCELL_BUILDER_HEALTHCHECK: FAIL")
         return 1


### PR DESCRIPTION
### Motivation
- Clarify how interactive RViz edits produce feedback and how that feedback is reviewed and applied without automatic overwrites or robot execution. 
- Make explicit that only matching placed objects are pose-updated and that invalid/unknown entries are skipped with warnings. 
- Ensure CI/healthcheck detects missing importer implementation, missing docs, missing UI labels, and missing test coverage for safe-for-robot-motion rejection.

### Description
- Add a new `## Apply RViz pose feedback` section to `docs/manuals/WORKCELL_BUILDER_OBJECT_PLACEMENT_MANAGER.md` describing `placed_objects_feedback.yaml`, review-first import, matching-only updates, warnings for invalid entries, no automatic overwrite of generated scene/config files, explicit save/generate, and no MoveIt/controller/hardware execution. 
- Extend `scripts/validate_workcell_builder_healthcheck.py` to check for the presence of `workcell_builder/workcell_builder/include/rviz_pose_feedback_importer.hpp` and `workcell_builder/workcell_builder/gui/rviz_pose_feedback_importer.cpp`. 
- Extend the healthcheck to assert the docs contain the `Apply RViz pose feedback` text, the Object Placement Manager UI includes `Import RViz Pose Feedback` and `Apply Valid Updates` labels, and that interactive preview tests include `safe_for_robot_motion` rejection coverage. 

### Testing
- Successfully ran `python -m py_compile scripts/validate_workcell_builder_healthcheck.py` to validate the script syntax. 
- Verified presence of new content and checks with ripgrep via `rg -n "Apply RViz pose feedback|Import RViz Pose Feedback|Apply Valid Updates|safe_for_robot_motion rejection|rviz_pose_feedback_importer" scripts/validate_workcell_builder_healthcheck.py docs/manuals/WORKCELL_BUILDER_OBJECT_PLACEMENT_MANAGER.md`, which reported the expected matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0998f90d2c8331a03b1d9b20275001)