### PR TITLE
Add strict --require-xacro enforcement and tests; static helper-script lookup assertions

### DIFF
--- a/scripts/extract_scene_urdf_visual_mesh_index.py
+++ b/scripts/extract_scene_urdf_visual_mesh_index.py
@@ -242,5 +242,9 @@ def main():
     (ROOT/'build').mkdir(exist_ok=True)
     rpt=ROOT/'build'/'workcell_studio_urdf_visual_mesh_index_report.json'; rpt.write_text(json.dumps(report,indent=2)+'\n')
     print(f"scanned={report['scene_count']} visuals={report['visual_count']} xacro_expanded={report['xacro_expanded_count']} best_effort={report['best_effort_count']}")
-    print(rpt); return 0
+    print(rpt)
+    if a.require_xacro and report['best_effort_count'] > 0:
+        print('strict xacro mode failed: one or more scenes used best_effort extraction')
+        return 3
+    return 0
 if __name__=='__main__': raise SystemExit(main())

--- a/tests/test_scene_urdf_visual_mesh_index.py
+++ b/tests/test_scene_urdf_visual_mesh_index.py
@@ -130,3 +130,51 @@ def test_scene_option_and_local_smoke_missing_xacro_graceful():
     proc2 = subprocess.run(['python3', str(smoke)], capture_output=True, text=True)
     assert proc2.returncode in (0, 2)
     assert 'Traceback' not in (proc2.stdout + proc2.stderr)
+
+
+def test_require_xacro_strict_rejects_best_effort_modes():
+    import sys
+    import scripts.extract_scene_urdf_visual_mesh_index as mesh_index
+
+    original_argv = sys.argv
+    try:
+        sys.argv = ['extract_scene_urdf_visual_mesh_index.py', '--all', '--prefer-xacro', '--require-xacro', '--no-write']
+        rc = mesh_index.main()
+    finally:
+        sys.argv = original_argv
+
+    if rc == 2:
+        # Environment has no xacro binary; strict non-zero behavior is covered by the failure-path test.
+        return
+
+    assert rc == 0
+    report = ROOT / 'build' / 'workcell_studio_urdf_visual_mesh_index_report.json'
+    data = json.loads(report.read_text())
+    assert data.get('best_effort_count', 0) == 0
+    assert data.get('xacro_expanded_count', 0) == data.get('scene_count', 0)
+    assert all(scene.get('extraction_mode') == 'xacro_expanded' for scene in data.get('scenes', []))
+
+
+def test_require_xacro_strict_nonzero_on_simulated_xacro_failure(monkeypatch):
+    import sys
+    import scripts.extract_scene_urdf_visual_mesh_index as mesh_index
+
+    monkeypatch.setattr(mesh_index.shutil, 'which', lambda _: '/usr/bin/xacro')
+
+    def _fake_expand(_path):
+        return None, 'best_effort', ['xacro expansion failed: simulated failure']
+
+    monkeypatch.setattr(mesh_index, 'expand_xacro', _fake_expand)
+    monkeypatch.setattr(
+        mesh_index,
+        'SCENES_ROOT',
+        ROOT / 'tests' / 'fixtures' / 'scene_readiness' / 'duplicate_mesh_workcell' / 'scenes',
+    )
+
+    original_argv = sys.argv
+    try:
+        sys.argv = ['extract_scene_urdf_visual_mesh_index.py', '--all', '--prefer-xacro', '--require-xacro', '--no-write']
+        rc = mesh_index.main()
+    finally:
+        sys.argv = original_argv
+    assert rc != 0

--- a/tests/test_workcell_studio_helper_script_install_lookup.py
+++ b/tests/test_workcell_studio_helper_script_install_lookup.py
@@ -18,3 +18,15 @@ def test_helper_scripts_installed_to_share_scripts():
 
 def test_missing_helper_script_message_is_clear():
     assert 'Could not find Workcell Studio helper script' in MAIN
+
+
+def test_visual_mesh_regen_uses_resolved_script_and_expected_flags():
+    assert '/workcell_ws/scripts/' not in MAIN
+    assert 'helper_script_search_paths' in MAIN
+    assert 'ament_index_cpp::get_package_share_directory("workcell_builder")' in MAIN
+    assert 'easy_manipulation_deployment/scripts/' in MAIN
+    assert 'QCoreApplication::applicationDirPath() + "/../../../scripts/"' in MAIN
+    assert 'QDir::currentPath() + "/scripts/"' in MAIN
+    assert 'fs::path("scripts") / "extract_scene_urdf_visual_mesh_index.py"' in MAIN
+    assert '"--scene"' in MAIN
+    assert '"--prefer-xacro"' in MAIN


### PR DESCRIPTION
### Motivation
- Ensure `--require-xacro` runs are strictly enforced so no `best_effort` scene extractions are accepted under strict mode. 
- Add unit/static tests to validate strict xacro behavior and to statically verify helper-script resolver and regen wiring in the GUI source.

### Description
- Update `scripts/extract_scene_urdf_visual_mesh_index.py` to return non-zero when `--require-xacro` is given and any scene falls back to a `best_effort` extraction by checking `report['best_effort_count']` and returning an error code.
- Add unit tests in `tests/test_scene_urdf_visual_mesh_index.py` that: verify strict runs do not accept `best_effort` scenes and that successful strict runs report `extraction_mode == 'xacro_expanded'` for all scenes; and simulate an xacro expansion failure via `monkeypatch` to assert strict mode returns non-zero.
- Extend `tests/test_workcell_studio_helper_script_install_lookup.py` with static assertions that `mainwindow.cpp` does not contain hardcoded `/workcell_ws/scripts/` paths, exposes resolver/search-path tokens (`helper_script_search_paths`, `ament_index_cpp::get_package_share_directory(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ddb18263483319e96ed3eff59a9bd)