### PR TITLE
Guard optional Scene Builder connect endpoints

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1591,6 +1591,11 @@ void MainWindow::setup_studio_shell()
   preview_process_ = new QProcess(this);
 
   build_studio_header_actions();
+  const auto connect_if = [](QObject * sender, QObject * receiver, auto signal, auto slot) {
+    if (sender && receiver) {
+      QObject::connect(sender, signal, receiver, slot);
+    }
+  };
 
   connect(studio_nav_, &QListWidget::currentRowChanged, this, [this](int idx){ if(idx>=0 && idx<studio_pages_->count()) studio_pages_->setCurrentIndex(idx);});
   show_studio_page(StudioPage::DashboardPage);
@@ -1619,20 +1624,20 @@ void MainWindow::setup_studio_shell()
   connect(empty_new_cell, &QPushButton::clicked, this, &MainWindow::open_new_scene_creation_flow);
   connect(dash_new_cell, &QPushButton::clicked, this, &MainWindow::open_new_scene_creation_flow);
   connect(dash_open_selected_scene, &QPushButton::clicked, this, [this](){ open_scene_builder_for_selected_scene("Dashboard Open Selected Scene"); });
-  connect(dashboard_open_scene_action_, &QAction::triggered, this, [this](){ open_scene_builder_for_selected_scene("Dashboard Open in Scene Builder"); });
-  connect(dashboard_validate_action_, &QAction::triggered, this, [this](){ if (action_validate_offline_) action_validate_offline_->trigger(); });
-  connect(dashboard_plan_action_, &QAction::triggered, this, [this](){ if (action_simulate_plan_preview_) action_simulate_plan_preview_->trigger(); });
-  connect(dashboard_export_action_, &QAction::triggered, this, [this](){ if (action_export_open_page_) action_export_open_page_->trigger(); });
-  connect(dashboard_delete_action_, &QAction::triggered, this, &MainWindow::delete_selected_scene);
+  connect_if(dashboard_open_scene_action_, this, &QAction::triggered, [this](){ open_scene_builder_for_selected_scene("Dashboard Open in Scene Builder"); });
+  connect_if(dashboard_validate_action_, this, &QAction::triggered, [this](){ if (action_validate_offline_) action_validate_offline_->trigger(); });
+  connect_if(dashboard_plan_action_, this, &QAction::triggered, [this](){ if (action_simulate_plan_preview_) action_simulate_plan_preview_->trigger(); });
+  connect_if(dashboard_export_action_, this, &QAction::triggered, [this](){ if (action_export_open_page_) action_export_open_page_->trigger(); });
+  connect_if(dashboard_delete_action_, this, &QAction::triggered, &MainWindow::delete_selected_scene);
   connect(existing_scene_table_, &QTableWidget::cellClicked, this, [this](int row, int col){ select_scene_by_row(row); if(col==2){open_scene_builder_for_selected_scene("Existing Scenes Open in Scene Builder");} else if(col==3){open_selected_scene_artifact("preview");} else if(col==4){open_selected_scene_artifact("smoke");} else if(col==5){QApplication::clipboard()->setText(selected_scene_launch_command()); append_studio_log("Copy Launch Command");}});
   connect(open_asset_folder_action, &QAction::triggered, this, [this](){ open_selected_scene_artifact("asset_folder"); });
   connect(copy_asset_path_action, &QAction::triggered, this, [this](){ QApplication::clipboard()->setText(selected_catalog_item_path()); });
   connect(import_asset_action, &QAction::triggered, this, [this](){ append_studio_log("Import STL / URDF: choose asset import flow from Asset Browser."); });
   connect(add_existing_stl_action, &QAction::triggered, this, [this](){ append_studio_log("Add Existing STL to Canvas: choose STL in Asset Browser and click Add to Canvas."); });
   connect(placeholder_action, &QAction::triggered, this, [this](){ append_studio_log("Generate Simple Box/Cylinder Placeholder: use quick-add placeholders in catalog."); });
-  connect(pick_source_button_, &QPushButton::clicked, this, &MainWindow::bind_selected_item_as_pick_zone);
-  connect(place_target_button_, &QPushButton::clicked, this, &MainWindow::bind_selected_item_as_place_zone);
-  connect(camera_button_, &QPushButton::clicked, this, &MainWindow::bind_selected_item_as_camera);
+  connect_if(pick_source_button_, this, &QPushButton::clicked, &MainWindow::bind_selected_item_as_pick_zone);
+  connect_if(place_target_button_, this, &QPushButton::clicked, &MainWindow::bind_selected_item_as_place_zone);
+  connect_if(camera_button_, this, &QPushButton::clicked, &MainWindow::bind_selected_item_as_camera);
 connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo readiness completed"); });
   connect(open_dash, &QPushButton::clicked, this, [this](){ open_selected_scene_artifact("demo_dashboard"); });
   connect(copy_summary, &QPushButton::clicked, this, [this](){ open_selected_scene_artifact("demo_summary_copy"); });
@@ -1641,30 +1646,30 @@ connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo
   connect(go_export, &QPushButton::clicked, this, [this](){ show_studio_page(StudioPage::ExportPage); append_studio_log("Go to Export: switched to Export page"); });
   connect(go_scene_builder, &QPushButton::clicked, this, [this](){ show_studio_page(StudioPage::SceneBuilderPage); append_studio_log("Go to Scene Builder: switched to Scene Builder page"); });
   connect(go_preview_commands, &QPushButton::clicked, this, [this](){ show_studio_page(StudioPage::PlanSimulatePage); append_studio_log("Go to Preview Commands: use Copy commands on Preview Launch page"); });
-  connect(run_build_button_, &QPushButton::clicked, this, &MainWindow::run_preview_build);
-  connect(run_preview_button_, &QPushButton::clicked, this, &MainWindow::run_fake_hardware_preview);
-  connect(stop_preview_button_, &QPushButton::clicked, this, &MainWindow::stop_preview_process);
-  connect(copy_build_button_, &QPushButton::clicked, this, [this](){ QApplication::clipboard()->setText(selected_scene_build_command()); });
-  connect(copy_source_button_, &QPushButton::clicked, this, [this](){ QApplication::clipboard()->setText(selected_scene_source_command()); });
-  connect(copy_launch_button_, &QPushButton::clicked, this, [this](){ QApplication::clipboard()->setText(selected_scene_launch_command()); });
-  connect(copy_all_button_, &QPushButton::clicked, this, [this](){ QApplication::clipboard()->setText(selected_scene_preview_command_block()); });
-  connect(open_preview_folder_button_, &QPushButton::clicked, this, [this](){ open_selected_scene_artifact("preview_launch_folder"); });
-  connect(open_preview_transcript_button_, &QPushButton::clicked, this, [this](){ open_selected_scene_artifact("preview_launch_transcript"); });
+  connect_if(run_build_button_, this, &QPushButton::clicked, &MainWindow::run_preview_build);
+  connect_if(run_preview_button_, this, &QPushButton::clicked, &MainWindow::run_fake_hardware_preview);
+  connect_if(stop_preview_button_, this, &QPushButton::clicked, &MainWindow::stop_preview_process);
+  connect_if(copy_build_button_, this, &QPushButton::clicked, [this](){ QApplication::clipboard()->setText(selected_scene_build_command()); });
+  connect_if(copy_source_button_, this, &QPushButton::clicked, [this](){ QApplication::clipboard()->setText(selected_scene_source_command()); });
+  connect_if(copy_launch_button_, this, &QPushButton::clicked, [this](){ QApplication::clipboard()->setText(selected_scene_launch_command()); });
+  connect_if(copy_all_button_, this, &QPushButton::clicked, [this](){ QApplication::clipboard()->setText(selected_scene_preview_command_block()); });
+  connect_if(open_preview_folder_button_, this, &QPushButton::clicked, [this](){ open_selected_scene_artifact("preview_launch_folder"); });
+  connect_if(open_preview_transcript_button_, this, &QPushButton::clicked, [this](){ open_selected_scene_artifact("preview_launch_transcript"); });
   connect(run_offline_validation_button, &QPushButton::clicked, this, &MainWindow::run_offline_validation);
   connect(validate_layout_button, &QPushButton::clicked, this, &MainWindow::run_layout_validation_only);
-  connect(open_validation_report_action, &QAction::triggered, this, &MainWindow::open_validation_report);
-  connect(copy_validation_summary_action, &QAction::triggered, this, &MainWindow::copy_validation_summary);
+  connect_if(open_validation_report_action, this, &QAction::triggered, &MainWindow::open_validation_report);
+  connect_if(copy_validation_summary_action, this, &QAction::triggered, &MainWindow::copy_validation_summary);
   connect(generate_readiness_pack_button, &QPushButton::clicked, this, &MainWindow::generate_readiness_pack);
-  connect(open_readiness_dashboard_action, &QAction::triggered, this, &MainWindow::open_readiness_dashboard);
-  connect(check_canvas_parity_action, &QAction::triggered, this, &MainWindow::check_canvas_generated_parity);
+  connect_if(open_readiness_dashboard_action, this, &QAction::triggered, &MainWindow::open_readiness_dashboard);
+  connect_if(check_canvas_parity_action, this, &QAction::triggered, &MainWindow::check_canvas_generated_parity);
   connect(export_scene_bundle_button, &QPushButton::clicked, this, &MainWindow::export_scene_bundle_for_selected_scene);
   connect(import_scene_bundle_button, &QPushButton::clicked, this, &MainWindow::import_scene_bundle_into_scenes_root);
-  connect(open_export_folder_action, &QAction::triggered, this, &MainWindow::open_scene_bundle_export_folder);
-  connect(open_scene_folder_action, &QAction::triggered, this, [this](){ open_selected_scene_artifact("preview_launch_folder"); });
-  connect(open_preview_report_action, &QAction::triggered, this, [this](){ open_selected_scene_artifact("preview_launch_transcript"); });
-  connect(open_dashboard_action, &QAction::triggered, this, [this](){ open_selected_scene_artifact("demo_dashboard"); });
-  connect(copy_source_action, &QAction::triggered, this, [this](){ QApplication::clipboard()->setText(selected_scene_source_command()); });
-  connect(copy_build_action, &QAction::triggered, this, [this](){ QApplication::clipboard()->setText(selected_scene_build_command()); });
+  connect_if(open_export_folder_action, this, &QAction::triggered, &MainWindow::open_scene_bundle_export_folder);
+  connect_if(open_scene_folder_action, this, &QAction::triggered, [this](){ open_selected_scene_artifact("preview_launch_folder"); });
+  connect_if(open_preview_report_action, this, &QAction::triggered, [this](){ open_selected_scene_artifact("preview_launch_transcript"); });
+  connect_if(open_dashboard_action, this, &QAction::triggered, [this](){ open_selected_scene_artifact("demo_dashboard"); });
+  connect_if(copy_source_action, this, &QAction::triggered, [this](){ QApplication::clipboard()->setText(selected_scene_source_command()); });
+  connect_if(copy_build_action, this, &QAction::triggered, [this](){ QApplication::clipboard()->setText(selected_scene_build_command()); });
   connect(run_self_test_button_, &QPushButton::clicked, this, &MainWindow::run_diagnostics_self_test);
   connect(run_golden_flow_button_, &QPushButton::clicked, this, &MainWindow::run_diagnostics_golden_flow_dry_run);
   connect(copy_diagnostics_report_button_, &QPushButton::clicked, this, &MainWindow::copy_diagnostics_report);
@@ -1735,7 +1740,7 @@ connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo
   connect(copy_asset_path_action, &QAction::triggered, this, [this](){ const QString p = selected_catalog_item_path(); if (p.isEmpty()) { QMessageBox::information(this, "Asset Catalog", "Select an asset first."); return; } QApplication::clipboard()->setText(p); append_studio_log("Copy Asset Path: " + p); });
   connect(add_to_canvas_button_, &QPushButton::clicked, this, [this](){ if (!asset_catalog_tree_ || !asset_catalog_tree_->currentItem()) { QMessageBox::information(this, "Asset Catalog", "Select an asset to add to canvas."); return; } auto *it = asset_catalog_tree_->currentItem(); const int idx = it->data(0, CatalogRoleIndex).toInt(); if (idx < 0 || idx >= asset_catalog_entries_.size()) return; const auto & e = asset_catalog_entries_[idx]; if (!e.disabled_reason.trimmed().isEmpty()) { QMessageBox::information(this, "Asset Catalog", e.disabled_reason); return; } add_asset_to_canvas_from_catalog(e.category, e.display_name, e.source_path); });
   connect(add_asset_button_, &QPushButton::clicked, this, &MainWindow::open_add_asset_dialog);
-  connect(scene_workflow_recommendation_button_, &QPushButton::clicked, this, [this]() {
+  connect_if(scene_workflow_recommendation_button_, this, &QPushButton::clicked, [this]() {
     trigger_recommended_workflow_action(resolve_recommended_workflow_action().handler);
   });
   connect(asset_catalog_tree_, &QTreeWidget::itemDoubleClicked, this, [this](QTreeWidgetItem *it, int){ if (!it) return; const int idx = it->data(0, CatalogRoleIndex).toInt(); if (idx < 0 || idx >= asset_catalog_entries_.size()) return; const auto & e = asset_catalog_entries_[idx]; if (!e.disabled_reason.trimmed().isEmpty()) return; add_asset_to_canvas_from_catalog(e.category, e.display_name, e.source_path); });


### PR DESCRIPTION
### Motivation

- Avoid null-pointer/wrong-endpoint `QObject::connect` calls in the Scene Builder initialization region when optional widgets or actions may be absent.
- Harden wiring for regeneration/workflow/preview controls without changing UI appearance or interaction model.

### Description

- Add a local lambda `connect_if` near `build_studio_header_actions()` that checks `sender` and `receiver` before invoking `QObject::connect`.
- Replace direct `connect(...)` calls for optional Scene Builder endpoints (dashboard actions, pick/place/camera buttons, preview command controls, validation/export actions, and the workflow recommendation button) with guarded `connect_if` calls.
- Preserve all existing handlers, lambdas, and the overall interaction flow, and avoid adding any visible or hidden proxy UI elements.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ddb1924508331a6b39bc8275b4bfa)