### PR TITLE
Add workflow label and safety token contract checks to scene-builder validation

### DIFF
--- a/scripts/validate_scene_builder_mainline_flow.py
+++ b/scripts/validate_scene_builder_mainline_flow.py
@@ -16,6 +16,42 @@ CHECKS = {
     "cell_definition_v1_draft_generate_repair_validate": (CPP, ["new cell_definition.yaml generated", "existing valid cell_definition.yaml preserved", "invalid cell_definition.yaml backed up and regenerated", "validate_cell_definition.py"]),
     "readiness_and_preflight_warnings": (CPP, ["generation_asset_support_preflight", "severe_preflight_failure", "blocked by severe schema/safety preflight failure"]),
     "action_wiring_tokens": (CPP, ["&MainWindow::open_add_asset_dialog", "&MainWindow::place_selected_asset_from_dialog", "&MainWindow::save_layout_changes", "&MainWindow::generate_yaml_draft_for_selected_scene", "&MainWindow::generate_scene_package_for_selected_scene", "&MainWindow::validate_generated_scene_for_selected_scene", "&MainWindow::preview_offline_plan_for_selected_scene", "&MainWindow::copy_build_launch_commands_for_selected_scene", "&MainWindow::delete_selected_item", "&MainWindow::bind_selected_item_as_pick_zone", "&MainWindow::bind_selected_item_as_place_zone", "&MainWindow::bind_selected_item_as_camera"]),
+    "workflow_labels_contract_all_8": (
+        CPP,
+        [
+            "1. YAML Draft:",
+            "2. Scene Manifest:",
+            "3. ROS Package:",
+            "4. Launch File:",
+            "5. Task Intent:",
+            "6. Task Recipe:",
+            "7. Build Command:",
+            "8. Fake-Hardware Launch:",
+        ],
+    ),
+    "recommended_action_handler_wiring_contract": (
+        CPP,
+        [
+            "Next action: <b>%1</b>",
+            "blocker_next = audit.next_recommended_action",
+        ],
+    ),
+    "guarded_action_tooltip_tokens_contract": (
+        CPP,
+        [
+            "Placement disabled:",
+            "Unavailable:",
+            "Delete robot is blocked/guarded unless Unlock Robot Base is enabled.",
+        ],
+    ),
+    "fake_hardware_launch_token_contract": (
+        CPP,
+        [
+            "# fake-hardware launch command",
+            "use_fake_hardware:=true",
+            "Plan & Simulate: prepared fake-hardware launch commands",
+        ],
+    ),
     "cmake_includes_helper_sources": (CMAKE, ["src_workcell_warning_once.cpp", "gui/asset_catalog_discovery.cpp", "src_workcell_studio_id_utils.cpp"]),
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the Scene Builder UI workflow checklist, recommended-action wiring, guarded-action tooltips, and fake-hardware launch tokens remain present in `mainwindow.cpp` to catch regressions in mainline flow text and safety hints.
- Keep validation failures specific and actionable by adding dedicated contract blocks for each requirement.

### Description
- Added four new contract entries to the `CHECKS` map in `scripts/validate_scene_builder_mainline_flow.py`: `workflow_labels_contract_all_8`, `recommended_action_handler_wiring_contract`, `guarded_action_tooltip_tokens_contract`, and `fake_hardware_launch_token_contract`.
- Each contract lists the exact token strings expected in `workcell_builder/workcell_builder/gui/mainwindow.cpp`, for example the eight workflow labels (`"1. YAML Draft:"` … `"8. Fake-Hardware Launch:"`), recommended-action wiring tokens (`"Next action: <b>%1</b>"`, `"blocker_next = audit.next_recommended_action"`), guarded tooltip markers (`"Placement disabled:"`, `"Unavailable:"`, guarded delete message), and fake-hardware launch tokens (`"# fake-hardware launch command"`, `"use_fake_hardware:=true"`, `"Plan & Simulate: prepared fake-hardware launch commands"`).
- Preserved the existing validation loop and failure format so missing tokens are reported under their specific contract name for precise diagnostics.

### Testing
- Ran `python3 scripts/validate_scene_builder_mainline_flow.py`, which exited successfully and printed `PASS` and `Validated 12 integration contracts.`.
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae8b6f7f88331b1731f9b54718a7c)