### PR TITLE
Align placed object preview/package URDF contract with environment YAML fields

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -119,6 +119,7 @@ add_executable(workcell_builder
     src_asset_discovery_helper.cpp
     src_generated_stl_writer.cpp
     src_generated_environment_asset_writer.cpp
+    src_placed_object_urdf_render.cpp
     src_object_placement_model.cpp
     src_robot_tool_compatibility.cpp
     src_workcell_scene_schema.cpp
@@ -233,6 +234,7 @@ if(BUILD_TESTING)
     test/generated_environment_asset_writer_test.cpp
     src_generated_stl_writer.cpp
     src_generated_environment_asset_writer.cpp
+    src_placed_object_urdf_render.cpp
     src_object_placement_model.cpp
     gui/workcell_builder_ui_utils.cpp
     gui/loadobjects.cpp)

--- a/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
@@ -31,6 +31,15 @@ std::vector<PlacedObject> load_placed_objects_from_environment_yaml(const std::s
       o.source_type = n["source"].as<std::string>("asset_stl");
       o.mesh_path = n["mesh"].as<std::string>("");
       if (o.mesh_path.rfind("/",0)==0 && o.mesh_path.rfind("package://",0)!=0 && warnings) warnings->push_back("external absolute mesh path: " + o.mesh_path);
+      o.collision_enabled = n["collision_enabled"].as<bool>(true);
+      o.parent_frame = n["parent_frame"].as<std::string>("world");
+      o.collision_mesh = n["collision_mesh"].as<std::string>(o.mesh_path);
+      auto scale = n["scale"];
+      if (scale && scale.IsSequence() && scale.size() == 3) {
+        o.scale_x = scale[0].as<double>(1.0);
+        o.scale_y = scale[1].as<double>(1.0);
+        o.scale_z = scale[2].as<double>(1.0);
+      }
       auto pose = n["pose"];
       if (pose && pose.IsMap()) {
         auto xyz = pose["xyz"]; auto rpy = pose["rpy"];
@@ -57,11 +66,11 @@ PlacedObjectYamlWriteResult save_placed_objects_to_environment_yaml(const std::s
       n["name"] = o.name;
       n["source"] = o.source_type.empty() ? "asset_stl" : o.source_type;
       n["mesh"] = o.mesh_path;
-      n["collision_mesh"] = o.mesh_path;
+      n["collision_mesh"] = o.collision_mesh.empty() ? o.mesh_path : o.collision_mesh;
       n["pose"] = to_yaml_pose(o);
-      n["scale"].push_back(1.0); n["scale"].push_back(1.0); n["scale"].push_back(1.0);
-      n["parent_frame"] = "world";
-      n["collision_enabled"] = true;
+      n["scale"].push_back(o.scale_x); n["scale"].push_back(o.scale_y); n["scale"].push_back(o.scale_z);
+      n["parent_frame"] = o.parent_frame.empty() ? "world" : o.parent_frame;
+      n["collision_enabled"] = o.collision_enabled;
       arr.push_back(n);
     }
     root["placed_objects"] = arr;

--- a/workcell_builder/workcell_builder/gui/placed_object_preview_writer.cpp
+++ b/workcell_builder/workcell_builder/gui/placed_object_preview_writer.cpp
@@ -5,6 +5,8 @@
 #include <fstream>
 #include <sstream>
 
+#include "placed_object_urdf_render.hpp"
+
 namespace workcell_builder
 {
 namespace fs = std::filesystem;
@@ -57,10 +59,7 @@ bool PlacedObjectPreviewWriter::write_preview(const std::string & scene_name, co
     for (const auto & w : mesh_check.warnings) { yaml << "    warning: \"" << w << "\"\n"; if (warnings) warnings->push_back(o.name + ": " + w); }
     if (!mesh_check.valid_for_urdf) continue;
     const std::string lname = sanitize_object_name(o.name);
-    xacro << "  <joint name=\"" << lname << "_joint\" type=\"fixed\">\n    <parent link=\"world\"/>\n    <child link=\"" << lname << "_link\"/>\n";
-    xacro << "    <origin xyz=\"" << o.x << " " << o.y << " " << o.z << "\" rpy=\"" << o.roll << " " << o.pitch << " " << o.yaw << "\"/>\n  </joint>\n";
-    xacro << "  <link name=\"" << lname << "_link\">\n    <visual><geometry><mesh filename=\"" << o.mesh_path << "\" scale=\"1 1 1\"/></geometry></visual>\n";
-    xacro << "    <collision><geometry><mesh filename=\"" << o.mesh_path << "\" scale=\"1 1 1\"/></geometry></collision>\n  </link>\n";
+    xacro << render_placed_object_urdf_snippet(o, lname);
   }
   xacro << "</robot>\n";
 

--- a/workcell_builder/workcell_builder/include/object_placement_model.hpp
+++ b/workcell_builder/workcell_builder/include/object_placement_model.hpp
@@ -13,7 +13,10 @@ struct PlacedObject
   std::string mesh_path;
   double x{0.0}, y{0.0}, z{0.0};
   double roll{0.0}, pitch{0.0}, yaw{0.0};
-  double scale{1.0};
+  double scale_x{1.0}, scale_y{1.0}, scale_z{1.0};
+  std::string parent_frame{"world"};
+  std::string collision_mesh;
+  bool collision_enabled{true};
   std::string status;
 };
 

--- a/workcell_builder/workcell_builder/include/placed_object_urdf_render.hpp
+++ b/workcell_builder/workcell_builder/include/placed_object_urdf_render.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+#include "object_placement_model.hpp"
+
+namespace workcell_builder
+{
+
+std::string render_placed_object_urdf_snippet(const PlacedObject & object, const std::string & link_name);
+
+}  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/src_generated_environment_asset_writer.cpp
+++ b/workcell_builder/workcell_builder/src_generated_environment_asset_writer.cpp
@@ -1,4 +1,5 @@
 #include "generated_environment_asset_writer.hpp"
+#include "placed_object_urdf_render.hpp"
 
 #include <boost/filesystem.hpp>
 #include <fstream>
@@ -107,12 +108,13 @@ GeneratedEnvironmentAssetResult write_generated_environment_asset(
            << "    child_link: " << spec.object_name << "\n";
 
   std::ofstream urdf_out(result.urdf_xacro_path.string());
+  PlacedObject urdf_object;
+  urdf_object.name = spec.object_name;
+  urdf_object.mesh_path = "package://" + spec.object_name + "_description/meshes/visual/" + spec.object_name + ".stl";
+  urdf_object.collision_mesh = "package://" + spec.object_name + "_description/meshes/collision/" + spec.object_name + ".stl";
   urdf_out << "<?xml version=\"1.0\"?>\n"
            << "<robot xmlns:xacro=\"http://www.ros.org/wiki/xacro\" name=\"" << spec.object_name << "\">\n"
-           << "  <link name=\"" << spec.object_name << "\">\n"
-           << "    <visual><geometry><mesh filename=\"package://" << spec.object_name << "_description/meshes/visual/" << spec.object_name << ".stl\"/></geometry></visual>\n"
-           << "    <collision><geometry><mesh filename=\"package://" << spec.object_name << "_description/meshes/collision/" << spec.object_name << ".stl\"/></geometry></collision>\n"
-           << "  </link>\n"
+           << render_placed_object_urdf_snippet(urdf_object, spec.object_name)
            << "</robot>\n";
 
   std::ofstream cmake_out((asset_root / "CMakeLists.txt").string());

--- a/workcell_builder/workcell_builder/src_object_placement_model.cpp
+++ b/workcell_builder/workcell_builder/src_object_placement_model.cpp
@@ -152,6 +152,10 @@ std::string serialize_placed_objects_to_environment_yaml(const std::vector<Place
     out << "  - name: " << o.name << "\n";
     out << "    source: " << o.source_type << "\n";
     out << "    mesh: " << o.mesh_path << "\n";
+    out << "    collision_mesh: " << (o.collision_mesh.empty() ? o.mesh_path : o.collision_mesh) << "\n";
+    out << "    collision_enabled: " << (o.collision_enabled ? "true" : "false") << "\n";
+    out << "    parent_frame: " << (o.parent_frame.empty() ? "world" : o.parent_frame) << "\n";
+    out << "    scale: [" << o.scale_x << ", " << o.scale_y << ", " << o.scale_z << "]\n";
     out << "    pose:\n";
     out << "      xyz: [" << o.x << ", " << o.y << ", " << o.z << "]\n";
     out << "      rpy: [" << o.roll << ", " << o.pitch << ", " << o.yaw << "]\n";
@@ -173,6 +177,23 @@ std::vector<PlacedObject> parse_placed_objects_from_environment_yaml(const std::
       current.name = sanitize_object_name(line.substr(line.find(":") + 1));
     } else if (line.find("source:") != std::string::npos) current.source_type = trim_copy_local(line.substr(line.find(":") + 1));
     else if (line.find("mesh:") != std::string::npos) current.mesh_path = trim_copy_local(line.substr(line.find(":") + 1));
+    else if (line.find("collision_mesh:") != std::string::npos) current.collision_mesh = trim_copy_local(line.substr(line.find(":") + 1));
+    else if (line.find("collision_enabled:") != std::string::npos) current.collision_enabled = trim_copy_local(line.substr(line.find(":") + 1)) != "false";
+    else if (line.find("parent_frame:") != std::string::npos) current.parent_frame = trim_copy_local(line.substr(line.find(":") + 1));
+    else if (line.find("scale:") != std::string::npos) {
+      const size_t lb = line.find("[");
+      const size_t rb = line.find("]");
+      if (lb != std::string::npos && rb != std::string::npos && rb > lb + 1) {
+        std::istringstream ss(line.substr(lb + 1, rb - lb - 1));
+        std::string token;
+        double v[3]{1.0, 1.0, 1.0};
+        int i = 0;
+        while (i < 3 && std::getline(ss, token, ',')) { std::istringstream value(trim_copy_local(token)); value >> v[i++]; }
+        current.scale_x = v[0];
+        current.scale_y = v[1];
+        current.scale_z = v[2];
+      }
+    }
     else if (line.find("xyz:") != std::string::npos || line.find("rpy:") != std::string::npos) {
       const size_t lb = line.find("[");
       const size_t rb = line.find("]");

--- a/workcell_builder/workcell_builder/src_placed_object_urdf_render.cpp
+++ b/workcell_builder/workcell_builder/src_placed_object_urdf_render.cpp
@@ -1,0 +1,31 @@
+#include "placed_object_urdf_render.hpp"
+
+#include <sstream>
+
+namespace workcell_builder
+{
+
+std::string render_placed_object_urdf_snippet(const PlacedObject & object, const std::string & link_name)
+{
+  const std::string parent_frame = object.parent_frame.empty() ? "world" : object.parent_frame;
+  const std::string collision_mesh = object.collision_mesh.empty() ? object.mesh_path : object.collision_mesh;
+
+  std::ostringstream urdf;
+  urdf << "  <joint name=\"" << link_name << "_joint\" type=\"fixed\">\n"
+       << "    <parent link=\"" << parent_frame << "\"/>\n"
+       << "    <child link=\"" << link_name << "_link\"/>\n"
+       << "    <origin xyz=\"" << object.x << " " << object.y << " " << object.z
+       << "\" rpy=\"" << object.roll << " " << object.pitch << " " << object.yaw << "\"/>\n"
+       << "  </joint>\n"
+       << "  <link name=\"" << link_name << "_link\">\n"
+       << "    <visual><geometry><mesh filename=\"" << object.mesh_path << "\" scale=\""
+       << object.scale_x << " " << object.scale_y << " " << object.scale_z << "\"/></geometry></visual>\n";
+  if (object.collision_enabled && !collision_mesh.empty()) {
+    urdf << "    <collision><geometry><mesh filename=\"" << collision_mesh << "\" scale=\""
+         << object.scale_x << " " << object.scale_y << " " << object.scale_z << "\"/></geometry></collision>\n";
+  }
+  urdf << "  </link>\n";
+  return urdf.str();
+}
+
+}  // namespace workcell_builder


### PR DESCRIPTION
### Motivation
- Ensure preview writer, YAML I/O, and generated environment package use the same placed-object data contract used for environment generation (pose + `collision_enabled`, `collision_mesh`, per-axis `scale`, `parent_frame`) to avoid behavioral drift.

### Description
- Extended the shared `PlacedObject` model to include `scale_x/scale_y/scale_z`, `parent_frame`, `collision_mesh`, and `collision_enabled` and kept existing pose fields intact (`object_placement_model.hpp`).
- Updated YAML load/save logic (`gui/object_placement_yaml_io.cpp`) and the simple serializer/parser (`src_object_placement_model.cpp`) to persist and read the new fields and to default `parent_frame` to `world` and `collision_mesh` to the visual mesh when omitted.
- Added a shared URDF snippet renderer `render_placed_object_urdf_snippet` (header + `src_placed_object_urdf_render.cpp`) that applies `parent_frame`, per-axis `scale`, uses `collision_mesh` when provided, and emits collision geometry only when `collision_enabled` is true.
- Switched both the preview xacro generator (`gui/placed_object_preview_writer.cpp`) and the generated-environment URDF writer (`src_generated_environment_asset_writer.cpp`) to use the new renderer to eliminate duplicated rendering logic.
- Added the new source file to `CMakeLists.txt` and updated test target sources so the helper is built/linked where needed.

### Testing
- No automated unit/integration test suite was executed in this run; changes were validated via static inspection and repository consistency checks (files updated, new source added to build lists, and commits created) which all completed successfully.
- Repository-level operations performed: updated files staged and committed (commit message: "Align placed object preview contract with environment YAML").
- Developers should run a full build and existing test suites (e.g., ament/gtests) in CI to verify runtime behavior and ensure no regressions before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b411aa8883318376cc57b090e1bc)