### PR TITLE
Add robot/tool pose YAML IO with validation and safe defaults

### DIFF
--- a/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
+++ b/workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp
@@ -10,12 +10,48 @@ namespace workcell_builder
 {
 namespace
 {
+constexpr double kSuspiciousPositionMagnitudeMeters = 100.0;
+
 YAML::Node to_yaml_pose(const PlacedObject & o)
 {
   YAML::Node pose;
   pose["xyz"].push_back(o.x); pose["xyz"].push_back(o.y); pose["xyz"].push_back(o.z);
   pose["rpy"].push_back(o.roll); pose["rpy"].push_back(o.pitch); pose["rpy"].push_back(o.yaw);
   return pose;
+}
+
+void append_pose_to_yaml(
+  YAML::Node * node, double x, double y, double z, double roll, double pitch, double yaw)
+{
+  (*node)["pose"]["xyz"].push_back(x);
+  (*node)["pose"]["xyz"].push_back(y);
+  (*node)["pose"]["xyz"].push_back(z);
+  (*node)["pose"]["rpy"].push_back(roll);
+  (*node)["pose"]["rpy"].push_back(pitch);
+  (*node)["pose"]["rpy"].push_back(yaw);
+}
+
+void warn_if_suspicious_pose(
+  const std::string & block_name, double x, double y, double z, std::vector<std::string> * warnings)
+{
+  if (!warnings) {
+    return;
+  }
+  if (std::fabs(x) > kSuspiciousPositionMagnitudeMeters ||
+    std::fabs(y) > kSuspiciousPositionMagnitudeMeters ||
+    std::fabs(z) > kSuspiciousPositionMagnitudeMeters)
+  {
+    warnings->push_back(block_name + " warning: suspiciously large xyz magnitude");
+  }
+}
+
+bool check_finite(const std::string & context, double value, std::vector<std::string> * warnings)
+{
+  if (std::isfinite(value)) {
+    return true;
+  }
+  if (warnings) warnings->push_back(context + " has non-finite numeric value");
+  return false;
 }
 }
 
@@ -266,6 +302,121 @@ PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(const std::strin
     r.objects_saved = zones.size();
   } catch (const std::exception & e) {
     r.warnings.push_back(std::string("failed to save task zones: ") + e.what());
+  }
+  return r;
+}
+
+bool load_robot_tool_pose_from_environment_yaml(
+  const std::string & path, RobotMountConfig * robot_mount, ToolAttachmentConfig * tool_attachment,
+  std::vector<std::string> * warnings)
+{
+  if (!robot_mount || !tool_attachment) {
+    if (warnings) warnings->push_back("robot/tool pose load failed: null output pointer");
+    return false;
+  }
+
+  *robot_mount = RobotMountConfig{};
+  *tool_attachment = ToolAttachmentConfig{};
+  bool ok = true;
+
+  try {
+    YAML::Node root = YAML::LoadFile(path);
+
+    auto load_pose = [&](const YAML::Node & block, double * x, double * y, double * z, double * roll, double * pitch, double * yaw) {
+      auto pose = block["pose"];
+      if (!pose || !pose.IsMap()) return;
+      auto xyz = pose["xyz"];
+      if (xyz && xyz.IsSequence() && xyz.size() == 3) {
+        *x = xyz[0].as<double>(*x);
+        *y = xyz[1].as<double>(*y);
+        *z = xyz[2].as<double>(*z);
+      }
+      auto rpy = pose["rpy"];
+      if (rpy && rpy.IsSequence() && rpy.size() == 3) {
+        *roll = rpy[0].as<double>(*roll);
+        *pitch = rpy[1].as<double>(*pitch);
+        *yaw = rpy[2].as<double>(*yaw);
+      }
+    };
+
+    const auto rm = root["robot_mount"];
+    if (rm && rm.IsMap()) {
+      robot_mount->parent_link = rm["parent_link"].as<std::string>(robot_mount->parent_link);
+      load_pose(
+        rm, &robot_mount->x, &robot_mount->y, &robot_mount->z, &robot_mount->roll,
+        &robot_mount->pitch, &robot_mount->yaw);
+    }
+
+    const auto ta = root["tool_attachment"];
+    if (ta && ta.IsMap()) {
+      tool_attachment->parent_link = ta["parent_link"].as<std::string>(tool_attachment->parent_link);
+      tool_attachment->child_link = ta["child_link"].as<std::string>(tool_attachment->child_link);
+      load_pose(
+        ta, &tool_attachment->x, &tool_attachment->y, &tool_attachment->z, &tool_attachment->roll,
+        &tool_attachment->pitch, &tool_attachment->yaw);
+    }
+  } catch (const std::exception & e) {
+    if (warnings) warnings->push_back(std::string("robot/tool yaml parse warning: ") + e.what());
+    return false;
+  }
+
+  ok = check_finite("robot_mount.x", robot_mount->x, warnings) &&
+    check_finite("robot_mount.y", robot_mount->y, warnings) &&
+    check_finite("robot_mount.z", robot_mount->z, warnings) &&
+    check_finite("robot_mount.roll", robot_mount->roll, warnings) &&
+    check_finite("robot_mount.pitch", robot_mount->pitch, warnings) &&
+    check_finite("robot_mount.yaw", robot_mount->yaw, warnings) &&
+    check_finite("tool_attachment.x", tool_attachment->x, warnings) &&
+    check_finite("tool_attachment.y", tool_attachment->y, warnings) &&
+    check_finite("tool_attachment.z", tool_attachment->z, warnings) &&
+    check_finite("tool_attachment.roll", tool_attachment->roll, warnings) &&
+    check_finite("tool_attachment.pitch", tool_attachment->pitch, warnings) &&
+    check_finite("tool_attachment.yaw", tool_attachment->yaw, warnings) && ok;
+
+  warn_if_suspicious_pose("robot_mount", robot_mount->x, robot_mount->y, robot_mount->z, warnings);
+  warn_if_suspicious_pose("tool_attachment", tool_attachment->x, tool_attachment->y, tool_attachment->z, warnings);
+  if (warnings && robot_mount->parent_link.empty()) warnings->push_back("robot_mount warning: empty parent_link");
+  if (warnings && tool_attachment->parent_link.empty()) warnings->push_back("tool_attachment warning: empty parent_link");
+  if (warnings && tool_attachment->child_link.empty()) warnings->push_back("tool_attachment warning: empty child_link");
+
+  return ok;
+}
+
+PlacedObjectYamlWriteResult save_robot_tool_pose_to_environment_yaml(
+  const std::string & path, const RobotMountConfig & robot_mount, const ToolAttachmentConfig & tool_attachment)
+{
+  PlacedObjectYamlWriteResult r;
+  r.path_written = path;
+  try {
+    YAML::Node root;
+    if (std::filesystem::exists(path)) {
+      try {
+        root = YAML::LoadFile(path);
+      } catch (const std::exception & e) {
+        r.warnings.push_back(std::string("existing environment yaml malformed; rewriting minimal root: ") + e.what());
+        root = YAML::Node(YAML::NodeType::Map);
+      }
+    } else {
+      root = YAML::Node(YAML::NodeType::Map);
+    }
+
+    YAML::Node rm;
+    rm["parent_link"] = robot_mount.parent_link;
+    append_pose_to_yaml(&rm, robot_mount.x, robot_mount.y, robot_mount.z, robot_mount.roll, robot_mount.pitch, robot_mount.yaw);
+    root["robot_mount"] = rm;
+
+    YAML::Node ta;
+    ta["parent_link"] = tool_attachment.parent_link;
+    ta["child_link"] = tool_attachment.child_link;
+    append_pose_to_yaml(&ta, tool_attachment.x, tool_attachment.y, tool_attachment.z, tool_attachment.roll, tool_attachment.pitch, tool_attachment.yaw);
+    root["tool_attachment"] = ta;
+
+    std::ofstream out(path);
+    out << root;
+    r.ok = out.good();
+    r.objects_saved = 2;
+  } catch (const std::exception & e) {
+    r.warnings.push_back(std::string("failed to save robot/tool pose: ") + e.what());
   }
   return r;
 }

--- a/workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp
+++ b/workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp
@@ -16,6 +16,29 @@ struct PlacedObjectYamlWriteResult
   size_t objects_saved{0};
 };
 
+struct RobotMountConfig
+{
+  std::string parent_link{"world"};
+  double x{0.0};
+  double y{0.0};
+  double z{0.0};
+  double roll{0.0};
+  double pitch{0.0};
+  double yaw{0.0};
+};
+
+struct ToolAttachmentConfig
+{
+  std::string parent_link;
+  std::string child_link;
+  double x{0.0};
+  double y{0.0};
+  double z{0.0};
+  double roll{0.0};
+  double pitch{0.0};
+  double yaw{0.0};
+};
+
 std::vector<PlacedObject> load_placed_objects_from_environment_yaml(
   const std::string & environment_yaml_path,
   std::vector<std::string> * warnings = nullptr);
@@ -39,5 +62,16 @@ std::vector<TaskZone> load_task_zones_from_environment_yaml(
 PlacedObjectYamlWriteResult save_task_zones_to_environment_yaml(
   const std::string & environment_yaml_path,
   const std::vector<TaskZone> & task_zones);
+
+bool load_robot_tool_pose_from_environment_yaml(
+  const std::string & environment_yaml_path,
+  RobotMountConfig * robot_mount,
+  ToolAttachmentConfig * tool_attachment,
+  std::vector<std::string> * warnings = nullptr);
+
+PlacedObjectYamlWriteResult save_robot_tool_pose_to_environment_yaml(
+  const std::string & environment_yaml_path,
+  const RobotMountConfig & robot_mount,
+  const ToolAttachmentConfig & tool_attachment);
 
 }  // namespace workcell_builder


### PR DESCRIPTION
### Motivation
- Persist robot mount and tool attachment pose metadata in `environment.yaml` and support legacy files that may lack these blocks.
- Make YAML IO robust so malformed or partially-populated files do not crash the application and unrelated metadata is preserved.

### Description
- Added typed structs `RobotMountConfig` and `ToolAttachmentConfig` and declared `load_robot_tool_pose_from_environment_yaml(...)` and `save_robot_tool_pose_to_environment_yaml(...)` in `object_placement_yaml_io.hpp`.
- Implemented loading in `object_placement_yaml_io.cpp` that safely parses `robot_mount` and `tool_attachment` blocks, supplies safe defaults when blocks are missing, and never throws on malformed YAML (exceptions are converted into warnings and a safe return).
- Added numeric validation to reject non-finite (`NaN`/`inf`) pose components and emit warnings for suspiciously large XYZ magnitudes and for empty `parent_link`/`child_link` values; helper functions `check_finite`, `warn_if_suspicious_pose`, and `append_pose_to_yaml` encapsulate this logic.
- Implemented writer that loads the existing root YAML (if present), updates only the `robot_mount` and `tool_attachment` keys, preserves other top-level keys (such as `placed_objects`, `camera_placements`, `task_zones`, and legacy metadata), and handles malformed existing YAML by warning and writing a minimal map.

### Testing
- Performed repository-level verification commands: ran `git diff` to inspect changes and committed the patch with `git commit`, both of which completed successfully.
- Invoked the PR creation helper which produced the PR description; that step succeeded.
- No unit or integration tests were run as part of this change (none added); recommend adding CI tests to validate YAML parsing and preservation semantics in a follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a035e94448331af6f782fda622f9f)