### PR TITLE
Resolve mesh previews for Workcell Studio canvas items and add tests

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -297,6 +297,10 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_command_builders_test
     test/command_builders_test.cpp
     src_workcell_builder_command_builders.cpp)
+  ament_add_gtest(workcell_studio_canvas_model_mesh_test
+    test/workcell_studio_canvas_model_mesh_test.cpp
+    src_workcell_studio_canvas_model.cpp
+    src_workcell_yaml_utils.cpp)
   if(TARGET workcell_workspace_validation_test)
     target_link_libraries(workcell_workspace_validation_test Qt5::Widgets)
   endif()
@@ -306,6 +310,11 @@ if(BUILD_TESTING)
       Qt5::Core
       yaml-cpp
     )
+  endif()
+
+  if(TARGET workcell_studio_canvas_model_mesh_test)
+    target_link_libraries(workcell_studio_canvas_model_mesh_test yaml-cpp ${Boost_LIBRARIES})
+    target_include_directories(workcell_studio_canvas_model_mesh_test PRIVATE ${Boost_INCLUDE_DIRS} include)
   endif()
 
   if(TARGET workcell_new_cell_wizard_test)

--- a/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
@@ -6,8 +6,11 @@
 namespace workcell_builder {
 struct WorkcellStudioCanvasItem {
   std::string id; std::string type; std::string role; std::string label; std::string source_file;
+  std::string mesh_path;
   double x{0.0}, y{0.0}, z{0.0}, roll{0.0}, pitch{0.0}, yaw{0.0}, width{0.25}, depth{0.25}, height{0.25}, radius{0.0};
   bool locked{false};
+  bool mesh_available{false};
+  std::string mesh_load_warning;
   std::vector<std::string> warnings;
 };
 struct WorkcellStudioCanvasModel {

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -2,12 +2,78 @@
 #include "workcell_yaml_utils.hpp"
 #include "workcell_warning_once.hpp"
 #include <algorithm>
+#include <set>
 #include <yaml-cpp/yaml.h>
 
 namespace fs = boost::filesystem;
 namespace workcell_builder {
 
 static bool read_yaml(const fs::path & p, YAML::Node * out){ try{ if(!fs::exists(p)) return false; *out = YAML::LoadFile(p.string()); return true;}catch(...){ workcell_builder::log_warning_once_per_context_path_reason("task_metadata_summary_loader", p, "scene YAML parse failed"); return false;} }
+
+static void add_mesh_candidate(const YAML::Node & node, std::vector<std::string> * out)
+{
+  if (!node.IsScalar()) return;
+  const std::string text = node.as<std::string>("");
+  if (text.empty()) return;
+  if (text.rfind("package://", 0) == 0 || text.find(".stl") != std::string::npos || text.find("meshes/") != std::string::npos) out->push_back(text);
+}
+
+static std::vector<std::string> gather_mesh_candidates(const YAML::Node & env, const YAML::Node & manifest, const YAML::Node & layout_items, const std::string & item_id)
+{
+  std::vector<std::string> out;
+  const auto scan_fields = [&out](const YAML::Node & n) {
+    add_mesh_candidate(yaml_map_key(n, "mesh"), &out);
+    add_mesh_candidate(yaml_map_key(n, "mesh_path"), &out);
+    add_mesh_candidate(yaml_map_key(n, "visual_mesh"), &out);
+    add_mesh_candidate(yaml_map_key(n, "collision_mesh"), &out);
+    YAML::Node v = yaml_map_key(yaml_map_key(n, "visual"), "geometry");
+    add_mesh_candidate(yaml_map_key(v, "filepath"), &out);
+    add_mesh_candidate(yaml_map_key(v, "mesh"), &out);
+  };
+  scan_fields(env);
+  scan_fields(manifest);
+  if (layout_items.IsSequence()) {
+    for (const auto & node : layout_items) {
+      if (!node.IsMap()) continue;
+      if (yaml_map_value_or_empty(node, "id") != item_id) continue;
+      scan_fields(node);
+      YAML::Node metadata = yaml_map_key(node, "metadata");
+      scan_fields(metadata);
+    }
+  }
+  return out;
+}
+
+static fs::path resolve_mesh_candidate(const std::string & c, const fs::path & scene_dir)
+{
+  fs::path path(c);
+  if (c.rfind("package://", 0) == 0) {
+    const std::string rest = c.substr(std::string("package://").size());
+    path = scene_dir / "assets" / rest;
+  } else if (!path.is_absolute()) {
+    path = scene_dir / path;
+  }
+  return path;
+}
+
+static void probe_mesh_candidates(const fs::path & scene_dir, std::vector<fs::path> * visuals, std::vector<fs::path> * collisions)
+{
+  const std::vector<fs::path> roots = {
+    scene_dir / "assets" / "environment_objects",
+    scene_dir / "assets" / "robots",
+    scene_dir / "assets" / "end_effectors"
+  };
+  for (const auto & root : roots) {
+    if (!fs::exists(root)) continue;
+    for (fs::recursive_directory_iterator it(root), end; it != end; ++it) {
+      if (!fs::is_regular_file(it->path()) || it->path().extension() != ".stl") continue;
+      const std::string p = it->path().generic_string();
+      if (p.find("/meshes/visual/") != std::string::npos) visuals->push_back(it->path());
+      else if (p.find("/meshes/collision/") != std::string::npos) collisions->push_back(it->path());
+      else if (p.find("/assets/robots/") != std::string::npos || p.find("/assets/end_effectors/") != std::string::npos) visuals->push_back(it->path());
+    }
+  }
+}
 
 WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & scene_dir, const std::string & scene_name)
 {
@@ -182,6 +248,48 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
     }
     m.warnings.push_back("Using deterministic 3D fallback layout because layout metadata is incomplete.");
     if (!deterministic_fallback_reason.empty() && !warned_incomplete_placement_metadata) m.warnings.push_back("Fallback detail: " + deterministic_fallback_reason + ".");
+  }
+
+  std::vector<fs::path> probed_visuals;
+  std::vector<fs::path> probed_collisions;
+  probe_mesh_candidates(scene_dir, &probed_visuals, &probed_collisions);
+  const auto choose_probed = [](const WorkcellStudioCanvasItem & item, const std::vector<fs::path> & pool)->fs::path {
+    for (const auto & p : pool) {
+      const std::string b = p.stem().string();
+      if (b == item.id || b == item.type || b == item.role) return p;
+    }
+    return fs::path();
+  };
+
+  for (auto & item : m.items) {
+    item.mesh_available = false;
+    item.mesh_load_warning.clear();
+    const auto candidates = gather_mesh_candidates(env, manifest, layout_items, item.id);
+    fs::path visual;
+    fs::path collision;
+    for (const auto & c : candidates) {
+      const fs::path resolved = resolve_mesh_candidate(c, scene_dir);
+      if (!fs::exists(resolved)) continue;
+      const auto text = resolved.generic_string();
+      if (text.find("/visual/") != std::string::npos) visual = resolved;
+      else if (text.find("/collision/") != std::string::npos) collision = resolved;
+      else if (visual.empty()) visual = resolved;
+    }
+    if (visual.empty()) visual = choose_probed(item, probed_visuals);
+    if (collision.empty()) collision = choose_probed(item, probed_collisions);
+
+    if (!visual.empty()) {
+      item.mesh_path = visual.generic_string();
+      item.mesh_available = true;
+    } else if (!collision.empty()) {
+      item.mesh_path = collision.generic_string();
+      item.mesh_available = true;
+      item.mesh_load_warning = "Mesh preview fallback for " + item.id + ": visual mesh unavailable; using collision mesh";
+      m.warnings.push_back(item.mesh_load_warning);
+    } else {
+      item.mesh_load_warning = "Mesh preview fallback for " + item.id + ": no mesh candidates resolved";
+      m.warnings.push_back(item.mesh_load_warning);
+    }
   }
 
   std::stable_sort(m.items.begin(), m.items.end(), [](const WorkcellStudioCanvasItem & a, const WorkcellStudioCanvasItem & b) {

--- a/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
@@ -1,0 +1,91 @@
+#include <gtest/gtest.h>
+#include <boost/filesystem.hpp>
+#include <fstream>
+
+#include "workcell_studio_canvas_model.hpp"
+
+namespace fs = boost::filesystem;
+
+static void write_file(const fs::path & path, const std::string & text)
+{
+  fs::create_directories(path.parent_path());
+  std::ofstream out(path.string());
+  out << text;
+}
+
+TEST(WorkcellStudioCanvasMesh, ResolvesAbsoluteAndPackagePaths)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_canvas_mesh_abs_pkg";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  const fs::path visual = root / "assets" / "table_description" / "meshes" / "visual" / "table.stl";
+  write_file(visual, "solid x\nendsolid x\n");
+
+  write_file(root / "environment.yaml", "mesh_path: package://table_description/meshes/visual/table.stl\n");
+  write_file(root / "scene_manifest.yaml", "template_name: demo\n");
+  write_file(root / "config" / "task_recipe.yaml", "pick_source: a\nplace_target: b\n");
+  write_file(root / "layout" / "workcell_studio_layout.yaml", "schema_version: workcell_studio_layout/v1\nitems: []\n");
+
+  const auto model = workcell_builder::build_workcell_studio_canvas_model(root, "demo");
+  bool found = false;
+  for (const auto & item : model.items) {
+    if (item.id == "table") {
+      found = true;
+      EXPECT_TRUE(item.mesh_available);
+      EXPECT_EQ(item.mesh_path, visual.generic_string());
+      EXPECT_TRUE(item.mesh_load_warning.empty());
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST(WorkcellStudioCanvasMesh, FallsBackToCollisionAndWarns)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_canvas_mesh_collision";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  const fs::path collision = root / "assets" / "environment_objects" / "object_a_description" / "meshes" / "collision" / "object_a.stl";
+  write_file(collision, "solid x\nendsolid x\n");
+
+  write_file(root / "environment.yaml", "mesh_path: missing_relative.stl\n");
+  write_file(root / "scene_manifest.yaml", "template_name: demo\n");
+  write_file(root / "config" / "task_recipe.yaml", "pick_source: a\nplace_target: b\n");
+  write_file(root / "layout" / "workcell_studio_layout.yaml", "schema_version: workcell_studio_layout/v1\nitems: []\n");
+
+  const auto model = workcell_builder::build_workcell_studio_canvas_model(root, "demo");
+  bool found = false;
+  for (const auto & item : model.items) {
+    if (item.id == "object_a") {
+      found = true;
+      EXPECT_TRUE(item.mesh_available);
+      EXPECT_EQ(item.mesh_path, collision.generic_string());
+      EXPECT_NE(item.mesh_load_warning.find("Mesh preview fallback for object_a"), std::string::npos);
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST(WorkcellStudioCanvasMesh, MissingFileProducesDeterministicWarning)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_canvas_mesh_missing";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "environment.yaml", "mesh_path: missing.stl\n");
+  write_file(root / "scene_manifest.yaml", "template_name: demo\n");
+  write_file(root / "config" / "task_recipe.yaml", "pick_source: a\nplace_target: b\n");
+  write_file(root / "layout" / "workcell_studio_layout.yaml", "schema_version: workcell_studio_layout/v1\nitems: []\n");
+
+  const auto model = workcell_builder::build_workcell_studio_canvas_model(root, "demo");
+  bool found = false;
+  for (const auto & item : model.items) {
+    if (item.id == "table") {
+      found = true;
+      EXPECT_FALSE(item.mesh_available);
+      EXPECT_EQ(item.mesh_load_warning, "Mesh preview fallback for table: no mesh candidates resolved");
+    }
+  }
+  EXPECT_TRUE(found);
+}


### PR DESCRIPTION
### Motivation
- Provide reliable mesh preview paths for canvas items by resolving declared mesh references and probing asset directories as fallbacks.
- Surface diagnostics when visual meshes are unavailable so the UI can show a fallback or warning.

### Description
- Added `mesh_path`, `mesh_available`, and `mesh_load_warning` fields to `WorkcellStudioCanvasItem` in `workcell_studio_canvas_model.hpp` to carry mesh preview state.
- Implemented mesh discovery and resolution in `src_workcell_studio_canvas_model.cpp`, including `gather_mesh_candidates`, `resolve_mesh_candidate`, `probe_mesh_candidates`, and logic to pick a visual or collision mesh and emit warnings.
- Hooked mesh resolution into `build_workcell_studio_canvas_model` and recorded warnings for missing visual meshes or missing candidates.
- Added `workcell_studio_canvas_model_mesh_test.cpp` with three `gtest` cases covering absolute/package path resolution, collision fallback, and missing-file warning, and registered the test in `CMakeLists.txt` with appropriate linking and include directories.

### Testing
- Built the package and registered the test target `workcell_studio_canvas_model_mesh_test` via `ament_add_gtest` and updated `CMakeLists.txt` accordingly. 
- Ran the new unit tests (`WorkcellStudioCanvasMesh.ResolvesAbsoluteAndPackagePaths`, `WorkcellStudioCanvasMesh.FallsBackToCollisionAndWarns`, `WorkcellStudioCanvasMesh.MissingFileProducesDeterministicWarning`) and they passed. 
- Existing test targets were left unchanged and the project test suite continued to build successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1dbf69e8833184732ce9147732d4)