### PR TITLE
Fix warning-once compile/linkage for workcell_builder tests

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -249,6 +249,7 @@ if(BUILD_TESTING)
     test/workcell_scene_status_test.cpp
     src_workcell_scene_status.cpp
     src_workcell_studio_scene_browser.cpp
+    src_workcell_warning_once.cpp
     src_conveyor_pick_preview.cpp
     src_workcell_perception_snapshot.cpp
     src_task_intent_readiness.cpp
@@ -274,6 +275,7 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_perception_snapshot_test
     test/workcell_perception_snapshot_test.cpp
     src_workcell_perception_snapshot.cpp
+    src_workcell_warning_once.cpp
     src_task_intent_readiness.cpp
     src_class_routing_model.cpp
     src_planning_readiness.cpp
@@ -314,6 +316,7 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_studio_canvas_model_mesh_test
     test/workcell_studio_canvas_model_mesh_test.cpp
     src_workcell_studio_canvas_model.cpp
+    src_workcell_warning_once.cpp
     src_workcell_yaml_utils.cpp)
   ament_add_gtest(workcell_asset_catalog_discovery_test
     test/asset_catalog_discovery_test.cpp

--- a/workcell_builder/workcell_builder/src_workcell_warning_once.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_warning_once.cpp
@@ -1,5 +1,11 @@
 #include "workcell_warning_once.hpp"
 
+#include <boost/system/error_code.hpp>
+
+#include <iostream>
+#include <mutex>
+#include <set>
+
 namespace workcell_builder {
 
 bool log_warning_once_per_context_path_reason(


### PR DESCRIPTION
## Summary
- add explicit includes to `src_workcell_warning_once.cpp` for symbols now used in the moved non-inline implementation:
  - `<boost/system/error_code.hpp>`
  - `<iostream>`
  - `<mutex>`
  - `<set>`
- ensure test targets that compile sources calling `log_warning_once_per_context_path_reason(...)` also compile/link `src_workcell_warning_once.cpp`:
  - `workcell_studio_canvas_model_mesh_test`
  - `workcell_perception_snapshot_test`
  - `workcell_scene_status_test`
- keep `src_workcell_warning_once.cpp` in the main `workcell_builder` executable source list (unchanged).

## Why
PR #1765 moved `log_warning_once_per_context_path_reason(...)` from an inline header implementation into `src_workcell_warning_once.cpp`. That makes missing includes and missing linkage visible at compile/link time in targets that only compile callers.

## Validation
- Ran usage scan:
  - `grep -R "log_warning_once_per_context_path_reason" workcell_builder/workcell_builder -n`
- Attempted requested build/tests in this environment:
  - `colcon build --symlink-install --packages-select workcell_builder` *(failed: `colcon` not installed in container)*
  - `ctest --test-dir build/workcell_builder --output-on-failure || true` *(build dir absent because build did not run)*

## Behavior impact
- No feature/UI/motion/planning/safety-default changes.
- This is a build/linkage-only fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae0244c5483319b7608c786c55ff1)