### PR TITLE
Fix selected-scene Scene Actions wiring contract in Workcell Studio

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1636,11 +1636,11 @@ void MainWindow::setup_studio_shell()
   connect(empty_new_cell, &QPushButton::clicked, this, &MainWindow::open_new_scene_creation_flow);
   connect(dash_new_cell, &QPushButton::clicked, this, &MainWindow::open_new_scene_creation_flow);
   connect(dash_open_selected_scene, &QPushButton::clicked, this, [this](){ open_scene_builder_for_selected_scene("Dashboard Open Selected Scene"); });
-  connect_action(dashboard_open_scene_action_, [this](){ open_scene_builder_for_selected_scene("Dashboard Open in Scene Builder"); });
-  connect_action(dashboard_validate_action_, [this](){ if (action_validate_offline_) action_validate_offline_->trigger(); });
-  connect_action(dashboard_plan_action_, [this](){ if (action_simulate_plan_preview_) action_simulate_plan_preview_->trigger(); });
-  connect_action(dashboard_export_action_, [this](){ if (action_export_open_page_) action_export_open_page_->trigger(); });
-  connect_action(dashboard_delete_action_, &MainWindow::delete_selected_scene);
+  connect(dashboard_open_scene_action_, &QAction::triggered, this, [this](){ open_scene_builder_for_selected_scene("Dashboard Open in Scene Builder"); });
+  connect(dashboard_validate_action_, &QAction::triggered, this, [this](){ if (action_validate_offline_) action_validate_offline_->trigger(); });
+  connect(dashboard_plan_action_, &QAction::triggered, this, [this](){ if (action_simulate_plan_preview_) action_simulate_plan_preview_->trigger(); });
+  connect(dashboard_export_action_, &QAction::triggered, this, [this](){ if (action_export_open_page_) action_export_open_page_->trigger(); });
+  connect(dashboard_delete_action_, &QAction::triggered, this, &MainWindow::delete_selected_scene);
   connect(existing_scene_table_, &QTableWidget::cellClicked, this, [this](int row, int col){ select_scene_by_row(row); if(col==2){open_scene_builder_for_selected_scene("Existing Scenes Open in Scene Builder");} else if(col==3){open_selected_scene_artifact("preview");} else if(col==4){open_selected_scene_artifact("smoke");} else if(col==5){QApplication::clipboard()->setText(selected_scene_launch_command()); append_studio_log("Copy Launch Command");}});
   connect(open_asset_folder_action, &QAction::triggered, this, [this](){ open_selected_scene_artifact("asset_folder"); });
   connect(copy_asset_path_action, &QAction::triggered, this, [this](){ QApplication::clipboard()->setText(selected_catalog_item_path()); });


### PR DESCRIPTION
## Summary
This PR fixes the exact **selected-scene Scene Actions wiring contract** expected by the UI acceptance validators.

### What changed
- Updated selected-scene Scene Actions signal wiring in:
  - `workcell_builder/workcell_builder/gui/mainwindow.cpp`
- Replaced helper-based `connect_action(...)` hookups with explicit `connect(..., &QAction::triggered, ...)` hookups for:
  - `dashboard_open_scene_action_` -> `open_scene_builder_for_selected_scene("Dashboard Open in Scene Builder")`
  - `dashboard_validate_action_` -> `action_validate_offline_->trigger()`
  - `dashboard_plan_action_` -> `action_simulate_plan_preview_->trigger()`
  - `dashboard_export_action_` -> `action_export_open_page_->trigger()`
  - `dashboard_delete_action_` -> `MainWindow::delete_selected_scene`

This preserves the current clean UI (single Scene Actions entry point, no added top-level clutter) and keeps all safety defaults/launch semantics unchanged.

## Contract fixed
- `selected-scene Scene Actions are connected to existing behaviors`
- `selected-scene Scene Actions wiring contract`

## Validator/test results
### Before
- `scripts/validate_scene_builder_ui_acceptance.py`: failing selected-scene Scene Actions wiring contract
- `scripts/validate_scene_builder_ux_integration.py`: failing selected-scene Scene Actions wiring contract

### After
- ✅ `python3 scripts/validate_scene_builder_ui_acceptance.py` (PASS)
- ✅ `python3 scripts/validate_scene_builder_ux_integration.py` (PASS)
- ✅ `python3 scripts/validate_scene3d_mesh_preview_contract.py` (PASS)
- ⚠️ `python3 scripts/validate_all_workcell_studio_scenes.py` failed due to missing local dependency: `ModuleNotFoundError: No module named 'yaml'`
- ✅ `python3 -m pytest -q tests/test_scene_builder_ui_acceptance.py` (19 passed)
- ✅ `python3 -m pytest -q tests/test_workcell_builder_canvas_navigation.py` (16 passed)
- ✅ `python3 -m pytest -q tests/test_workcell_studio_scene_builder_interactive_canvas.py` (7 passed)

## Manual/build validation
- `colcon build --symlink-install --packages-select workcell_builder`: **not run locally in this environment**
- GUI manual flow validation: **not run locally in this environment**

## Remaining unrelated failures
- Only observed remaining issue is environment/dependency-related:
  - `scripts/validate_all_workcell_studio_scenes.py` requires `PyYAML` (`yaml` module), unavailable in this runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ebff001b48331a404ff84b034e67b)