### PR TITLE
Handle Escape cancel for Scene3D gizmo drags and avoid undo spam

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -999,14 +999,11 @@ void MainWindow::setup_studio_shell()
       if (!digital_twin_scene_) return;
       for (auto * item : digital_twin_scene_->items()) {
         if (item->data(RoleId).toString() != id) continue;
-        const QPointF old_pos = item->pos();
         item->setPos(x * 100.0, y * 100.0);
         item->setData(RolePoseZ, z);
         item->setData(RoleRoll, r);
         item->setData(RolePitch, p);
         item->setData(RoleYaw, yaw);
-        undo_stack_.push_back({"gizmo_transform", id, old_pos, item->pos(), false, false});
-        redo_stack_.clear();
         refresh_selection_transform_editor_from_item(item);
         mark_layout_dirty("Scene3D Gizmo Transform");
         break;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -2,6 +2,8 @@
 
 #include <QMatrix4x4>
 #include <QMouseEvent>
+#include <QKeyEvent>
+#include <QCursor>
 #include <QPainter>
 #include <QVector3D>
 #include <QVector4D>
@@ -824,6 +826,18 @@ void Scene3DViewportWidget::mousePressEvent(QMouseEvent * e) {
     const int dx = qAbs(e->x() - width() / 2);
     const int dy = qAbs(e->y() - height() / 2);
     active_axis_ = (dx > dy) ? QStringLiteral("x") : QStringLiteral("y");
+    for (const auto & it : items) {
+      if (it.id != selected_id) continue;
+      drag_start_pose_.item_id = it.id;
+      drag_start_pose_.x = it.x;
+      drag_start_pose_.y = it.y;
+      drag_start_pose_.z = it.z;
+      drag_start_pose_.roll = it.roll;
+      drag_start_pose_.pitch = it.pitch;
+      drag_start_pose_.yaw = it.yaw;
+      drag_in_progress_ = true;
+      break;
+    }
   }
 }
 void Scene3DViewportWidget::mouseMoveEvent(QMouseEvent * e)
@@ -885,10 +899,49 @@ void Scene3DViewportWidget::mouseMoveEvent(QMouseEvent * e)
   }
   hovered_id_ = hovered;
 }
+void Scene3DViewportWidget::mouseReleaseEvent(QMouseEvent * e)
+{
+  if (e->button() == Qt::LeftButton) {
+    dragging_gizmo_ = false;
+    drag_in_progress_ = false;
+    active_axis_.clear();
+  }
+  QOpenGLWidget::mouseReleaseEvent(e);
+}
+
 void Scene3DViewportWidget::wheelEvent(QWheelEvent * e)
 {
   const double delta_steps = static_cast<double>(e->angleDelta().y()) / 120.0;
   const double zoom_factor = std::pow(0.9, delta_steps);
   distance_ = qBound(min_distance_, distance_ * zoom_factor, max_distance_);
   update();
+}
+
+void Scene3DViewportWidget::keyPressEvent(QKeyEvent * e)
+{
+  if (e->key() == Qt::Key_Escape) {
+    if (!drag_in_progress_) {
+      e->ignore();
+      return;
+    }
+    for (auto & it : items) {
+      if (it.id != drag_start_pose_.item_id) continue;
+      it.x = drag_start_pose_.x;
+      it.y = drag_start_pose_.y;
+      it.z = drag_start_pose_.z;
+      it.roll = drag_start_pose_.roll;
+      it.pitch = drag_start_pose_.pitch;
+      it.yaw = drag_start_pose_.yaw;
+      if (transform_changed_cb) transform_changed_cb(it.id, it.x, it.y, it.z, it.roll, it.pitch, it.yaw);
+      break;
+    }
+    dragging_gizmo_ = false;
+    drag_in_progress_ = false;
+    active_axis_.clear();
+    QToolTip::showText(QCursor::pos(), QStringLiteral("Gizmo drag cancelled."), this);
+    update();
+    e->accept();
+    return;
+  }
+  QOpenGLWidget::keyPressEvent(e);
 }

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -74,7 +74,9 @@ protected:
   void paintGL() override;
   void mousePressEvent(QMouseEvent * e) override;
   void mouseMoveEvent(QMouseEvent * e) override;
+  void mouseReleaseEvent(QMouseEvent * e) override;
   void wheelEvent(QWheelEvent * e) override;
+  void keyPressEvent(QKeyEvent * e) override;
 
 private:
   struct ItemBounds { double x, y, z, sx, sy, sz; };
@@ -104,6 +106,14 @@ private:
   QPoint drag_start_;
   bool dragging_gizmo_{ false };
   QString active_axis_;
+  struct DragPose
+  {
+    QString item_id;
+    double x{ 0.0 }, y{ 0.0 }, z{ 0.0 };
+    double roll{ 0.0 }, pitch{ 0.0 }, yaw{ 0.0 };
+  };
+  DragPose drag_start_pose_;
+  bool drag_in_progress_{ false };
   QString hovered_id_;
   struct MeshCacheEntry
   {


### PR DESCRIPTION
### Motivation
- Enable cancelling an in-progress 3D gizmo drag with `Escape` and restore the item to the pose at drag start. 
- Prevent duplicate undo entries created by continuous transform updates during dragging so only the release-time commit produces an undo entry.

### Description
- Added `keyPressEvent(QKeyEvent*)` override in `Scene3DViewportWidget` to handle `Qt::Key_Escape` and ignore it when no drag is active. 
- Introduced `DragPose drag_start_pose_` and `bool drag_in_progress_` to capture the selected item's pose at drag start and track drag lifecycle, and capture the start pose on drag begin in `mousePressEvent`. 
- Restores the item to `drag_start_pose_`, emits `transform_changed_cb` with restored values, clears drag state, and shows a cancel tooltip when `Escape` is pressed; added `mouseReleaseEvent` to clear drag state on release. 
- Updated the transform callback in `mainwindow.cpp` to stop pushing per-update undo entries from the continuous transform updates so cancel restores do not create duplicate undo commits (the release path remains the single commit point).

### Testing
- Performed automated source inspections to verify the presence of new members (`drag_start_pose_`, `drag_in_progress_`), the `keyPressEvent` override, and the `mouseReleaseEvent` insertion; inspections matched the expected diffs and succeeded. 
- No unit tests or CI runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1655b5fc833191bce88cc676f7d2)