### PR TITLE
Add 'Important' label mode, compact Labels dropdown, and rename 3D view to '3D Layout Preview'

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -84,6 +84,21 @@ bool include_in_fit_bounds_physical_only(const ScenePreviewWidget::PreviewItem &
   }
   return true;
 }
+
+
+bool is_high_priority_role(NormalizedRole role)
+{
+  switch (role) {
+    case NormalizedRole::RobotBase:
+    case NormalizedRole::Camera:
+    case NormalizedRole::PickZone:
+    case NormalizedRole::PlaceBin:
+    case NormalizedRole::SafetyZone:
+      return true;
+    default:
+      return false;
+  }
+}
 QColor item_color(const ScenePreviewWidget::PreviewItem & it)
 {
   switch (classify_item_role(it)) {
@@ -201,7 +216,22 @@ void Scene3DViewportWidget::paintGL()
   for (const auto & it : items) {
     const QPointF p = project_to_screen(it.x + (it.sx * 0.5), it.y + (it.sy * 0.5), it.z + it.sz + 0.08);
     const bool selected = (it.id == selected_id);
-    const bool draw_label = label_mode == ScenePreviewWidget::LabelMode::All || selected;
+    const NormalizedRole role = classify_item_role(it);
+    bool draw_label = false;
+    switch (label_mode) {
+      case ScenePreviewWidget::LabelMode::Off:
+        draw_label = false;
+        break;
+      case ScenePreviewWidget::LabelMode::Important:
+        draw_label = selected || is_high_priority_role(role);
+        break;
+      case ScenePreviewWidget::LabelMode::Selected:
+        draw_label = selected;
+        break;
+      case ScenePreviewWidget::LabelMode::All:
+        draw_label = true;
+        break;
+    }
     if (show_warning_labels && !it.warnings.isEmpty()) {
       painter.setPen(Qt::NoPen);
       painter.setBrush(QColor("#f59e0b"));

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -17,7 +17,7 @@ public:
 
   QVector<ScenePreviewWidget::PreviewItem> items;
   QString selected_id;
-  ScenePreviewWidget::LabelMode label_mode{ ScenePreviewWidget::LabelMode::SelectedOnly };
+  ScenePreviewWidget::LabelMode label_mode{ ScenePreviewWidget::LabelMode::Important };
   bool show_warnings{ true }, show_safety{ true }, show_pick_place{ true };
   bool show_reachability_heatmap{ true }, show_collision_warnings{ true }, show_work_envelope{ true }, show_warning_labels{ true };
   bool show_task_route{ true }, show_approach_retreat{ true };

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -26,8 +26,15 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   auto * controls = new QHBoxLayout();
   controls->addWidget(new QLabel("View mode", this));
   mode_selector_ = new QComboBox(this);
-  mode_selector_->addItems({"3D View", "2D Layout", "Debug Overlays"});
+  mode_selector_->addItems({"3D Layout Preview", "2D Layout", "Debug Overlays"});
   controls->addWidget(mode_selector_);
+  controls->addSpacing(8);
+  controls->addWidget(new QLabel("Labels:", this));
+  labels_selector_ = new QComboBox(this);
+  labels_selector_->addItems({"Off", "Important", "Selected", "All"});
+  labels_selector_->setCurrentText("Important");
+  labels_selector_->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+  controls->addWidget(labels_selector_);
   reset_view_button_ = new QPushButton("Reset View", this); controls->addWidget(reset_view_button_);
   fit_scene_button_ = new QPushButton("Fit Scene", this); controls->addWidget(fit_scene_button_);
   overlays_selector_ = new QComboBox(this); overlays_selector_->addItems({"Overlays", "Reachability Heatmap", "Collision Warnings", "Safety Zones", "Work Envelope", "Warning Labels", "Labels", "Pick/Place Zones", "Task Route", "Approach/Retreat", "Camera FOV", "Pick Coverage", "EPD Detections", "Detection Labels", "Warnings", "Focus Selected", "Fit Selected", "Clear Selection"}); controls->addWidget(overlays_selector_);
@@ -52,6 +59,15 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   stack_->addWidget(view3d_container_); stack_->addWidget(view2d_container_); root->addWidget(stack_, 1);
   connect(mode_selector_, qOverload<int>(&QComboBox::currentIndexChanged), this, &ScenePreviewWidget::on_mode_changed);
   connect(reset_view_button_, &QPushButton::clicked, this, &ScenePreviewWidget::on_reset_view_clicked);
+  connect(labels_selector_, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int){
+    auto *v = static_cast<Scene3DViewportWidget *>(simple_3d_view_);
+    const QString choice = labels_selector_->currentText();
+    if (choice == "Off") v->label_mode = LabelMode::Off;
+    else if (choice == "Important") v->label_mode = LabelMode::Important;
+    else if (choice == "Selected") v->label_mode = LabelMode::Selected;
+    else v->label_mode = LabelMode::All;
+    v->update();
+  });
   connect(fit_scene_button_, &QPushButton::clicked, this, &ScenePreviewWidget::on_fit_scene_clicked);
   connect(overlays_selector_, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int){
     auto *v = static_cast<Scene3DViewportWidget *>(simple_3d_view_);
@@ -76,7 +92,7 @@ void ScenePreviewWidget::set_3d_available(bool available, const QString & reason
   preview3d_available_ = available;
   unavailable_reason_ = reason;
   if (!mode_default_initialized_) {
-    mode_selector_->setCurrentText(preview3d_available_ ? "3D View" : "2D Layout");
+    mode_selector_->setCurrentText(preview3d_available_ ? "3D Layout Preview" : "2D Layout");
     mode_default_initialized_ = true;
   }
   refresh_mode_and_state();
@@ -91,7 +107,7 @@ void ScenePreviewWidget::set_task_overlay_visibility(bool task_route, bool pick_
   v->show_pick_place = pick_place_zones;
   v->show_approach_retreat = approach_retreat;
   if (labels) v->label_mode = LabelMode::All;
-  else if (v->label_mode == LabelMode::All) v->label_mode = LabelMode::SelectedOnly;
+  else if (v->label_mode == LabelMode::All) v->label_mode = LabelMode::Important;
   v->update();
 }
 void ScenePreviewWidget::select_preview_item(const QString & id){ selected_preview_item_id_ = id; static_cast<Scene3DViewportWidget *>(simple_3d_view_)->selected_id = id; simple_3d_view_->update(); }
@@ -103,7 +119,7 @@ void ScenePreviewWidget::on_clear_selection_clicked(){ selected_preview_item_id_
 void ScenePreviewWidget::refresh_mode_and_state()
 {
   const QString mode = mode_selector_->currentText();
-  const bool requested_3d = (mode == "3D View") || (mode == "Debug Overlays");
+  const bool requested_3d = (mode == "3D Layout Preview") || (mode == "Debug Overlays");
   const bool use3d = requested_3d && preview3d_available_;
   auto * viewport = static_cast<Scene3DViewportWidget *>(simple_3d_view_);
   viewport->debug_overlays_mode = (mode == "Debug Overlays");
@@ -112,7 +128,7 @@ void ScenePreviewWidget::refresh_mode_and_state()
     stack_->setCurrentWidget(view2d_container_);
     fallback_banner_label_->setVisible(scene_selected_);
     const QString reason = unavailable_reason_.isEmpty() ? "initialization failed" : unavailable_reason_;
-    emit studio_log_requested(QString("3D View unavailable, using 2D Layout: %1").arg(reason));
+    emit studio_log_requested(QString("3D Layout Preview unavailable, using 2D Layout: %1").arg(reason));
   } else {
     fallback_banner_label_->setVisible(false);
     stack_->setCurrentWidget(use3d ? view3d_container_ : view2d_container_);
@@ -157,8 +173,8 @@ void ScenePreviewWidget::set_perception_overlay_visibility(bool camera_fov, bool
 void ScenePreviewWidget::set_reachability_overlay_model(const ReachabilityOverlayModel & model){ reachability_overlay_model_ = model; auto *v=static_cast<Scene3DViewportWidget *>(simple_3d_view_); v->reach_overlay = model; emit studio_log_requested(QString("reachability overlay loaded: warning count=%1").arg(model.warnings.size())); refresh_info_chip(); simple_3d_view_->update(); }
 void ScenePreviewWidget::set_collision_overlay_model(const CollisionOverlayModel & model){ collision_overlay_model_ = model; auto *v=static_cast<Scene3DViewportWidget *>(simple_3d_view_); v->collision_overlay = model; emit studio_log_requested(QString("collision preview checks complete: warning count=%1").arg(model.warnings.size())); refresh_info_chip(); simple_3d_view_->update(); }
 
-void ScenePreviewWidget::set_label_mode(LabelMode mode){ auto *v=static_cast<Scene3DViewportWidget *>(simple_3d_view_); v->label_mode = mode; v->update(); }
+void ScenePreviewWidget::set_label_mode(LabelMode mode){ auto *v=static_cast<Scene3DViewportWidget *>(simple_3d_view_); v->label_mode = mode; if (labels_selector_) { if (mode == LabelMode::Off) labels_selector_->setCurrentText("Off"); else if (mode == LabelMode::Important) labels_selector_->setCurrentText("Important"); else if (mode == LabelMode::Selected) labels_selector_->setCurrentText("Selected"); else labels_selector_->setCurrentText("All"); } v->update(); }
 
 int ScenePreviewWidget::total_warning_count() const { int count = 0; for (const auto & item : preview_items_) count += item.warnings.size(); count += overlay_model_.warnings.size() + reachability_overlay_model_.warnings.size() + collision_overlay_model_.warnings.size() + camera_overlay_model_.warnings.size(); for (const auto & det : epd_detections_) count += det.warnings.size(); return count; }
 bool ScenePreviewWidget::task_is_ready() const { return overlay_model_.has_intent_metadata && overlay_model_.pick_source_id != "unknown" && overlay_model_.place_target_id != "unknown"; }
-void ScenePreviewWidget::refresh_info_chip() { if (!info_chip_label_) return; const QString mode = mode_selector_ ? mode_selector_->currentText() : QStringLiteral("2D Layout"); const bool requested_3d = (mode == "3D View") || (mode == "Debug Overlays"); const QString render_mode = requested_3d && preview3d_available_ ? mode : QStringLiteral("2D Layout (Fallback)"); info_chip_label_->setText(QString("Scene: %1\nMode: %2\nItems: %3  Warn: %4  Task: %5").arg(preview_scene_name_).arg(render_mode).arg(preview_items_.size()).arg(total_warning_count()).arg(task_is_ready() ? "Ready" : "Missing")); info_chip_label_->adjustSize(); if (fallback_info_chip_proxy_) fallback_info_chip_proxy_->setPos(12.0, 12.0); }
+void ScenePreviewWidget::refresh_info_chip() { if (!info_chip_label_) return; const QString mode = mode_selector_ ? mode_selector_->currentText() : QStringLiteral("2D Layout"); const bool requested_3d = (mode == "3D Layout Preview") || (mode == "Debug Overlays"); const QString render_mode = requested_3d && preview3d_available_ ? mode : QStringLiteral("2D Layout (Fallback)"); info_chip_label_->setText(QString("Scene: %1\nMode: %2\nItems: %3  Warn: %4  Task: %5").arg(preview_scene_name_).arg(render_mode).arg(preview_items_.size()).arg(total_warning_count()).arg(task_is_ready() ? "Ready" : "Missing")); info_chip_label_->adjustSize(); if (fallback_info_chip_proxy_) fallback_info_chip_proxy_->setPos(12.0, 12.0); }

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -61,7 +61,7 @@ public:
     bool selectable{true};
   };
   enum class ReachStatus { Reachable, NearLimit, OutOfReach, Unknown };
-  enum class LabelMode { Off, SelectedOnly, All };
+  enum class LabelMode { Off, Important, Selected, All };
   struct ReachabilityOverlayModel
   {
     QString robot_base_id{"unknown"};
@@ -141,6 +141,7 @@ private:
   QPushButton * reset_view_button_{ nullptr };
   QPushButton * fit_scene_button_{ nullptr };
   QComboBox * overlays_selector_{ nullptr };
+  QComboBox * labels_selector_{ nullptr };
   QStackedWidget * stack_{ nullptr };
   QWidget * view3d_container_{ nullptr };
   QWidget * view2d_container_{ nullptr };


### PR DESCRIPTION
### Motivation
- Provide more granular control over which item labels are shown in the preview (including an "Important" mode that prioritizes high-priority roles and the selected item).
- Surface a compact, discoverable UI control for label visibility in the preview toolbar and make the default label behavior more useful for typical previews.
- Clarify the 3D preview naming to "3D Layout Preview" while preserving existing 2D/debug modes and selection behavior.

### Description
- Expanded `ScenePreviewWidget::LabelMode` from `{ Off, SelectedOnly, All }` to `{ Off, Important, Selected, All }` and added a `labels_selector_` member to `scene_preview_widget.h`.
- Added a compact `Labels:` dropdown to the preview controls in `scene_preview_widget.cpp` with options `Off / Important / Selected / All`, defaulting to `Important`, and wired user selection to update `Scene3DViewportWidget::label_mode`.
- Renamed UI strings and mode logic from `"3D View"` to `"3D Layout Preview"` (including default selection and logging) while keeping `2D Layout` and `Debug Overlays` unchanged.
- Set the viewport default label mode to `Important` in `scene3d_viewport_widget.h` and implemented the `Important` semantics in `scene3d_viewport_widget.cpp` by adding `is_high_priority_role()` and switching label-drawing logic in `paintGL()` to show labels for high-priority roles (robot/camera/pick/place/safety) and the selected item, while still honoring `Off`, `Selected`, and `All` modes.
- Preserved warning badge drawing so badges remain visible even when textual labels are reduced, and left selection callbacks / selection propagation unchanged (`select_cb` and `select_preview_item` remain intact).
- Synchronized programmatic calls to `set_label_mode()` with the new dropdown so the UI stays in sync when label mode is changed from code.

### Testing
- Performed repository diffs and inspected changes with `git diff` and `rg` to verify the intended modifications were applied to the four files (`scene_preview_widget.h/.cpp` and `scene3d_viewport_widget.h/.cpp`). (succeeded)
- Created a local commit with the changes to ensure the patch can be recorded in the repo (commit succeeded).
- No automated unit/integration tests were executed as part of this change; manual code inspection confirmed label rendering logic and UI wiring were updated as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0f4737a483319c4d204d7ad97f32)