### PR TITLE
Fix Boost filesystem/system linkage for scene xacro attachment test

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -425,8 +425,12 @@ if(BUILD_TESTING)
     ament_target_dependencies(workcell_scene_xacro_tool_attachment_test
       ament_index_cpp
     )
+    target_link_libraries(workcell_scene_xacro_tool_attachment_test
+      ${Boost_LIBRARIES}
+    )
     target_include_directories(workcell_scene_xacro_tool_attachment_test
       PRIVATE
+        ${Boost_INCLUDE_DIRS}
         include
     )
   endif()


### PR DESCRIPTION
## Summary
- fixed missing Boost linkage for `workcell_scene_xacro_tool_attachment_test` in `workcell_builder/workcell_builder/CMakeLists.txt`
- kept existing `ament_index_cpp` linkage intact
- added `${Boost_LIBRARIES}` to `target_link_libraries(...)` and `${Boost_INCLUDE_DIRS}` to `target_include_directories(...)` for the test target, matching existing CMake style in this repo
- verified other tests using `boost::filesystem` are already covered by existing Boost linkage blocks; no broad refactor performed

## Validation
- attempted: `colcon build --symlink-install --packages-select workcell_builder`
  - failed in this environment because `colcon` is not installed (`colcon: command not found`)
- attempted: `ctest --test-dir build/workcell_builder --output-on-failure || true`
  - build directory not present because build could not be run in this environment

## Behavior impact
- no production runtime behavior changed
- no robot motion/planning/safety defaults changed
- change is limited to test target linkage

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0d7039988331b527783add85f7c3)