### PR TITLE
Handle incomplete perception pose vectors in readiness report

### DIFF
--- a/scripts/generate_workcell_studio_readiness_pack.py
+++ b/scripts/generate_workcell_studio_readiness_pack.py
@@ -54,15 +54,49 @@ def _generate_perception_readiness(profile_path: Path, snapshot_path: Path, outp
     prof = yaml.safe_load(profile_path.read_text(encoding='utf-8')) if profile_path.exists() else {}
     snap = yaml.safe_load(snapshot_path.read_text(encoding='utf-8')) if snapshot_path.exists() else {}
     warnings, blockers = [], []
-    obj = ((snap.get('objects') or [{}])[0]) if isinstance(snap, dict) else {}
-    frame_ok = isinstance(obj, dict) and obj.get('frame_id') == ((prof.get('frames') or {}).get('scene_frame') if isinstance(prof, dict) else None)
-    if not frame_ok:
-        warnings.append('Detected object frame does not match scene frame')
-    label = obj.get('label') if isinstance(obj, dict) else None
-    routeable = isinstance(label, str) and bool(label.strip())
-    pose = obj.get('pose', {}) if isinstance(obj, dict) else {}
-    xyz = pose.get('xyz', []) if isinstance(pose, dict) else []
-    in_pick_zone_hint = isinstance(xyz, list) and len(xyz) == 3 and 0.0 <= float(xyz[0]) <= 1.5 and -1.0 <= float(xyz[1]) <= 1.0
+
+    objects = snap.get('objects') if isinstance(snap, dict) and isinstance(snap.get('objects'), list) else []
+    scene_frame = (prof.get('frames') or {}).get('scene_frame') if isinstance(prof, dict) else None
+    frame_ok = False
+    routeable = False
+    in_pick_zone_hint = False
+    selected_obj = None
+
+    for idx, obj in enumerate(objects):
+        if not isinstance(obj, dict):
+            warnings.append(f"Skipping detected object index {idx}: object payload is not a mapping.")
+            continue
+
+        pose = obj.get('pose', {}) if isinstance(obj.get('pose'), dict) else {}
+        xyz = pose.get('xyz', []) if isinstance(pose, dict) else []
+        if not (isinstance(xyz, list) and len(xyz) >= 3):
+            warnings.append(
+                f"Skipping detected object '{obj.get('id', f'index_{idx}')}' due to incomplete pose.xyz vector (size={len(xyz) if isinstance(xyz, list) else 'n/a'})."
+            )
+            continue
+
+        try:
+            x = float(xyz[0])
+            y = float(xyz[1])
+        except (TypeError, ValueError):
+            warnings.append(
+                f"Skipping detected object '{obj.get('id', f'index_{idx}')}' due to non-numeric pose.xyz values."
+            )
+            continue
+
+        selected_obj = obj
+        frame_ok = obj.get('frame_id') == scene_frame
+        if not frame_ok:
+            warnings.append('Detected object frame does not match scene frame')
+
+        label = obj.get('label')
+        routeable = isinstance(label, str) and bool(label.strip())
+        in_pick_zone_hint = 0.0 <= x <= 1.5 and -1.0 <= y <= 1.0
+        break
+
+    if selected_obj is None:
+        blockers.append('No valid detected object with complete pose.xyz[0..2] available for readiness checks.')
+
     status = 'perception_replay_ready'
     if not routeable:
         blockers.append('Object label/class missing for routing check')

--- a/tests/test_generate_workcell_studio_readiness_pack_perception.py
+++ b/tests/test_generate_workcell_studio_readiness_pack_perception.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from scripts.generate_workcell_studio_readiness_pack import _generate_perception_readiness
+
+
+def test_generate_perception_readiness_skips_incomplete_pose_xyz(tmp_path: Path) -> None:
+    profile = tmp_path / "profile.yaml"
+    snapshot = tmp_path / "snapshot.yaml"
+    output = tmp_path / "report.json"
+
+    profile.write_text(
+        """
+schema: workcell_perception_profile/v1
+frames:
+  scene_frame: world
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    snapshot.write_text(
+        """
+schema_version: detected_objects/v1
+objects:
+  - id: bad_obj
+    label: cube
+    frame_id: world
+    pose:
+      xyz: [0.1, 0.2]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    status, warnings, blockers = _generate_perception_readiness(profile, snapshot, output)
+
+    assert status == "perception_partial"
+    assert any("Skipping detected object 'bad_obj'" in item for item in warnings)
+    assert any("No valid detected object" in item for item in blockers)
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["status"] == "perception_partial"


### PR DESCRIPTION
### Motivation
- Prevent exceptions when readiness code indexed `pose.xyz` for detected objects with incomplete vectors and make perception readiness generation more robust.
- Prefer skipping malformed detections with warning context and continuing to find a valid object rather than throwing.

### Description
- Updated `_generate_perception_readiness` in `scripts/generate_workcell_studio_readiness_pack.py` to iterate detected objects and only index Cartesian components when `pose.xyz` is a list with `len >= 3` and numeric entries. 
- Added defensive checks that skip non-mapping objects or those with incomplete/non-numeric `xyz`, appending warnings instead of raising, and break on the first valid object found. 
- Emit a blocker (`No valid detected object with complete pose.xyz[0..2] available for readiness checks.`) when no usable object remains and ensure report `status` becomes `perception_partial` when blockers exist. 
- Added regression test `tests/test_generate_workcell_studio_readiness_pack_perception.py` that supplies a snapshot with an incomplete `pose.xyz` and asserts the report is produced without throwing and contains the expected warnings/blockers.

### Testing
- Ran `pytest -q tests/test_generate_workcell_studio_readiness_pack_perception.py`, which completed successfully with `1 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0acc42fab08331af0b7c3dc33feef8)