### PR TITLE
Move Scene Builder Undo/Redo out of footer into Actions/More menus

### DIFF
--- a/scripts/validate_scene_builder_ui_acceptance.py
+++ b/scripts/validate_scene_builder_ui_acceptance.py
@@ -118,6 +118,17 @@ def run_checks(file_text_map:dict[str,str]|None=None)->list[CheckResult]:
     ))
     checks.append(_token_check("canvas mode and view dropdown controls",all_text,["Mode","View"]))
     checks.append(_token_check("actions side-tab grouped sections",all_text,["Actions","Layout","Generate","Validate","Simulate","Export","Diagnostics"]))
+    checks.append(_token_check("layout undo/redo exposed via action surfaces",all_text,["Undo Layout Edit","Redo Layout Edit"]))
+    checks.append(_regex_absent_check(
+        "no always-visible direct undo/redo canvas-footer buttons",
+        main,
+        {
+            "undo_direct_canvas_button": r'undo_layout_button_\s*=\s*new\s+QPushButton\s*\(\s*"Undo"\s*,\s*scene_builder\s*\)',
+            "redo_direct_canvas_button": r'redo_layout_button_\s*=\s*new\s+QPushButton\s*\(\s*"Redo"\s*,\s*scene_builder\s*\)',
+            "undo_footer_addwidget": r'layout_controls->addWidget\s*\(\s*undo_layout_button_\s*\)',
+            "redo_footer_addwidget": r'layout_controls->addWidget\s*\(\s*redo_layout_button_\s*\)',
+        },
+    ))
     checks.append(_token_check("canonical duplicate visible-label targets",all_text,["Create editable layout from preview","Canvas/Generated Parity"]))
 
     return checks

--- a/tests/test_scene_builder_ui_acceptance.py
+++ b/tests/test_scene_builder_ui_acceptance.py
@@ -64,11 +64,14 @@ def _base_fixture() -> dict[str, str]:
                 'QComboBox *mode = new QComboBox(this); mode->setObjectName("Mode");',
                 'QComboBox *view = new QComboBox(this); view->setObjectName("View");',
                 'QString side_tab = "Actions";',
+                'QString section_layout = "Layout";',
                 'QString grouped = "Grouped sections";',
                 'QString parity = "Canvas/Generated Parity";',
+                'QString undo_layout = "Undo Layout Edit";',
+                'QString redo_layout = "Redo Layout Edit";',
             ]
         ),
-        "preview_cpp": "Preview panel supports 2D Layout and 3D Layout Preview",
+        "preview_cpp": "Preview panel supports 2D Layout and 3D Layout Preview. Actions Layout Generate Validate Simulate Export Diagnostics",
         "layout_editor_cpp": "metres radians",
     }
 
@@ -89,6 +92,14 @@ def test_validator_fails_with_clear_diagnostics_when_tokens_or_patterns_missing(
     assert "Focus Canvas action wording" in failed
     assert any("Focus Canvas" in d for d in failed["Focus Canvas action wording"])
     assert "fixed-width button anti-pattern checks" in failed
+
+
+def test_validator_fails_when_undo_redo_are_direct_canvas_buttons():
+    broken = _base_fixture()
+    broken["mainwindow_cpp"] += '\nundo_layout_button_ = new QPushButton("Undo", scene_builder);\nlayout_controls->addWidget(undo_layout_button_);\nredo_layout_button_ = new QPushButton("Redo", scene_builder);\nlayout_controls->addWidget(redo_layout_button_);\n'
+    checks = run_checks(broken)
+    failed = {c.name: c.details for c in checks if not c.ok}
+    assert "no always-visible direct undo/redo canvas-footer buttons" in failed
 
 
 def test_validator_fails_when_forbidden_top_bar_primary_actions_exist():

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1079,6 +1079,8 @@ void MainWindow::setup_studio_shell()
     return button;
   };
   register_scene_action("layout.save", "Save Layout", [this]() { if (save_layout_button_) save_layout_button_->click(); });
+  register_scene_action("layout.undo", "Undo Layout Edit", [this]() { undo_layout_edit(); });
+  register_scene_action("layout.redo", "Redo Layout Edit", [this]() { redo_layout_edit(); });
   register_scene_action("layout.duplicate", "Duplicate Selected", [this]() { duplicate_selected_item(); });
   register_scene_action("layout.remove", "Remove Selected Layout Item", [this]() { delete_selected_item(); });
   register_scene_action("generate.scene_package", "Generate", [this]() { generate_scene_package_for_selected_scene(); });
@@ -1206,6 +1208,12 @@ void MainWindow::setup_studio_shell()
   scene_builder_secondary_overflow_button_->setText("More");
   scene_builder_secondary_overflow_button_->setPopupMode(QToolButton::InstantPopup);
   scene_builder_secondary_overflow_menu_ = new QMenu(scene_builder_secondary_overflow_button_);
+  auto * secondary_layout_menu = scene_builder_secondary_overflow_menu_->addMenu("Layout");
+  secondary_layout_menu->addAction(scene_builder_action("layout.undo"));
+  secondary_layout_menu->addAction(scene_builder_action("layout.redo"));
+  secondary_layout_menu->addAction(scene_builder_action("layout.save"));
+  secondary_layout_menu->addAction(scene_builder_action("layout.duplicate"));
+  secondary_layout_menu->addAction(scene_builder_action("layout.remove"));
   scene_builder_secondary_overflow_button_->setMenu(scene_builder_secondary_overflow_menu_);
   controls->addWidget(scene_builder_secondary_overflow_button_);
   auto * export_snapshot = new QPushButton("Export Canvas Snapshot", scene_builder); center_panel_layout->addLayout(controls);
@@ -1215,8 +1223,8 @@ void MainWindow::setup_studio_shell()
   center_panel_layout->addWidget(scene_preview_widget_, 1);
   minimap_view_ = new QGraphicsView(scene_builder); minimap_view_->setObjectName("digital_twin_minimap"); minimap_view_->setFixedSize(210, 140); center_panel_layout->addWidget(minimap_view_, 0, Qt::AlignRight);
   auto * layout_controls = new QHBoxLayout();
-  undo_layout_button_ = new QPushButton("Undo", scene_builder); layout_controls->addWidget(undo_layout_button_);
-  redo_layout_button_ = new QPushButton("Redo", scene_builder); layout_controls->addWidget(redo_layout_button_);
+  undo_layout_button_ = nullptr;
+  redo_layout_button_ = nullptr;
   create_starter_layout_button_ = new QPushButton("Create editable layout from preview", scene_builder);
   create_starter_layout_button_->setVisible(false);
   layout_controls->addWidget(create_starter_layout_button_);
@@ -1399,6 +1407,8 @@ void MainWindow::setup_studio_shell()
   auto * diagnostics_actions = make_action_section("Diagnostics");
 
   create_action_button(layout_actions, "layout.save");
+  create_action_button(layout_actions, "layout.undo");
+  create_action_button(layout_actions, "layout.redo");
   create_action_button(layout_actions, "layout.duplicate");
   create_action_button(layout_actions, "layout.remove");
   create_action_button(generate_actions, "generate.scene_package");
@@ -1676,8 +1686,6 @@ connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo
     rebuild_digital_twin_canvas();
   });
   connect(toggle_warnings_box_, &QCheckBox::toggled, this, [this](bool){ rebuild_digital_twin_canvas(); });
-  connect(undo_layout_button_, &QPushButton::clicked, this, &MainWindow::undo_layout_edit);
-  connect(redo_layout_button_, &QPushButton::clicked, this, &MainWindow::redo_layout_edit);
   connect(duplicate_layout_button_, &QPushButton::clicked, this, &MainWindow::duplicate_selected_item);
   connect(delete_layout_button_, &QPushButton::clicked, this, &MainWindow::delete_selected_item);
   for (auto *sb : {inspector_x_, inspector_y_, inspector_z_, inspector_roll_, inspector_pitch_, inspector_yaw_}) connect(sb, qOverload<double>(&QDoubleSpinBox::valueChanged), this, [this](double){ if (inspector_live_update_box_ && inspector_live_update_box_->isChecked()) apply_selection_transform_from_editor(); });
@@ -1711,6 +1719,8 @@ connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo
   for (auto * box : {show_reach_overlay_box_, show_camera_fov_overlay_box_, show_pick_place_overlay_box_, show_trajectory_overlay_box_}) connect(box, &QCheckBox::toggled, this, [this](bool){ rebuild_digital_twin_canvas(); });
   auto * del_sc = new QShortcut(QKeySequence(Qt::Key_Delete), scene_builder); connect(del_sc,&QShortcut::activated,this,&MainWindow::delete_selected_item);
   auto * save_sc = new QShortcut(QKeySequence::Save, scene_builder); connect(save_sc,&QShortcut::activated,this,&MainWindow::save_layout_changes);
+  auto * undo_sc = new QShortcut(QKeySequence::Undo, scene_builder); connect(undo_sc, &QShortcut::activated, this, &MainWindow::undo_layout_edit);
+  auto * redo_sc = new QShortcut(QKeySequence::Redo, scene_builder); connect(redo_sc, &QShortcut::activated, this, &MainWindow::redo_layout_edit);
   auto * esc_sc = new QShortcut(QKeySequence(Qt::Key_Escape), scene_builder); connect(esc_sc,&QShortcut::activated,this,[this](){ set_canvas_interaction_mode(CanvasInteractionMode::Select); if(digital_twin_scene_) digital_twin_scene_->clearSelection(); ghost_preview_item_=nullptr; rebuild_digital_twin_canvas(); });
   auto * fit_sc = new QShortcut(QKeySequence(Qt::Key_F), scene_builder); connect(fit_sc,&QShortcut::activated,fit_button,&QAction::trigger);
   connect(run_layout_merge_button, &QPushButton::clicked, this, [this](){ run_layout_merge_for_selected_scene(false); });
@@ -3731,6 +3741,12 @@ void MainWindow::update_scene_builder_top_controls_overflow()
     scene_builder_top_controls_host_->parentWidget()->width() : width();
   const bool constrained = available_width < 1280;
   scene_builder_secondary_overflow_menu_->clear();
+  auto * secondary_layout_menu = scene_builder_secondary_overflow_menu_->addMenu("Layout");
+  secondary_layout_menu->addAction(scene_builder_action("layout.undo"));
+  secondary_layout_menu->addAction(scene_builder_action("layout.redo"));
+  secondary_layout_menu->addAction(scene_builder_action("layout.save"));
+  secondary_layout_menu->addAction(scene_builder_action("layout.duplicate"));
+  secondary_layout_menu->addAction(scene_builder_action("layout.remove"));
   const auto remap_menu = [this](QToolButton * button) {
       if (!button || !button->menu()) return;
       scene_builder_secondary_overflow_menu_->addMenu(button->menu());


### PR DESCRIPTION
### Motivation
- Reduce clutter in the Scene Builder viewport/footer by removing always-visible Undo/Redo buttons while preserving undo/redo behavior.
- Surface Undo/Redo via existing action surfaces and keyboard shortcuts so they remain discoverable without occupying canvas/footer real estate.

### Description
- Removed direct `QPushButton` creation and footer-placement for Undo/Redo in `workcell_builder/workcell_builder/gui/mainwindow.cpp` and left the underlying handlers (`undo_layout_edit` / `redo_layout_edit`) intact.
- Added `layout.undo` and `layout.redo` actions to the scene action registry and exposed them in the `Actions` tab `Layout` section via `create_action_button` calls and in the secondary overflow `More > Layout` submenu so they remain accessible from menus.
- Added standard keyboard shortcuts by wiring `QKeySequence::Undo` and `QKeySequence::Redo` to the existing handlers in `mainwindow.cpp` and removed footer `connect(...)` bindings for the removed buttons.
- Added static acceptance checks to `scripts/validate_scene_builder_ui_acceptance.py` that require Undo/Redo to be exposed as action-surface labels and to fail if Undo/Redo are reintroduced as always-visible direct canvas/footer `QPushButton`s, and added/updated tests in `tests/test_scene_builder_ui_acceptance.py` to cover the new rules.

### Testing
- Ran unit tests with `pytest tests/test_scene_builder_ui_acceptance.py -q` which passed (`10 passed`).
- Ran the UI acceptance script with `python3 scripts/validate_scene_builder_ui_acceptance.py`; the new Undo/Redo-specific checks passed but the script returned failure due to pre-existing top-level label/policy checks unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8a0c25408331916d52f3063ab1db)