### PR TITLE
Add reusable Workcell Studio ID utility for add/save flows

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -145,6 +145,7 @@ add_executable(workcell_builder
     src_workcell_studio_canvas_model.cpp
     src_workcell_studio_layout_editor.cpp
     src_workcell_studio_layout_merge.cpp
+    src_workcell_studio_id_utils.cpp
     src_external_asset_importer.cpp
     gui/asset_picker_dialog.cpp
     gui/object_placement_dialog.cpp

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -100,6 +100,7 @@
 #include "workcell_studio_canvas_model.hpp"
 #include "scene_preview_widget.h"
 #include "workcell_studio_layout_editor.hpp"
+#include "workcell_studio_id_utils.hpp"
 #include "gui/new_cell_wizard.h"
 #include "include/workcell_builder_command_builders.hpp"
 
@@ -3166,8 +3167,14 @@ void MainWindow::save_layout_changes()
   for (auto * gi : digital_twin_scene_->items()) {
     if (gi->data(RoleRole).toString() != "asset") continue;
     YAML::Node item(YAML::NodeType::Map);
-    item["id"] = gi->data(RoleId).toString().toStdString();
-    item["name"] = gi->data(RoleDisplayName).toString().toStdString();
+    const std::string item_id = gi->data(RoleId).toString().toStdString();
+    if (!workcell_builder::workcell_studio_is_valid_id(item_id)) {
+      QMessageBox::warning(this, "Save Layout", QString("Invalid ID for YAML/package compatibility: %1").arg(QString::fromStdString(item_id)));
+      append_studio_log(QString("Save blocked: invalid id '%1'").arg(QString::fromStdString(item_id)));
+      return;
+    }
+    item["id"] = item_id;
+    item["display_name"] = gi->data(RoleDisplayName).toString().toStdString();
     item["category"] = gi->data(RoleCategory).toString().toStdString();
     item["type"] = gi->data(RoleType).toString().toStdString();
     item["source_path"] = gi->data(RoleSource).toString().toStdString();
@@ -3286,11 +3293,16 @@ void MainWindow::add_asset_to_canvas_from_catalog(const QString & category, cons
 {
   if (!digital_twin_scene_) { rebuild_digital_twin_canvas(); }
   if (!digital_twin_scene_) return;
-  const QString prefix = id_prefix_from_category(category);
-  int suffix = 1;
-  QString new_id;
-  auto exists = [&](const QString & candidate){ for (auto * gi : digital_twin_scene_->items()) if (gi->data(RoleId).toString() == candidate) return true; return false; };
-  do { new_id = QString("%1_%2").arg(prefix).arg(suffix++, 2, 10, QLatin1Char('0')); } while (exists(new_id));
+  std::set<std::string> reserved_ids;
+  for (auto * gi : digital_twin_scene_->items()) {
+    const QString existing_id = gi->data(RoleId).toString().trimmed();
+    if (!existing_id.isEmpty()) reserved_ids.insert(existing_id.toStdString());
+  }
+  const fs::path layout_path = selected_scene_environment_layout_path(scene_browser_result_, selected_scene_index_);
+  const auto existing_layout_ids = workcell_builder::workcell_studio_collect_layout_ids(layout_path);
+  reserved_ids.insert(existing_layout_ids.begin(), existing_layout_ids.end());
+  const std::string id_prefix = workcell_builder::workcell_studio_id_prefix_for_type(category.toStdString());
+  const QString new_id = QString::fromStdString(workcell_builder::workcell_studio_next_id(category.toStdString(), reserved_ids));
 
   auto * item = new DraggableCanvasItem(QRectF(0, 0, 35.0, 35.0));
   QPointF placement = default_xy_for_category(category);
@@ -3301,7 +3313,7 @@ void MainWindow::add_asset_to_canvas_from_catalog(const QString & category, cons
   item->setPos(placement);
   item->setData(RoleId, new_id);
   item->setData(RoleDisplayName, display_name);
-  item->setData(RoleType, prefix);
+  item->setData(RoleType, QString::fromStdString(id_prefix));
   item->setData(RoleCategory, category);
   item->setData(RoleRole, "asset");
   item->setData(RoleSource, source_path);

--- a/workcell_builder/workcell_builder/include/workcell_studio_id_utils.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_studio_id_utils.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <boost/filesystem.hpp>
+#include <set>
+#include <string>
+
+namespace workcell_builder {
+
+std::string workcell_studio_id_prefix_for_type(const std::string & type_or_category);
+bool workcell_studio_is_valid_id(const std::string & id);
+std::set<std::string> workcell_studio_collect_layout_ids(const boost::filesystem::path & layout_path);
+std::string workcell_studio_next_id(const std::string & type_or_category, const std::set<std::string> & reserved_ids);
+
+}  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/src_workcell_studio_id_utils.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_id_utils.cpp
@@ -1,0 +1,98 @@
+#include "workcell_studio_id_utils.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <regex>
+#include <yaml-cpp/yaml.h>
+
+namespace fs = boost::filesystem;
+
+namespace workcell_builder {
+namespace {
+
+std::string lowercase(std::string text)
+{
+  std::transform(text.begin(), text.end(), text.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+  return text;
+}
+
+std::string read_string(const YAML::Node & node)
+{
+  if (!node || !node.IsScalar()) return "";
+  try {
+    return node.as<std::string>("");
+  } catch (...) {
+    return "";
+  }
+}
+
+void add_id_if_valid(const YAML::Node & node, std::set<std::string> * ids)
+{
+  const std::string id = read_string(node);
+  if (!id.empty()) ids->insert(id);
+}
+
+}  // namespace
+
+std::string workcell_studio_id_prefix_for_type(const std::string & type_or_category)
+{
+  const std::string text = lowercase(type_or_category);
+  if (text.find("table") != std::string::npos) return "table";
+  if (text.find("bin") != std::string::npos) return "bin";
+  if (text.find("conveyor") != std::string::npos) return "conveyor";
+  if (text.find("camera") != std::string::npos) return "camera";
+  if (text.find("pick") != std::string::npos && text.find("zone") != std::string::npos) return "pick_zone";
+  if (text.find("place") != std::string::npos && text.find("zone") != std::string::npos) return "place_zone";
+  if (text.find("object") != std::string::npos) return "object";
+  if (text.find("safety") != std::string::npos) return "safety_zone";
+  if (text.find("fixture") != std::string::npos) return "fixture";
+  return "object";
+}
+
+bool workcell_studio_is_valid_id(const std::string & id)
+{
+  static const std::regex kIdPattern("^[a-z][a-z0-9_]{1,62}$");
+  return std::regex_match(id, kIdPattern);
+}
+
+std::set<std::string> workcell_studio_collect_layout_ids(const fs::path & layout_path)
+{
+  std::set<std::string> ids;
+  if (!fs::exists(layout_path)) return ids;
+  YAML::Node root;
+  try {
+    root = YAML::LoadFile(layout_path.string());
+  } catch (...) {
+    return ids;
+  }
+  YAML::Node placed = root["placed_assets"];
+  if (placed && placed.IsSequence()) {
+    for (const auto & item : placed) {
+      if (!item.IsMap()) continue;
+      add_id_if_valid(item["id"], &ids);
+    }
+  }
+  YAML::Node items = root["items"];
+  if (items && items.IsSequence()) {
+    for (const auto & item : items) {
+      if (!item.IsMap()) continue;
+      add_id_if_valid(item["id"], &ids);
+    }
+  }
+  return ids;
+}
+
+std::string workcell_studio_next_id(const std::string & type_or_category, const std::set<std::string> & reserved_ids)
+{
+  const std::string prefix = workcell_studio_id_prefix_for_type(type_or_category);
+  for (int suffix = 1; suffix <= 99; ++suffix) {
+    char buffer[32];
+    std::snprintf(buffer, sizeof(buffer), "%s_%02d", prefix.c_str(), suffix);
+    const std::string candidate(buffer);
+    if (reserved_ids.find(candidate) == reserved_ids.end()) return candidate;
+  }
+  return prefix + "_99";
+}
+
+}  // namespace workcell_builder


### PR DESCRIPTION
### Motivation
- Provide a single reusable utility for deterministic, collision-safe machine IDs used by canvas add flows and layout serialization.
- Ensure IDs are YAML/package compatible and keep an immutable machine `id` separate from an editable `display_name` to avoid accidental package breakage.

### Description
- Added a new utility module with `workcell_studio_id_prefix_for_type`, `workcell_studio_is_valid_id`, `workcell_studio_collect_layout_ids`, and `workcell_studio_next_id` in `workcell_studio_id_utils.*` to map type/category -> deterministic prefix, validate IDs against the regex `^[a-z][a-z0-9_]{1,62}$`, gather IDs from existing layout YAML, and allocate a `_NN` suffix (01..99) next ID.
- Wired the utility into `MainWindow::add_asset_to_canvas_from_catalog()` so new IDs are chosen via `workcell_studio_next_id()` while checking collisions against both current canvas items and IDs collected from the saved layout YAML via `workcell_studio_collect_layout_ids()`.
- Wired the utility into `MainWindow::save_layout_changes()` to validate `id` with `workcell_studio_is_valid_id()` before writing and switched the serialized UI field from `name` to `display_name` so `id` remains the immutable machine identifier.
- Added the new source file to the build by updating `CMakeLists.txt`.

### Testing
- Ran `pytest -q tests/test_workcell_studio_asset_to_canvas.py tests/test_workcell_studio_new_cell_button_audit.py` and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a24946e4c8331861c6fc4408a6c70)