### PR TITLE
Fix mesh cache invalidation for Reload Meshes action

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -223,7 +223,12 @@ void Scene3DViewportWidget::set_isometric_view()
 void Scene3DViewportWidget::set_top_view() { yaw_ = 0.0; pitch_ = -1.35; update(); }
 void Scene3DViewportWidget::set_front_view() { yaw_ = 0.0; pitch_ = 0.0; update(); }
 void Scene3DViewportWidget::set_side_view() { yaw_ = -M_PI_2; pitch_ = 0.0; update(); }
-void Scene3DViewportWidget::invalidate_mesh_cache() { update(); }
+void Scene3DViewportWidget::invalidate_mesh_cache()
+{
+  mesh_cache_.clear();
+  warned_mesh_fallbacks_.clear();
+  update();
+}
 void Scene3DViewportWidget::fit_scene() {
   if (items.isEmpty()) { set_isometric_view(); return; }
   QVector3D bmin(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());


### PR DESCRIPTION
### Motivation
- The existing Reload Meshes flow repainted the view without actually invalidating parsed STL results or the warning-once state, which prevented immediate mesh refresh after external STL edits.

### Description
- Change `Scene3DViewportWidget::invalidate_mesh_cache()` to call `mesh_cache_.clear()`, `warned_mesh_fallbacks_.clear()`, and then `update()` so cached meshes and fallback warnings are fully reset before repaint.

### Testing
- Ran `git diff` to confirm the code delta and `git commit` to persist the change, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b01c483c88331b4b3813dbefa689a)