### PR TITLE
Add scene manifests for ur10_2f_test and ur3_suction_test

### DIFF
--- a/scenes/ur10_2f_test/scene_manifest.yaml
+++ b/scenes/ur10_2f_test/scene_manifest.yaml
@@ -1,0 +1,22 @@
+scene:
+  name: ur10_2f_test
+  folder: scenes/ur10_2f_test
+  package: ur10_2f_test
+
+files:
+  environment: environment.yaml
+  cell_definition: cell_definition.yaml
+  layout: layout/workcell_studio_layout.yaml
+  launch: launch/demo.launch.py
+  urdf_xacro: urdf/scene.urdf.xacro
+
+robot:
+  model: ur10
+  planning_group: manipulator
+  base_frame: base_link
+  ee_link: gripper_base_link
+
+end_effector:
+  type: finger
+  brand: robotiq_85_gripper
+  grasp_frame: gripper_base_link

--- a/scenes/ur3_suction_test/scene_manifest.yaml
+++ b/scenes/ur3_suction_test/scene_manifest.yaml
@@ -1,0 +1,22 @@
+scene:
+  name: ur3_suction_test
+  folder: scenes/ur3_suction_test
+  package: ur3_suction_test
+
+files:
+  environment: environment.yaml
+  cell_definition: cell_definition.yaml
+  layout: layout/workcell_studio_layout.yaml
+  launch: launch/demo.launch.py
+  urdf_xacro: urdf/scene.urdf.xacro
+
+robot:
+  model: ur3
+  planning_group: manipulator
+  base_frame: base_link
+  ee_link: suction_cup_link
+
+end_effector:
+  type: suction
+  brand: single_suction_gripper
+  grasp_frame: suction_cup_link


### PR DESCRIPTION
### Motivation
- Provide canonical scene manifests so tooling can discover scene identity and canonical file references for these scenes. 
- Keep metadata consistent with neighboring scenes by using the same top-level keys and naming style. 
- Capture robot and end-effector information inferred from each scene's URDF/Xacro to support downstream validation and runtime configuration.

### Description
- Add `scenes/ur10_2f_test/scene_manifest.yaml` containing `scene`, `files`, `robot`, and `end_effector` keys and references to `environment.yaml`, `cell_definition.yaml`, `layout/workcell_studio_layout.yaml`, `launch/demo.launch.py`, and `urdf/scene.urdf.xacro`.
- Add `scenes/ur3_suction_test/scene_manifest.yaml` containing `scene`, `files`, `robot`, and `end_effector` keys and references to the same canonical files as above.
- Populate `robot` and `end_effector` fields based on each scene's URDF/Xacro: `ur10` + `robotiq_85_gripper` (finger) for `ur10_2f_test`, and `ur3` + `single_suction_gripper` (suction) for `ur3_suction_test`.

### Testing
- Verified new files are present with `rg`/`nl -ba` and inspected the manifest contents successfully. 
- Performed `git status --short` to confirm the files were staged and `git commit` to record the change successfully. 
- Created the PR metadata via the repository helper which returned the PR title and body successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7dfde8588331a91d3a0ccb142b55)