### PR TITLE
Add internal STL parser/cache for Scene3D viewport with guardrails and tests

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -294,11 +294,24 @@ if(BUILD_TESTING)
     src_placed_object_urdf_render.cpp
     src_object_placement_model.cpp)
 
+  ament_add_gtest(workcell_scene3d_stl_parser_test
+    test/scene3d_stl_parser_test.cpp
+    gui/scene3d_viewport_widget.cpp)
+
   ament_add_gtest(workcell_command_builders_test
     test/command_builders_test.cpp
     src_workcell_builder_command_builders.cpp)
   if(TARGET workcell_workspace_validation_test)
     target_link_libraries(workcell_workspace_validation_test Qt5::Widgets)
+  endif()
+
+  if(TARGET workcell_scene3d_stl_parser_test)
+    target_link_libraries(workcell_scene3d_stl_parser_test
+      Qt5::Widgets
+      Qt5::OpenGL
+      OpenGL::GL
+    )
+    target_include_directories(workcell_scene3d_stl_parser_test PRIVATE gui)
   endif()
 
   if(TARGET workcell_command_builders_test)

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -6,12 +6,94 @@
 #include <QVector3D>
 #include <QVector4D>
 #include <QToolTip>
+#include <QFile>
+#include <QFileInfo>
+#include <QDataStream>
+#include <QDebug>
+#include <QTextStream>
+#include <QtEndian>
+#include <cstring>
 #include <QtMath>
 
 #include <algorithm>
 #include <limits>
 
 namespace {
+constexpr int kMeshTriangleLimit = 100000;
+
+bool parse_ascii_stl(const QByteArray & bytes, Scene3DViewportWidget::InternalTriangleMesh & out_mesh,
+                     QString & out_error, int triangle_limit)
+{
+  QTextStream stream(bytes);
+  QString token;
+  while (stream >> token) {
+    if (token.compare("facet", Qt::CaseInsensitive) != 0) continue;
+    QString normal_tok;
+    if (!(stream >> normal_tok) || normal_tok.compare("normal", Qt::CaseInsensitive) != 0) {
+      out_error = "invalid facet normal token";
+      return false;
+    }
+    float nx, ny, nz;
+    if (!(stream >> nx >> ny >> nz)) { out_error = "invalid normal values"; return false; }
+    QString outer, loop;
+    if (!(stream >> outer >> loop) || outer.compare("outer", Qt::CaseInsensitive) != 0 || loop.compare("loop", Qt::CaseInsensitive) != 0) {
+      out_error = "invalid outer loop token";
+      return false;
+    }
+    Scene3DViewportWidget::InternalTriangleMesh::Triangle tri;
+    tri.normal = QVector3D(nx, ny, nz);
+    for (int i = 0; i < 3; ++i) {
+      QString vertex;
+      float vx, vy, vz;
+      if (!(stream >> vertex >> vx >> vy >> vz) || vertex.compare("vertex", Qt::CaseInsensitive) != 0) { out_error = "invalid vertex token"; return false; }
+      tri.vertices[i] = QVector3D(vx, vy, vz);
+    }
+    QString endloop, endfacet;
+    if (!(stream >> endloop >> endfacet) || endloop.compare("endloop", Qt::CaseInsensitive) != 0 || endfacet.compare("endfacet", Qt::CaseInsensitive) != 0) {
+      out_error = "invalid endloop/endfacet token";
+      return false;
+    }
+    out_mesh.triangles.push_back(tri);
+    if (out_mesh.triangles.size() > triangle_limit) { out_error = "mesh triangle count exceeds limit"; return false; }
+  }
+  if (out_mesh.triangles.isEmpty()) { out_error = "ascii STL contains no triangles"; return false; }
+  return true;
+}
+
+bool parse_binary_stl(const QByteArray & bytes, Scene3DViewportWidget::InternalTriangleMesh & out_mesh,
+                      QString & out_error, int triangle_limit)
+{
+  if (bytes.size() < 84) { out_error = "binary STL too small"; return false; }
+  const uchar * data = reinterpret_cast<const uchar *>(bytes.constData());
+  const quint32 tri_count = qFromLittleEndian<quint32>(data + 80);
+  if (tri_count > static_cast<quint32>(triangle_limit)) { out_error = "mesh triangle count exceeds limit"; return false; }
+  const qint64 expected_size = 84LL + static_cast<qint64>(tri_count) * 50LL;
+  if (bytes.size() < expected_size) { out_error = "binary STL truncated"; return false; }
+  out_mesh.triangles.reserve(static_cast<int>(tri_count));
+  const uchar * tri_ptr = data + 84;
+  auto read_float = [](const uchar * p) {
+    quint32 raw = qFromLittleEndian<quint32>(p);
+    float value;
+    std::memcpy(&value, &raw, sizeof(float));
+    return value;
+  };
+  for (quint32 i = 0; i < tri_count; ++i, tri_ptr += 50) {
+    Scene3DViewportWidget::InternalTriangleMesh::Triangle tri;
+    tri.normal = QVector3D(read_float(tri_ptr), read_float(tri_ptr + 4), read_float(tri_ptr + 8));
+    for (int vi = 0; vi < 3; ++vi) {
+      const uchar * vp = tri_ptr + 12 + vi * 12;
+      tri.vertices[vi] = QVector3D(read_float(vp), read_float(vp + 4), read_float(vp + 8));
+    }
+    out_mesh.triangles.push_back(tri);
+  }
+  return !out_mesh.triangles.isEmpty();
+}
+
+bool looks_like_ascii_stl(const QByteArray & bytes)
+{
+  const QByteArray prefix = bytes.left(256).trimmed().toLower();
+  return prefix.startsWith("solid") && prefix.contains("facet");
+}
 enum class NormalizedRole
 {
   RobotBase,
@@ -191,6 +273,9 @@ void Scene3DViewportWidget::paintGL()
   std::sort(draw_items.begin(), draw_items.end(), [&](const auto * a, const auto * b) { return a->z > b->z; });
 
   for (const auto * it : draw_items) {
+    if (classify_item_role(*it) == NormalizedRole::Object && !it->source_path.trimmed().isEmpty()) {
+      (void)ensure_mesh_cached(it->source_path);
+    }
     const NormalizedRole role = classify_item_role(*it);
     if (!show_safety && role == NormalizedRole::SafetyZone) continue;
 
@@ -261,6 +346,61 @@ void Scene3DViewportWidget::paintGL()
       painter.drawText(QPointF(p.x() + 10.0, p.y() + 10.0), warning_debug_text(it.warnings));
     }
   }
+}
+
+bool Scene3DViewportWidget::parse_stl_bytes_for_test(const QByteArray & bytes, const QString & source_hint,
+                                                     InternalTriangleMesh & out_mesh, QString & out_error,
+                                                     int triangle_limit)
+{
+  out_mesh.triangles.clear();
+  const bool ext_ascii_hint = source_hint.endsWith(".stla", Qt::CaseInsensitive);
+  const bool ext_binary_hint = source_hint.endsWith(".stlb", Qt::CaseInsensitive);
+  const bool ascii = ext_ascii_hint || (!ext_binary_hint && looks_like_ascii_stl(bytes));
+  if (ascii) return parse_ascii_stl(bytes, out_mesh, out_error, triangle_limit);
+  return parse_binary_stl(bytes, out_mesh, out_error, triangle_limit);
+}
+
+bool Scene3DViewportWidget::try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical) const
+{
+  QFileInfo info(path);
+  if (!info.exists() || !info.isFile()) return false;
+  out_canonical = info.canonicalFilePath();
+  if (out_canonical.isEmpty()) out_canonical = info.absoluteFilePath();
+  return !out_canonical.isEmpty();
+}
+
+const Scene3DViewportWidget::MeshCacheEntry & Scene3DViewportWidget::ensure_mesh_cached(const QString & path)
+{
+  QString canonical;
+  if (!try_resolve_canonical_mesh_path(path, canonical)) {
+    static MeshCacheEntry missing;
+    missing.loaded = true;
+    missing.valid = false;
+    missing.warning = QStringLiteral("mesh missing on disk");
+    qWarning() << "Scene3DViewportWidget mesh fallback: missing mesh" << path;
+    return missing;
+  }
+  auto it = mesh_cache_.find(canonical);
+  if (it != mesh_cache_.end()) return it.value();
+  MeshCacheEntry entry;
+  entry.loaded = true;
+  QFile file(canonical);
+  if (!file.open(QIODevice::ReadOnly)) {
+    entry.warning = QStringLiteral("mesh unreadable");
+    qWarning() << "Scene3DViewportWidget mesh fallback: unreadable mesh" << canonical;
+    return mesh_cache_.insert(canonical, entry).value();
+  }
+  const QByteArray bytes = file.readAll();
+  QString parse_error;
+  entry.valid = parse_stl_bytes_for_test(bytes, canonical, entry.mesh, parse_error, kMeshTriangleLimit);
+  if (!entry.valid) {
+    entry.oversized = parse_error.contains("exceeds limit");
+    entry.warning = entry.oversized ? QStringLiteral("mesh oversized") : QStringLiteral("mesh invalid");
+    qWarning() << "Scene3DViewportWidget mesh fallback:"
+               << (entry.oversized ? "oversized mesh" : "invalid mesh")
+               << canonical << "reason:" << parse_error;
+  }
+  return mesh_cache_.insert(canonical, entry).value();
 }
 
 

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -4,7 +4,10 @@
 
 #include <QOpenGLFunctions>
 #include <QOpenGLWidget>
+#include <QHash>
 #include <QVector3D>
+
+#include <array>
 
 #include <functional>
 
@@ -13,6 +16,16 @@ class Scene3DViewportWidget : public QOpenGLWidget, protected QOpenGLFunctions
 {
   Q_OBJECT
 public:
+  struct InternalTriangleMesh
+  {
+    struct Triangle
+    {
+      std::array<QVector3D, 3> vertices;
+      QVector3D normal;
+    };
+    QVector<Triangle> triangles;
+  };
+
   explicit Scene3DViewportWidget(QWidget * parent = nullptr);
 
   QVector<ScenePreviewWidget::PreviewItem> items;
@@ -39,6 +52,10 @@ public:
   void set_front_view();
   void set_side_view();
   void set_isometric_view();
+
+  static bool parse_stl_bytes_for_test(const QByteArray & bytes, const QString & source_hint,
+                                       InternalTriangleMesh & out_mesh, QString & out_error,
+                                       int triangle_limit = 100000);
 
 protected:
   void initializeGL() override;
@@ -71,6 +88,17 @@ private:
   void draw_warning_badge_anchor(const ScenePreviewWidget::PreviewItem & it);
   QPoint last_;
   QString hovered_id_;
+  struct MeshCacheEntry
+  {
+    bool loaded{ false };
+    bool valid{ false };
+    bool oversized{ false };
+    QString warning;
+    InternalTriangleMesh mesh;
+  };
+  QHash<QString, MeshCacheEntry> mesh_cache_;
+  bool try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical) const;
+  const MeshCacheEntry & ensure_mesh_cached(const QString & path);
   QVector3D orbit_offset_{ 0.0f, 0.0f, 0.0f };
   double yaw_{ -0.9 };
   double pitch_{ 0.7 };

--- a/workcell_builder/workcell_builder/test/scene3d_stl_parser_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_stl_parser_test.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+
+#include "../gui/scene3d_viewport_widget.h"
+
+#include <cstring>
+
+TEST(Scene3DStlParserTest, ParsesAsciiStl)
+{
+  const QByteArray ascii =
+    "solid t\n"
+    "facet normal 0 0 1\n"
+    "outer loop\n"
+    "vertex 0 0 0\n"
+    "vertex 1 0 0\n"
+    "vertex 0 1 0\n"
+    "endloop\n"
+    "endfacet\n"
+    "endsolid\n";
+
+  Scene3DViewportWidget::InternalTriangleMesh mesh;
+  QString err;
+  EXPECT_TRUE(Scene3DViewportWidget::parse_stl_bytes_for_test(ascii, "mesh.stl", mesh, err));
+  ASSERT_EQ(mesh.triangles.size(), 1);
+  EXPECT_FLOAT_EQ(mesh.triangles[0].vertices[1].x(), 1.0f);
+}
+
+TEST(Scene3DStlParserTest, ParsesBinaryStl)
+{
+  QByteArray bytes;
+  bytes.resize(84 + 50);
+  bytes.fill('\0');
+  quint32 tri_count = 1;
+  std::memcpy(bytes.data() + 80, &tri_count, sizeof(tri_count));
+  auto putf = [&](int off, float v){ std::memcpy(bytes.data() + off, &v, sizeof(float)); };
+  putf(84 + 0, 0.0f); putf(84 + 4, 0.0f); putf(84 + 8, 1.0f);
+  putf(84 + 12, 0.0f); putf(84 + 16, 0.0f); putf(84 + 20, 0.0f);
+  putf(84 + 24, 1.0f); putf(84 + 28, 0.0f); putf(84 + 32, 0.0f);
+  putf(84 + 36, 0.0f); putf(84 + 40, 1.0f); putf(84 + 44, 0.0f);
+
+  Scene3DViewportWidget::InternalTriangleMesh mesh;
+  QString err;
+  EXPECT_TRUE(Scene3DViewportWidget::parse_stl_bytes_for_test(bytes, "mesh.stl", mesh, err));
+  ASSERT_EQ(mesh.triangles.size(), 1);
+  EXPECT_FLOAT_EQ(mesh.triangles[0].normal.z(), 1.0f);
+}
+
+TEST(Scene3DStlParserTest, FailsOnInvalidAndOversized)
+{
+  Scene3DViewportWidget::InternalTriangleMesh mesh;
+  QString err;
+  EXPECT_FALSE(Scene3DViewportWidget::parse_stl_bytes_for_test("solid broken", "broken.stl", mesh, err));
+
+  const QByteArray ascii =
+    "solid t\n"
+    "facet normal 0 0 1\nouter loop\nvertex 0 0 0\nvertex 1 0 0\nvertex 0 1 0\nendloop\nendfacet\n"
+    "facet normal 0 0 1\nouter loop\nvertex 0 0 0\nvertex 1 0 0\nvertex 0 1 0\nendloop\nendfacet\n"
+    "endsolid\n";
+  err.clear();
+  EXPECT_FALSE(Scene3DViewportWidget::parse_stl_bytes_for_test(ascii, "many.stl", mesh, err, 1));
+  EXPECT_TRUE(err.contains("exceeds limit"));
+}


### PR DESCRIPTION
### Motivation
- Provide a dependency-light internal STL loader so scene object STLs can be previewed without adding heavy mesh libraries. 
- Avoid repeatedly re-reading mesh files during `paintGL()` by caching parsed meshes keyed by a canonical absolute path. 
- Fail fast and clearly for missing/invalid/oversized meshes using a triangle-count guard and explicit fallback logging.

### Description
- Added an internal mesh type `Scene3DViewportWidget::InternalTriangleMesh` (triangles with vertices + normals) and a `MeshCacheEntry` state to `scene3d_viewport_widget.h`. 
- Implemented ASCII and binary STL parsing helpers (`parse_ascii_stl`, `parse_binary_stl`) plus content sniffing and an exposed helper `parse_stl_bytes_for_test` to pick parser based on content/extension in `scene3d_viewport_widget.cpp`. 
- Added canonical-path mesh cache (`mesh_cache_`), a resolver `try_resolve_canonical_mesh_path`, and a loader `ensure_mesh_cached` that records `loaded/valid/oversized/warning` states and emits `qWarning()` fallback messages for missing/unreadable/invalid/oversized meshes. 
- Integrated cache population so object items with a `source_path` call `ensure_mesh_cached` from `paintGL()`, and added a triangle-count guard (`kMeshTriangleLimit = 100000`) and fallback behavior; also wired a new GTest target and test file for the parser. 

### Testing
- Added unit tests in `test/scene3d_stl_parser_test.cpp` covering ASCII parsing, binary parsing, invalid input, and triangle-limit overflow as the `workcell_scene3d_stl_parser_test` gtest target. 
- Attempted to run the scoped test with `colcon test --packages-select workcell_builder --ctest-args -R scene3d_stl_parser_test --output-on-failure`, but execution failed because `colcon` is not available in the current environment (error: `/bin/bash: colcon: command not found`). 
- The test target is registered in `CMakeLists.txt` and the tests should run in a normal build/test environment that has `colcon`/CTest available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1dc15ddc8331991c225eb6e62f66)