### PR TITLE
Add minimal cell_definition.yaml and Workcell Studio layouts for scene packages

### DIFF
--- a/scenes/suction_test/cell_definition.yaml
+++ b/scenes/suction_test/cell_definition.yaml
@@ -1,0 +1,36 @@
+schema_version: cell_definition/v1
+cell:
+  id: suction_test
+  name: suction_test
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: suction
+  type: suction
+  brand: generic
+  grasp_frame: tool0
+environment:
+  frame: world
+  layout: layout/workcell_studio_layout.yaml
+task:
+  id: default_task
+  type: pick_place
+  source_object: commissioning_object
+  destinations:
+    - id: default_drop_zone
+      frame: world
+      pose_xyz: [0.5, -0.3, 0.1]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: default_place
+      when:
+        always: true
+      destination: default_drop_zone
+commissioning:
+  self_test_enabled: true
+  export_bundle: false

--- a/scenes/suction_test/layout/workcell_studio_layout.yaml
+++ b/scenes/suction_test/layout/workcell_studio_layout.yaml
@@ -1,0 +1,12 @@
+schema_version: workcell_studio_layout/v1
+items:
+  - id: robot_base
+    type: robot
+    pose:
+      xyz: [0.0, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+  - id: table_main
+    type: table
+    pose:
+      xyz: [0.5, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]

--- a/scenes/ur10_2f_test/cell_definition.yaml
+++ b/scenes/ur10_2f_test/cell_definition.yaml
@@ -1,0 +1,36 @@
+schema_version: cell_definition/v1
+cell:
+  id: ur10_2f_test
+  name: ur10_2f_test
+robot:
+  model: ur10
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: robotiq_2f
+  type: finger
+  brand: robotiq
+  grasp_frame: tool0
+environment:
+  frame: world
+  layout: layout/workcell_studio_layout.yaml
+task:
+  id: default_task
+  type: pick_place
+  source_object: commissioning_object
+  destinations:
+    - id: default_drop_zone
+      frame: world
+      pose_xyz: [0.5, -0.3, 0.1]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: default_place
+      when:
+        always: true
+      destination: default_drop_zone
+commissioning:
+  self_test_enabled: true
+  export_bundle: false

--- a/scenes/ur10_2f_test/layout/workcell_studio_layout.yaml
+++ b/scenes/ur10_2f_test/layout/workcell_studio_layout.yaml
@@ -1,0 +1,12 @@
+schema_version: workcell_studio_layout/v1
+items:
+  - id: robot_base
+    type: robot
+    pose:
+      xyz: [0.0, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+  - id: table_main
+    type: table
+    pose:
+      xyz: [0.5, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]

--- a/scenes/ur3_suction_test/cell_definition.yaml
+++ b/scenes/ur3_suction_test/cell_definition.yaml
@@ -1,0 +1,36 @@
+schema_version: cell_definition/v1
+cell:
+  id: ur3_suction_test
+  name: ur3_suction_test
+robot:
+  model: ur3
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: suction
+  type: suction
+  brand: generic
+  grasp_frame: tool0
+environment:
+  frame: world
+  layout: layout/workcell_studio_layout.yaml
+task:
+  id: default_task
+  type: pick_place
+  source_object: commissioning_object
+  destinations:
+    - id: default_drop_zone
+      frame: world
+      pose_xyz: [0.5, -0.3, 0.1]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: default_place
+      when:
+        always: true
+      destination: default_drop_zone
+commissioning:
+  self_test_enabled: true
+  export_bundle: false

--- a/scenes/ur3_suction_test/layout/workcell_studio_layout.yaml
+++ b/scenes/ur3_suction_test/layout/workcell_studio_layout.yaml
@@ -1,0 +1,12 @@
+schema_version: workcell_studio_layout/v1
+items:
+  - id: robot_base
+    type: robot
+    pose:
+      xyz: [0.0, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+  - id: table_main
+    type: table
+    pose:
+      xyz: [0.5, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]

--- a/scenes/ur5_2f_builder_pick_place_demo/cell_definition.yaml
+++ b/scenes/ur5_2f_builder_pick_place_demo/cell_definition.yaml
@@ -1,0 +1,36 @@
+schema_version: cell_definition/v1
+cell:
+  id: ur5_2f_builder_pick_place_demo
+  name: ur5_2f_builder_pick_place_demo
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: robotiq_2f
+  type: finger
+  brand: robotiq
+  grasp_frame: tool0
+environment:
+  frame: world
+  layout: layout/workcell_studio_layout.yaml
+task:
+  id: default_task
+  type: pick_place
+  source_object: commissioning_object
+  destinations:
+    - id: default_drop_zone
+      frame: world
+      pose_xyz: [0.5, -0.3, 0.1]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: default_place
+      when:
+        always: true
+      destination: default_drop_zone
+commissioning:
+  self_test_enabled: true
+  export_bundle: false

--- a/scenes/ur5_2f_builder_pick_place_demo/layout/workcell_studio_layout.yaml
+++ b/scenes/ur5_2f_builder_pick_place_demo/layout/workcell_studio_layout.yaml
@@ -1,0 +1,22 @@
+schema_version: workcell_studio_layout/v1
+items:
+  - id: robot_base
+    type: robot
+    pose:
+      xyz: [0.0, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+  - id: table_main
+    type: table
+    pose:
+      xyz: [0.5, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+  - id: pick_zone
+    type: pick_zone
+    pose:
+      xyz: [0.2, 0.0, 0.74]
+      rpy: [0.0, 0.0, 0.0]
+  - id: place_zone
+    type: place_zone
+    pose:
+      xyz: [0.6, -0.2, 0.74]
+      rpy: [0.0, 0.0, 0.0]

--- a/scenes/ur5_2f_sorting_test/cell_definition.yaml
+++ b/scenes/ur5_2f_sorting_test/cell_definition.yaml
@@ -1,0 +1,36 @@
+schema_version: cell_definition/v1
+cell:
+  id: ur5_2f_sorting_test
+  name: ur5_2f_sorting_test
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: robotiq_2f
+  type: finger
+  brand: robotiq
+  grasp_frame: tool0
+environment:
+  frame: world
+  layout: layout/workcell_studio_layout.yaml
+task:
+  id: default_task
+  type: pick_place
+  source_object: commissioning_object
+  destinations:
+    - id: default_drop_zone
+      frame: world
+      pose_xyz: [0.5, -0.3, 0.1]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: default_place
+      when:
+        always: true
+      destination: default_drop_zone
+commissioning:
+  self_test_enabled: true
+  export_bundle: false

--- a/scenes/ur5_2f_sorting_test/layout/workcell_studio_layout.yaml
+++ b/scenes/ur5_2f_sorting_test/layout/workcell_studio_layout.yaml
@@ -1,0 +1,27 @@
+schema_version: workcell_studio_layout/v1
+items:
+  - id: robot_base
+    type: robot
+    pose:
+      xyz: [0.0, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+  - id: table_main
+    type: table
+    pose:
+      xyz: [0.5, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+  - id: pick_zone
+    type: pick_zone
+    pose:
+      xyz: [0.12, 0.0, 0.74]
+      rpy: [0.0, 0.0, 0.0]
+  - id: place_zone_a
+    type: place_zone
+    pose:
+      xyz: [0.40, -0.20, 0.74]
+      rpy: [0.0, 0.0, 0.0]
+  - id: place_zone_b
+    type: place_zone
+    pose:
+      xyz: [0.40, 0.00, 0.74]
+      rpy: [0.0, 0.0, 0.0]

--- a/scenes/ur5_2f_test/cell_definition.yaml
+++ b/scenes/ur5_2f_test/cell_definition.yaml
@@ -1,0 +1,36 @@
+schema_version: cell_definition/v1
+cell:
+  id: ur5_2f_test
+  name: ur5_2f_test
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: robotiq_2f
+  type: finger
+  brand: robotiq
+  grasp_frame: tool0
+environment:
+  frame: world
+  layout: layout/workcell_studio_layout.yaml
+task:
+  id: default_task
+  type: pick_place
+  source_object: commissioning_object
+  destinations:
+    - id: default_drop_zone
+      frame: world
+      pose_xyz: [0.5, -0.3, 0.1]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: default_place
+      when:
+        always: true
+      destination: default_drop_zone
+commissioning:
+  self_test_enabled: true
+  export_bundle: false

--- a/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml
+++ b/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml
@@ -1,0 +1,12 @@
+schema_version: workcell_studio_layout/v1
+items:
+  - id: robot_base
+    type: robot
+    pose:
+      xyz: [0.0, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+  - id: table_main
+    type: table
+    pose:
+      xyz: [0.5, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]

--- a/scenes/ur5_3f_test/cell_definition.yaml
+++ b/scenes/ur5_3f_test/cell_definition.yaml
@@ -1,0 +1,36 @@
+schema_version: cell_definition/v1
+cell:
+  id: ur5_3f_test
+  name: ur5_3f_test
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: robotiq_3f
+  type: finger
+  brand: robotiq
+  grasp_frame: tool0
+environment:
+  frame: world
+  layout: layout/workcell_studio_layout.yaml
+task:
+  id: default_task
+  type: pick_place
+  source_object: commissioning_object
+  destinations:
+    - id: default_drop_zone
+      frame: world
+      pose_xyz: [0.5, -0.3, 0.1]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: default_place
+      when:
+        always: true
+      destination: default_drop_zone
+commissioning:
+  self_test_enabled: true
+  export_bundle: false

--- a/scenes/ur5_3f_test/layout/workcell_studio_layout.yaml
+++ b/scenes/ur5_3f_test/layout/workcell_studio_layout.yaml
@@ -1,0 +1,12 @@
+schema_version: workcell_studio_layout/v1
+items:
+  - id: robot_base
+    type: robot
+    pose:
+      xyz: [0.0, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+  - id: table_main
+    type: table
+    pose:
+      xyz: [0.5, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]

--- a/scenes/ur5_airpick4_test/cell_definition.yaml
+++ b/scenes/ur5_airpick4_test/cell_definition.yaml
@@ -1,0 +1,36 @@
+schema_version: cell_definition/v1
+cell:
+  id: ur5_airpick4_test
+  name: ur5_airpick4_test
+robot:
+  model: ur5
+  planning_group: manipulator
+  base_frame: world
+  tool_link: tool0
+  home_named_target: home
+  safe_joint_state: []
+end_effector:
+  id: suction
+  type: suction
+  brand: onrobot
+  grasp_frame: tool0
+environment:
+  frame: world
+  layout: layout/workcell_studio_layout.yaml
+task:
+  id: default_task
+  type: pick_place
+  source_object: commissioning_object
+  destinations:
+    - id: default_drop_zone
+      frame: world
+      pose_xyz: [0.5, -0.3, 0.1]
+      pose_rpy: [0.0, 0.0, 0.0]
+  rules:
+    - id: default_place
+      when:
+        always: true
+      destination: default_drop_zone
+commissioning:
+  self_test_enabled: true
+  export_bundle: false

--- a/scenes/ur5_airpick4_test/layout/workcell_studio_layout.yaml
+++ b/scenes/ur5_airpick4_test/layout/workcell_studio_layout.yaml
@@ -1,0 +1,12 @@
+schema_version: workcell_studio_layout/v1
+items:
+  - id: robot_base
+    type: robot
+    pose:
+      xyz: [0.0, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]
+  - id: table_main
+    type: table
+    pose:
+      xyz: [0.5, 0.0, 0.0]
+      rpy: [0.0, 0.0, 0.0]


### PR DESCRIPTION
### Motivation
- Provide minimal Workcell Studio-compatible metadata for several scene packages so YAML consumers and tooling can discover a `cell_definition` and a `workcell_studio_layout` for demos.
- Follow existing fixture conventions to avoid changing runtime behavior and keep launch/URDF semantics unchanged.

### Description
- Added `cell_definition.yaml` to each scene: `suction_test`, `ur10_2f_test`, `ur3_suction_test`, `ur5_2f_builder_pick_place_demo`, `ur5_2f_sorting_test`, `ur5_2f_test`, `ur5_3f_test`, and `ur5_airpick4_test` with a minimal `cell_definition/v1` structure referencing a local `layout/workcell_studio_layout.yaml`.
- Added `layout/workcell_studio_layout.yaml` in each scene with `schema_version: workcell_studio_layout/v1`, a top-level `items` sequence, non-empty `id` fields, and `pose.xyz` / `pose.rpy` arrays containing at least three numeric entries.
- Populated minimal implied items only (robot base + table everywhere, and pick/place / sorting zones for scenes where those assets are implied by existing URDFs).
- Did not modify any launch files, URDFs, or runtime behavior; only added new YAML assets.

### Testing
- Ran a Python YAML validation script that loaded each new `workcell_studio_layout.yaml` and asserted `schema_version`, that `items` is a list, that each item has a non-empty `id`, and that `pose.xyz` and `pose.rpy` are numeric arrays of length >= 3 for all 8 scenes, and all assertions passed.
- Verified the new files are present in the repo (added and committed) as part of the change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7dedc1e48331a6e1bf5313b7411e)