### PR TITLE
Normalize scene manifests to reproducibility format

### DIFF
--- a/scenes/suction_test/scene_manifest.yaml
+++ b/scenes/suction_test/scene_manifest.yaml
@@ -1,5 +1,14 @@
 scene:
   name: suction_test
+  folder: scenes/suction_test
+  package: suction_test
+
+files:
+  environment: environment.yaml
+  cell_definition: cell_definition.yaml
+  layout: layout/workcell_studio_layout.yaml
+  launch: launch/demo.launch.py
+  urdf_xacro: urdf/scene.urdf.xacro
 
 robot:
   model: ur5

--- a/scenes/ur5_2f_builder_pick_place_demo/scene_manifest.yaml
+++ b/scenes/ur5_2f_builder_pick_place_demo/scene_manifest.yaml
@@ -1,5 +1,14 @@
 scene:
   name: ur5_2f_builder_pick_place_demo
+  folder: scenes/ur5_2f_builder_pick_place_demo
+  package: ur5_2f_builder_pick_place_demo
+
+files:
+  environment: environment.yaml
+  cell_definition: cell_definition.yaml
+  layout: layout/workcell_studio_layout.yaml
+  launch: launch/demo.launch.py
+  urdf_xacro: urdf/scene.urdf.xacro
 
 robot:
   model: ur5

--- a/scenes/ur5_2f_sorting_test/scene_manifest.yaml
+++ b/scenes/ur5_2f_sorting_test/scene_manifest.yaml
@@ -1,5 +1,14 @@
 scene:
   name: ur5_2f_sorting_test
+  folder: scenes/ur5_2f_sorting_test
+  package: ur5_2f_sorting_test
+
+files:
+  environment: environment.yaml
+  cell_definition: cell_definition.yaml
+  layout: layout/workcell_studio_layout.yaml
+  launch: launch/demo.launch.py
+  urdf_xacro: urdf/scene.urdf.xacro
 
 robot:
   model: ur5

--- a/scenes/ur5_2f_test/scene_manifest.yaml
+++ b/scenes/ur5_2f_test/scene_manifest.yaml
@@ -1,5 +1,14 @@
 scene:
   name: ur5_2f_test
+  folder: scenes/ur5_2f_test
+  package: ur5_2f_test
+
+files:
+  environment: environment.yaml
+  cell_definition: cell_definition.yaml
+  layout: layout/workcell_studio_layout.yaml
+  launch: launch/demo.launch.py
+  urdf_xacro: urdf/scene.urdf.xacro
 
 robot:
   model: ur5

--- a/scenes/ur5_3f_test/scene_manifest.yaml
+++ b/scenes/ur5_3f_test/scene_manifest.yaml
@@ -1,5 +1,14 @@
 scene:
   name: ur5_3f_test
+  folder: scenes/ur5_3f_test
+  package: ur5_3f_test
+
+files:
+  environment: environment.yaml
+  cell_definition: cell_definition.yaml
+  layout: layout/workcell_studio_layout.yaml
+  launch: launch/demo.launch.py
+  urdf_xacro: urdf/scene.urdf.xacro
 
 robot:
   model: ur5

--- a/scenes/ur5_airpick4_test/scene_manifest.yaml
+++ b/scenes/ur5_airpick4_test/scene_manifest.yaml
@@ -1,5 +1,14 @@
 scene:
   name: ur5_airpick4_test
+  folder: scenes/ur5_airpick4_test
+  package: ur5_airpick4_test
+
+files:
+  environment: environment.yaml
+  cell_definition: cell_definition.yaml
+  layout: layout/workcell_studio_layout.yaml
+  launch: launch/demo.launch.py
+  urdf_xacro: urdf/scene.urdf.xacro
 
 robot:
   model: ur5


### PR DESCRIPTION
### Motivation
- Several scene manifests contained full builder exports instead of the lightweight reproducibility manifest expected by tooling, causing inconsistency in scene metadata. 
- Align manifests with the same structure used by `scenes/ur10_2f_test/scene_manifest.yaml` and `scenes/ur3_suction_test/scene_manifest.yaml` so validators and downstream tools can reliably locate required artifacts.

### Description
- For each affected scene manifest added `scene.folder` and `scene.package` and a `files` mapping containing `environment`, `cell_definition`, `layout`, `launch`, and `urdf_xacro` entries. 
- Preserved existing `robot` and `end_effector` summary sections and avoided adding builder-export internals (camera/workspace/safety/metadata blocker lists). 
- Changes applied to the following manifests: `scenes/suction_test/scene_manifest.yaml`, `scenes/ur5_2f_builder_pick_place_demo/scene_manifest.yaml`, `scenes/ur5_2f_sorting_test/scene_manifest.yaml`, `scenes/ur5_2f_test/scene_manifest.yaml`, `scenes/ur5_3f_test/scene_manifest.yaml`, and `scenes/ur5_airpick4_test/scene_manifest.yaml`. 
- All referenced paths use relative files inside each scene (for example `environment: environment.yaml`, `layout: layout/workcell_studio_layout.yaml`, etc.).

### Testing
- Verified required files exist in each scene with the shell check: `for d in scenes/*; do ...; done` which returned `ok` for all required artifact paths. 
- Ran `python scripts/validate_all_workcell_studio_scenes.py` and confirmed every scene shows `yaml_parse["scene_manifest.yaml"] == "ok"` and the validator report indicates `status_counts.blocked == 0`. 
- Validator JSON report generated at `build/workcell_studio_scene_reproducibility_report.json` showing all scenes in `warning` state with no `blocked` entries and layout previewable where applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d809670d48331baf7a5892dcab74f)