### PR TITLE
Strengthen scene reproducibility test validations

### DIFF
--- a/tests/test_all_workcell_studio_scene_reproducibility.py
+++ b/tests/test_all_workcell_studio_scene_reproducibility.py
@@ -22,4 +22,24 @@ def test_all_scene_reproducibility_validator_runs_and_emits_json_report():
     payload = json.loads(report.read_text(encoding="utf-8"))
     assert isinstance(payload.get("scene_count"), int)
     assert isinstance(payload.get("scenes"), list)
+
+    status_counts = payload.get("status_counts")
+    assert isinstance(status_counts, dict)
+    assert status_counts.get("blocked") == 0
+
+    required_yaml_files = {
+        "scene_manifest.yaml",
+        "environment.yaml",
+        "cell_definition.yaml",
+        "layout/workcell_studio_layout.yaml",
+    }
+
+    for scene in payload["scenes"]:
+        assert scene.get("status") in {"ready", "warning"}
+
+        yaml_parse = scene.get("yaml_parse")
+        assert isinstance(yaml_parse, dict)
+        for yaml_name in required_yaml_files:
+            assert yaml_parse.get(yaml_name) == "ok"
+
     assert "Traceback" not in (proc.stdout + proc.stderr)


### PR DESCRIPTION
### Motivation
- Improve confidence in scene reproducibility by asserting the generated report includes status summaries and that no scenes are `blocked`.
- Ensure required YAML files parse successfully for every scene to catch missing or malformed scene metadata early.
- Maintain tolerance for non-blocking issues by allowing `warning` statuses while rejecting `blocked` scenes.

### Description
- Added an assertion that the report contains a `status_counts` map and that `status_counts.get("blocked") == 0`.
- Added per-scene assertions that each scene's `status` is in `{"ready", "warning"}` to preserve warning tolerance.
- Added iteration over each scene's `yaml_parse` map to assert required YAML files (`scene_manifest.yaml`, `environment.yaml`, `cell_definition.yaml`, `layout/workcell_studio_layout.yaml`) have status `"ok"`.
- Kept the existing subprocess invocation and the `Traceback` guard exactly as before to preserve existing failure diagnostics.

### Testing
- Ran `pytest -q tests/test_all_workcell_studio_scene_reproducibility.py` which exercised the updated assertions.
- The test run failed because the generated report contained blocked scenes (`status_counts['blocked'] == 8`), causing the new assertion to fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7e0fc2648331acacd9bb2892dc33)