### PR TITLE
Ingest xacro-expanded visual mesh index into Scene Builder 3D preview

### DIFF
--- a/scripts/validate_scene3d_mesh_preview_contract.py
+++ b/scripts/validate_scene3d_mesh_preview_contract.py
@@ -203,7 +203,7 @@ def main():
         'p.yaw =',
         'p.locked = true',
         'p.editable = false',
-        'p.lock_reason = "URDF visual preview item (locked)"',
+        'p.lock_reason = "URDF visual preview-only item (locked)"',
     ]:
         must(token in mw_src, f"missing preview ingestion token: {token}")
     must("use_fake_hardware:=true" in mw_src, "fake hardware launch token missing")

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -4990,26 +4990,40 @@ void MainWindow::populate_scene_hierarchy()
       }
     }
   }
+  int visual_index_loaded_count = 0;
+  int visual_preview_added_count = 0;
+  bool visual_index_safe_for_preview = false;
+  QString visual_index_extraction_mode = "unknown";
   if (fs::exists(urdf_visual_index)) {
     try {
       const YAML::Node urdf_index = YAML::LoadFile(urdf_visual_index.string());
+      visual_index_safe_for_preview = workcell_builder::yaml_map_key(urdf_index, "safe_for_preview").as<bool>(false);
+      visual_index_extraction_mode = QString::fromStdString(
+        workcell_builder::yaml_map_value_or_empty(urdf_index, "extraction_mode"));
       const YAML::Node visual_items = workcell_builder::yaml_map_key(urdf_index, "visual_items");
       if (visual_items && visual_items.IsSequence()) {
         for (const auto &v : visual_items) {
           if (!v.IsMap()) continue;
+          ++visual_index_loaded_count;
           const QString id = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "id"));
           if (id.isEmpty() || preview_ids.contains(id)) continue;
+          const bool render_expected = workcell_builder::yaml_map_key(v, "render_expected").as<bool>(false);
+          if (!render_expected) continue;
           ScenePreviewWidget::PreviewItem p;
           p.id = id;
           p.display_name = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "link"));
-          p.category = "URDF Visual";
-          p.role = "urdf_visual";
+          if (p.display_name.trimmed().isEmpty()) p.display_name = id;
+          p.category = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "category"));
+          if (p.category.trimmed().isEmpty()) p.category = "URDF Visual";
+          p.role = p.category;
           p.status = "ready";
           p.source_path = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "source_path"));
+          if (p.source_path.trimmed().isEmpty() || !fs::exists(fs::path(p.source_path.toStdString()))) continue;
           p.mesh_path = p.source_path;
           p.locked = true;
           p.editable = false;
-          p.lock_reason = "URDF visual preview item (locked)";
+          p.selectable = true;
+          p.lock_reason = "URDF visual preview-only item (locked)";
           const YAML::Node pose = workcell_builder::yaml_map_key(v, "pose");
           const YAML::Node xyz = workcell_builder::yaml_map_key(pose, "xyz");
           const YAML::Node rpy = workcell_builder::yaml_map_key(pose, "rpy");
@@ -5035,9 +5049,18 @@ void MainWindow::populate_scene_hierarchy()
             p.has_mesh_metadata = true;
           }
           preview_items.push_back(p);
+          ++visual_preview_added_count;
           preview_ids.insert(id);
           add_tree_node(p);
         }
+      }
+      append_studio_log(QString("Visual mesh index loaded from: %1").arg(QString::fromStdString(urdf_visual_index.string())));
+      append_studio_log(QString("Visual mesh index safe_for_preview: %1").arg(visual_index_safe_for_preview ? "true" : "false"));
+      append_studio_log(QString("Visual mesh index extraction_mode: %1").arg(visual_index_extraction_mode));
+      append_studio_log(QString("Visual mesh index loaded: %1 visual items").arg(visual_index_loaded_count));
+      append_studio_log(QString("Visual mesh preview items added: %1").arg(visual_preview_added_count));
+      if (visual_index_safe_for_preview && visual_preview_added_count == 0) {
+        append_studio_log("Visual mesh index safe but no preview items were ingested");
       }
     } catch (...) {
       append_studio_log("Preview warning: failed to parse generated/scene_visual_mesh_index.json");

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -494,6 +494,13 @@ void Scene3DViewportWidget::paintGL()
     if (r.isEmpty()) return QStringLiteral("Item");
     return role.left(10);
   };
+  const auto compact_label = [&](const ScenePreviewWidget::PreviewItem & it) {
+    QString label = it.display_name.trimmed();
+    if (label.isEmpty()) label = it.id.trimmed();
+    if (label.isEmpty()) label = compact_role(it.role);
+    if (label.size() > 18) label = label.left(17) + QStringLiteral("…");
+    return label;
+  };
   const double zoom_factor = distance_ / qMax(0.25, scene_radius_);
   const bool crowded = items.size() > 30;
   const bool zoomed_far = zoom_factor > 5.2;
@@ -525,7 +532,9 @@ void Scene3DViewportWidget::paintGL()
         draw_label = true;
         break;
     }
+    const bool is_urdf_visual = it.locked && !it.editable && it.lock_reason.contains("URDF visual", Qt::CaseInsensitive);
     if (suppress_dense_non_critical_labels && !selected && !is_critical_label_role(role)) draw_label = false;
+    if (is_urdf_visual && !selected && label_mode != ScenePreviewWidget::LabelMode::All) draw_label = false;
     if (show_warning_labels && !it.warnings.isEmpty()) {
       if (debug_overlays_mode && show_warning_labels && !it.warnings.isEmpty()) {
         const QString debug_warning_text = warning_debug_text(it.warnings);
@@ -539,7 +548,7 @@ void Scene3DViewportWidget::paintGL()
     }
     if (draw_label) {
       const QString missing_reason = placeholder_reason_for_item(it);
-      const QString text = selected ? it.id : (missing_reason.isEmpty() ? compact_role(it.role) : QString("%1 missing geometry").arg(compact_role(it.role)));
+      const QString text = selected ? compact_label(it) : (missing_reason.isEmpty() ? compact_label(it) : QString("%1 missing").arg(compact_role(it.role)));
       const QPointF label_anchor(p.x() + 12.0, p.y() - 10.0);
       const QPointF label_pos = apply_label_overlap_offset(label_anchor, placed_label_points, robot_base_points, is_critical_label_role(role));
       placed_label_points.push_back(label_pos);


### PR DESCRIPTION
## Summary
This PR fixes Scene Builder 3D ingestion so generated `scenes/<scene>/generated/scene_visual_mesh_index.json` visual entries are actually converted into mesh-backed preview items and shown in the viewport.

## What changed
- **MainWindow visual-index ingestion (`mainwindow.cpp`)**
  - Reads and logs index metadata:
    - `safe_for_preview`
    - `extraction_mode`
    - loaded source path
    - total loaded visual item count
    - total preview items added
  - Ingestion now gates items by contract:
    - requires `render_expected: true`
    - requires non-empty existing `source_path`
    - keeps pose from `pose.xyz` / `pose.rpy`
    - keeps `scale`
    - uses source path as mesh path
  - URDF visual preview items are explicitly created as:
    - locked
    - non-editable (preview-only)
    - mesh-backed when resolved
  - Emits warning log when `safe_for_preview: true` but `0` preview items were ingested.

- **Viewport label/readability improvements (`scene3d_viewport_widget.cpp`)**
  - Label text now prefers readable `display_name`/link name, falls back to id/role, with clean truncation.
  - Suppresses non-selected URDF-visual labels outside `All` mode to reduce dense overlap and repeated `urdf_visual`-style clutter.

- **Contract validator update**
  - Updated `scripts/validate_scene3d_mesh_preview_contract.py` lock-reason token to match the stronger preview-only lock semantics.

## Behavioral outcomes
- Visual index is consumed after generation from disk path `generated/scene_visual_mesh_index.json`.
- Valid xacro-expanded visual items are transformed into locked preview-only mesh items and sent into the 3D preview list.
- Overlay mesh counts now reflect ingested mesh-backed URDF visuals instead of only editable/layout primitives.
- Save Layout behavior remains unchanged for editable layout flow; URDF visual preview items are non-editable preview representations.

## Requested confirmations
- URDF visual items are locked and preview-only: **implemented in ingestion path**.
- Full robot articulation / motion playback: **not attempted** (out of scope).

## Validation run
- `python3 scripts/validate_scene3d_visual_diagnostics.py`
- `python3 -m pytest -q tests/test_scene3d_asset_drag_drop_static.py tests/test_workcell_studio_helper_script_install_lookup.py`
- `python3 -m pytest -q tests/test_scene_urdf_visual_mesh_index.py tests/test_workcell_builder_canvas_navigation.py tests/test_workcell_studio_scene_builder_interactive_canvas.py tests/test_scene_builder_ui_acceptance.py`

Note: `scripts/validate_scene3d_mesh_preview_contract.py` currently fails on a pre-existing extractor strict-mode assertion unrelated to this ingestion patch (`missing guard against silent best-effort fallback when require-xacro is set`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e10f68d848331a003af2e83ce1b27)