### PR TITLE
Prompt-before-write refactor for pick/place zone binding with No-path regression test

### DIFF
--- a/tests/test_workcell_builder_pick_place_zone_prompt_flow.py
+++ b/tests/test_workcell_builder_pick_place_zone_prompt_flow.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CPP = ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp"
+
+
+def _body(fn: str, text: str) -> str:
+    start = text.index(f"void MainWindow::{fn}()")
+    brace = text.index("{", start)
+    depth = 0
+    for i in range(brace, len(text)):
+        ch = text[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace:i+1]
+    raise AssertionError("function body not found")
+
+
+def test_pick_zone_no_decline_does_not_mutate_source_or_zone_fields():
+    text = CPP.read_text(encoding="utf-8")
+    body = _body("bind_selected_item_as_pick_zone", text)
+
+    prompt_idx = body.index("QMessageBox::question")
+    src_update_idx = body.index('update_selected_scene_task_intent_binding("Pick Source"')
+    zone_update_idx = body.index('update_selected_scene_task_intent_binding("Pick Zone"')
+    assert prompt_idx < src_update_idx
+    assert prompt_idx < zone_update_idx
+
+    else_block = body.split("else", 1)[1]
+    assert 'update_selected_scene_task_intent_binding("Pick Source"' not in else_block
+    assert 'update_selected_scene_task_intent_binding("Pick Zone"' not in else_block
+
+
+def test_place_zone_no_decline_does_not_mutate_target_or_zone_fields():
+    text = CPP.read_text(encoding="utf-8")
+    body = _body("bind_selected_item_as_place_zone", text)
+
+    prompt_idx = body.index("QMessageBox::question")
+    target_update_idx = body.index('update_selected_scene_task_intent_binding("Place Target"')
+    zone_update_idx = body.index('update_selected_scene_task_intent_binding("Place Zone"')
+    assert prompt_idx < target_update_idx
+    assert prompt_idx < zone_update_idx
+
+    else_block = body.split("else", 1)[1]
+    assert 'update_selected_scene_task_intent_binding("Place Target"' not in else_block
+    assert 'update_selected_scene_task_intent_binding("Place Zone"' not in else_block

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1868,14 +1868,18 @@ void MainWindow::bind_selected_item_as_pick_zone()
     append_studio_log(QString("Use Selected as Pick Source/Zone warning: selected item '%1' may be incompatible (role/category: %2). Applying override.")
       .arg(state.id, state.role_or_category.isEmpty() ? "unknown" : state.role_or_category));
   }
-  const bool pick_zone_written = update_selected_scene_task_intent_binding("Pick Zone", {"pick", "zone", "id"}, state.id.trimmed());
-  if (!pick_zone_written) return;
   const auto choice = QMessageBox::question(this, "Workcell Studio", "Use this zone for task intent?", QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
   append_studio_log("Task intent zone prompt (pick) shown: Use this zone for task intent?");
   if (choice == QMessageBox::Yes) {
-    update_selected_scene_task_intent_binding("Pick Source", {"pick", "source", "id"}, state.id.trimmed());
+    const bool pick_zone_written = update_selected_scene_task_intent_binding("Pick Zone", {"pick", "zone", "id"}, state.id.trimmed());
+    if (!pick_zone_written) return;
+    const bool pick_source_written = update_selected_scene_task_intent_binding("Pick Source", {"pick", "source", "id"}, state.id.trimmed());
+    if (pick_source_written) {
+      append_studio_log("Task intent binding applied: zone metadata saved and pick source bound.");
+    }
   } else {
     append_studio_log("Task intent zone prompt declined for pick source binding.");
+    append_studio_log("Task intent binding skipped: pick zone metadata and pick source left unchanged.");
   }
 }
 
@@ -1890,14 +1894,18 @@ void MainWindow::bind_selected_item_as_place_zone()
     append_studio_log(QString("Use Selected as Place Target/Zone warning: selected item '%1' may be incompatible (role/category: %2). Applying override.")
       .arg(state.id, state.role_or_category.isEmpty() ? "unknown" : state.role_or_category));
   }
-  const bool place_zone_written = update_selected_scene_task_intent_binding("Place Zone", {"place", "zone", "id"}, state.id.trimmed());
-  if (!place_zone_written) return;
   const auto choice = QMessageBox::question(this, "Workcell Studio", "Use this zone for task intent?", QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
   append_studio_log("Task intent zone prompt (place) shown: Use this zone for task intent?");
   if (choice == QMessageBox::Yes) {
-    update_selected_scene_task_intent_binding("Place Target", {"place", "target", "id"}, state.id.trimmed());
+    const bool place_zone_written = update_selected_scene_task_intent_binding("Place Zone", {"place", "zone", "id"}, state.id.trimmed());
+    if (!place_zone_written) return;
+    const bool place_target_written = update_selected_scene_task_intent_binding("Place Target", {"place", "target", "id"}, state.id.trimmed());
+    if (place_target_written) {
+      append_studio_log("Task intent binding applied: zone metadata saved and place target bound.");
+    }
   } else {
     append_studio_log("Task intent zone prompt declined for place target binding.");
+    append_studio_log("Task intent binding skipped: place zone metadata and place target left unchanged.");
   }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent accidental mutation of task-intent YAML when user declines the pick/place zone confirmation by prompting before any task-intent writes.  
- Make behavior explicit: only apply zone metadata + binding when user confirms, and emit clear logs for accepted/declined flows.  
- Preserve existing YAML merge/update-in-place semantics so unknown/manual fields are retained.  

### Description
- Reordered the pick/place binding flow in `workcell_builder/workcell_builder/gui/mainwindow.cpp` so the `QMessageBox::question` prompt runs before calling `update_selected_scene_task_intent_binding(...)`.  
- Chosen explicit behavior: on **Yes** run the zone metadata save and the corresponding source/target binding calls; on **No** do not call any binding/update functions and emit skip log lines.  
- Added clearer log entries for both accepted (`Task intent binding applied: ...`) and declined (`Task intent binding skipped: ...`) branches.  
- Added a regression test `tests/test_workcell_builder_pick_place_zone_prompt_flow.py` that asserts the prompt precedes any zone/source/target update calls and that the No branch does not perform writes; kept existing `update_selected_scene_task_intent_binding(...)` usage so YAML merge/update-in-place semantics are preserved.  

### Testing
- Ran `pytest -q tests/test_workcell_builder_pick_place_zone_prompt_flow.py` and it passed (2 tests).  
- Ran `pytest -q tests/test_workcell_builder_task_intent_zones.py` and it passed (1 test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0acadc76688331bb180e612c950ab0)