### PR TITLE
Add overlay-inclusive 'Fit overlays' option for scene preview framing

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -64,8 +64,9 @@ NormalizedRole classify_item_role(const ScenePreviewWidget::PreviewItem & it)
 
 
 
-bool include_in_fit_bounds_physical_only(const ScenePreviewWidget::PreviewItem & it)
+bool include_in_fit_bounds(const ScenePreviewWidget::PreviewItem & it, bool include_overlays)
 {
+  if (include_overlays) return true;
   // FIT_PHYSICAL_ONLY_FILTER: keep fit_scene() bounds focused on physical geometry.
   const NormalizedRole role = classify_item_role(it);
   switch (role) {
@@ -120,10 +121,10 @@ void Scene3DViewportWidget::fit_scene() {
   if (items.isEmpty()) { set_isometric_view(); return; }
   QVector3D bmin(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
   QVector3D bmax(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
-  bool has_physical_item = false;
+  bool has_fittable_item = false;
   for (const auto & it : items) {
-    if (!include_in_fit_bounds_physical_only(it)) continue;
-    has_physical_item = true;
+    if (!include_in_fit_bounds(it, fit_include_overlays)) continue;
+    has_fittable_item = true;
     bmin.setX(std::min(bmin.x(), static_cast<float>(it.x)));
     bmin.setY(std::min(bmin.y(), static_cast<float>(it.y)));
     bmin.setZ(std::min(bmin.z(), static_cast<float>(it.z)));
@@ -131,7 +132,7 @@ void Scene3DViewportWidget::fit_scene() {
     bmax.setY(std::max(bmax.y(), static_cast<float>(it.y + it.sy)));
     bmax.setZ(std::max(bmax.z(), static_cast<float>(it.z + it.sz)));
   }
-  if (!has_physical_item) { set_isometric_view(); return; } // FIT_FALLBACK_ISO_IF_NO_PHYSICAL
+  if (!has_fittable_item) { set_isometric_view(); return; } // FIT_FALLBACK_ISO_IF_NO_PHYSICAL
   orbit_offset_ = (bmin + bmax) * 0.5f;
   const QVector3D ext = bmax - bmin;
   const double radius = qMax(0.25, 0.5 * qSqrt(ext.x() * ext.x() + ext.y() * ext.y() + ext.z() * ext.z()));

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -23,6 +23,7 @@ public:
   bool show_task_route{ true }, show_approach_retreat{ true };
   bool show_camera_fov{ true }, show_pick_coverage{ true }, show_epd_detections{ true }, show_detection_labels{ true };
   bool debug_overlays_mode{ false };
+  bool fit_include_overlays{ false };
   ScenePreviewWidget::TaskOverlayModel task_overlay;
   ScenePreviewWidget::ReachabilityOverlayModel reach_overlay;
   ScenePreviewWidget::CollisionOverlayModel collision_overlay;

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -30,7 +30,7 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   controls->addWidget(mode_selector_);
   reset_view_button_ = new QPushButton("Reset View", this); controls->addWidget(reset_view_button_);
   fit_scene_button_ = new QPushButton("Fit Scene", this); controls->addWidget(fit_scene_button_);
-  overlays_selector_ = new QComboBox(this); overlays_selector_->addItems({"Overlays", "Reachability Heatmap", "Collision Warnings", "Safety Zones", "Work Envelope", "Warning Labels", "Labels", "Pick/Place Zones", "Task Route", "Approach/Retreat", "Camera FOV", "Pick Coverage", "EPD Detections", "Detection Labels", "Warnings", "Focus Selected", "Fit Selected", "Clear Selection"}); controls->addWidget(overlays_selector_);
+  overlays_selector_ = new QComboBox(this); overlays_selector_->addItems({"Overlays", "Reachability Heatmap", "Collision Warnings", "Safety Zones", "Work Envelope", "Warning Labels", "Labels", "Pick/Place Zones", "Task Route", "Approach/Retreat", "Camera FOV", "Pick Coverage", "EPD Detections", "Detection Labels", "Warnings", "Focus Selected", "Fit Scene", "Fit overlays", "Clear Selection"}); controls->addWidget(overlays_selector_);
   controls->addStretch(1);
   root->addLayout(controls);
   stack_ = new QStackedWidget(this);
@@ -62,7 +62,8 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
     else if (choice == "Work Envelope") v->show_work_envelope = !v->show_work_envelope;
     else if (choice == "Warning Labels") v->show_warning_labels = !v->show_warning_labels;
     else if (choice == "Focus Selected") on_focus_selected_clicked();
-    else if (choice == "Fit Selected") on_fit_scene_clicked();
+    else if (choice == "Fit Scene") on_fit_scene_clicked();
+    else if (choice == "Fit overlays") on_fit_overlays_clicked();
     else if (choice == "Clear Selection") on_clear_selection_clicked();
     v->update();
   });
@@ -97,7 +98,8 @@ void ScenePreviewWidget::set_task_overlay_visibility(bool task_route, bool pick_
 void ScenePreviewWidget::select_preview_item(const QString & id){ selected_preview_item_id_ = id; static_cast<Scene3DViewportWidget *>(simple_3d_view_)->selected_id = id; simple_3d_view_->update(); }
 QString ScenePreviewWidget::selected_preview_item_id() const { return selected_preview_item_id_; }
 void ScenePreviewWidget::on_reset_view_clicked(){ static_cast<Scene3DViewportWidget *>(simple_3d_view_)->reset_view(); reset_fallback_scene_view(); }
-void ScenePreviewWidget::on_fit_scene_clicked(){ static_cast<Scene3DViewportWidget *>(simple_3d_view_)->fit_scene(); fit_fallback_scene_to_items(); }
+void ScenePreviewWidget::on_fit_scene_clicked(){ auto *v = static_cast<Scene3DViewportWidget *>(simple_3d_view_); v->fit_include_overlays = false; v->fit_scene(); fit_fallback_scene_to_items(false); }
+void ScenePreviewWidget::on_fit_overlays_clicked(){ auto *v = static_cast<Scene3DViewportWidget *>(simple_3d_view_); v->fit_include_overlays = true; v->fit_scene(); fit_fallback_scene_to_items(true); v->fit_include_overlays = false; }
 void ScenePreviewWidget::on_focus_selected_clicked(){ static_cast<Scene3DViewportWidget *>(simple_3d_view_)->focus_selected(); }
 void ScenePreviewWidget::on_clear_selection_clicked(){ selected_preview_item_id_.clear(); static_cast<Scene3DViewportWidget *>(simple_3d_view_)->selected_id.clear(); simple_3d_view_->update(); emit studio_log_requested("Cleared preview selection."); emit preview_item_selected(QString(), QStringLiteral("unknown")); }
 void ScenePreviewWidget::refresh_mode_and_state()
@@ -125,28 +127,42 @@ void ScenePreviewWidget::refresh_mode_and_state()
   error_state_label_->setVisible(rendering_failed);
   refresh_info_chip();
 }
-QRectF ScenePreviewWidget::rendered_items_bounds_2d() const
+QRectF ScenePreviewWidget::rendered_items_bounds_2d(bool include_overlays) const
 {
-  if (!fallback_2d_view_ || !fallback_2d_view_->scene()) return QRectF();
   QRectF bounds;
-  const auto items = fallback_2d_view_->scene()->items();
-  for (QGraphicsItem * item : items) {
+  auto include_in_fit_bounds = [include_overlays](const PreviewItem & it) {
+    if (include_overlays) return true;
+    const QString role = it.role.trimmed().toLower();
+    const QString category = it.category.trimmed().toLower();
+    const QString mix = role + "|" + category;
+    return !mix.contains("safety_zone") && !mix.contains("safety") && !mix.contains("warning_anchor") && !mix.contains("warning_badge");
+  };
+  for (const auto & it : preview_items_) {
+    if (!include_in_fit_bounds(it)) continue;
+    const QRectF rect(it.x, it.z, it.sx, it.sz);
+    bounds = bounds.isNull() ? rect : bounds.united(rect);
+  }
+
+  if (bounds.isValid() && !bounds.isEmpty()) return bounds;
+  if (!fallback_2d_view_ || !fallback_2d_view_->scene()) return QRectF();
+  const auto scene_items = fallback_2d_view_->scene()->items();
+  for (QGraphicsItem * item : scene_items) {
     if (!item || !item->isVisible()) continue;
     bounds = bounds.isNull() ? item->sceneBoundingRect() : bounds.united(item->sceneBoundingRect());
   }
   return bounds;
 }
-void ScenePreviewWidget::fit_fallback_scene_to_items()
+void ScenePreviewWidget::fit_fallback_scene_to_items(bool include_overlays)
 {
   if (!fallback_2d_view_) return;
-  const QRectF bounds = rendered_items_bounds_2d();
+  const QRectF bounds = rendered_items_bounds_2d(include_overlays);
   if (bounds.isValid() && !bounds.isEmpty()) fallback_2d_view_->fitInView(bounds.adjusted(-20, -20, 20, 20), Qt::KeepAspectRatio);
 }
 void ScenePreviewWidget::reset_fallback_scene_view()
 {
   if (!fallback_2d_view_) return;
   fallback_2d_view_->resetTransform();
-  fit_fallback_scene_to_items();
+  fit_fallback_scene_to_items(false);
 }
 
 void ScenePreviewWidget::set_camera_overlay_model(const CameraOverlayModel & model){ camera_overlay_model_ = model; auto *v=static_cast<Scene3DViewportWidget *>(simple_3d_view_); v->camera_overlay = model; refresh_info_chip(); simple_3d_view_->update(); }

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -126,12 +126,13 @@ private slots:
   void on_reset_view_clicked();
   void on_fit_scene_clicked();
   void on_focus_selected_clicked();
+  void on_fit_overlays_clicked();
   void on_clear_selection_clicked();
 
 private:
   void refresh_mode_and_state();
-  QRectF rendered_items_bounds_2d() const;
-  void fit_fallback_scene_to_items();
+  QRectF rendered_items_bounds_2d(bool include_overlays) const;
+  void fit_fallback_scene_to_items(bool include_overlays = false);
   void reset_fallback_scene_view();
   void refresh_info_chip();
   int total_warning_count() const;


### PR DESCRIPTION
### Motivation

- Prevent overlay-only geometry (safety envelopes, warning anchors, etc.) from dominating automatic framing while still allowing users to explicitly include overlays when desired.

### Description

- Added a viewport flag `fit_include_overlays` to `Scene3DViewportWidget` (default `false`) to toggle overlay-inclusive fit behavior.
- Reworked the fit selection to use `include_in_fit_bounds(..., bool include_overlays)` and updated `Scene3DViewportWidget::fit_scene()` to honor the new flag so overlay-only roles are excluded by default and included when requested.
- Added UI action `Fit overlays` alongside `Fit Scene` in the preview controls and wired it to `on_fit_overlays_clicked()` that temporarily enables `fit_include_overlays`, calls `fit_scene()`, and triggers the fallback 2D fit path accordingly; kept existing `on_fit_scene_clicked()` behavior unchanged for the default physical-only fit.
- Applied equivalent filtering to the 2D fallback path by adding `rendered_items_bounds_2d(bool include_overlays)` and `fit_fallback_scene_to_items(bool include_overlays)` so large overlay graphics don’t dominate framing unless overlay-fit is explicitly chosen.

### Testing

- Ran automated code searches (`rg`) to confirm new symbols and call sites for `fit_include_overlays`, `Fit overlays`, `rendered_items_bounds_2d(...)`, `on_fit_overlays_clicked`, and `include_in_fit_bounds(...)`, and verified expected occurrences (passed).
- Inspected the modified source files (`scene3d_viewport_widget.h/.cpp` and `scene_preview_widget.h/.cpp`) to ensure the new API and UI wiring are present and consistent (passed).
- No compilation or unit test suite was executed as part of this change in the current run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0f5bf7508331b8139008fd22a97c)