### PR TITLE
Refactor gizmo drag to use session-based cumulative deltas

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -253,6 +253,14 @@ double distance_to_polyline_2d(const QPointF & p, const QVector<QPointF> & polyl
   for (int i = 1; i < polyline.size(); ++i) best = qMin(best, distance_to_segment_2d(p, polyline[i - 1], polyline[i]));
   return best;
 }
+
+double wrap_angle_pi(double angle)
+{
+  constexpr double kTwoPi = 2.0 * M_PI;
+  double wrapped = std::fmod(angle + M_PI, kTwoPi);
+  if (wrapped < 0.0) wrapped += kTwoPi;
+  return wrapped - M_PI;
+}
 }
 
 
@@ -936,8 +944,11 @@ void Scene3DViewportWidget::mousePressEvent(QMouseEvent * e) {
   if (e->button() != Qt::LeftButton) return;
   QString best_id, best_role;
   if (pick_item_at_screen(e->pos(), best_id, best_role) && !best_id.isEmpty() && select_cb) select_cb(best_id, best_role);
-  drag_start_ = e->pos();
+  drag_start_screen_ = e->pos();
   dragging_gizmo_ = false;
+  drag_active_handle_ = GizmoHandle::None;
+  drag_in_progress_ = false;
+  drag_cancelled_ = false;
   if ((gizmo_mode == GizmoMode::Move || gizmo_mode == GizmoMode::Rotate) && !selected_id.isEmpty()) {
     for (const auto & it : items) {
       if (it.id != selected_id) continue;
@@ -962,7 +973,6 @@ void Scene3DViewportWidget::mousePressEvent(QMouseEvent * e) {
       drag_start_pose_.roll = it.roll;
       drag_start_pose_.pitch = it.pitch;
       drag_start_pose_.yaw = it.yaw;
-      drag_in_progress_ = true;
       break;
     }
     double score = std::numeric_limits<double>::max();
@@ -970,13 +980,14 @@ void Scene3DViewportWidget::mousePressEvent(QMouseEvent * e) {
     bool picked = false;
     if (gizmo_mode == GizmoMode::Move) {
       picked = pick_gizmo_axis_at_screen(e->pos(), axis, &score);
-      if (picked) active_gizmo_handle_ = (axis == "x") ? GizmoHandle::MoveX : (axis == "y" ? GizmoHandle::MoveY : GizmoHandle::MoveZ);
+      if (picked) drag_active_handle_ = (axis == "x") ? GizmoHandle::MoveX : (axis == "y" ? GizmoHandle::MoveY : GizmoHandle::MoveZ);
     } else if (gizmo_mode == GizmoMode::Rotate) {
       picked = pick_gizmo_rotation_ring_at_screen(e->pos(), axis, &score);
-      if (picked) active_gizmo_handle_ = (axis == "x") ? GizmoHandle::Roll : (axis == "y" ? GizmoHandle::Pitch : GizmoHandle::Yaw);
+      if (picked) drag_active_handle_ = (axis == "x") ? GizmoHandle::Roll : (axis == "y" ? GizmoHandle::Pitch : GizmoHandle::Yaw);
     }
     active_axis_ = axis;
     dragging_gizmo_ = picked && !axis.isEmpty();
+    drag_in_progress_ = dragging_gizmo_;
   }
 }
 void Scene3DViewportWidget::mouseMoveEvent(QMouseEvent * e)
@@ -989,25 +1000,34 @@ void Scene3DViewportWidget::mouseMoveEvent(QMouseEvent * e)
         if (status_message_cb) status_message_cb(QStringLiteral("Locked: %1").arg(item_locked_reason(it)));
         return;
       }
-      const QPoint delta = e->pos() - drag_start_;
-      if (gizmo_mode == GizmoMode::Move) {
+      const QPoint delta = e->pos() - drag_start_screen_;
+      if (gizmo_mode == GizmoMode::Move && drag_active_handle_ != GizmoHandle::None) {
         double step = 0.0;
         if (snap_mode == SnapMode::Cm1) step = 0.01;
         if (snap_mode == SnapMode::Cm5) step = 0.05;
         if (snap_mode == SnapMode::Cm10) step = 0.10;
-        const double raw = (active_axis_ == "x" ? delta.x() : -delta.y()) * 0.002;
+        const bool axis_x = (drag_active_handle_ == GizmoHandle::MoveX);
+        const double raw = (axis_x ? delta.x() : -delta.y()) * 0.002;
         const double snapped = step > 0.0 ? std::round(raw / step) * step : raw;
-        if (active_axis_ == "x") it.x += snapped; else if (active_axis_ == "y") it.y += snapped; else it.z += snapped;
-      } else if (gizmo_mode == GizmoMode::Rotate) {
+        it.x = drag_start_pose_.x;
+        it.y = drag_start_pose_.y;
+        it.z = drag_start_pose_.z;
+        if (drag_active_handle_ == GizmoHandle::MoveX) it.x = drag_start_pose_.x + snapped;
+        else if (drag_active_handle_ == GizmoHandle::MoveY) it.y = drag_start_pose_.y + snapped;
+        else if (drag_active_handle_ == GizmoHandle::MoveZ) it.z = drag_start_pose_.z + snapped;
+      } else if (gizmo_mode == GizmoMode::Rotate && drag_active_handle_ != GizmoHandle::None) {
         double step = 0.0;
         if (snap_mode == SnapMode::Deg5) step = qDegreesToRadians(5.0);
         if (snap_mode == SnapMode::Deg15) step = qDegreesToRadians(15.0);
         const double raw = (delta.x() - delta.y()) * 0.01;
         const double snapped = step > 0.0 ? std::round(raw / step) * step : raw;
-        if (active_axis_ == "x") it.roll += snapped; else if (active_axis_ == "y") it.pitch += snapped; else it.yaw += snapped;
+        it.roll = drag_start_pose_.roll;
+        it.pitch = drag_start_pose_.pitch;
+        it.yaw = drag_start_pose_.yaw;
+        if (drag_active_handle_ == GizmoHandle::Roll) it.roll = wrap_angle_pi(drag_start_pose_.roll + snapped);
+        else if (drag_active_handle_ == GizmoHandle::Pitch) it.pitch = wrap_angle_pi(drag_start_pose_.pitch + snapped);
+        else if (drag_active_handle_ == GizmoHandle::Yaw) it.yaw = wrap_angle_pi(drag_start_pose_.yaw + snapped);
       }
-      drag_start_ = e->pos();
-      if (transform_changed_cb) transform_changed_cb(it.id, it.x, it.y, it.z, it.roll, it.pitch, it.yaw);
       update();
       return;
     }
@@ -1066,8 +1086,17 @@ void Scene3DViewportWidget::mouseMoveEvent(QMouseEvent * e)
 void Scene3DViewportWidget::mouseReleaseEvent(QMouseEvent * e)
 {
   if (e->button() == Qt::LeftButton) {
+    if (drag_in_progress_ && !drag_cancelled_ && transform_changed_cb) {
+      for (const auto & it : items) {
+        if (it.id != drag_start_pose_.item_id) continue;
+        transform_changed_cb(it.id, it.x, it.y, it.z, it.roll, it.pitch, it.yaw);
+        break;
+      }
+    }
     dragging_gizmo_ = false;
     drag_in_progress_ = false;
+    drag_cancelled_ = false;
+    drag_active_handle_ = GizmoHandle::None;
     active_axis_.clear();
   }
   QOpenGLWidget::mouseReleaseEvent(e);
@@ -1101,6 +1130,8 @@ void Scene3DViewportWidget::keyPressEvent(QKeyEvent * e)
     }
     dragging_gizmo_ = false;
     drag_in_progress_ = false;
+    drag_cancelled_ = true;
+    drag_active_handle_ = GizmoHandle::None;
     active_axis_.clear();
     QToolTip::showText(QCursor::pos(), QStringLiteral("Gizmo drag cancelled."), this);
     update();

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -116,7 +116,7 @@ private:
   bool draw_mesh_preview_if_available(const ScenePreviewWidget::PreviewItem & it, const QColor & color, bool preview_path = true);
   void draw_unit_cube_triangles(const QColor & color);
   QPoint last_;
-  QPoint drag_start_;
+  QPoint drag_start_screen_;
   bool dragging_gizmo_{ false };
   QString active_axis_;
   struct DragPose
@@ -127,7 +127,8 @@ private:
   };
   DragPose drag_start_pose_;
   bool drag_in_progress_{ false };
-  GizmoHandle active_gizmo_handle_{ GizmoHandle::None };
+  bool drag_cancelled_{ false };
+  GizmoHandle drag_active_handle_{ GizmoHandle::None };
   GizmoHandle hovered_gizmo_handle_{ GizmoHandle::None };
   QString hovered_id_;
   struct MeshCacheEntry


### PR DESCRIPTION
### Motivation
- Make gizmo dragging behave as a single coherent session so pointer movement is interpreted cumulatively rather than as incremental per-frame deltas.
- Ensure snapping applies to the cumulative motion and rotations are normalized to avoid angle wrap artifacts.
- Emit exactly one transform commit on release and provide a reliable Escape cancel that restores the start pose and suppresses the release commit.

### Description
- Added drag session state fields to `scene3d_viewport_widget.h`: `drag_start_screen_`, `drag_start_pose_` (x/y/z/roll/pitch/yaw), `drag_active_handle_`, `drag_in_progress_`, and `drag_cancelled_`.
- Implemented `wrap_angle_pi` helper and used it to normalize rotation outputs to `[-pi, pi]` during drag updates.
- Updated `mousePressEvent` to capture the start pointer and starting pose and to initialize drag session state without mutating the item pose on press.
- Updated `mouseMoveEvent` to compute the cumulative pointer delta from `drag_start_screen_`, map that delta via the active handle into world translation/rotation, apply snapping to the cumulative value, and compose the current pose as `start_pose + snapped_delta` (no incremental accumulation); `mouseReleaseEvent` now emits a single `transform_changed_cb` when the drag completes and clears session state, while `Escape` cancels and restores the start pose.

### Testing
- Ran scoped static checks using `rg` to verify modified symbols and event handlers and the grep checks succeeded.
- Applied the patch and verified the source changes were written successfully (apply_patch reported success).
- Created a local commit to record the change (commit succeeded); no automated unit tests were present or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b18adabc48331a22569ae742ff324)