### PR TITLE
Fix workcell_builder build break from duplicate mesh fields and STL stream parsing

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <sstream>
 
 namespace {
 constexpr int kMeshTriangleLimit = 100000;
@@ -24,32 +25,40 @@ constexpr int kMeshTriangleLimit = 100000;
 bool parse_ascii_stl(const QByteArray & bytes, Scene3DViewportWidget::InternalTriangleMesh & out_mesh,
                      QString & out_error, int triangle_limit)
 {
-  QTextStream stream(bytes);
-  QString token;
+  std::istringstream stream(QString::fromUtf8(bytes).toStdString());
+  std::string token;
   while (stream >> token) {
-    if (token.compare("facet", Qt::CaseInsensitive) != 0) continue;
-    QString normal_tok;
-    if (!(stream >> normal_tok) || normal_tok.compare("normal", Qt::CaseInsensitive) != 0) {
+    if (QString::fromStdString(token).compare("facet", Qt::CaseInsensitive) != 0) continue;
+    std::string normal_tok;
+    if (!(stream >> normal_tok) || QString::fromStdString(normal_tok).compare("normal", Qt::CaseInsensitive) != 0) {
       out_error = "invalid facet normal token";
       return false;
     }
     float nx, ny, nz;
     if (!(stream >> nx >> ny >> nz)) { out_error = "invalid normal values"; return false; }
-    QString outer, loop;
-    if (!(stream >> outer >> loop) || outer.compare("outer", Qt::CaseInsensitive) != 0 || loop.compare("loop", Qt::CaseInsensitive) != 0) {
+    std::string outer, loop;
+    if (!(stream >> outer >> loop) ||
+        QString::fromStdString(outer).compare("outer", Qt::CaseInsensitive) != 0 ||
+        QString::fromStdString(loop).compare("loop", Qt::CaseInsensitive) != 0) {
       out_error = "invalid outer loop token";
       return false;
     }
     Scene3DViewportWidget::InternalTriangleMesh::Triangle tri;
     tri.normal = QVector3D(nx, ny, nz);
     for (int i = 0; i < 3; ++i) {
-      QString vertex;
+      std::string vertex;
       float vx, vy, vz;
-      if (!(stream >> vertex >> vx >> vy >> vz) || vertex.compare("vertex", Qt::CaseInsensitive) != 0) { out_error = "invalid vertex token"; return false; }
+      if (!(stream >> vertex >> vx >> vy >> vz) ||
+          QString::fromStdString(vertex).compare("vertex", Qt::CaseInsensitive) != 0) {
+        out_error = "invalid vertex token";
+        return false;
+      }
       tri.vertices[i] = QVector3D(vx, vy, vz);
     }
-    QString endloop, endfacet;
-    if (!(stream >> endloop >> endfacet) || endloop.compare("endloop", Qt::CaseInsensitive) != 0 || endfacet.compare("endfacet", Qt::CaseInsensitive) != 0) {
+    std::string endloop, endfacet;
+    if (!(stream >> endloop >> endfacet) ||
+        QString::fromStdString(endloop).compare("endloop", Qt::CaseInsensitive) != 0 ||
+        QString::fromStdString(endfacet).compare("endfacet", Qt::CaseInsensitive) != 0) {
       out_error = "invalid endloop/endfacet token";
       return false;
     }

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -39,7 +39,6 @@ public:
     QStringList warnings;
     bool has_mesh_metadata{ false };
     double mesh_r{ 0.0 }, mesh_p{ 0.0 }, mesh_y{ 0.0 };
-    double mesh_scale_x{ 1.0 }, mesh_scale_y{ 1.0 }, mesh_scale_z{ 1.0 };
     bool has_origin_offset{ false };
     double origin_offset_x{ 0.0 }, origin_offset_y{ 0.0 }, origin_offset_z{ 0.0 };
   };

--- a/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
@@ -6,7 +6,6 @@
 namespace workcell_builder {
 struct WorkcellStudioCanvasItem {
   std::string id; std::string type; std::string role; std::string label; std::string source_file;
-  std::string mesh_path;
   double x{0.0}, y{0.0}, z{0.0}, roll{0.0}, pitch{0.0}, yaw{0.0}, width{0.25}, depth{0.25}, height{0.25}, radius{0.0};
   std::string mesh_path;
   std::string mesh_type;
@@ -15,8 +14,6 @@ struct WorkcellStudioCanvasItem {
   bool mesh_available{false};
   std::string mesh_load_warning;
   bool locked{false};
-  bool mesh_available{false};
-  std::string mesh_load_warning;
   std::vector<std::string> warnings;
 };
 struct WorkcellStudioCanvasModel {

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -129,16 +129,42 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   m.place_target = task_ok ? read_string_or_warn(yaml_map_key(task, "place_target"), "task_recipe.place_target", "Task intent missing") : "Task intent missing";
   m.release_strategy = task_ok ? read_string_or_warn(yaml_map_key(task, "release_strategy"), "task_recipe.release_strategy", "Generate task recipe to populate this panel") : "Generate task recipe to populate this panel";
 
-  m.items.push_back({"robot_base","robot_base","robot","Robot Base","environment.yaml",0,0,0,0,0,0,0.35,0.35,0.35,0,true,{}});
-  m.items.push_back({"robot_reach","reach","reach","Robot Reach","environment.yaml",0,0,0,0,0,0,0,0,0,1.2,true,{}});
-  m.items.push_back({"table","table","table","Table","environment.yaml",0.7,0.0,0,0,0,0,1.0,0.6,0.2,0,false,{}});
-  m.items.push_back({"conveyor","conveyor","conveyor","Conveyor","environment.yaml",-0.8,-0.3,0,0,0,0,1.2,0.3,0.2,0,false,{}});
-  m.items.push_back({"camera","camera","camera","Camera FOV","environment.yaml",-0.2,1.0,1.2,0,0,-1.57,0.18,0.18,0.2,0,false,{}});
-  m.items.push_back({"pick_zone","zone","pick_zone","Pick Source","config/task_recipe.yaml",0.55,0.0,0,0,0,0,0.35,0.35,0.1,0,false,{}});
-  m.items.push_back({"place_zone","zone","place_zone","Place Target","config/task_recipe.yaml",1.0,0.1,0,0,0,0,0.35,0.35,0.1,0,false,{}});
-  m.items.push_back({"bin_a","bin","bin","Bin A","environment.yaml",1.3,-0.5,0,0,0,0,0.32,0.25,0.2,0,false,{}});
-  m.items.push_back({"object_a","object","object","Object","environment.yaml",0.6,0.1,0,0,0,0,0.08,0.08,0.08,0,false,{}});
-  m.items.push_back({"home_pose","safety","safety/home","config/workcell_builder_task_intent.yaml","config/workcell_builder_task_intent.yaml",-0.4,0.5,0,0,0,0,0.14,0.14,0.14,0,true,{}});
+  const auto push_default_item = [&m](const std::string & id, const std::string & type, const std::string & role,
+                                       const std::string & label, const std::string & source_file,
+                                       double x, double y, double z,
+                                       double roll, double pitch, double yaw,
+                                       double width, double depth, double height,
+                                       double radius, bool locked) {
+    WorkcellStudioCanvasItem item;
+    item.id = id;
+    item.type = type;
+    item.role = role;
+    item.label = label;
+    item.source_file = source_file;
+    item.x = x;
+    item.y = y;
+    item.z = z;
+    item.roll = roll;
+    item.pitch = pitch;
+    item.yaw = yaw;
+    item.width = width;
+    item.depth = depth;
+    item.height = height;
+    item.radius = radius;
+    item.locked = locked;
+    m.items.push_back(item);
+  };
+
+  push_default_item("robot_base", "robot_base", "robot", "Robot Base", "environment.yaml", 0, 0, 0, 0, 0, 0, 0.35, 0.35, 0.35, 0, true);
+  push_default_item("robot_reach", "reach", "reach", "Robot Reach", "environment.yaml", 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.2, true);
+  push_default_item("table", "table", "table", "Table", "environment.yaml", 0.7, 0.0, 0, 0, 0, 0, 1.0, 0.6, 0.2, 0, false);
+  push_default_item("conveyor", "conveyor", "conveyor", "Conveyor", "environment.yaml", -0.8, -0.3, 0, 0, 0, 0, 1.2, 0.3, 0.2, 0, false);
+  push_default_item("camera", "camera", "camera", "Camera FOV", "environment.yaml", -0.2, 1.0, 1.2, 0, 0, -1.57, 0.18, 0.18, 0.2, 0, false);
+  push_default_item("pick_zone", "zone", "pick_zone", "Pick Source", "config/task_recipe.yaml", 0.55, 0.0, 0, 0, 0, 0, 0.35, 0.35, 0.1, 0, false);
+  push_default_item("place_zone", "zone", "place_zone", "Place Target", "config/task_recipe.yaml", 1.0, 0.1, 0, 0, 0, 0, 0.35, 0.35, 0.1, 0, false);
+  push_default_item("bin_a", "bin", "bin", "Bin A", "environment.yaml", 1.3, -0.5, 0, 0, 0, 0, 0.32, 0.25, 0.2, 0, false);
+  push_default_item("object_a", "object", "object", "Object", "environment.yaml", 0.6, 0.1, 0, 0, 0, 0, 0.08, 0.08, 0.08, 0, false);
+  push_default_item("home_pose", "safety", "safety/home", "config/workcell_builder_task_intent.yaml", "config/workcell_builder_task_intent.yaml", -0.4, 0.5, 0, 0, 0, 0, 0.14, 0.14, 0.14, 0, true);
 
   const std::string schema_version = read_string_or_warn(yaml_map_key(layout, "schema_version"), "schema_version", "");
   YAML::Node layout_items = yaml_map_key(layout, "items");


### PR DESCRIPTION
## Summary
- Removed duplicate `mesh_scale_x/mesh_scale_y/mesh_scale_z` declarations from `ScenePreviewWidget::PreviewItem` in `scene_preview_widget.h`.
- Removed duplicate `mesh_path`, `mesh_available`, and `mesh_load_warning` declarations from `WorkcellStudioCanvasItem` in `workcell_studio_canvas_model.hpp`.
- Fixed ASCII STL parsing in `scene3d_viewport_widget.cpp` by switching `parse_ascii_stl()` from invalid `QTextStream` boolean-style extraction to `std::istringstream` token parsing.
- Replaced fragile positional aggregate `push_back` initializers in `src_workcell_studio_canvas_model.cpp` with explicit field assignment via a helper lambda, preventing struct-order breakage.

## Validation
- Searched for duplicates:
  - `rg -n "mesh_scale_x" workcell_builder/workcell_builder`
  - `rg -n "mesh_path" workcell_builder/workcell_builder/include workcell_builder/workcell_builder/gui`
- Attempted build:
  - `~/.local/bin/colcon build --symlink-install --packages-select workcell_builder`
  - Build is blocked in this environment due to missing ROS/ament toolchain (`ament_cmake` not found), but the prior redeclaration and QTextStream compile issues are addressed in source.
- Ran quick test discovery command:
  - `ctest --test-dir build/workcell_builder --output-on-failure || true`

## Scope control
- No 3D viewport redesign.
- No new STL features.
- No changes to scene generation logic beyond compile-safe item construction.
- No changes to robot motion/planning behavior.
- No changes to safety/fake-hardware defaults.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a221946c48331bb65eaf5e61a92da)