### PR TITLE
Fix stale ScenePreviewWidget LabelMode enum usage in mainwindow

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -907,7 +907,7 @@ void MainWindow::setup_studio_shell()
   auto * controls = new QHBoxLayout();
   canvas_mode_label_ = new QLabel("Mode: Select · 3D View", scene_builder); controls->addWidget(canvas_mode_label_);
   scene_preview_widget_ = new ScenePreviewWidget(scene_builder);
-  scene_preview_widget_->set_label_mode(ScenePreviewWidget::LabelMode::SelectedOnly);
+  scene_preview_widget_->set_label_mode(ScenePreviewWidget::LabelMode::Selected);
   connect(scene_preview_widget_, &ScenePreviewWidget::studio_log_requested, this, [this](const QString &m){ append_studio_log(m); });
   connect(scene_preview_widget_, &ScenePreviewWidget::preview_item_selected, this, [this](const QString &id, const QString &role){
     apply_scene_selection(id, role, id.trimmed().isEmpty(), false);
@@ -1042,7 +1042,7 @@ void MainWindow::setup_studio_shell()
   auto * scene_card_layout = make_card(selection_tab_layout, "Scene");
   auto * selected_item_card_layout = make_card(selection_tab_layout, "Selected Item");
   auto * readiness_card_layout = make_card(readiness_tab_layout, "Readiness");
-  auto * actions_card_layout = make_card(actions_tab_layout, "Actions");
+  make_card(actions_tab_layout, "Actions");
   make_row(scene_card_layout, "Name", "No scene selected", false);
   make_row(scene_card_layout, "Status", "unknown", false);
   make_row(scene_card_layout, "Robot", "unknown", false);


### PR DESCRIPTION
### Motivation
- The UI initialization used a removed enum value `ScenePreviewWidget::LabelMode::SelectedOnly`, causing a compile error, and an unused local `actions_card_layout` could produce warnings-as-errors later.

### Description
- Replace `ScenePreviewWidget::LabelMode::SelectedOnly` with `ScenePreviewWidget::LabelMode::Selected` in `workcell_builder/workcell_builder/gui/mainwindow.cpp`.
- Remove the unused local by invoking `make_card(actions_tab_layout, "Actions");` without storing the returned layout in `mainwindow.cpp` to avoid unused-variable warnings.
- Limited change to this single spot after searching for `SelectedOnly` to ensure no other codepaths were affected and without altering UI behavior or robot/safety logic.

### Testing
- Ran `grep -R "SelectedOnly" workcell_builder/workcell_builder -n` and confirmed there are no remaining occurrences after the change.
- Attempted `colcon build --symlink-install --packages-select workcell_builder`, but the container environment does not have `colcon` installed so a full package build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1a9ebaf08331b3a0bfffcbeb9404)