### PR TITLE
Track generated layout assets and warn on preview-only unsupported metadata

### DIFF
--- a/scripts/generate_workcell_from_cell_definition.py
+++ b/scripts/generate_workcell_from_cell_definition.py
@@ -32,6 +32,7 @@ SUPPORTED_TASK_TYPES = {
     "inspection_then_place",
     "custom",
 }
+SUPPORTED_LAYOUT_ASSET_TYPES = {"table", "support_surface", "robot_base", "sensor", "camera", "conveyor", "bin", "fixture"}
 
 
 def _load_module(module_name: str, module_path: Path):
@@ -352,6 +353,62 @@ def _build_environment_objects(cell_def: dict[str, Any]) -> dict[str, Any]:
     return {"schema_version": "environment_objects/v1", "objects": objects}
 
 
+def _extract_asset_tracking(cell_def: dict[str, Any], warnings: list[str]) -> dict[str, Any]:
+    tracked: list[dict[str, Any]] = []
+    supported: list[dict[str, Any]] = []
+    unsupported: list[dict[str, Any]] = []
+    seen_unsupported: set[str] = set()
+
+    def _append(entry: dict[str, Any], source: str) -> None:
+        asset_id = str(entry.get("id", entry.get("name", "unknown_asset")))
+        mesh_ref = entry.get("mesh") or entry.get("mesh_path")
+        pose = entry.get("pose") if isinstance(entry.get("pose"), dict) else {}
+        pose_xyz = pose.get("xyz", entry.get("pose_xyz"))
+        pose_rpy = pose.get("rpy", entry.get("pose_rpy"))
+        asset_type = str(entry.get("type", "unknown")).strip().lower()
+        item = {
+            "asset_id": asset_id,
+            "asset_type": asset_type or "unknown",
+            "source": source,
+            "mesh_ref": mesh_ref,
+            "transform": {"frame": pose.get("frame", entry.get("frame", "world")), "xyz": pose_xyz, "rpy": pose_rpy},
+        }
+        tracked.append(item)
+        if source == "environment.layout":
+            if asset_type in SUPPORTED_LAYOUT_ASSET_TYPES:
+                supported.append(item)
+            else:
+                unsupported.append(item)
+                if asset_id not in seen_unsupported:
+                    warnings.append(f"Generated preview metadata only: {asset_id}")
+                    seen_unsupported.add(asset_id)
+        else:
+            supported.append(item)
+
+    for key in ("support_surfaces", "environment", "assets", "objects"):
+        entries = cell_def.get(key, []) if isinstance(cell_def.get(key), list) else []
+        for entry in entries:
+            if isinstance(entry, dict):
+                _append(entry, f"cell_def.{key}")
+
+    environment = cell_def.get("environment", {}) if isinstance(cell_def.get("environment"), dict) else {}
+    layout_path = environment.get("layout")
+    if isinstance(layout_path, str) and layout_path.strip():
+        resolved = (REPO_ROOT / layout_path).resolve()
+        if resolved.is_file():
+            try:
+                validator = _load_module("generated_environment_layout_validator", SCRIPTS_DIR / "validate_environment_layout.py")
+                layout_data, _, _ = validator.load_layout(resolved)
+                for asset in layout_data.get("assets", []) if isinstance(layout_data.get("assets"), list) else []:
+                    if isinstance(asset, dict):
+                        _append(asset, "environment.layout")
+            except Exception as exc:
+                warnings.append(f"Layout asset tracking skipped for '{layout_path}': {exc}")
+        else:
+            warnings.append(f"Layout asset tracking skipped; file not found: {layout_path}")
+    return {"tracked": tracked, "supported": supported, "unsupported": unsupported}
+
+
 def _run_optional_bundle_export(
     bundle_exporter: Any,
     package_name: str,
@@ -418,8 +475,16 @@ def generate_package(
         return 1
 
     scene_manifest = _augment_scene_manifest(loaded, scene_generator.build_scene_manifest(loaded), warnings)
+    asset_tracking = _extract_asset_tracking(loaded, warnings)
     task_recipe = _normalize_task_recipe(scene_generator.build_task_recipe(loaded), warnings)
     scene_manifest["task_recipe"] = task_recipe
+    scene_manifest["generated_assets"] = {
+        "tracked_count": len(asset_tracking["tracked"]),
+        "supported_count": len(asset_tracking["supported"]),
+        "unsupported_count": len(asset_tracking["unsupported"]),
+        "supported": asset_tracking["supported"],
+        "unsupported": asset_tracking["unsupported"],
+    }
 
     package_dir = output_dir / package_name
     if package_dir.exists() and not force:
@@ -479,6 +544,18 @@ def generate_package(
         + "# URDF placeholders\n\nReview and connect approved robot/environment geometry assets manually.\n",
         encoding="utf-8",
     )
+    (package_dir / "urdf" / "generated_asset_metadata.yaml").write_text(
+        _header_yaml(cell_definition_path)
+        + _yaml_text_from(
+            scene_generator,
+            {
+                "schema_version": "generated_asset_metadata/v1",
+                "supported_assets": asset_tracking["supported"],
+                "unsupported_assets": asset_tracking["unsupported"],
+            },
+        ),
+        encoding="utf-8",
+    )
 
     dry_result = dry_runner.evaluate_scene(package_name, scene_manifest_path)
 
@@ -505,6 +582,8 @@ def generate_package(
     command_script_path = generated_dir / "generated_gated_dry_run_command.sh"
     detected_example = _build_detected_objects_example(loaded, task_recipe)
     env_objects = _build_environment_objects(loaded)
+    env_objects["tracked_assets"] = asset_tracking["tracked"]
+    env_objects["unsupported_assets"] = asset_tracking["unsupported"]
     destinations = _build_destinations_export(task_recipe)
     detected_example_path.write_text(_yaml_text_from(scene_generator, detected_example), encoding="utf-8")
     env_objects_path.write_text(_yaml_text_from(scene_generator, env_objects), encoding="utf-8")
@@ -535,6 +614,8 @@ def generate_package(
         "environment_objects_path": str(env_objects_path),
         "destinations_path": str(destinations_path),
         "warnings": warnings,
+        "tracked_assets": asset_tracking["tracked"],
+        "unsupported_assets": asset_tracking["unsupported"],
         "blockers": [],
         "recommended_commands": {"preflight": preflight_cmd, "gated_dry_run": gated_cmd},
         "approval": {"status": "unapproved", "approved_by": None, "approved_at": None, "notes": ""},

--- a/tests/test_cell_definition_tools.py
+++ b/tests/test_cell_definition_tools.py
@@ -339,6 +339,51 @@ class WorkcellPackageGenerationTests(unittest.TestCase):
             warning_blob = "\n".join(summary_payload.get("warnings", []))
             self.assertNotIn("Execution plan generation status: FAIL", warning_blob)
 
+    def test_unsupported_layout_assets_emit_warning_and_are_not_silently_omitted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            layout_path = tmp_path / "environment_layout.yaml"
+            layout_path.write_text(
+                "\n".join(
+                    [
+                        "schema_version: environment_layout/v1",
+                        "layout_id: unsupported_layout",
+                        "assets:",
+                        "  - id: table_ok",
+                        "    type: table",
+                        "    pose: {frame: world, xyz: [0.0, 0.0, 0.0], rpy: [0.0, 0.0, 0.0]}",
+                        "  - id: lidar_unsupported",
+                        "    type: lidar",
+                        "    pose: {frame: world, xyz: [1.0, 0.0, 0.5], rpy: [0.0, 0.0, 0.0]}",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            cell_path = tmp_path / "cell.yaml"
+            cell_path.write_text(
+                (
+                    (FIXTURES / "cell_definition_sort_by_colour.yaml").read_text(encoding="utf-8")
+                    + f"\nenvironment:\n  frame: world\n  layout: {layout_path}\n  support_surfaces: []\n"
+                ),
+                encoding="utf-8",
+            )
+            rc = workcell_generator.generate_package(
+                cell_definition_path=cell_path,
+                output_dir=tmp_path,
+                package_name="generated_with_unsupported_layout",
+                force=False,
+                dry_run=False,
+            )
+            self.assertEqual(rc, 0)
+            gen = tmp_path / "generated_with_unsupported_layout" / "generated"
+            summary = json.loads((gen / "generated_workcell_summary.json").read_text(encoding="utf-8"))
+            self.assertTrue(any("Generated preview metadata only: lidar_unsupported" in w for w in summary.get("warnings", [])))
+            self.assertTrue(any(a.get("asset_id") == "lidar_unsupported" for a in summary.get("unsupported_assets", [])))
+            env_payload, _, _ = scene_contract_validator._read_manifest(str(gen / "generated_environment_objects.yaml"))
+            self.assertTrue(any(a.get("asset_id") == "lidar_unsupported" for a in env_payload.get("unsupported_assets", [])))
+            self.assertGreater(len(env_payload.get("tracked_assets", [])), 0)
+
 
 class CellDefinitionWizardTests(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
### Motivation

- Ensure every canvas/layout asset encountered during workcell generation is tracked and surfaced in generated metadata instead of being silently omitted. 
- Emit an explicit, searchable warning for unsupported layout asset types using the required token format so preview-only items are obvious to reviewers. 
- Propagate asset IDs, transforms and mesh references into generated outputs (manifest/URDF metadata/summary) where possible while preserving current behavior for passing fixtures.

### Description

- Added `SUPPORTED_LAYOUT_ASSET_TYPES` and a new `_extract_asset_tracking` helper that collects `tracked`, `supported`, and `unsupported` assets from cell-definition lists and from a referenced `environment.layout` file when present, preserving `asset_id`, `asset_type`, `transform`, `mesh_ref`, and source. 
- For unsupported layout assets the generator now emits the required warning string `Generated preview metadata only: <asset_id>` (deduplicated per asset) and treats them as metadata-only (non-fatal). 
- Integrated asset tracking into package generation so outputs include the collected metadata: `scene_manifest.generated_assets`, `generated/environment_objects.yaml` now contains `tracked_assets` and `unsupported_assets`, `generated_workcell_summary.json` includes `tracked_assets`/`unsupported_assets`, and `urdf/generated_asset_metadata.yaml` is written with supported/unsupported entries (IDs/transforms/mesh refs propagated). 
- Added a regression test `test_unsupported_layout_assets_emit_warning_and_are_not_silently_omitted` that creates a layout with an unsupported asset type and asserts the warning and presence of the unsupported asset in generated summary and environment outputs.

### Testing

- Ran targeted unit tests: `python -m pytest -q tests/test_cell_definition_tools.py -k 'unsupported_layout_assets or grasp_strategy_metadata_propagates_to_generated_package_outputs or generated_package_offline_validation_is_practical'` and all selected tests passed (3 passed). 
- Ran broader generation/preview suites: `python -m pytest -q tests/test_generated_workcell_bundle.py tests/test_generated_workcell_visual_preview.py` and both passed (9 passed). 
- Existing generation behavior for current fixtures was preserved as verified by the existing tests and newly added assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b21493e1c83319bf18080a828e0f8)