### PR TITLE
Separate overlay vs physical counts and show Locked URDF in scene HUD

### DIFF
--- a/tests/test_scene3d_asset_drag_drop_static.py
+++ b/tests/test_scene3d_asset_drag_drop_static.py
@@ -18,3 +18,6 @@ def test_scene3d_asset_drag_drop_tokens_exist():
     assert "parse_collada_bytes_for_test" in viewport_cpp
     assert "ext == QStringLiteral(\"dae\")" in viewport_cpp
     assert "unsupported mesh format" in viewport_cpp
+    assert "Locked URDF" in viewport_cpp
+    assert "Overlays %1" in viewport_cpp
+    assert "Items %1 • Mesh %2 • Boxes %3 • Missing %4" in viewport_cpp

--- a/tests/test_workcell_studio_scene_builder_interactive_canvas.py
+++ b/tests/test_workcell_studio_scene_builder_interactive_canvas.py
@@ -19,3 +19,11 @@ def test_focus_selected_centers_on_selected_item():
     text = (ROOT / 'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp').read_text(encoding='utf-8')
     assert 'if (it.id != selected_id) continue;' in text
     assert 'orbit_offset_' in text
+
+
+def test_info_chip_and_viewport_have_locked_urdf_and_separated_overlay_mesh_counters():
+    viewport = (ROOT / 'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp').read_text(encoding='utf-8')
+    preview = (ROOT / 'workcell_builder/workcell_builder/gui/scene_preview_widget.cpp').read_text(encoding='utf-8')
+    assert 'Items %1 • Mesh %2 • Boxes %3 • Missing %4' in viewport
+    assert 'Overlays %1 • Locked URDF %2' in viewport
+    assert 'Items %1 M%2 B%3 Miss%4 Ov%5 L-URDF%6' in preview

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -304,6 +304,26 @@ bool include_in_fit_bounds(const ScenePreviewWidget::PreviewItem & it, bool incl
   return true;
 }
 
+bool is_overlay_only_item(const ScenePreviewWidget::PreviewItem & it)
+{
+  const NormalizedRole role = classify_item_role(it);
+  if (role == NormalizedRole::SafetyZone || role == NormalizedRole::WarningAnchor) return true;
+  const QString role_text = it.role.trimmed().toLower();
+  const QString category = it.category.trimmed().toLower();
+  const QString lock_reason = it.lock_reason.trimmed().toLower();
+  return role_text.contains("overlay") || role_text.contains("helper") || role_text.contains("guide") ||
+         category.contains("overlay") || lock_reason.contains("overlay");
+}
+
+bool is_locked_urdf_item(const ScenePreviewWidget::PreviewItem & it)
+{
+  if (!(it.locked && !it.editable)) return false;
+  const QString category = it.category.trimmed().toLower();
+  const QString lock_reason = it.lock_reason.trimmed().toLower();
+  return category.contains("urdf") || lock_reason.contains("urdf") || lock_reason.contains("robot model") ||
+         lock_reason.contains("robotmodel") || lock_reason.contains("urdf visual");
+}
+
 
 bool is_critical_label_role(NormalizedRole role)
 {
@@ -468,11 +488,26 @@ void Scene3DViewportWidget::paintGL()
   int mesh_backed_count = 0;
   int placeholder_count = 0;
   int wireframe_box_count = 0;
+  int overlay_count = 0;
+  int locked_urdf_count = 0;
+  int physical_item_count = 0;
   for (const auto * it : draw_items) {
     const NormalizedRole role = classify_item_role(*it);
     if (!show_safety && role == NormalizedRole::SafetyZone) continue;
+    const bool overlay_only = is_overlay_only_item(*it);
+    if (overlay_only) ++overlay_count;
+    else ++physical_item_count;
+    if (is_locked_urdf_item(*it)) ++locked_urdf_count;
 
-    draw_truthful_item_geometry(*it, &placeholder_count, &mesh_backed_count, &wireframe_box_count);
+    int item_placeholder_count = 0;
+    int item_mesh_backed_count = 0;
+    int item_wireframe_box_count = 0;
+    draw_truthful_item_geometry(*it, &item_placeholder_count, &item_mesh_backed_count, &item_wireframe_box_count);
+    if (!overlay_only) {
+      placeholder_count += item_placeholder_count;
+      mesh_backed_count += item_mesh_backed_count;
+      wireframe_box_count += item_wireframe_box_count;
+    }
     if (it->id == selected_id) {
       const ItemBounds bounds = item_bounds_for_role(*it);
       const bool editable = item_is_editable_for_gizmo(*it);
@@ -560,15 +595,17 @@ void Scene3DViewportWidget::paintGL()
   const int preview_count = items.size() - editable_count;
   painter.setPen(Qt::NoPen);
   painter.setBrush(QColor(15, 23, 42, 190));
-  painter.drawRoundedRect(QRectF(12.0, 12.0, 220.0, 58.0), 6.0, 6.0);
+  painter.drawRoundedRect(QRectF(12.0, 12.0, 360.0, 74.0), 6.0, 6.0);
   painter.setPen(QColor("#e2e8f0"));
-  painter.drawText(QRectF(20.0, 18.0, 204.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter, "View: 3D");
-  painter.drawText(QRectF(20.0, 34.0, 204.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
+  painter.drawText(QRectF(20.0, 18.0, 344.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter, "View: 3D");
+  painter.drawText(QRectF(20.0, 34.0, 344.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
                    QString("Scene: %1").arg(scene_name));
-  painter.drawText(QRectF(20.0, 50.0, 204.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
-                   QString("Items %1 • Mesh %2 • Box %3 • Missing %4").arg(items.size()).arg(mesh_backed_count).arg(wireframe_box_count).arg(placeholder_count));
-  painter.drawText(QRectF(20.0, 66.0, 204.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
-                   QString("Mode: %1").arg(gizmo_mode_label()));
+  painter.drawText(QRectF(20.0, 50.0, 344.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
+                   QString("Items %1 • Mesh %2 • Boxes %3 • Missing %4")
+                     .arg(physical_item_count).arg(mesh_backed_count).arg(wireframe_box_count).arg(placeholder_count));
+  painter.drawText(QRectF(20.0, 66.0, 344.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
+                   QString("Overlays %1 • Locked URDF %2 • Mode: %3")
+                     .arg(overlay_count).arg(locked_urdf_count).arg(gizmo_mode_label()));
   if (drag_asset_preview_visible_) {
     const double x = (drag_asset_screen_pos_.x() - width() * 0.5) / 50.0;
     const double y = (height() * 0.6 - drag_asset_screen_pos_.y()) / 50.0;

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -316,4 +316,52 @@ void ScenePreviewWidget::set_label_mode(LabelMode mode){ auto *v=static_cast<Sce
 
 int ScenePreviewWidget::total_warning_count() const { int count = 0; for (const auto & item : preview_items_) count += item.warnings.size(); count += overlay_model_.warnings.size() + reachability_overlay_model_.warnings.size() + collision_overlay_model_.warnings.size() + camera_overlay_model_.warnings.size(); for (const auto & det : epd_detections_) count += det.warnings.size(); return count; }
 bool ScenePreviewWidget::task_is_ready() const { return overlay_model_.has_intent_metadata && overlay_model_.pick_source_id != "unknown" && overlay_model_.place_target_id != "unknown"; }
-void ScenePreviewWidget::refresh_info_chip() { if (!info_chip_label_) return; const QString mode = mode_selector_ ? mode_selector_->currentText() : QStringLiteral("2D Layout"); const bool requested_3d = (mode == "3D Layout Preview") || (mode == "Debug Overlays"); const QString render_mode = requested_3d && preview3d_available_ ? mode : QStringLiteral("2D Layout (Fallback)"); const QString summary = preview_status_summary_.isEmpty() ? QString("Items: %1").arg(preview_items_.size()) : preview_status_summary_; info_chip_label_->setText(QString("Scene: %1\nMode: %2\n%3  Warn: %4  Task: %5").arg(preview_scene_name_).arg(render_mode).arg(summary).arg(total_warning_count()).arg(task_is_ready() ? "Ready" : "Missing")); info_chip_label_->adjustSize(); if (fallback_info_chip_proxy_) fallback_info_chip_proxy_->setPos(12.0, 12.0); if (toolbar_status_chip_) { const QString interaction = interaction_mode_selector_ ? interaction_mode_selector_->currentText() : QStringLiteral("Select"); const QString snap = snap_mode_selector_ ? snap_mode_selector_->currentText() : QStringLiteral("Off"); toolbar_status_chip_->setText(QString("%1 • Snap %2 • Warn %3").arg(interaction).arg(snap).arg(total_warning_count())); }}
+void ScenePreviewWidget::refresh_info_chip()
+{
+  if (!info_chip_label_) return;
+  const QString mode = mode_selector_ ? mode_selector_->currentText() : QStringLiteral("2D Layout");
+  const bool requested_3d = (mode == "3D Layout Preview") || (mode == "Debug Overlays");
+  const QString render_mode = requested_3d && preview3d_available_ ? mode : QStringLiteral("2D Layout (Fallback)");
+  const QString summary = preview_status_summary_.isEmpty() ? QString("Items: %1").arg(preview_items_.size()) : preview_status_summary_;
+
+  int mesh_count = 0;
+  int box_count = 0;
+  int missing_count = 0;
+  int overlay_count = 0;
+  int locked_urdf_count = 0;
+  int physical_count = 0;
+  for (const auto & item : preview_items_) {
+    const QString role = item.role.trimmed().toLower();
+    const QString category = item.category.trimmed().toLower();
+    const QString lock_reason = item.lock_reason.trimmed().toLower();
+    const bool overlay_only = role.contains("overlay") || role.contains("helper") || role.contains("guide") ||
+                              role.contains("warning_anchor") || role.contains("warning_badge") ||
+                              category.contains("overlay") || lock_reason.contains("overlay");
+    if (overlay_only) {
+      ++overlay_count;
+      continue;
+    }
+    ++physical_count;
+    const bool mesh_backed = item.mesh_available || item.has_mesh_metadata || !item.mesh_path.trimmed().isEmpty() || !item.source_path.trimmed().isEmpty();
+    if (mesh_backed) ++mesh_count;
+    else if (item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001) ++box_count;
+    else ++missing_count;
+
+    if (item.locked && !item.editable &&
+        (category.contains("urdf") || lock_reason.contains("urdf") || lock_reason.contains("robot model") ||
+         lock_reason.contains("robotmodel") || lock_reason.contains("urdf visual"))) ++locked_urdf_count;
+  }
+
+  const QString compact_stats = QString("Items %1 M%2 B%3 Miss%4 Ov%5 L-URDF%6")
+                                  .arg(physical_count).arg(mesh_count).arg(box_count).arg(missing_count).arg(overlay_count).arg(locked_urdf_count);
+  info_chip_label_->setText(QString("Scene: %1\nMode: %2\n%3\n%4  Warn: %5  Task: %6")
+                              .arg(preview_scene_name_).arg(render_mode).arg(summary).arg(compact_stats)
+                              .arg(total_warning_count()).arg(task_is_ready() ? "Ready" : "Missing"));
+  info_chip_label_->adjustSize();
+  if (fallback_info_chip_proxy_) fallback_info_chip_proxy_->setPos(12.0, 12.0);
+  if (toolbar_status_chip_) {
+    const QString interaction = interaction_mode_selector_ ? interaction_mode_selector_->currentText() : QStringLiteral("Select");
+    const QString snap = snap_mode_selector_ ? snap_mode_selector_->currentText() : QStringLiteral("Off");
+    toolbar_status_chip_->setText(QString("%1 • Snap %2 • Warn %3").arg(interaction).arg(snap).arg(total_warning_count()));
+  }
+}


### PR DESCRIPTION
### Motivation
- Make the 3D viewport status and preview info chip clearly distinguish overlay-only artifacts from real physical geometry so users can tell if mesh previews actually loaded. 
- Surface locked URDF items detected via existing `locked && !editable` semantics plus lock/category markers so URDF visuals are visible in status at a glance.

### Description
- Added helper predicates `is_overlay_only_item` and `is_locked_urdf_item` to `scene3d_viewport_widget.cpp` for explicit overlay and locked-URDF detection. 
- Adjusted the 3D viewport paint path to maintain separate counters for physical items, mesh-backed items, wireframe boxes, missing placeholders, overlays, and locked URDFs and excluded overlay-only items from physical mesh/box/missing counts. 
- Expanded the HUD layout and text to show `Items`, `Mesh`, `Boxes`, `Missing`, `Overlays`, and `Locked URDF` in the viewport (`scene3d_viewport_widget.cpp`).
- Mirrored the summary in `scene_preview_widget.cpp` by adding a compact stats line (`Items/M/B/Miss/Ov/L-URDF`) to the info chip to provide immediate preview feedback. 
- Added static assertions to `tests/test_scene3d_asset_drag_drop_static.py` and `tests/test_workcell_studio_scene_builder_interactive_canvas.py` to check for the new status text tokens.

### Testing
- Ran the updated static tests with `pytest -q tests/test_scene3d_asset_drag_drop_static.py tests/test_workcell_studio_scene_builder_interactive_canvas.py`. 
- Result: `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e141fc3a8833188e0774f8a7ec473)