### PR TITLE
Harden scene builder nav/button label validation

### DIFF
--- a/scripts/validate_scene_builder_ui_acceptance.py
+++ b/scripts/validate_scene_builder_ui_acceptance.py
@@ -102,18 +102,22 @@ def run_checks(file_text_map:dict[str,str]|None=None)->list[CheckResult]:
         "allowed visible top-level set only",
         main,
         {"Studio Home","New Cell","Scenes/Open","Run Next","More"},
-        ["Validate","Generate","Plan","Simulate","Export","Readiness"],
+        [],
     ))
     checks.append(_regex_absent_check(
         "forbidden direct top-bar primary actions",
         main,
         {
-            "validate_action": r'\bValidate\b',
-            "generate_action": r'\bGenerate\b',
-            "plan_action": r'\bPlan\b',
-            "simulate_action": r'\bSimulate\b',
-            "export_action": r'\bExport\b',
-            "readiness_action": r'\bReadiness\b',
+            "direct_toolbar_actions": r'addWidget\(new\s+(?:QPushButton|QToolButton)\([^;]*"(?:Validate|Generate|Plan|Simulate|Export|Readiness|Delete\s+Scene|Select|Place\s+Asset|Move|Inspect|Save\s+Layout|Undo|Redo)"',
+        },
+    ))
+    checks.append(_regex_absent_check(
+        "no trailing-underscore nav labels",
+        main,
+        {
+            "run_next_trailing_underscore": r'"Run\s+Next_"',
+            "more_trailing_underscore": r'"More_"',
+            "scenes_open_trailing_underscore": r'"Scenes/Open_"',
         },
     ))
     checks.append(_token_check("canvas mode and view dropdown controls",all_text,["Mode","View"]))

--- a/scripts/validate_scene_builder_ux_integration.py
+++ b/scripts/validate_scene_builder_ux_integration.py
@@ -28,7 +28,7 @@ def main() -> int:
     model_cpp = read("workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp")
 
     ok = []
-    ok.append(check("primary actions present", all(t in mainwindow_cpp for t in ["Select", "Place Asset", "Move", "Inspect", "Save Layout"])))
+    ok.append(check("primary actions available in actions/menu surfaces", all(t in mainwindow_cpp for t in ["Select", "Place Asset", "Move", "Inspect", "Save Layout"])))
     ok.append(check("secondary menus present", all(t in mainwindow_cpp for t in ["Overlays", "Canvas More", "Visual Modes", "Label mode", "Mesh preview mode", "Snap mode"])))
     ok.append(check("toolbar overflow wiring", all(t in mainwindow_cpp + mainwindow_h for t in ["scene_builder_secondary_overflow_button_", "scene_builder_secondary_overflow_menu_", "update_scene_builder_top_controls_overflow"])) )
     ok.append(check("no fixed-width toolbar anti-pattern", "setFixedWidth" not in mainwindow_cpp or "button" not in mainwindow_cpp))
@@ -39,8 +39,10 @@ def main() -> int:
     ok.append(check("viewport helper passes", all(t in viewport_h + viewport_cpp for t in ["draw_ground_grid_pass", "draw_world_axes_pass", "scene_bounds_from_visible_items", "View: 3D"])) )
     ok.append(check("fake-hardware safety token retained", "use_fake_hardware:=true" in mainwindow_cpp))
     ok.append(check("allowed visible top-level set", all(t in mainwindow_cpp for t in ["Studio Home", "New Cell", "Scenes/Open", "Run Next", "More"])))
-    forbidden_topbar = re.findall(r"addWidget\(new\s+(?:QPushButton|QToolButton)\([^;]*\"(Validate|Generate|Plan|Simulate|Export|Readiness)\"", mainwindow_cpp)
-    ok.append(check("forbidden direct top-bar primary actions absent", len(forbidden_topbar) == 0, detail=str(forbidden_topbar)))
+    forbidden_topbar = re.findall(r"addWidget\(new\s+(?:QPushButton|QToolButton)\([^;]*\"(Validate|Generate|Plan|Simulate|Export|Readiness|Delete Scene|Select|Place Asset|Move|Inspect|Save Layout|Undo|Redo)\"", mainwindow_cpp)
+    ok.append(check("forbidden direct always-visible button actions absent", len(forbidden_topbar) == 0, detail=str(forbidden_topbar)))
+    trailing_nav = re.findall(r"\"(?:Run\s+Next_|More_|Scenes/Open_)\"", mainwindow_cpp)
+    ok.append(check("no trailing-underscore nav labels", len(trailing_nav) == 0, detail=str(trailing_nav)))
     ok.append(check("canvas mode and view dropdown controls present", all(t in mainwindow_cpp for t in ["Mode", "View"])))
     ok.append(check("actions side-tab grouped sections present", all(t in mainwindow_cpp for t in ["Actions", "Layout", "Generate", "Validate", "Simulate", "Export", "Diagnostics"])))
     ok.append(check("shared action registry exists", "scene_builder_action_registry_" in mainwindow_h and "register_scene_builder_action" in mainwindow_cpp))

--- a/tests/test_scene_builder_ui_acceptance.py
+++ b/tests/test_scene_builder_ui_acceptance.py
@@ -65,6 +65,10 @@ def _base_fixture() -> dict[str, str]:
                 'QComboBox *view = new QComboBox(this); view->setObjectName("View");',
                 'QString side_tab = "Actions";',
                 'QString grouped = "Grouped sections";',
+                'QString validate_label = "Validate";',
+                'QString simulate_label = "Simulate";',
+                'QString export_label = "Export";',
+                'QString diagnostics_label = "Diagnostics";',
                 'QString parity = "Canvas/Generated Parity";',
             ]
         ),
@@ -91,12 +95,46 @@ def test_validator_fails_with_clear_diagnostics_when_tokens_or_patterns_missing(
     assert "fixed-width button anti-pattern checks" in failed
 
 
-def test_validator_fails_when_forbidden_top_bar_primary_actions_exist():
+def test_validator_fails_when_forbidden_direct_always_visible_actions_exist():
     broken = _base_fixture()
-    broken["mainwindow_cpp"] += '\nQAction *validate = toolbar->addAction("Validate");\n'
+    broken["mainwindow_cpp"] += (
+        '\nQToolBar* toolbar = new QToolBar(this);'
+        '\ntoolbar->addWidget(new QPushButton("Validate", this));'
+        '\ntoolbar->addWidget(new QToolButton(this)); // Select'
+        '\ntoolbar->addWidget(new QPushButton("Delete Scene", this));\n'
+    )
     checks = run_checks(broken)
     failed = {c.name: c.details for c in checks if not c.ok}
     assert "forbidden direct top-bar primary actions" in failed
+
+
+def test_validator_allows_forbidden_labels_when_only_in_menu_or_actions_tab():
+    allowed = _base_fixture()
+    allowed["mainwindow_cpp"] += "\n" + "\n".join([
+        "actions_menu->addAction(\"Validate\");",
+        "actions_menu->addAction(\"Plan\");",
+        "actions_menu->addAction(\"Simulate\");",
+        "actions_menu->addAction(\"Export\");",
+        "actions_menu->addAction(\"Delete Scene\");",
+        "actions_menu->addAction(\"Select\");",
+        "actions_menu->addAction(\"Place Asset\");",
+        "actions_menu->addAction(\"Move\");",
+        "actions_menu->addAction(\"Inspect\");",
+        "actions_menu->addAction(\"Save Layout\");",
+        "actions_menu->addAction(\"Undo\");",
+        "actions_menu->addAction(\"Redo\");",
+    ])
+    checks = run_checks(allowed)
+    failed = {c.name: c.details for c in checks if not c.ok}
+    assert "forbidden direct top-bar primary actions" not in failed
+
+
+def test_validator_rejects_trailing_underscore_nav_labels():
+    broken = _base_fixture()
+    broken["mainwindow_cpp"] += "\nQString bad1 = \"Run Next_\";\nQString bad2 = \"More_\";\nQString bad3 = \"Scenes/Open_\";\n"
+    checks = run_checks(broken)
+    failed = {c.name: c.details for c in checks if not c.ok}
+    assert "no trailing-underscore nav labels" in failed
 
 
 def test_validator_reports_new_scene3d_acceptance_failures_when_markers_absent():


### PR DESCRIPTION
### Motivation
- Prevent forbidden action labels from appearing as direct always-visible toolbar buttons which can confuse the UX and bypass intended menu/action surfaces.
- Catch accidental navigation label typos with trailing underscores (e.g., `Run Next_`, `More_`, `Scenes/Open_`) which indicate broken or temporary strings.

### Description
- Update `scripts/validate_scene_builder_ui_acceptance.py` to reject specific forbidden labels only when rendered as direct toolbar widgets by matching `addWidget(new QPushButton|QToolButton(...))` and to add a regex check that rejects trailing-underscore nav labels. 
- Mirror the same direct-button restriction and trailing-underscore check in `scripts/validate_scene_builder_ux_integration.py` and clarify the primary-action presence check wording.
- Extend `tests/test_scene_builder_ui_acceptance.py` with tests that fail when forbidden labels appear as always-visible toolbar buttons, allow these labels when they appear only in menus/actions-tab entries, and fail when trailing-underscore nav labels are present.

### Testing
- Ran the unit tests with `pytest -q tests/test_scene_builder_ui_acceptance.py` and all tests passed (`11 passed`).
- Ran the integration validator with `python scripts/validate_scene_builder_ux_integration.py` and it reported all checks as `PASS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8a8ad0d08331aa33f883aaa334c2)