### PR TITLE
Add robot/tool attachment metadata with backward-compatible defaults

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -240,6 +240,8 @@ if(BUILD_TESTING)
     gui/loadobjects.cpp)
   ament_add_gtest(workcell_generate_yaml_end_effector_metadata_test
     test/generate_yaml_end_effector_metadata_test.cpp)
+  ament_add_gtest(workcell_scene_xacro_tool_attachment_test
+    test/scene_xacro_tool_attachment_test.cpp)
   ament_add_gtest(workcell_scene_status_test
     test/workcell_scene_status_test.cpp
     src_workcell_scene_status.cpp

--- a/workcell_builder/workcell_builder/include/yaml_parser/generate_yaml.h
+++ b/workcell_builder/workcell_builder/include/yaml_parser/generate_yaml.h
@@ -157,6 +157,18 @@ bool normalized_spawn_gripper_controller(const EndEffector & ee)
   }
   return ee.spawn_gripper_controller;
 }
+
+void emit_origin_map(YAML::Emitter * out, const Origin & origin)
+{
+  *out << YAML::BeginMap;
+  *out << YAML::Key << "xyz";
+  *out << YAML::Value << YAML::Flow << YAML::BeginSeq << origin.x << origin.y << origin.z <<
+    YAML::EndSeq;
+  *out << YAML::Key << "rpy";
+  *out << YAML::Value << YAML::Flow << YAML::BeginSeq << origin.roll << origin.pitch << origin.yaw <<
+    YAML::EndSeq;
+  *out << YAML::EndMap;
+}
 }  // namespace
 
 
@@ -190,6 +202,24 @@ public:
       if (scene.robot_vector[0].origin.is_origin) {
         OriginParser::generate_origin(&out, scene.robot_vector[0].origin);
       }
+      out << YAML::Key << "robot_mount";
+      out << YAML::Value << YAML::BeginMap;
+      out << YAML::Key << "pose";
+      out << YAML::Value;
+      if (scene.robot_vector[0].origin.is_origin) {
+        emit_origin_map(&out, scene.robot_vector[0].origin);
+      } else {
+        Origin fallback{};
+        fallback.is_origin = true;
+        fallback.x = 0.0F;
+        fallback.y = 0.0F;
+        fallback.z = 0.0F;
+        fallback.roll = 0.0F;
+        fallback.pitch = 0.0F;
+        fallback.yaw = 0.0F;
+        emit_origin_map(&out, fallback);
+      }
+      out << YAML::EndMap;
       out << YAML::Key << "links";
       out << YAML::Value << YAML::BeginSeq;
 
@@ -249,6 +279,21 @@ public:
       out << YAML::EndMap;
 
       OriginParser::generate_origin(&out, resolve_end_effector_mount_origin(scene.ee_vector[0]));
+      const Origin ee_mount_origin = resolve_end_effector_mount_origin(scene.ee_vector[0]);
+      out << YAML::Key << "tool_attachment";
+      out << YAML::Value << YAML::BeginMap;
+      const std::string default_joint_name =
+        scene.ee_vector[0].name.empty() ? "ee_fixed_joint" : scene.ee_vector[0].name + "_fixed_joint";
+      out << YAML::Key << "joint_name";
+      out << YAML::Value << default_joint_name;
+      out << YAML::Key << "parent_link";
+      out << YAML::Value << scene.ee_vector[0].robot_link;
+      out << YAML::Key << "child_link";
+      out << YAML::Value << scene.ee_vector[0].base_link;
+      out << YAML::Key << "origin";
+      out << YAML::Value;
+      emit_origin_map(&out, ee_mount_origin);
+      out << YAML::EndMap;
 
       out << YAML::Key << "links";
       out << YAML::Value << YAML::BeginSeq;

--- a/workcell_builder/workcell_builder/test/generate_yaml_end_effector_metadata_test.cpp
+++ b/workcell_builder/workcell_builder/test/generate_yaml_end_effector_metadata_test.cpp
@@ -77,6 +77,18 @@ TEST(GenerateYAMLMetadataTest, FingerGripperIncludesNormalizedAndLegacyKeys)
   EXPECT_EQ(end_effector["gripper_type"].as<std::string>(), "finger");
   EXPECT_TRUE(end_effector["spawn_gripper_controller"].as<bool>());
   EXPECT_EQ(end_effector["finger_count"].as<int>(), 2);
+
+  const YAML::Node tool_attachment = end_effector["tool_attachment"];
+  ASSERT_TRUE(tool_attachment);
+  EXPECT_EQ(tool_attachment["parent_link"].as<std::string>(), "tool0");
+  EXPECT_EQ(tool_attachment["child_link"].as<std::string>(), "robotiq_85_base_link");
+  EXPECT_EQ(tool_attachment["joint_name"].as<std::string>(), "robotiq_85_fixed_joint");
+  ASSERT_TRUE(tool_attachment["origin"]);
+  ASSERT_TRUE(tool_attachment["origin"]["rpy"]);
+  ASSERT_EQ(tool_attachment["origin"]["rpy"].size(), 3U);
+  EXPECT_FLOAT_EQ(tool_attachment["origin"]["rpy"][0].as<float>(), -1.5708F);
+  EXPECT_FLOAT_EQ(tool_attachment["origin"]["rpy"][1].as<float>(), -1.5708F);
+  EXPECT_FLOAT_EQ(tool_attachment["origin"]["rpy"][2].as<float>(), 0.0F);
 }
 
 TEST(GenerateYAMLMetadataTest, SuctionGripperIncludesNormalizedKeysWithoutFingerCount)
@@ -108,4 +120,19 @@ TEST(GenerateYAMLMetadataTest, SuctionGripperIncludesNormalizedKeysWithoutFinger
   EXPECT_EQ(end_effector["gripper_type"].as<std::string>(), "airpick");
   EXPECT_FALSE(end_effector["spawn_gripper_controller"].as<bool>());
   EXPECT_FALSE(end_effector["finger_count"]);
+}
+
+TEST(GenerateYAMLMetadataTest, RobotMountPoseFallsBackToIdentityWhenAbsent)
+{
+  Scene scene = make_base_scene();
+  const YAML::Node root = generate_environment_yaml(scene);
+  const YAML::Node robot = root["robot"];
+  ASSERT_TRUE(robot);
+  ASSERT_TRUE(robot["robot_mount"]);
+  ASSERT_TRUE(robot["robot_mount"]["pose"]);
+  ASSERT_TRUE(robot["robot_mount"]["pose"]["rpy"]);
+  ASSERT_EQ(robot["robot_mount"]["pose"]["rpy"].size(), 3U);
+  EXPECT_FLOAT_EQ(robot["robot_mount"]["pose"]["rpy"][0].as<float>(), 0.0F);
+  EXPECT_FLOAT_EQ(robot["robot_mount"]["pose"]["rpy"][1].as<float>(), 0.0F);
+  EXPECT_FLOAT_EQ(robot["robot_mount"]["pose"]["rpy"][2].as<float>(), 0.0F);
 }

--- a/workcell_builder/workcell_builder/test/scene_xacro_tool_attachment_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene_xacro_tool_attachment_test.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+#include <fstream>
+#include <sstream>
+
+#include "attributes/end_effector.h"
+#include "attributes/robot.h"
+#include "attributes/scene.h"
+#include "scene_xacro_parser.h"
+
+TEST(SceneXacroToolAttachmentTest, EmitsConfiguredEndEffectorMountRpySnippet)
+{
+  Scene scene;
+  scene.name = "demo_scene";
+  scene.robot_loaded = true;
+  scene.ee_loaded = true;
+
+  Robot robot;
+  robot.name = "custom_arm";
+  robot.brand = "custom";
+  robot.filepath = "$(find custom_description)/urdf/custom_arm.urdf.xacro";
+  robot.base_link = "base_link";
+  scene.robot_vector.push_back(robot);
+
+  EndEffector ee;
+  ee.name = "robotiq_85";
+  ee.brand = "robotiq_85_gripper";
+  ee.filepath = "$(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro";
+  ee.base_link = "gripper_base_link";
+  ee.robot_link = "tool0";
+  ee.origin.is_origin = true;
+  ee.origin.x = 0.0F;
+  ee.origin.y = 0.0F;
+  ee.origin.z = 0.0F;
+  ee.origin.roll = -1.5708F;
+  ee.origin.pitch = -1.5708F;
+  ee.origin.yaw = 0.0F;
+  scene.ee_vector.push_back(ee);
+
+  const boost::filesystem::path out_dir =
+    boost::filesystem::temp_directory_path() / boost::filesystem::unique_path("scene_xacro_test_%%%%-%%%%");
+  boost::filesystem::create_directories(out_dir);
+  const boost::filesystem::path out_file = out_dir / "scene.urdf.xacro";
+
+  generate_scene_xacro(scene, out_file.string());
+
+  std::ifstream file(out_file.string());
+  ASSERT_TRUE(file.is_open());
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  const std::string content = buffer.str();
+
+  EXPECT_NE(content.find("rpy=\"-1.5708 -1.5708 0.0\""), std::string::npos);
+
+  boost::filesystem::remove_all(out_dir);
+}


### PR DESCRIPTION
### Motivation
- Make URDF/Xacro generation downstream-friendly by emitting explicit robot mount and tool-attachment metadata so templates and scripts can place attach joints accurately using configured poses.
- Support explicit tool fixed-joint fields (parent/child link, origin, optional joint name) while remaining backward-compatible with existing end-effector origin/default behavior and tool-family defaults.
- Provide an automated check that the configured end-effector mount orientation produces the exact URDF snippet expected (`rpy="-1.5708 -1.5708 0.0"`).

### Description
- Added `emit_origin_map` helper and extended `GenerateYAML::generate_yaml` to emit `robot.robot_mount.pose` sourced from the robot `origin` (with identity fallback) in `include/yaml_parser/generate_yaml.h`.
- Added `end_effector.tool_attachment` emission with `joint_name` (generated default), `parent_link`, `child_link`, and `origin.xyz`/`origin.rpy` taken from resolved mount origin in `include/yaml_parser/generate_yaml.h`.
- Kept existing end-effector origin/default resolution via `resolve_end_effector_mount_origin` and the `tool_mount_defaults` profile lookup so known gripper families can supply metadata-based defaults without hardcoding every tool.
- Added/updated unit tests and test registration: extended `test/generate_yaml_end_effector_metadata_test.cpp` to assert `tool_attachment` and `robot.robot_mount.pose` fields, added `test/scene_xacro_tool_attachment_test.cpp` to assert the generated xacro contains `rpy="-1.5708 -1.5708 0.0"`, and registered the new test in `CMakeLists.txt`.

### Testing
- No test suite was executed in this session; the change adds the following automated tests to the project test list but they were not run here: the extended `workcell_generate_yaml_end_effector_metadata_test` and the new `workcell_scene_xacro_tool_attachment_test` (registered in `CMakeLists.txt`).
- The tests contain explicit assertions for the new metadata fields and the URDF rpy snippet, so running the package tests (`colcon build` / `colcon test` or `ctest`) will verify the behavior introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0361d9b88331ad30d15732c26d63)