### PR TITLE
Fix workcell_builder compile regression from missing connect_if helper

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -98,6 +98,7 @@
 #include <functional>
 #include <iostream>
 #include <string>
+#include <utility>
 #include "workcell_builder_ui_utils.hpp"
 
 
@@ -176,6 +177,15 @@ protected:
     return QGraphicsRectItem::itemChange(change, value);
   }
 };
+
+template <typename Sender, typename Receiver, typename Signal, typename Slot>
+void connect_if(Sender * sender, Receiver * receiver, Signal signal, Slot && slot)
+{
+  if (!sender || !receiver) {
+    return;
+  }
+  QObject::connect(sender, signal, receiver, std::forward<Slot>(slot));
+}
 
 bool is_empty_directory(const fs::path & directory_path)
 {


### PR DESCRIPTION
## Summary
This PR fixes a compile regression in `workcell_builder` where `MainWindow::setup_studio_shell()` called `connect_if(...)` without a visible declaration.

## Root cause
`connect_if` was referenced in:
- `workcell_builder/workcell_builder/gui/mainwindow.cpp`

but no declaration/definition was visible in that translation unit, causing:
- `error: ‘connect_if’ was not declared in this scope; did you mean ‘connect’?`

## Fix
Added a small local helper in `mainwindow.cpp` (anonymous-namespace helper area) that performs a null-safe Qt connect and supports the existing call style:
- checks both sender and receiver for null
- calls `QObject::connect(sender, signal, receiver, std::forward<Slot>(slot))`

Also added `#include <utility>` for `std::forward`.

No UI flow, launch files, EPD, or dependencies were changed.

## Validation
Executed these exact commands:
1. `source /opt/ros/humble/setup.bash`
2. `cd ~/workcell_ws`
3. `colcon build --symlink-install --packages-select workcell_builder`
4. `colcon build --symlink-install --packages-skip tesseract_rviz --allow-overriding ruckig tesseract_monitoring tesseract_msgs tesseract_rosutils`

In this environment, both build commands were blocked before execution because `/opt/ros/humble/setup.bash` does not exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0a8c146c8331acf7ebd243d266d5)