### PR TITLE
Simplify dashboard scene list labels to scene name only

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -2397,7 +2397,7 @@ void MainWindow::refresh_studio_home_scene_table()
       const bool lmatch_q = lq.isEmpty() || scene_name.toLower().contains(lq);
       const bool lmatch_status = (lstatus == "All") || (lstatus == "Ready" && status == "READY") || (lstatus == "Warning" && status == "WARNINGS") || (lstatus == "Blocked" && (status != "READY" && status != "WARNINGS"));
       if (lmatch_q && lmatch_status) {
-        auto * item = new QListWidgetItem(QString("%1\n%2 | %3 | %4").arg(scene_name, QString::fromStdString(sc.robot_summary), QString::fromStdString(sc.gripper_summary), status));
+        auto * item = new QListWidgetItem(scene_name);
         item->setData(Qt::UserRole, static_cast<int>(i));
         dashboard_library_list_->addItem(item);
       }


### PR DESCRIPTION
### Motivation
- Reduce duplicated summary text in the left-side scene list by showing only the scene name in the compact list, keeping robot/gripper/status/provenance details in the right-side detail surfaces.

### Description
- Change left library population in `MainWindow::refresh_studio_home_scene_table` to create `QListWidgetItem(scene_name)` instead of the prior combined `"%1\n%2 | %3 | %4"` pipe-delimited label, leaving table columns and the selected-scene details card unchanged.

### Testing
- Ran code searches (`rg`) to locate the list population site and confirm the pattern was replaced, inspected the diff with `git diff`, and committed the change, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8a3aafcc8331a625bf6e16fd3ea4)