### PR TITLE
docs: add Placed object end-to-end generation section to manuals

### DIFF
--- a/docs/manuals/SCENE_CREATION_WORKFLOW.md
+++ b/docs/manuals/SCENE_CREATION_WORKFLOW.md
@@ -129,3 +129,24 @@ See `docs/manuals/INDUSTRIAL_SCENARIO_PACKS.md` for generated-cell scenario vali
 10. Launch generated scene in RViz/MoveIt fake hardware mode.
 
 Preview files are temporary. `environment.yaml` is the scene persistence point. Real scene files are updated only by explicit save/generate actions. This workflow introduces no controller execution and no real hardware execution.
+
+## Placed object end-to-end generation
+
+1. Import an STL file in Object Placement Manager (or select an existing managed STL asset).
+2. Confirm the STL is stored in the managed asset path and place it into the scene with initial XYZ/RPY pose values.
+3. Open RViz STL Preview to generate temporary preview artifacts under `/tmp/workcell_builder_preview/<scene_name>/...`.
+4. Optionally refine object pose in interactive RViz preview and export feedback to `placed_objects_feedback.yaml` in the same temporary preview location.
+5. Import RViz pose feedback into Object Placement Manager and review/apply valid pose updates by object name.
+6. Save placed objects to scene YAML so `environment.yaml` is updated as the persistence source of record.
+7. Run Generate YAML / Generate Files to regenerate scene artifacts from persisted data.
+8. Confirm generated placed-object URDF/Xacro outputs are produced; these generated URDF/Xacro files are the runtime source consumed by RViz/MoveIt visualization flows.
+9. Build the generated scene package/workspace so runtime launch files resolve the updated generated artifacts.
+10. Launch the demo/preview runtime (typically fake hardware mode) and verify the placed objects appear correctly in RViz/MoveIt.
+
+**Important runtime boundary**
+
+- Preview files are temporary and live under `/tmp/workcell_builder_preview/...`; they are not persistent scene truth.
+- `environment.yaml` is the persistence source for placed object data.
+- Generated URDF/Xacro is the runtime source used by RViz/MoveIt after generation/build.
+- This feature does not enable robot motion, controller execution, or real hardware execution.
+

--- a/docs/manuals/WORKCELL_BUILDER_OBJECT_PLACEMENT_MANAGER.md
+++ b/docs/manuals/WORKCELL_BUILDER_OBJECT_PLACEMENT_MANAGER.md
@@ -83,3 +83,24 @@ This is generation-time/offline-only workflow. No MoveIt planning call, no traje
 10. Launch generated scene in RViz/MoveIt fake hardware mode.
 
 Preview files are temporary. `environment.yaml` is the scene persistence point. Real scene files are updated only by explicit save/generate actions. This workflow introduces no controller execution and no real hardware execution.
+
+## Placed object end-to-end generation
+
+1. Import an STL file in Object Placement Manager (or select an existing managed STL asset).
+2. Confirm the STL is stored in the managed asset path and place it into the scene with initial XYZ/RPY pose values.
+3. Open RViz STL Preview to generate temporary preview artifacts under `/tmp/workcell_builder_preview/<scene_name>/...`.
+4. Optionally refine object pose in interactive RViz preview and export feedback to `placed_objects_feedback.yaml` in the same temporary preview location.
+5. Import RViz pose feedback into Object Placement Manager and review/apply valid pose updates by object name.
+6. Save placed objects to scene YAML so `environment.yaml` is updated as the persistence source of record.
+7. Run Generate YAML / Generate Files to regenerate scene artifacts from persisted data.
+8. Confirm generated placed-object URDF/Xacro outputs are produced; these generated URDF/Xacro files are the runtime source consumed by RViz/MoveIt visualization flows.
+9. Build the generated scene package/workspace so runtime launch files resolve the updated generated artifacts.
+10. Launch the demo/preview runtime (typically fake hardware mode) and verify the placed objects appear correctly in RViz/MoveIt.
+
+**Important runtime boundary**
+
+- Preview files are temporary and live under `/tmp/workcell_builder_preview/...`; they are not persistent scene truth.
+- `environment.yaml` is the persistence source for placed object data.
+- Generated URDF/Xacro is the runtime source used by RViz/MoveIt after generation/build.
+- This feature does not enable robot motion, controller execution, or real hardware execution.
+


### PR DESCRIPTION
### Motivation

- Provide a clear, operator-focused 10-step workflow from STL import through demo launch verification for placed objects. 
- Explicitly clarify persistence and runtime boundaries to avoid confusion about preview artifacts and robot motion capabilities.

### Description

- Added a new section titled exactly `Placed object end-to-end generation` to `docs/manuals/WORKCELL_BUILDER_OBJECT_PLACEMENT_MANAGER.md` and `docs/manuals/SCENE_CREATION_WORKFLOW.md`. 
- Documented a 10-step flow covering STL import, preview artifact generation, RViz pose feedback import, saving to `environment.yaml`, running Generate YAML/Files, building the scene package, and launching the demo preview. 
- Clearly stated that preview artifacts are temporary under `/tmp/workcell_builder_preview/...`, that `environment.yaml` is the persistence source, and that generated URDF/Xacro files are the runtime source consumed by RViz/MoveIt. 
- Explicitly noted that this workflow does not enable robot motion, controller execution, or real hardware execution.

### Testing

- Appended the new section via an automated inline Python edit and validated file contents with `sed -n` and `nl -ba` inspections, which succeeded. 
- Verified repository state with `git status --short` and committed the changes with `git commit`, which succeeded. 
- No unit or integration tests were required because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b5ff5f3c8331a2470a9b4cdcd2d1)