### PR TITLE
Normalize Scene Builder top-header labels to "Scenes", "Run Next", "More"

### DIFF
--- a/scripts/validate_scene_builder_ui_acceptance.py
+++ b/scripts/validate_scene_builder_ui_acceptance.py
@@ -54,6 +54,28 @@ def _regex_absent_check(name,haystack,forbidden):
     hits=[f"forbidden pattern matched ({label}): {pat}" for label,pat in forbidden.items() if re.search(pat,haystack,re.MULTILINE)]
     return CheckResult(name,not hits,hits)
 
+def _top_header_label_hygiene_check(name:str,haystack:str)->CheckResult:
+    details=[]
+    required={
+        "scenes_open_button":"Scenes",
+        "run_next_button":"Run Next",
+        "more_button":"More",
+    }
+    for button,label in required.items():
+        pattern=rf'{button}\s*->\s*setText\("([^"]+)"\);'
+        m=re.search(pattern,haystack)
+        if not m:
+            details.append(f'missing top-header label assignment for {button}')
+            continue
+        value=m.group(1)
+        if value!=label:
+            details.append(f'{button} must be exactly "{label}" (found "{value}")')
+        if "/" in value:
+            details.append(f'forbidden top-header label hack (slash-composed): "{value}"')
+        if value.endswith("_"):
+            details.append(f'forbidden top-header label hack (trailing underscore): "{value}"')
+    return CheckResult(name,not details,details)
+
 def _visible_label_set_check(name:str,haystack:str,allowed:set[str],forbidden_hint:list[str])->CheckResult:
     present=[label for label in allowed if label in haystack]
     missing=[label for label in sorted(allowed) if label not in present]
@@ -101,9 +123,10 @@ def run_checks(file_text_map:dict[str,str]|None=None)->list[CheckResult]:
     checks.append(_visible_label_set_check(
         "allowed visible top-level set only",
         main,
-        {"Studio Home","New Cell","Scenes/Open","Run Next","More"},
+        {"Studio Home","New Cell","Scenes","Run Next","More"},
         ["Validate","Generate","Plan","Simulate","Export","Readiness"],
     ))
+    checks.append(_top_header_label_hygiene_check("top-header labels are exact and menu-hint free",main))
     checks.append(_regex_absent_check(
         "forbidden direct top-bar primary actions",
         main,

--- a/scripts/validate_scene_builder_ux_integration.py
+++ b/scripts/validate_scene_builder_ux_integration.py
@@ -38,7 +38,19 @@ def main() -> int:
     ok.append(check("workflow rail editable layout stage", "Editable layout" in mainwindow_cpp))
     ok.append(check("viewport helper passes", all(t in viewport_h + viewport_cpp for t in ["draw_ground_grid_pass", "draw_world_axes_pass", "scene_bounds_from_visible_items", "View: 3D"])) )
     ok.append(check("fake-hardware safety token retained", "use_fake_hardware:=true" in mainwindow_cpp))
-    ok.append(check("allowed visible top-level set", all(t in mainwindow_cpp for t in ["Studio Home", "New Cell", "Scenes/Open", "Run Next", "More"])))
+    ok.append(check("allowed visible top-level set", all(t in mainwindow_cpp for t in ["Studio Home", "New Cell", "Scenes", "Run Next", "More"])))
+    top_header_exact = all(t in mainwindow_cpp for t in [
+        'scenes_open_button->setText("Scenes");',
+        'run_next_button->setText("Run Next");',
+        'more_button->setText("More");',
+    ])
+    ok.append(check("top header exact labels", top_header_exact))
+    top_labels = {}
+    for button in ["scenes_open_button", "run_next_button", "more_button"]:
+        m = re.search(rf'{button}\s*->\s*setText\("([^"]+)"\);', mainwindow_cpp)
+        top_labels[button] = m.group(1) if m else ""
+    no_label_hacks = all("/" not in text and not text.endswith("_") for text in top_labels.values())
+    ok.append(check("top header labels avoid slash/underscore hacks", no_label_hacks))
     forbidden_topbar = re.findall(r"addWidget\(new\s+(?:QPushButton|QToolButton)\([^;]*\"(Validate|Generate|Plan|Simulate|Export|Readiness)\"", mainwindow_cpp)
     ok.append(check("forbidden direct top-bar primary actions absent", len(forbidden_topbar) == 0, detail=str(forbidden_topbar)))
     ok.append(check("canvas mode and view dropdown controls present", all(t in mainwindow_cpp for t in ["Mode", "View"])))

--- a/tests/test_scene_builder_ui_acceptance.py
+++ b/tests/test_scene_builder_ui_acceptance.py
@@ -58,9 +58,12 @@ def _base_fixture() -> dict[str, str]:
                 'auto cb = "asset_drop_cb";',
                 'QString top_home = "Studio Home";',
                 'QString top_new = "New Cell";',
-                'QString top_scenes = "Scenes/Open";',
+                'QString top_scenes = "Scenes";',
                 'QString top_run = "Run Next";',
                 'QString top_more = "More";',
+                'scenes_open_button->setText("Scenes");',
+                'run_next_button->setText("Run Next");',
+                'more_button->setText("More");',
                 'QComboBox *mode = new QComboBox(this); mode->setObjectName("Mode");',
                 'QComboBox *view = new QComboBox(this); view->setObjectName("View");',
                 'QString side_tab = "Actions";',
@@ -68,7 +71,7 @@ def _base_fixture() -> dict[str, str]:
                 'QString parity = "Canvas/Generated Parity";',
             ]
         ),
-        "preview_cpp": "Preview panel supports 2D Layout and 3D Layout Preview",
+        "preview_cpp": "Preview panel supports 2D Layout and 3D Layout Preview with Validate Simulate Export Diagnostics sections",
         "layout_editor_cpp": "metres radians",
     }
 
@@ -113,6 +116,17 @@ def test_validator_reports_new_scene3d_acceptance_failures_when_markers_absent()
     assert "scene3d pick handle API markers" in failed
     assert "escape cancel restore path markers" in failed
     assert "locked item gating/status markers" in failed
+
+
+def test_validator_fails_for_top_header_label_hacks():
+    broken = _base_fixture()
+    broken["mainwindow_cpp"] = broken["mainwindow_cpp"].replace('scenes_open_button->setText("Scenes");','scenes_open_button->setText("Scenes/Open");')
+    broken["mainwindow_cpp"] = broken["mainwindow_cpp"].replace('run_next_button->setText("Run Next");','run_next_button->setText("Run Next_");')
+    checks = run_checks(broken)
+    failed = {c.name: c.details for c in checks if not c.ok}
+
+    assert "top-header labels are exact and menu-hint free" in failed
+    assert any("forbidden top-header label hack" in d for d in failed["top-header labels are exact and menu-hint free"])
 
 
 def test_repository_ui_acceptance_validator_runs_on_current_sources():

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1815,7 +1815,7 @@ void MainWindow::build_studio_header_actions()
     top_bar->addWidget(button);
   }
   auto * scenes_open_button = new QToolButton(this);
-  scenes_open_button->setText("Scenes/Open");
+  scenes_open_button->setText("Scenes");
   scenes_open_button->setPopupMode(QToolButton::InstantPopup);
   auto * scenes_open_menu = new QMenu(scenes_open_button);
   scenes_open_menu->addAction(action_workspace_open_scene_builder_);


### PR DESCRIPTION
### Motivation

- Remove embedded menu hints from top-header labels and ensure the top command bar shows explicit, exact labels `Scenes`, `Run Next`, and `More` while relying on `QToolButton` popup modes for menu affordance.

### Description

- Updated `workcell_builder/workcell_builder/gui/mainwindow.cpp` to set `scenes_open_button->setText("Scenes")` (replacing `Scenes/Open`) and retained `QToolButton::InstantPopup` behavior for menus.
- Added `_top_header_label_hygiene_check` to `scripts/validate_scene_builder_ui_acceptance.py` and replaced the allowed visible-top set to include `Scenes` (instead of `Scenes/Open`), enforcing exact `setText(...)` assignments and rejecting slash-composed or trailing-underscore label hacks.
- Updated `scripts/validate_scene_builder_ux_integration.py` to require exact `scenes_open_button->setText("Scenes");`, `run_next_button->setText("Run Next");`, and `more_button->setText("More");` and to detect label-hack patterns.
- Updated `tests/test_scene_builder_ui_acceptance.py` fixture and added `test_validator_fails_for_top_header_label_hacks` to validate the new acceptance checks and adjusted tokens used by the test fixture to satisfy related checks.

### Testing

- Ran `pytest -q tests/test_scene_builder_ui_acceptance.py` and all tests passed (`10 passed`).
- Ran `python3 scripts/validate_scene_builder_ux_integration.py` and the integration checks passed. 
- The acceptance validator logic was exercised by the unit tests (`run_checks`), and the new negative regression test ensures `Scenes/Open` and trailing-underscore hacks fail as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c89f5a9848331954b50a6c0ecbbf0)