### PR TITLE
Fix Scene3DViewportWidget paintGL draw_item_batch syntax build break

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -554,7 +554,7 @@ void Scene3DViewportWidget::paintGL()
         // draw_box_outline(bounds.x, bounds.y, bounds.z, bounds.sx, bounds.sy, bounds.sz, QColor("#f8fafc"));
       }
     }
-  }
+  };
   draw_item_batch(overlay_items, false);  // draw translucent overlays before solids to keep physical meshes legible.
   draw_item_batch(physical_items, true);
 
@@ -633,7 +633,6 @@ void Scene3DViewportWidget::paintGL()
       painter.drawText(label_pos, text);
     }
   }
-  const int editable_count = std::count_if(items.cbegin(), items.cend(), [](const auto & it) { return it.editable; });
   painter.setPen(Qt::NoPen);
   painter.setBrush(QColor(15, 23, 42, 190));
   painter.drawRoundedRect(QRectF(12.0, 12.0, 360.0, 74.0), 6.0, 6.0);


### PR DESCRIPTION
### Motivation
- A recent change introduced a syntax error in `Scene3DViewportWidget::paintGL()` where the local `draw_item_batch` helper lambda was not properly terminated, causing a compile-time error and a build failure.

### Description
- Terminated the local lambda by adding the missing `};` so calls to `draw_item_batch(overlay_items, false)` and `draw_item_batch(physical_items, true)` occur after the lambda declaration completes.  
- Removed the unused `const int editable_count = ...` local to silence the compiler warning.  
- Preserved existing rendering behavior and stats semantics: overlays are drawn before physical items, only the physical batch contributes to mesh/box/missing counts, locked URDF counting and label suppression behavior were not changed, and `paintGL()` still cleanly closes before the next method.

### Testing
- Ran `python3 scripts/validate_scene3d_mesh_preview_contract.py` which failed with a pre-existing strict-mode xacro extractor assertion unrelated to this syntax-only fix.  
- Ran `python3 scripts/validate_all_workcell_studio_scenes.py` which completed with warnings (scenes scanned).  
- Ran unit tests: `python3 -m pytest -q tests/test_scene3d_asset_drag_drop_static.py` ✅, `python3 -m pytest -q tests/test_workcell_builder_canvas_navigation.py` ✅, `python3 -m pytest -q tests/test_workcell_studio_scene_builder_interactive_canvas.py` ✅, and `python3 -m pytest -q tests/test_scene_builder_ui_acceptance.py` ✅.  
- Ran UX/UI validators `python3 scripts/validate_scene_builder_ux_integration.py` and `python3 scripts/validate_scene_builder_ui_acceptance.py` which reported pre-existing Scene Actions wiring contract failures unrelated to this fix.  
- Attempted to run `colcon build --packages-select workcell_builder` but the expected workspace path was not available in this environment so a local `colcon` build could not be completed here.

Exact fixes: added the missing `};` terminating the `draw_item_batch` lambda, removed the unused `editable_count`, and made no changes to xacro extraction, MainWindow resolution, or scene generation policies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e1cb9556c8331a04546bcba1bade4)