### PR TITLE
Fix missing rebuild_canvas_inspector linker error

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -3229,6 +3229,24 @@ double MainWindow::current_nudge_step_m(Qt::KeyboardModifiers modifiers) const
   return std::max(0.001, step);
 }
 
+void MainWindow::rebuild_canvas_inspector()
+{
+  if (!digital_twin_scene_ || selection_update_guard_) return;
+  if (digital_twin_scene_->selectedItems().isEmpty()) {
+    refresh_selected_scene_item_labels(current_selected_scene_item());
+    return;
+  }
+
+  auto * item = digital_twin_scene_->selectedItems().front();
+  if (!item) {
+    refresh_selected_scene_item_labels(current_selected_scene_item());
+    return;
+  }
+
+  select_canvas_item(item);
+  if (scene_preview_widget_) scene_preview_widget_->select_preview_item(item->data(RoleId).toString().trimmed());
+}
+
 void MainWindow::keyPressEvent(QKeyEvent * event)
 {
   if (!digital_twin_scene_ || digital_twin_scene_->selectedItems().isEmpty()) { QMainWindow::keyPressEvent(event); return; }


### PR DESCRIPTION
### Motivation
- `MainWindow::keyPressEvent(QKeyEvent*)` invoked `rebuild_canvas_inspector()`, but the method had a declaration in `mainwindow.h` without a matching definition, causing an undefined reference at link time.

### Description
- Added an exact-definition `void MainWindow::rebuild_canvas_inspector()` to `workcell_builder/workcell_builder/gui/mainwindow.cpp` that matches the header declaration.
- Implemented the function as a lightweight UI refresh that updates inspector labels/fields from the current canvas selection, calls `select_canvas_item(item)` for the selected item, and keeps `scene_preview_widget_` selection in sync.
- The implementation intentionally avoids scene regeneration, file writes, ROS/motion or safety changes, and preserves existing `keyPressEvent()` behavior.

### Testing
- Attempted `colcon build --symlink-install --packages-select workcell_builder`, but the environment does not have `colcon` installed so the build could not be executed here (`colcon: command not found`).
- Attempted `ctest --test-dir build/workcell_builder --output-on-failure || true`, but the `build/workcell_builder` directory is not present in this environment, so tests could not be run.
- Static verification: grep/inspection confirmed the declaration and call sites and that the new definition matches the header signature exactly, resolving the missing-symbol root cause.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1d44cb08833196f2f914afd1d738)