### PR TITLE
Add Scene3D marker coverage to static and acceptance validators

### DIFF
--- a/scripts/validate_scene_builder_ui_acceptance.py
+++ b/scripts/validate_scene_builder_ui_acceptance.py
@@ -31,6 +31,8 @@ def run_checks(file_text_map:dict[str,str]|None=None)->list[CheckResult]:
             'preview_cpp':_load_text([REPO_ROOT/'workcell_builder/workcell_builder/gui/scene_preview_widget.cpp']),
             'layout_editor_cpp':_load_text([REPO_ROOT/'workcell_builder/workcell_builder/gui/environment_layout_editor.cpp']),
             'object_placement_cpp':_load_text([REPO_ROOT/'workcell_builder/workcell_builder/gui/object_placement_dialog.cpp']),
+            'viewport_h':_load_text([REPO_ROOT/'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h']),
+            'viewport_cpp':_load_text([REPO_ROOT/'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp']),
         }
     main=file_text_map.get('mainwindow_cpp','')
     all_text="\n".join(file_text_map.values())
@@ -47,6 +49,12 @@ def run_checks(file_text_map:dict[str,str]|None=None)->list[CheckResult]:
     checks.append(_token_check("3D/2D layout wording",all_text,["3D Layout Preview","2D Layout"]))
     checks.append(_token_check("fake hardware launch token",all_text,["use_fake_hardware:=true"]))
     checks.append(_token_check("scene3d gizmo tokens",all_text,["Gizmo:","Scene3D Gizmo Transform","Snap:","Move","Rotate"]))
+    checks.append(_token_check("scene3d pick handle API markers",all_text,["pick_gizmo_axis_at_screen","pick_gizmo_rotation_ring_at_screen","active_gizmo_handle"]))
+    checks.append(_token_check("scene3d snap value markers",all_text,["snap_translation_value","snap_rotation_value"]))
+    checks.append(_token_check("escape cancel restore path markers",all_text,["Qt::Key_Escape","restore"]))
+    checks.append(_token_check("mouse release single-commit path markers",all_text,["mouseReleaseEvent","commit","single-commit"]))
+    checks.append(_token_check("locked item gating/status markers",all_text,["Locked:","locked"]))
+    checks.append(_token_check("inspector sync/layout dirty markers",all_text,["inspector","sync","layout dirty"]))
     checks.append(_regex_absent_check("no hidden QPushButton indirection anti-pattern",main,{"menu_action_new_cell":r'addAction\("Create New Cell"\s*,',"menu_action_plan_simulate":r'addAction\("Open Plan & Simulate"\s*,'}))
     checks.append(_regex_absent_check("fixed-width button anti-pattern checks",main,{"qpushbutton_fixed_width_literal":r"\b[a-zA-Z_][a-zA-Z0-9_]*button[a-zA-Z0-9_]*\s*->\s*setFixedWidth\s*\(\s*\d+\s*\)"}))
     return checks

--- a/tests/test_scene3d_transform_gizmos_static.py
+++ b/tests/test_scene3d_transform_gizmos_static.py
@@ -3,11 +3,23 @@ from pathlib import Path
 
 def test_scene3d_transform_gizmo_tokens_exist():
     viewport_h = Path("workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h").read_text(encoding="utf-8")
+    viewport_cpp = Path("workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp").read_text(encoding="utf-8")
+    editor_cpp = Path("workcell_builder/workcell_builder/gui/environment_layout_editor.cpp").read_text(encoding="utf-8")
     preview_cpp = Path("workcell_builder/workcell_builder/gui/scene_preview_widget.cpp").read_text(encoding="utf-8")
     main_cpp = Path("workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
 
     assert "enum class GizmoMode" in viewport_h
     assert "enum class SnapMode" in viewport_h
     assert "transform_changed_cb" in viewport_h
+    assert "pick_gizmo_axis_at_screen" in viewport_h
+    assert "pick_gizmo_rotation_ring_at_screen" in viewport_h
+    assert "active_gizmo_handle" in viewport_h
+    assert ("snap_translation_value" in viewport_h) or ("Snap:" in preview_cpp)
+    assert ("snap_rotation_value" in viewport_h) or ("Rotate" in preview_cpp)
+    assert "Qt::Key_Escape" in viewport_cpp and ("restore" in viewport_cpp or "cancel" in viewport_cpp)
+    assert "mouseReleaseEvent" in viewport_cpp and ("commit" in viewport_cpp or "transform_changed_cb" in viewport_cpp)
+    assert "Locked:" in viewport_cpp or "Locked:" in editor_cpp
+    assert "inspector" in main_cpp and ("refresh_selection_transform_editor_from_item" in main_cpp or "apply_inspector_pose_to_item" in main_cpp)
+    assert "mark_layout_dirty" in main_cpp
     assert '"Move"' in preview_cpp and '"Rotate"' in preview_cpp
     assert "Scene3D Gizmo Transform" in main_cpp

--- a/tests/test_scene_builder_ui_acceptance.py
+++ b/tests/test_scene_builder_ui_acceptance.py
@@ -22,6 +22,21 @@ def _base_fixture() -> dict[str, str]:
                 'QString rpy = "RPY";',
                 'QString x_units = "X position in metres";',
                 'QString yaw_units = "Yaw in radians";',
+                'QLabel *g = new QLabel("Gizmo:");',
+                'QLabel *s = new QLabel("Snap:");',
+                'QString mode_move = "Move";',
+                'QString mode_rotate = "Rotate";',
+                'QString title = "Scene3D Gizmo Transform";',
+                'QString pick_axis = "pick_gizmo_axis_at_screen";',
+                'QString pick_ring = "pick_gizmo_rotation_ring_at_screen";',
+                'QString active_handle = "active_gizmo_handle";',
+                'QString snap_t = "snap_translation_value";',
+                'QString snap_r = "snap_rotation_value";',
+                'if (e->key() == Qt::Key_Escape) { restore(); }',
+                'void mouseReleaseEvent(QMouseEvent*) { /* single-commit */ commit(); }',
+                'if (item->locked()) { status->setText("Locked:"); }',
+                'inspector->sync();',
+                'mark layout dirty;',
             ]
         ),
         "preview_cpp": "Preview panel supports 2D Layout and 3D Layout Preview",
@@ -45,6 +60,22 @@ def test_validator_fails_with_clear_diagnostics_when_tokens_or_patterns_missing(
     assert "Focus Canvas action wording" in failed
     assert any("Focus Canvas" in d for d in failed["Focus Canvas action wording"])
     assert "fixed-width button anti-pattern checks" in failed
+
+
+def test_validator_reports_new_scene3d_acceptance_failures_when_markers_absent():
+    broken = _base_fixture()
+    broken["mainwindow_cpp"] = "\n".join(
+        line
+        for line in broken["mainwindow_cpp"].splitlines()
+        if "pick_gizmo_axis_at_screen" not in line and "Qt::Key_Escape" not in line and "Locked:" not in line
+    )
+
+    checks = run_checks(broken)
+    failed = {c.name: c.details for c in checks if not c.ok}
+
+    assert "scene3d pick handle API markers" in failed
+    assert "escape cancel restore path markers" in failed
+    assert "locked item gating/status markers" in failed
 
 
 def test_repository_ui_acceptance_validator_runs_on_current_sources():


### PR DESCRIPTION
### Motivation
- Improve UI acceptance checks to explicitly verify Scene3D gizmo and inspector-related code paths (picking APIs, snap values, Escape cancel/restore, commit flow, locked-item gating) so regressions are caught by static tests.
- Keep the existing fake-hardware launch token enforcement while extending checks to cover inspector sync and layout-dirty marking to ensure editor state integration is validated.

### Description
- Updated `scripts/validate_scene_builder_ui_acceptance.py` to load `scene3d_viewport_widget.h` and `scene3d_viewport_widget.cpp` and add token checks for `pick_gizmo_axis_at_screen`, `pick_gizmo_rotation_ring_at_screen`, `active_gizmo_handle`, `snap_translation_value`, `snap_rotation_value`, `Qt::Key_Escape`/`restore`, `mouseReleaseEvent`/`commit`/`single-commit`, `Locked:`/`locked`, and inspector `sync`/layout-dirty markers.
- Extended `tests/test_scene_builder_ui_acceptance.py` fixture content to include the newly required tokens (gizmo labels, snap/mode tokens, Escape and commit markers, locked status, inspector sync and a layout-dirty marker) and added a negative test `test_validator_reports_new_scene3d_acceptance_failures_when_markers_absent` to verify clear diagnostics when key Scene3D markers are missing.
- Expanded `tests/test_scene3d_transform_gizmos_static.py` to assert presence of the Scene3D marker tokens across header and source files, including pick API symbols, Escape handling, mouse-release/commit paths, lock gating/status text, inspector callbacks, and layout-dirty/`mark_layout_dirty` invocation, with tolerant checks where the token may appear in alternate files.
- Made assertion checks tolerant of reasonable code variations (e.g. accept either `snap_translation_value` token or UI `Snap:` label, and accept `restore` or `cancel` for escape handling) to avoid brittle failures.

### Testing
- Ran the updated test-suite: `pytest -q tests/test_scene3d_transform_gizmos_static.py tests/test_scene_builder_ui_acceptance.py`; all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b18b1a63c83318cc2875dbd31b4a5)