### PR TITLE
Add TaskZone model and YAML IO with robust parsing

### DIFF
--- a/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
@@ -1,7 +1,9 @@
 #include "object_placement_yaml_io.hpp"
 
+#include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <unordered_set>
 #include <yaml-cpp/yaml.h>
 
 namespace workcell_builder
@@ -132,6 +134,139 @@ PlacedObjectYamlWriteResult save_camera_placements_to_environment_yaml(const std
     root["camera_placements"]=arr;
     std::ofstream out(path); out<<root; r.ok=out.good(); r.objects_saved=cameras.size();
   } catch (const std::exception & e) { r.warnings.push_back(std::string("failed to save camera placements: ")+e.what()); }
+  return r;
+}
+
+
+std::vector<TaskZone> load_task_zones_from_environment_yaml(const std::string & path, std::vector<std::string> * warnings)
+{
+  std::vector<TaskZone> out;
+  std::unordered_set<std::string> seen_ids;
+  try {
+    YAML::Node root = YAML::LoadFile(path);
+    auto arr = root["task_zones"];
+    if (!arr) return out;
+    if (!arr.IsSequence()) {
+      if (warnings) warnings->push_back("task_zones exists but is not a sequence; ignoring");
+      return out;
+    }
+
+    auto finite_or_warn = [&](double v, const std::string & id, const std::string & field) {
+      if (!std::isfinite(v)) {
+        if (warnings) warnings->push_back("task_zone rejected: " + id + " -> invalid non-finite " + field);
+        return false;
+      }
+      return true;
+    };
+
+    for (const auto & n : arr) {
+      if (!n.IsMap() || !n["id"]) {
+        if (warnings) warnings->push_back("malformed task_zones entry skipped");
+        continue;
+      }
+
+      TaskZone z;
+      z.id = n["id"].as<std::string>("");
+      if (z.id.empty()) {
+        if (warnings) warnings->push_back("task_zone skipped: empty id");
+        continue;
+      }
+      if (seen_ids.count(z.id) > 0) {
+        if (warnings) warnings->push_back("duplicate task_zone id: " + z.id);
+      }
+      seen_ids.insert(z.id);
+
+      z.type = n["type"].as<std::string>("");
+      z.parent_frame = n["parent_frame"].as<std::string>("world");
+      z.frame_id = n["frame_id"].as<std::string>("");
+      z.enabled = n["enabled"].as<bool>(true);
+      z.status = n["status"].as<std::string>("");
+
+      auto pose = n["pose"];
+      if (pose && pose.IsMap()) {
+        auto xyz = pose["xyz"]; auto rpy = pose["rpy"];
+        if (xyz && xyz.IsSequence() && xyz.size() == 3) {
+          z.x = xyz[0].as<double>(0.0); z.y = xyz[1].as<double>(0.0); z.z = xyz[2].as<double>(0.0);
+        }
+        if (rpy && rpy.IsSequence() && rpy.size() == 3) {
+          z.roll = rpy[0].as<double>(0.0); z.pitch = rpy[1].as<double>(0.0); z.yaw = rpy[2].as<double>(0.0);
+        }
+      }
+
+      auto dims = n["dimensions"];
+      if (dims && dims.IsMap()) {
+        z.dim_x = dims["x"].as<double>(z.dim_x);
+        z.dim_y = dims["y"].as<double>(z.dim_y);
+        z.dim_z = dims["z"].as<double>(z.dim_z);
+      }
+
+      auto allowed = n["allowed_object_types"];
+      if (allowed && allowed.IsSequence()) {
+        for (const auto & a : allowed) {
+          z.allowed_object_types.push_back(a.as<std::string>(""));
+        }
+      }
+
+      if (!finite_or_warn(z.x, z.id, "pose.xyz") || !finite_or_warn(z.y, z.id, "pose.xyz") ||
+        !finite_or_warn(z.z, z.id, "pose.xyz") || !finite_or_warn(z.roll, z.id, "pose.rpy") ||
+        !finite_or_warn(z.pitch, z.id, "pose.rpy") || !finite_or_warn(z.yaw, z.id, "pose.rpy") ||
+        !finite_or_warn(z.dim_x, z.id, "dimensions.x") || !finite_or_warn(z.dim_y, z.id, "dimensions.y") ||
+        !finite_or_warn(z.dim_z, z.id, "dimensions.z"))
+      {
+        continue;
+      }
+
+      if (z.dim_x <= 0.0 || z.dim_y <= 0.0 || z.dim_z <= 0.0) {
+        if (warnings) warnings->push_back("task_zone warning: " + z.id + " has non-positive dimension(s)");
+      }
+      if (std::fabs(z.x) > 100.0 || std::fabs(z.y) > 100.0 || std::fabs(z.z) > 100.0 ||
+          std::fabs(z.dim_x) > 100.0 || std::fabs(z.dim_y) > 100.0 || std::fabs(z.dim_z) > 100.0) {
+        if (warnings) warnings->push_back("task_zone warning: " + z.id + " has suspiciously large pose/dimension values");
+      }
+
+      out.push_back(z);
+    }
+  } catch (const std::exception & e) {
+    if (warnings) warnings->push_back(std::string("task_zones yaml parse warning: ") + e.what());
+  }
+  return out;
+}
+
+PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(const std::string & path, const std::vector<TaskZone> & zones)
+{
+  PlacedObjectYamlWriteResult r; r.path_written = path;
+  try {
+    YAML::Node root;
+    if (std::filesystem::exists(path)) root = YAML::LoadFile(path);
+
+    YAML::Node arr(YAML::NodeType::Sequence);
+    for (const auto & z : zones) {
+      YAML::Node n;
+      n["id"] = z.id;
+      n["type"] = z.type;
+      n["parent_frame"] = z.parent_frame.empty() ? "world" : z.parent_frame;
+      n["pose"]["xyz"].push_back(z.x); n["pose"]["xyz"].push_back(z.y); n["pose"]["xyz"].push_back(z.z);
+      n["pose"]["rpy"].push_back(z.roll); n["pose"]["rpy"].push_back(z.pitch); n["pose"]["rpy"].push_back(z.yaw);
+      n["dimensions"]["x"] = z.dim_x;
+      n["dimensions"]["y"] = z.dim_y;
+      n["dimensions"]["z"] = z.dim_z;
+      if (!z.frame_id.empty()) n["frame_id"] = z.frame_id;
+      if (!z.allowed_object_types.empty()) {
+        for (const auto & t : z.allowed_object_types) n["allowed_object_types"].push_back(t);
+      }
+      n["enabled"] = z.enabled;
+      if (!z.status.empty()) n["status"] = z.status;
+      arr.push_back(n);
+    }
+
+    root["task_zones"] = arr;
+    std::ofstream out(path);
+    out << root;
+    r.ok = out.good();
+    r.objects_saved = zones.size();
+  } catch (const std::exception & e) {
+    r.warnings.push_back(std::string("failed to save task zones: ") + e.what());
+  }
   return r;
 }
 

--- a/workcell_builder/workcell_builder/include/object_placement_model.hpp
+++ b/workcell_builder/workcell_builder/include/object_placement_model.hpp
@@ -43,6 +43,20 @@ struct CameraPlacement
   std::string status;
 };
 
+struct TaskZone
+{
+  std::string id;
+  std::string type;
+  std::string parent_frame{"world"};
+  double x{0.0}, y{0.0}, z{0.0};
+  double roll{0.0}, pitch{0.0}, yaw{0.0};
+  double dim_x{0.0}, dim_y{0.0}, dim_z{0.0};
+  std::string frame_id;
+  std::vector<std::string> allowed_object_types;
+  bool enabled{true};
+  std::string status;
+};
+
 std::string sanitize_object_name(const std::string & name);
 bool validate_placed_object(const PlacedObject & object, std::string * warning);
 bool validate_camera_placement(const CameraPlacement & camera, std::string * warning);

--- a/workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp
+++ b/workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp
@@ -32,4 +32,12 @@ PlacedObjectYamlWriteResult save_camera_placements_to_environment_yaml(
   const std::string & environment_yaml_path,
   const std::vector<CameraPlacement> & cameras);
 
+std::vector<TaskZone> load_task_zones_from_environment_yaml(
+  const std::string & environment_yaml_path,
+  std::vector<std::string> * warnings = nullptr);
+
+PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(
+  const std::string & environment_yaml_path,
+  const std::vector<TaskZone> & zones);
+
 }  // namespace workcell_builder


### PR DESCRIPTION
### Motivation
- Provide first-class support for task zones in the environment model and GUI by adding a `TaskZone` type and corresponding YAML load/save APIs so the editor/UI can read, display, and persist task zone metadata and warnings.

### Description
- Add `TaskZone` struct to `workcell_builder/include/object_placement_model.hpp` with fields `id`, `type`, `parent_frame`, pose `x/y/z` and `roll/pitch/yaw`, dimensions `dim_x/dim_y/dim_z`, `frame_id`, `allowed_object_types`, `enabled`, and `status`.
- Add API declarations `load_task_zones_from_environment_yaml(...)` and `save_task_zones_to_environment_yaml(...)` to `workcell_builder/include/object_placement_yaml_io.hpp`.
- Implement `load_task_zones_from_environment_yaml` and `save_task_zones_to_environment_yaml` in `workcell_builder/gui/object_placement_yaml_io.cpp`, loading the existing YAML root and updating only `root["task_zones"]` to preserve sibling keys like `placed_objects` and `camera_placements`.
- Implement defensive parsing that returns an empty list when `task_zones` is missing, skips malformed entries with warnings, rejects non-finite (`NaN`/`inf`) pose/dimension values, warns on zero/negative dimensions, warns on suspiciously large values, warns on duplicate `id`, defaults `parent_frame` to `world`, and preserves optional fields such as `allowed_object_types`, `frame_id`, and `status`; warnings are propagated via the same warnings-vector pattern used by placed objects and cameras.

### Testing
- Repository preflight commands completed successfully: the changes were committed and `git status --short` / `git rev-parse --short HEAD` returned a clean state and commit `1bf8dcb` respectively.
- A PR record was created via the `make_pr` helper and returned the PR metadata without errors.
- No automated unit tests or CI test suite were executed as part of this change in the local rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09bc7c5a208331be136fc381cb9242)