### PR TITLE
Strengthen static contract checks for URDF visual transform/preview pipeline

### DIFF
--- a/scripts/validate_scene3d_mesh_preview_contract.py
+++ b/scripts/validate_scene3d_mesh_preview_contract.py
@@ -51,6 +51,44 @@ def main():
     ]:
         must(token in extractor_src, f"missing extractor token: {token}")
 
+    # Contract: URDF graph parsing (joint structures + parent/child link handling).
+    for token in [
+        "def parse_urdf_graph",
+        "'inbound_joints'",
+        "'outbound_joints'",
+        "joint.find('parent')",
+        "joint.find('child')",
+        "links[parent]['outbound_joints'].append(j)",
+        "links[child]['inbound_joints'].append(j)",
+    ]:
+        must(token in extractor_src, f"missing URDF graph token: {token}")
+
+    # Contract: link->world transform computation path exists.
+    for token in [
+        "def compute_link_world_tfs",
+        "matmul4(cur_tf, tf_from_xyz_rpy",
+        "link_world_tfs, link_status, gw = compute_link_world_tfs",
+    ]:
+        must(token in extractor_src, f"missing link-world transform token: {token}")
+
+    # Contract: visual schema exposes local/link/world pose information + status.
+    for token in [
+        '"transform_status"',
+        '"local_visual_pose"',
+        '"link_world_pose"',
+        '"pose"',
+    ]:
+        must(token in extractor_src, f"missing visual schema token: {token}")
+
+    # Contract: collapsed-pose detection + warning emission are implemented.
+    for token in [
+        "def has_collapsed_visual_poses",
+        "collapse_warning = \"all visual poses collapsed; transform assembly likely failed\"",
+        "has_transform_collapse_warning = has_collapsed_visual_poses(items)",
+        "warnings.append(collapse_warning)",
+    ]:
+        must(token in extractor_src, f"missing collapsed-pose warning token: {token}")
+
     test_src = (ROOT / "tests/test_scene_urdf_visual_mesh_index.py").read_text(encoding="utf-8")
     for token in ["assert data['resolved'] > 0", "assert not unresolved_only", "assert ur_scene_resolved"]:
         must(token in test_src, f"missing test assertion token: {token}")
@@ -58,6 +96,21 @@ def main():
     mw_src = MAINWINDOW.read_text(encoding="utf-8")
     for token in ["scene_visual_mesh_index.json", "urdf_visual", "Preview warning: URDF visual unresolved", "p.locked = true"]:
         must(token in mw_src, f"missing mainwindow token: {token}")
+
+    # Contract: preview ingestion reads computed world pose for placement and keeps URDF locking behavior.
+    for token in [
+        'yaml_map_key(v, "pose")',
+        'p.x =',
+        'p.y =',
+        'p.z =',
+        'p.roll =',
+        'p.pitch =',
+        'p.yaw =',
+        'p.locked = true',
+        'p.editable = false',
+        'p.lock_reason = "URDF visual preview item (locked)"',
+    ]:
+        must(token in mw_src, f"missing preview ingestion token: {token}")
     must("use_fake_hardware:=true" in mw_src, "fake hardware launch token missing")
 
     print("scene3d mesh preview contract: OK")


### PR DESCRIPTION
### Motivation
- Tighten the static contract that validates the URDF visual extraction and preview pipeline so the extractor and preview code clearly declare joint/link parsing, transform assembly, visual pose metadata, collapsed-pose detection, and preview ingestion behavior.
- Make the validator assert presence of the tokens that downstream consumers must implement so schema/behavior drift is detected early.

### Description
- Expanded `scripts/validate_scene3d_mesh_preview_contract.py` to check the extractor for URDF graph parsing tokens such as `def parse_urdf_graph`, `'inbound_joints'`, `'outbound_joints'`, `joint.find('parent')`, `joint.find('child')`, and the link/joint append calls. 
- Added checks for link->world transform assembly tokens including `def compute_link_world_tfs`, `matmul4(cur_tf, tf_from_xyz_rpy`, and the call site `link_world_tfs, link_status, gw = compute_link_world_tfs`.
- Added visual schema and collapsed-pose assertions to require presence of fields/tokens like `"transform_status"`, `"local_visual_pose"`, `"link_world_pose"`, `"pose"`, `def has_collapsed_visual_poses`, the collapse warning string, and the warning append logic.
- Added MainWindow/preview ingestion checks to ensure the preview consumer reads the computed `pose` (`yaml_map_key(v, "pose")`, `p.x =`..`p.yaw =`) and preserves URDF preview locking (`p.locked = true`, `p.editable = false`, `p.lock_reason = "URDF visual preview item (locked)"`).

### Testing
- Ran `python3 scripts/validate_scene3d_mesh_preview_contract.py`, which exercised the new static checks and exited non-zero due to a missing token. 
- The run failed with `AssertionError: missing visual schema token: "transform_status"`, indicating the repository does not yet provide that exact schema token and the tightened contract detected the gap.
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0daf17d39483319703c876d7ef5ffb)