### PR TITLE
Add legacy readiness diagnostics and stricter healthcheck coverage

### DIFF
--- a/scripts/check_scene_readiness.py
+++ b/scripts/check_scene_readiness.py
@@ -265,6 +265,76 @@ def _analyze_scene_package(scene_pkg: Path, repo_root: Path) -> dict[str, Any]:
     if c_place and c_place not in zone_ids:
         warnings.append(f"Cell definition task.place.target.id not found in task_zones: {c_place}")
 
+    robot_cfg = env_data.get("robot") if isinstance(env_data.get("robot"), dict) else {}
+    ee_cfg = env_data.get("end_effector") if isinstance(env_data.get("end_effector"), dict) else {}
+    robot_mount = robot_cfg.get("robot_mount") if isinstance(robot_cfg, dict) else None
+    tool_attachment = ee_cfg.get("tool_attachment") if isinstance(ee_cfg, dict) else None
+
+    warnings.append(
+        "Legacy compatibility: robot_mount "
+        + ("present." if isinstance(robot_mount, dict) else "missing.")
+    )
+    warnings.append(
+        "Legacy compatibility: tool_attachment "
+        + ("present." if isinstance(tool_attachment, dict) else "missing.")
+    )
+
+    if isinstance(tool_attachment, dict):
+        parent_link = str(tool_attachment.get("parent_link") or "").strip()
+        child_link = str(tool_attachment.get("child_link") or "").strip()
+        warnings.append(
+            "Legacy compatibility: tool_attachment parent/child link completeness "
+            + ("complete." if parent_link and child_link else "incomplete.")
+        )
+
+    rec_used = False
+    for key in ("use_recommended_gripper_orientation", "use_recommended_orientation"):
+        if key in ee_cfg:
+            rec_used = bool(ee_cfg.get(key))
+            break
+    warnings.append(
+        "Legacy compatibility: recommended gripper orientation "
+        + ("used." if rec_used else "not used.")
+    )
+
+    known_gripper = str(ee_cfg.get("name") or ee_cfg.get("id") or "").lower()
+    if known_gripper and any(tok in known_gripper for tok in ("robotiq", "onrobot", "airpick", "gripper", "suction")):
+        src = tool_attachment if isinstance(tool_attachment, dict) else ee_cfg.get("origin")
+        origin = (src.get("origin") if isinstance(src, dict) and isinstance(src.get("origin"), dict) else src) if isinstance(src, dict) else {}
+        rpy = origin.get("rpy") if isinstance(origin, dict) else None
+        if isinstance(rpy, list) and len(rpy) == 3:
+            vals = [float(v) for v in rpy]
+            if all(abs(v) < 1e-9 for v in vals):
+                warnings.append("Legacy compatibility: known gripper has zero RPY (0,0,0).")
+
+    generated_text = ""
+    if placed_objects:
+        # Re-use earlier generated URDF linkage checks path to avoid duplicate WARN lines.
+        generated_text, _, _ = _collect_generated_urdf_text(scene_pkg)
+    else:
+        generated_text, generated_errors, generated_warnings = _collect_generated_urdf_text(scene_pkg)
+        errors.extend(generated_errors)
+        warnings.extend(generated_warnings)
+    if generated_text:
+        if isinstance(robot_mount, dict):
+            mount_pose = robot_mount.get("pose") if isinstance(robot_mount.get("pose"), dict) else {}
+            xyz = mount_pose.get("xyz")
+            if isinstance(xyz, list) and len(xyz) == 3:
+                xyz_str = " ".join(str(v) for v in xyz)
+                warnings.append(
+                    "Legacy compatibility: generated URDF robot base origin "
+                    + ("contains expected pose." if xyz_str in generated_text else "missing expected pose.")
+                )
+        if isinstance(tool_attachment, dict):
+            attach_origin = tool_attachment.get("origin") if isinstance(tool_attachment.get("origin"), dict) else {}
+            xyz = attach_origin.get("xyz")
+            if isinstance(xyz, list) and len(xyz) == 3:
+                xyz_str = " ".join(str(v) for v in xyz)
+                warnings.append(
+                    "Legacy compatibility: generated URDF tool attach origin "
+                    + ("contains expected pose." if xyz_str in generated_text else "missing expected pose.")
+                )
+
     return {
         "scene_package": str(scene_pkg),
         "errors": errors,

--- a/scripts/validate_workcell_builder_healthcheck.py
+++ b/scripts/validate_workcell_builder_healthcheck.py
@@ -369,6 +369,43 @@ def main() -> int:
         f"UI marker exists in {opd_path.relative_to(repo_root)}: 'Save Placed Objects to Scene YAML'",
         errors,
     )
+    _check(
+        "Use Recommended Gripper Orientation" in scene_cpp or "Use Recommended Gripper Orientation" in opd_text,
+        "UI contains 'Use Recommended Gripper Orientation'",
+        errors,
+    )
+
+    yaml_io_text = (
+        (repo_root / "workcell_builder/workcell_builder/include/object_placement_yaml_io.hpp").read_text(encoding="utf-8")
+        + "\n"
+        + (repo_root / "workcell_builder/workcell_builder/gui/object_placement_yaml_io.cpp").read_text(encoding="utf-8")
+    )
+    for marker in ["robot_mount", "tool_attachment"]:
+        _check(marker in yaml_io_text, f"robot/tool YAML IO marker exists: {marker}", errors)
+
+    _check(
+        "Robot base and tool attachment pose" in docs_text,
+        "docs mention 'Robot base and tool attachment pose'",
+        errors,
+    )
+
+    tests_union = "\n".join(
+        [
+            (repo_root / "tests/test_workcell_builder_gripper_mount_orientation.py").read_text(encoding="utf-8")
+            if (repo_root / "tests/test_workcell_builder_gripper_mount_orientation.py").exists() else "",
+            (repo_root / "workcell_builder/workcell_builder/test/generate_yaml_end_effector_metadata_test.cpp").read_text(encoding="utf-8")
+            if (repo_root / "workcell_builder/workcell_builder/test/generate_yaml_end_effector_metadata_test.cpp").exists() else "",
+        ]
+    )
+    for marker in ["robot_mount", "tool_attachment", "-1.5708 -1.5708 0.0"]:
+        _check(marker in tests_union, f"tests mention {marker}", errors)
+
+    urdf_tool_test = (repo_root / "workcell_builder/workcell_builder/test/scene_xacro_tool_attachment_test.cpp").read_text(encoding="utf-8") if (repo_root / "workcell_builder/workcell_builder/test/scene_xacro_tool_attachment_test.cpp").exists() else ""
+    _check(
+        "rpy=\"-1.5708 -1.5708 0.0\"" in urdf_tool_test or ("fixed" in urdf_tool_test.lower() and "origin" in urdf_tool_test.lower()),
+        "URDF tests assert tool fixed-joint origin behavior",
+        errors,
+    )
 
     if errors:
         print("WORKCELL_BUILDER_HEALTHCHECK: FAIL")


### PR DESCRIPTION
### Motivation
- Surface legacy robot/tool mount metadata and URDF linkage issues as non-blocking warnings so older scenes are diagnosable without failing the pipeline.  
- Detect common completeness problems (missing mount/attach, incomplete parent/child links, absent recommended orientation) to aid migration.  
- Tighten CI/healthcheck assertions to ensure YAML IO, UI, docs, tests, and URDF expectations remain present and correct.

### Description
- Extended `scripts/check_scene_readiness.py` to emit legacy compatibility warnings for `robot_mount` presence/missing and `tool_attachment` presence/missing.  
- Added checks for `tool_attachment` parent/child link completeness, whether recommended gripper orientation is used, and a warning when a recognized gripper reports zero RPY.  
- Added checks that inspect generated URDF/Xacro text (reusing earlier collection when possible) and warn whether the generated URDF contains the expected robot base origin and tool attach origin.  
- Updated `scripts/validate_workcell_builder_healthcheck.py` to assert that robot/tool YAML IO markers exist, the UI contains `Use Recommended Gripper Orientation`, docs mention `Robot base and tool attachment pose`, tests mention `robot_mount`, `tool_attachment` and the `-1.5708 -1.5708 0.0` RPY marker, and URDF tests assert tool fixed-joint origin behavior.

### Testing
- Compiled the modified scripts with `python3 -m py_compile scripts/check_scene_readiness.py scripts/validate_workcell_builder_healthcheck.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a06aff7788331b6adafcdff6bf3e8)