### PR TITLE
Use mesh-derived world AABBs in Scene3D viewport bounds logic

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -232,12 +232,13 @@ void Scene3DViewportWidget::fit_scene() {
   for (const auto & it : items) {
     if (!include_in_fit_bounds(it, fit_include_overlays)) continue;
     has_fittable_item = true;
-    bmin.setX(std::min(bmin.x(), static_cast<float>(it.x)));
-    bmin.setY(std::min(bmin.y(), static_cast<float>(it.y)));
-    bmin.setZ(std::min(bmin.z(), static_cast<float>(it.z)));
-    bmax.setX(std::max(bmax.x(), static_cast<float>(it.x + it.sx)));
-    bmax.setY(std::max(bmax.y(), static_cast<float>(it.y + it.sy)));
-    bmax.setZ(std::max(bmax.z(), static_cast<float>(it.z + it.sz)));
+    const ItemBounds bounds = item_bounds_for_role(it);
+    bmin.setX(std::min(bmin.x(), static_cast<float>(bounds.x)));
+    bmin.setY(std::min(bmin.y(), static_cast<float>(bounds.y)));
+    bmin.setZ(std::min(bmin.z(), static_cast<float>(bounds.z)));
+    bmax.setX(std::max(bmax.x(), static_cast<float>(bounds.x + bounds.sx)));
+    bmax.setY(std::max(bmax.y(), static_cast<float>(bounds.y + bounds.sy)));
+    bmax.setZ(std::max(bmax.z(), static_cast<float>(bounds.z + bounds.sz)));
   }
   if (!has_fittable_item) { set_isometric_view(); return; } // FIT_FALLBACK_ISO_IF_NO_PHYSICAL
   orbit_offset_ = (bmin + bmax) * 0.5f;
@@ -444,7 +445,7 @@ const Scene3DViewportWidget::MeshCacheEntry & Scene3DViewportWidget::ensure_mesh
     entry.oversized = parse_error.contains("exceeds limit");
     entry.warning = entry.oversized ? QStringLiteral("mesh oversized") : QStringLiteral("mesh invalid");
   }
-  entry.has_bounds = compute_mesh_bounds_for_test(entry.mesh, entry.min_bounds, entry.max_bounds);
+  entry.has_bounds = compute_mesh_bounds_for_test(entry.mesh, entry.local_min, entry.local_max);
   return mesh_cache_.insert(canonical, entry).value();
 }
 
@@ -693,6 +694,9 @@ bool Scene3DViewportWidget::ray_intersects_aabb(const QVector3D & ray_origin, co
 }
 Scene3DViewportWidget::ItemBounds Scene3DViewportWidget::item_bounds_for_role(const ScenePreviewWidget::PreviewItem & item) const
 {
+  ItemBounds mesh_bounds{};
+  if (mesh_world_bounds_for_item(item, mesh_bounds)) return mesh_bounds;
+
   const NormalizedRole role = classify_item_role(item);
   if (role == NormalizedRole::Object || role == NormalizedRole::WarningAnchor) {
     const double cube = (role == NormalizedRole::Object)
@@ -701,6 +705,52 @@ Scene3DViewportWidget::ItemBounds Scene3DViewportWidget::item_bounds_for_role(co
     return { item.x, item.y, item.z, cube, cube, cube };
   }
   return { item.x, item.y, item.z, item.sx, item.sy, item.sz };
+}
+
+bool Scene3DViewportWidget::mesh_world_bounds_for_item(const ScenePreviewWidget::PreviewItem & item, ItemBounds & out_bounds) const
+{
+  const QString mesh_source = !item.mesh_path.trimmed().isEmpty() ? item.mesh_path : item.source_path;
+  if (mesh_source.trimmed().isEmpty()) return false;
+  const MeshCacheEntry & cache = const_cast<Scene3DViewportWidget *>(this)->ensure_mesh_cached(mesh_source);
+  if (!cache.loaded || !cache.valid || !cache.has_bounds) return false;
+
+  QMatrix4x4 transform;
+  transform.translate(item.x, item.y, item.z);
+  transform.rotate(qRadiansToDegrees(item.roll), 1.0f, 0.0f, 0.0f);
+  transform.rotate(qRadiansToDegrees(item.pitch), 0.0f, 1.0f, 0.0f);
+  transform.rotate(qRadiansToDegrees(item.yaw), 0.0f, 0.0f, 1.0f);
+  transform.rotate(qRadiansToDegrees(item.mesh_r), 1.0f, 0.0f, 0.0f);
+  transform.rotate(qRadiansToDegrees(item.mesh_p), 0.0f, 1.0f, 0.0f);
+  transform.rotate(qRadiansToDegrees(item.mesh_y), 0.0f, 0.0f, 1.0f);
+  if (item.has_origin_offset) transform.translate(item.origin_offset_x, item.origin_offset_y, item.origin_offset_z);
+  transform.scale(item.mesh_scale_x, item.mesh_scale_y, item.mesh_scale_z);
+
+  const QVector3D lmin = cache.local_min;
+  const QVector3D lmax = cache.local_max;
+  QVector3D wmin(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
+  QVector3D wmax(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
+  for (int xi = 0; xi < 2; ++xi) {
+    for (int yi = 0; yi < 2; ++yi) {
+      for (int zi = 0; zi < 2; ++zi) {
+        const QVector3D local_corner(
+          xi == 0 ? lmin.x() : lmax.x(),
+          yi == 0 ? lmin.y() : lmax.y(),
+          zi == 0 ? lmin.z() : lmax.z());
+        const QVector3D world_corner = transform * local_corner;
+        wmin.setX(qMin(wmin.x(), world_corner.x()));
+        wmin.setY(qMin(wmin.y(), world_corner.y()));
+        wmin.setZ(qMin(wmin.z(), world_corner.z()));
+        wmax.setX(qMax(wmax.x(), world_corner.x()));
+        wmax.setY(qMax(wmax.y(), world_corner.y()));
+        wmax.setZ(qMax(wmax.z(), world_corner.z()));
+      }
+    }
+  }
+  out_bounds = { wmin.x(), wmin.y(), wmin.z(),
+                 qMax(0.0f, wmax.x() - wmin.x()),
+                 qMax(0.0f, wmax.y() - wmin.y()),
+                 qMax(0.0f, wmax.z() - wmin.z()) };
+  return true;
 }
 bool Scene3DViewportWidget::pick_item_at_screen(
   const QPoint & pos, QString & out_id, QString & out_role, QString * out_tooltip) const

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -76,6 +76,7 @@ private:
   QPointF project_to_screen(double x, double y, double z) const;
   bool pick_item_at_screen(const QPoint & pos, QString & out_id, QString & out_role, QString * out_tooltip = nullptr) const;
   ItemBounds item_bounds_for_role(const ScenePreviewWidget::PreviewItem & item) const;
+  bool mesh_world_bounds_for_item(const ScenePreviewWidget::PreviewItem & item, ItemBounds & out_bounds) const;
   bool ray_intersects_aabb(const QVector3D & ray_origin, const QVector3D & ray_dir,
                            const ScenePreviewWidget::PreviewItem & item, float & out_t) const;
   void camera_matrices(QMatrix4x4 & out_proj, QMatrix4x4 & out_view) const;
@@ -104,8 +105,8 @@ private:
     QString warning;
     InternalTriangleMesh mesh;
     bool has_bounds{ false };
-    QVector3D min_bounds;
-    QVector3D max_bounds;
+    QVector3D local_min;
+    QVector3D local_max;
   };
   QHash<QString, MeshCacheEntry> mesh_cache_;
   QSet<QString> warned_mesh_fallbacks_;


### PR DESCRIPTION
### Motivation
- Improve viewport framing and selection by using actual mesh geometry bounds when mesh previews are available instead of only item primitive extents.
- Ensure focus/fit behavior accounts for mesh pose, origin offsets and per-axis scale so framed extents match visible mesh geometry.
- Preserve the existing primitive fallback for items with missing/invalid meshes to avoid regressions.

### Description
- Extended `MeshCacheEntry` in `scene3d_viewport_widget.h` to store mesh-local AABB with `has_bounds`, `local_min`, and `local_max` fields, replacing the previous `min_bounds`/`max_bounds` naming.
- Compute and store mesh-local bounds during STL parse/cache load by calling `compute_mesh_bounds_for_test(...)` into the new `local_min`/`local_max` fields.
- Added `mesh_world_bounds_for_item(...)` helper that transforms the mesh-local AABB into a world-space AABB using the preview transform stack (item translation/rotation, mesh rotation, optional origin offset, and mesh scale) and returns an `ItemBounds` AABB.
- Updated `item_bounds_for_role(...)` to prefer mesh-derived world AABB when available and fall back to existing primitive/box sizing when mesh bounds are unavailable.
- Updated `fit_scene()` to aggregate bounds via `item_bounds_for_role(...)` so mesh-backed items contribute correct mesh-derived extents, and `focus_selected()` now implicitly uses mesh-derived bounds via the same helper; `fit_include_overlays` filtering is still respected.

### Testing
- Ran repository searches with `rg` to verify modified symbols and references and they succeeded (no errors reported).
- Verified modified files are staged and committed via `git add`/`git commit` which completed successfully.
- No automated unit or integration test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b01c3487c8331b29c43cb9b348d0e)