### PR TITLE
Respect locked preview metadata in 3D gizmo interactions

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -989,7 +989,13 @@ void MainWindow::setup_studio_shell()
   canvas_mode_label_ = new QLabel("Mode: Select · 3D Layout Preview", scene_builder); controls->addWidget(canvas_mode_label_);
   scene_preview_widget_ = new ScenePreviewWidget(scene_builder);
   scene_preview_widget_->set_label_mode(ScenePreviewWidget::LabelMode::Selected);
-  connect(scene_preview_widget_, &ScenePreviewWidget::studio_log_requested, this, [this](const QString &m){ append_studio_log(m); });
+  connect(scene_preview_widget_, &ScenePreviewWidget::studio_log_requested, this, [this](const QString &m){
+    append_studio_log(m);
+    if (m.startsWith("Locked:", Qt::CaseInsensitive) && inspector_warning_label_) {
+      inspector_warning_label_->setText(
+        "Warnings: " + m + " | Reachability: preview-only | Collision: preview-only | Safety zone: preview-only | Pick source reach: unknown | Place target reach: unknown | Warning count: 1 | Preview-only");
+    }
+  });
   connect(scene_preview_widget_, &ScenePreviewWidget::preview_item_selected, this, [this](const QString &id, const QString &role){
     apply_scene_selection(id, role, id.trimmed().isEmpty(), false);
   });
@@ -1873,6 +1879,9 @@ MainWindow::SelectedSceneItemState MainWindow::current_selected_scene_item() con
     if (state.role_or_category.isEmpty()) state.role_or_category = item->data(RoleCategory).toString().trimmed();
     if (state.role_or_category.isEmpty()) state.role_or_category = item->data(RoleType).toString().trimmed();
     state.source_path = item->data(RoleSource).toString().trimmed();
+    state.locked = item->data(RoleLocked).toBool();
+    state.editable = !state.locked;
+    state.lock_reason = state.locked ? item->data(RoleWarning).toString().trimmed() : QString();
     state.pose_available = true;
     state.pose_x = item->pos().x() / 100.0;
     state.pose_y = item->pos().y() / 100.0;
@@ -1935,7 +1944,8 @@ void MainWindow::refresh_selected_scene_item_labels(const SelectedSceneItemState
   const QString role = state.role_or_category.isEmpty() ? "unknown" : state.role_or_category;
   const QString source = state.source_path.isEmpty() ? "unknown" : state.source_path;
   const QString pose = state.pose_available ? (state.pose_text.isEmpty() ? QString("x=%1 y=%2 z=%3").arg(state.pose_x).arg(state.pose_y).arg(state.pose_z) : state.pose_text) : "pose unknown";
-  inspector_label_->setText(QString("Name: %1\nRole: %2\nID: %3\nSource: %4").arg(display, role, state.id, source));
+  const QString locked_line = state.locked ? QString("Locked: %1").arg(state.lock_reason.isEmpty() ? QStringLiteral("item is locked") : state.lock_reason) : QStringLiteral("Locked: no");
+  inspector_label_->setText(QString("Name: %1\nRole: %2\nID: %3\nSource: %4\n%5").arg(display, role, state.id, source, locked_line));
   inspector_label_->setToolTip(source);
   live_coordinate_label_->setText(QString("Transform: %1").arg(pose));
 }
@@ -4190,6 +4200,13 @@ void MainWindow::populate_scene_hierarchy()
     p.origin_offset_z = item.origin_offset_z;
     p.mesh_available = item.mesh_available;
     p.mesh_load_warning = QString::fromStdString(item.mesh_load_warning);
+    p.locked = item.locked;
+    p.editable = !item.locked;
+    if (item.locked) {
+      const QString base_reason = p.warnings.isEmpty() ? QStringLiteral("item is locked") : p.warnings.front();
+      p.lock_reason = base_reason;
+      p.warnings << QStringLiteral("Locked: %1").arg(base_reason);
+    }
     preview_items.push_back(p);
     if (allowed_scene_roles.contains(p.role)) {
       add_tree_node(p);

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -178,6 +178,9 @@ private:
     QString display_name;
     QString role_or_category;
     QString source_path;
+    bool editable{ true };
+    bool locked{ false };
+    QString lock_reason;
     bool pose_available{ false };
     double pose_x{ 0.0 };
     double pose_y{ 0.0 };

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -148,6 +148,18 @@ QString warning_debug_text(const QStringList & warnings)
   return QStringLiteral("%1 (+%2 more)").arg(warnings.front()).arg(warnings.size() - 1);
 }
 
+bool item_is_editable_for_gizmo(const ScenePreviewWidget::PreviewItem & it)
+{
+  if (it.locked) return false;
+  return it.editable;
+}
+
+QString item_locked_reason(const ScenePreviewWidget::PreviewItem & it)
+{
+  const QString reason = it.lock_reason.trimmed();
+  return reason.isEmpty() ? QStringLiteral("item is locked") : reason;
+}
+
 NormalizedRole classify_item_role(const ScenePreviewWidget::PreviewItem & it)
 {
   const QString role = normalized_token(it.role);
@@ -326,7 +338,8 @@ void Scene3DViewportWidget::paintGL()
     }
     if (it->id == selected_id) {
       const ItemBounds bounds = item_bounds_for_role(*it);
-      draw_box_outline(bounds.x, bounds.y, bounds.z, bounds.sx, bounds.sy, bounds.sz, QColor("#f8fafc"));
+      const bool editable = item_is_editable_for_gizmo(*it);
+      draw_box_outline(bounds.x, bounds.y, bounds.z, bounds.sx, bounds.sy, bounds.sz, editable ? QColor("#f8fafc") : QColor("#94a3b8"));
     }
   }
 
@@ -819,7 +832,18 @@ void Scene3DViewportWidget::mousePressEvent(QMouseEvent * e) {
   QString best_id, best_role;
   if (pick_item_at_screen(e->pos(), best_id, best_role) && !best_id.isEmpty() && select_cb) select_cb(best_id, best_role);
   drag_start_ = e->pos();
-  dragging_gizmo_ = (gizmo_mode == GizmoMode::Move || gizmo_mode == GizmoMode::Rotate) && !selected_id.isEmpty();
+  dragging_gizmo_ = false;
+  if ((gizmo_mode == GizmoMode::Move || gizmo_mode == GizmoMode::Rotate) && !selected_id.isEmpty()) {
+    for (const auto & it : items) {
+      if (it.id != selected_id) continue;
+      if (!item_is_editable_for_gizmo(it)) {
+        if (status_message_cb) status_message_cb(QStringLiteral("Locked: %1").arg(item_locked_reason(it)));
+        return;
+      }
+      dragging_gizmo_ = true;
+      break;
+    }
+  }
   if (dragging_gizmo_) {
     const int dx = qAbs(e->x() - width() / 2);
     const int dy = qAbs(e->y() - height() / 2);
@@ -831,6 +855,11 @@ void Scene3DViewportWidget::mouseMoveEvent(QMouseEvent * e)
   if (dragging_gizmo_ && (e->buttons() & Qt::LeftButton) && !selected_id.isEmpty()) {
     for (auto & it : items) {
       if (it.id != selected_id) continue;
+      if (!item_is_editable_for_gizmo(it)) {
+        dragging_gizmo_ = false;
+        if (status_message_cb) status_message_cb(QStringLiteral("Locked: %1").arg(item_locked_reason(it)));
+        return;
+      }
       const QPoint delta = e->pos() - drag_start_;
       if (gizmo_mode == GizmoMode::Move) {
         double step = 0.0;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -46,6 +46,7 @@ public:
   ScenePreviewWidget::CameraOverlayModel camera_overlay;
   QVector<ScenePreviewWidget::EpdDetectionOverlayModel> epd_detections;
   std::function<void(const QString &, const QString &)> select_cb;
+  std::function<void(const QString &)> status_message_cb;
   std::function<void(const QString &, double, double, double, double, double, double)> transform_changed_cb;
   enum class GizmoMode { Select, Move, Rotate, ScaleDisabled };
   enum class SnapMode { Off, Cm1, Cm5, Cm10, Deg5, Deg15 };

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -163,6 +163,9 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
     v->update();
   });
   static_cast<Scene3DViewportWidget *>(simple_3d_view_)->select_cb = [this](const QString & id, const QString & role){ select_preview_item(id); emit preview_item_selected(id, role); emit studio_log_requested(QString("Selected preview item: %1 (%2)").arg(id, role)); };
+  static_cast<Scene3DViewportWidget *>(simple_3d_view_)->status_message_cb = [this](const QString & message) {
+    emit studio_log_requested(message);
+  };
   refresh_info_chip();
   refresh_mode_and_state();
 }

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -36,6 +36,9 @@ public:
     bool mesh_available{ false };
     QString mesh_load_warning;
     bool selectable{ true };
+    bool editable{ true };
+    bool locked{ false };
+    QString lock_reason;
     bool metadata_complete{ true };
     QStringList warnings;
     bool has_mesh_metadata{ false };


### PR DESCRIPTION
### Motivation
- Ensure locked/ non-editable preview items remain selectable but cannot be transformed via the 3D gizmo.  
- Surface a human-readable lock reason to the user when interaction is blocked.  
- Render gizmo/selection visuals in a disabled style for locked items so the UI clearly indicates non-editability.  

### Description
- Added edit/lock metadata to the preview model by extending `ScenePreviewWidget::PreviewItem` with `editable`, `locked`, and `lock_reason` fields.  
- Added a `status_message_cb` to `Scene3DViewportWidget` plus helpers `item_is_editable_for_gizmo` and `item_locked_reason`, and used these to block gizmo activation/drag when an item is locked or non-editable and to emit `Locked: <reason>` via the callback.  
- Adjusted rendering in `Scene3DViewportWidget::paintGL()` to draw selected items with a disabled-style outline when not editable, preserving selection but visually indicating lock state.  
- Wired the viewport `status_message_cb` through `ScenePreviewWidget` to `studio_log_requested` so lock messages surface in the existing UI logging channel.  
- Extended `MainWindow::SelectedSceneItemState` to carry `locked`/`editable`/`lock_reason`, populate those values from canvas items, include `Locked: <reason>` in the inspector summary text, and propagate lock metadata into constructed `PreviewItem`s (including adding a lock-related warning).  

### Testing
- Ran repository searches to validate changes with `rg -n "Locked:|lock_reason|editable"` which returned the updated sites and succeeded.  
- Verified working-tree state with `git status --short` and committed the change successfully.  
- Generated PR metadata via the `make_pr` helper which completed successfully.  
- Note: no automated build or unit test run was executed in this rollout (changes are UI/interaction wiring and were validated via code inspection and the commits above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1658b3c88331b06ba6688ef4ed9a)