### PR TITLE
Use shared ID allocator for asset placement to avoid ID collisions

### DIFF
--- a/tests/test_workcell_studio_asset_id_generation_regression.py
+++ b/tests/test_workcell_studio_asset_id_generation_regression.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+CPP = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+
+
+def test_commit_armed_asset_placement_uses_shared_id_generator_with_layout_merge():
+    required_tokens = [
+        'void MainWindow::commit_armed_asset_placement',
+        'std::set<std::string> reserved_ids;',
+        'gi->data(RoleId).toString().trimmed()',
+        'selected_scene_environment_layout_path(scene_browser_result_, selected_scene_index_)',
+        'workcell_builder::workcell_studio_collect_layout_ids(layout_path)',
+        'reserved_ids.insert(layout_ids.begin(), layout_ids.end());',
+        'workcell_builder::workcell_studio_next_id(category.toStdString(), reserved_ids)',
+        'item->setData(RoleId, new_id);',
+        'item->setData(RoleType, role_type);',
+        'item->setData(RoleDisplayName, display_name);',
+    ]
+    for token in required_tokens:
+        assert token in CPP
+
+
+def test_no_local_id_suffix_loop_in_commit_armed_asset_placement():
+    forbidden_tokens = [
+        'const QString prefix = id_prefix_from_category(category);',
+        'int suffix = 1;',
+        'do { new_id = QString("%1_%2")',
+    ]
+    for token in forbidden_tokens:
+        assert token not in CPP
+
+
+def test_arm_place_asset_mode_only_arms_state_not_id_generation():
+    arm_start = CPP.index('void MainWindow::arm_place_asset_mode')
+    commit_start = CPP.index('void MainWindow::commit_armed_asset_placement')
+    arm_block = CPP[arm_start:commit_start]
+    assert 'workcell_studio_next_id' not in arm_block
+    assert 'workcell_studio_collect_layout_ids' not in arm_block

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -3446,16 +3446,6 @@ void MainWindow::arm_place_asset_mode(const QString & category, const QString & 
 {
   if (!digital_twin_scene_) { rebuild_digital_twin_canvas(); }
   if (!digital_twin_scene_) return;
-  std::set<std::string> reserved_ids;
-  for (auto * gi : digital_twin_scene_->items()) {
-    const QString existing_id = gi->data(RoleId).toString().trimmed();
-    if (!existing_id.isEmpty()) reserved_ids.insert(existing_id.toStdString());
-  }
-  const fs::path layout_path = selected_scene_environment_layout_path(scene_browser_result_, selected_scene_index_);
-  const auto existing_layout_ids = workcell_builder::workcell_studio_collect_layout_ids(layout_path);
-  reserved_ids.insert(existing_layout_ids.begin(), existing_layout_ids.end());
-  const std::string id_prefix = workcell_builder::workcell_studio_id_prefix_for_type(category.toStdString());
-  const QString new_id = QString::fromStdString(workcell_builder::workcell_studio_next_id(category.toStdString(), reserved_ids));
   place_asset_armed_ = true;
   armed_asset_category_ = category;
   armed_asset_display_name_ = display_name;
@@ -3470,11 +3460,18 @@ void MainWindow::commit_armed_asset_placement(const QPointF & canvas_pos_px)
   const QString category = armed_asset_category_;
   const QString display_name = armed_asset_display_name_;
   const QString source_path = armed_asset_source_path_;
-  const QString prefix = id_prefix_from_category(category);
-  int suffix = 1;
-  QString new_id;
-  auto exists = [&](const QString & candidate){ for (auto * gi : digital_twin_scene_->items()) if (gi->data(RoleId).toString() == candidate) return true; return false; };
-  do { new_id = QString("%1_%2").arg(prefix).arg(suffix++, 2, 10, QLatin1Char('0')); } while (exists(new_id));
+  std::set<std::string> reserved_ids;
+  for (auto * gi : digital_twin_scene_->items()) {
+    const QString existing_id = gi->data(RoleId).toString().trimmed();
+    if (!existing_id.isEmpty()) reserved_ids.insert(existing_id.toStdString());
+  }
+  const fs::path layout_path = selected_scene_environment_layout_path(scene_browser_result_, selected_scene_index_);
+  const auto layout_ids = workcell_builder::workcell_studio_collect_layout_ids(layout_path);
+  reserved_ids.insert(layout_ids.begin(), layout_ids.end());
+  const QString new_id = QString::fromStdString(
+    workcell_builder::workcell_studio_next_id(category.toStdString(), reserved_ids));
+  const QString role_type = QString::fromStdString(
+    workcell_builder::workcell_studio_id_prefix_for_type(category.toStdString()));
 
   auto * item = new DraggableCanvasItem(QRectF(0, 0, 35.0, 35.0));
   QPointF placement = snap_canvas_position(canvas_pos_px);
@@ -3488,7 +3485,7 @@ void MainWindow::commit_armed_asset_placement(const QPointF & canvas_pos_px)
   item->setPos(placement);
   item->setData(RoleId, new_id);
   item->setData(RoleDisplayName, display_name);
-  item->setData(RoleType, QString::fromStdString(id_prefix));
+  item->setData(RoleType, role_type);
   item->setData(RoleCategory, category);
   item->setData(RoleRole, "asset");
   item->setData(RoleSource, source_path);


### PR DESCRIPTION
### Motivation
- Prevent divergence between in-memory placement and saved layout IDs by removing local ad-hoc ID generation and using the shared allocator. 
- Ensure placed assets receive IDs that account for both current canvas items and IDs already present in the selected environment layout. 
- Make metadata assignment consistent and predictable for downstream save/preview/export logic.

### Description
- Removed unused ID pre-generation from `arm_place_asset_mode()` so it only arms the placement state (`place_asset_armed_`, `armed_asset_*`) and no longer computes a `new_id`. 
- Reworked `commit_armed_asset_placement()` to collect reserved IDs from canvas items via `RoleId` and merge them with IDs returned by `workcell_studio_collect_layout_ids(selected_scene_environment_layout_path(...))`, then call `workcell_studio_next_id(category.toStdString(), reserved_ids)` to obtain the new ID. 
- Standardized placed-item metadata assignments so `RoleId` is the generated ID, `RoleType` is `workcell_studio_id_prefix_for_type(category.toStdString())`, and `RoleDisplayName` is the armed display name. 
- Removed the local `prefix/suffix` `do-while` ID loop to avoid local allocator divergence and to rely exclusively on the shared `workcell_studio_next_id` implementation. 

### Testing
- Added `tests/test_workcell_studio_asset_id_generation_regression.py` to assert the new allocation flow and that arm mode no longer performs ID generation. 
- Ran `pytest -q tests/test_workcell_studio_asset_id_generation_regression.py tests/test_workcell_studio_real_asset_placement.py` and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0acc3f77048331aad9473de680b77f)