### PR TITLE
Fix Qt5 compatibility regressions in scene preview widgets

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -903,7 +903,8 @@ bool Scene3DViewportWidget::pick_gizmo_axis_at_screen(const QPoint & pos, QStrin
   if (selected == nullptr) return false;
 
   const QVector3D origin(selected->x + (selected->sx * 0.5), selected->y + (selected->sy * 0.5), selected->z + (selected->sz * 0.5));
-  const double axis_len = qMax(0.25, 0.75 * qMax({ selected->sx, selected->sy, selected->sz }));
+  const double item_extent = std::max({selected->sx, selected->sy, selected->sz});
+  const double axis_len = qMax(0.25, 0.75 * item_extent);
   const QPointF screen_p = QPointF(pos);
   const QPointF origin_s = project_to_screen(origin.x(), origin.y(), origin.z());
   if (!qIsFinite(origin_s.x()) || !qIsFinite(origin_s.y())) return false;
@@ -942,7 +943,8 @@ bool Scene3DViewportWidget::pick_gizmo_rotation_ring_at_screen(const QPoint & po
   if (selected == nullptr) return false;
 
   const QVector3D origin(selected->x + (selected->sx * 0.5), selected->y + (selected->sy * 0.5), selected->z + (selected->sz * 0.5));
-  const double radius = qMax(0.2, 0.65 * qMax({ selected->sx, selected->sy, selected->sz }));
+  const double item_extent = std::max({selected->sx, selected->sy, selected->sz});
+  const double radius = qMax(0.2, 0.65 * item_extent);
   const QPointF screen_p = QPointF(pos);
   constexpr int kRingSamples = 48;
   constexpr double kRingThresholdPx = 11.0;
@@ -1180,7 +1182,7 @@ void Scene3DViewportWidget::dragMoveEvent(QDragMoveEvent * event)
   const QByteArray payload = event->mimeData()->data("application/x-workcell-asset-catalog-item");
   drag_asset_payload_ = QJsonDocument::fromJson(payload).object();
   drag_asset_label_ = drag_asset_payload_.value("display_name").toString("asset");
-  drag_asset_screen_pos_ = event->position().toPoint();
+  drag_asset_screen_pos_ = event->pos();
   drag_asset_preview_visible_ = true;
   drag_asset_drop_status_ = QStringLiteral("Drop to place %1").arg(drag_asset_label_);
   event->acceptProposedAction();
@@ -1197,11 +1199,11 @@ void Scene3DViewportWidget::dropEvent(QDropEvent * event)
 {
   if (!event->mimeData() || !event->mimeData()->hasFormat("application/x-workcell-asset-catalog-item")) return;
   const QJsonObject payload = QJsonDocument::fromJson(event->mimeData()->data("application/x-workcell-asset-catalog-item")).object();
-  const QPoint p = event->position().toPoint();
+  const QPoint p = event->pos();
   const double x = snap_translation_value((p.x() - width() * 0.5) / 50.0, snap_mode);
   const double y = snap_translation_value((height() * 0.6 - p.y()) / 50.0, snap_mode);
   const double z = 0.0;
-  const bool shift_drop = (event->modifiers() & Qt::ShiftModifier);
+  const bool shift_drop = (event->keyboardModifiers() & Qt::ShiftModifier);
   if (asset_drop_cb) asset_drop_cb(payload, x, y, z, shift_drop);
   drag_asset_preview_visible_ = false;
   event->acceptProposedAction();

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -78,7 +78,7 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   clear_selection_button_ = new QPushButton("Clear Selection", this); controls->addWidget(clear_selection_button_);
   auto * mouse_help_label = new QLabel(QStringLiteral("ⓘ"), this);
   mouse_help_label->setToolTip(scene_preview_mouse_help_tooltip(QString()));
-  mouse_help_label->setStatusTip(QStringLiteral(kScenePreviewMouseHelpText));
+  mouse_help_label->setStatusTip(QString::fromUtf8(kScenePreviewMouseHelpText));
   controls->addWidget(mouse_help_label);
   overlays_selector_ = new QComboBox(this); overlays_selector_->addItems({"Overlays", "Reachability Heatmap", "Collision Warnings", "Safety Zones", "Work Envelope", "Warning Labels", "Labels", "Pick/Place Zones", "Task Route", "Approach/Retreat", "Camera FOV", "Pick Coverage", "EPD Detections", "Detection Labels", "Warnings", "Focus Selected", "Fit Scene", "Fit overlays", "Clear Selection"}); controls->addWidget(overlays_selector_);
   controls->addStretch(1);


### PR DESCRIPTION
### Motivation
- Resolve compilation and API-compatibility failures in the scene preview UI that were caused by Qt6-only APIs and initializer-list usage which break builds on Qt5 toolchains.
- Ensure drag/drop and string-literal handling in the preview widgets behave correctly across Qt5-based environments.

### Description
- Replace `QStringLiteral(kScenePreviewMouseHelpText)` with `QString::fromUtf8(kScenePreviewMouseHelpText)` in `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp` to avoid a constructor/parse failure.
- Replace `qMax({ ... })` initializer-list usages in `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp` with an intermediate `std::max({ ... })` (`item_extent`) and then use `qMax` on scalar values for Qt5-compatible semantics.
- Replace Qt6-only drag/drop event calls `event->position()` and `event->modifiers()` with Qt5-compatible `event->pos()` and `event->keyboardModifiers()` in `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`.
- Files modified: `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp` and `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`.

### Testing
- Attempted to run an automated build with `colcon build --symlink-install --packages-select workcell_builder`, but the command could not be executed in this environment because `colcon` is not installed (`colcon: command not found`).
- The original automated build logs demonstrated the Qt5-related compile errors that motivated these changes, and the diff addresses those specific errors, but a full automated build could not be completed here due to the missing `colcon` tool.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b70fc65908331a91f45ba256c8a9e)