### PR TITLE
Normalize Workcell Studio scene reproducibility metadata reporting

### DIFF
--- a/docs/manuals/WORKCELL_STUDIO_SCENE_REPRODUCIBILITY.md
+++ b/docs/manuals/WORKCELL_STUDIO_SCENE_REPRODUCIBILITY.md
@@ -1,0 +1,26 @@
+# Workcell Studio Scene Reproducibility
+
+Use `python3 scripts/validate_all_workcell_studio_scenes.py` to generate
+`build/workcell_studio/all_scene_reproducibility_report.json`.
+
+## Status taxonomy
+
+- **PASS**: Required scene metadata/layout files exist and parse; preview/generation metadata is complete for this contract.
+- **WARN**: Scene is usable but reproducibility metadata has gaps (for example optional artifacts or runtime-intent metadata missing).
+- **FAIL**: Blocking contract issue (missing required file, unreadable YAML/mesh index, or empty renderable mesh contract).
+- **SKIP**: Reserved for explicit exclusion flows.
+
+> PASS means the scene contract is reproducible in Workcell Studio metadata terms.
+> It does **not** mean real-hardware safety certification, MoveIt execution approval, or grasp safety validation.
+
+## How to fix WARN scenes
+
+1. Open the JSON report and inspect `warning_groups` for each scene.
+2. Fix warnings by category:
+   - `metadata`: fill or correct scene/source-of-truth descriptors.
+   - `preview`: correct layout metadata that affects preview readiness.
+   - `generation`: add or regenerate generated artifacts when available.
+   - `launch_simulation`: capture launch/simulation warning details when applicable.
+   - `runtime_smoke`: document or provide smoke-intent metadata (without claiming unvalidated runtime readiness).
+3. Re-run validator and confirm warnings are specific and non-empty.
+4. Keep runtime honesty: if smoke launch or MoveIt execution is unvalidated, do not mark runtime-ready.

--- a/scenes/suction_test/generated/scene_visual_mesh_index.json
+++ b/scenes/suction_test/generated/scene_visual_mesh_index.json
@@ -1,37 +1,37 @@
 {
   "scene_name": "suction_test",
-  "generated_at": "2026-05-20T14:35:22.164630+00:00",
+  "generated_at": "2026-05-21T08:49:38.852349+00:00",
   "extractor_version": "2.0",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1779281021.4466772,
+  "source_mtime": 1779351590.9354017,
   "included_source_paths": [
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/urdf/table.urdf.xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro"
+    "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro",
+    "/workspace/Easy_Manipulator_Improved/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro"
   ],
   "included_source_mtimes": {
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro": 1779281020.1186926,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/urdf/table.urdf.xacro": 1779281020.5426877,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro": 1779281021.4466772
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/urdf/table.urdf.xacro": 1779351589.9034092,
+    "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro": 1779351590.9354017,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro": 1779351591.0434008,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779351589.8194098
   },
   "unresolved_include_count": 1,
-  "unresolved_placeholder_count": 3,
+  "unresolved_placeholder_count": 2,
   "has_transform_collapse_warning": false,
   "candidate_mesh_count": 3,
   "emitted_visual_count": 3,
   "transform_status_counts": {
-    "resolved": 0,
-    "partial": 3,
+    "resolved": 1,
+    "partial": 2,
     "local_only": 0
   },
   "identical_position_clustered": true,
@@ -43,16 +43,19 @@
   ],
   "stale_index": true,
   "stale_reasons": [
+    "source_newer:single_suction_gripper.urdf.xacro",
     "unsafe_index"
   ],
   "visual_items": [
     {
-      "id": "urdf_visual_0_wrist_fixture",
-      "link": "wrist_fixture",
+      "id": "urdf_visual_0_single_suction_gripper_base_link",
+      "link": "single_suction_gripper_base_link",
       "visual": "",
-      "parent_link": "${parent}",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
-      "package_uri": "package://single_suction_description/meshes/wrist_fixture.STL",
+      "parent_link": "",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "cylinder",
       "pose": {
         "xyz": [
           0.0,
@@ -79,21 +82,19 @@
       },
       "link_world_pose": {
         "xyz": [
-          0.0,
-          0.0,
-          0.0
+          0,
+          0,
+          0
         ],
         "rpy": [
           0.0,
-          -0.0,
+          0.0,
           0.0
         ]
       },
-      "joint_chain": [
-        "${prefix}gripper_base_joint"
-      ],
-      "transform_source": "partial; link=wrist_fixture",
-      "transform_status": "partial",
+      "joint_chain": [],
+      "transform_source": "resolved; link=single_suction_gripper_base_link",
+      "transform_status": "resolved",
       "scale": [
         1.0,
         1.0,
@@ -101,10 +102,12 @@
       ],
       "category": "robot_visual",
       "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".stl",
+      "warning": "",
+      "mesh_extension": "",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": "",
+      "radius": 0.02,
+      "length": 0.05
     },
     {
       "id": "urdf_visual_1_table_${prefix}",
@@ -112,7 +115,9 @@
       "visual": "table_${prefix}",
       "parent_link": "${parent}",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
       "package_uri": "package://table_description/meshes/visual/table.stl",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -164,7 +169,7 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".stl",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     },
     {
       "id": "urdf_visual_2_${name}_link",
@@ -172,7 +177,9 @@
       "visual": "",
       "parent_link": "${name}_bottom_screw_frame",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
       "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -225,7 +232,7 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".dae",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     }
   ],
   "warnings": [

--- a/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json
@@ -1,611 +1,61 @@
 {
   "scene_name": "ur10_2f_test",
-  "generated_at": "2026-05-20T14:35:22.198682+00:00",
+  "generated_at": "2026-05-21T08:49:38.888337+00:00",
   "extractor_version": "2.0",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1779281021.4466772,
+  "source_mtime": 1779351590.9354017,
   "included_source_paths": [
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.transmission.xacro",
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/urdf/table.urdf.xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro"
+    "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
+    "/workspace/Easy_Manipulator_Improved/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro"
   ],
   "included_source_mtimes": {
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro": 1779281020.1066928,
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.transmission.xacro": 1779281020.1066928,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/urdf/table.urdf.xacro": 1779281020.6186867,
-    "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro": 1779281021.4466772
+    "/workspace/Easy_Manipulator_Improved/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro": 1779351591.0434008,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro": 1779351590.9354017,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/urdf/table.urdf.xacro": 1779351589.9954085,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779351589.8194098
   },
   "unresolved_include_count": 1,
-  "unresolved_placeholder_count": 11,
+  "unresolved_placeholder_count": 2,
   "has_transform_collapse_warning": false,
-  "candidate_mesh_count": 11,
-  "emitted_visual_count": 11,
+  "candidate_mesh_count": 2,
+  "emitted_visual_count": 2,
   "transform_status_counts": {
     "resolved": 0,
-    "partial": 11,
+    "partial": 2,
     "local_only": 0
   },
-  "identical_position_clustered": false,
+  "identical_position_clustered": true,
   "safe_for_preview": false,
   "unsafe_reasons": [
     "unresolved_placeholders",
-    "best_effort_unresolved_includes"
+    "best_effort_unresolved_includes",
+    "identical_world_positions"
   ],
   "stale_index": true,
   "stale_reasons": [
+    "source_newer:robotiq_85_gripper.urdf.xacro",
     "unsafe_index"
   ],
   "visual_items": [
     {
-      "id": "urdf_visual_0_${prefix}gripper_base_link",
-      "link": "${prefix}gripper_base_link",
-      "visual": "",
-      "parent_link": "${parent}",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-      "pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_base_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "robot_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_1_${prefix}gripper_finger1_knuckle_link",
-      "link": "${prefix}gripper_finger1_knuckle_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "pose": {
-        "xyz": [
-          0.05490451627,
-          0.03060114443,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.05490451627,
-          0.03060114443,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_knuckle_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_2_${prefix}gripper_finger2_knuckle_link",
-      "link": "${prefix}gripper_finger2_knuckle_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "pose": {
-        "xyz": [
-          0.05490451627,
-          -0.03060114443,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.05490451627,
-          -0.03060114443,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_knuckle_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_3_${prefix}gripper_finger1_finger_link",
-      "link": "${prefix}gripper_finger1_finger_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_finger1_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "pose": {
-        "xyz": [
-          0.050818991720000005,
-          -0.0008848999199999978,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.050818991720000005,
-          -0.0008848999199999978,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_joint",
-        "${prefix}gripper_finger1_finger_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_finger_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_4_${prefix}gripper_finger2_finger_link",
-      "link": "${prefix}gripper_finger2_finger_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_finger2_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "pose": {
-        "xyz": [
-          0.050818991720000005,
-          -0.06208718878,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.050818991720000005,
-          -0.06208718878,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_joint",
-        "${prefix}gripper_finger2_finger_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_finger_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_5_${prefix}gripper_finger1_inner_knuckle_link",
-      "link": "${prefix}gripper_finger1_inner_knuckle_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "pose": {
-        "xyz": [
-          0.06142,
-          0.0127,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.06142,
-          0.0127,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_inner_knuckle_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_inner_knuckle_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_6_${prefix}gripper_finger2_inner_knuckle_link",
-      "link": "${prefix}gripper_finger2_inner_knuckle_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "pose": {
-        "xyz": [
-          0.06142,
-          -0.0127,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.06142,
-          -0.0127,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_inner_knuckle_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_inner_knuckle_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_7_${prefix}gripper_finger1_finger_tip_link",
-      "link": "${prefix}gripper_finger1_finger_tip_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_finger1_inner_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "pose": {
-        "xyz": [
-          0.10445959806999999,
-          -0.024899408209999998,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.10445959806999999,
-          -0.024899408209999998,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_inner_knuckle_joint",
-        "${prefix}gripper_finger1_finger_tip_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_finger_tip_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_8_${prefix}gripper_finger2_finger_tip_link",
-      "link": "${prefix}gripper_finger2_finger_tip_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_finger2_inner_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "pose": {
-        "xyz": [
-          0.10445959806999999,
-          -0.05029940820999999,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.10445959806999999,
-          -0.05029940820999999,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_inner_knuckle_joint",
-        "${prefix}gripper_finger2_finger_tip_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_finger_tip_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_9_table_${prefix}",
+      "id": "urdf_visual_0_table_${prefix}",
       "link": "table_${prefix}",
       "visual": "None_${prefix}",
       "parent_link": "${parent}",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
       "package_uri": "package://workbench_description/meshes/visual/table.stl",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -657,15 +107,17 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".stl",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     },
     {
-      "id": "urdf_visual_10_${name}_link",
+      "id": "urdf_visual_1_${name}_link",
       "link": "${name}_link",
       "visual": "",
       "parent_link": "${name}_bottom_screw_frame",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
       "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -718,7 +170,7 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".dae",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     }
   ],
   "warnings": [

--- a/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json
@@ -1,37 +1,37 @@
 {
   "scene_name": "ur3_suction_test",
-  "generated_at": "2026-05-20T14:35:22.231644+00:00",
+  "generated_at": "2026-05-21T08:49:38.924644+00:00",
   "extractor_version": "2.0",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1779281021.4466772,
+  "source_mtime": 1779351590.9354017,
   "included_source_paths": [
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/urdf/table.urdf.xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro"
+    "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
+    "/workspace/Easy_Manipulator_Improved/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro"
   ],
   "included_source_mtimes": {
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro": 1779281020.1186926,
-    "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro": 1779281021.4466772,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/urdf/table.urdf.xacro": 1779281020.5426877,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779281020.4666886
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/urdf/table.urdf.xacro": 1779351589.9034092,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro": 1779351590.9354017,
+    "/workspace/Easy_Manipulator_Improved/workcell_builder/workcell_builder/assets/end_effectors/single_suction_gripper/single_suction_description/urdf/single_suction_gripper.urdf.xacro": 1779351591.0434008,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779351589.8194098
   },
   "unresolved_include_count": 1,
-  "unresolved_placeholder_count": 3,
+  "unresolved_placeholder_count": 2,
   "has_transform_collapse_warning": false,
   "candidate_mesh_count": 3,
   "emitted_visual_count": 3,
   "transform_status_counts": {
-    "resolved": 0,
-    "partial": 3,
+    "resolved": 1,
+    "partial": 2,
     "local_only": 0
   },
   "identical_position_clustered": true,
@@ -43,16 +43,19 @@
   ],
   "stale_index": true,
   "stale_reasons": [
+    "source_newer:single_suction_gripper.urdf.xacro",
     "unsafe_index"
   ],
   "visual_items": [
     {
-      "id": "urdf_visual_0_wrist_fixture",
-      "link": "wrist_fixture",
+      "id": "urdf_visual_0_single_suction_gripper_base_link",
+      "link": "single_suction_gripper_base_link",
       "visual": "",
-      "parent_link": "${parent}",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
-      "package_uri": "package://single_suction_description/meshes/wrist_fixture.STL",
+      "parent_link": "",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "cylinder",
       "pose": {
         "xyz": [
           0.0,
@@ -79,21 +82,19 @@
       },
       "link_world_pose": {
         "xyz": [
-          0.0,
-          0.0,
-          0.0
+          0,
+          0,
+          0
         ],
         "rpy": [
           0.0,
-          -0.0,
+          0.0,
           0.0
         ]
       },
-      "joint_chain": [
-        "${prefix}gripper_base_joint"
-      ],
-      "transform_source": "partial; link=wrist_fixture",
-      "transform_status": "partial",
+      "joint_chain": [],
+      "transform_source": "resolved; link=single_suction_gripper_base_link",
+      "transform_status": "resolved",
       "scale": [
         1.0,
         1.0,
@@ -101,10 +102,12 @@
       ],
       "category": "robot_visual",
       "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".stl",
+      "warning": "",
+      "mesh_extension": "",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": "",
+      "radius": 0.02,
+      "length": 0.05
     },
     {
       "id": "urdf_visual_1_table_${prefix}",
@@ -112,7 +115,9 @@
       "visual": "table_${prefix}",
       "parent_link": "${parent}",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
       "package_uri": "package://table_description/meshes/visual/table.stl",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -164,7 +169,7 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".stl",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     },
     {
       "id": "urdf_visual_2_${name}_link",
@@ -172,7 +177,9 @@
       "visual": "",
       "parent_link": "${name}_bottom_screw_frame",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
       "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -225,7 +232,7 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".dae",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     }
   ],
   "warnings": [

--- a/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json
@@ -1,611 +1,61 @@
 {
   "scene_name": "ur5_2f_builder_pick_place_demo",
-  "generated_at": "2026-05-20T14:35:22.275685+00:00",
+  "generated_at": "2026-05-21T08:49:38.971575+00:00",
   "extractor_version": "2.0",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro",
-  "source_mtime": 1779281021.4506772,
+  "source_mtime": 1779351590.9354017,
   "included_source_paths": [
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.transmission.xacro",
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/urdf/table.urdf.xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro"
+    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro",
+    "/workspace/Easy_Manipulator_Improved/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro"
   ],
   "included_source_mtimes": {
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro": 1779281020.1066928,
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.transmission.xacro": 1779281020.1066928,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro": 1779281021.4506772,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/urdf/table.urdf.xacro": 1779281020.6186867
+    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro": 1779351590.9354017,
+    "/workspace/Easy_Manipulator_Improved/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro": 1779351591.0434008,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/urdf/table.urdf.xacro": 1779351589.9954085,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779351589.8194098
   },
   "unresolved_include_count": 1,
-  "unresolved_placeholder_count": 11,
+  "unresolved_placeholder_count": 2,
   "has_transform_collapse_warning": false,
-  "candidate_mesh_count": 11,
-  "emitted_visual_count": 11,
+  "candidate_mesh_count": 2,
+  "emitted_visual_count": 2,
   "transform_status_counts": {
     "resolved": 0,
-    "partial": 11,
+    "partial": 2,
     "local_only": 0
   },
-  "identical_position_clustered": false,
+  "identical_position_clustered": true,
   "safe_for_preview": false,
   "unsafe_reasons": [
     "unresolved_placeholders",
-    "best_effort_unresolved_includes"
+    "best_effort_unresolved_includes",
+    "identical_world_positions"
   ],
   "stale_index": true,
   "stale_reasons": [
+    "source_newer:robotiq_85_gripper.urdf.xacro",
     "unsafe_index"
   ],
   "visual_items": [
     {
-      "id": "urdf_visual_0_${prefix}gripper_base_link",
-      "link": "${prefix}gripper_base_link",
-      "visual": "",
-      "parent_link": "${parent}",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-      "pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_base_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "robot_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_1_${prefix}gripper_finger1_knuckle_link",
-      "link": "${prefix}gripper_finger1_knuckle_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "pose": {
-        "xyz": [
-          0.05490451627,
-          0.03060114443,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.05490451627,
-          0.03060114443,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_knuckle_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_2_${prefix}gripper_finger2_knuckle_link",
-      "link": "${prefix}gripper_finger2_knuckle_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "pose": {
-        "xyz": [
-          0.05490451627,
-          -0.03060114443,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.05490451627,
-          -0.03060114443,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_knuckle_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_3_${prefix}gripper_finger1_finger_link",
-      "link": "${prefix}gripper_finger1_finger_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_finger1_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "pose": {
-        "xyz": [
-          0.050818991720000005,
-          -0.0008848999199999978,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.050818991720000005,
-          -0.0008848999199999978,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_joint",
-        "${prefix}gripper_finger1_finger_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_finger_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_4_${prefix}gripper_finger2_finger_link",
-      "link": "${prefix}gripper_finger2_finger_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_finger2_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "pose": {
-        "xyz": [
-          0.050818991720000005,
-          -0.06208718878,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.050818991720000005,
-          -0.06208718878,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_joint",
-        "${prefix}gripper_finger2_finger_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_finger_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_5_${prefix}gripper_finger1_inner_knuckle_link",
-      "link": "${prefix}gripper_finger1_inner_knuckle_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "pose": {
-        "xyz": [
-          0.06142,
-          0.0127,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.06142,
-          0.0127,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_inner_knuckle_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_inner_knuckle_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_6_${prefix}gripper_finger2_inner_knuckle_link",
-      "link": "${prefix}gripper_finger2_inner_knuckle_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "pose": {
-        "xyz": [
-          0.06142,
-          -0.0127,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.06142,
-          -0.0127,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_inner_knuckle_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_inner_knuckle_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_7_${prefix}gripper_finger1_finger_tip_link",
-      "link": "${prefix}gripper_finger1_finger_tip_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_finger1_inner_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "pose": {
-        "xyz": [
-          0.10445959806999999,
-          -0.024899408209999998,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.10445959806999999,
-          -0.024899408209999998,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_inner_knuckle_joint",
-        "${prefix}gripper_finger1_finger_tip_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_finger_tip_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_8_${prefix}gripper_finger2_finger_tip_link",
-      "link": "${prefix}gripper_finger2_finger_tip_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_finger2_inner_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "pose": {
-        "xyz": [
-          0.10445959806999999,
-          -0.05029940820999999,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.10445959806999999,
-          -0.05029940820999999,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_inner_knuckle_joint",
-        "${prefix}gripper_finger2_finger_tip_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_finger_tip_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_9_table_${prefix}",
+      "id": "urdf_visual_0_table_${prefix}",
       "link": "table_${prefix}",
       "visual": "None_${prefix}",
       "parent_link": "${parent}",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
       "package_uri": "package://workbench_description/meshes/visual/table.stl",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -657,15 +107,17 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".stl",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     },
     {
-      "id": "urdf_visual_10_${name}_link",
+      "id": "urdf_visual_1_${name}_link",
       "link": "${name}_link",
       "visual": "",
       "parent_link": "${name}_bottom_screw_frame",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
       "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -718,7 +170,7 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".dae",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     }
   ],
   "warnings": [

--- a/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json
@@ -1,37 +1,35 @@
 {
   "scene_name": "ur5_2f_sorting_test",
-  "generated_at": "2026-05-20T14:35:22.320677+00:00",
+  "generated_at": "2026-05-21T08:49:39.019990+00:00",
   "extractor_version": "2.0",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1779281021.454677,
+  "source_mtime": 1779351590.9514015,
   "included_source_paths": [
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.transmission.xacro",
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro"
+    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro",
+    "/workspace/Easy_Manipulator_Improved/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro"
   ],
   "included_source_mtimes": {
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro": 1779281020.1066928,
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.transmission.xacro": 1779281020.1066928,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro": 1779281021.454677
+    "/workspace/Easy_Manipulator_Improved/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro": 1779351591.0434008,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro": 1779351590.9514015,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779351589.8194098
   },
   "unresolved_include_count": 1,
-  "unresolved_placeholder_count": 10,
+  "unresolved_placeholder_count": 18,
   "has_transform_collapse_warning": false,
-  "candidate_mesh_count": 10,
-  "emitted_visual_count": 10,
+  "candidate_mesh_count": 23,
+  "emitted_visual_count": 23,
   "transform_status_counts": {
-    "resolved": 0,
-    "partial": 10,
+    "resolved": 5,
+    "partial": 18,
     "local_only": 0
   },
   "identical_position_clustered": false,
@@ -42,19 +40,24 @@
   ],
   "stale_index": true,
   "stale_reasons": [
+    "source_newer:scene.urdf.xacro",
+    "source_newer:scene.urdf.xacro",
+    "source_newer:robotiq_85_gripper.urdf.xacro",
     "unsafe_index"
   ],
   "visual_items": [
     {
-      "id": "urdf_visual_0_${prefix}gripper_base_link",
-      "link": "${prefix}gripper_base_link",
+      "id": "urdf_visual_0_table_",
+      "link": "table_",
       "visual": "",
-      "parent_link": "${parent}",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "parent_link": "world",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
       "pose": {
         "xyz": [
-          0.0,
+          0.15,
           0.0,
           0.0
         ],
@@ -78,7 +81,7 @@
       },
       "link_world_pose": {
         "xyz": [
-          0.0,
+          0.15,
           0.0,
           0.0
         ],
@@ -89,10 +92,145 @@
         ]
       },
       "joint_chain": [
-        "${prefix}gripper_base_joint"
+        "world_to_table"
       ],
-      "transform_source": "partial; link=${prefix}gripper_base_link",
+      "transform_source": "partial; link=table_",
       "transform_status": "partial",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "category": "environment_visual",
+      "resolved": true,
+      "warning": "unresolved xacro substitution placeholder",
+      "mesh_extension": "",
+      "render_expected": true,
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": "urdf_visual_1_table_",
+      "link": "table_",
+      "visual": "",
+      "parent_link": "world",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "joint_chain": [
+        "world_to_table"
+      ],
+      "transform_source": "partial; link=table_",
+      "transform_status": "partial",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "category": "environment_visual",
+      "resolved": true,
+      "warning": "unresolved xacro substitution placeholder",
+      "mesh_extension": "",
+      "render_expected": true,
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": "urdf_visual_2_robot_mount_plate",
+      "link": "robot_mount_plate",
+      "visual": "",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
+      "pose": {
+        "xyz": [
+          -0.29000000000000004,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          -0.29000000000000004,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "joint_chain": [
+        "world_to_table",
+        "table_to_robot_mount_plate"
+      ],
+      "transform_source": "resolved; link=robot_mount_plate",
+      "transform_status": "resolved",
       "scale": [
         1.0,
         1.0,
@@ -100,22 +238,94 @@
       ],
       "category": "robot_visual",
       "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
+      "warning": "",
+      "mesh_extension": "",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
     },
     {
-      "id": "urdf_visual_1_${prefix}gripper_finger1_knuckle_link",
-      "link": "${prefix}gripper_finger1_knuckle_link",
+      "id": "urdf_visual_3_camera_mast",
+      "link": "camera_mast",
       "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "cylinder",
       "pose": {
         "xyz": [
-          0.05490451627,
-          0.03060114443,
+          -0.03,
+          0.28,
+          0.32
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.32
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          -0.03,
+          0.28,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "joint_chain": [
+        "world_to_table",
+        "table_to_camera_mast"
+      ],
+      "transform_source": "resolved; link=camera_mast",
+      "transform_status": "resolved",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "category": "environment_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": "",
+      "render_expected": true,
+      "render_skip_reason": "",
+      "radius": 0.01,
+      "length": 0.64
+    },
+    {
+      "id": "urdf_visual_4_bin_a",
+      "link": "bin_a",
+      "visual": "",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
+      "pose": {
+        "xyz": [
+          0.15,
+          -0.24,
           0.0
         ],
         "rpy": [
@@ -138,8 +348,8 @@
       },
       "link_world_pose": {
         "xyz": [
-          0.05490451627,
-          0.03060114443,
+          0.15,
+          -0.24,
           0.0
         ],
         "rpy": [
@@ -149,34 +359,41 @@
         ]
       },
       "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_joint"
+        "world_to_table",
+        "table_to_bin_a"
       ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_knuckle_link",
+      "transform_source": "partial; link=bin_a",
       "transform_status": "partial",
       "scale": [
         1.0,
         1.0,
         1.0
       ],
-      "category": "gripper_visual",
+      "category": "unknown_visual",
       "resolved": true,
       "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
+      "mesh_extension": "",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
     },
     {
-      "id": "urdf_visual_2_${prefix}gripper_finger2_knuckle_link",
-      "link": "${prefix}gripper_finger2_knuckle_link",
+      "id": "urdf_visual_5_bin_a",
+      "link": "bin_a",
       "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
       "pose": {
         "xyz": [
-          0.05490451627,
-          -0.03060114443,
+          0.15,
+          -0.24,
           0.0
         ],
         "rpy": [
@@ -199,8 +416,8 @@
       },
       "link_world_pose": {
         "xyz": [
-          0.05490451627,
-          -0.03060114443,
+          0.15,
+          -0.24,
           0.0
         ],
         "rpy": [
@@ -210,34 +427,41 @@
         ]
       },
       "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_joint"
+        "world_to_table",
+        "table_to_bin_a"
       ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_knuckle_link",
+      "transform_source": "partial; link=bin_a",
       "transform_status": "partial",
       "scale": [
         1.0,
         1.0,
         1.0
       ],
-      "category": "gripper_visual",
+      "category": "unknown_visual",
       "resolved": true,
       "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
+      "mesh_extension": "",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
     },
     {
-      "id": "urdf_visual_3_${prefix}gripper_finger1_finger_link",
-      "link": "${prefix}gripper_finger1_finger_link",
+      "id": "urdf_visual_6_bin_a",
+      "link": "bin_a",
       "visual": "",
-      "parent_link": "${prefix}gripper_finger1_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
       "pose": {
         "xyz": [
-          0.050818991720000005,
-          -0.0008848999199999978,
+          0.15,
+          -0.24,
           0.0
         ],
         "rpy": [
@@ -260,8 +484,8 @@
       },
       "link_world_pose": {
         "xyz": [
-          0.050818991720000005,
-          -0.0008848999199999978,
+          0.15,
+          -0.24,
           0.0
         ],
         "rpy": [
@@ -271,35 +495,177 @@
         ]
       },
       "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_joint",
-        "${prefix}gripper_finger1_finger_joint"
+        "world_to_table",
+        "table_to_bin_a"
       ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_finger_link",
+      "transform_source": "partial; link=bin_a",
       "transform_status": "partial",
       "scale": [
         1.0,
         1.0,
         1.0
       ],
-      "category": "gripper_visual",
+      "category": "unknown_visual",
       "resolved": true,
       "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
+      "mesh_extension": "",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
     },
     {
-      "id": "urdf_visual_4_${prefix}gripper_finger2_finger_link",
-      "link": "${prefix}gripper_finger2_finger_link",
+      "id": "urdf_visual_7_bin_a",
+      "link": "bin_a",
       "visual": "",
-      "parent_link": "${prefix}gripper_finger2_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
       "pose": {
         "xyz": [
-          0.050818991720000005,
-          -0.06208718878,
+          0.15,
+          -0.24,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.15,
+          -0.24,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "joint_chain": [
+        "world_to_table",
+        "table_to_bin_a"
+      ],
+      "transform_source": "partial; link=bin_a",
+      "transform_status": "partial",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "unresolved xacro substitution placeholder",
+      "mesh_extension": "",
+      "render_expected": true,
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": "urdf_visual_8_bin_a",
+      "link": "bin_a",
+      "visual": "",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
+      "pose": {
+        "xyz": [
+          0.15,
+          -0.24,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.15,
+          -0.24,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "joint_chain": [
+        "world_to_table",
+        "table_to_bin_a"
+      ],
+      "transform_source": "partial; link=bin_a",
+      "transform_status": "partial",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "unresolved xacro substitution placeholder",
+      "mesh_extension": "",
+      "render_expected": true,
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": "urdf_visual_9_bin_b",
+      "link": "bin_b",
+      "visual": "",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.0,
           0.0
         ],
         "rpy": [
@@ -322,8 +688,8 @@
       },
       "link_world_pose": {
         "xyz": [
-          0.050818991720000005,
-          -0.06208718878,
+          0.15,
+          0.0,
           0.0
         ],
         "rpy": [
@@ -333,35 +699,41 @@
         ]
       },
       "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_joint",
-        "${prefix}gripper_finger2_finger_joint"
+        "world_to_table",
+        "table_to_bin_b"
       ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_finger_link",
+      "transform_source": "partial; link=bin_b",
       "transform_status": "partial",
       "scale": [
         1.0,
         1.0,
         1.0
       ],
-      "category": "gripper_visual",
+      "category": "unknown_visual",
       "resolved": true,
       "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
+      "mesh_extension": "",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
     },
     {
-      "id": "urdf_visual_5_${prefix}gripper_finger1_inner_knuckle_link",
-      "link": "${prefix}gripper_finger1_inner_knuckle_link",
+      "id": "urdf_visual_10_bin_b",
+      "link": "bin_b",
       "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
       "pose": {
         "xyz": [
-          0.06142,
-          0.0127,
+          0.15,
+          0.0,
           0.0
         ],
         "rpy": [
@@ -384,8 +756,8 @@
       },
       "link_world_pose": {
         "xyz": [
-          0.06142,
-          0.0127,
+          0.15,
+          0.0,
           0.0
         ],
         "rpy": [
@@ -395,34 +767,41 @@
         ]
       },
       "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_inner_knuckle_joint"
+        "world_to_table",
+        "table_to_bin_b"
       ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_inner_knuckle_link",
+      "transform_source": "partial; link=bin_b",
       "transform_status": "partial",
       "scale": [
         1.0,
         1.0,
         1.0
       ],
-      "category": "gripper_visual",
+      "category": "unknown_visual",
       "resolved": true,
       "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
+      "mesh_extension": "",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
     },
     {
-      "id": "urdf_visual_6_${prefix}gripper_finger2_inner_knuckle_link",
-      "link": "${prefix}gripper_finger2_inner_knuckle_link",
+      "id": "urdf_visual_11_bin_b",
+      "link": "bin_b",
       "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
       "pose": {
         "xyz": [
-          0.06142,
-          -0.0127,
+          0.15,
+          0.0,
           0.0
         ],
         "rpy": [
@@ -445,8 +824,8 @@
       },
       "link_world_pose": {
         "xyz": [
-          0.06142,
-          -0.0127,
+          0.15,
+          0.0,
           0.0
         ],
         "rpy": [
@@ -456,34 +835,177 @@
         ]
       },
       "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_inner_knuckle_joint"
+        "world_to_table",
+        "table_to_bin_b"
       ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_inner_knuckle_link",
+      "transform_source": "partial; link=bin_b",
       "transform_status": "partial",
       "scale": [
         1.0,
         1.0,
         1.0
       ],
-      "category": "gripper_visual",
+      "category": "unknown_visual",
       "resolved": true,
       "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
+      "mesh_extension": "",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
     },
     {
-      "id": "urdf_visual_7_${prefix}gripper_finger1_finger_tip_link",
-      "link": "${prefix}gripper_finger1_finger_tip_link",
+      "id": "urdf_visual_12_bin_b",
+      "link": "bin_b",
       "visual": "",
-      "parent_link": "${prefix}gripper_finger1_inner_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
       "pose": {
         "xyz": [
-          0.10445959806999999,
-          -0.024899408209999998,
+          0.15,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "joint_chain": [
+        "world_to_table",
+        "table_to_bin_b"
+      ],
+      "transform_source": "partial; link=bin_b",
+      "transform_status": "partial",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "unresolved xacro substitution placeholder",
+      "mesh_extension": "",
+      "render_expected": true,
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": "urdf_visual_13_bin_b",
+      "link": "bin_b",
+      "visual": "",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "joint_chain": [
+        "world_to_table",
+        "table_to_bin_b"
+      ],
+      "transform_source": "partial; link=bin_b",
+      "transform_status": "partial",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "unresolved xacro substitution placeholder",
+      "mesh_extension": "",
+      "render_expected": true,
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": "urdf_visual_14_reject_bin",
+      "link": "reject_bin",
+      "visual": "",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.24,
           0.0
         ],
         "rpy": [
@@ -506,8 +1028,8 @@
       },
       "link_world_pose": {
         "xyz": [
-          0.10445959806999999,
-          -0.024899408209999998,
+          0.15,
+          0.24,
           0.0
         ],
         "rpy": [
@@ -517,35 +1039,41 @@
         ]
       },
       "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_inner_knuckle_joint",
-        "${prefix}gripper_finger1_finger_tip_joint"
+        "world_to_table",
+        "table_to_reject_bin"
       ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_finger_tip_link",
+      "transform_source": "partial; link=reject_bin",
       "transform_status": "partial",
       "scale": [
         1.0,
         1.0,
         1.0
       ],
-      "category": "gripper_visual",
+      "category": "unknown_visual",
       "resolved": true,
       "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
+      "mesh_extension": "",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
     },
     {
-      "id": "urdf_visual_8_${prefix}gripper_finger2_finger_tip_link",
-      "link": "${prefix}gripper_finger2_finger_tip_link",
+      "id": "urdf_visual_15_reject_bin",
+      "link": "reject_bin",
       "visual": "",
-      "parent_link": "${prefix}gripper_finger2_inner_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
       "pose": {
         "xyz": [
-          0.10445959806999999,
-          -0.05029940820999999,
+          0.15,
+          0.24,
           0.0
         ],
         "rpy": [
@@ -568,8 +1096,8 @@
       },
       "link_world_pose": {
         "xyz": [
-          0.10445959806999999,
-          -0.05029940820999999,
+          0.15,
+          0.24,
           0.0
         ],
         "rpy": [
@@ -579,12 +1107,416 @@
         ]
       },
       "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_inner_knuckle_joint",
-        "${prefix}gripper_finger2_finger_tip_joint"
+        "world_to_table",
+        "table_to_reject_bin"
       ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_finger_tip_link",
+      "transform_source": "partial; link=reject_bin",
       "transform_status": "partial",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "unresolved xacro substitution placeholder",
+      "mesh_extension": "",
+      "render_expected": true,
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": "urdf_visual_16_reject_bin",
+      "link": "reject_bin",
+      "visual": "",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.24,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.15,
+          0.24,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "joint_chain": [
+        "world_to_table",
+        "table_to_reject_bin"
+      ],
+      "transform_source": "partial; link=reject_bin",
+      "transform_status": "partial",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "unresolved xacro substitution placeholder",
+      "mesh_extension": "",
+      "render_expected": true,
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": "urdf_visual_17_reject_bin",
+      "link": "reject_bin",
+      "visual": "",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.24,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.15,
+          0.24,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "joint_chain": [
+        "world_to_table",
+        "table_to_reject_bin"
+      ],
+      "transform_source": "partial; link=reject_bin",
+      "transform_status": "partial",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "unresolved xacro substitution placeholder",
+      "mesh_extension": "",
+      "render_expected": true,
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": "urdf_visual_18_reject_bin",
+      "link": "reject_bin",
+      "visual": "",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.24,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.15,
+          0.24,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "joint_chain": [
+        "world_to_table",
+        "table_to_reject_bin"
+      ],
+      "transform_source": "partial; link=reject_bin",
+      "transform_status": "partial",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "unresolved xacro substitution placeholder",
+      "mesh_extension": "",
+      "render_expected": true,
+      "render_skip_reason": "",
+      "size": [
+        0.0,
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": "urdf_visual_19_item_red",
+      "link": "item_red",
+      "visual": "",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "box",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "joint_chain": [
+        "world_to_table",
+        "table_to_item_red"
+      ],
+      "transform_source": "resolved; link=item_red",
+      "transform_status": "resolved",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": "",
+      "render_expected": true,
+      "render_skip_reason": "",
+      "size": [
+        0.04,
+        0.04,
+        0.08
+      ]
+    },
+    {
+      "id": "urdf_visual_20_item_blue",
+      "link": "item_blue",
+      "visual": "",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "cylinder",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "joint_chain": [
+        "world_to_table",
+        "table_to_item_blue"
+      ],
+      "transform_source": "resolved; link=item_blue",
+      "transform_status": "resolved",
+      "scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "category": "unknown_visual",
+      "resolved": true,
+      "warning": "",
+      "mesh_extension": "",
+      "render_expected": true,
+      "render_skip_reason": "",
+      "radius": 0.02,
+      "length": 0.06
+    },
+    {
+      "id": "urdf_visual_21_item_green",
+      "link": "item_green",
+      "visual": "",
+      "parent_link": "table_",
+      "source_path": "",
+      "resolved_path": "",
+      "package_uri": "",
+      "geometry_type": "sphere",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "local_visual_pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "link_world_pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "joint_chain": [
+        "world_to_table",
+        "table_to_item_green"
+      ],
+      "transform_source": "resolved; link=item_green",
+      "transform_status": "resolved",
       "scale": [
         1.0,
         1.0,
@@ -592,18 +1524,21 @@
       ],
       "category": "gripper_visual",
       "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
+      "warning": "",
+      "mesh_extension": "",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": "",
+      "radius": 0.025
     },
     {
-      "id": "urdf_visual_9_${name}_link",
+      "id": "urdf_visual_22_${name}_link",
       "link": "${name}_link",
       "visual": "",
       "parent_link": "${name}_bottom_screw_frame",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
       "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -656,7 +1591,7 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".dae",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     }
   ],
   "warnings": [

--- a/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
@@ -1,611 +1,61 @@
 {
   "scene_name": "ur5_2f_test",
-  "generated_at": "2026-05-20T14:35:22.365708+00:00",
+  "generated_at": "2026-05-21T08:49:39.067724+00:00",
   "extractor_version": "2.0",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1779281021.454677,
+  "source_mtime": 1779351590.9514015,
   "included_source_paths": [
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.transmission.xacro",
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/urdf/table.urdf.xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro"
+    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+    "/workspace/Easy_Manipulator_Improved/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro"
   ],
   "included_source_mtimes": {
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro": 1779281020.1066928,
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.transmission.xacro": 1779281020.1066928,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/urdf/table.urdf.xacro": 1779281020.6186867,
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro": 1779281021.454677
+    "/workspace/Easy_Manipulator_Improved/workcell_builder/workcell_builder/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/urdf/robotiq_85_gripper.urdf.xacro": 1779351591.0434008,
+    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro": 1779351590.9514015,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/urdf/table.urdf.xacro": 1779351589.9954085,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779351589.8194098
   },
   "unresolved_include_count": 1,
-  "unresolved_placeholder_count": 11,
+  "unresolved_placeholder_count": 2,
   "has_transform_collapse_warning": false,
-  "candidate_mesh_count": 11,
-  "emitted_visual_count": 11,
+  "candidate_mesh_count": 2,
+  "emitted_visual_count": 2,
   "transform_status_counts": {
     "resolved": 0,
-    "partial": 11,
+    "partial": 2,
     "local_only": 0
   },
-  "identical_position_clustered": false,
+  "identical_position_clustered": true,
   "safe_for_preview": false,
   "unsafe_reasons": [
     "unresolved_placeholders",
-    "best_effort_unresolved_includes"
+    "best_effort_unresolved_includes",
+    "identical_world_positions"
   ],
   "stale_index": true,
   "stale_reasons": [
+    "source_newer:robotiq_85_gripper.urdf.xacro",
     "unsafe_index"
   ],
   "visual_items": [
     {
-      "id": "urdf_visual_0_${prefix}gripper_base_link",
-      "link": "${prefix}gripper_base_link",
-      "visual": "",
-      "parent_link": "${parent}",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-      "pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_base_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "robot_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_1_${prefix}gripper_finger1_knuckle_link",
-      "link": "${prefix}gripper_finger1_knuckle_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "pose": {
-        "xyz": [
-          0.05490451627,
-          0.03060114443,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.05490451627,
-          0.03060114443,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_knuckle_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_2_${prefix}gripper_finger2_knuckle_link",
-      "link": "${prefix}gripper_finger2_knuckle_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "pose": {
-        "xyz": [
-          0.05490451627,
-          -0.03060114443,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.05490451627,
-          -0.03060114443,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_knuckle_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_3_${prefix}gripper_finger1_finger_link",
-      "link": "${prefix}gripper_finger1_finger_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_finger1_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "pose": {
-        "xyz": [
-          0.050818991720000005,
-          -0.0008848999199999978,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.050818991720000005,
-          -0.0008848999199999978,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_joint",
-        "${prefix}gripper_finger1_finger_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_finger_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_4_${prefix}gripper_finger2_finger_link",
-      "link": "${prefix}gripper_finger2_finger_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_finger2_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "pose": {
-        "xyz": [
-          0.050818991720000005,
-          -0.06208718878,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.050818991720000005,
-          -0.06208718878,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_joint",
-        "${prefix}gripper_finger2_finger_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_finger_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_5_${prefix}gripper_finger1_inner_knuckle_link",
-      "link": "${prefix}gripper_finger1_inner_knuckle_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "pose": {
-        "xyz": [
-          0.06142,
-          0.0127,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.06142,
-          0.0127,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_inner_knuckle_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_inner_knuckle_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_6_${prefix}gripper_finger2_inner_knuckle_link",
-      "link": "${prefix}gripper_finger2_inner_knuckle_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_base_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "pose": {
-        "xyz": [
-          0.06142,
-          -0.0127,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.06142,
-          -0.0127,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_inner_knuckle_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_inner_knuckle_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_7_${prefix}gripper_finger1_finger_tip_link",
-      "link": "${prefix}gripper_finger1_finger_tip_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_finger1_inner_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "pose": {
-        "xyz": [
-          0.10445959806999999,
-          -0.024899408209999998,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.10445959806999999,
-          -0.024899408209999998,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger1_inner_knuckle_joint",
-        "${prefix}gripper_finger1_finger_tip_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger1_finger_tip_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_8_${prefix}gripper_finger2_finger_tip_link",
-      "link": "${prefix}gripper_finger2_finger_tip_link",
-      "visual": "",
-      "parent_link": "${prefix}gripper_finger2_inner_knuckle_link",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "pose": {
-        "xyz": [
-          0.10445959806999999,
-          -0.05029940820999999,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "local_visual_pose": {
-        "xyz": [
-          0.0,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          0.0,
-          0.0
-        ]
-      },
-      "link_world_pose": {
-        "xyz": [
-          0.10445959806999999,
-          -0.05029940820999999,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "joint_chain": [
-        "${prefix}gripper_base_joint",
-        "${prefix}gripper_finger2_inner_knuckle_joint",
-        "${prefix}gripper_finger2_finger_tip_joint"
-      ],
-      "transform_source": "partial; link=${prefix}gripper_finger2_finger_tip_link",
-      "transform_status": "partial",
-      "scale": [
-        1.0,
-        1.0,
-        1.0
-      ],
-      "category": "gripper_visual",
-      "resolved": true,
-      "warning": "unresolved xacro substitution placeholder",
-      "mesh_extension": ".dae",
-      "render_expected": true,
-      "render_warning": ""
-    },
-    {
-      "id": "urdf_visual_9_table_${prefix}",
+      "id": "urdf_visual_0_table_${prefix}",
       "link": "table_${prefix}",
       "visual": "None_${prefix}",
       "parent_link": "${parent}",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
       "package_uri": "package://workbench_description/meshes/visual/table.stl",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -657,15 +107,17 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".stl",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     },
     {
-      "id": "urdf_visual_10_${name}_link",
+      "id": "urdf_visual_1_${name}_link",
       "link": "${name}_link",
       "visual": "",
       "parent_link": "${name}_bottom_screw_frame",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
       "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -718,7 +170,7 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".dae",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     }
   ],
   "warnings": [

--- a/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json
@@ -1,11 +1,11 @@
 {
   "scene_name": "ur5_3f_test",
-  "generated_at": "2026-05-20T14:35:22.403054+00:00",
+  "generated_at": "2026-05-21T08:49:39.113731+00:00",
   "extractor_version": "2.0",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1779281021.454677,
+  "source_mtime": 1779351590.9554014,
   "included_source_paths": [
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro",
@@ -15,12 +15,12 @@
     "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro"
   ],
   "included_source_mtimes": {
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro": 1779281021.454677,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/urdf/table.urdf.xacro": 1779281020.6186867
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/urdf/table.urdf.xacro": 1779351589.9954085,
+    "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro": 1779351590.9554014,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779351589.8194098
   },
   "unresolved_include_count": 1,
   "unresolved_placeholder_count": 2,
@@ -41,6 +41,8 @@
   ],
   "stale_index": true,
   "stale_reasons": [
+    "source_newer:scene.urdf.xacro",
+    "source_newer:scene.urdf.xacro",
     "unsafe_index"
   ],
   "visual_items": [
@@ -50,7 +52,9 @@
       "visual": "None_${prefix}",
       "parent_link": "${parent}",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
       "package_uri": "package://workbench_description/meshes/visual/table.stl",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -102,7 +106,7 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".stl",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     },
     {
       "id": "urdf_visual_1_${name}_link",
@@ -110,7 +114,9 @@
       "visual": "",
       "parent_link": "${name}_bottom_screw_frame",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
       "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -163,7 +169,7 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".dae",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     }
   ],
   "warnings": [

--- a/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json
@@ -1,28 +1,28 @@
 {
   "scene_name": "ur5_airpick4_test",
-  "generated_at": "2026-05-20T14:35:22.441751+00:00",
+  "generated_at": "2026-05-21T08:49:39.160613+00:00",
   "extractor_version": "2.0",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1779281021.454677,
+  "source_mtime": 1779351590.9554014,
   "included_source_paths": [
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro",
     "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/urdf/table.urdf.xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro"
+    "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
+    "/workspace/Easy_Manipulator_Improved/workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro"
   ],
   "included_source_mtimes": {
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro": 1779281021.454677,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro": 1779281020.0426934,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779281020.4666886,
-    "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/urdf/table.urdf.xacro": 1779281020.6186867
+    "/workspace/Easy_Manipulator_Improved/workcell_builder/workcell_builder/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/urdf/onrobot_airpick4_gripper.urdf.xacro": 1779351591.0434008,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro": 1779351590.9554014,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/urdf/table.urdf.xacro": 1779351589.9954085,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_materials.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i_imu_modules.urdf.xacro": 1779351589.8194098,
+    "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/urdf/_d435i.urdf.xacro": 1779351589.8194098
   },
   "unresolved_include_count": 1,
   "unresolved_placeholder_count": 3,
@@ -43,6 +43,7 @@
   ],
   "stale_index": true,
   "stale_reasons": [
+    "source_newer:onrobot_airpick4_gripper.urdf.xacro",
     "unsafe_index"
   ],
   "visual_items": [
@@ -52,7 +53,9 @@
       "visual": "None_${prefix}",
       "parent_link": "${parent}",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
       "package_uri": "package://workbench_description/meshes/visual/table.stl",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -104,7 +107,7 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".stl",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     },
     {
       "id": "urdf_visual_1_${name}_link",
@@ -112,7 +115,9 @@
       "visual": "",
       "parent_link": "${name}_bottom_screw_frame",
       "source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
       "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -165,15 +170,17 @@
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".dae",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": ""
     },
     {
       "id": "urdf_visual_2_${prefix}gripper_base_link",
       "link": "${prefix}gripper_base_link",
       "visual": "",
       "parent_link": "${parent}",
-      "source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+      "source_path": "",
+      "resolved_path": "",
       "package_uri": "package://onrobot_airpick4_description/meshes/airpick4.stl",
+      "geometry_type": "mesh",
       "pose": {
         "xyz": [
           0.0,
@@ -221,11 +228,11 @@
         0.001
       ],
       "category": "robot_visual",
-      "resolved": true,
+      "resolved": false,
       "warning": "unresolved xacro substitution placeholder",
       "mesh_extension": ".stl",
       "render_expected": true,
-      "render_warning": ""
+      "render_skip_reason": "unresolved mesh path: package://onrobot_airpick4_description/meshes/airpick4.stl"
     }
   ],
   "warnings": [

--- a/scripts/validate_all_workcell_studio_scenes.py
+++ b/scripts/validate_all_workcell_studio_scenes.py
@@ -8,6 +8,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+WARNING_CATEGORIES = ("metadata", "preview", "generation", "launch_simulation", "runtime_smoke")
+
 PASS = "PASS"
 WARN = "WARN"
 FAIL = "FAIL"
@@ -58,6 +60,7 @@ class SceneAudit:
     fake_hardware_smoke_command: str
     blockers: list[str]
     warnings: list[str]
+    warning_groups: dict[str, list[str]]
 
 
 def resolve_scenes_root(repo_root: Path) -> Path:
@@ -141,7 +144,7 @@ def audit_scene(repo_root: Path, scene_dir: Path) -> SceneAudit:
     optional = {k: (scene_dir / rel).exists() for k, rel in OPTIONAL_FILES.items()}
 
     blockers: list[str] = []
-    warnings: list[str] = []
+    warning_groups: dict[str, list[str]] = {k: [] for k in WARNING_CATEGORIES}
 
     for key, present in files.items():
         if not present:
@@ -164,7 +167,8 @@ def audit_scene(repo_root: Path, scene_dir: Path) -> SceneAudit:
 
     layout_issues = _layout_metadata_issues(layout_data) if layout_status == "ok" else ["layout not parseable"]
     if layout_issues:
-        warnings.extend([f"layout metadata issue: {issue}" for issue in layout_issues])
+        warning_groups["metadata"].extend([f"layout metadata issue: {issue}" for issue in layout_issues])
+        warning_groups["preview"].append("preview readiness degraded by layout metadata issues")
 
     generated_index = (scene_dir / "generated" / "scene_visual_mesh_index.json").exists()
     regen_status = "not_needed" if generated_index else "attempted"
@@ -193,12 +197,19 @@ def audit_scene(repo_root: Path, scene_dir: Path) -> SceneAudit:
 
     for key, present in optional.items():
         if not present and key not in {"scene_urdf", "scene_urdf_xacro"}:
-            warnings.append(f"optional file missing: {OPTIONAL_FILES[key]}")
+            if key in {"task_recipe", "task_intent"}:
+                warning_groups["runtime_smoke"].append(f"optional file missing: {OPTIONAL_FILES[key]}")
+            elif key in {"generated_environment_assets", "generated_layout"}:
+                warning_groups["generation"].append(f"optional file missing: {OPTIONAL_FILES[key]}")
+            else:
+                warning_groups["metadata"].append(f"optional file missing: {OPTIONAL_FILES[key]}")
 
     preview_readiness = "ready" if not blockers and not layout_issues else ("degraded" if not blockers else "blocked")
 
     if scene_dir.name not in KNOWN_SCENES:
-        warnings.append("scene is not in known-scenes audit set")
+        warning_groups["metadata"].append("scene is not in known-scenes audit set")
+
+    warnings = [w for group in WARNING_CATEGORIES for w in warning_groups[group] if w]
 
     status = PASS
     if blockers:
@@ -220,6 +231,7 @@ def audit_scene(repo_root: Path, scene_dir: Path) -> SceneAudit:
         fake_hardware_smoke_command=fake_cmd,
         blockers=blockers,
         warnings=warnings,
+        warning_groups=warning_groups,
     )
 
 

--- a/tests/test_all_scene_reproducibility.py
+++ b/tests/test_all_scene_reproducibility.py
@@ -49,6 +49,7 @@ def test_validator_emits_per_scene_report_and_contract_keys():
         "fake_hardware_smoke_command",
         "blockers",
         "warnings",
+        "warning_groups",
     }
     for scene in scenes:
         assert expected_keys.issubset(scene.keys())
@@ -57,3 +58,24 @@ def test_validator_emits_per_scene_report_and_contract_keys():
         assert isinstance(scene["warnings"], list)
 
     assert "ModuleNotFoundError: No module named 'yaml'" not in (proc.stdout + proc.stderr)
+
+
+def test_scene_warnings_are_grouped_and_non_ambiguous():
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts" / "validate_all_workcell_studio_scenes.py"
+    report = repo_root / "build" / "workcell_studio" / "all_scene_reproducibility_report.json"
+
+    subprocess.run([sys.executable, str(script)], cwd=repo_root, check=True, capture_output=True, text=True)
+    payload = json.loads(report.read_text(encoding="utf-8"))
+
+    for scene in payload.get("scenes", []):
+        groups = scene.get("warning_groups")
+        assert isinstance(groups, dict)
+        assert set(groups.keys()) == {"metadata", "preview", "generation", "launch_simulation", "runtime_smoke"}
+        for key, items in groups.items():
+            assert isinstance(items, list), f"{scene.get('scene_name')}:{key}"
+            for msg in items:
+                assert isinstance(msg, str) and msg.strip(), f"{scene.get('scene_name')}:{key}"
+        for warning in scene.get("warnings", []):
+            assert warning.strip()
+            assert any(token in warning.lower() for token in ("missing", "issue", "degraded", "failed", "unreadable", "not in known-scenes"))

--- a/tests/test_all_workcell_studio_scene_reproducibility.py
+++ b/tests/test_all_workcell_studio_scene_reproducibility.py
@@ -20,3 +20,26 @@ def test_all_scene_reproducibility_validator_runs_and_emits_json_report():
     assert payload.get("status_counts", {}).keys() >= {"PASS", "WARN", "FAIL", "SKIP"}
 
     assert "Traceback" not in (proc.stdout + proc.stderr)
+
+
+def test_known_scene_set_matches_expected_contract():
+    repo_root = Path(__file__).resolve().parents[1]
+    script_text = (repo_root / "scripts" / "validate_all_workcell_studio_scenes.py").read_text(encoding="utf-8")
+    for name in [
+        "suction_test",
+        "ur10_2f_test",
+        "ur3_suction_test",
+        "ur5_2f_builder_pick_place_demo",
+        "ur5_2f_sorting_test",
+        "ur5_2f_test",
+        "ur5_3f_test",
+        "ur5_airpick4_test",
+    ]:
+        assert name in script_text
+
+
+def test_validator_has_no_suction_only_special_case():
+    repo_root = Path(__file__).resolve().parents[1]
+    script_text = (repo_root / "scripts" / "validate_all_workcell_studio_scenes.py").read_text(encoding="utf-8")
+    assert "== \"suction_test\"" not in script_text
+    assert "!= \"suction_test\"" not in script_text


### PR DESCRIPTION
## Summary
- Ran all-scene reproducibility validation and confirmed every known shipped scene is currently `WARN` with no `FAIL` entries.
- Normalized validator output to include explicit `warning_groups` by category:
  - `metadata`
  - `preview`
  - `generation`
  - `launch_simulation`
  - `runtime_smoke`
- Kept runtime honesty: no scene was promoted to runtime-ready/execution-ready without smoke/runtime evidence.
- Regenerated `generated/scene_visual_mesh_index.json` for all known scenes using the extractor contract (`--all --prefer-xacro`).
- Added/updated tests that lock in reproducibility contract behavior and clarity requirements.
- Added user-facing reproducibility doc for PASS/WARN/FAIL/SKIP meaning and WARN remediation workflow.

## Before/After all-scene matrix
| Scene | Before | After |
|---|---|---|
| suction_test | WARN | WARN |
| ur10_2f_test | WARN | WARN |
| ur3_suction_test | WARN | WARN |
| ur5_2f_builder_pick_place_demo | WARN | WARN |
| ur5_2f_sorting_test | WARN | WARN |
| ur5_2f_test | WARN | WARN |
| ur5_3f_test | WARN | WARN |
| ur5_airpick4_test | WARN | WARN |

## Exact WARN reasons before fixes
(From report fields; same four warnings across all known scenes)
- optional file missing: `generated/environment_assets.yaml`
- optional file missing: `layout/workcell_studio_layout.generated.yaml`
- optional file missing: `config/task_recipe.yaml`
- optional file missing: `config/workcell_builder_task_intent.yaml`

## Exact WARN reasons remaining after fixes
(Still the same underlying warnings; now grouped clearly in report)
- optional file missing: `generated/environment_assets.yaml` (`generation`)
- optional file missing: `layout/workcell_studio_layout.generated.yaml` (`generation`)
- optional file missing: `config/task_recipe.yaml` (`runtime_smoke`)
- optional file missing: `config/workcell_builder_task_intent.yaml` (`runtime_smoke`)

## Scenes moved closer to PASS
- All 8 known scenes moved closer to PASS in terms of reproducibility *diagnostic clarity* because warnings are now category-grouped and non-ambiguous.
- No scene moved from WARN to PASS in this PR because runtime/smoke metadata gaps remain and were not faked.

## Tests/validation run
- `python3 scripts/validate_all_workcell_studio_scenes.py`
- `python3 scripts/extract_scene_urdf_visual_mesh_index.py --all --prefer-xacro`
- `python3 scripts/validate_scene3d_mesh_preview_contract.py`
- `python3 scripts/validate_scene3d_visual_diagnostics.py`
- `python3 scripts/validate_scene_builder_ui_acceptance.py`
- `python3 scripts/validate_scene_builder_ux_integration.py`
- `python3 -m pytest -q tests/test_all_scene_reproducibility.py`
- `python3 -m pytest -q tests/test_all_workcell_studio_scene_reproducibility.py`
- `python3 -m pytest -q tests/test_scene_builder_ui_acceptance.py`
- `python3 -m pytest -q tests/test_workcell_builder_canvas_navigation.py`
- `python3 -m pytest -q tests/test_workcell_studio_scene_builder_interactive_canvas.py`

## Manual build/GUI validation
- `colcon build` / GUI validation was **not run** in this PR.
- No claims are made about MoveIt/grasp execution behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ec69edeb0833189de35fe3896d5d7)