### PR TITLE
Add mesh preview metadata fields to canvas and preview models

### DIFF
--- a/tests/test_workcell_studio_mesh_preview_compatibility_tokens.py
+++ b/tests/test_workcell_studio_mesh_preview_compatibility_tokens.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_canvas_and_preview_item_mesh_fields_have_legacy_safe_defaults():
+    canvas_h = (ROOT / "workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp").read_text(encoding="utf-8")
+    preview_h = (ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.h").read_text(encoding="utf-8")
+
+    for token in [
+        "std::string mesh_path;",
+        "std::string mesh_type;",
+        "double mesh_scale_x{1.0}, mesh_scale_y{1.0}, mesh_scale_z{1.0};",
+        "double mesh_r{0.0}, mesh_p{0.0}, mesh_y{0.0};",
+        "bool mesh_available{false};",
+        "std::string mesh_load_warning;",
+    ]:
+        assert token in canvas_h
+
+    for token in [
+        "QString mesh_path;",
+        "QString mesh_type;",
+        "double mesh_scale_x{ 1.0 }, mesh_scale_y{ 1.0 }, mesh_scale_z{ 1.0 };",
+        "double mesh_roll{ 0.0 }, mesh_pitch{ 0.0 }, mesh_yaw{ 0.0 };",
+        "bool mesh_available{ false };",
+        "QString mesh_load_warning;",
+    ]:
+        assert token in preview_h
+
+
+def test_mainwindow_maps_mesh_preview_fields_and_legacy_primitive_fallback_path_remains():
+    mainwindow_cpp = (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+    preview_cpp = (ROOT / "workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp").read_text(encoding="utf-8")
+
+    for token in [
+        "p.mesh_path = QString::fromStdString(item.mesh_path);",
+        "p.mesh_type = QString::fromStdString(item.mesh_type);",
+        "p.mesh_scale_x = item.mesh_scale_x;",
+        "p.mesh_scale_y = item.mesh_scale_y;",
+        "p.mesh_scale_z = item.mesh_scale_z;",
+        "p.mesh_roll = item.mesh_r;",
+        "p.mesh_pitch = item.mesh_p;",
+        "p.mesh_yaw = item.mesh_y;",
+        "p.mesh_available = item.mesh_available;",
+        "p.mesh_load_warning = QString::fromStdString(item.mesh_load_warning);",
+    ]:
+        assert token in mainwindow_cpp
+
+    for token in ["draw_box(", "draw_table_slab", "draw_object_cube", "draw_conveyor"]:
+        assert token in preview_cpp

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -3563,6 +3563,16 @@ void MainWindow::populate_scene_hierarchy()
     p.sx = item.width;
     p.sy = item.depth;
     p.sz = item.height;
+    p.mesh_path = QString::fromStdString(item.mesh_path);
+    p.mesh_type = QString::fromStdString(item.mesh_type);
+    p.mesh_scale_x = item.mesh_scale_x;
+    p.mesh_scale_y = item.mesh_scale_y;
+    p.mesh_scale_z = item.mesh_scale_z;
+    p.mesh_roll = item.mesh_r;
+    p.mesh_pitch = item.mesh_p;
+    p.mesh_yaw = item.mesh_y;
+    p.mesh_available = item.mesh_available;
+    p.mesh_load_warning = QString::fromStdString(item.mesh_load_warning);
     preview_items.push_back(p);
     if (allowed_scene_roles.contains(p.role)) {
       add_tree_node(p);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -28,6 +28,12 @@ public:
     QString status{ "unknown" };
     QString source_path;
     QString role;
+    QString mesh_path;
+    QString mesh_type;
+    double mesh_scale_x{ 1.0 }, mesh_scale_y{ 1.0 }, mesh_scale_z{ 1.0 };
+    double mesh_roll{ 0.0 }, mesh_pitch{ 0.0 }, mesh_yaw{ 0.0 };
+    bool mesh_available{ false };
+    QString mesh_load_warning;
     bool selectable{ true };
     bool metadata_complete{ true };
     QStringList warnings;

--- a/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
@@ -7,6 +7,12 @@ namespace workcell_builder {
 struct WorkcellStudioCanvasItem {
   std::string id; std::string type; std::string role; std::string label; std::string source_file;
   double x{0.0}, y{0.0}, z{0.0}, roll{0.0}, pitch{0.0}, yaw{0.0}, width{0.25}, depth{0.25}, height{0.25}, radius{0.0};
+  std::string mesh_path;
+  std::string mesh_type;
+  double mesh_scale_x{1.0}, mesh_scale_y{1.0}, mesh_scale_z{1.0};
+  double mesh_r{0.0}, mesh_p{0.0}, mesh_y{0.0};
+  bool mesh_available{false};
+  std::string mesh_load_warning;
   bool locked{false};
   std::vector<std::string> warnings;
 };


### PR DESCRIPTION
### Motivation
- Add optional mesh preview metadata to support future 3D mesh previews while maintaining legacy behavior for items that lack mesh info.
- Keep existing construction sites compiling without changes by providing conservative default values for all new fields.
- Ensure the preview rendering fallback to primitives remains available for legacy items without mesh metadata.

### Description
- Extended `WorkcellStudioCanvasItem` in `workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp` with optional/default-safe fields: `mesh_path`, `mesh_type`, `mesh_scale_x/mesh_scale_y/mesh_scale_z`, `mesh_r/mesh_p/mesh_y`, `mesh_available`, and `mesh_load_warning`.
- Extended `ScenePreviewWidget::PreviewItem` in `workcell_builder/workcell_builder/gui/scene_preview_widget.h` with matching fields and conservative defaults so existing callers need not provide mesh values.
- Mapped the new mesh fields through when building preview items in `mainwindow.cpp` so `WorkcellStudioCanvasItem` -> `ScenePreviewWidget::PreviewItem` carries mesh metadata when present.
- Added `tests/test_workcell_studio_mesh_preview_compatibility_tokens.py` to assert presence of the new fields, mapping statements, and that primitive fallback tokens remain in the preview code.

### Testing
- Ran `pytest -q tests/test_workcell_studio_mesh_preview_compatibility_tokens.py` and it passed with `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1dbe77808331a33b02025a7c4436)