### PR TITLE
Move selected-scene dashboard actions into Scene Actions menu

### DIFF
--- a/scripts/validate_scene_builder_ui_acceptance.py
+++ b/scripts/validate_scene_builder_ui_acceptance.py
@@ -151,6 +151,17 @@ def run_checks(file_text_map:dict[str,str]|None=None)->list[CheckResult]:
             "redo_direct_button": r'(?:addWidget\s*\(\s*new\s+(?:QPushButton|QToolButton)\s*\(|new\s+(?:QPushButton|QToolButton)\s*\()\s*\"Redo\"',
         },
     ))
+    checks.append(_regex_absent_check(
+        "forbidden always-visible selected-scene action buttons",
+        main,
+        {
+            "open_in_scene_builder_direct_button": r'dashboard_open_scene_button_\s*=\s*new\s+QPushButton\s*\(\s*"Open in Scene Builder"',
+            "validate_direct_button": r'dashboard_validate_button_\s*=\s*new\s+QPushButton\s*\(\s*"Validate"',
+            "plan_simulate_direct_button": r'dashboard_plan_button_\s*=\s*new\s+QPushButton\s*\(\s*"Plan / Simulate"',
+            "export_direct_button": r'dashboard_export_button_\s*=\s*new\s+QPushButton\s*\(\s*"Export"',
+            "delete_scene_direct_button": r'dashboard_delete_button_\s*=\s*new\s+QPushButton\s*\(\s*"Delete Scene"',
+        },
+    ))
     checks.append(_token_check("canvas mode and view dropdown controls",all_text,["Mode","View"]))
     checks.append(_token_check("actions side-tab grouped sections",all_text,["Actions","Layout","Generate","Validate","Simulate","Export","Diagnostics"]))
     checks.append(_token_check("layout undo/redo exposed via action surfaces",all_text,["Undo Layout Edit","Redo Layout Edit"]))

--- a/scripts/validate_scene_builder_ux_integration.py
+++ b/scripts/validate_scene_builder_ux_integration.py
@@ -62,6 +62,9 @@ def main() -> int:
     ok.append(check("Run Next uses recommendation actions", "refresh_run_next_menu" in mainwindow_cpp and "trigger_recommended_workflow_action" in mainwindow_cpp))
     ok.append(check("no duplicate layout label variants", "Create Starter Layout from Preview" not in mainwindow_cpp and "Create editable layout from preview" in mainwindow_cpp))
     ok.append(check("canonical duplicate visible labels present", all(t in mainwindow_cpp for t in ["Create editable layout from preview", "Canvas/Generated Parity"])))
+    ok.append(check("selected-scene actions moved to Scene Actions menu", all(t in mainwindow_cpp + mainwindow_h for t in ["Scene Actions", "dashboard_scene_actions_button_", "dashboard_scene_actions_menu_", "dashboard_open_scene_action_", "dashboard_delete_action_"])))
+    forbidden_selected_scene_buttons = re.findall(r'dashboard_(?:open_scene|validate|plan|export|delete)_button_\s*=\s*new\s+QPushButton\s*\(\s*"(?:Open in Scene Builder|Validate|Plan / Simulate|Export|Delete Scene)"', mainwindow_cpp)
+    ok.append(check("no always-visible selected-scene action QPushButtons", len(forbidden_selected_scene_buttons) == 0, detail=str(forbidden_selected_scene_buttons)))
     # Ensure scene set before item state update in refresh flow.
     flow = re.search(r"selected_scene_state_\s*=\s*\{\};.*selected_scene_state_\.valid\s*=\s*true;.*selected_item_state_\s*=\s*current_selected_scene_item\(\);", mainwindow_cpp, flags=re.S)
     ok.append(check("scene state updated before item state", flow is not None))

--- a/tests/test_scene_builder_ui_acceptance.py
+++ b/tests/test_scene_builder_ui_acceptance.py
@@ -144,18 +144,22 @@ def test_validator_fails_for_top_header_label_hacks():
 
 def test_validator_fails_when_new_forbidden_always_visible_buttons_exist():
     broken = _base_fixture()
-    broken["mainwindow_cpp"] += '\nQPushButton *btn = new QPushButton("Delete Scene", scene_builder);\nQPushButton *btn2 = new QPushButton("Select", scene_builder);\nQPushButton *btn3 = new QPushButton("Place Asset", scene_builder);\nQPushButton *btn4 = new QPushButton("Move", scene_builder);\nQPushButton *btn5 = new QPushButton("Inspect", scene_builder);\nQPushButton *btn6 = new QPushButton("Save Layout", scene_builder);\nQPushButton *btn7 = new QPushButton("Undo", scene_builder);\nQPushButton *btn8 = new QPushButton("Redo", scene_builder);\nQPushButton *btn9 = new QPushButton("Validate", scene_builder);\nQPushButton *btn10 = new QPushButton("Plan", scene_builder);\nQPushButton *btn11 = new QPushButton("Simulate", scene_builder);\nQPushButton *btn12 = new QPushButton("Export", scene_builder);\n'
+    broken["mainwindow_cpp"] += '\nQPushButton *btn = new QPushButton("Delete Scene", scene_builder);\nQPushButton *btn2 = new QPushButton("Select", scene_builder);\nQPushButton *btn3 = new QPushButton("Place Asset", scene_builder);\nQPushButton *btn4 = new QPushButton("Move", scene_builder);\nQPushButton *btn5 = new QPushButton("Inspect", scene_builder);\nQPushButton *btn6 = new QPushButton("Save Layout", scene_builder);\nQPushButton *btn7 = new QPushButton("Undo", scene_builder);\nQPushButton *btn8 = new QPushButton("Redo", scene_builder);\nQPushButton *btn9 = new QPushButton("Validate", scene_builder);\nQPushButton *btn10 = new QPushButton("Plan", scene_builder);\nQPushButton *btn11 = new QPushButton("Simulate", scene_builder);\nQPushButton *btn12 = new QPushButton("Export", scene_builder);\ndashboard_open_scene_button_ = new QPushButton("Open in Scene Builder", dashboard_selected_scene_card_);\ndashboard_validate_button_ = new QPushButton("Validate", dashboard_selected_scene_card_);\ndashboard_plan_button_ = new QPushButton("Plan / Simulate", dashboard_selected_scene_card_);\ndashboard_export_button_ = new QPushButton("Export", dashboard_selected_scene_card_);\ndashboard_delete_button_ = new QPushButton("Delete Scene", dashboard_selected_scene_card_);\n'
     checks = run_checks(broken)
     failed = {c.name: c.details for c in checks if not c.ok}
 
     assert "forbidden direct top-bar primary actions" in failed
     assert "allowed visible top-level set only" in failed
+    assert "forbidden always-visible selected-scene action buttons" in failed
 
 
 def test_validator_allows_forbidden_labels_in_actions_tab_or_menus_only():
-    checks = run_checks(_base_fixture())
+    fixture = _base_fixture()
+    fixture["mainwindow_cpp"] += '\nQToolButton *dashboard_scene_actions_button_ = new QToolButton(this);\nQMenu *dashboard_scene_actions_menu_ = new QMenu(this);\ndashboard_scene_actions_menu_->addAction("Open in Scene Builder");\ndashboard_scene_actions_menu_->addAction("Validate");\ndashboard_scene_actions_menu_->addAction("Plan / Simulate");\ndashboard_scene_actions_menu_->addAction("Export");\ndashboard_scene_actions_menu_->addSeparator();\ndashboard_scene_actions_menu_->addAction("Delete Scene");\n'
+    checks = run_checks(fixture)
     failed = {c.name: c.details for c in checks if not c.ok}
     assert "forbidden direct top-bar primary actions" not in failed
+    assert "forbidden always-visible selected-scene action buttons" not in failed
 
 
 def test_validator_rejects_explicit_trailing_underscore_nav_labels():

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -803,11 +803,19 @@ void MainWindow::setup_studio_shell()
   dashboard_selected_scene_details_->setWordWrap(true);
   selected_row->addWidget(dashboard_selected_scene_details_);
   auto * dashboard_actions = new QVBoxLayout();
-  dashboard_open_scene_button_ = new QPushButton("Open in Scene Builder", dashboard_selected_scene_card_); dashboard_open_scene_button_->setObjectName("studioHomeSecondaryButton"); dashboard_actions->addWidget(dashboard_open_scene_button_);
-  dashboard_validate_button_ = new QPushButton("Validate", dashboard_selected_scene_card_); dashboard_validate_button_->setObjectName("studioHomeSecondaryButton"); dashboard_actions->addWidget(dashboard_validate_button_);
-  dashboard_plan_button_ = new QPushButton("Plan / Simulate", dashboard_selected_scene_card_); dashboard_plan_button_->setObjectName("studioHomeSecondaryButton"); dashboard_actions->addWidget(dashboard_plan_button_);
-  dashboard_export_button_ = new QPushButton("Export", dashboard_selected_scene_card_); dashboard_export_button_->setObjectName("studioHomeSecondaryButton"); dashboard_actions->addWidget(dashboard_export_button_);
-  dashboard_delete_button_ = new QPushButton("Delete Scene", dashboard_selected_scene_card_); dashboard_delete_button_->setObjectName("studioHomeDangerButton"); dashboard_actions->addWidget(dashboard_delete_button_);
+  dashboard_scene_actions_button_ = new QToolButton(dashboard_selected_scene_card_);
+  dashboard_scene_actions_button_->setText("Scene Actions");
+  dashboard_scene_actions_button_->setObjectName("studioHomeSecondaryButton");
+  dashboard_scene_actions_button_->setPopupMode(QToolButton::InstantPopup);
+  dashboard_scene_actions_menu_ = new QMenu(dashboard_scene_actions_button_);
+  dashboard_open_scene_action_ = dashboard_scene_actions_menu_->addAction("Open in Scene Builder");
+  dashboard_validate_action_ = dashboard_scene_actions_menu_->addAction("Validate");
+  dashboard_plan_action_ = dashboard_scene_actions_menu_->addAction("Plan / Simulate");
+  dashboard_export_action_ = dashboard_scene_actions_menu_->addAction("Export");
+  dashboard_scene_actions_menu_->addSeparator();
+  dashboard_delete_action_ = dashboard_scene_actions_menu_->addAction("Delete Scene");
+  dashboard_scene_actions_button_->setMenu(dashboard_scene_actions_menu_);
+  dashboard_actions->addWidget(dashboard_scene_actions_button_);
   selected_row->addLayout(dashboard_actions);
   auto * dashboard_middle_split = new QSplitter(Qt::Horizontal, dashboard);
   auto * left_library_card = new QFrame(dashboard);
@@ -1613,11 +1621,11 @@ void MainWindow::setup_studio_shell()
   connect(empty_new_cell, &QPushButton::clicked, this, &MainWindow::open_new_scene_creation_flow);
   connect(dash_new_cell, &QPushButton::clicked, this, &MainWindow::open_new_scene_creation_flow);
   connect(dash_open_selected_scene, &QPushButton::clicked, this, [this](){ open_scene_builder_for_selected_scene("Dashboard Open Selected Scene"); });
-  connect(dashboard_open_scene_button_, &QPushButton::clicked, this, [this](){ open_scene_builder_for_selected_scene("Dashboard Open in Scene Builder"); });
-  connect(dashboard_validate_button_, &QPushButton::clicked, this, [this](){ if (action_validate_offline_) action_validate_offline_->trigger(); });
-  connect(dashboard_plan_button_, &QPushButton::clicked, this, [this](){ if (action_simulate_plan_preview_) action_simulate_plan_preview_->trigger(); });
-  connect(dashboard_export_button_, &QPushButton::clicked, this, [this](){ if (action_export_open_page_) action_export_open_page_->trigger(); });
-  connect(dashboard_delete_button_, &QPushButton::clicked, this, &MainWindow::delete_selected_scene);
+  connect(dashboard_open_scene_action_, &QAction::triggered, this, [this](){ open_scene_builder_for_selected_scene("Dashboard Open in Scene Builder"); });
+  connect(dashboard_validate_action_, &QAction::triggered, this, [this](){ if (action_validate_offline_) action_validate_offline_->trigger(); });
+  connect(dashboard_plan_action_, &QAction::triggered, this, [this](){ if (action_simulate_plan_preview_) action_simulate_plan_preview_->trigger(); });
+  connect(dashboard_export_action_, &QAction::triggered, this, [this](){ if (action_export_open_page_) action_export_open_page_->trigger(); });
+  connect(dashboard_delete_action_, &QAction::triggered, this, &MainWindow::delete_selected_scene);
   connect(existing_scene_table_, &QTableWidget::cellClicked, this, [this](int row, int col){ select_scene_by_row(row); if(col==2){open_scene_builder_for_selected_scene("Existing Scenes Open in Scene Builder");} else if(col==3){open_selected_scene_artifact("preview");} else if(col==4){open_selected_scene_artifact("smoke");} else if(col==5){QApplication::clipboard()->setText(selected_scene_launch_command()); append_studio_log("Copy Launch Command");}});
   connect(open_asset_folder_action, &QAction::triggered, this, [this](){ open_selected_scene_artifact("asset_folder"); });
   connect(copy_asset_path_action, &QAction::triggered, this, [this](){ QApplication::clipboard()->setText(selected_catalog_item_path()); });
@@ -2541,14 +2549,15 @@ void MainWindow::refresh_selected_scene_details_card()
   if (!dashboard_selected_scene_details_) return;
   if (!selected_scene_state_.valid) {
     dashboard_selected_scene_details_->setText("Select a scene to view details.");
-    if (dashboard_open_scene_button_) dashboard_open_scene_button_->setEnabled(false);
-    if (dashboard_validate_button_) dashboard_validate_button_->setEnabled(false);
-    if (dashboard_plan_button_) dashboard_plan_button_->setEnabled(false);
-    if (dashboard_export_button_) dashboard_export_button_->setEnabled(false);
-    if (dashboard_delete_button_) dashboard_delete_button_->setEnabled(false);
-    if (dashboard_validate_button_) dashboard_validate_button_->setToolTip("Select a scene to validate.");
-    if (dashboard_plan_button_) dashboard_plan_button_->setToolTip("Select a scene to open Plan / Simulate.");
-    if (dashboard_export_button_) dashboard_export_button_->setToolTip("Select a scene to export.");
+    if (dashboard_scene_actions_button_) dashboard_scene_actions_button_->setEnabled(false);
+    if (dashboard_open_scene_action_) dashboard_open_scene_action_->setEnabled(false);
+    if (dashboard_validate_action_) dashboard_validate_action_->setEnabled(false);
+    if (dashboard_plan_action_) dashboard_plan_action_->setEnabled(false);
+    if (dashboard_export_action_) dashboard_export_action_->setEnabled(false);
+    if (dashboard_delete_action_) dashboard_delete_action_->setEnabled(false);
+    if (dashboard_validate_action_) dashboard_validate_action_->setToolTip("Select a scene to validate.");
+    if (dashboard_plan_action_) dashboard_plan_action_->setToolTip("Select a scene to open Plan / Simulate.");
+    if (dashboard_export_action_) dashboard_export_action_->setToolTip("Select a scene to export.");
     return;
   }
   const auto & s = scene_browser_result_.scenes[(size_t)selected_scene_state_.index];
@@ -2561,14 +2570,15 @@ void MainWindow::refresh_selected_scene_details_card()
   const ActionGate generate_gate = build_generate_scene_gate(s, validation_stale_);
   const ActionGate plan_gate = build_plan_simulate_gate(s, launch_artifacts_ready_);
   const ActionGate export_gate = build_export_gate(s);
-  if (dashboard_open_scene_button_) dashboard_open_scene_button_->setEnabled(true);
-  if (dashboard_validate_button_) dashboard_validate_button_->setEnabled(true);
-  if (dashboard_validate_button_) dashboard_validate_button_->setToolTip(generate_gate.tooltip);
-  if (dashboard_plan_button_) dashboard_plan_button_->setEnabled(plan_gate.enabled);
-  if (dashboard_plan_button_) dashboard_plan_button_->setToolTip(plan_gate.tooltip);
-  if (dashboard_export_button_) dashboard_export_button_->setEnabled(export_gate.enabled);
-  if (dashboard_export_button_) dashboard_export_button_->setToolTip(export_gate.tooltip);
-  if (dashboard_delete_button_) dashboard_delete_button_->setEnabled(true);
+  if (dashboard_scene_actions_button_) dashboard_scene_actions_button_->setEnabled(true);
+  if (dashboard_open_scene_action_) dashboard_open_scene_action_->setEnabled(true);
+  if (dashboard_validate_action_) dashboard_validate_action_->setEnabled(true);
+  if (dashboard_validate_action_) dashboard_validate_action_->setToolTip(generate_gate.tooltip);
+  if (dashboard_plan_action_) dashboard_plan_action_->setEnabled(plan_gate.enabled);
+  if (dashboard_plan_action_) dashboard_plan_action_->setToolTip(plan_gate.tooltip);
+  if (dashboard_export_action_) dashboard_export_action_->setEnabled(export_gate.enabled);
+  if (dashboard_export_action_) dashboard_export_action_->setToolTip(export_gate.tooltip);
+  if (dashboard_delete_action_) dashboard_delete_action_->setEnabled(true);
 }
 
 

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -369,11 +369,13 @@ private:
   QFrame * dashboard_empty_state_card_{ nullptr };
   QFrame * dashboard_selected_scene_card_{ nullptr };
   QLabel * dashboard_selected_scene_details_{ nullptr };
-  QPushButton * dashboard_open_scene_button_{ nullptr };
-  QPushButton * dashboard_validate_button_{ nullptr };
-  QPushButton * dashboard_plan_button_{ nullptr };
-  QPushButton * dashboard_export_button_{ nullptr };
-  QPushButton * dashboard_delete_button_{ nullptr };
+  QToolButton * dashboard_scene_actions_button_{ nullptr };
+  QMenu * dashboard_scene_actions_menu_{ nullptr };
+  QAction * dashboard_open_scene_action_{ nullptr };
+  QAction * dashboard_validate_action_{ nullptr };
+  QAction * dashboard_plan_action_{ nullptr };
+  QAction * dashboard_export_action_{ nullptr };
+  QAction * dashboard_delete_action_{ nullptr };
   QTableWidget * existing_scene_table_{ nullptr };
   QLabel * dashboard_summary_label_{ nullptr };
   QLabel * scene_builder_title_{ nullptr };


### PR DESCRIPTION
### Motivation
- Reduce always-visible action clutter in the selected-scene details card by consolidating scene-level actions into a single overflow control. 
- Preserve existing behavior targets and the existing Delete Scene confirm/delete flow while making the action surface menu-driven.

### Description
- Replaced the five always-visible `QPushButton` widgets in the selected-scene details card (`Open in Scene Builder`, `Validate`, `Plan / Simulate`, `Export`, `Delete Scene`) with a single `QToolButton` labeled `Scene Actions` that hosts a `QMenu` containing those actions and a separator before `Delete Scene`.
- Introduced `QAction` members for each moved action and updated connections to use `QAction::triggered` so existing handlers (e.g. `open_scene_builder_for_selected_scene`, `action_validate_offline_`, `action_simulate_plan_preview_`, `action_export_open_page_`, and `delete_selected_scene`) are preserved unchanged.
- Updated selected-scene state refresh logic to enable/disable and set tooltips on the new menu actions/toolbutton instead of the removed direct buttons.
- Updated `mainwindow.h` to replace the old `QPushButton*` fields with `QToolButton*`, `QMenu*`, and `QAction*` fields for the dashboard scene actions.
- Extended static validators and tests to detect and reject implementations that leave those selected-scene labels as always-visible `QPushButton`s while allowing them to exist as menu entries: updated `scripts/validate_scene_builder_ui_acceptance.py`, `scripts/validate_scene_builder_ux_integration.py`, and `tests/test_scene_builder_ui_acceptance.py` accordingly.

### Testing
- Ran `python3 scripts/validate_scene_builder_ux_integration.py`, which passed (checks for Scene Actions wiring and absence of direct QPushButtons passed).
- Ran `pytest -q tests/test_scene_builder_ui_acceptance.py`, which passed (all tests in that suite passed: `14 passed`).
- Ran `python3 scripts/validate_scene_builder_ui_acceptance.py`, which still reports existing repository baseline failures unrelated to this change (these are pre-existing tokens/labels checks and were not introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d734dde808331b483c1bb7f3a7a83)