### PR TITLE
Fix Scene3D mesh-preview regression test to avoid unintended Qt/OpenGL compilation

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -265,9 +265,15 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_conveyor_pick_preview_test
     test/conveyor_pick_preview_test.cpp
     src_conveyor_pick_preview.cpp)
+  # Source-text-only regression test: intentionally does not compile
+  # Scene3DViewportWidget. Real widget compilation coverage remains in
+  # workcell_scene3d_stl_parser_test and the main workcell_builder target.
   ament_add_gtest(workcell_scene3d_mesh_preview_regression_test
-    test/scene3d_mesh_preview_regression_test.cpp
-    gui/scene3d_viewport_widget.cpp)
+    test/scene3d_mesh_preview_regression_test.cpp)
+  if(TARGET workcell_scene3d_mesh_preview_regression_test)
+    target_compile_definitions(workcell_scene3d_mesh_preview_regression_test PRIVATE
+      WORKCELL_BUILDER_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+  endif()
   ament_add_gtest(workcell_task_intent_readiness_test
     test/task_intent_readiness_test.cpp
     src_task_intent_readiness.cpp)

--- a/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
@@ -16,7 +16,7 @@ std::string load_file(const std::string & path)
 
 TEST(Scene3DMeshPreviewRegression, KeepsTransformStackAndFallback)
 {
-  const std::string src = load_file("gui/scene3d_viewport_widget.cpp");
+  const std::string src = load_file(std::string(WORKCELL_BUILDER_SOURCE_DIR) + "/gui/scene3d_viewport_widget.cpp");
   ASSERT_FALSE(src.empty());
 
   const auto t = src.find("glTranslated(it.x, it.y, it.z)");
@@ -37,7 +37,7 @@ TEST(Scene3DMeshPreviewRegression, KeepsTransformStackAndFallback)
 
 TEST(Scene3DMeshPreviewRegression, KeepsSelectionAndOverlayRendering)
 {
-  const std::string src = load_file("gui/scene3d_viewport_widget.cpp");
+  const std::string src = load_file(std::string(WORKCELL_BUILDER_SOURCE_DIR) + "/gui/scene3d_viewport_widget.cpp");
   ASSERT_FALSE(src.empty());
   EXPECT_NE(src.find("if (it->id == selected_id)"), std::string::npos);
   EXPECT_NE(src.find("draw_box_outline(bounds.x, bounds.y, bounds.z, bounds.sx, bounds.sy, bounds.sz"), std::string::npos);
@@ -46,7 +46,7 @@ TEST(Scene3DMeshPreviewRegression, KeepsSelectionAndOverlayRendering)
 
 TEST(Scene3DMeshPreviewRegression, KeepsMeshCacheBoundsAndModeHooks)
 {
-  const std::string src = load_file("gui/scene3d_viewport_widget.cpp");
+  const std::string src = load_file(std::string(WORKCELL_BUILDER_SOURCE_DIR) + "/gui/scene3d_viewport_widget.cpp");
   ASSERT_FALSE(src.empty());
   EXPECT_NE(src.find("entry.has_bounds = compute_mesh_bounds_for_test(entry.mesh, entry.min_bounds, entry.max_bounds);"), std::string::npos);
   EXPECT_NE(src.find("if (mode == ScenePreviewWidget::MeshPreviewMode::Primitives) return false;"), std::string::npos);


### PR DESCRIPTION
## Summary
This PR is a focused build fix for `workcell_builder`.

`workcell_scene3d_mesh_preview_regression_test` is a source-text regression test, but it was compiling `gui/scene3d_viewport_widget.cpp` after PR #1807. That pulled in Qt Widgets/OpenGL headers through AUTOMOC and caused build failures (e.g. `QWidget: No such file or directory`) in configurations where this lightweight test target is not set up as a Qt widget target.

## Changes
- In `workcell_builder/workcell_builder/CMakeLists.txt`:
  - Updated `workcell_scene3d_mesh_preview_regression_test` to compile only:
    - `test/scene3d_mesh_preview_regression_test.cpp`
  - Removed `gui/scene3d_viewport_widget.cpp` from that target.
  - Added:
    - `WORKCELL_BUILDER_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"`
  - Added a clarifying comment that this target is intentionally source-text-only, and real widget compilation coverage remains in:
    - `workcell_scene3d_stl_parser_test`
    - main `workcell_builder` target

- In `workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp`:
  - Updated file loading to use:
    - `std::string(WORKCELL_BUILDER_SOURCE_DIR) + "/gui/scene3d_viewport_widget.cpp"`
  - Kept existing assertions intact (transform stack, preview fallback, selection rendering, warning label rendering, mesh-cache bounds, and `MeshPreviewMode::Primitives` hook).

## Scope and behavior
- No Scene3D runtime behavior changes.
- No redesign or dependency broadening.
- `workcell_scene3d_stl_parser_test` Qt/OpenGL compilation/linkage remains unchanged.

## Validation attempted
Tried to run requested commands, but `colcon` is not installed in this environment (`/bin/bash: colcon: command not found`):
- `colcon build --symlink-install --packages-select workcell_builder`
- `colcon test --packages-select workcell_builder --ctest-args -R "workcell_scene3d_mesh_preview_regression_test|workcell_scene3d_stl_parser_test" --output-on-failure`
- `colcon test-result --verbose`

Please run these in a ROS/colcon-enabled environment to confirm end-to-end build/test status.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b6bcb7fe88331934cf977080acbbb)