### PR TITLE
Guard mesh preview fallback warnings and cache missing mesh failures

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -284,7 +284,8 @@ void Scene3DViewportWidget::paintGL()
 
   for (const auto * it : draw_items) {
     if (classify_item_role(*it) == NormalizedRole::Object && !it->source_path.trimmed().isEmpty()) {
-      (void)ensure_mesh_cached(it->source_path);
+      const MeshCacheEntry & mesh_entry = ensure_mesh_cached(it->source_path);
+      if (!mesh_entry.valid) warn_mesh_fallback_once(it->id, mesh_entry.warning, it->source_path);
     }
     const NormalizedRole role = classify_item_role(*it);
     if (!show_safety && role == NormalizedRole::SafetyZone) continue;
@@ -382,25 +383,32 @@ bool Scene3DViewportWidget::try_resolve_canonical_mesh_path(const QString & path
   return !out_canonical.isEmpty();
 }
 
+bool Scene3DViewportWidget::warn_mesh_fallback_once(const QString & item_id, const QString & reason, const QString & path)
+{
+  const QString key = QStringLiteral("%1|%2|%3").arg(item_id, reason, path);
+  if (warned_mesh_fallbacks_.contains(key)) return false;
+  warned_mesh_fallbacks_.insert(key);
+  qWarning().noquote() << QStringLiteral("Mesh preview fallback for %1: %2").arg(item_id, reason);
+  return true;
+}
+
 const Scene3DViewportWidget::MeshCacheEntry & Scene3DViewportWidget::ensure_mesh_cached(const QString & path)
 {
+  const QFileInfo input_info(path);
   QString canonical;
-  if (!try_resolve_canonical_mesh_path(path, canonical)) {
-    static MeshCacheEntry missing;
-    missing.loaded = true;
-    missing.valid = false;
-    missing.warning = QStringLiteral("mesh missing on disk");
-    qWarning() << "Scene3DViewportWidget mesh fallback: missing mesh" << path;
-    return missing;
-  }
+  if (!try_resolve_canonical_mesh_path(path, canonical)) canonical = input_info.absoluteFilePath();
   auto it = mesh_cache_.find(canonical);
   if (it != mesh_cache_.end()) return it.value();
   MeshCacheEntry entry;
   entry.loaded = true;
+  if (!input_info.exists() || !input_info.isFile()) {
+    entry.valid = false;
+    entry.warning = QStringLiteral("mesh missing on disk");
+    return mesh_cache_.insert(canonical, entry).value();
+  }
   QFile file(canonical);
   if (!file.open(QIODevice::ReadOnly)) {
     entry.warning = QStringLiteral("mesh unreadable");
-    qWarning() << "Scene3DViewportWidget mesh fallback: unreadable mesh" << canonical;
     return mesh_cache_.insert(canonical, entry).value();
   }
   const QByteArray bytes = file.readAll();
@@ -409,9 +417,6 @@ const Scene3DViewportWidget::MeshCacheEntry & Scene3DViewportWidget::ensure_mesh
   if (!entry.valid) {
     entry.oversized = parse_error.contains("exceeds limit");
     entry.warning = entry.oversized ? QStringLiteral("mesh oversized") : QStringLiteral("mesh invalid");
-    qWarning() << "Scene3DViewportWidget mesh fallback:"
-               << (entry.oversized ? "oversized mesh" : "invalid mesh")
-               << canonical << "reason:" << parse_error;
   }
   return mesh_cache_.insert(canonical, entry).value();
 }

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -5,6 +5,7 @@
 #include <QOpenGLFunctions>
 #include <QOpenGLWidget>
 #include <QHash>
+#include <QSet>
 #include <QVector3D>
 
 #include <array>
@@ -101,7 +102,9 @@ private:
     InternalTriangleMesh mesh;
   };
   QHash<QString, MeshCacheEntry> mesh_cache_;
+  QSet<QString> warned_mesh_fallbacks_;
   bool try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical) const;
+  bool warn_mesh_fallback_once(const QString & item_id, const QString & reason, const QString & path);
   const MeshCacheEntry & ensure_mesh_cached(const QString & path);
   QVector3D orbit_offset_{ 0.0f, 0.0f, 0.0f };
   double yaw_{ -0.9 };


### PR DESCRIPTION
### Motivation
- Prevent repeated per-frame `qWarning` spam when mesh previews fail and keep missing/invalid meshes non-blocking. 
- Cache negative resolution/parsing results so the viewport does not repeatedly try to re-open/parse unresolved mesh files every frame.

### Description
- Added a one-time warning set `warned_mesh_fallbacks_` and helper `warn_mesh_fallback_once()` that keys messages as `<item-id>|<reason>|<path>` and emits the exact single-line message `Mesh preview fallback for <id>: <reason>` via `qWarning().noquote()`.
- Replaced repeated unguarded `qWarning` calls in the mesh resolution and draw paths with guarded warning-once behavior by calling `warn_mesh_fallback_once()` from the render loop when `ensure_mesh_cached()` returns an invalid entry.
- Made missing/unreadable/invalid mesh outcomes cacheable: when canonical resolution fails the code falls back to the absolute path and inserts a negative `MeshCacheEntry` (with `valid=false` and a `warning` string) into `mesh_cache_` to avoid repeated IO and parsing attempts.

### Testing
- Verified symbols and changes with repository searches such as `rg -n "warn_mesh_fallback_once|warned_mesh_fallbacks_"` and `rg -n "Mesh preview fallback"` which reported the new helper and the standardized message string as expected.
- No full build or unit test run was executed locally; compiled build and CI tests are expected to validate integration and runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0034d6548331a151dc24769b25c9)