### PR TITLE
Add smoke contract for Home selected-scene Scene Actions surface

### DIFF
--- a/scripts/validate_scene_builder_ui_acceptance.py
+++ b/scripts/validate_scene_builder_ui_acceptance.py
@@ -54,6 +54,10 @@ def _regex_absent_check(name,haystack,forbidden):
     hits=[f"forbidden pattern matched ({label}): {pat}" for label,pat in forbidden.items() if re.search(pat,haystack,re.MULTILINE)]
     return CheckResult(name,not hits,hits)
 
+def _regex_present_check(name,haystack,required):
+    missing=[f"missing pattern ({label}): {pat}" for label,pat in required.items() if not re.search(pat,haystack,re.MULTILINE|re.DOTALL)]
+    return CheckResult(name,not missing,missing)
+
 def _top_header_label_hygiene_check(name:str,haystack:str)->CheckResult:
     details=[]
     required={
@@ -177,6 +181,30 @@ def run_checks(file_text_map:dict[str,str]|None=None)->list[CheckResult]:
             "plan_simulate_direct_button": r'dashboard_plan_button_\s*=\s*new\s+QPushButton\s*\(\s*"Plan / Simulate"',
             "export_direct_button": r'dashboard_export_button_\s*=\s*new\s+QPushButton\s*\(\s*"Export"',
             "delete_scene_direct_button": r'dashboard_delete_button_\s*=\s*new\s+QPushButton\s*\(\s*"Delete Scene"',
+        },
+    ))
+    checks.append(_regex_present_check(
+        "selected-scene card exposes only Scene Actions control with menu wiring",
+        main,
+        {
+            "scene_actions_control_label": r'dashboard_scene_actions_button_\s*=\s*new\s+QToolButton\([^\n]+\);\s*.*?dashboard_scene_actions_button_->setText\("Scene Actions"\);',
+            "scene_actions_menu_assigned": r'dashboard_scene_actions_button_->setMenu\(dashboard_scene_actions_menu_\);',
+            "open_action": r'dashboard_open_scene_action_\s*=\s*dashboard_scene_actions_menu_->addAction\("Open in Scene Builder"\);',
+            "validate_action": r'dashboard_validate_action_\s*=\s*dashboard_scene_actions_menu_->addAction\("Validate"\);',
+            "plan_action": r'dashboard_plan_action_\s*=\s*dashboard_scene_actions_menu_->addAction\("Plan / Simulate"\);',
+            "export_action": r'dashboard_export_action_\s*=\s*dashboard_scene_actions_menu_->addAction\("Export"\);',
+            "separator_before_delete": r'dashboard_export_action_\s*=\s*dashboard_scene_actions_menu_->addAction\("Export"\);\s*dashboard_scene_actions_menu_->addSeparator\(\);\s*dashboard_delete_action_\s*=\s*dashboard_scene_actions_menu_->addAction\("Delete Scene"\);',
+        },
+    ))
+    checks.append(_regex_present_check(
+        "selected-scene Scene Actions are connected to existing behaviors",
+        main,
+        {
+            "open_trigger": r'connect\(dashboard_open_scene_action_,\s*&QAction::triggered,\s*this,\s*\[this\]\(\)\{\s*open_scene_builder_for_selected_scene\("Dashboard Open in Scene Builder"\);\s*\}\);',
+            "validate_trigger": r'connect\(dashboard_validate_action_,\s*&QAction::triggered,\s*this,\s*\[this\]\(\)\{\s*if\s*\(action_validate_offline_\)\s*action_validate_offline_->trigger\(\);\s*\}\);',
+            "plan_trigger": r'connect\(dashboard_plan_action_,\s*&QAction::triggered,\s*this,\s*\[this\]\(\)\{\s*if\s*\(action_simulate_plan_preview_\)\s*action_simulate_plan_preview_->trigger\(\);\s*\}\);',
+            "export_trigger": r'connect\(dashboard_export_action_,\s*&QAction::triggered,\s*this,\s*\[this\]\(\)\{\s*if\s*\(action_export_open_page_\)\s*action_export_open_page_->trigger\(\);\s*\}\);',
+            "delete_trigger": r'connect\(dashboard_delete_action_,\s*&QAction::triggered,\s*this,\s*&MainWindow::delete_selected_scene\);',
         },
     ))
     checks.append(_token_check("canvas mode and view dropdown controls",all_text,["Mode","View"]))

--- a/scripts/validate_scene_builder_ux_integration.py
+++ b/scripts/validate_scene_builder_ux_integration.py
@@ -79,6 +79,31 @@ def main() -> int:
     ok.append(check("selected-scene actions moved to Scene Actions menu", all(t in mainwindow_cpp + mainwindow_h for t in ["Scene Actions", "dashboard_scene_actions_button_", "dashboard_scene_actions_menu_", "dashboard_open_scene_action_", "dashboard_delete_action_"])))
     forbidden_selected_scene_buttons = re.findall(r'dashboard_(?:open_scene|validate|plan|export|delete)_button_\s*=\s*new\s+QPushButton\s*\(\s*"(?:Open in Scene Builder|Validate|Plan / Simulate|Export|Delete Scene)"', mainwindow_cpp)
     ok.append(check("no always-visible selected-scene action QPushButtons", len(forbidden_selected_scene_buttons) == 0, detail=str(forbidden_selected_scene_buttons)))
+    scene_actions_menu_contract = re.search(
+        r'dashboard_scene_actions_button_\s*=\s*new\s+QToolButton\([^\n]+\);\s*'
+        r'.*?dashboard_scene_actions_button_->setText\("Scene Actions"\);\s*'
+        r'.*?dashboard_scene_actions_menu_\s*=\s*new\s+QMenu\([^\n]+\);\s*'
+        r'.*?dashboard_open_scene_action_\s*=\s*dashboard_scene_actions_menu_->addAction\("Open in Scene Builder"\);\s*'
+        r'.*?dashboard_validate_action_\s*=\s*dashboard_scene_actions_menu_->addAction\("Validate"\);\s*'
+        r'.*?dashboard_plan_action_\s*=\s*dashboard_scene_actions_menu_->addAction\("Plan / Simulate"\);\s*'
+        r'.*?dashboard_export_action_\s*=\s*dashboard_scene_actions_menu_->addAction\("Export"\);\s*'
+        r'.*?dashboard_scene_actions_menu_->addSeparator\(\);\s*'
+        r'.*?dashboard_delete_action_\s*=\s*dashboard_scene_actions_menu_->addAction\("Delete Scene"\);\s*'
+        r'.*?dashboard_scene_actions_button_->setMenu\(dashboard_scene_actions_menu_\);',
+        mainwindow_cpp,
+        flags=re.S,
+    )
+    ok.append(check("selected-scene Scene Actions menu contract", scene_actions_menu_contract is not None))
+    action_wiring_contract = all(
+        re.search(pattern, mainwindow_cpp) is not None for pattern in [
+            r'connect\(dashboard_open_scene_action_,\s*&QAction::triggered,\s*this,\s*\[this\]\(\)\{\s*open_scene_builder_for_selected_scene\("Dashboard Open in Scene Builder"\);\s*\}\);',
+            r'connect\(dashboard_validate_action_,\s*&QAction::triggered,\s*this,\s*\[this\]\(\)\{\s*if\s*\(action_validate_offline_\)\s*action_validate_offline_->trigger\(\);\s*\}\);',
+            r'connect\(dashboard_plan_action_,\s*&QAction::triggered,\s*this,\s*\[this\]\(\)\{\s*if\s*\(action_simulate_plan_preview_\)\s*action_simulate_plan_preview_->trigger\(\);\s*\}\);',
+            r'connect\(dashboard_export_action_,\s*&QAction::triggered,\s*this,\s*\[this\]\(\)\{\s*if\s*\(action_export_open_page_\)\s*action_export_open_page_->trigger\(\);\s*\}\);',
+            r'connect\(dashboard_delete_action_,\s*&QAction::triggered,\s*this,\s*&MainWindow::delete_selected_scene\);',
+        ]
+    )
+    ok.append(check("selected-scene Scene Actions wiring contract", action_wiring_contract))
     # Ensure scene set before item state update in refresh flow.
     flow = re.search(r"selected_scene_state_\s*=\s*\{\};.*selected_scene_state_\.valid\s*=\s*true;.*selected_item_state_\s*=\s*current_selected_scene_item\(\);", mainwindow_cpp, flags=re.S)
     ok.append(check("scene state updated before item state", flow is not None))

--- a/tests/test_scene_builder_ui_acceptance.py
+++ b/tests/test_scene_builder_ui_acceptance.py
@@ -72,6 +72,21 @@ def _base_fixture() -> dict[str, str]:
                 'QString parity = "Canvas/Generated Parity";',
                 'QString undo_layout = "Undo Layout Edit";',
                 'QString redo_layout = "Redo Layout Edit";',
+                'dashboard_scene_actions_button_ = new QToolButton(dashboard_selected_scene_card_);',
+                'dashboard_scene_actions_button_->setText("Scene Actions");',
+                'dashboard_scene_actions_menu_ = new QMenu(dashboard_scene_actions_button_);',
+                'dashboard_open_scene_action_ = dashboard_scene_actions_menu_->addAction("Open in Scene Builder");',
+                'dashboard_validate_action_ = dashboard_scene_actions_menu_->addAction("Validate");',
+                'dashboard_plan_action_ = dashboard_scene_actions_menu_->addAction("Plan / Simulate");',
+                'dashboard_export_action_ = dashboard_scene_actions_menu_->addAction("Export");',
+                'dashboard_scene_actions_menu_->addSeparator();',
+                'dashboard_delete_action_ = dashboard_scene_actions_menu_->addAction("Delete Scene");',
+                'dashboard_scene_actions_button_->setMenu(dashboard_scene_actions_menu_);',
+                'connect(dashboard_open_scene_action_, &QAction::triggered, this, [this](){ open_scene_builder_for_selected_scene("Dashboard Open in Scene Builder"); });',
+                'connect(dashboard_validate_action_, &QAction::triggered, this, [this](){ if (action_validate_offline_) action_validate_offline_->trigger(); });',
+                'connect(dashboard_plan_action_, &QAction::triggered, this, [this](){ if (action_simulate_plan_preview_) action_simulate_plan_preview_->trigger(); });',
+                'connect(dashboard_export_action_, &QAction::triggered, this, [this](){ if (action_export_open_page_) action_export_open_page_->trigger(); });',
+                'connect(dashboard_delete_action_, &QAction::triggered, this, &MainWindow::delete_selected_scene);',
             ]
         ),
         "preview_cpp": "Preview panel supports 2D Layout and 3D Layout Preview. Actions Layout Generate Validate Simulate Export Diagnostics",
@@ -159,6 +174,13 @@ def test_validator_allows_forbidden_labels_in_actions_tab_or_menus_only():
     failed = {c.name: c.details for c in checks if not c.ok}
     assert "forbidden direct top-bar primary actions" not in failed
     assert "forbidden always-visible selected-scene action buttons" not in failed
+
+
+def test_repository_contract_rejects_reintroduced_selected_scene_direct_buttons():
+    checks = run_checks()
+    failed = {c.name: c.details for c in checks if not c.ok}
+    assert "forbidden always-visible selected-scene action buttons" not in failed
+    assert "selected-scene card exposes only Scene Actions control with menu wiring" not in failed
 
 
 def test_validator_rejects_explicit_trailing_underscore_nav_labels():


### PR DESCRIPTION
### Motivation
- Harden a small regression/smoke contract after the Scene Actions cleanup so the Studio Home selected-scene card stays clean and actions remain correctly wired. 
- Prevent reintroduction of five always-visible selected-scene QPushButton members while keeping the single `Scene Actions` menu as the only visible control. 
- Keep checks lightweight and non-invasive without changing runtime UI behavior or features.

### Description
- Added a reusable `_regex_present_check` helper and used it in `scripts/validate_scene_builder_ui_acceptance.py` to assert the `Scene Actions` `QToolButton` label, `QMenu` assignment, presence of `QAction` entries (`Open in Scene Builder`, `Validate`, `Plan / Simulate`, `Export`, `Delete Scene`) and a separator before `Delete Scene`. 
- Added wiring assertions in the same validator to ensure `dashboard_open_scene_action_`, `dashboard_validate_action_`, `dashboard_plan_action_`, `dashboard_export_action_`, and `dashboard_delete_action_` are connected to the existing handlers (`open_scene_builder_for_selected_scene`, `action_validate_offline_`, `action_simulate_plan_preview_`, `action_export_open_page_`, and `delete_selected_scene`). 
- Kept the UX script aligned by adding the same menu/connection contracts to `scripts/validate_scene_builder_ux_integration.py` and extended the test fixture and a repository-level regression test in `tests/test_scene_builder_ui_acceptance.py` that fails if the five direct selected-scene buttons reappear. 

### Testing
- Ran unit tests: `python3 -m pytest -q tests/test_scene_builder_ui_acceptance.py`, result: `16 passed` (all tests passed). 
- Ran UX integration script: `python3 scripts/validate_scene_builder_ux_integration.py`, result: all checks passed. 
- Ran acceptance validator script: `python3 scripts/validate_scene_builder_ui_acceptance.py`, result: all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d75ef41d08331b54ac9d3d56e6874)