### PR TITLE
Improve Scene Builder canvas interaction and transform editing UX

### DIFF
--- a/tests/test_workcell_studio_scene_builder_interactive_canvas.py
+++ b/tests/test_workcell_studio_scene_builder_interactive_canvas.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_scene_preview_view_buttons_and_clear_selection_present():
+    text = (ROOT / 'workcell_builder/workcell_builder/gui/scene_preview_widget.cpp').read_text(encoding='utf-8')
+    for token in ['Isometric', 'Top', 'Front', 'Side', 'Focus Selected', 'Clear Selection']:
+        assert token in text
+
+
+def test_mainwindow_keyboard_nudge_and_units_tooltips_present():
+    text = (ROOT / 'workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+    for token in ['Qt::Key_PageUp', 'Qt::Key_PageDown', 'Nudge step:', 'X position in metres', 'Yaw in radians', 'RoleLocked']:
+        assert token in text
+
+
+def test_focus_selected_centers_on_selected_item():
+    text = (ROOT / 'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp').read_text(encoding='utf-8')
+    assert 'if (it.id != selected_id) continue;' in text
+    assert 'orbit_offset_' in text

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -930,8 +930,8 @@ void MainWindow::setup_studio_shell()
   camera_view->setMenu(camera_view_menu);
   controls->addWidget(camera_view);
   toggle_grid_box_ = new QCheckBox("Toggle Grid", scene_builder); toggle_grid_box_->setChecked(true);
-  snap_to_grid_box_ = new QCheckBox("Snap Grid", scene_builder); snap_to_grid_box_->setChecked(true);
-  snap_step_label_ = new QLabel("Grid 0.05 m", scene_builder);
+  snap_to_grid_box_ = new QCheckBox("Snap: 5 cm", scene_builder); snap_to_grid_box_->setToolTip("Snap applies to drag, keyboard nudge, and transform edits."); snap_to_grid_box_->setChecked(true);
+  snap_step_label_ = new QLabel("Nudge step: 0.05 m", scene_builder);
   fine_move_mode_box_ = new QCheckBox("Fine Move Mode", scene_builder);
   unlock_robot_base_box_ = new QCheckBox("Unlock Robot Base", scene_builder);
   toggle_labels_box_ = new QCheckBox("Toggle Labels", scene_builder); toggle_labels_box_->setChecked(true);
@@ -1456,6 +1456,8 @@ connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo
   connect(duplicate_layout_button_, &QPushButton::clicked, this, &MainWindow::duplicate_selected_item);
   connect(delete_layout_button_, &QPushButton::clicked, this, &MainWindow::delete_selected_item);
   for (auto *sb : {inspector_x_, inspector_y_, inspector_z_, inspector_roll_, inspector_pitch_, inspector_yaw_}) connect(sb, qOverload<double>(&QDoubleSpinBox::valueChanged), this, [this](double){ apply_inspector_pose_to_item(); });
+  inspector_x_->setToolTip("X position in metres"); inspector_y_->setToolTip("Y position in metres"); inspector_z_->setToolTip("Z position in metres");
+  inspector_roll_->setToolTip("Roll in radians"); inspector_pitch_->setToolTip("Pitch in radians"); inspector_yaw_->setToolTip("Yaw in radians");
   connect(save_layout_button_, &QPushButton::clicked, this, &MainWindow::save_layout_changes);
   connect(select_mode_button, &QPushButton::clicked, this, [this](){ set_canvas_interaction_mode(CanvasInteractionMode::Select); });
   connect(place_mode_button, &QPushButton::clicked, this, [this](){ set_canvas_interaction_mode(CanvasInteractionMode::Place); });
@@ -3218,6 +3220,42 @@ void MainWindow::undo_layout_edit(){ if(undo_stack_.empty() || !digital_twin_sce
 void MainWindow::redo_layout_edit(){ if(redo_stack_.empty() || !digital_twin_scene_) return; auto c=redo_stack_.back(); redo_stack_.pop_back(); for(auto *i:digital_twin_scene_->items()) if(i->data(RoleId).toString()==c.item_id){ i->setPos(c.new_pos); break;} undo_stack_.push_back(c); mark_layout_dirty("Redo"); }
 void MainWindow::duplicate_selected_item(){ if(!digital_twin_scene_||digital_twin_scene_->selectedItems().isEmpty()) return; auto *s=digital_twin_scene_->selectedItems().front(); if(s->data(RoleLocked).toBool()){ append_studio_log("Duplicate blocked: locked item"); return; } auto *c=new DraggableCanvasItem(static_cast<QGraphicsRectItem*>(s)->rect()); c->setPos(s->pos()+QPointF(18,18)); c->setBrush(static_cast<QGraphicsRectItem*>(s)->brush()); for(int r=RoleId;r<=RoleSource;++r) c->setData(r,s->data(r)); c->setData(RoleId, s->data(RoleId).toString()+"_copy"); c->setFlags(s->flags()); digital_twin_scene_->addItem(c); c->setSelected(true); undo_stack_.push_back({"duplicate", c->data(RoleId).toString(), s->pos(), c->pos(), true, false}); mark_layout_dirty("Duplicate Selected"); append_studio_log(QString("Duplicate selected item: %1").arg(c->data(RoleId).toString())); refresh_scene_builder_left_explorer(); }
 void MainWindow::delete_selected_item(){ if(!digital_twin_scene_||digital_twin_scene_->selectedItems().isEmpty()) return; auto *s=digital_twin_scene_->selectedItems().front(); const QString id=s->data(RoleId).toString(); const QString t=s->data(RoleType).toString(); if(t=="robot_base"||t=="reach"||t=="safety/home"){ QMessageBox::warning(this,"Remove Selected Layout Item","Delete robot is blocked/guarded unless Unlock Robot Base is enabled."); return;} if(QMessageBox::question(this,"Remove Selected Layout Item","Remove selected layout instance from environment_layout.yaml?")!=QMessageBox::Yes) return; undo_stack_.push_back({"delete", id, s->pos(), s->pos(), false, true}); delete s; refresh_scene_builder_left_explorer(); mark_layout_dirty("Remove Selected Layout Item"); append_studio_log(QString("Removed layout item %1 from canvas; save layout to persist.").arg(id)); }
+
+double MainWindow::current_nudge_step_m(Qt::KeyboardModifiers modifiers) const
+{
+  double step = (snap_to_grid_box_ && snap_to_grid_box_->isChecked()) ? snap_step_m_ : 0.01;
+  if (modifiers & Qt::ShiftModifier) step *= 5.0;
+  if (modifiers & Qt::ControlModifier) step *= 0.2;
+  return std::max(0.001, step);
+}
+
+void MainWindow::keyPressEvent(QKeyEvent * event)
+{
+  if (!digital_twin_scene_ || digital_twin_scene_->selectedItems().isEmpty()) { QMainWindow::keyPressEvent(event); return; }
+  auto * item = digital_twin_scene_->selectedItems().front();
+  if (!item || item->data(RoleLocked).toBool()) { QMainWindow::keyPressEvent(event); return; }
+  const double step_m = current_nudge_step_m(event->modifiers());
+  const double step_px = step_m * 100.0;
+  QPointF delta; double dz = 0.0;
+  switch (event->key()) {
+    case Qt::Key_Left: delta.rx() -= step_px; break;
+    case Qt::Key_Right: delta.rx() += step_px; break;
+    case Qt::Key_Up: delta.ry() -= step_px; break;
+    case Qt::Key_Down: delta.ry() += step_px; break;
+    case Qt::Key_PageUp: dz += step_m; break;
+    case Qt::Key_PageDown: dz -= step_m; break;
+    default: QMainWindow::keyPressEvent(event); return;
+  }
+  const QPointF old_pos = item->pos();
+  item->setPos(snap_canvas_position(old_pos + delta));
+  item->setData(RolePoseZ, item->data(RolePoseZ).toDouble() + dz);
+  if (snap_step_label_) snap_step_label_->setText(QString("Nudge step: %1 m").arg(step_m, 0, 'f', 3));
+  undo_stack_.push_back({"nudge", item->data(RoleId).toString(), old_pos, item->pos(), false, false});
+  redo_stack_.clear();
+  mark_layout_dirty("Nudge Move");
+  rebuild_canvas_inspector();
+  event->accept();
+}
 
 
 void MainWindow::add_asset_to_canvas_from_catalog(const QString & category, const QString & display_name, const QString & source_path)

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -181,6 +181,7 @@ private:
   enum class CanvasInteractionMode { Select, Place, Move, Inspect };
   void set_canvas_interaction_mode(CanvasInteractionMode mode);
   QPointF snap_canvas_position(const QPointF & pos) const;
+  double current_nudge_step_m(Qt::KeyboardModifiers modifiers) const;
   void refresh_minimap_card();
   void select_canvas_item(QGraphicsItem * item);
   void apply_scene_selection(const QString & id, const QString & role, bool intentional_clear = false, bool center_canvas = true);
@@ -207,6 +208,7 @@ private:
   void refresh_scene_builder_left_explorer();
   void refresh_scene_builder_view_chips();
   void populate_scene_hierarchy();
+  void keyPressEvent(QKeyEvent * event) override;
   void populate_asset_catalog();
   void on_hierarchy_item_selected(QTreeWidgetItem * item);
   void on_asset_filter_changed(int index);

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -157,7 +157,18 @@ void Scene3DViewportWidget::fit_scene() {
   distance_ = qBound(min_distance_, fit_distance, max_distance_);
   update();
 }
-void Scene3DViewportWidget::focus_selected() { fit_scene(); }
+void Scene3DViewportWidget::focus_selected() {
+  for (const auto & it : items) {
+    if (it.id != selected_id) continue;
+    const ItemBounds b = item_bounds_for_role(it);
+    orbit_offset_ = QVector3D(static_cast<float>(b.x + b.sx * 0.5), static_cast<float>(b.y + b.sy * 0.5), static_cast<float>(b.z + b.sz * 0.5));
+    scene_radius_ = qMax(0.2, 0.5 * qSqrt(b.sx * b.sx + b.sy * b.sy + b.sz * b.sz));
+    distance_ = qBound(min_distance_, scene_radius_ * 4.0, max_distance_);
+    update();
+    return;
+  }
+  fit_scene();
+}
 void Scene3DViewportWidget::initializeGL() { initializeOpenGLFunctions(); glEnable(GL_DEPTH_TEST); glEnable(GL_CULL_FACE); glClearColor(0.04f, 0.06f, 0.12f, 1.0f); }
 void Scene3DViewportWidget::resizeGL(int w, int h) { glViewport(0, 0, w, h); }
 

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -36,7 +36,13 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   labels_selector_->setSizeAdjustPolicy(QComboBox::AdjustToContents);
   controls->addWidget(labels_selector_);
   reset_view_button_ = new QPushButton("Reset View", this); controls->addWidget(reset_view_button_);
+  isometric_view_button_ = new QPushButton("Isometric", this); controls->addWidget(isometric_view_button_);
+  top_view_button_ = new QPushButton("Top", this); controls->addWidget(top_view_button_);
+  front_view_button_ = new QPushButton("Front", this); controls->addWidget(front_view_button_);
+  side_view_button_ = new QPushButton("Side", this); controls->addWidget(side_view_button_);
   fit_scene_button_ = new QPushButton("Fit Scene", this); controls->addWidget(fit_scene_button_);
+  focus_selected_button_ = new QPushButton("Focus Selected", this); controls->addWidget(focus_selected_button_);
+  clear_selection_button_ = new QPushButton("Clear Selection", this); controls->addWidget(clear_selection_button_);
   overlays_selector_ = new QComboBox(this); overlays_selector_->addItems({"Overlays", "Reachability Heatmap", "Collision Warnings", "Safety Zones", "Work Envelope", "Warning Labels", "Labels", "Pick/Place Zones", "Task Route", "Approach/Retreat", "Camera FOV", "Pick Coverage", "EPD Detections", "Detection Labels", "Warnings", "Focus Selected", "Fit Scene", "Fit overlays", "Clear Selection"}); controls->addWidget(overlays_selector_);
   controls->addStretch(1);
   root->addLayout(controls);
@@ -69,6 +75,12 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
     v->update();
   });
   connect(fit_scene_button_, &QPushButton::clicked, this, &ScenePreviewWidget::on_fit_scene_clicked);
+  connect(isometric_view_button_, &QPushButton::clicked, this, [this](){ static_cast<Scene3DViewportWidget *>(simple_3d_view_)->set_isometric_view(); });
+  connect(top_view_button_, &QPushButton::clicked, this, [this](){ static_cast<Scene3DViewportWidget *>(simple_3d_view_)->set_top_view(); });
+  connect(front_view_button_, &QPushButton::clicked, this, [this](){ static_cast<Scene3DViewportWidget *>(simple_3d_view_)->set_front_view(); });
+  connect(side_view_button_, &QPushButton::clicked, this, [this](){ static_cast<Scene3DViewportWidget *>(simple_3d_view_)->set_side_view(); });
+  connect(focus_selected_button_, &QPushButton::clicked, this, &ScenePreviewWidget::on_focus_selected_clicked);
+  connect(clear_selection_button_, &QPushButton::clicked, this, &ScenePreviewWidget::on_clear_selection_clicked);
   connect(overlays_selector_, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int){
     auto *v = static_cast<Scene3DViewportWidget *>(simple_3d_view_);
     const QString choice = overlays_selector_->currentText();

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -141,6 +141,12 @@ private:
   QComboBox * mode_selector_{ nullptr };
   QPushButton * reset_view_button_{ nullptr };
   QPushButton * fit_scene_button_{ nullptr };
+  QPushButton * isometric_view_button_{ nullptr };
+  QPushButton * top_view_button_{ nullptr };
+  QPushButton * front_view_button_{ nullptr };
+  QPushButton * side_view_button_{ nullptr };
+  QPushButton * focus_selected_button_{ nullptr };
+  QPushButton * clear_selection_button_{ nullptr };
   QComboBox * overlays_selector_{ nullptr };
   QComboBox * labels_selector_{ nullptr };
   QStackedWidget * stack_{ nullptr };


### PR DESCRIPTION
## Summary
- improved Scene Preview controls with direct view buttons for Isometric/Top/Front/Side plus Focus Selected and Clear Selection
- strengthened selection feedback flow by wiring clear-selection and focus controls directly to the 3D viewport selection state
- added keyboard nudge support in the Scene Builder editor for selected editable items:
  - Arrow keys nudge X/Y on layout plane
  - PageUp/PageDown adjust Z
  - Shift for larger steps, Ctrl for finer steps
  - updates nudge-step status text and marks layout dirty
  - blocks nudging on locked items
- added transform inspector unit tooltips (metres/radians) to make editing semantics explicit
- improved Focus Selected behavior in the 3D viewport to center camera on the selected item bounds (fallback to fit scene when nothing selected)

## Safety / scope adherence
- no runtime robot execution behavior changed
- no generated launch/runtime behavior changed
- no STL mesh rendering added
- locked item protection preserved for edit/nudge paths

## Tests
- added lightweight static tests in `tests/test_workcell_studio_scene_builder_interactive_canvas.py` to verify:
  - presence of new scene preview view controls
  - keyboard nudge logic tokens and unit tooltip strings
  - selected-item camera focusing logic

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1bd2de788331b3cc15c646a219b4)