### PR TITLE
Add static pytest guards for scene3d mesh preview draw path

### DIFF
--- a/tests/test_scene3d_viewport_mesh_preview_static.py
+++ b/tests/test_scene3d_viewport_mesh_preview_static.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+CPP = ROOT / "workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp"
+
+
+def _draw_mesh_preview_fn_body() -> str:
+    src = CPP.read_text(encoding="utf-8")
+    match = re.search(
+        r"bool\s+Scene3DViewportWidget::draw_mesh_preview_if_available\s*\([^)]*\)\s*\{(?P<body>.*?)\n\}",
+        src,
+        re.DOTALL,
+    )
+    assert match, "draw_mesh_preview_if_available definition not found"
+    return match.group("body")
+
+
+def test_draw_mesh_preview_uses_mesh_cache_helper():
+    body = _draw_mesh_preview_fn_body()
+    assert "ensure_mesh_cached(" in body
+
+
+def test_draw_mesh_preview_has_explicit_mesh_preview_mode_branches():
+    body = _draw_mesh_preview_fn_body()
+    for mode in ["Primitives", "Meshes", "Auto"]:
+        token = f"MeshPreviewMode::{mode}"
+        assert token in body, f"expected explicit branch token in draw path: {token}"
+
+
+def test_draw_mesh_preview_draws_cached_triangles_not_just_unit_cube_fallback():
+    body = _draw_mesh_preview_fn_body()
+    assert "for (const auto & tri :" in body
+    assert ".mesh.triangles" in body
+
+    fallback_pos = body.find("draw_unit_cube_triangles(")
+    triangles_loop_pos = body.find("for (const auto & tri :")
+    assert fallback_pos != -1, "expected primitive fallback call for invalid mesh path"
+    assert triangles_loop_pos != -1, "expected explicit triangle iteration draw path"
+    assert triangles_loop_pos > fallback_pos, "expected non-fallback mesh draw path after fallback guard"


### PR DESCRIPTION
### Motivation
- Add a lightweight, formatting-robust source-inspection test to lock down invariants in `draw_mesh_preview_if_available` in `scene3d_viewport_widget.cpp` so future edits do not silently remove the mesh-cache usage, explicit preview-mode branches, or the real-mesh triangle draw path.

### Description
- Add `tests/test_scene3d_viewport_mesh_preview_static.py` which extracts the `draw_mesh_preview_if_available` function body via regex and performs token-based assertions to avoid brittle line-number or formatting coupling.
- The tests assert the function references `ensure_mesh_cached`, contains explicit `MeshPreviewMode::Primitives`, `MeshPreviewMode::Meshes`, and `MeshPreviewMode::Auto` tokens, and that a valid-mesh draw path iterates `*.mesh.triangles` rather than relying solely on `draw_unit_cube_triangles` fallback.

### Testing
- Ran `pytest -q tests/test_scene3d_viewport_mesh_preview_static.py`; result was `2 passed, 1 failed` because the `MeshPreviewMode::Auto` explicit-branch token is not currently present in the function body.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b01c74654833191a432475e1281b3)