### PR TITLE
Fix workcell_builder compile errors in mainwindow.cpp and scene_select.cpp

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -31,6 +31,7 @@
 #include <QTextEdit>
 #include <QPlainTextEdit>
 #include <QToolBar>
+#include <QToolTip>
 #include <QApplication>
 #include <QClipboard>
 #include <QDir>
@@ -108,6 +109,7 @@
 #include "workcell_studio_scene_browser.hpp"
 #include "workcell_studio_canvas_model.hpp"
 #include "scene_preview_widget.h"
+#include "scene3d_viewport_widget.h"
 #include "workcell_studio_layout_editor.hpp"
 #include "workcell_studio_id_utils.hpp"
 #include "gui/new_cell_wizard.h"
@@ -116,6 +118,8 @@
 #include "gui/transform_clipboard_utils.h"
 
 namespace fs = boost::filesystem;
+
+static QStringList generation_asset_support_preflight(const fs::path & layout_path, bool * severe_failure);
 
 namespace {
 [[maybe_unused]] static const char * kSelectionTransformActionTokens =
@@ -4863,7 +4867,18 @@ MainWindow::RecommendedWorkflowAction MainWindow::resolve_recommended_workflow_a
       RecommendedWorkflowActionHandler::OpenOrCreateScene);
     return action;
   }
-  if (scene_items_.empty()) {
+  bool has_asset_items = false;
+  if (digital_twin_scene_ != nullptr) {
+    const auto canvas_items = digital_twin_scene_->items();
+    for (QGraphicsItem * item : canvas_items) {
+      if (item != nullptr && item->data(RoleRole).toString() == "asset") {
+        has_asset_items = true;
+        break;
+      }
+    }
+  }
+
+  if (!has_asset_items) {
     set_action("add_asset", "Add asset", true, QString(),
       "Populate the layout with at least one asset so there is content to save and generate.",
       RecommendedWorkflowActionHandler::AddAsset);

--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -655,6 +655,7 @@ struct TaskGraspConfig
   std::string allowed_yaw_angles_deg = "0";
   int suction_cups = 1;
   std::string release_strategy = "open_gripper";
+  std::string camera_topic = "";
 };
 
 TaskGraspConfig infer_task_grasp_defaults(const Scene & scene)
@@ -2747,19 +2748,19 @@ std::string SceneSelect::build_workcell_readiness_report(
     warnings.emplace_back("perception_detection selected but EPD adapter not configured yet");
   }
   warnings.emplace_back("real hardware mode requires explicit validation");
-  std::vector<ObjectFootprint> layout_objects;
+  std::vector<workcell_builder::ObjectFootprint> layout_objects;
   for (const auto & obj : scene.object_vector) {
-    ObjectFootprint fp;
+    workcell_builder::ObjectFootprint fp;
     fp.name = obj.name;
-    fp.x = obj.object_center.cartesian.at(0);
-    fp.y = obj.object_center.cartesian.at(1);
-    fp.z = obj.object_center.cartesian.at(2);
+    fp.x = obj.ext_joint.origin.is_origin ? obj.ext_joint.origin.x : 0.0;
+    fp.y = obj.ext_joint.origin.is_origin ? obj.ext_joint.origin.y : 0.0;
+    fp.z = obj.ext_joint.origin.is_origin ? obj.ext_joint.origin.z : 0.0;
     layout_objects.push_back(fp);
   }
-  const auto overlay = evaluate_offline_readiness_overlay(
+  const auto overlay = workcell_builder::evaluate_offline_readiness_overlay(
     layout_objects,
-    estimate_robot_reach_envelope(scene.robot_vector.empty() ? "" : scene.robot_vector[0].name),
-    WorkspaceBounds{},
+    workcell_builder::estimate_robot_reach_envelope(scene.robot_vector.empty() ? "" : scene.robot_vector[0].name),
+    workcell_builder::WorkspaceBounds{},
     {},
     {},
     task_cfg.pick_source,


### PR DESCRIPTION
### Motivation
- Restore a clean `workcell_builder` build after recent Scene Builder / 3D canvas changes that introduced C++ compile errors. 
- Address only the immediate compile failures in `mainwindow.cpp` and `scene_select.cpp` without redesigning features or changing runtime/safety defaults. 

### Description
- Added missing includes in `mainwindow.cpp` for `Scene3DViewportWidget` and `QToolTip` by adding `#include "scene3d_viewport_widget.h"` and `#include <QToolTip>`. 
- Declared `generation_asset_support_preflight` before its first use via a forward declaration `static QStringList generation_asset_support_preflight(const fs::path & layout_path, bool * severe_failure);`. 
- Replaced a stale `scene_items_` member reference in `MainWindow::resolve_recommended_workflow_action()` with a local canvas inspection that checks `digital_twin_scene_->items()` for any item whose `data(RoleRole).toString() == "asset"`. 
- Fixed `scene_select.cpp` readiness-overlay integration by qualifying overlay symbols with `workcell_builder::` (`ObjectFootprint`, `WorkspaceBounds`, `estimate_robot_reach_envelope`, and `evaluate_offline_readiness_overlay`) and replaced the invalid `Object::object_center` usage with conservative coordinates derived from `obj.ext_joint.origin` (guarded by `is_origin`); also added a metadata-only `camera_topic` field to the local `TaskGraspConfig`. 

### Testing
- Attempted `colcon build --symlink-install --packages-select workcell_builder` to validate the build, but the execution environment does not have `colcon` installed so the build could not be run here. 
- Attempted `colcon test --packages-select workcell_builder --ctest-args --output-on-failure` and `colcon test-result --verbose`, but these could not be executed for the same `colcon: command not found` limitation. 
- Changes are focused to resolve the listed compile errors only and were validated via source edits and diffs; a full package build/test should be run in a normal development environment with `colcon` available to confirm success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b730b3fb083319f04a90dfc13abd6)