### PR TITLE
Fix regressions from PRs #1757-#1764 in workcell_builder

### DIFF
--- a/tests/test_workcell_builder_regression_repairs.py
+++ b/tests/test_workcell_builder_regression_repairs.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+CPP = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+DISC_H = Path('workcell_builder/workcell_builder/gui/asset_catalog_discovery.h').read_text(encoding='utf-8')
+DISC_CPP = Path('workcell_builder/workcell_builder/gui/asset_catalog_discovery.cpp').read_text(encoding='utf-8')
+CMAKE = Path('workcell_builder/workcell_builder/CMakeLists.txt').read_text(encoding='utf-8')
+
+
+def test_discovered_asset_role_hint_model_is_defined_and_populated():
+    assert 'std::string role_hint;' in DISC_H
+    assert 'entry.role_hint = infer_role_hint(entry.category, entry.source_kind);' in DISC_CPP
+    assert 'inferred.role_hint = infer_role_hint(inferred.category, inferred.source_kind);' in DISC_CPP
+
+
+def test_generate_yaml_repairs_invalid_existing_cell_definition():
+    assert 'existing valid cell_definition.yaml preserved' in CPP
+    assert 'invalid cell_definition.yaml backed up and regenerated' in CPP
+    assert 'new cell_definition.yaml generated' in CPP
+    assert 'validate_cell_definition.py' in CPP
+
+
+def test_pick_place_yes_path_uses_single_multi_key_write_helper():
+    assert 'update_selected_scene_task_intent_bindings("Pick Zone + Pick Source"' in CPP
+    assert 'update_selected_scene_task_intent_bindings("Place Zone + Place Target"' in CPP
+
+
+def test_more_actions_qactions_wired_and_no_stale_hidden_buttons():
+    for token in [
+        '&MainWindow::generate_yaml_draft_for_selected_scene',
+        '&MainWindow::generate_or_update_task_intent_for_selected_scene',
+        '&MainWindow::copy_build_launch_commands_for_selected_scene',
+        '&MainWindow::delete_selected_item',
+        '&MainWindow::bind_selected_item_as_pick_zone',
+        '&MainWindow::bind_selected_item_as_place_zone',
+        '&MainWindow::bind_selected_item_as_camera',
+    ]:
+        assert token in CPP
+
+
+def test_asset_catalog_discovery_test_links_warning_once_impl():
+    assert 'ament_add_gtest(workcell_asset_catalog_discovery_test' in CMAKE
+    assert 'src_workcell_warning_once.cpp' in CMAKE

--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -146,6 +146,7 @@ add_executable(workcell_builder
     src_workcell_studio_layout_editor.cpp
     src_workcell_studio_layout_merge.cpp
     src_workcell_studio_id_utils.cpp
+    src_workcell_warning_once.cpp
     src_external_asset_importer.cpp
     gui/asset_picker_dialog.cpp
     gui/object_placement_dialog.cpp
@@ -317,6 +318,7 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_asset_catalog_discovery_test
     test/asset_catalog_discovery_test.cpp
     gui/asset_catalog_discovery.cpp
+    src_workcell_warning_once.cpp
     src_workcell_yaml_utils.cpp)
   if(TARGET workcell_scene_preview_widget_ui_test)
     target_link_libraries(workcell_scene_preview_widget_ui_test Qt5::Widgets Qt5::OpenGL OpenGL::GL)

--- a/workcell_builder/workcell_builder/gui/asset_catalog_discovery.cpp
+++ b/workcell_builder/workcell_builder/gui/asset_catalog_discovery.cpp
@@ -3,6 +3,7 @@
 #include "workcell_warning_once.hpp"
 
 #include <yaml-cpp/yaml.h>
+#include <boost/algorithm/string.hpp>
 #include <algorithm>
 #include <set>
 
@@ -10,6 +11,17 @@ namespace fs = boost::filesystem;
 
 namespace workcell_builder {
 namespace {
+std::string infer_role_hint(const std::string & category, const std::string & source_kind)
+{
+  const std::string key = boost::algorithm::to_lower_copy(category + " " + source_kind);
+  if (key.find("robot") != std::string::npos) return "robot";
+  if (key.find("end_effector") != std::string::npos || key.find("end effector") != std::string::npos) return "end_effector";
+  if (key.find("table") != std::string::npos) return "table";
+  if (key.find("conveyor") != std::string::npos) return "conveyor";
+  if (key.find("camera") != std::string::npos || key.find("sensor") != std::string::npos) return "camera";
+  if (key.find("bin") != std::string::npos || key.find("place") != std::string::npos) return "place_target";
+  return "object";
+}
 
 bool has_supported_geometry(const fs::path & dir)
 {
@@ -68,6 +80,7 @@ void parse_manifest_file(
     const fs::path canonical_path = fs::exists(resolved_path, source_ec) ? fs::canonical(resolved_path, source_ec) : resolved_path;
     entry.source_path = canonical_path.string();
     entry.source_kind = "manifest";
+    entry.role_hint = infer_role_hint(entry.category, entry.source_kind);
     const bool ready = fs::exists(resolved_path) && (fs::is_regular_file(resolved_path) || has_supported_geometry(resolved_path));
     entry.availability = ready ? "ready" : "incomplete";
     entry.reason = ready ? std::string() : "manifest path missing or lacks supported geometry";
@@ -94,6 +107,7 @@ void discover_from_root(const fs::path & root, std::vector<DiscoveredAssetCatalo
     inferred.display_name = inferred.asset_id;
     inferred.category = category;
     inferred.source_kind = "inferred";
+    inferred.role_hint = infer_role_hint(inferred.category, inferred.source_kind);
     boost::system::error_code source_ec;
     inferred.source_path = fs::canonical(candidate, source_ec).string();
     if (source_ec) inferred.source_path = candidate.string();
@@ -131,6 +145,7 @@ void add_template_asset_refs(const fs::path & repo_root, std::vector<DiscoveredA
       entry.display_name = entry.asset_id;
       entry.category = "Template References";
       entry.source_kind = "scene_template";
+      entry.role_hint = infer_role_hint(entry.category, entry.source_kind);
       entry.source_path = path.empty() ? key : path;
       const fs::path resolved = path.empty() ? fs::path() : (repo_root / path);
       const bool ready = !path.empty() && fs::exists(resolved);

--- a/workcell_builder/workcell_builder/gui/asset_catalog_discovery.h
+++ b/workcell_builder/workcell_builder/gui/asset_catalog_discovery.h
@@ -13,6 +13,7 @@ struct DiscoveredAssetCatalogEntry
   std::string category;
   std::string source_path;
   std::string source_kind;
+  std::string role_hint;
   std::string availability;
   std::string reason;
 };

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1612,7 +1612,88 @@ void MainWindow::refresh_task_intent_panel()
 
 void MainWindow::validate_task_intent_for_selected_scene(){ refresh_task_intent_panel(); append_studio_log("Task intent validation completed (Fake Hardware | No Robot Motion | Preview Only)"); }
 void MainWindow::generate_or_update_task_intent_for_selected_scene(){ if (selected_scene_index_ < 0) return; const auto & sc = scene_browser_result_.scenes[(size_t)selected_scene_index_]; QString script; helper_script_exists("create_or_update_builder_task_intent.py", &script); workcell_builder::TaskIntentCommandInput input; input.scene_package = QString::fromStdString(sc.scene_dir.string()); input.task_id = QString::fromStdString(sc.scene_name) + "_pick_place"; input.task_type = "pick_place"; input.task_template = "pick_place"; input.grasp_strategy = "finger_top"; const auto resolved_input = workcell_builder::resolve_task_intent_command_input_defaults(input); const auto plan = workcell_builder::build_task_intent_command_plan(script, resolved_input); if (!plan.ready()) { append_studio_log("Generate/Update Task Intent: " + plan.missing_fields_message()); return; } QProcess process; process.start("python3", QStringList() << plan.script_path << plan.arguments); if (!process.waitForFinished(120000)) { append_studio_log("Generate/Update Task Intent: timed out while waiting for helper script."); return; } const int exit_code = process.exitCode(); const QString stdout_text = QString::fromUtf8(process.readAllStandardOutput()).trimmed(); const QString stderr_text = QString::fromUtf8(process.readAllStandardError()).trimmed(); if (exit_code != 0) { append_studio_log(QString("Generate/Update Task Intent failed (exit=%1).").arg(exit_code)); if (!stderr_text.isEmpty()) append_studio_log("stderr: " + stderr_text.left(400)); if (!stdout_text.isEmpty()) append_studio_log("stdout: " + stdout_text.left(400)); return; } append_studio_log("Generate/Update Task Intent: " + plan.display_command() + " (Preview Only)"); if (!stdout_text.isEmpty()) append_studio_log("stdout: " + stdout_text.left(400)); refresh_task_intent_panel(); refresh_new_cell_checklist(); }
-void MainWindow::generate_yaml_draft_for_selected_scene(){ if (selected_scene_index_ < 0) return; const auto & sc = scene_browser_result_.scenes[(size_t)selected_scene_index_]; QString script; if (!helper_script_exists("create_or_update_builder_task_intent.py", &script)) { append_studio_log("Generate YAML: helper script search failed (task intent helper missing)."); } const fs::path scene_dir = sc.scene_dir; const fs::path env = scene_dir / "environment.yaml"; const fs::path cell = scene_dir / "cell_definition.yaml"; const fs::path manifest = scene_dir / "scene_manifest.yaml"; const fs::path layout = scene_dir / "environment_layout.yaml"; if (!fs::exists(env)) { std::ofstream out(env.string()); out << "scene_name: " << sc.scene_name << "\n"; out << "safety:\n  fake_hardware_first: true\n  runtime_execution_enabled: false\n  motion_command_sent: false\n"; out << "defaults:\n  robot: ur5\n  end_effector: robotiq_2f\n  object: placeholder_object\n  gripper_mount_rpy: [-1.5708, -1.5708, 0.0]\n"; } if (!fs::exists(cell)) { const std::string scene_name = sc.scene_name; const std::string cell_id = scene_name + "_cell"; const std::string task_id = scene_name + "_pick_place"; std::ofstream out(cell.string()); out << "schema_version: cell_definition/v1\n"; out << "cell:\n  id: " << cell_id << "\n  name: " << scene_name << "\n  description: Auto-generated preview-safe draft for selected scene metadata\n"; out << "robot:\n  id: ur5_preview\n  model: ur5\n  planning_group: manipulator\n  base_frame: world\n  tool_link: tool0\n  home_named_target: home\n  safe_joint_state: []\n"; out << "end_effector:\n  id: robotiq_2f_preview\n  type: finger\n  brand: robotiq\n  grasp_frame: tool0\n  allowed_touch_links: [robotiq_2f_85_left_finger_tip_link, robotiq_2f_85_right_finger_tip_link]\n"; out << "camera:\n  id: camera_main\n  type: depth_camera\n  frame: camera_depth_optical_frame\n"; out << "environment:\n  frame: world\n  layout: environment_layout.yaml\n  support_surfaces:\n    - {id: table_main, type: table, frame: world, pose_xyz: [0.0, 0.0, 0.0], pose_rpy: [0.0, 0.0, 0.0], dimensions: [1.2, 0.8, 0.05]}\n"; out << "objects:\n  - {id: preview_object, class: unknown, shape: box, color: unknown, material: unknown, frame: world, dimensions: [0.05, 0.05, 0.05], pose_xyz: [0.55, 0.0, 0.1], pose_rpy: [0.0, 0.0, 0.0]}\n"; out << "task:\n  id: " << task_id << "\n  type: pick_place\n  source_object: preview_object\n  destinations:\n    - {id: place_bin, frame: world, pose_xyz: [0.35, -0.25, 0.1], pose_rpy: [0.0, 0.0, 0.0]}\n  rules:\n    - {id: default_place, when: {always: true}, destination: place_bin}\n"; out << "commissioning:\n  self_test_enabled: true\n  export_bundle: true\n  require_operator_review: true\n  fake_hardware_default: true\n  fake_hardware_first: true\n  runtime_execution_enabled: false\n"; } if (!fs::exists(manifest)) { std::ofstream out(manifest.string()); out << "schema_version: workcell_scene_manifest/v1\nscene_name: " << sc.scene_name << "\n"; out << "safety:\n  fake_hardware_first: true\n  runtime_execution_enabled: false\n"; } if (!fs::exists(layout)) { std::ofstream out(layout.string()); out << "layout:\n  items: []\n"; } append_studio_log(QString("Generate YAML: ensured environment.yaml, cell_definition.yaml, scene_manifest.yaml, environment_layout.yaml for '%1'.").arg(QString::fromStdString(sc.scene_name))); refresh_scene_browser_ui(); refresh_scene_builder_selected_scene_ui(); refresh_new_cell_checklist(); }
+void MainWindow::generate_yaml_draft_for_selected_scene()
+{
+  if (selected_scene_index_ < 0) return;
+  const auto & sc = scene_browser_result_.scenes[(size_t)selected_scene_index_];
+  QString script;
+  if (!helper_script_exists("create_or_update_builder_task_intent.py", &script)) {
+    append_studio_log("Generate YAML: helper script search failed (task intent helper missing).");
+  }
+  const fs::path scene_dir = sc.scene_dir;
+  const fs::path env = scene_dir / "environment.yaml";
+  const fs::path cell = scene_dir / "cell_definition.yaml";
+  const fs::path manifest = scene_dir / "scene_manifest.yaml";
+  const fs::path layout = scene_dir / "environment_layout.yaml";
+
+  if (!fs::exists(env)) {
+    std::ofstream out(env.string());
+    out << "scene_name: " << sc.scene_name << "\n";
+    out << "safety:\n  fake_hardware_first: true\n  runtime_execution_enabled: false\n  motion_command_sent: false\n";
+    out << "defaults:\n  robot: ur5\n  end_effector: robotiq_2f\n  object: placeholder_object\n  gripper_mount_rpy: [-1.5708, -1.5708, 0.0]\n";
+  }
+
+  const auto write_cell_draft = [&]() {
+    const std::string scene_name = sc.scene_name;
+    const std::string cell_id = scene_name + "_cell";
+    const std::string task_id = scene_name + "_pick_place";
+    std::ofstream out(cell.string());
+    out << "schema_version: cell_definition/v1\n";
+    out << "cell:\n  id: " << cell_id << "\n  name: " << scene_name << "\n  description: Auto-generated preview-safe draft for selected scene metadata\n";
+    out << "robot:\n  id: ur5_preview\n  model: ur5\n  planning_group: manipulator\n  base_frame: world\n  tool_link: tool0\n  home_named_target: home\n  safe_joint_state: []\n";
+    out << "end_effector:\n  id: robotiq_2f_preview\n  type: finger\n  brand: robotiq\n  grasp_frame: tool0\n  allowed_touch_links: [robotiq_2f_85_left_finger_tip_link, robotiq_2f_85_right_finger_tip_link]\n";
+    out << "camera:\n  id: camera_main\n  type: depth_camera\n  frame: camera_depth_optical_frame\n";
+    out << "environment:\n  frame: world\n  layout: environment_layout.yaml\n  support_surfaces:\n    - {id: table_main, type: table, frame: world, pose_xyz: [0.0, 0.0, 0.0], pose_rpy: [0.0, 0.0, 0.0], dimensions: [1.2, 0.8, 0.05]}\n";
+    out << "objects:\n  - {id: preview_object, class: unknown, shape: box, color: unknown, material: unknown, frame: world, dimensions: [0.05, 0.05, 0.05], pose_xyz: [0.55, 0.0, 0.1], pose_rpy: [0.0, 0.0, 0.0]}\n";
+    out << "task:\n  id: " << task_id << "\n  type: pick_place\n  source_object: preview_object\n  destinations:\n    - {id: place_bin, frame: world, pose_xyz: [0.35, -0.25, 0.1], pose_rpy: [0.0, 0.0, 0.0]}\n  rules:\n    - {id: default_place, when: {always: true}, destination: place_bin}\n";
+    out << "commissioning:\n  self_test_enabled: true\n  export_bundle: true\n  require_operator_review: true\n  fake_hardware_default: true\n  fake_hardware_first: true\n  runtime_execution_enabled: false\n";
+  };
+
+  if (!fs::exists(cell)) {
+    write_cell_draft();
+    append_studio_log("Generate YAML: new cell_definition.yaml generated.");
+  } else {
+    QString validate_cell_script;
+    bool valid_existing_cell = false;
+    if (helper_script_exists("validate_cell_definition.py", &validate_cell_script)) {
+      QProcess validate_process;
+      validate_process.start("python3", QStringList() << validate_cell_script << QString::fromStdString(cell.string()));
+      if (validate_process.waitForFinished(120000) && validate_process.exitCode() == 0) {
+        valid_existing_cell = true;
+      }
+    }
+    if (valid_existing_cell) {
+      append_studio_log("Generate YAML: existing valid cell_definition.yaml preserved.");
+    } else {
+      const fs::path backup = cell.string() + ".invalid." + std::to_string(std::time(nullptr)) + ".bak";
+      boost::system::error_code ec;
+      fs::copy_file(cell, backup, fs::copy_option::overwrite_if_exists, ec);
+      if (ec) {
+        append_studio_log(QString("Generate YAML: invalid cell_definition.yaml detected but backup failed (%1); not rewriting.")
+          .arg(QString::fromStdString(ec.message())));
+      } else {
+        write_cell_draft();
+        append_studio_log(QString("Generate YAML: invalid cell_definition.yaml backed up and regenerated (%1).")
+          .arg(QString::fromStdString(backup.string())));
+      }
+    }
+  }
+
+  if (!fs::exists(manifest)) {
+    std::ofstream out(manifest.string());
+    out << "schema_version: workcell_scene_manifest/v1\nscene_name: " << sc.scene_name << "\n";
+    out << "safety:\n  fake_hardware_first: true\n  runtime_execution_enabled: false\n";
+  }
+  if (!fs::exists(layout)) {
+    std::ofstream out(layout.string());
+    out << "layout:\n  items: []\n";
+  }
+  append_studio_log(QString("Generate YAML: ensured environment.yaml, cell_definition.yaml, scene_manifest.yaml, environment_layout.yaml for '%1'.").arg(QString::fromStdString(sc.scene_name)));
+  refresh_scene_browser_ui();
+  refresh_scene_builder_selected_scene_ui();
+  refresh_new_cell_checklist();
+}
+
 void MainWindow::generate_scene_package_for_selected_scene(){ if (selected_scene_index_ < 0) return; generate_yaml_draft_for_selected_scene(); const auto & sc = scene_browser_result_.scenes[(size_t)selected_scene_index_]; const QString scene_dir = QString::fromStdString(sc.scene_dir.string()); const QString scene_name = QString::fromStdString(sc.scene_name); const QString cell_definition_path = QString::fromStdString((sc.scene_dir / "cell_definition.yaml").string()); const QString output_dir = QString::fromStdString(sc.scene_dir.parent_path().string()); if (!QFileInfo::exists(cell_definition_path)) { append_studio_log("Generate ROS Scene Package: Generate YAML first."); return; } bool severe_preflight_failure = false; const QStringList preflight_warnings = generation_asset_support_preflight(sc.scene_dir / "environment_layout.yaml", &severe_preflight_failure); for (const QString & warning : preflight_warnings) { append_studio_log(warning); readiness_warning_details_.append(warning); } if (severe_preflight_failure) { append_studio_log("Generate ROS Scene Package blocked by severe schema/safety preflight failure."); refresh_new_cell_checklist(); return; } QString validate_cell_script; if (helper_script_exists("validate_cell_definition.py", &validate_cell_script)) { QProcess validate_process; validate_process.start("python3", QStringList() << validate_cell_script << cell_definition_path); if (!validate_process.waitForFinished(120000)) { append_studio_log("Generate ROS Scene Package: timed out while validating cell definition."); return; } const QString stderr_text = QString::fromUtf8(validate_process.readAllStandardError()).trimmed(); const QString stdout_text = QString::fromUtf8(validate_process.readAllStandardOutput()).trimmed(); if (validate_process.exitCode() != 0) { append_studio_log("Generate ROS Scene Package blocked: cell_definition.yaml validation failed."); const QStringList validator_lines = (stderr_text + "\n" + stdout_text).split('\n', Qt::SkipEmptyParts); bool found_missing_key_error = false; for (const QString & line : validator_lines) { const QString trimmed = line.trimmed(); if (trimmed.contains("Missing required top-level key:")) { append_studio_log("validator: " + trimmed); found_missing_key_error = true; } } if (!found_missing_key_error) { if (!stderr_text.isEmpty()) append_studio_log("validator stderr: " + stderr_text.left(600)); if (!stdout_text.isEmpty()) append_studio_log("validator stdout: " + stdout_text.left(600)); } return; } } if (output_dir.trimmed().isEmpty() || scene_name.trimmed().isEmpty()) { append_studio_log("Generate ROS Scene Package: output directory and package name are required."); return; } QString script; helper_script_exists("generate_workcell_from_cell_definition.py", &script); const auto plan = workcell_builder::build_generate_workcell_command_plan(script, scene_dir, output_dir, scene_name); if (!plan.ready()) { append_studio_log("Generate ROS Scene Package: " + plan.missing_fields_message()); return; } QProcess process; process.start("python3", QStringList() << plan.script_path << plan.arguments); if (!process.waitForFinished(180000)) { append_studio_log("Generate ROS Scene Package: timed out while waiting for helper script."); return; } const int exit_code = process.exitCode(); const QString stdout_text = QString::fromUtf8(process.readAllStandardOutput()).trimmed(); const QString stderr_text = QString::fromUtf8(process.readAllStandardError()).trimmed(); if (exit_code != 0) { append_studio_log(QString("Generate ROS Scene Package failed (exit=%1).").arg(exit_code)); if (!stderr_text.isEmpty()) append_studio_log("stderr: " + stderr_text.left(400)); if (!stdout_text.isEmpty()) append_studio_log("stdout: " + stdout_text.left(400)); launch_artifacts_ready_ = false; return; } launch_artifacts_ready_ = true; append_studio_log("Generate ROS Scene Package: " + plan.display_command()); append_studio_log(QString("Generated package location: %1/%2").arg(output_dir, scene_name)); append_studio_log(QString("Next: colcon build --symlink-install --packages-select %1").arg(scene_name)); append_studio_log("Next: source install/setup.bash"); append_studio_log(QString("Next: ros2 launch %1 demo.launch.py use_fake_hardware:=true launch_rviz:=true").arg(scene_name)); if (!stdout_text.isEmpty()) append_studio_log("stdout: " + stdout_text.left(400)); refresh_scene_browser_ui(); refresh_scene_builder_selected_scene_ui(); refresh_new_cell_checklist(); }
 void MainWindow::validate_generated_scene_for_selected_scene(){ if (selected_scene_index_ < 0) return; const auto & sc = scene_browser_result_.scenes[(size_t)selected_scene_index_]; QString script; if (!helper_script_exists("validate_builder_generated_scene.py", &script)) { append_studio_log("Validate Generated Scene: script missing. Searched: " + helper_script_search_paths("validate_builder_generated_scene.py").join(" | ")); return; } const auto plan = workcell_builder::build_validate_generated_scene_command_plan(script, QString::fromStdString(sc.scene_dir.string())); if (!plan.ready()) { append_studio_log("Validate Generated Scene: " + plan.missing_fields_message()); return; } QProcess process; process.start("python3", QStringList() << plan.script_path << plan.arguments); if (!process.waitForFinished(120000)) { append_studio_log("Validate Generated Scene: timed out while waiting for helper script."); return; } validation_stale_ = false; append_studio_log("Validate Generated Scene: " + plan.display_command()); refresh_new_cell_checklist(); }
 void MainWindow::copy_build_launch_commands_for_selected_scene(){ if (!has_selected_scene()) return; const QString block = selected_scene_preview_command_block(); QApplication::clipboard()->setText(block); append_studio_log("Copy Build & Launch Commands"); }
@@ -1754,6 +1835,14 @@ QString MainWindow::selected_scene_binding_id() const
 bool MainWindow::update_selected_scene_task_intent_binding(
   const QString & binding_label, const std::vector<std::string> & key_path, const QString & selected_id)
 {
+  return update_selected_scene_task_intent_bindings(binding_label, {key_path}, selected_id);
+}
+
+bool MainWindow::update_selected_scene_task_intent_bindings(
+  const QString & binding_label,
+  const std::vector<std::vector<std::string>> & key_paths,
+  const QString & selected_id)
+{
   if (selected_scene_index_ < 0 || selected_scene_index_ >= (int)scene_browser_result_.scenes.size()) return false;
   const auto & sc = scene_browser_result_.scenes[(size_t)selected_scene_index_];
   const fs::path task_intent_path = sc.scene_dir / "config" / "workcell_builder_task_intent.yaml";
@@ -1826,12 +1915,15 @@ bool MainWindow::update_selected_scene_task_intent_binding(
   safety["allow_rviz_motion"] = true;
   safety["allow_real_hardware_motion"] = false;
   safety["real_robot_locked"] = true;
-  YAML::Node cursor = task;
-  for (size_t i = 0; i + 1 < key_path.size(); ++i) {
-    if (!cursor[key_path[i]] || !cursor[key_path[i]].IsMap()) cursor[key_path[i]] = YAML::Node(YAML::NodeType::Map);
-    cursor = cursor[key_path[i]];
+  for (const auto & key_path : key_paths) {
+    if (key_path.empty()) continue;
+    YAML::Node cursor = task;
+    for (size_t i = 0; i + 1 < key_path.size(); ++i) {
+      if (!cursor[key_path[i]] || !cursor[key_path[i]].IsMap()) cursor[key_path[i]] = YAML::Node(YAML::NodeType::Map);
+      cursor = cursor[key_path[i]];
+    }
+    cursor[key_path.back()] = selected_id.toStdString();
   }
-  cursor[key_path.back()] = selected_id.toStdString();
   std::ofstream out(task_intent_path.string());
   out << root;
   out.close();
@@ -1870,11 +1962,9 @@ void MainWindow::bind_selected_item_as_pick_zone()
   const auto choice = QMessageBox::question(this, "Workcell Studio", "Use this zone for task intent?", QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
   append_studio_log("Task intent zone prompt (pick) shown: Use this zone for task intent?");
   if (choice == QMessageBox::Yes) {
-    const bool pick_zone_written = update_selected_scene_task_intent_binding("Pick Zone", {"pick", "zone", "id"}, state.id.trimmed());
-    if (!pick_zone_written) return;
-    const bool pick_source_written = update_selected_scene_task_intent_binding("Pick Source", {"pick", "source", "id"}, state.id.trimmed());
-    if (pick_source_written) {
-      append_studio_log("Task intent binding applied: zone metadata saved and pick source bound.");
+    const bool pick_written = update_selected_scene_task_intent_bindings("Pick Zone + Pick Source", {{"pick", "zone", "id"}, {"pick", "source", "id"}}, state.id.trimmed());
+    if (pick_written) {
+      append_studio_log("Task intent binding applied: pick zone metadata and pick source bound.");
     }
   } else {
     append_studio_log("Task intent zone prompt declined for pick source binding.");
@@ -1896,11 +1986,9 @@ void MainWindow::bind_selected_item_as_place_zone()
   const auto choice = QMessageBox::question(this, "Workcell Studio", "Use this zone for task intent?", QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
   append_studio_log("Task intent zone prompt (place) shown: Use this zone for task intent?");
   if (choice == QMessageBox::Yes) {
-    const bool place_zone_written = update_selected_scene_task_intent_binding("Place Zone", {"place", "zone", "id"}, state.id.trimmed());
-    if (!place_zone_written) return;
-    const bool place_target_written = update_selected_scene_task_intent_binding("Place Target", {"place", "target", "id"}, state.id.trimmed());
-    if (place_target_written) {
-      append_studio_log("Task intent binding applied: zone metadata saved and place target bound.");
+    const bool place_written = update_selected_scene_task_intent_bindings("Place Zone + Place Target", {{"place", "zone", "id"}, {"place", "target", "id"}}, state.id.trimmed());
+    if (place_written) {
+      append_studio_log("Task intent binding applied: place zone metadata and place target bound.");
     }
   } else {
     append_studio_log("Task intent zone prompt declined for place target binding.");

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -167,6 +167,10 @@ private:
     const QString & binding_label,
     const std::vector<std::string> & key_path,
     const QString & selected_id);
+  bool update_selected_scene_task_intent_bindings(
+    const QString & binding_label,
+    const std::vector<std::vector<std::string>> & key_paths,
+    const QString & selected_id);
   void refresh_after_task_binding_change(const QString & binding_label, const QString & selected_id);
   QString selected_scene_launch_command() const;
   QString selected_scene_build_command() const;

--- a/workcell_builder/workcell_builder/include/workcell_warning_once.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_warning_once.hpp
@@ -1,38 +1,13 @@
 #pragma once
 
 #include <boost/filesystem.hpp>
-#include <boost/system/error_code.hpp>
-
-#include <iostream>
-#include <mutex>
-#include <set>
 #include <string>
 
 namespace workcell_builder {
 
-inline bool log_warning_once_per_context_path_reason(
+bool log_warning_once_per_context_path_reason(
   const std::string & context,
   const boost::filesystem::path & canonical_path,
-  const std::string & reason)
-{
-  static std::mutex mutex;
-  static std::set<std::string> seen;
-
-  boost::system::error_code ec;
-  const boost::filesystem::path normalized_path =
-    boost::filesystem::weakly_canonical(canonical_path, ec);
-  const std::string path_key = (ec ? canonical_path.lexically_normal() : normalized_path).string();
-  const std::string key = context + "\n" + path_key + "\n" + reason;
-
-  std::lock_guard<std::mutex> lock(mutex);
-  if (!seen.insert(key).second) {
-    return false;
-  }
-
-  std::cerr << "[workcell_builder] warning context=" << context
-            << " path=" << path_key
-            << " reason=" << reason << std::endl;
-  return true;
-}
+  const std::string & reason);
 
 }  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/src_workcell_warning_once.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_warning_once.cpp
@@ -1,0 +1,30 @@
+#include "workcell_warning_once.hpp"
+
+namespace workcell_builder {
+
+bool log_warning_once_per_context_path_reason(
+  const std::string & context,
+  const boost::filesystem::path & canonical_path,
+  const std::string & reason)
+{
+  static std::mutex mutex;
+  static std::set<std::string> seen;
+
+  boost::system::error_code ec;
+  const boost::filesystem::path normalized_path =
+    boost::filesystem::weakly_canonical(canonical_path, ec);
+  const std::string path_key = (ec ? canonical_path.lexically_normal() : normalized_path).string();
+  const std::string key = context + "\n" + path_key + "\n" + reason;
+
+  std::lock_guard<std::mutex> lock(mutex);
+  if (!seen.insert(key).second) {
+    return false;
+  }
+
+  std::cerr << "[workcell_builder] warning context=" << context
+            << " path=" << path_key
+            << " reason=" << reason << std::endl;
+  return true;
+}
+
+}  // namespace workcell_builder


### PR DESCRIPTION
## Summary
This PR applies targeted regression fixes in `workcell_builder` for issues introduced around PRs #1757-#1764, without changing robot motion/planner behavior or safety defaults.

### What was fixed
- **Asset catalog role model mismatch**
  - Added `role_hint` to `DiscoveredAssetCatalogEntry`.
  - Populated `role_hint` during discovery for manifest, inferred, and template entries.
  - Added safe role inference mapping from category/source kind (`robot`, `end_effector`, `table`, `conveyor`, `camera`, `place_target`, fallback `object`).
  - Resolves compile/runtime mismatch for `entry.role_hint` usage in UI mapping.

- **Asset catalog discovery test linkage**
  - Moved `log_warning_once_per_context_path_reason(...)` implementation to a dedicated source file:
    - `workcell_builder/workcell_builder/src_workcell_warning_once.cpp`
  - Kept declaration in `include/workcell_warning_once.hpp`.
  - Added source to both:
    - `workcell_builder` executable sources
    - `workcell_asset_catalog_discovery_test` gtest sources
  - Prevents undefined-reference linkage failures.

- **Generate YAML now repairs invalid existing `cell_definition.yaml`**
  - In `generate_yaml_draft_for_selected_scene()`:
    - If file is missing: generate valid `cell_definition/v1` draft.
    - If file exists and validates: preserve it and log preservation.
    - If file exists and fails validation: create timestamped backup and regenerate valid draft.
  - Added explicit logs:
    - `existing valid cell_definition.yaml preserved`
    - `invalid cell_definition.yaml backed up and regenerated`
    - `new cell_definition.yaml generated`

- **Reduced pick/place task-intent backup/write duplication**
  - Added batch helper `update_selected_scene_task_intent_bindings(...)` to update multiple key paths in one YAML load/save cycle.
  - Refactored Yes-path bindings:
    - Pick: `pick.zone.id` + `pick.source.id`
    - Place: `place.zone.id` + `place.target.id`
  - Keeps No-path behavior unchanged (no write/no backup).

- **More Actions wiring regression guard**
  - Added light static regression coverage for expected QAction handler bindings.

- **Tests added/updated**
  - `tests/test_workcell_builder_regression_repairs.py` includes checks for:
    - role_hint model/usage
    - generate-yaml repair/preserve log and validation path tokens
    - single-call pick/place binding flow
    - more-actions wiring tokens
    - asset-catalog discovery test linking source inclusion

## Validation run
- `colcon build --symlink-install --packages-select workcell_builder` *(failed in this environment: `colcon` not installed)*
- `ctest --test-dir build/workcell_builder --output-on-failure || true` *(no build dir available in this environment)*
- `python3 -m pytest -q tests/` *(suite executed; many unrelated pre-existing failures outside this patch scope)*

## Safety / behavior constraints
- No robot motion behavior changes introduced.
- No planner/execution behavior changes introduced.
- Fake-hardware and safety defaults were not weakened.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ade2294708331839e8da5415af8d1)