### PR TITLE
Remove hidden Scene Builder menu button proxies

### DIFF
--- a/scripts/validate_scene_builder_ui_acceptance.py
+++ b/scripts/validate_scene_builder_ui_acceptance.py
@@ -147,6 +147,14 @@ def run_checks(file_text_map:dict[str,str]|None=None)->list[CheckResult]:
     checks.append(_token_check("inspector sync/layout dirty markers",all_text,["inspector","sync","layout dirty"]))
     checks.append(_regex_absent_check("no hidden QPushButton indirection anti-pattern",main,{"menu_action_new_cell":r'addAction\("Create New Cell"\s*,',"menu_action_plan_simulate":r'addAction\("Open Plan & Simulate"\s*,'}))
     checks.append(_regex_absent_check("fixed-width button anti-pattern checks",main,{"qpushbutton_fixed_width_literal":r"\b[a-zA-Z_][a-zA-Z0-9_]*button[a-zA-Z0-9_]*\s*->\s*setFixedWidth\s*\(\s*\d+\s*\)"}))
+    checks.append(_regex_absent_check(
+        "no hidden QPushButton menu-proxy click wiring",
+        main,
+        {
+            "menu_proxy_click_indirection": r'addAction\s*\(\s*"[^"]+"\s*,\s*[a-zA-Z_][a-zA-Z0-9_]*button[a-zA-Z0-9_]*\s*,\s*&QPushButton::click\s*\)',
+            "canvas_snapshot_proxy": r'addAction\s*\(\s*"Export Canvas Snapshot"\s*,\s*[a-zA-Z_][a-zA-Z0-9_]*\s*,\s*&QPushButton::click\s*\)',
+        },
+    ))
     checks.append(_visible_label_set_check(
         "allowed visible top-level set only",
         main,

--- a/scripts/validate_scene_builder_ux_integration.py
+++ b/scripts/validate_scene_builder_ux_integration.py
@@ -32,6 +32,8 @@ def main() -> int:
     ok.append(check("secondary menus present", all(t in mainwindow_cpp for t in ["Overlays", "Canvas More", "Visual Modes", "Label mode", "Mesh preview mode", "Snap mode"])))
     ok.append(check("toolbar overflow wiring", all(t in mainwindow_cpp + mainwindow_h for t in ["scene_builder_secondary_overflow_button_", "scene_builder_secondary_overflow_menu_", "update_scene_builder_top_controls_overflow"])) )
     ok.append(check("no fixed-width toolbar anti-pattern", "setFixedWidth" not in mainwindow_cpp or "button" not in mainwindow_cpp))
+    proxy_click_hits = re.findall(r'addAction\s*\(\s*"[^"]+"\s*,\s*[a-zA-Z_][a-zA-Z0-9_]*button[a-zA-Z0-9_]*\s*,\s*&QPushButton::click\s*\)', mainwindow_cpp)
+    ok.append(check("no hidden QPushButton menu-proxy click wiring", len(proxy_click_hits) == 0, detail=str(proxy_click_hits)))
     ok.append(check("scene/item state split", all(t in mainwindow_h + mainwindow_cpp for t in ["SelectedSceneState", "SelectedSceneItemState", "selected_scene_state_", "selected_item_state_", "refresh_scene_builder_selected_scene_ui"])))
     ok.append(check("provenance summary helper", all(t in model_h + model_cpp for t in ["WorkcellStudioProvenanceStatus", "provenance_summary_text", "Editable layout:", "Preview fallback:"])))
     ok.append(check("create editable layout action wiring", all(t in mainwindow_cpp + mainwindow_h for t in ["create_starter_layout_from_preview", "refresh_create_starter_layout_action", "Create editable layout from preview"])))

--- a/tests/test_scene_builder_ui_acceptance.py
+++ b/tests/test_scene_builder_ui_acceptance.py
@@ -194,6 +194,14 @@ def test_validator_allows_secondary_canvas_controls_inside_more_menu_surfaces():
     assert "secondary canvas controls remain available in menu surfaces" not in failed
 
 
+
+def test_validator_fails_when_menu_actions_use_hidden_qpushbutton_click_proxy():
+    broken = _base_fixture()
+    broken["mainwindow_cpp"] += '\ncanvas_more_menu->addAction("Revert Layout", revert_layout_button_, &QPushButton::click);\n'
+    checks = run_checks(broken)
+    failed = {c.name: c.details for c in checks if not c.ok}
+    assert "no hidden QPushButton menu-proxy click wiring" in failed
+
 def test_repository_contract_rejects_reintroduced_selected_scene_direct_buttons():
     checks = run_checks()
     failed = {c.name: c.details for c in checks if not c.ok}

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1225,7 +1225,7 @@ void MainWindow::setup_studio_shell()
   secondary_layout_menu->addAction(scene_builder_action("layout.remove"));
   scene_builder_secondary_overflow_button_->setMenu(scene_builder_secondary_overflow_menu_);
   controls->addWidget(scene_builder_secondary_overflow_button_);
-  auto * export_snapshot = new QPushButton("Export Canvas Snapshot", scene_builder); center_panel_layout->addLayout(controls);
+  center_panel_layout->addLayout(controls);
   digital_twin_canvas_ = new QGraphicsView(scene_builder); digital_twin_canvas_->setObjectName("digital_twin_canvas_"); digital_twin_canvas_->setMinimumHeight(420);
   digital_twin_canvas_->viewport()->installEventFilter(this);
   scene_preview_widget_->set_fallback_2d_view(digital_twin_canvas_);
@@ -1237,18 +1237,14 @@ void MainWindow::setup_studio_shell()
   create_starter_layout_button_ = new QPushButton("Create editable layout from preview", scene_builder);
   create_starter_layout_button_->setVisible(false);
   layout_controls->addWidget(create_starter_layout_button_);
-  revert_layout_button_ = new QPushButton("Revert Layout", scene_builder);
-  auto * run_layout_merge_button = new QPushButton("Run Layout Merge", scene_builder);
-  auto * open_layout_merge_report_button = new QPushButton("Open Merge Report", scene_builder);
-  auto * copy_layout_merge_summary_button = new QPushButton("Copy Merge Summary", scene_builder);
   canvas_more_menu->addSeparator();
   canvas_more_menu->addAction("Duplicate Selected", this, [this](){ duplicate_selected_item(); });
   canvas_more_menu->addAction("Remove Selected Layout Item", this, [this](){ delete_selected_item(); });
-  canvas_more_menu->addAction("Revert Layout", revert_layout_button_, &QPushButton::click);
-  canvas_more_menu->addAction("Run Layout Merge", run_layout_merge_button, &QPushButton::click);
-  canvas_more_menu->addAction("Open Merge Report", open_layout_merge_report_button, &QPushButton::click);
-  canvas_more_menu->addAction("Copy Merge Summary", copy_layout_merge_summary_button, &QPushButton::click);
-  canvas_more_menu->addAction("Export Canvas Snapshot", export_snapshot, &QPushButton::click);
+  canvas_more_menu->addAction("Revert Layout", this, &MainWindow::revert_layout_changes);
+  canvas_more_menu->addAction("Run Layout Merge", this, [this](){ run_layout_merge_for_selected_scene(false); });
+  canvas_more_menu->addAction("Open Merge Report", this, &MainWindow::open_layout_merge_report);
+  canvas_more_menu->addAction("Copy Merge Summary", this, &MainWindow::copy_layout_merge_summary);
+  canvas_more_menu->addAction("Export Canvas Snapshot", this, &MainWindow::export_canvas_snapshot);
   connect(label_selected, &QAction::triggered, this, [this]() { if (scene_preview_widget_) scene_preview_widget_->set_label_mode(ScenePreviewWidget::LabelMode::Selected); });
   connect(label_all, &QAction::triggered, this, [this]() { if (scene_preview_widget_) scene_preview_widget_->set_label_mode(ScenePreviewWidget::LabelMode::Important); });
   connect(label_off, &QAction::triggered, this, [this]() { if (scene_preview_widget_) scene_preview_widget_->set_label_mode(ScenePreviewWidget::LabelMode::Off); });
@@ -1732,10 +1728,6 @@ connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo
   auto * redo_sc = new QShortcut(QKeySequence::Redo, scene_builder); connect(redo_sc, &QShortcut::activated, this, &MainWindow::redo_layout_edit);
   auto * esc_sc = new QShortcut(QKeySequence(Qt::Key_Escape), scene_builder); connect(esc_sc,&QShortcut::activated,this,[this](){ set_canvas_interaction_mode(CanvasInteractionMode::Select); if(digital_twin_scene_) digital_twin_scene_->clearSelection(); ghost_preview_item_=nullptr; rebuild_digital_twin_canvas(); });
   auto * fit_sc = new QShortcut(QKeySequence(Qt::Key_F), scene_builder); connect(fit_sc,&QShortcut::activated,fit_button,&QAction::trigger);
-  connect(run_layout_merge_button, &QPushButton::clicked, this, [this](){ run_layout_merge_for_selected_scene(false); });
-  connect(open_layout_merge_report_button, &QPushButton::clicked, this, &MainWindow::open_layout_merge_report);
-  connect(copy_layout_merge_summary_button, &QPushButton::clicked, this, &MainWindow::copy_layout_merge_summary);
-  connect(revert_layout_button_, &QPushButton::clicked, this, &MainWindow::revert_layout_changes);
   connect(scene_hierarchy_tree_, &QTreeWidget::itemClicked, this, [this](QTreeWidgetItem *item, int column){ Q_UNUSED(column); on_hierarchy_item_selected(item); });
   connect(asset_filter_combo_, qOverload<int>(&QComboBox::currentIndexChanged), this, &MainWindow::on_asset_filter_changed);
   connect(open_asset_folder_action, &QAction::triggered, this, [this](){ const QString p = selected_catalog_item_path(); if (p.isEmpty()) { QMessageBox::information(this, "Asset Catalog", "Select an asset first."); return; } QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(p).isDir() ? p : QFileInfo(p).absolutePath())); });
@@ -1750,7 +1742,6 @@ connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo
   connect(import_asset_action, &QAction::triggered, this, [this](){ QMessageBox::information(this, "Asset Catalog", "Import STL / URDF keeps existing behavior via filesystem import workflows."); });
   connect(add_existing_stl_action, &QAction::triggered, this, [this](){ QMessageBox::information(this, "Asset Catalog", "Add Existing STL to Canvas keeps existing behavior for scene assets."); });
   connect(placeholder_action, &QAction::triggered, this, [this](){ add_asset_to_canvas_from_catalog("Custom", "Generated Placeholder", "placeholder://generated"); });
-  connect(export_snapshot, &QPushButton::clicked, this, [this](){ if (!digital_twin_canvas_ || !digital_twin_canvas_->scene()) return; fs::path out; if (selected_scene_index_ >= 0 && selected_scene_index_ < (int)scene_browser_result_.scenes.size()) { const auto & s = scene_browser_result_.scenes[(size_t)selected_scene_index_]; out = s.scene_dir / "preview" / "workcell_studio_canvas_snapshot.png"; } else { out = fs::path(diagnostics_output_root().toStdString()) / "preview" / "workcell_studio_canvas_snapshot.png"; } fs::create_directories(out.parent_path()); QImage image(1280, 800, QImage::Format_ARGB32_Premultiplied); image.fill(QColor("#0f131a")); QPainter painter(&image); digital_twin_canvas_->scene()->render(&painter); painter.end(); image.save(QString::fromStdString(out.string())); append_studio_log("Export Canvas Snapshot: " + QString::fromStdString(out.string())); });
   connect(preview_process_, &QProcess::readyReadStandardOutput, this, &MainWindow::handle_preview_stdout);
   connect(preview_process_, &QProcess::readyReadStandardError, this, &MainWindow::handle_preview_stderr);
   connect(preview_process_, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this, &MainWindow::handle_preview_finished);
@@ -1773,6 +1764,27 @@ void MainWindow::register_scene_builder_action(const QString & key, QAction * ac
 {
   if (!action) return;
   scene_builder_action_registry_.insert(key, action);
+}
+
+
+void MainWindow::export_canvas_snapshot()
+{
+  if (!digital_twin_canvas_ || !digital_twin_canvas_->scene()) return;
+  fs::path out;
+  if (selected_scene_index_ >= 0 && selected_scene_index_ < (int)scene_browser_result_.scenes.size()) {
+    const auto & s = scene_browser_result_.scenes[(size_t)selected_scene_index_];
+    out = s.scene_dir / "preview" / "workcell_studio_canvas_snapshot.png";
+  } else {
+    out = fs::path(diagnostics_output_root().toStdString()) / "preview" / "workcell_studio_canvas_snapshot.png";
+  }
+  fs::create_directories(out.parent_path());
+  QImage image(1280, 800, QImage::Format_ARGB32_Premultiplied);
+  image.fill(QColor("#0f131a"));
+  QPainter painter(&image);
+  digital_twin_canvas_->scene()->render(&painter);
+  painter.end();
+  image.save(QString::fromStdString(out.string()));
+  append_studio_log("Export Canvas Snapshot: " + QString::fromStdString(out.string()));
 }
 
 void MainWindow::build_studio_header_actions()

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -299,6 +299,7 @@ private:
   void run_layout_merge_for_selected_scene(bool from_generate_scene = false);
   void open_layout_merge_report();
   void copy_layout_merge_summary();
+  void export_canvas_snapshot();
   void refresh_scene_bundle_export_panel();
   void export_scene_bundle_for_selected_scene();
   void import_scene_bundle_into_scenes_root();
@@ -495,7 +496,6 @@ private:
   QPushButton * delete_layout_button_{ nullptr };
   QPushButton * save_layout_button_{ nullptr };
   QPushButton * create_starter_layout_button_{ nullptr };
-  QPushButton * revert_layout_button_{ nullptr };
   QGraphicsView * minimap_view_{ nullptr };
   bool minimap_requested_visible_{ true };
   QVector<AssetCatalogEntry> asset_catalog_entries_;


### PR DESCRIPTION
## Summary
This PR removes hidden `QPushButton` proxy/indirection patterns from Scene Builder menu actions and replaces them with direct `QAction` wiring to `MainWindow` handlers.

### Hidden/proxy buttons removed from menu-trigger role
- `revert_layout_button_`
- `run_layout_merge_button`
- `open_layout_merge_report_button`
- `copy_layout_merge_summary_button`
- `export_snapshot`

### Replacements
- `Revert Layout` now wires directly to `MainWindow::revert_layout_changes`
- `Run Layout Merge` now wires directly via lambda to `run_layout_merge_for_selected_scene(false)`
- `Open Merge Report` now wires directly to `MainWindow::open_layout_merge_report`
- `Copy Merge Summary` now wires directly to `MainWindow::copy_layout_merge_summary`
- `Export Canvas Snapshot` now wires directly to a new helper `MainWindow::export_canvas_snapshot`

## Behavior preservation
- Existing behavior for all affected menu actions is preserved.
- No visible toolbar controls were added/removed/redesigned.
- Existing visible controls (`Select`, `Place Asset`, `Move`, `Inspect`, `Save Layout`, and conditional "Create editable layout from preview") remain unchanged.

## Validator updates
- Added static check to fail on hidden button click indirection patterns such as:
  - `addAction("...", some_button, &QPushButton::click)`
- Added UX integration validator check for the same anti-pattern.

## Test updates
- Added regression test that fails when menu actions are wired through hidden `QPushButton` click proxies.
- Existing Scene Actions/Home and toolbar declutter validator contracts remain passing.

## Validation run
- `python3 -m pytest -q tests/test_scene_builder_ui_acceptance.py`
- `python3 scripts/validate_scene_builder_ux_integration.py`
- `python3 scripts/validate_scene_builder_ui_acceptance.py`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d77d409bc833187845db4767b17c0)