### PR TITLE
Render STL mesh previews with immediate-mode diffuse shading

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -434,7 +434,45 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
   if (preview_path && it.has_origin_offset) glTranslated(it.origin_offset_x, it.origin_offset_y, it.origin_offset_z);
   glScaled(it.mesh_scale_x, it.mesh_scale_y, it.mesh_scale_z);
 
-  draw_unit_cube_triangles(color);
+  const MeshCacheEntry & cache = ensure_mesh_cached(it.source_path);
+  if (!cache.valid || cache.mesh.triangles.isEmpty()) {
+    draw_unit_cube_triangles(color);
+    glPopMatrix();
+    return true;
+  }
+
+  const QVector3D default_up_normal(0.0f, 1.0f, 0.0f);
+  QVector3D light_dir(0.35f, 0.8f, 0.45f);
+  if (light_dir.lengthSquared() > 1e-12f) light_dir.normalize();
+  else light_dir = default_up_normal;
+  const float ambient = 0.18f;
+  const float diffuse_scale = 0.82f;
+
+  glBegin(GL_TRIANGLES);
+  for (const auto & tri : cache.mesh.triangles) {
+    QVector3D normal = tri.normal;
+    const bool normal_invalid = !qIsFinite(normal.x()) || !qIsFinite(normal.y()) || !qIsFinite(normal.z()) ||
+                                normal.lengthSquared() <= 1e-12f;
+    if (normal_invalid) {
+      const QVector3D edge0 = tri.vertices[1] - tri.vertices[0];
+      const QVector3D edge1 = tri.vertices[2] - tri.vertices[0];
+      normal = QVector3D::crossProduct(edge0, edge1);
+    }
+    if (qIsFinite(normal.x()) && qIsFinite(normal.y()) && qIsFinite(normal.z()) && normal.lengthSquared() > 1e-12f) {
+      normal.normalize();
+    } else {
+      normal = default_up_normal;
+    }
+
+    const float diffuse = qMax(0.0f, QVector3D::dotProduct(normal, light_dir));
+    const float shade = ambient + diffuse * diffuse_scale;
+    glColor4f(color.redF() * shade, color.greenF() * shade, color.blueF() * shade, 1.0f);
+    glVertex3f(tri.vertices[0].x(), tri.vertices[0].y(), tri.vertices[0].z());
+    glVertex3f(tri.vertices[1].x(), tri.vertices[1].y(), tri.vertices[1].z());
+    glVertex3f(tri.vertices[2].x(), tri.vertices[2].y(), tri.vertices[2].z());
+  }
+  glEnd();
+
   glPopMatrix();
   return true;
 }


### PR DESCRIPTION
### Motivation
- Improve mesh preview visuals by shading parsed STL triangles with a simple lighting model while keeping a safe fallback for invalid or missing meshes.
- Maintain compatibility with ROS 2 Humble and existing OpenGL immediate-mode rendering used elsewhere in the widget.

### Description
- Updated `draw_mesh_preview_if_available(...)` in `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp` to fetch the parsed mesh from the mesh cache and render its triangles when available instead of always drawing a cube fallback.
- Implemented per-triangle normal handling that starts from the STL normal, falls back to a face normal computed via cross product if the STL normal is invalid or near-zero, safely normalizes, and finally uses a default up normal when necessary.
- Added a fixed light direction `(0.35, 0.8, 0.45)` (normalized), a small ambient floor, and a diffuse scale so each triangle is shaded via `diffuse = max(0, dot(normal, light_dir))` and `color * (ambient + diffuse * scale)`.
- Kept immediate-mode rendering with `glBegin(GL_TRIANGLES)`, `glColor4f(...)`, and `glVertex3f(...)` to avoid introducing new rendering dependencies and preserve existing behavior; the cube fallback remains for missing/invalid mesh cache entries.

### Testing
- Attempted to build the mesh-preview regression target with `cmake --build build --target workcell_scene3d_mesh_preview_regression_test -j2`, but the build failed because the environment does not contain a configured `build/` directory (automated build did not run to completion).
- No other automated tests were executed in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0037848c833182a2e7996aa54697)