### PR TITLE
Refactor environment_layout save to preserve non-placement YAML content

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -3121,9 +3121,13 @@ void MainWindow::save_layout_changes()
   if (!digital_twin_scene_) return;
   const fs::path layout_path = selected_scene_environment_layout_path(scene_browser_result_, selected_scene_index_);
   if (layout_path.empty()) return;
+  const std::string scene_name = (selected_scene_index_ >= 0 && selected_scene_index_ < static_cast<int>(scene_browser_result_.scenes.size())) ?
+    scene_browser_result_.scenes[static_cast<size_t>(selected_scene_index_)].scene_name : "unknown";
   YAML::Node root;
+  bool existing_layout_file = false;
   bool malformed_existing = false;
   if (fs::exists(layout_path)) {
+    existing_layout_file = true;
     try {
       root = YAML::LoadFile(layout_path.string());
     } catch (const YAML::Exception &) {
@@ -3146,13 +3150,19 @@ void MainWindow::save_layout_changes()
     root = YAML::Node();
   }
   if (!root || !root.IsMap()) {
-    const std::string scene_name = (selected_scene_index_ >= 0 && selected_scene_index_ < static_cast<int>(scene_browser_result_.scenes.size())) ? scene_browser_result_.scenes[static_cast<size_t>(selected_scene_index_)].scene_name : "unknown";
     root = minimal_environment_layout(scene_name);
   }
+  // Ownership boundary: the canvas placement serializer only owns and mutates:
+  // - schema_version (required environment_layout/v1 metadata)
+  // - placed_assets (asset placement list)
+  // All other top-level and nested fields are preserved exactly as loaded.
   root["schema_version"] = "environment_layout/v1";
+  if (!root["scene_name"] || !root["scene_name"].IsScalar()) {
+    root["scene_name"] = scene_name;
+  }
   const QString backup_stamp = QDateTime::currentDateTimeUtc().toString("yyyyMMdd_HHmmss_zzz");
   const fs::path layout_backup = layout_path.parent_path() / ("environment_layout." + backup_stamp.toStdString() + ".bak.yaml");
-  if (fs::exists(layout_path)) {
+  if (existing_layout_file) {
     boost::system::error_code ec;
     fs::copy_file(layout_path, layout_backup, fs::copy_option::overwrite_if_exists, ec);
     if (!ec) {


### PR DESCRIPTION
### Motivation
- Preserve user- or tool-owned YAML data when saving canvas placements instead of blindly replacing `environment_layout.yaml`.
- Ensure safe updates by backing up existing valid files and keeping the malformed-file guard, and create a minimal valid `environment_layout/v1` doc when missing.
- Clearly document the ownership boundary for the placement serializer so future changes do not accidentally mutate unrelated fields.

### Description
- Updated `MainWindow::save_layout_changes()` in `mainwindow.cpp` to parse an existing `environment_layout.yaml` into a `YAML::Node` when present and track whether the file existed via the `existing_layout_file` flag.
- Added an ownership-boundary comment and limited mutations to placement-owned nodes by writing `schema_version` and `placed_assets` and backfilling `scene_name` only if absent or non-scalar, while preserving all other top-level and nested fields.
- Retained and improved backup behavior by creating a timestamped backup for any existing `environment_layout.yaml` prior to overwrite and preserving the existing malformed-file backup-and-abort handling.
- Kept existing behavior of creating a minimal valid document via `minimal_environment_layout(...)` when no valid map is present, and ensured legacy `environment.yaml` is not modified by this flow.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a24968c008331b3fdf961e702b695)