### PR TITLE
Fix TaskZone duplication and test linkage in workcell_builder

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -300,7 +300,10 @@ if(BUILD_TESTING)
   endif()
 
   if(TARGET workcell_command_builders_test)
-    target_link_libraries(workcell_command_builders_test Qt5::Core)
+    target_link_libraries(workcell_command_builders_test
+      Qt5::Core
+      yaml-cpp
+    )
   endif()
 
   if(TARGET workcell_new_cell_wizard_test)

--- a/workcell_builder/workcell_builder/gui/object_placement_dialog.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_dialog.cpp
@@ -150,9 +150,9 @@ ObjectPlacementDialog::ObjectPlacementDialog(QWidget * parent)
     const int row_index = task_zone_table_->currentRow();
     if (row_index < 0 || row_index >= static_cast<int>(task_zones_.size())) return;
     auto & z = task_zones_[static_cast<size_t>(row_index)];
-    z.size_x = task_zone_table_->item(row_index, 8) ? task_zone_table_->item(row_index, 8)->text().toDouble() : z.size_x;
-    z.size_y = task_zone_table_->item(row_index, 9) ? task_zone_table_->item(row_index, 9)->text().toDouble() : z.size_y;
-    z.size_z = task_zone_table_->item(row_index, 10) ? task_zone_table_->item(row_index, 10)->text().toDouble() : z.size_z;
+    z.dim_x = task_zone_table_->item(row_index, 8) ? task_zone_table_->item(row_index, 8)->text().toDouble() : z.dim_x;
+    z.dim_y = task_zone_table_->item(row_index, 9) ? task_zone_table_->item(row_index, 9)->text().toDouble() : z.dim_y;
+    z.dim_z = task_zone_table_->item(row_index, 10) ? task_zone_table_->item(row_index, 10)->text().toDouble() : z.dim_z;
     rebuild_table();
   });
   mk("Save Task Zones to Scene YAML", [this]() {
@@ -357,8 +357,8 @@ void ObjectPlacementDialog::rebuild_table()
     const auto & z = task_zones_[static_cast<size_t>(i)];
     const std::array<QString, 13> vals = {
       QString::fromStdString(z.id), QString::fromStdString(z.type), QString::number(z.x), QString::number(z.y), QString::number(z.z),
-      QString::number(z.roll), QString::number(z.pitch), QString::number(z.yaw), QString::number(z.size_x),
-      QString::number(z.size_y), QString::number(z.size_z), QString::fromStdString(z.frame), QString::fromStdString(z.status)
+      QString::number(z.roll), QString::number(z.pitch), QString::number(z.yaw), QString::number(z.dim_x),
+      QString::number(z.dim_y), QString::number(z.dim_z), QString::fromStdString(z.frame_id), QString::fromStdString(z.status)
     };
     for (int c = 0; c < 13; ++c) task_zone_table_->setItem(i, c, new QTableWidgetItem(vals[static_cast<size_t>(c)]));
   }

--- a/workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp
+++ b/workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp
@@ -16,17 +16,6 @@ struct PlacedObjectYamlWriteResult
   size_t objects_saved{0};
 };
 
-struct TaskZone
-{
-  std::string id;
-  std::string type{"pick"};
-  double x{0.0}, y{0.0}, z{0.0};
-  double roll{0.0}, pitch{0.0}, yaw{0.0};
-  double size_x{0.2}, size_y{0.2}, size_z{0.2};
-  std::string frame{"world"};
-  std::string status;
-};
-
 std::vector<PlacedObject> load_placed_objects_from_environment_yaml(
   const std::string & environment_yaml_path,
   std::vector<std::string> * warnings = nullptr);

--- a/workcell_builder/workcell_builder/test/placed_object_preview_writer_test.cpp
+++ b/workcell_builder/workcell_builder/test/placed_object_preview_writer_test.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <fstream>
 #include <sstream>
@@ -9,8 +9,8 @@
 
 TEST(PlacedObjectPreviewWriter, WritesPreviewFilesWithCameraEntries)
 {
-  const auto temp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path("wb_preview_%%%%%%");
-  boost::filesystem::create_directories(temp);
+  const auto temp = std::filesystem::temp_directory_path() / "wb_preview_test";
+  std::filesystem::create_directories(temp);
 
   workcell_builder::PlacedObject object;
   object.name = "camera_target";
@@ -22,11 +22,11 @@ TEST(PlacedObjectPreviewWriter, WritesPreviewFilesWithCameraEntries)
   std::vector<std::string> warnings;
   ASSERT_TRUE(writer.write_preview("test_scene", {object}, &out_dir, &warnings));
 
-  const boost::filesystem::path xacro_path = boost::filesystem::path(out_dir) / "placed_objects_preview.urdf.xacro";
-  const boost::filesystem::path camera_yaml_path = boost::filesystem::path(out_dir) / "camera_frustum_preview.yaml";
+  const std::filesystem::path xacro_path = std::filesystem::path(out_dir) / "placed_objects_preview.urdf.xacro";
+  const std::filesystem::path camera_yaml_path = std::filesystem::path(out_dir) / "camera_frustum_preview.yaml";
 
-  ASSERT_TRUE(boost::filesystem::exists(xacro_path));
-  ASSERT_TRUE(boost::filesystem::exists(camera_yaml_path));
+  ASSERT_TRUE(std::filesystem::exists(xacro_path));
+  ASSERT_TRUE(std::filesystem::exists(camera_yaml_path));
 
   std::ifstream xacro_file(xacro_path.string());
   std::stringstream xacro_buffer;


### PR DESCRIPTION
### Motivation
- Duplicate `TaskZone` definitions and mismatched field names caused compile errors and incorrect usage between model, YAML IO, and UI code.
- Several gtest targets failed to link due to missing `yaml-cpp` and Boost filesystem linkage, producing undefined YAML and filesystem symbols.

### Description
- Removed the duplicate `TaskZone` struct from `include/object_placement_yaml_io.hpp` and rely on the canonical `TaskZone` in `include/object_placement_model.hpp`.
- Aligned UI and YAML code with the canonical `TaskZone` fields by updating `gui/object_placement_dialog.cpp` to use `dim_x/dim_y/dim_z` and `frame_id` instead of `size_x/size_y/size_z` and `frame`.
- Added `yaml-cpp` to the link libraries for the `workcell_command_builders_test` target in `CMakeLists.txt` to resolve undefined YAML symbols.
- Converted the `placed_object_preview_writer` test to use C++17 `std::filesystem` in `test/placed_object_preview_writer_test.cpp` to avoid Boost filesystem linkage issues.

### Testing
- Attempted `colcon build --symlink-install --packages-select workcell_builder`, but the build could not be executed here because `colcon` is not available in the environment (`colcon: command not found`).
- No automated tests (`ctest`) were run in this environment due to the missing build tool; CI should run `colcon` and `ctest` to validate the changes end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09fde541b48331b564ca0ee4d3da80)