### PR TITLE
Fix Qt5 qMin/qreal type mismatch in Scene3D mesh shading

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -660,9 +660,10 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
     const float diffuse = qMax(0.0f, QVector3D::dotProduct(normal, light_dir));
     const float shade = ambient + diffuse * diffuse_scale;
     const float edge_boost = 0.08f * (1.0f - diffuse);
-    glColor4f(qMin(1.0f, color.redF() * shade + edge_boost),
-              qMin(1.0f, color.greenF() * shade + edge_boost),
-              qMin(1.0f, color.blueF() * shade + edge_boost), 1.0f);
+    const float red = qMin(1.0f, static_cast<float>(color.redF()) * shade + edge_boost);
+    const float green = qMin(1.0f, static_cast<float>(color.greenF()) * shade + edge_boost);
+    const float blue = qMin(1.0f, static_cast<float>(color.blueF()) * shade + edge_boost);
+    glColor4f(red, green, blue, 1.0f);
     glVertex3f(tri.vertices[0].x(), tri.vertices[0].y(), tri.vertices[0].z());
     glVertex3f(tri.vertices[1].x(), tri.vertices[1].y(), tri.vertices[1].z());
     glVertex3f(tri.vertices[2].x(), tri.vertices[2].y(), tri.vertices[2].z());


### PR DESCRIPTION
## Summary
- Fixed the `workcell_builder` Qt5 compile error in `Scene3DViewportWidget::draw_mesh_preview_if_available` caused by mixed template argument types in `qMin(float, qreal)`.
- Replaced direct `glColor4f(qMin(...))` calls with explicit float channel computation:
  - `red`, `green`, `blue` now use `static_cast<float>(color.*F())` before shading/clamping.
  - Preserved the existing upper clamp behavior (`qMin(1.0f, ...)`) and `glColor4f` float arguments.

## Qt5 mixed-type audit
- Audited nearby `qMin`, `qMax`, and `qBound` usages in `scene3d_viewport_widget.cpp`.
- No additional Qt5 template mismatches requiring changes were found beyond the mesh shading callsite.

## Validation
- `colcon build --symlink-install --packages-select workcell_builder` could not be executed in this environment because `colcon` is not installed (`colcon: command not found`).
- Static/contract checks run:
  - `python3 -m pytest -q tests/test_scene3d_transform_gizmos_static.py` ✅ passed
  - `python3 scripts/validate_scene3d_mesh_preview_contract.py` ✅ passed
  - `python3 scripts/validate_scene_builder_full_contract.py` ❌ failed due to pre-existing scene builder token-contract failures unrelated to this tiny mesh shading type fix.

## Behavior impact
- No UI redesigns, no added buttons/actions, and no fake-hardware safety behavior changes.
- Change is limited to Qt5 type-safe casting in mesh preview shading.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8598e29c8331a6d6953088912acf)