### PR TITLE
Make Activity Log start collapsed and restore height on expand

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1195,22 +1195,26 @@ void MainWindow::setup_studio_shell()
   studio_pages_->addWidget(validation);  // ValidationPage
   studio_pages_->addWidget(export_page);  // ExportPage
   auto * body=new QHBoxLayout(); body->addWidget(studio_pages_,1); root_layout->insertLayout(0,body,1);
+  constexpr int kCollapsedLogPanelHeight = 52;
+  constexpr int kExpandedLogPanelHeight = 240;
   auto * log_card = new QFrame(content); log_card->setObjectName("studioCard");
+  log_card->setMaximumHeight(kCollapsedLogPanelHeight);
   auto * log_layout = new QVBoxLayout(log_card);
   auto * log_head = new QHBoxLayout();
   log_head->addWidget(new QLabel("Activity Log", log_card));
-  scene_builder_log_toggle_button_ = new QPushButton("Hide Log", log_card);
+  scene_builder_log_toggle_button_ = new QPushButton("Show Log", log_card);
   scene_builder_log_toggle_button_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
   log_head->addWidget(scene_builder_log_toggle_button_, 0, Qt::AlignRight);
   auto * clear_log = new QPushButton("Clear", log_card);
   log_head->addWidget(clear_log, 0, Qt::AlignRight);
   log_layout->addLayout(log_head);
   scene_builder_log_panel_ = log_card;
-  studio_log_=new QTextEdit(log_card); studio_log_->setObjectName("studioHomeLog"); studio_log_->setReadOnly(true); studio_log_->setMaximumHeight(110); studio_log_->setPlaceholderText("Recent actions and diagnostics");
+  studio_log_=new QTextEdit(log_card); studio_log_->setObjectName("studioHomeLog"); studio_log_->setReadOnly(true); studio_log_->setMaximumHeight(kExpandedLogPanelHeight); studio_log_->setPlaceholderText("Recent actions and diagnostics");
   log_layout->addWidget(studio_log_);
   studio_log_->setVisible(false);
-  scene_builder_log_toggle_button_->setText("Show Log");
-  root_layout->addWidget(log_card);
+  root_layout->addWidget(log_card, 0);
+  root_layout->setStretch(0, 1);
+  root_layout->setStretch(1, 0);
   preview_process_ = new QProcess(this);
 
   QToolBar * top_bar = new QToolBar("Workcell Studio Command Bar", this);
@@ -1303,9 +1307,12 @@ void MainWindow::setup_studio_shell()
   });
   connect(clear_log, &QPushButton::clicked, this, [this](){ if (studio_log_) studio_log_->clear(); });
   connect(scene_builder_log_toggle_button_, &QPushButton::clicked, this, [this]() {
-    if (!studio_log_ || !scene_builder_log_toggle_button_) return;
+    if (!studio_log_ || !scene_builder_log_toggle_button_ || !scene_builder_log_panel_) return;
+    constexpr int kCollapsedLogPanelHeight = 52;
+    constexpr int kExpandedLogPanelHeight = 240;
     const bool show = !studio_log_->isVisible();
     studio_log_->setVisible(show);
+    scene_builder_log_panel_->setMaximumHeight(show ? kExpandedLogPanelHeight : kCollapsedLogPanelHeight);
     scene_builder_log_toggle_button_->setText(show ? "Hide Log" : "Show Log");
   });
   connect(empty_new_cell, &QPushButton::clicked, this, &MainWindow::open_new_scene_creation_flow);


### PR DESCRIPTION
### Motivation
- Improve layout by starting the Activity Log in a compact, non-obtrusive state so the central canvas/main studio content retains vertical priority. 
- Provide a clear, discoverable toggle that expands to a practical, readable log height and switches its label between `Show Log` and `Hide Log`.
- Keep the `Clear` control always accessible and do not change log content generation or diagnostics behavior.

### Description
- Added constants `kCollapsedLogPanelHeight` and `kExpandedLogPanelHeight` and set the Activity Log card (`scene_builder_log_panel_`) to start with `setMaximumHeight(kCollapsedLogPanelHeight)` in `workcell_builder/workcell_builder/gui/mainwindow.cpp`.
- Initialized the toggle button text to `Show Log` and set the `studio_log_` maximum height to `kExpandedLogPanelHeight` so the expanded view is readable.
- Updated the toggle click handler to change visibility and to set `scene_builder_log_panel_->setMaximumHeight(...)` to the expanded or collapsed height and update the toggle text accordingly, while preserving the always-visible `Clear` button.
- Adjusted root layout usage (`root_layout->addWidget(log_card, 0)` and `root_layout->setStretch(...)`) to prioritize the main studio content vertically when the log is collapsed.

### Testing
- Ran repository inspections and searches with `rg` and file edits with `sed`/Python script to apply the change, which located and replaced the log card/toggle blocks successfully (commands completed without error).
- Verified the code diff with `git -C /workspace/Easy_Manipulator_Improved diff -- workcell_builder/workcell_builder/gui/mainwindow.cpp` which showed the intended insertions and deletions and reported success.
- Committed the change with `git -C /workspace/Easy_Manipulator_Improved commit -m "Adjust studio log panel collapse/expand behavior"` which succeeded.
- No automated unit/GUI tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0f695b0483318d6458993c907e27)