### PR TITLE
Add Scene3D visual diagnostics report + validator and contract coverage

### DIFF
--- a/scenes/suction_test/generated/scene_visual_mesh_index.json
+++ b/scenes/suction_test/generated/scene_visual_mesh_index.json
@@ -7,8 +7,8 @@
       "id": "urdf_visual_regex_0",
       "link": "unknown_link",
       "visual": "",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
-      "package_uri": "package://table_description/meshes/visual/table.stl",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "package_uri": "package://single_suction_description/meshes/wrist_fixture.STL",
       "pose": {
         "xyz": [
           0,
@@ -64,6 +64,65 @@
     },
     {
       "id": "urdf_visual_regex_1",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "package_uri": "package://single_suction_description/meshes/wrist_fixture.STL",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_2",
       "link": "unknown_link",
       "visual": "",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
@@ -122,7 +181,66 @@
       "render_warning": ""
     },
     {
-      "id": "urdf_visual_regex_2",
+      "id": "urdf_visual_regex_3",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "package_uri": "package://table_description/meshes/visual/table.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_4",
       "link": "unknown_link",
       "visual": "",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
@@ -183,6 +301,7 @@
   ],
   "warnings": [
     "xacro executable unavailable; using best_effort parsing",
-    "unresolved xacro include: $(find ur_description)/urdf/ur_macro.xacro"
+    "unresolved xacro include: $(find ur_description)/urdf/ur_macro.xacro",
+    "all visual poses collapsed; transform assembly likely failed"
   ]
 }

--- a/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json
@@ -7,6 +7,1068 @@
       "id": "urdf_visual_regex_0",
       "link": "unknown_link",
       "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_1",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_base_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_base_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_2",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_3",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_4",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_5",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_6",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_7",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_8",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_9",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_10",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_11",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_12",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_13",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_14",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_15",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_16",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_17",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_18",
+      "link": "unknown_link",
+      "visual": "",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
       "package_uri": "package://workbench_description/meshes/visual/table.stl",
       "pose": {
@@ -63,7 +1125,7 @@
       "render_warning": ""
     },
     {
-      "id": "urdf_visual_regex_1",
+      "id": "urdf_visual_regex_19",
       "link": "unknown_link",
       "visual": "",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/collision/table.stl",
@@ -122,7 +1184,7 @@
       "render_warning": ""
     },
     {
-      "id": "urdf_visual_regex_2",
+      "id": "urdf_visual_regex_20",
       "link": "unknown_link",
       "visual": "",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
@@ -183,6 +1245,7 @@
   ],
   "warnings": [
     "xacro executable unavailable; using best_effort parsing",
-    "unresolved xacro include: $(find ur_description)/urdf/ur_macro.xacro"
+    "unresolved xacro include: $(find ur_description)/urdf/ur_macro.xacro",
+    "all visual poses collapsed; transform assembly likely failed"
   ]
 }

--- a/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json
@@ -7,8 +7,8 @@
       "id": "urdf_visual_regex_0",
       "link": "unknown_link",
       "visual": "",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
-      "package_uri": "package://table_description/meshes/visual/table.stl",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "package_uri": "package://single_suction_description/meshes/wrist_fixture.STL",
       "pose": {
         "xyz": [
           0,
@@ -64,6 +64,65 @@
     },
     {
       "id": "urdf_visual_regex_1",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "package_uri": "package://single_suction_description/meshes/wrist_fixture.STL",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_2",
       "link": "unknown_link",
       "visual": "",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
@@ -122,7 +181,66 @@
       "render_warning": ""
     },
     {
-      "id": "urdf_visual_regex_2",
+      "id": "urdf_visual_regex_3",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "package_uri": "package://table_description/meshes/visual/table.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_4",
       "link": "unknown_link",
       "visual": "",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
@@ -183,6 +301,7 @@
   ],
   "warnings": [
     "xacro executable unavailable; using best_effort parsing",
-    "unresolved xacro include: $(find ur_description)/urdf/ur_macro.xacro"
+    "unresolved xacro include: $(find ur_description)/urdf/ur_macro.xacro",
+    "all visual poses collapsed; transform assembly likely failed"
   ]
 }

--- a/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json
@@ -7,6 +7,1068 @@
       "id": "urdf_visual_regex_0",
       "link": "unknown_link",
       "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_1",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_base_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_base_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_2",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_3",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_4",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_5",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_6",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_7",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_8",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_9",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_10",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_11",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_12",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_13",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_14",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_15",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_16",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_17",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_18",
+      "link": "unknown_link",
+      "visual": "",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
       "package_uri": "package://workbench_description/meshes/visual/table.stl",
       "pose": {
@@ -63,7 +1125,7 @@
       "render_warning": ""
     },
     {
-      "id": "urdf_visual_regex_1",
+      "id": "urdf_visual_regex_19",
       "link": "unknown_link",
       "visual": "",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/collision/table.stl",
@@ -122,7 +1184,7 @@
       "render_warning": ""
     },
     {
-      "id": "urdf_visual_regex_2",
+      "id": "urdf_visual_regex_20",
       "link": "unknown_link",
       "visual": "",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
@@ -183,6 +1245,7 @@
   ],
   "warnings": [
     "xacro executable unavailable; using best_effort parsing",
-    "unresolved xacro include: $(find ur_description)/urdf/ur_macro.xacro"
+    "unresolved xacro include: $(find ur_description)/urdf/ur_macro.xacro",
+    "all visual poses collapsed; transform assembly likely failed"
   ]
 }

--- a/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json
@@ -7,6 +7,1068 @@
       "id": "urdf_visual_regex_0",
       "link": "unknown_link",
       "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_1",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_base_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_base_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_2",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_3",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_4",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_5",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_6",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_7",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_8",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_9",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_10",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_11",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_12",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_13",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_14",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_15",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_16",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_17",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_18",
+      "link": "unknown_link",
+      "visual": "",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
       "package_uri": "package://realsense2_description/meshes/d435.dae",
       "pose": {
@@ -65,6 +1127,7 @@
   ],
   "warnings": [
     "xacro executable unavailable; using best_effort parsing",
-    "unresolved xacro include: $(find ur_description)/urdf/ur_macro.xacro"
+    "unresolved xacro include: $(find ur_description)/urdf/ur_macro.xacro",
+    "all visual poses collapsed; transform assembly likely failed"
   ]
 }

--- a/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
@@ -7,6 +7,1068 @@
       "id": "urdf_visual_regex_0",
       "link": "unknown_link",
       "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_1",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_base_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_base_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_2",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_3",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_4",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_5",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_6",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_7",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_8",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_9",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_10",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_11",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_12",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_13",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_inner_knuckle_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_14",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_15",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_16",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".dae",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_17",
+      "link": "unknown_link",
+      "visual": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "package_uri": "package://robotiq_85_description/meshes/collision/robotiq_85_finger_tip_link.stl",
+      "pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0,
+          0,
+          0
+        ],
+        "rpy": [
+          0,
+          0,
+          0
+        ]
+      },
+      "parent_link": "",
+      "joint_chain": [],
+      "transform_source": "local_only; regex_fallback",
+      "transform_status": "resolved",
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "material": {},
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": ".stl",
+      "render_expected": true,
+      "render_warning": ""
+    },
+    {
+      "id": "urdf_visual_regex_18",
+      "link": "unknown_link",
+      "visual": "",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
       "package_uri": "package://workbench_description/meshes/visual/table.stl",
       "pose": {
@@ -63,7 +1125,7 @@
       "render_warning": ""
     },
     {
-      "id": "urdf_visual_regex_1",
+      "id": "urdf_visual_regex_19",
       "link": "unknown_link",
       "visual": "",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/collision/table.stl",
@@ -122,7 +1184,7 @@
       "render_warning": ""
     },
     {
-      "id": "urdf_visual_regex_2",
+      "id": "urdf_visual_regex_20",
       "link": "unknown_link",
       "visual": "",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
@@ -183,6 +1245,7 @@
   ],
   "warnings": [
     "xacro executable unavailable; using best_effort parsing",
-    "unresolved xacro include: $(find ur_description)/urdf/ur_macro.xacro"
+    "unresolved xacro include: $(find ur_description)/urdf/ur_macro.xacro",
+    "all visual poses collapsed; transform assembly likely failed"
   ]
 }

--- a/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json
@@ -184,7 +184,7 @@
       "id": "urdf_visual_regex_3",
       "link": "unknown_link",
       "visual": "",
-      "source_path": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
       "package_uri": "package://onrobot_airpick4_description/meshes/airpick4.stl",
       "pose": {
         "xyz": [
@@ -225,7 +225,7 @@
       "parent_link": "",
       "joint_chain": [],
       "transform_source": "local_only; regex_fallback",
-      "transform_status": "local_only",
+      "transform_status": "resolved",
       "scale": [
         1,
         1,
@@ -233,8 +233,8 @@
       ],
       "material": {},
       "category": "unknown_visual",
-      "resolved": false,
-      "warning": "unresolved mesh path: package://onrobot_airpick4_description/meshes/airpick4.stl",
+      "resolved": true,
+      "warning": "",
       "mesh_extension": ".stl",
       "render_expected": true,
       "render_warning": ""
@@ -243,7 +243,7 @@
       "id": "urdf_visual_regex_4",
       "link": "unknown_link",
       "visual": "",
-      "source_path": "",
+      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
       "package_uri": "package://onrobot_airpick4_description/meshes/airpick4.stl",
       "pose": {
         "xyz": [
@@ -284,7 +284,7 @@
       "parent_link": "",
       "joint_chain": [],
       "transform_source": "local_only; regex_fallback",
-      "transform_status": "local_only",
+      "transform_status": "resolved",
       "scale": [
         1,
         1,
@@ -292,8 +292,8 @@
       ],
       "material": {},
       "category": "unknown_visual",
-      "resolved": false,
-      "warning": "unresolved mesh path: package://onrobot_airpick4_description/meshes/airpick4.stl",
+      "resolved": true,
+      "warning": "",
       "mesh_extension": ".stl",
       "render_expected": true,
       "render_warning": ""
@@ -302,8 +302,6 @@
   "warnings": [
     "xacro executable unavailable; using best_effort parsing",
     "unresolved xacro include: $(find ur_description)/urdf/ur_macro.xacro",
-    "unresolved mesh path: package://onrobot_airpick4_description/meshes/airpick4.stl",
-    "unresolved mesh path: package://onrobot_airpick4_description/meshes/airpick4.stl",
     "all visual poses collapsed; transform assembly likely failed"
   ]
 }

--- a/scripts/validate_scene3d_mesh_preview_contract.py
+++ b/scripts/validate_scene3d_mesh_preview_contract.py
@@ -104,6 +104,20 @@ def main():
     for token in ["assert data['resolved'] > 0", "assert 'mesh_format_counts' in data", "assert data.get('renderable_mesh_count', 0) > 0"]:
         must(token in test_src, f"missing test assertion token: {token}")
 
+
+    diag_src = (ROOT / "scripts/validate_scene3d_visual_diagnostics.py").read_text(encoding="utf-8")
+    for token in [
+        "workcell_studio_scene3d_visual_diagnostics.json",
+        "loaded_mesh_count",
+        "failed_mesh_count",
+        "world_bounds",
+        "largest_mesh",
+        "smallest_mesh",
+        "many mesh items share identical world positions",
+        "extreme mesh scale detected",
+    ]:
+        must(token in diag_src, f"missing diagnostics token: {token}")
+
     mw_src = MAINWINDOW.read_text(encoding="utf-8")
     for token in ["scene_visual_mesh_index.json", "urdf_visual", "Preview warning: URDF visual unresolved", "p.locked = true"]:
         must(token in mw_src, f"missing mainwindow token: {token}")

--- a/scripts/validate_scene3d_visual_diagnostics.py
+++ b/scripts/validate_scene3d_visual_diagnostics.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json, math
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCENES = ROOT / 'scenes'
+BUILD = ROOT / 'build'
+OUT = BUILD / 'workcell_studio_scene3d_visual_diagnostics.json'
+
+def bounds_from_items(items):
+    mins=[float('inf')]*3; maxs=[float('-inf')]*3; ok=False
+    for it in items:
+        pose=(it.get('pose') or {})
+        xyz=pose.get('xyz') or [0,0,0]
+        if not (isinstance(xyz,list) and len(xyz)==3):
+            continue
+        s=it.get('scale') or [1,1,1]
+        if not (isinstance(s,list) and len(s)==3): s=[1,1,1]
+        ext=[abs(float(v)) for v in s]
+        lo=[float(xyz[i])-ext[i]*0.5 for i in range(3)]
+        hi=[float(xyz[i])+ext[i]*0.5 for i in range(3)]
+        mins=[min(mins[i], lo[i]) for i in range(3)]
+        maxs=[max(maxs[i], hi[i]) for i in range(3)]
+        ok=True
+    return ({'min':mins,'max':maxs,'extents':[maxs[i]-mins[i] for i in range(3)]} if ok else {'min':[0,0,0],'max':[0,0,0],'extents':[0,0,0]})
+
+def main():
+    BUILD.mkdir(parents=True, exist_ok=True)
+    diagnostics={'scenes':[], 'warning_count':0}
+    hard_errors=[]
+    for scene in sorted([p for p in SCENES.iterdir() if p.is_dir()]):
+        idx=scene/'generated'/'scene_visual_mesh_index.json'
+        if not idx.exists():
+            hard_errors.append(f'missing index: {idx}')
+            continue
+        payload=json.loads(idx.read_text())
+        items=payload.get('visual_items', [])
+        mesh_items=[i for i in items if i.get('mesh_extension')]
+        loaded=[i for i in mesh_items if i.get('resolved')]
+        failed=[i for i in mesh_items if not i.get('resolved')]
+        exts=[]
+        for i in mesh_items:
+            s=i.get('scale') or [1,1,1]
+            if isinstance(s,list) and len(s)==3:
+                exts.append(max(abs(float(s[0])),abs(float(s[1])),abs(float(s[2]))))
+        largest=max(exts) if exts else 0.0
+        smallest=min(exts) if exts else 0.0
+        b=bounds_from_items(mesh_items or items)
+        radius=0.5*math.sqrt(sum(float(v)*float(v) for v in b['extents']))
+        warnings=[]
+        xyzs=[tuple((i.get('pose') or {}).get('xyz') or [0,0,0]) for i in mesh_items]
+        if xyzs and len(set(xyzs)) <= max(1, len(xyzs)//4): warnings.append('many mesh items share identical world positions')
+        if largest>20.0 or (smallest>0 and smallest<0.001): warnings.append('extreme mesh scale detected')
+        if radius>200 or (radius>0 and radius<0.001): warnings.append('scene bounds radius extreme')
+        if largest>0 and smallest>0 and (largest/max(smallest,1e-12))>10000: warnings.append('fit view may be dominated by one bad mesh')
+        if any((i.get('mesh_extension')=='.dae' and i.get('render_expected') and not i.get('resolved')) for i in mesh_items): warnings.append('dae parser or load produced non-renderable meshes')
+        diagnostics['warning_count'] += len(warnings)
+        diagnostics['scenes'].append({
+            'scene': scene.name,
+            'item_count': len(items),
+            'mesh_item_count': len(mesh_items),
+            'loaded_mesh_count': len(loaded),
+            'failed_mesh_count': len(failed),
+            'world_bounds': b,
+            'largest_mesh': largest,
+            'smallest_mesh': smallest,
+            'fit_radius': radius,
+            'warnings': warnings,
+        })
+    OUT.write_text(json.dumps(diagnostics, indent=2)+"\n")
+    if hard_errors:
+        print('\n'.join(hard_errors))
+        raise SystemExit(1)
+    print(f'Wrote {OUT} for {len(diagnostics["scenes"])} scenes; warnings={diagnostics["warning_count"]}')
+
+if __name__=='__main__':
+    main()

--- a/tests/test_scene_urdf_visual_mesh_index.py
+++ b/tests/test_scene_urdf_visual_mesh_index.py
@@ -95,3 +95,17 @@ def test_scene_urdf_visual_mesh_index_generation():
     dae_present = any((i.get('mesh_extension') or '').lower() == '.dae' for i in all_items)
     if dae_present:
         assert mesh_counts.get('.dae', 0) > 0
+
+
+def test_scene3d_visual_diagnostics_report_generation():
+    proc = subprocess.run(['python3', str(ROOT / 'scripts' / 'validate_scene3d_visual_diagnostics.py')], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    assert 'Traceback' not in (proc.stdout + proc.stderr)
+
+    report = ROOT / 'build' / 'workcell_studio_scene3d_visual_diagnostics.json'
+    assert report.exists()
+    data = json.loads(report.read_text())
+    assert 'scenes' in data and data['scenes']
+    first = data['scenes'][0]
+    for key in ['item_count','mesh_item_count','loaded_mesh_count','failed_mesh_count','world_bounds','largest_mesh','smallest_mesh','warnings']:
+        assert key in first


### PR DESCRIPTION
## Summary
This PR adds scene-level visual placement diagnostics output so Scene Builder 3D mesh sanity can be inspected quickly from generated data, with static contract/test coverage.

## What was added
- New script: `scripts/validate_scene3d_visual_diagnostics.py`
  - Reads `scenes/*/generated/scene_visual_mesh_index.json`
  - Writes `build/workcell_studio_scene3d_visual_diagnostics.json`
  - Emits per-scene diagnostics fields:
    - `item_count`
    - `mesh_item_count`
    - `loaded_mesh_count`
    - `failed_mesh_count`
    - `world_bounds` (`min`, `max`, `extents`)
    - `largest_mesh`
    - `smallest_mesh`
    - `fit_radius`
    - `warnings`
  - Warning heuristics include:
    - collapsed/identical mesh positions
    - extreme scale
    - extreme scene radius
    - fit-view domination by one outlier mesh
    - DAE non-renderable/load warning condition

- Updated static contract validator: `scripts/validate_scene3d_mesh_preview_contract.py`
  - Verifies diagnostics script/report tokens exist
  - Verifies warning token presence for extreme-scale and collapsed-position diagnostics

- Updated tests: `tests/test_scene_urdf_visual_mesh_index.py`
  - Added diagnostics generation test
  - Verifies diagnostics report exists
  - Verifies required diagnostics keys exist
  - Verifies no traceback in diagnostics script output

- Refreshed generated scene mesh index files in `scenes/*/generated/scene_visual_mesh_index.json` after regeneration.

## Coverage and counts
- Scenes covered: **8**
- Total loaded mesh count: **100**
- Total failed mesh count: **0**
- Scale/collapse warnings found:
  - Identical-position warning triggered in all 8 scenes (`many mesh items share identical world positions`)

## Behavior constraints confirmation
- No UI redesign attempted
- No new top-level buttons added
- No scene launch flow changes attempted
- No fake-hardware changes attempted
- No EPD behavior changes attempted
- No robot articulation changes attempted
- URDF preview lock/edit model untouched in this PR

## Validation run
- `python3 scripts/extract_scene_urdf_visual_mesh_index.py`
- `python3 scripts/validate_scene3d_mesh_preview_contract.py`
- `python3 scripts/validate_scene3d_visual_diagnostics.py`
- `python3 -m pytest -q tests/test_scene_urdf_visual_mesh_index.py`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0db39791e48331873e6ba2428da3c8)