### PR TITLE
Add RViz/MoveIt simulation validation manual

### DIFF
--- a/docs/manuals/RVIZ_MOVEIT_SIMULATION_VALIDATION.md
+++ b/docs/manuals/RVIZ_MOVEIT_SIMULATION_VALIDATION.md
@@ -1,0 +1,90 @@
+# RViz/MoveIt Simulation Validation
+
+## Purpose and Scope
+
+This manual defines validation steps for **RViz/MoveIt simulation launch only**. It verifies that the simulation stack starts correctly, key nodes come up, and expected simulation-only behavior is observable.
+
+This document is **not** a procedure for validating real robot hardware, field safety, or production readiness.
+
+## Validation Modes
+
+### 1) Headless (CI-friendly) Validation
+
+Use headless mode when validating launch behavior without a GUI.
+
+Example commands:
+
+```bash
+ros2 launch <your_package> <your_launch_file>.launch.py launch_rviz:=false use_fake_hardware:=true
+```
+
+```bash
+ros2 launch <your_package> <your_launch_file>.launch.py launch_rviz:=false use_fake_hardware:=true --show-args
+```
+
+Recommended for automation:
+- CI pipelines
+- Remote test environments
+- Fast launch-regression checks
+
+### 2) Manual GUI Validation (RViz)
+
+Use GUI mode when a human operator needs to visually verify planning scene and interaction behavior.
+
+Example commands:
+
+```bash
+ros2 launch <your_package> <your_launch_file>.launch.py launch_rviz:=true use_fake_hardware:=true
+```
+
+```bash
+ros2 launch <your_package> <your_launch_file>.launch.py launch_rviz:=true use_fake_hardware:=true rviz_config:=<path_to_config.rviz>
+```
+
+Recommended for:
+- Visual sanity checks
+- Interactive planning checks in simulation
+- Operator sign-off for simulation workflows
+
+## Result Definitions
+
+Use the following standardized outcomes:
+
+- **PASS**: Launch completed and expected simulation components behaved correctly.
+- **WARN**: Launch succeeded with non-blocking issues (for example: recoverable warnings, delayed non-critical topics).
+- **FAIL**: Validation objective not met (launch failure, critical node missing, fatal runtime issue).
+- **SKIP**: Validation intentionally not executed (for example: dependency unavailable, test explicitly deferred).
+
+## JSON Report Requirements
+
+Store machine-readable results at:
+
+- `artifacts/reports/rviz_moveit_simulation_validation.json`
+
+Minimum required key fields:
+
+- `validation_name` (string)
+- `timestamp_utc` (string, ISO-8601)
+- `mode` (string: `headless` or `gui`)
+- `launch_rviz` (boolean)
+- `use_fake_hardware` (boolean)
+- `status` (string: `PASS` | `WARN` | `FAIL` | `SKIP`)
+- `summary` (string)
+- `checks` (array of per-check objects)
+- `errors` (array)
+- `warnings` (array)
+
+## Real Hardware Exclusion (Explicit)
+
+This validation is **simulation-only** and is **not real-hardware validation**.
+
+No result from this document alone may be used as evidence that physical robot hardware is safe, calibrated, or ready for operation.
+
+## Hardware Gate (Explicit)
+
+Set `use_fake_hardware:=false` **only after**:
+
+1. Manual readiness gates are completed and approved, **and**
+2. A separate, documented hardware validation process is executed.
+
+Any attempt to run with `use_fake_hardware:=false` before these conditions is out of scope for this manual.


### PR DESCRIPTION
### Motivation

- Provide a concise, machine-readable procedure for validating RViz/MoveIt simulation launches only, scoped to simulation and explicitly excluding real-hardware validation.
- Standardize headless CI-friendly and manual GUI command examples using the `launch_rviz` and `use_fake_hardware` toggles to reduce onboarding friction and launch mistakes.
- Ensure automated reporting and clear PASS/WARN/FAIL/SKIP semantics so CI and tooling can consume validation outcomes reliably.

### Description

- Add `docs/manuals/RVIZ_MOVEIT_SIMULATION_VALIDATION.md` which defines purpose/scope and states this is not real-hardware validation. 
- Include headless examples using `launch_rviz:=false use_fake_hardware:=true` and GUI examples using `launch_rviz:=true use_fake_hardware:=true` plus an `rviz_config` example. 
- Define standardized result semantics (`PASS`, `WARN`, `FAIL`, `SKIP`) and require a JSON report at `artifacts/reports/rviz_moveit_simulation_validation.json` with specific keys such as `validation_name`, `timestamp_utc`, `mode`, `launch_rviz`, `use_fake_hardware`, `status`, `summary`, `checks`, `errors`, and `warnings`. 
- Add an explicit hardware gate requiring `use_fake_hardware:=false` only after manual readiness gates and a separate documented hardware validation process.

### Testing

- This is a documentation-only change and no runtime validation tests were executed. 
- Automated repository commands to create and commit the file succeeded (`git add`/`git commit`) and the file contents were printed for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ed61909ec8331bff363166e4c3f64)