### PR TITLE
Add STL parser tests, mesh-bounds helpers, and mesh-mode fallback checks

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -373,6 +373,32 @@ bool Scene3DViewportWidget::parse_stl_bytes_for_test(const QByteArray & bytes, c
   return parse_binary_stl(bytes, out_mesh, out_error, triangle_limit);
 }
 
+bool Scene3DViewportWidget::compute_mesh_bounds_for_test(const InternalTriangleMesh & mesh, QVector3D & out_min, QVector3D & out_max)
+{
+  if (mesh.triangles.isEmpty()) return false;
+  out_min = QVector3D(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
+  out_max = QVector3D(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
+  for (const auto & tri : mesh.triangles) {
+    for (const auto & v : tri.vertices) {
+      out_min.setX(qMin(out_min.x(), v.x()));
+      out_min.setY(qMin(out_min.y(), v.y()));
+      out_min.setZ(qMin(out_min.z(), v.z()));
+      out_max.setX(qMax(out_max.x(), v.x()));
+      out_max.setY(qMax(out_max.y(), v.y()));
+      out_max.setZ(qMax(out_max.z(), v.z()));
+    }
+  }
+  return true;
+}
+
+bool Scene3DViewportWidget::should_attempt_mesh_draw_for_mode_for_test(ScenePreviewWidget::MeshPreviewMode mode,
+                                                                        bool cache_loaded, bool cache_valid)
+{
+  if (mode == ScenePreviewWidget::MeshPreviewMode::Primitives) return false;
+  if (mode == ScenePreviewWidget::MeshPreviewMode::Meshes) return cache_loaded && cache_valid;
+  return cache_loaded && cache_valid;
+}
+
 bool Scene3DViewportWidget::try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical) const
 {
   QFileInfo info(path);
@@ -413,6 +439,7 @@ const Scene3DViewportWidget::MeshCacheEntry & Scene3DViewportWidget::ensure_mesh
                << (entry.oversized ? "oversized mesh" : "invalid mesh")
                << canonical << "reason:" << parse_error;
   }
+  entry.has_bounds = compute_mesh_bounds_for_test(entry.mesh, entry.min_bounds, entry.max_bounds);
   return mesh_cache_.insert(canonical, entry).value();
 }
 

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -58,6 +58,9 @@ public:
   static bool parse_stl_bytes_for_test(const QByteArray & bytes, const QString & source_hint,
                                        InternalTriangleMesh & out_mesh, QString & out_error,
                                        int triangle_limit = 100000);
+  static bool compute_mesh_bounds_for_test(const InternalTriangleMesh & mesh, QVector3D & out_min, QVector3D & out_max);
+  static bool should_attempt_mesh_draw_for_mode_for_test(ScenePreviewWidget::MeshPreviewMode mode,
+                                                         bool cache_loaded, bool cache_valid);
 
 protected:
   void initializeGL() override;
@@ -99,6 +102,9 @@ private:
     bool oversized{ false };
     QString warning;
     InternalTriangleMesh mesh;
+    bool has_bounds{ false };
+    QVector3D min_bounds;
+    QVector3D max_bounds;
   };
   QHash<QString, MeshCacheEntry> mesh_cache_;
   bool try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical) const;

--- a/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
@@ -43,3 +43,11 @@ TEST(Scene3DMeshPreviewRegression, KeepsSelectionAndOverlayRendering)
   EXPECT_NE(src.find("draw_box_outline(bounds.x, bounds.y, bounds.z, bounds.sx, bounds.sy, bounds.sz"), std::string::npos);
   EXPECT_NE(src.find("if (show_warning_labels && !it.warnings.isEmpty())"), std::string::npos);
 }
+
+TEST(Scene3DMeshPreviewRegression, KeepsMeshCacheBoundsAndModeHooks)
+{
+  const std::string src = load_file("gui/scene3d_viewport_widget.cpp");
+  ASSERT_FALSE(src.empty());
+  EXPECT_NE(src.find("entry.has_bounds = compute_mesh_bounds_for_test(entry.mesh, entry.min_bounds, entry.max_bounds);"), std::string::npos);
+  EXPECT_NE(src.find("if (mode == ScenePreviewWidget::MeshPreviewMode::Primitives) return false;"), std::string::npos);
+}

--- a/workcell_builder/workcell_builder/test/scene3d_stl_parser_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_stl_parser_test.cpp
@@ -44,18 +44,54 @@ TEST(Scene3DStlParserTest, ParsesBinaryStl)
   EXPECT_FLOAT_EQ(mesh.triangles[0].normal.z(), 1.0f);
 }
 
-TEST(Scene3DStlParserTest, FailsOnInvalidAndOversized)
+TEST(Scene3DStlParserTest, RejectsTriangleLimit)
 {
   Scene3DViewportWidget::InternalTriangleMesh mesh;
   QString err;
-  EXPECT_FALSE(Scene3DViewportWidget::parse_stl_bytes_for_test("solid broken", "broken.stl", mesh, err));
-
   const QByteArray ascii =
     "solid t\n"
     "facet normal 0 0 1\nouter loop\nvertex 0 0 0\nvertex 1 0 0\nvertex 0 1 0\nendloop\nendfacet\n"
     "facet normal 0 0 1\nouter loop\nvertex 0 0 0\nvertex 1 0 0\nvertex 0 1 0\nendloop\nendfacet\n"
     "endsolid\n";
-  err.clear();
   EXPECT_FALSE(Scene3DViewportWidget::parse_stl_bytes_for_test(ascii, "many.stl", mesh, err, 1));
   EXPECT_TRUE(err.contains("exceeds limit"));
+}
+
+TEST(Scene3DStlParserTest, ReportsInvalidParseReason)
+{
+  Scene3DViewportWidget::InternalTriangleMesh mesh;
+  QString err;
+  EXPECT_FALSE(Scene3DViewportWidget::parse_stl_bytes_for_test("solid broken", "broken.stl", mesh, err));
+  EXPECT_FALSE(err.isEmpty());
+}
+
+TEST(Scene3DStlParserTest, ComputesMeshBoundsFromKnownTriangleSet)
+{
+  const QByteArray ascii =
+    "solid t\n"
+    "facet normal 0 0 1\nouter loop\nvertex -1 -2 -3\nvertex 4 5 6\nvertex 0 1 2\nendloop\nendfacet\n"
+    "facet normal 0 0 1\nouter loop\nvertex 2 1 0\nvertex -3 2 1\nvertex 0 -4 3\nendloop\nendfacet\n"
+    "endsolid\n";
+  Scene3DViewportWidget::InternalTriangleMesh mesh;
+  QString err;
+  ASSERT_TRUE(Scene3DViewportWidget::parse_stl_bytes_for_test(ascii, "bounds.stl", mesh, err));
+  QVector3D min_bounds;
+  QVector3D max_bounds;
+  ASSERT_TRUE(Scene3DViewportWidget::compute_mesh_bounds_for_test(mesh, min_bounds, max_bounds));
+  EXPECT_FLOAT_EQ(min_bounds.x(), -3.0f);
+  EXPECT_FLOAT_EQ(min_bounds.y(), -4.0f);
+  EXPECT_FLOAT_EQ(min_bounds.z(), -3.0f);
+  EXPECT_FLOAT_EQ(max_bounds.x(), 4.0f);
+  EXPECT_FLOAT_EQ(max_bounds.y(), 5.0f);
+  EXPECT_FLOAT_EQ(max_bounds.z(), 6.0f);
+}
+
+TEST(Scene3DStlParserTest, MeshModeFallbackBehaviorAtMethodLevel)
+{
+  using Mode = ScenePreviewWidget::MeshPreviewMode;
+  EXPECT_FALSE(Scene3DViewportWidget::should_attempt_mesh_draw_for_mode_for_test(Mode::Primitives, true, true));
+  EXPECT_TRUE(Scene3DViewportWidget::should_attempt_mesh_draw_for_mode_for_test(Mode::Meshes, true, true));
+  EXPECT_FALSE(Scene3DViewportWidget::should_attempt_mesh_draw_for_mode_for_test(Mode::Meshes, true, false));
+  EXPECT_TRUE(Scene3DViewportWidget::should_attempt_mesh_draw_for_mode_for_test(Mode::Auto, true, true));
+  EXPECT_FALSE(Scene3DViewportWidget::should_attempt_mesh_draw_for_mode_for_test(Mode::Auto, false, false));
 }


### PR DESCRIPTION
### Motivation
- Increase unit-test coverage for STL parsing (ASCII and binary) and explicit failure modes such as triangle-count limits and invalid input. 
- Verify computed mesh bounds are correct for known triangle sets so downstream viewport logic can rely on cached extents. 
- Provide a small, testable decision hook for mesh-vs-primitive rendering fallback logic to allow deterministic method-level testing without GPU/OpenGL dependencies.

### Description
- Added two test-facing helpers on `Scene3DViewportWidget`: `compute_mesh_bounds_for_test(...)` and `should_attempt_mesh_draw_for_mode_for_test(...)` and implemented them in the `.cpp` file. 
- Extended `MeshCacheEntry` with `has_bounds`, `min_bounds`, and `max_bounds`, and populated these in `ensure_mesh_cached` using `compute_mesh_bounds_for_test`. 
- Expanded `scene3d_stl_parser_test.cpp` with tests for valid ASCII STL parsing, valid binary STL parsing, triangle limit rejection, invalid-parse failure reason reporting, a mesh-bounds verification with a known triangle set, and method-level mesh-mode fallback checks. 
- Updated `scene3d_mesh_preview_regression_test.cpp` to assert the presence of mesh-cache bounds population and primitives-mode guard lines in source to prevent regressions.

### Testing
- Attempted to run the targeted ROS test selection with `colcon test --packages-select workcell_builder --ctest-args -R "scene3d_stl_parser_test|scene3d_mesh_preview_regression_test"`, but `colcon` is not installed in this environment so tests were not executed here. 
- The changes were compiled and committed locally in the repository as part of the PR preparation. 
- All new tests are written to avoid GPU/OpenGL assertions to remain compatible with ROS 2 Humble CI environments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0038a7ac833199b714de77ccec18)