### PR TITLE
Add Canvas/RViz parity checks and readiness UI wiring

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -79,6 +79,7 @@
 #include <QDrag>
 #include <QMimeData>
 #include <QSet>
+#include <QRegularExpression>
 #include <QHBoxLayout>
 #include <QJsonDocument>
 #include <QtConcurrent>
@@ -1410,6 +1411,7 @@ void MainWindow::setup_studio_shell()
   auto * open_validation_report_action = validation_more_menu->addAction("Open Validation Report");
   auto * copy_validation_summary_action = validation_more_menu->addAction("Copy Validation Summary");
   auto * open_readiness_dashboard_action = validation_more_menu->addAction("Open Readiness Dashboard");
+  auto * check_canvas_parity_action = validation_more_menu->addAction("Check Canvas/RViz Parity");
   validation_more_actions_button_->setMenu(validation_more_menu);
   vl->addWidget(validation_more_actions_button_);
   auto * generate_readiness_pack_button = new QPushButton("Generate Readiness Pack", validation); vl->addWidget(generate_readiness_pack_button);
@@ -1604,6 +1606,7 @@ connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo
   connect(copy_validation_summary_action, &QAction::triggered, this, &MainWindow::copy_validation_summary);
   connect(generate_readiness_pack_button, &QPushButton::clicked, this, &MainWindow::generate_readiness_pack);
   connect(open_readiness_dashboard_action, &QAction::triggered, this, &MainWindow::open_readiness_dashboard);
+  connect(check_canvas_parity_action, &QAction::triggered, this, &MainWindow::check_canvas_generated_parity);
   connect(export_scene_bundle_button, &QPushButton::clicked, this, &MainWindow::export_scene_bundle_for_selected_scene);
   connect(import_scene_bundle_button, &QPushButton::clicked, this, &MainWindow::import_scene_bundle_into_scenes_root);
   connect(open_export_folder_action, &QAction::triggered, this, &MainWindow::open_scene_bundle_export_folder);
@@ -1871,7 +1874,7 @@ void MainWindow::generate_yaml_draft_for_selected_scene()
   refresh_new_cell_checklist();
 }
 
-void MainWindow::generate_scene_package_for_selected_scene(){ if (selected_scene_index_ < 0) return; generate_yaml_draft_for_selected_scene(); const auto & sc = scene_browser_result_.scenes[(size_t)selected_scene_index_]; const QString scene_dir = QString::fromStdString(sc.scene_dir.string()); const QString scene_name = QString::fromStdString(sc.scene_name); const QString cell_definition_path = QString::fromStdString((sc.scene_dir / "cell_definition.yaml").string()); const QString output_dir = QString::fromStdString(sc.scene_dir.parent_path().string()); if (!QFileInfo::exists(cell_definition_path)) { append_studio_log("Generate ROS Scene Package: Generate YAML first."); return; } bool severe_preflight_failure = false; const QStringList preflight_warnings = generation_asset_support_preflight(sc.scene_dir / "environment_layout.yaml", &severe_preflight_failure); for (const QString & warning : preflight_warnings) { append_studio_log(warning); readiness_warning_details_.append(warning); } if (severe_preflight_failure) { append_studio_log("Generate ROS Scene Package blocked by severe schema/safety preflight failure."); refresh_new_cell_checklist(); return; } QString validate_cell_script; if (helper_script_exists("validate_cell_definition.py", &validate_cell_script)) { QProcess validate_process; validate_process.start("python3", QStringList() << validate_cell_script << cell_definition_path); if (!validate_process.waitForFinished(120000)) { append_studio_log("Generate ROS Scene Package: timed out while validating cell definition."); return; } const QString stderr_text = QString::fromUtf8(validate_process.readAllStandardError()).trimmed(); const QString stdout_text = QString::fromUtf8(validate_process.readAllStandardOutput()).trimmed(); if (validate_process.exitCode() != 0) { append_studio_log("Generate ROS Scene Package blocked: cell_definition.yaml validation failed."); const QStringList validator_lines = (stderr_text + "\n" + stdout_text).split('\n', Qt::SkipEmptyParts); bool found_missing_key_error = false; for (const QString & line : validator_lines) { const QString trimmed = line.trimmed(); if (trimmed.contains("Missing required top-level key:")) { append_studio_log("validator: " + trimmed); found_missing_key_error = true; } } if (!found_missing_key_error) { if (!stderr_text.isEmpty()) append_studio_log("validator stderr: " + stderr_text.left(600)); if (!stdout_text.isEmpty()) append_studio_log("validator stdout: " + stdout_text.left(600)); } return; } } if (output_dir.trimmed().isEmpty() || scene_name.trimmed().isEmpty()) { append_studio_log("Generate ROS Scene Package: output directory and package name are required."); return; } QString script; helper_script_exists("generate_workcell_from_cell_definition.py", &script); const auto plan = workcell_builder::build_generate_workcell_command_plan(script, scene_dir, output_dir, scene_name); if (!plan.ready()) { append_studio_log("Generate ROS Scene Package: " + plan.missing_fields_message()); return; } QProcess process; process.start("python3", QStringList() << plan.script_path << plan.arguments); if (!process.waitForFinished(180000)) { append_studio_log("Generate ROS Scene Package: timed out while waiting for helper script."); return; } const int exit_code = process.exitCode(); const QString stdout_text = QString::fromUtf8(process.readAllStandardOutput()).trimmed(); const QString stderr_text = QString::fromUtf8(process.readAllStandardError()).trimmed(); if (exit_code != 0) { append_studio_log(QString("Generate ROS Scene Package failed (exit=%1).").arg(exit_code)); if (!stderr_text.isEmpty()) append_studio_log("stderr: " + stderr_text.left(400)); if (!stdout_text.isEmpty()) append_studio_log("stdout: " + stdout_text.left(400)); launch_artifacts_ready_ = false; return; } launch_artifacts_ready_ = true; append_studio_log("Generate ROS Scene Package: " + plan.display_command()); append_studio_log(QString("Generated package location: %1/%2").arg(output_dir, scene_name)); append_studio_log(QString("Next: colcon build --symlink-install --packages-select %1").arg(scene_name)); append_studio_log("Next: source install/setup.bash"); append_studio_log(QString("Next: ros2 launch %1 demo.launch.py use_fake_hardware:=true launch_rviz:=true").arg(scene_name)); if (!stdout_text.isEmpty()) append_studio_log("stdout: " + stdout_text.left(400)); refresh_scene_browser_ui(); refresh_scene_builder_selected_scene_ui(); refresh_new_cell_checklist(); }
+void MainWindow::generate_scene_package_for_selected_scene(){ if (selected_scene_index_ < 0) return; QString parity_warning; bool severe_parity_mismatch = false; const bool parity_ran = run_canvas_generated_parity_check(&parity_warning, &severe_parity_mismatch); if (parity_ran) { refresh_canvas_generated_parity_ui(); if (!parity_warning.isEmpty()) { append_studio_log("Generate ROS Scene Package warning: " + parity_warning); } if (severe_parity_mismatch) { append_studio_log("Generate ROS Scene Package blocked: severe Canvas/Generated parity mismatch."); QMessageBox::warning(this, "Generate Scene Package", "Canvas/generated parity reported severe mismatches. Resolve blockers before generating package."); refresh_new_cell_checklist(); return; } } generate_yaml_draft_for_selected_scene(); const auto & sc = scene_browser_result_.scenes[(size_t)selected_scene_index_]; const QString scene_dir = QString::fromStdString(sc.scene_dir.string()); const QString scene_name = QString::fromStdString(sc.scene_name); const QString cell_definition_path = QString::fromStdString((sc.scene_dir / "cell_definition.yaml").string()); const QString output_dir = QString::fromStdString(sc.scene_dir.parent_path().string()); if (!QFileInfo::exists(cell_definition_path)) { append_studio_log("Generate ROS Scene Package: Generate YAML first."); return; } bool severe_preflight_failure = false; const QStringList preflight_warnings = generation_asset_support_preflight(sc.scene_dir / "environment_layout.yaml", &severe_preflight_failure); for (const QString & warning : preflight_warnings) { append_studio_log(warning); readiness_warning_details_.append(warning); } if (severe_preflight_failure) { append_studio_log("Generate ROS Scene Package blocked by severe schema/safety preflight failure."); refresh_new_cell_checklist(); return; } QString validate_cell_script; if (helper_script_exists("validate_cell_definition.py", &validate_cell_script)) { QProcess validate_process; validate_process.start("python3", QStringList() << validate_cell_script << cell_definition_path); if (!validate_process.waitForFinished(120000)) { append_studio_log("Generate ROS Scene Package: timed out while validating cell definition."); return; } const QString stderr_text = QString::fromUtf8(validate_process.readAllStandardError()).trimmed(); const QString stdout_text = QString::fromUtf8(validate_process.readAllStandardOutput()).trimmed(); if (validate_process.exitCode() != 0) { append_studio_log("Generate ROS Scene Package blocked: cell_definition.yaml validation failed."); const QStringList validator_lines = (stderr_text + "\n" + stdout_text).split('\n', Qt::SkipEmptyParts); bool found_missing_key_error = false; for (const QString & line : validator_lines) { const QString trimmed = line.trimmed(); if (trimmed.contains("Missing required top-level key:")) { append_studio_log("validator: " + trimmed); found_missing_key_error = true; } } if (!found_missing_key_error) { if (!stderr_text.isEmpty()) append_studio_log("validator stderr: " + stderr_text.left(600)); if (!stdout_text.isEmpty()) append_studio_log("validator stdout: " + stdout_text.left(600)); } return; } } if (output_dir.trimmed().isEmpty() || scene_name.trimmed().isEmpty()) { append_studio_log("Generate ROS Scene Package: output directory and package name are required."); return; } QString script; helper_script_exists("generate_workcell_from_cell_definition.py", &script); const auto plan = workcell_builder::build_generate_workcell_command_plan(script, scene_dir, output_dir, scene_name); if (!plan.ready()) { append_studio_log("Generate ROS Scene Package: " + plan.missing_fields_message()); return; } QProcess process; process.start("python3", QStringList() << plan.script_path << plan.arguments); if (!process.waitForFinished(180000)) { append_studio_log("Generate ROS Scene Package: timed out while waiting for helper script."); return; } const int exit_code = process.exitCode(); const QString stdout_text = QString::fromUtf8(process.readAllStandardOutput()).trimmed(); const QString stderr_text = QString::fromUtf8(process.readAllStandardError()).trimmed(); if (exit_code != 0) { append_studio_log(QString("Generate ROS Scene Package failed (exit=%1).").arg(exit_code)); if (!stderr_text.isEmpty()) append_studio_log("stderr: " + stderr_text.left(400)); if (!stdout_text.isEmpty()) append_studio_log("stdout: " + stdout_text.left(400)); launch_artifacts_ready_ = false; return; } launch_artifacts_ready_ = true; append_studio_log("Generate ROS Scene Package: " + plan.display_command()); append_studio_log(QString("Generated package location: %1/%2").arg(output_dir, scene_name)); append_studio_log(QString("Next: colcon build --symlink-install --packages-select %1").arg(scene_name)); append_studio_log("Next: source install/setup.bash"); append_studio_log(QString("Next: ros2 launch %1 demo.launch.py use_fake_hardware:=true launch_rviz:=true").arg(scene_name)); if (!stdout_text.isEmpty()) append_studio_log("stdout: " + stdout_text.left(400)); refresh_scene_browser_ui(); refresh_scene_builder_selected_scene_ui(); refresh_new_cell_checklist(); }
 void MainWindow::validate_generated_scene_for_selected_scene(){ if (selected_scene_index_ < 0) return; const auto & sc = scene_browser_result_.scenes[(size_t)selected_scene_index_]; QString script; if (!helper_script_exists("validate_builder_generated_scene.py", &script)) { append_studio_log("Validate Generated Scene: script missing. Searched: " + helper_script_search_paths("validate_builder_generated_scene.py").join(" | ")); return; } const auto plan = workcell_builder::build_validate_generated_scene_command_plan(script, QString::fromStdString(sc.scene_dir.string())); if (!plan.ready()) { append_studio_log("Validate Generated Scene: " + plan.missing_fields_message()); return; } QProcess process; process.start("python3", QStringList() << plan.script_path << plan.arguments); if (!process.waitForFinished(120000)) { append_studio_log("Validate Generated Scene: timed out while waiting for helper script."); return; } validation_stale_ = false; append_studio_log("Validate Generated Scene: " + plan.display_command()); refresh_new_cell_checklist(); }
 void MainWindow::copy_build_launch_commands_for_selected_scene(){ if (!has_selected_scene()) return; const QString block = selected_scene_preview_command_block(); QApplication::clipboard()->setText(block); append_studio_log("Copy Build & Launch Commands"); }
 void MainWindow::open_selected_task_file(){ if (selected_scene_index_ < 0) return; const auto & sc = scene_browser_result_.scenes[(size_t)selected_scene_index_]; const auto ti = load_scene_task_intent_summary(sc.scene_dir); if (ti.status=="MISSING_TASK_FILE"){ append_studio_log("Open Task File: missing. Searched: " + ti.searched_paths.join(" | ")); return; } QDesktopServices::openUrl(QUrl::fromLocalFile(ti.source_file)); }
@@ -2903,6 +2906,24 @@ void MainWindow::refresh_preview_launch_ui()
 
 void MainWindow::run_offline_validation() { validation_stale_ = false; append_studio_log("Full offline validation completed"); open_selected_scene_artifact("run_acceptance"); refresh_new_cell_checklist(); }
 void MainWindow::run_layout_validation_only() { validation_stale_ = false; append_studio_log("Layout validation completed"); open_selected_scene_artifact("run_acceptance"); }
+void MainWindow::check_canvas_generated_parity()
+{
+  QString user_warning;
+  bool severe_mismatch = false;
+  const bool ran = run_canvas_generated_parity_check(&user_warning, &severe_mismatch);
+  refresh_canvas_generated_parity_ui();
+  refresh_scene_workflow_rail();
+  if (!ran) {
+    return;
+  }
+  if (severe_mismatch) {
+    QMessageBox::warning(
+      this, "Canvas/RViz Parity",
+      "Canvas/generated parity is blocked by severe mismatches.\nResolve blockers before generating scene package.");
+  } else if (!user_warning.isEmpty()) {
+    QMessageBox::information(this, "Canvas/RViz Parity", user_warning);
+  }
+}
 void MainWindow::open_validation_report() { open_selected_scene_artifact("smoke"); }
 void MainWindow::copy_validation_summary() { QApplication::clipboard()->setText(validation_summary_label_ ? validation_summary_label_->text() : QString("Validation Summary unavailable")); }
 void MainWindow::generate_readiness_pack() {
@@ -2913,6 +2934,100 @@ void MainWindow::generate_readiness_pack() {
   std::system(cmd.toStdString().c_str());
 }
 void MainWindow::open_readiness_dashboard() { open_selected_scene_artifact("demo_dashboard"); }
+QString MainWindow::canvas_generated_parity_state_text(CanvasGeneratedParityState state) const
+{
+  switch (state) {
+    case CanvasGeneratedParityState::Passed: return "Passed";
+    case CanvasGeneratedParityState::Warnings: return "Warnings";
+    case CanvasGeneratedParityState::Blocked: return "Blocked";
+    case CanvasGeneratedParityState::NotChecked:
+    default:
+      return "Not checked";
+  }
+}
+
+void MainWindow::refresh_canvas_generated_parity_ui()
+{
+  if (!readiness_label_) return;
+  const QString parity_line = QString("Canvas/Generated parity: %1").arg(
+    canvas_generated_parity_state_text(canvas_generated_parity_state_));
+  QString text = readiness_label_->text();
+  if (text.contains("Canvas/Generated parity:")) {
+    text.replace(QRegularExpression("Canvas/Generated parity:.*"), parity_line);
+  } else {
+    text += QString("\n") + parity_line;
+  }
+  readiness_label_->setText(text);
+}
+
+bool MainWindow::parse_canvas_generated_parity_report(
+  const QString & report_path, int * mismatches, int * warnings, int * blockers) const
+{
+  QFile file(report_path);
+  if (!file.open(QIODevice::ReadOnly)) return false;
+  const auto doc = QJsonDocument::fromJson(file.readAll());
+  if (!doc.isObject()) return false;
+  const auto root = doc.object();
+  const auto summary = root.value("summary").toObject();
+  *mismatches = summary.value("mismatch_count").toInt(root.value("mismatch_count").toInt(0));
+  *warnings = summary.value("warning_count").toInt(root.value("warning_count").toInt(0));
+  *blockers = summary.value("blocker_count").toInt(root.value("blocker_count").toInt(0));
+  return true;
+}
+
+bool MainWindow::run_canvas_generated_parity_check(QString * user_warning, bool * severe_mismatch)
+{
+  if (user_warning) user_warning->clear();
+  if (severe_mismatch) *severe_mismatch = false;
+  if (selected_scene_index_ < 0 || selected_scene_index_ >= static_cast<int>(scene_browser_result_.scenes.size())) {
+    append_studio_log("Check Canvas/RViz Parity: no scene selected.");
+    return false;
+  }
+  QString script;
+  if (!helper_script_exists("validate_scene_builder_canvas_generated_parity.py", &script)) {
+    append_studio_log("Check Canvas/RViz Parity: missing helper script validate_scene_builder_canvas_generated_parity.py.");
+    return false;
+  }
+  const auto & s = scene_browser_result_.scenes[static_cast<size_t>(selected_scene_index_)];
+  const QString report_path = QString::fromStdString((s.scene_dir / "smoke" / "scene_builder_canvas_generated_parity_report.json").string());
+  const QString cmd = QString("python3 '%1' '%2' --json --output '%3'")
+    .arg(script, QString::fromStdString(s.scene_dir.string()), report_path);
+  append_studio_log("Check Canvas/RViz Parity command: " + cmd);
+  QProcess process;
+  process.start("/bin/bash", QStringList() << "-lc" << cmd);
+  if (!process.waitForFinished(120000)) {
+    append_studio_log("Check Canvas/RViz Parity: timed out.");
+    return false;
+  }
+  const int exit_code = process.exitCode();
+  append_studio_log(QString("Check Canvas/RViz Parity exit status: %1").arg(exit_code));
+  append_studio_log("Check Canvas/RViz Parity report path: " + report_path);
+  canvas_generated_parity_report_path_ = report_path;
+  int mismatches = 0;
+  int warnings = 0;
+  int blockers = 0;
+  if (!parse_canvas_generated_parity_report(report_path, &mismatches, &warnings, &blockers)) {
+    append_studio_log("Check Canvas/RViz Parity: failed to parse report JSON.");
+    canvas_generated_parity_state_ = CanvasGeneratedParityState::NotChecked;
+    return false;
+  }
+  canvas_generated_parity_mismatches_ = mismatches;
+  canvas_generated_parity_warnings_ = warnings;
+  canvas_generated_parity_blockers_ = blockers;
+  if (blockers > 0 || mismatches >= 3) {
+    canvas_generated_parity_state_ = CanvasGeneratedParityState::Blocked;
+    if (severe_mismatch) *severe_mismatch = true;
+  } else if (warnings > 0 || mismatches > 0) {
+    canvas_generated_parity_state_ = CanvasGeneratedParityState::Warnings;
+    if (user_warning) {
+      *user_warning = QString("Parity check found warnings/mismatches (mismatches=%1, warnings=%2). Generation remains available.")
+        .arg(mismatches).arg(warnings);
+    }
+  } else {
+    canvas_generated_parity_state_ = CanvasGeneratedParityState::Passed;
+  }
+  return true;
+}
 
 void MainWindow::run_preview_build(){ QStringList blockers; if(!selected_scene_preview_ready(&blockers)){ QMessageBox::warning(this,"Plan & Simulate",blockers.join("\n")); return; } if(detect_workspace_root().isEmpty()){ QMessageBox::warning(this,"Preview Launch","Workspace root not detected. Copy commands and run manually."); return;} active_preview_command_=selected_scene_build_command(); if(preview_log_) preview_log_->appendPlainText("$ "+active_preview_command_); set_preview_state("BUILD_RUNNING"); write_preview_launch_transcript(true, active_preview_command_, "build_started"); preview_process_->start("/bin/bash", {"-lc", active_preview_command_}); }
 void MainWindow::run_fake_hardware_preview(){ QStringList blockers; if(!selected_scene_preview_ready(&blockers)){ QMessageBox::warning(this,"Plan & Simulate",blockers.join("\n")); return; } QString command = "cd "+detect_workspace_root()+" && source install/setup.bash && "+selected_scene_launch_command(); if(!preview_command_is_safe(command,&blockers)){ QMessageBox::warning(this,"Plan & Simulate",blockers.join("\n")); return; } auto rc = QMessageBox::question(this,"Confirm Fake-Hardware Preview", "Command:\n"+command+"\n\nFake hardware only. No real hardware. No runtime execution. No robot motion commanded."); if(rc!=QMessageBox::Yes) return; active_preview_command_=command; if(preview_log_) preview_log_->appendPlainText("$ "+command); set_preview_state("PREVIEW_RUNNING"); write_preview_launch_transcript(true, command, "preview_started"); preview_process_->start("/bin/bash", {"-lc", command}); refresh_new_cell_checklist(); }
@@ -4617,6 +4732,7 @@ void MainWindow::refresh_new_cell_checklist()
       readiness_text += "\n\nWarnings: none";
     }
     readiness_label_->setText(format_scene_builder_status_text(readiness_text));
+    refresh_canvas_generated_parity_ui();
   }
 }
 

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -290,6 +290,7 @@ private:
   void run_diagnostics_golden_flow_dry_run();
   void run_offline_validation();
   void run_layout_validation_only();
+  void check_canvas_generated_parity();
   void open_validation_report();
   void copy_validation_summary();
   void generate_readiness_pack();
@@ -300,6 +301,12 @@ private:
   QStringList helper_script_search_paths(const QString & script_name) const;
   QString diagnostics_output_root() const;
   QString diagnostics_status_from_counts(int blocked, int warn) const;
+  enum class CanvasGeneratedParityState { NotChecked, Passed, Warnings, Blocked };
+  QString canvas_generated_parity_state_text(CanvasGeneratedParityState state) const;
+  void refresh_canvas_generated_parity_ui();
+  bool run_canvas_generated_parity_check(QString * user_warning = nullptr, bool * severe_mismatch = nullptr);
+  bool parse_canvas_generated_parity_report(
+    const QString & report_path, int * mismatches, int * warnings, int * blockers) const;
   void append_diagnostics_row(const QString & name, const QString & status, const QString & details, const QString & fix, const QString & related_path);
   void write_diagnostics_report(const QJsonObject & report, const QString & summary, const QString & dashboard_html);
   Ui::MainWindow * ui;
@@ -434,6 +441,11 @@ private:
   bool layout_saved_{ false };
   bool validation_stale_{ true };
   bool launch_artifacts_ready_{ false };
+  CanvasGeneratedParityState canvas_generated_parity_state_{ CanvasGeneratedParityState::NotChecked };
+  QString canvas_generated_parity_report_path_;
+  int canvas_generated_parity_mismatches_{ 0 };
+  int canvas_generated_parity_warnings_{ 0 };
+  int canvas_generated_parity_blockers_{ 0 };
   bool inspector_update_guard_{ false };
   bool selection_update_guard_{ false };
   QString current_selected_scene_item_id_;


### PR DESCRIPTION
### Motivation
- Surface and track parity between the canvas (scene builder) and generated RViz/scene outputs so users can detect mismatches before generating packages.
- Provide an explicit Validation action to run the parity validator and show results in the readiness UI line so workflow steps are clearer.
- Make generation non-blocking for non-severe parity issues while blocking on severe mismatches to prevent producing broken packages.

### Description
- Added a parity state model and storage in `MainWindow` including an enum `CanvasGeneratedParityState` (`NotChecked`, `Passed`, `Warnings`, `Blocked`), last report path, and counters for mismatches/warnings/blockers; added declarations for helper functions in `mainwindow.h`.
- Added a new Validation → More Actions menu item `Check Canvas/RViz Parity` and connected it to `check_canvas_generated_parity()` in `mainwindow.cpp`.
- Implemented `check_canvas_generated_parity()` and `run_canvas_generated_parity_check()` which invoke the helper script `validate_scene_builder_canvas_generated_parity.py` via `QProcess`, log the command/exit status/report path to the studio log, parse the JSON report, and map counts to UI states.
- Implemented JSON parsing helper `parse_canvas_generated_parity_report()` to extract `mismatch_count`, `warning_count`, and `blocker_count` and stored the counts on `MainWindow`.
- Updated readiness text to include the line `Canvas/Generated parity: <state>` and wired `refresh_canvas_generated_parity_ui()` into readiness refresh flows.
- Integrated parity preflight into `generate_scene_package_for_selected_scene()` so generation logs warnings for non-severe results but blocks (with an explicit `QMessageBox` and log entry) if parity is considered severe (current threshold: `blockers > 0 || mismatches >= 3`).

### Testing
- Ran repository symbol/content checks using `rg` to verify the new symbols, menu label, and function references were present and correctly wired; these checks succeeded.
- Performed automated edits/patch application and local file verification to ensure the changes were applied to `mainwindow.h` and `mainwindow.cpp`; these operations succeeded.
- No build or runtime integration tests were executed in this change; runtime behavior (invoking the helper script and UI dialogs) should be validated during integration/manual testing or CI build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b214d8b808331beb98be9323dd5e5)