### PR TITLE
Add static Scene Builder UI acceptance validator and pytest coverage

### DIFF
--- a/scripts/validate_scene_builder_ui_acceptance.py
+++ b/scripts/validate_scene_builder_ui_acceptance.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse,re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+@dataclass
+class CheckResult:
+    name:str
+    ok:bool
+    details:list[str]
+
+def _load_text(paths:Iterable[Path])->str:
+    return "\n".join(p.read_text(encoding='utf-8') for p in paths if p.exists())
+
+def _token_check(name,haystack,required):
+    missing=[t for t in required if t not in haystack]
+    return CheckResult(name,not missing,[f"missing token: {t}" for t in missing])
+
+def _regex_absent_check(name,haystack,forbidden):
+    hits=[f"forbidden pattern matched ({label}): {pat}" for label,pat in forbidden.items() if re.search(pat,haystack,re.MULTILINE)]
+    return CheckResult(name,not hits,hits)
+
+def run_checks(file_text_map:dict[str,str]|None=None)->list[CheckResult]:
+    if file_text_map is None:
+        file_text_map={
+            'mainwindow_cpp':_load_text([REPO_ROOT/'workcell_builder/workcell_builder/gui/mainwindow.cpp']),
+            'preview_cpp':_load_text([REPO_ROOT/'workcell_builder/workcell_builder/gui/scene_preview_widget.cpp']),
+            'layout_editor_cpp':_load_text([REPO_ROOT/'workcell_builder/workcell_builder/gui/environment_layout_editor.cpp']),
+            'object_placement_cpp':_load_text([REPO_ROOT/'workcell_builder/workcell_builder/gui/object_placement_dialog.cpp']),
+        }
+    main=file_text_map.get('mainwindow_cpp','')
+    all_text="\n".join(file_text_map.values())
+    checks=[]
+    xyz_rpy_ok=bool(re.search(r"XYZ\s*/\s*RPY|Proposed XYZ/RPY|pose XYZ/RPY",all_text) or ("XYZ" in all_text and "RPY" in all_text))
+    checks.append(CheckResult("manual XYZ/RPY field identifiers",xyz_rpy_ok,[] if xyz_rpy_ok else ["missing XYZ/RPY field identifier token"]))
+    checks.append(_token_check("manual axis/unit labels",all_text,["X position in metres","Yaw in radians"]))
+    checks.append(_token_check("unit strings (metres/radians)",all_text,["metres","radians"]))
+    checks.append(_token_check("hide/show panel controls",all_text,["Hide","Show"]))
+    focus_ok=("Focus Canvas" in all_text) or ("Focus Selected" in all_text)
+    checks.append(CheckResult("Focus Canvas action wording",focus_ok,[] if focus_ok else ["missing token: Focus Canvas (or Focus Selected)"]))
+    checks.append(_token_check("splitter/resizable layout usage",all_text,["QSplitter","setStretchFactor"]))
+    checks.append(_token_check("More Actions grouping",all_text,["More Actions","QToolButton","QMenu"]))
+    checks.append(_token_check("3D/2D layout wording",all_text,["3D Layout Preview","2D Layout"]))
+    checks.append(_token_check("fake hardware launch token",all_text,["use_fake_hardware:=true"]))
+    checks.append(_regex_absent_check("no hidden QPushButton indirection anti-pattern",main,{"menu_action_new_cell":r'addAction\("Create New Cell"\s*,',"menu_action_plan_simulate":r'addAction\("Open Plan & Simulate"\s*,'}))
+    checks.append(_regex_absent_check("fixed-width button anti-pattern checks",main,{"qpushbutton_fixed_width_literal":r"\b[a-zA-Z_][a-zA-Z0-9_]*button[a-zA-Z0-9_]*\s*->\s*setFixedWidth\s*\(\s*\d+\s*\)"}))
+    return checks
+
+def main()->int:
+    argparse.ArgumentParser(description='Static Scene Builder UI acceptance checks').parse_args()
+    checks=run_checks()
+    for c in checks:
+        print(f"{'PASS' if c.ok else 'FAIL'}: {c.name}")
+        for d in c.details: print(f"  - {d}")
+    return 0 if all(c.ok for c in checks) else 1
+
+if __name__=='__main__':
+    raise SystemExit(main())

--- a/tests/test_scene_builder_ui_acceptance.py
+++ b/tests/test_scene_builder_ui_acceptance.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from scripts.validate_scene_builder_ui_acceptance import run_checks
+
+
+def _base_fixture() -> dict[str, str]:
+    return {
+        "mainwindow_cpp": "\n".join(
+            [
+                'QSplitter *split = new QSplitter(this);',
+                'split->setStretchFactor(0, 3);',
+                'QToolButton *more = new QToolButton(this);',
+                'more->setText("More Actions");',
+                'QMenu *menu = new QMenu(this);',
+                'QString previewTitle = "3D Layout Preview";',
+                'QString fallback = "2D Layout";',
+                'QString focus = "Focus Canvas";',
+                'QString hide = "Hide";',
+                'QString show = "Show";',
+                'auto cmd = "ros2 launch scene demo.launch.py use_fake_hardware:=true";',
+                'QString xyz = "XYZ";',
+                'QString rpy = "RPY";',
+                'QString x_units = "X position in metres";',
+                'QString yaw_units = "Yaw in radians";',
+            ]
+        ),
+        "preview_cpp": "Preview panel supports 2D Layout and 3D Layout Preview",
+        "layout_editor_cpp": "metres radians",
+    }
+
+
+def test_validator_passes_with_required_tokens_present():
+    checks = run_checks(_base_fixture())
+    assert all(c.ok for c in checks), [f"{c.name}: {c.details}" for c in checks if not c.ok]
+
+
+def test_validator_fails_with_clear_diagnostics_when_tokens_or_patterns_missing():
+    broken = _base_fixture()
+    broken["mainwindow_cpp"] = broken["mainwindow_cpp"].replace("Focus Canvas", "")
+    broken["mainwindow_cpp"] += '\nconnect(btn, &QPushButton::click);\naction_button->setFixedWidth(120);\n'
+
+    checks = run_checks(broken)
+    failed = {c.name: c.details for c in checks if not c.ok}
+
+    assert "Focus Canvas action wording" in failed
+    assert any("Focus Canvas" in d for d in failed["Focus Canvas action wording"])
+    assert "fixed-width button anti-pattern checks" in failed
+
+
+def test_repository_ui_acceptance_validator_runs_on_current_sources():
+    checks = run_checks()
+    assert checks
+    assert any(c.name == "fake hardware launch token" for c in checks)


### PR DESCRIPTION
### Motivation
- Provide a CI-friendly, deterministic static validator to ensure Scene Builder GUI sources contain required tokens, handlers, and safety/flexibility wording without running a GUI.
- Catch GUI anti-patterns (hidden QPushButton indirection, fixed-width button usage) and missing safety tokens (fake-hardware launch) early in CI.
- Keep checks lightweight and language/text based so they can run in headless test environments.

### Description
- Add `scripts/validate_scene_builder_ui_acceptance.py` implementing token checks for `XYZ`/`RPY` fields, unit wording (`metres`, `radians`), hide/show controls, `Focus Canvas` (with `Focus Selected` compatibility), `QSplitter`/`setStretchFactor` usage, `More Actions` grouping (`QToolButton`/`QMenu`), `3D Layout Preview`/`2D Layout` wording, and `use_fake_hardware:=true` presence, plus regex-based anti-pattern guards for hidden `QPushButton` click indirection and practical fixed-width button detection.
- Validator prints per-check `PASS`/`FAIL` diagnostics and returns non-zero when any check fails.
- Add `tests/test_scene_builder_ui_acceptance.py` with three lightweight deterministic pytest cases that use text fixtures to assert success, assert clear diagnostics on a broken fixture, and exercise the validator against repository sources without requiring GUI runtime.

### Testing
- Ran `pytest -q tests/test_scene_builder_ui_acceptance.py`, which completed successfully with `3 passed`.
- Executed the validator directly via `python3 scripts/validate_scene_builder_ui_acceptance.py`, which printed per-check `PASS`/`FAIL` output and exited with code `0` on current sources.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0af12494748331b69edcf3fdbe0b51)