### PR TITLE
Declutter Scene Builder toolbar by nesting secondary controls

### DIFF
--- a/scripts/validate_scene_builder_ui_acceptance.py
+++ b/scripts/validate_scene_builder_ui_acceptance.py
@@ -208,6 +208,31 @@ def run_checks(file_text_map:dict[str,str]|None=None)->list[CheckResult]:
         },
     ))
     checks.append(_token_check("canvas mode and view dropdown controls",all_text,["Mode","View"]))
+    checks.append(_regex_absent_check(
+        "secondary canvas controls are not direct always-visible toolbar widgets",
+        main,
+        {
+            "overlays_direct_widget": r'controls->addWidget\s*\(\s*scene_builder_overlays_button_\s*\)',
+            "canvas_more_direct_widget": r'controls->addWidget\s*\(\s*scene_builder_canvas_more_button_\s*\)',
+            "visual_modes_direct_widget": r'controls->addWidget\s*\(\s*scene_builder_visual_modes_button_\s*\)',
+            "toggle_grid_direct_widget": r'controls->addWidget\s*\(\s*toggle_grid_box_\s*\)',
+            "snap_direct_widget": r'controls->addWidget\s*\(\s*snap_to_grid_box_\s*\)',
+            "fine_move_direct_widget": r'controls->addWidget\s*\(\s*fine_move_mode_box_\s*\)',
+            "unlock_direct_widget": r'controls->addWidget\s*\(\s*unlock_robot_base_box_\s*\)',
+            "labels_direct_widget": r'controls->addWidget\s*\(\s*toggle_labels_box_\s*\)',
+            "warnings_direct_widget": r'controls->addWidget\s*\(\s*toggle_warnings_box_\s*\)',
+            "minimap_direct_widget": r'controls->addWidget\s*\(\s*show_minimap_box_\s*\)',
+        },
+    ))
+    checks.append(_regex_present_check(
+        "secondary canvas controls remain available in menu surfaces",
+        main,
+        {
+            "overlays_nested_in_more": r'scene_builder_secondary_overflow_menu_->addMenu\(overlays_menu\)->setText\("Overlays"\);',
+            "visual_modes_nested_in_more": r'scene_builder_secondary_overflow_menu_->addMenu\(visual_modes_menu\)->setText\("Visual Modes"\);',
+            "layout_settings_nested_in_more": r'scene_builder_secondary_overflow_menu_->addMenu\(canvas_more_menu\)->setText\("Layout/Edit Settings"\);',
+        },
+    ))
     checks.append(_token_check("actions side-tab grouped sections",all_text,["Actions","Layout","Generate","Validate","Simulate","Export","Diagnostics"]))
     checks.append(_token_check("layout undo/redo exposed via action surfaces",all_text,["Undo Layout Edit","Redo Layout Edit"]))
     checks.append(_regex_absent_check(

--- a/scripts/validate_scene_builder_ux_integration.py
+++ b/scripts/validate_scene_builder_ux_integration.py
@@ -70,6 +70,20 @@ def main() -> int:
     forbidden_topbar = re.findall(r"addWidget\s*\(\s*new\s+(?:QPushButton|QToolButton)\s*\(\s*\"(Validate|Generate|Plan|Simulate|Export|Readiness|Delete Scene|Select|Place Asset|Move|Inspect|Save Layout|Undo|Redo)\"", mainwindow_cpp)
     ok.append(check("forbidden direct top-bar primary actions absent", len(forbidden_topbar) == 0, detail=str(forbidden_topbar)))
     ok.append(check("canvas mode and view dropdown controls present", all(t in mainwindow_cpp for t in ["Mode", "View"])))
+    secondary_direct_widget_hits = re.findall(
+        r'controls->addWidget\s*\(\s*(scene_builder_overlays_button_|scene_builder_canvas_more_button_|scene_builder_visual_modes_button_|toggle_grid_box_|snap_to_grid_box_|fine_move_mode_box_|unlock_robot_base_box_|toggle_labels_box_|toggle_warnings_box_|show_minimap_box_)\s*\)',
+        mainwindow_cpp,
+    )
+    ok.append(check("secondary canvas controls are not direct always-visible toolbar widgets", len(secondary_direct_widget_hits) == 0, detail=str(secondary_direct_widget_hits)))
+    secondary_menu_contract = all(
+        token in mainwindow_cpp
+        for token in [
+            'scene_builder_secondary_overflow_menu_->addMenu(overlays_menu)->setText("Overlays");',
+            'scene_builder_secondary_overflow_menu_->addMenu(visual_modes_menu)->setText("Visual Modes");',
+            'scene_builder_secondary_overflow_menu_->addMenu(canvas_more_menu)->setText("Layout/Edit Settings");',
+        ]
+    )
+    ok.append(check("secondary canvas controls remain available in menu surfaces", secondary_menu_contract))
     ok.append(check("actions side-tab grouped sections present", all(t in mainwindow_cpp for t in ["Actions", "Layout", "Generate", "Validate", "Simulate", "Export", "Diagnostics"])))
     ok.append(check("shared action registry exists", "scene_builder_action_registry_" in mainwindow_h and "register_scene_builder_action" in mainwindow_cpp))
     ok.append(check("top header uses shared actions", "scenes_open_menu->addAction(action_generate_yaml_)" in mainwindow_cpp and "more_menu->addAction(action_diagnostics_run_self_test_)" in mainwindow_cpp))

--- a/tests/test_scene_builder_ui_acceptance.py
+++ b/tests/test_scene_builder_ui_acceptance.py
@@ -64,6 +64,9 @@ def _base_fixture() -> dict[str, str]:
                 'scenes_open_button->setText("Scenes");',
                 'run_next_button->setText("Run Next");',
                 'more_button->setText("More");',
+                'scene_builder_secondary_overflow_menu_->addMenu(overlays_menu)->setText("Overlays");',
+                'scene_builder_secondary_overflow_menu_->addMenu(visual_modes_menu)->setText("Visual Modes");',
+                'scene_builder_secondary_overflow_menu_->addMenu(canvas_more_menu)->setText("Layout/Edit Settings");',
                 'QComboBox *mode = new QComboBox(this); mode->setObjectName("Mode");',
                 'QComboBox *view = new QComboBox(this); view->setObjectName("View");',
                 'QString side_tab = "Actions";',
@@ -174,6 +177,21 @@ def test_validator_allows_forbidden_labels_in_actions_tab_or_menus_only():
     failed = {c.name: c.details for c in checks if not c.ok}
     assert "forbidden direct top-bar primary actions" not in failed
     assert "forbidden always-visible selected-scene action buttons" not in failed
+
+def test_validator_fails_when_secondary_canvas_controls_are_added_as_direct_toolbar_widgets():
+    broken = _base_fixture()
+    broken["mainwindow_cpp"] += '\ncontrols->addWidget(scene_builder_overlays_button_);\ncontrols->addWidget(scene_builder_canvas_more_button_);\ncontrols->addWidget(scene_builder_visual_modes_button_);\ncontrols->addWidget(toggle_grid_box_);\ncontrols->addWidget(snap_to_grid_box_);\ncontrols->addWidget(fine_move_mode_box_);\ncontrols->addWidget(unlock_robot_base_box_);\ncontrols->addWidget(toggle_labels_box_);\ncontrols->addWidget(toggle_warnings_box_);\ncontrols->addWidget(show_minimap_box_);\n'
+    checks = run_checks(broken)
+    failed = {c.name: c.details for c in checks if not c.ok}
+    assert "secondary canvas controls are not direct always-visible toolbar widgets" in failed
+
+
+def test_validator_allows_secondary_canvas_controls_inside_more_menu_surfaces():
+    fixture = _base_fixture()
+    fixture["mainwindow_cpp"] += '\nscene_builder_secondary_overflow_menu_->addMenu(overlays_menu)->setText("Overlays");\nscene_builder_secondary_overflow_menu_->addMenu(visual_modes_menu)->setText("Visual Modes");\nscene_builder_secondary_overflow_menu_->addMenu(canvas_more_menu)->setText("Layout/Edit Settings");\n'
+    checks = run_checks(fixture)
+    failed = {c.name: c.details for c in checks if not c.ok}
+    assert "secondary canvas controls remain available in menu surfaces" not in failed
 
 
 def test_repository_contract_rejects_reintroduced_selected_scene_direct_buttons():

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1156,7 +1156,7 @@ void MainWindow::setup_studio_shell()
   mk(show_reach_overlay_box_); mk(show_camera_fov_overlay_box_); mk(show_pick_place_overlay_box_); mk(show_trajectory_overlay_box_); mk(show_approach_retreat_overlay_box);
   auto * show_warnings_action = overlays_menu->addAction("Show Warnings"); show_warnings_action->setCheckable(true); show_warnings_action->setChecked(true);
   auto * show_labels_action = overlays_menu->addAction("Detection Labels"); show_labels_action->setCheckable(true); show_labels_action->setChecked(true);
-  overlays_button->setMenu(overlays_menu); controls->addWidget(overlays_button);
+  overlays_button->setMenu(overlays_menu);
   connect(show_warnings_action, &QAction::toggled, toggle_warnings_box_, &QCheckBox::setChecked);
   connect(show_labels_action, &QAction::toggled, toggle_labels_box_, &QCheckBox::setChecked);
   connect(show_approach_retreat_overlay_box, &QCheckBox::toggled, this, [this, show_approach_retreat_overlay_box](bool){
@@ -1192,7 +1192,6 @@ void MainWindow::setup_studio_shell()
   canvas_more_menu->addAction("Toggle Labels")->setCheckable(true);
   canvas_more_menu->addAction("Toggle Warnings")->setCheckable(true);
   canvas_more_actions->setMenu(canvas_more_menu);
-  controls->addWidget(canvas_more_actions);
   scene_builder_visual_modes_button_ = new QToolButton(scene_builder);
   scene_builder_visual_modes_button_->setObjectName("scene_builder_secondary_visual_modes_button");  // acceptance: secondary grouped actions
   scene_builder_visual_modes_button_->setText("Visual Modes");
@@ -1210,12 +1209,14 @@ void MainWindow::setup_studio_shell()
   auto * snap_1cm = snap_mode_menu->addAction("Snap: 1 cm");
   auto * snap_off = snap_mode_menu->addAction("Snap Off");
   scene_builder_visual_modes_button_->setMenu(visual_modes_menu);
-  controls->addWidget(scene_builder_visual_modes_button_);
   scene_builder_secondary_overflow_button_ = new QToolButton(scene_builder);
   scene_builder_secondary_overflow_button_->setObjectName("scene_builder_secondary_overflow_button");
   scene_builder_secondary_overflow_button_->setText("More");
   scene_builder_secondary_overflow_button_->setPopupMode(QToolButton::InstantPopup);
   scene_builder_secondary_overflow_menu_ = new QMenu(scene_builder_secondary_overflow_button_);
+  scene_builder_secondary_overflow_menu_->addMenu(overlays_menu)->setText("Overlays");
+  scene_builder_secondary_overflow_menu_->addMenu(visual_modes_menu)->setText("Visual Modes");
+  scene_builder_secondary_overflow_menu_->addMenu(canvas_more_menu)->setText("Layout/Edit Settings");
   auto * secondary_layout_menu = scene_builder_secondary_overflow_menu_->addMenu("Layout");
   secondary_layout_menu->addAction(scene_builder_action("layout.undo"));
   secondary_layout_menu->addAction(scene_builder_action("layout.redo"));


### PR DESCRIPTION
## Summary
This PR declutters the Scene Builder top/canvas toolbar by keeping only core editing controls always visible and moving secondary controls into existing menu surfaces under the existing **More** dropdown.

### Always-visible controls kept in the top editing strip
- Select
- Place Asset
- Move
- Inspect
- Save Layout
- Camera / View
- More

### Controls moved into dropdown/menu surfaces
- **Overlays** submenu (under More)
  - Show Reach
  - Camera FOV
  - Pick Coverage
  - EPD Detections
  - Approach/Retreat
  - Show Warnings
  - Detection Labels
- **Visual Modes** submenu (under More)
  - Label mode
  - Mesh preview mode
  - Snap mode (Snap: 5 cm / Snap: 1 cm / Snap Off)
- **Layout/Edit Settings** submenu (under More)
  - Snap/Grid settings
  - Fine Move Mode
  - Unlock Robot Base
  - Show Minimap
  - Toggle Labels
  - Toggle Warnings
  - Reload Meshes
  - Export Canvas Snapshot (and existing layout actions)

## Implementation notes
- No functionality was removed.
- Existing QAction/QCheckBox objects and connections were preserved; controls were relocated from direct toolbar placement into menus.
- No new top-level toolbar buttons were added.

## Validator and test updates
- Updated `scripts/validate_scene_builder_ui_acceptance.py` to:
  - fail when secondary controls are added as direct always-visible toolbar widgets
  - pass when they are attached to menu surfaces under More
- Updated `scripts/validate_scene_builder_ux_integration.py` with the same contract checks.
- Added regression tests in `tests/test_scene_builder_ui_acceptance.py` for:
  - rejecting direct always-visible secondary toolbar widgets
  - allowing secondary controls in menu surfaces

## Verification run
- `python3 -m pytest -q tests/test_scene_builder_ui_acceptance.py` → pass
- `python3 scripts/validate_scene_builder_ux_integration.py` → pass
- `python3 scripts/validate_scene_builder_ui_acceptance.py` → pass

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d76e2ec10833199956d08218b9b67)