### PR TITLE
Add mesh preview transform stack and mesh fallback continuity checks

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -260,6 +260,8 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_conveyor_pick_preview_test
     test/conveyor_pick_preview_test.cpp
     src_conveyor_pick_preview.cpp)
+  ament_add_gtest(workcell_scene3d_mesh_preview_regression_test
+    test/scene3d_mesh_preview_regression_test.cpp)
   ament_add_gtest(workcell_task_intent_readiness_test
     test/task_intent_readiness_test.cpp
     src_task_intent_readiness.cpp)

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -204,7 +204,10 @@ void Scene3DViewportWidget::paintGL()
       case NormalizedRole::Object: draw_object_cube(*it); break;
       case NormalizedRole::SafetyZone: draw_safety_zone(*it); break;
       case NormalizedRole::WarningAnchor: draw_warning_badge_anchor(*it); break;
-      case NormalizedRole::Generic: draw_box(it->x, it->y, it->z, it->sx, it->sy, it->sz, item_color(*it)); break;
+      case NormalizedRole::Generic:
+        if (!draw_mesh_preview_if_available(*it, item_color(*it), true))
+          draw_box(it->x, it->y, it->z, it->sx, it->sy, it->sz, item_color(*it));
+        break;
     }
     if (it->id == selected_id) {
       const ItemBounds bounds = item_bounds_for_role(*it);
@@ -264,6 +267,46 @@ void Scene3DViewportWidget::paintGL()
 }
 
 
+
+
+bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWidget::PreviewItem & it, const QColor & color, bool preview_path)
+{
+  if (!it.has_mesh_metadata) return false;
+
+  glPushMatrix();
+  glTranslated(it.x, it.y, it.z);
+  glRotated(qRadiansToDegrees(it.roll), 1.0, 0.0, 0.0);
+  glRotated(qRadiansToDegrees(it.pitch), 0.0, 1.0, 0.0);
+  glRotated(qRadiansToDegrees(it.yaw), 0.0, 0.0, 1.0);
+  glRotated(qRadiansToDegrees(it.mesh_r), 1.0, 0.0, 0.0);
+  glRotated(qRadiansToDegrees(it.mesh_p), 0.0, 1.0, 0.0);
+  glRotated(qRadiansToDegrees(it.mesh_y), 0.0, 0.0, 1.0);
+  if (preview_path && it.has_origin_offset) glTranslated(it.origin_offset_x, it.origin_offset_y, it.origin_offset_z);
+  glScaled(it.mesh_scale_x, it.mesh_scale_y, it.mesh_scale_z);
+
+  draw_unit_cube_triangles(color);
+  glPopMatrix();
+  return true;
+}
+
+void Scene3DViewportWidget::draw_unit_cube_triangles(const QColor & color)
+{
+  glColor4f(color.redF(), color.greenF(), color.blueF(), 1.0f);
+  glBegin(GL_TRIANGLES);
+  const GLfloat v[8][3] = {
+    {0.f, 0.f, 0.f}, {1.f, 0.f, 0.f}, {1.f, 1.f, 0.f}, {0.f, 1.f, 0.f},
+    {0.f, 0.f, 1.f}, {1.f, 0.f, 1.f}, {1.f, 1.f, 1.f}, {0.f, 1.f, 1.f}
+  };
+  auto tri = [&](int a, int b, int c){ glVertex3fv(v[a]); glVertex3fv(v[b]); glVertex3fv(v[c]); };
+  tri(0,1,2); tri(0,2,3);
+  tri(4,6,5); tri(4,7,6);
+  tri(0,4,5); tri(0,5,1);
+  tri(1,5,6); tri(1,6,2);
+  tri(2,6,7); tri(2,7,3);
+  tri(3,7,4); tri(3,4,0);
+  glEnd();
+}
+
 void Scene3DViewportWidget::draw_robot_base_with_axis(const ScenePreviewWidget::PreviewItem & it)
 {
   const double radius = qMax(0.06, qMin(it.sx, it.sz) * 0.45);
@@ -303,6 +346,7 @@ void Scene3DViewportWidget::draw_place_target_bin(const ScenePreviewWidget::Prev
 }
 void Scene3DViewportWidget::draw_object_cube(const ScenePreviewWidget::PreviewItem & it)
 {
+  if (draw_mesh_preview_if_available(it, item_color(it), true)) return;
   const double cube = qMax(0.05, qMin(it.sx, qMin(it.sy, it.sz)));
   draw_box(it.x, it.y, it.z, cube, cube, cube, item_color(it));
 }

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -69,6 +69,8 @@ private:
   void draw_object_cube(const ScenePreviewWidget::PreviewItem & it);
   void draw_safety_zone(const ScenePreviewWidget::PreviewItem & it);
   void draw_warning_badge_anchor(const ScenePreviewWidget::PreviewItem & it);
+  bool draw_mesh_preview_if_available(const ScenePreviewWidget::PreviewItem & it, const QColor & color, bool preview_path = true);
+  void draw_unit_cube_triangles(const QColor & color);
   QPoint last_;
   QString hovered_id_;
   QVector3D orbit_offset_{ 0.0f, 0.0f, 0.0f };

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -31,6 +31,11 @@ public:
     bool selectable{ true };
     bool metadata_complete{ true };
     QStringList warnings;
+    bool has_mesh_metadata{ false };
+    double mesh_r{ 0.0 }, mesh_p{ 0.0 }, mesh_y{ 0.0 };
+    double mesh_scale_x{ 1.0 }, mesh_scale_y{ 1.0 }, mesh_scale_z{ 1.0 };
+    bool has_origin_offset{ false };
+    double origin_offset_x{ 0.0 }, origin_offset_y{ 0.0 }, origin_offset_z{ 0.0 };
   };
   struct CameraOverlayModel
   {
@@ -75,6 +80,11 @@ public:
     QString selected_item_status{"unknown"};
     QString metadata_source{"preview"};
     QStringList warnings;
+    bool has_mesh_metadata{ false };
+    double mesh_r{ 0.0 }, mesh_p{ 0.0 }, mesh_y{ 0.0 };
+    double mesh_scale_x{ 1.0 }, mesh_scale_y{ 1.0 }, mesh_scale_z{ 1.0 };
+    bool has_origin_offset{ false };
+    double origin_offset_x{ 0.0 }, origin_offset_y{ 0.0 }, origin_offset_z{ 0.0 };
   };
   struct CollisionOverlayModel
   {
@@ -82,6 +92,11 @@ public:
     QStringList colliding_items;
     QStringList near_miss_items;
     QStringList warnings;
+    bool has_mesh_metadata{ false };
+    double mesh_r{ 0.0 }, mesh_p{ 0.0 }, mesh_y{ 0.0 };
+    double mesh_scale_x{ 1.0 }, mesh_scale_y{ 1.0 }, mesh_scale_z{ 1.0 };
+    bool has_origin_offset{ false };
+    double origin_offset_x{ 0.0 }, origin_offset_y{ 0.0 }, origin_offset_z{ 0.0 };
   };
 
   struct TaskOverlayModel

--- a/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
@@ -1,0 +1,45 @@
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace {
+std::string load_file(const std::string & path)
+{
+  std::ifstream in(path);
+  std::ostringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
+}
+}
+
+TEST(Scene3DMeshPreviewRegression, KeepsTransformStackAndFallback)
+{
+  const std::string src = load_file("gui/scene3d_viewport_widget.cpp");
+  ASSERT_FALSE(src.empty());
+
+  const auto t = src.find("glTranslated(it.x, it.y, it.z)");
+  const auto r = src.find("glRotated(qRadiansToDegrees(it.roll)");
+  const auto mr = src.find("glRotated(qRadiansToDegrees(it.mesh_r)");
+  const auto s = src.find("glScaled(it.mesh_scale_x, it.mesh_scale_y, it.mesh_scale_z)");
+  ASSERT_NE(t, std::string::npos);
+  ASSERT_NE(r, std::string::npos);
+  ASSERT_NE(mr, std::string::npos);
+  ASSERT_NE(s, std::string::npos);
+  EXPECT_LT(t, r);
+  EXPECT_LT(r, mr);
+  EXPECT_LT(mr, s);
+
+  EXPECT_NE(src.find("if (preview_path && it.has_origin_offset)"), std::string::npos);
+  EXPECT_NE(src.find("if (!draw_mesh_preview_if_available(*it, item_color(*it), true))"), std::string::npos);
+}
+
+TEST(Scene3DMeshPreviewRegression, KeepsSelectionAndOverlayRendering)
+{
+  const std::string src = load_file("gui/scene3d_viewport_widget.cpp");
+  ASSERT_FALSE(src.empty());
+  EXPECT_NE(src.find("if (it->id == selected_id)"), std::string::npos);
+  EXPECT_NE(src.find("draw_box_outline(bounds.x, bounds.y, bounds.z, bounds.sx, bounds.sy, bounds.sz"), std::string::npos);
+  EXPECT_NE(src.find("if (show_warning_labels && !it.warnings.isEmpty())"), std::string::npos);
+}


### PR DESCRIPTION
### Motivation
- Ensure mesh-enabled preview items are rendered with the correct transform stack so visuals align with item and mesh metadata. 
- Apply origin offset only for preview mesh rendering and not for canonical scene transforms. 
- Preserve existing selection outline, warning badges, and overlay/painter behavior unchanged when enabling mesh rendering. 
- Maintain primitive fallback behavior when mesh metadata is absent or unavailable.

### Description
- Added mesh metadata fields to `PreviewItem` (`has_mesh_metadata`, `mesh_r/p/y`, `mesh_scale_x/y/z`, `has_origin_offset`, `origin_offset_x/y/z`) in `scene_preview_widget.h` to carry mesh-local transforms and origin offsets. 
- Implemented `draw_mesh_preview_if_available(...)` and `draw_unit_cube_triangles(...)` in `scene3d_viewport_widget.cpp` and declared them in the header, which apply transforms in order: item translation (`x/y/z`), item rotation (`roll/pitch/yaw`), mesh-local rotation offsets (`mesh_r/p/y`), (preview-only) origin offset, then mesh scale (`mesh_scale_x/y/z`) before drawing triangles. 
- Integrated the mesh draw path as a non-destructive option in the render switch so `Object` and `Generic` roles will use `draw_mesh_preview_if_available(...)` when `has_mesh_metadata` is true and otherwise fall back to existing `draw_box`/primitive code. 
- Kept selection outline and overlay/warning-label rendering logic intact and unmodified, and registered a new gtest `scene3d_mesh_preview_regression_test.cpp` in `CMakeLists.txt` to assert transform-ordering and overlay/selection continuity tokens in the source.

### Testing
- Added an automated gtest `workcell_scene3d_mesh_preview_regression_test` that checks for the presence and ordering of the transform calls (`glTranslated`, `glRotated` for item RPY, `glRotated` for mesh RPY, `glScaled`) and that preview-only origin offset and fallback/overlay tokens are present. 
- The new test was added to `workcell_builder` CMake test targets in `CMakeLists.txt`. 
- Tests were not executed in this environment because no build directory was available here, so the new test has not yet been run (status unknown).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1dc5a02883318c9ae7321e05be8b)