### PR TITLE
Add scene builder full-contract validator orchestrator

### DIFF
--- a/scripts/validate_scene_builder_full_contract.py
+++ b/scripts/validate_scene_builder_full_contract.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_VALIDATORS = [
+    "scripts/validate_scene_builder_mainline_flow.py",
+    "scripts/validate_scene_builder_ui_acceptance.py",
+    "scripts/validate_scene3d_mesh_preview_contract.py",
+    "scripts/validate_scene_builder_canvas_generated_parity.py",
+]
+SNIPPET_LINES = 6
+
+
+def _snippet(text: str) -> str:
+    lines = [line for line in text.strip().splitlines() if line.strip()]
+    if not lines:
+        return "(no output)"
+    return " | ".join(lines[:SNIPPET_LINES])
+
+
+def run_validator(path: str) -> dict[str, object]:
+    command = [sys.executable, str(ROOT / path)]
+    proc = subprocess.run(command, cwd=ROOT, capture_output=True, text=True)
+    merged = "\n".join(part for part in [proc.stdout, proc.stderr] if part)
+    return {
+        "path": path,
+        "exit_code": proc.returncode,
+        "status": "PASS" if proc.returncode == 0 else "FAIL",
+        "snippet": _snippet(merged),
+    }
+
+
+def print_summary(results: list[dict[str, object]]) -> None:
+    print("Scene Builder Full Contract Validation")
+    print("=" * 80)
+    print(f"{'Validator':62} {'Result':8} Exit  Snippet")
+    print("-" * 80)
+    for result in results:
+        print(
+            f"{result['path'][:62]:62} "
+            f"{result['status']:8} "
+            f"{result['exit_code']!s:4}  "
+            f"{result['snippet']}"
+        )
+    print("-" * 80)
+    failures = [r for r in results if r["exit_code"] != 0]
+    print(f"Overall: {'PASS' if not failures else 'FAIL'} ({len(results) - len(failures)}/{len(results)} passed)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run full Scene Builder contract validators.")
+    parser.add_argument(
+        "--validators",
+        nargs="*",
+        default=DEFAULT_VALIDATORS,
+        help="Optional override validator paths (relative to repo root).",
+    )
+    args = parser.parse_args()
+
+    results = [run_validator(path) for path in args.validators]
+    print_summary(results)
+    return 0 if all(result["exit_code"] == 0 for result in results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_scene_builder_full_contract_runner.py
+++ b/tests/test_scene_builder_full_contract_runner.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path("scripts/validate_scene_builder_full_contract.py")
+
+
+def test_runner_exists_and_references_required_validators():
+    assert SCRIPT.is_file()
+    text = SCRIPT.read_text(encoding="utf-8")
+    for token in [
+        "validate_scene_builder_mainline_flow.py",
+        "validate_scene_builder_ui_acceptance.py",
+        "validate_scene3d_mesh_preview_contract.py",
+        "validate_scene_builder_canvas_generated_parity.py",
+    ]:
+        assert token in text
+
+
+def test_runner_reports_combined_outcomes(tmp_path: Path):
+    pass_script = tmp_path / "pass_validator.py"
+    fail_script = tmp_path / "fail_validator.py"
+    pass_script.write_text("print('PASS validator ran')\n", encoding="utf-8")
+    fail_script.write_text("import sys\nprint('FAIL validator ran')\nsys.exit(2)\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--validators",
+            str(pass_script),
+            str(fail_script),
+        ],
+        cwd=Path.cwd(),
+        capture_output=True,
+        text=True,
+    )
+
+    out = result.stdout
+    assert result.returncode != 0
+    assert "PASS validator ran" in out
+    assert "FAIL validator ran" in out
+    assert "Overall: FAIL" in out


### PR DESCRIPTION
### Motivation
- Provide a single runner to execute all Scene Builder contract validators and produce a concise, actionable PASS/FAIL summary for CI and local validation.
- Capture each validator's outcome and representative output to make failures easier to triage without opening each validator individually.

### Description
- Add `scripts/validate_scene_builder_full_contract.py` which runs the four validators: `scripts/validate_scene_builder_mainline_flow.py`, `scripts/validate_scene_builder_ui_acceptance.py`, `scripts/validate_scene3d_mesh_preview_contract.py`, and `scripts/validate_scene_builder_canvas_generated_parity.py`.
- Each validator is executed as a subprocess, with exit code and merged stdout/stderr captured and reduced to a short snippet for display.
- The runner prints a compact table of `Validator / Result / Exit / Snippet` and returns non-zero if any validator fails, and supports an optional `--validators` override for custom test lists.
- Add `tests/test_scene_builder_full_contract_runner.py` which asserts the runner file references the required validators and verifies combined outcome reporting using temporary pass/fail validator scripts.

### Testing
- Run `pytest -q tests/test_scene_builder_full_contract_runner.py` which executed the two new tests and succeeded (2 passed).
- The integration-style test creates temporary pass/fail scripts, invokes the runner with `--validators`, and asserts the runner prints both validators' outputs and exits non-zero when one fails.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b2785e83c8331bfc356d0147059df)