### PR TITLE
Fix Scene3DViewportWidget::paintGL brace mismatch breaking workcell_builder build

### DIFF
--- a/scripts/validate_scene3d_mesh_preview_contract.py
+++ b/scripts/validate_scene3d_mesh_preview_contract.py
@@ -20,6 +20,28 @@ def main():
     src = CPP.read_text(encoding="utf-8")
     diag_src = (ROOT / "scripts/validate_scene3d_visual_diagnostics.py").read_text(encoding="utf-8")
     body = fn_body(src, "bool Scene3DViewportWidget::draw_mesh_preview_if_available")
+    # Lightweight guard: ensure paintGL closes before the next method definition.
+    paint_sig = "void Scene3DViewportWidget::paintGL()"
+    bounds_sig = "bool Scene3DViewportWidget::scene_bounds_from_visible_items("
+    paint_pos = src.find(paint_sig)
+    bounds_pos = src.find(bounds_sig)
+    must(paint_pos != -1 and bounds_pos != -1 and bounds_pos > paint_pos, "paintGL or scene_bounds_from_visible_items signature missing/reordered")
+    paint_open = src.find("{", paint_pos)
+    must(paint_open != -1 and paint_open < bounds_pos, "paintGL opening brace not found")
+    depth = 0
+    paint_close = -1
+    for i in range(paint_open, len(src)):
+        ch = src[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                paint_close = i
+                break
+    must(paint_close != -1, "paintGL closing brace not found")
+    must(paint_close < bounds_pos, "paintGL does not close before scene_bounds_from_visible_items (possible unmatched brace)")
+
     for token in [
         "fit_include_overlays",
         "scene_bounds_from_visible_items",

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -522,46 +522,41 @@ void Scene3DViewportWidget::paintGL()
   int overlay_count = 0;
   int locked_urdf_count = 0;
   int physical_item_count = 0;
-  for (const auto * it : draw_items) {
-    const NormalizedRole role = classify_item_role(*it);
-    if (!show_safety && role == NormalizedRole::SafetyZone) continue;
-    const bool overlay_only = is_overlay_only_item(*it);
-    if (overlay_only) ++overlay_count;
-    else ++physical_item_count;
-    if (is_locked_urdf_item(*it)) ++locked_urdf_count;
-
-    int item_placeholder_count = 0;
-    int item_mesh_backed_count = 0;
-    int item_wireframe_box_count = 0;
-    draw_truthful_item_geometry(*it, &item_placeholder_count, &item_mesh_backed_count, &item_wireframe_box_count);
-    if (!overlay_only) {
-      placeholder_count += item_placeholder_count;
-      mesh_backed_count += item_mesh_backed_count;
-      wireframe_box_count += item_wireframe_box_count;
-    }
-    if (it->id == selected_id) {
   std::vector<const ScenePreviewWidget::PreviewItem *> overlay_items;
   std::vector<const ScenePreviewWidget::PreviewItem *> physical_items;
   for (const auto * it : draw_items) {
     const NormalizedRole role = classify_item_role(*it);
     if (!show_safety && role == NormalizedRole::SafetyZone) continue;
+    if (is_locked_urdf_item(*it)) ++locked_urdf_count;
     if (is_overlay_visual_role(role)) overlay_items.push_back(it);
-    else physical_items.push_back(it);
+    else {
+      physical_items.push_back(it);
+      ++physical_item_count;
+    }
   }
+  overlay_count = static_cast<int>(overlay_items.size());
 
-  auto draw_item_batch = [&](const std::vector<const ScenePreviewWidget::PreviewItem *> & batch) {
+  auto draw_item_batch = [&](const std::vector<const ScenePreviewWidget::PreviewItem *> & batch, bool count_in_stats) {
     for (const auto * it : batch) {
-      draw_truthful_item_geometry(*it, &placeholder_count, &mesh_backed_count, &wireframe_box_count);
+      int item_placeholder_count = 0;
+      int item_mesh_backed_count = 0;
+      int item_wireframe_box_count = 0;
+      draw_truthful_item_geometry(*it, &item_placeholder_count, &item_mesh_backed_count, &item_wireframe_box_count);
+      if (count_in_stats) {
+        placeholder_count += item_placeholder_count;
+        mesh_backed_count += item_mesh_backed_count;
+        wireframe_box_count += item_wireframe_box_count;
+      }
       if (it->id == selected_id) {
-      const ItemBounds bounds = item_bounds_for_role(*it);
-      const bool editable = item_is_editable_for_gizmo(*it);
-      draw_box_outline(bounds.x, bounds.y, bounds.z, bounds.sx, bounds.sy, bounds.sz, editable ? QColor("#f8fafc") : QColor("#94a3b8"));
-      // draw_box_outline(bounds.x, bounds.y, bounds.z, bounds.sx, bounds.sy, bounds.sz, QColor("#f8fafc"));
+        const ItemBounds bounds = item_bounds_for_role(*it);
+        const bool editable = item_is_editable_for_gizmo(*it);
+        draw_box_outline(bounds.x, bounds.y, bounds.z, bounds.sx, bounds.sy, bounds.sz, editable ? QColor("#f8fafc") : QColor("#94a3b8"));
+        // draw_box_outline(bounds.x, bounds.y, bounds.z, bounds.sx, bounds.sy, bounds.sz, QColor("#f8fafc"));
       }
     }
-  };
-  draw_item_batch(overlay_items);  // draw translucent overlays before solids to keep physical meshes legible.
-  draw_item_batch(physical_items);
+  }
+  draw_item_batch(overlay_items, false);  // draw translucent overlays before solids to keep physical meshes legible.
+  draw_item_batch(physical_items, true);
 
   glDisable(GL_BLEND);
 
@@ -639,7 +634,6 @@ void Scene3DViewportWidget::paintGL()
     }
   }
   const int editable_count = std::count_if(items.cbegin(), items.cend(), [](const auto & it) { return it.editable; });
-  const int preview_count = items.size() - editable_count;
   painter.setPen(Qt::NoPen);
   painter.setBrush(QColor(15, 23, 42, 190));
   painter.drawRoundedRect(QRectF(12.0, 12.0, 360.0, 74.0), 6.0, 6.0);


### PR DESCRIPTION
### Motivation
- A mismatched brace inside `Scene3DViewportWidget::paintGL()` caused later methods to be parsed as nested and broke the build, so the function scope must be restored exactly. 
- Remove a small unused local (`preview_count`) discovered while repairing the scope to avoid unused-variable warnings. 
- Add a lightweight static guard in a validation script to catch accidental unmatched-brace regressions early. 

### Description
- Restored a single coherent `paintGL()` flow by removing the stray/duplicated partial loop and ensuring the `for (const auto * it : draw_items)` partition closes exactly once so `paintGL()` now closes before `scene_bounds_from_visible_items()`. 
- Reworked item partitioning to explicitly build `overlay_items` and `physical_items`, preserve overlay-first drawing, and accumulate mesh/box/missing counts correctly without changing rendering policies or visual heuristics. 
- Removed the unused `const int preview_count = items.size() - editable_count;` from the overlay stats block. 
- Added a lightweight brace-scope guard to `scripts/validate_scene3d_mesh_preview_contract.py` that verifies `paintGL()` has a matching closing brace before `scene_bounds_from_visible_items()` to detect this class of regressions. 

### Testing
- Ran `python3 scripts/validate_scene3d_mesh_preview_contract.py`, which reports a pre-existing extractor strict-mode assertion failure unrelated to this brace fix (expected and not introduced here). 
- Ran `python3 scripts/validate_all_workcell_studio_scenes.py`, which completed with scene warnings but no regression failures. 
- Ran unit/integration tests: `tests/test_scene3d_asset_drag_drop_static.py` (1 test) passed, `tests/test_workcell_builder_canvas_navigation.py` (16 tests) passed, `tests/test_workcell_studio_scene_builder_interactive_canvas.py` (7 tests) passed, and `tests/test_scene_builder_ui_acceptance.py` (19 tests) passed except for an existing selected-scene Scene Actions wiring contract unrelated to this change. 
- Attempted `colcon build --packages-select workcell_builder` as requested but the workspace `~/workcell_ws` was not present in this environment so a full colcon build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e1a71ef1083318e8024c2cfbd5be6)