### PR TITLE
Export robot mount and tool attachment metadata into cell definition

### DIFF
--- a/scripts/export_builder_scene_to_cell_definition.py
+++ b/scripts/export_builder_scene_to_cell_definition.py
@@ -218,6 +218,9 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
 
     robot_env = env.get("robot") if isinstance(env.get("robot"), dict) else {}
     ee_env = env.get("end_effector") if isinstance(env.get("end_effector"), dict) else {}
+    env_metadata = env.get("metadata") if isinstance(env.get("metadata"), dict) else {}
+    robot_mount = env_metadata.get("robot_mount") if isinstance(env_metadata.get("robot_mount"), dict) else {}
+    tool_attachment = env_metadata.get("tool_attachment") if isinstance(env_metadata.get("tool_attachment"), dict) else {}
     objects_env = env.get("objects") if isinstance(env.get("objects"), dict) else {}
 
     robot_meta = meta.get("robot") if isinstance(meta.get("robot"), dict) else {}
@@ -230,6 +233,20 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
     robot_name = robot_env.get("name") or robot_meta.get("selected_name") or "unknown_robot"
     ee_name = ee_env.get("name") or ee_meta.get("selected_name") or "unknown_end_effector"
     task_type = _task_type_from_meta(meta)
+    robot_id = robot_mount.get("id") or robot_env.get("id") or robot_name
+    robot_base_link = robot_mount.get("base_link") or robot_env.get("base_link") or "base_link"
+    robot_parent_frame = robot_mount.get("parent_frame") or "world"
+    robot_pose = robot_mount.get("pose") if isinstance(robot_mount.get("pose"), dict) else {
+        "xyz": [0.0, 0.0, 0.0],
+        "rpy": [0.0, 0.0, 0.0],
+    }
+    ee_id = tool_attachment.get("id") or ee_env.get("id") or ee_name
+    ee_parent_link = tool_attachment.get("parent_link") or ee_env.get("parent_link") or "tool0"
+    ee_child_link = tool_attachment.get("child_link") or ee_env.get("base_link") or "tool0"
+    ee_attach_pose = tool_attachment.get("attach_pose") if isinstance(tool_attachment.get("attach_pose"), dict) else {
+        "xyz": [0.0, 0.0, 0.0],
+        "rpy": [0.0, 0.0, 0.0],
+    }
 
     assets: list[dict[str, Any]] = []
     object_entries: list[dict[str, Any]] = []
@@ -287,20 +304,27 @@ def export_scene(scene_path: Path, output_dir: Path, validate: bool) -> dict[str
         "schema_version": "cell_definition/v1",
         "cell": {"id": scene_path.name, "name": scene_path.name, "planning_frame": "world"},
         "robot": {
+            "id": robot_id,
             "name": robot_name,
             "model": robot_name,
             "capability": robot_meta.get("capability_id"),
             "planning_group": robot_env.get("planning_group", "manipulator"),
+            "base_link": robot_base_link,
+            "parent_frame": robot_parent_frame,
+            "pose": robot_pose,
             "base_frame": robot_env.get("base_link", "base_link"),
             "tool_link": ee_env.get("parent_link", "tool0"),
             "home_named_target": "home",
         },
         "end_effector": {
-            "id": ee_name,
+            "id": ee_id,
             "name": ee_name,
             "capability": ee_meta.get("capability_id"),
             "type": ee_meta.get("family"),
             "grasp_frame": ee_env.get("base_link", "tool0"),
+            "parent_link": ee_parent_link,
+            "child_link": ee_child_link,
+            "attach_pose": ee_attach_pose,
             "allowed_touch_links": [],
         },
         "camera": ({"id": (env.get("camera_placements", [{}])[0].get("name") if isinstance(env.get("camera_placements"), list) and env.get("camera_placements") else (sensors_meta[0].get("capability_id") if sensors_meta and isinstance(sensors_meta[0], dict) else "realsense_d435i")),

--- a/scripts/validate_cell_definition.py
+++ b/scripts/validate_cell_definition.py
@@ -243,6 +243,16 @@ def _validate_dimensions(summary: ValidationSummary, owner: str, dims: Any) -> N
             summary.errors.append(f"{owner}.dimensions[{idx}] must be a positive number.")
 
 
+def _validate_xyz_rpy_pose(summary: ValidationSummary, owner: str, pose: Any) -> None:
+    if not isinstance(pose, dict):
+        summary.errors.append(f"{owner} must be a mapping with xyz/rpy.")
+        return
+    if not _is_numeric_list(pose.get("xyz"), 3):
+        summary.errors.append(f"{owner}.xyz must be numeric list length 3.")
+    if not _is_numeric_list(pose.get("rpy"), 3):
+        summary.errors.append(f"{owner}.rpy must be numeric list length 3.")
+
+
 def _check_duplicate_ids(summary: ValidationSummary, owner: str, entries: Any) -> None:
     if not isinstance(entries, list):
         return
@@ -397,6 +407,17 @@ def validate_cell_definition(
 
     if not isinstance(robot.get("model"), str) or not robot.get("model", "").strip():
         result.errors.append("robot.model must be a non-empty string.")
+    robot_id = robot.get("id")
+    if robot_id is not None and (not isinstance(robot_id, str) or not robot_id.strip()):
+        result.errors.append("robot.id must be a non-empty string when provided.")
+    robot_base_link = robot.get("base_link")
+    if robot_base_link is not None and (not isinstance(robot_base_link, str) or not robot_base_link.strip()):
+        result.errors.append("robot.base_link must be a non-empty string when provided.")
+    robot_parent_frame = robot.get("parent_frame")
+    if robot_parent_frame is not None and (not isinstance(robot_parent_frame, str) or not robot_parent_frame.strip()):
+        result.errors.append("robot.parent_frame must be a non-empty string when provided.")
+    if "pose" in robot:
+        _validate_xyz_rpy_pose(result, "robot.pose", robot.get("pose"))
 
     if "safe_joint_state" not in robot:
         result.errors.append("robot.safe_joint_state key is required (empty list allowed when home_named_target exists).")
@@ -412,6 +433,17 @@ def validate_cell_definition(
     ee_type = end_effector.get("type")
     if isinstance(ee_type, str) and ee_type not in KNOWN_END_EFFECTOR_TYPES:
         result.warnings.append(f"Unknown end_effector.type '{ee_type}'. Continuing because this is metadata-only validation.")
+    ee_id = end_effector.get("id")
+    if ee_id is not None and (not isinstance(ee_id, str) or not ee_id.strip()):
+        result.errors.append("end_effector.id must be a non-empty string when provided.")
+    ee_parent_link = end_effector.get("parent_link")
+    if ee_parent_link is not None and (not isinstance(ee_parent_link, str) or not ee_parent_link.strip()):
+        result.errors.append("end_effector.parent_link must be a non-empty string when provided.")
+    ee_child_link = end_effector.get("child_link")
+    if ee_child_link is not None and (not isinstance(ee_child_link, str) or not ee_child_link.strip()):
+        result.errors.append("end_effector.child_link must be a non-empty string when provided.")
+    if "attach_pose" in end_effector:
+        _validate_xyz_rpy_pose(result, "end_effector.attach_pose", end_effector.get("attach_pose"))
 
     support_surfaces = environment.get("support_surfaces")
     if isinstance(support_surfaces, list):


### PR DESCRIPTION
### Motivation
- Include robot mount and tool attachment metadata from scene environment so generated `cell_definition.yaml` carries mount frames and attach poses for downstream tooling and preview workflows.
- Keep existing cell definition schema and exporter behavior intact while allowing richer metadata when available.

### Description
- Read `environment.metadata.robot_mount` and `environment.metadata.tool_attachment` into the exporter with safe fallbacks when those blocks are absent.
- Populate generated `cell_definition.yaml` with `robot.id`, `robot.base_link`, `robot.parent_frame`, and `robot.pose`, and with `end_effector.id`, `end_effector.parent_link`, `end_effector.child_link`, and `end_effector.attach_pose` while preserving all existing top-level keys.
- Maintain backward compatibility by defaulting values when metadata blocks are missing so old scene packages still export usable cell definitions.
- Extend validation in `scripts/validate_cell_definition.py` by adding `_validate_xyz_rpy_pose` and optional checks for the new robot and end-effector fields so the validator accepts and type-checks the new structures when present.

### Testing
- Compiled modified modules with `python3 -m py_compile scripts/export_builder_scene_to_cell_definition.py scripts/validate_cell_definition.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a06aef4fc83319f5e9aa1b98c4569)