### PR TITLE
Add structural Scene Builder architecture guards to acceptance validators

### DIFF
--- a/scripts/validate_scene_builder_ui_acceptance.py
+++ b/scripts/validate_scene_builder_ui_acceptance.py
@@ -54,6 +54,13 @@ def _regex_absent_check(name,haystack,forbidden):
     hits=[f"forbidden pattern matched ({label}): {pat}" for label,pat in forbidden.items() if re.search(pat,haystack,re.MULTILINE)]
     return CheckResult(name,not hits,hits)
 
+def _visible_label_set_check(name:str,haystack:str,allowed:set[str],forbidden_hint:list[str])->CheckResult:
+    present=[label for label in allowed if label in haystack]
+    missing=[label for label in sorted(allowed) if label not in present]
+    forbidden=[label for label in forbidden_hint if re.search(rf"\b{re.escape(label)}\b",haystack)]
+    details=[*(f"missing visible top-level label: {m}" for m in missing),*(f"forbidden visible top-level label: {f}" for f in forbidden)]
+    return CheckResult(name,not details,details)
+
 def run_checks(file_text_map:dict[str,str]|None=None)->list[CheckResult]:
     if file_text_map is None:
         file_text_map={
@@ -91,7 +98,27 @@ def run_checks(file_text_map:dict[str,str]|None=None)->list[CheckResult]:
     checks.append(_token_check("inspector sync/layout dirty markers",all_text,["inspector","sync","layout dirty"]))
     checks.append(_regex_absent_check("no hidden QPushButton indirection anti-pattern",main,{"menu_action_new_cell":r'addAction\("Create New Cell"\s*,',"menu_action_plan_simulate":r'addAction\("Open Plan & Simulate"\s*,'}))
     checks.append(_regex_absent_check("fixed-width button anti-pattern checks",main,{"qpushbutton_fixed_width_literal":r"\b[a-zA-Z_][a-zA-Z0-9_]*button[a-zA-Z0-9_]*\s*->\s*setFixedWidth\s*\(\s*\d+\s*\)"}))
-    # Top-level clutter guard
+    checks.append(_visible_label_set_check(
+        "allowed visible top-level set only",
+        all_text,
+        {"Studio Home","New Cell","Scenes/Open","Run Next","More"},
+        ["Validate","Generate","Plan","Simulate","Export","Readiness"],
+    ))
+    checks.append(_regex_absent_check(
+        "forbidden direct top-bar primary actions",
+        all_text,
+        {
+            "validate_action": r'\bValidate\b',
+            "generate_action": r'\bGenerate\b',
+            "plan_action": r'\bPlan\b',
+            "simulate_action": r'\bSimulate\b',
+            "export_action": r'\bExport\b',
+            "readiness_action": r'\bReadiness\b',
+        },
+    ))
+    checks.append(_token_check("canvas mode and view dropdown controls",all_text,["Mode","View"]))
+    checks.append(_token_check("actions side-tab grouped sections",all_text,["Actions","Grouped sections"]))
+    checks.append(_token_check("canonical duplicate visible-label targets",all_text,["Create editable layout from preview","Canvas/Generated Parity"]))
 
     return checks
 

--- a/scripts/validate_scene_builder_ux_integration.py
+++ b/scripts/validate_scene_builder_ux_integration.py
@@ -38,6 +38,11 @@ def main() -> int:
     ok.append(check("workflow rail editable layout stage", "Editable layout" in mainwindow_cpp))
     ok.append(check("viewport helper passes", all(t in viewport_h + viewport_cpp for t in ["draw_ground_grid_pass", "draw_world_axes_pass", "scene_bounds_from_visible_items", "View: 3D"])) )
     ok.append(check("fake-hardware safety token retained", "use_fake_hardware:=true" in mainwindow_cpp))
+    ok.append(check("allowed visible top-level set", all(t in mainwindow_cpp for t in ["Studio Home", "New Cell", "Scenes/Open", "Run Next", "More"])))
+    ok.append(check("forbidden direct top-bar primary actions absent", not any(t in mainwindow_cpp for t in ["Validate", "Generate", "Plan", "Simulate", "Export", "Readiness"])))
+    ok.append(check("canvas mode and view dropdown controls present", all(t in mainwindow_cpp for t in ["Mode", "View"])))
+    ok.append(check("actions side-tab grouped sections present", all(t in mainwindow_cpp for t in ["Actions", "Grouped sections"])))
+    ok.append(check("canonical duplicate visible labels present", all(t in mainwindow_cpp for t in ["Create editable layout from preview", "Canvas/Generated Parity"])))
     # Ensure scene set before item state update in refresh flow.
     flow = re.search(r"selected_scene_state_\s*=\s*\{\};.*selected_scene_state_\.valid\s*=\s*true;.*selected_item_state_\s*=\s*current_selected_scene_item\(\);", mainwindow_cpp, flags=re.S)
     ok.append(check("scene state updated before item state", flow is not None))

--- a/tests/test_scene_builder_ui_acceptance.py
+++ b/tests/test_scene_builder_ui_acceptance.py
@@ -56,6 +56,16 @@ def _base_fixture() -> dict[str, str]:
                 'void dropEvent(QDropEvent*){}',
                 'QString drop = "Drop to place table";',
                 'auto cb = "asset_drop_cb";',
+                'QString top_home = "Studio Home";',
+                'QString top_new = "New Cell";',
+                'QString top_scenes = "Scenes/Open";',
+                'QString top_run = "Run Next";',
+                'QString top_more = "More";',
+                'QComboBox *mode = new QComboBox(this); mode->setObjectName("Mode");',
+                'QComboBox *view = new QComboBox(this); view->setObjectName("View");',
+                'QString side_tab = "Actions";',
+                'QString grouped = "Grouped sections";',
+                'QString parity = "Canvas/Generated Parity";',
             ]
         ),
         "preview_cpp": "Preview panel supports 2D Layout and 3D Layout Preview",
@@ -79,6 +89,14 @@ def test_validator_fails_with_clear_diagnostics_when_tokens_or_patterns_missing(
     assert "Focus Canvas action wording" in failed
     assert any("Focus Canvas" in d for d in failed["Focus Canvas action wording"])
     assert "fixed-width button anti-pattern checks" in failed
+
+
+def test_validator_fails_when_forbidden_top_bar_primary_actions_exist():
+    broken = _base_fixture()
+    broken["mainwindow_cpp"] += '\nQAction *validate = toolbar->addAction("Validate");\n'
+    checks = run_checks(broken)
+    failed = {c.name: c.details for c in checks if not c.ok}
+    assert "forbidden direct top-bar primary actions" in failed
 
 
 def test_validator_reports_new_scene3d_acceptance_failures_when_markers_absent():


### PR DESCRIPTION
### Motivation
- Prevent UI/UX regressions by adding static checks that enforce the Scene Builder top-level/toolbar architecture and canonical labels.
- Surface structural deviations (forbidden primary actions, missing canvas controls, duplicate canonical labels) early during CI-like validation.

### Description
- Added `_visible_label_set_check` and new checks to `scripts/validate_scene_builder_ui_acceptance.py` to verify allowed top-level labels, forbid direct top-bar primary actions, ensure presence of `Mode`/`View` dropdowns, assert an `Actions` side-tab with grouped sections, and detect canonical duplicate visible labels.
- Extended `scripts/validate_scene_builder_ux_integration.py` to assert the same architecture requirements against repository sources.
- Updated `tests/test_scene_builder_ui_acceptance.py` fixture data to include required tokens (`Studio Home`, `New Cell`, `Scenes/Open`, `Run Next`, `More`, `Mode`, `View`, `Actions`, `Grouped sections`, `Canvas/Generated Parity`) and added a regression test that fails when a forbidden top-bar action like `Validate` is present.

### Testing
- Ran `pytest -q tests/test_scene_builder_ui_acceptance.py` and all tests passed (`9 passed`).
- New regression test `test_validator_fails_when_forbidden_top_bar_primary_actions_exist` verifies that forbidden top-bar actions cause validation to fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c70d50fdc8331bd302a561ee09b0a)