### PR TITLE
Add RViz/MoveIt simulation launch validation script

### DIFF
--- a/scripts/validate_rviz_moveit_simulation_launches.py
+++ b/scripts/validate_rviz_moveit_simulation_launches.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import signal
+import subprocess
+from pathlib import Path
+from typing import Any
+
+DEFAULT_JSON_OUTPUT = Path("build/workcell_studio/rviz_moveit_simulation_launch_report.json")
+DEFAULT_TIMEOUT_SEC = 45
+TAIL_CHARS = 5000
+
+REAL_HARDWARE_TOKENS = [
+    "use_fake_hardware:=false",
+    "fake_hardware:=false",
+    "use_mock_hardware:=false",
+    "hardware_mode:=real",
+    "driver_mode:=real",
+    "hardware_driver",
+    "ur_robot_driver",
+    "realsense",
+    "ethercat",
+    "canopen",
+]
+
+PASS_EVIDENCE_PATTERNS = {
+    "robot_description": ["robot_description"],
+    "robot_state_publisher": ["robot_state_publisher"],
+    "move_group": ["move_group"],
+    "fake_controller": ["fake", "controller_manager", "ros2_control"],
+}
+
+WARN_EVIDENCE_PATTERNS = {
+    "rviz": ["rviz"],
+}
+
+BLOCKER_PATTERNS = {
+    "missing_launch_or_package": ["package '", "not found", "launch file", "does not exist"],
+    "xacro_urdf_failure": ["xacro", "urdf", "error", "failed"],
+    "controller_manager_crash": ["controller_manager", "segmentation fault", "crash", "fatal"],
+    "parse_failure": ["traceback", "syntaxerror", "unable to parse"],
+    "real_driver_attempt": ["ur_robot_driver", "real hardware", "hardware interface", "ethercat", "canopen"],
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate fake-hardware RViz/MoveIt simulation launches for scenes.")
+    parser.add_argument("--scene", help="Single scene name under scenes/<scene>/")
+    parser.add_argument("--all", action="store_true", dest="run_all", help="Run against all discovered scenes")
+    parser.add_argument("--timeout-sec", type=int, default=DEFAULT_TIMEOUT_SEC)
+    parser.add_argument("--headless", action="store_true", help="Imply launch_rviz:=false")
+    parser.add_argument("--launch-rviz", action="store_true", help="Manual GUI mode launch_rviz:=true")
+    parser.add_argument("--json-output", type=Path, default=DEFAULT_JSON_OUTPUT)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def discover_scenes(root: Path) -> list[dict[str, Any]]:
+    scenes_dir = root / "scenes"
+    if not scenes_dir.is_dir():
+        return []
+    discovered: list[dict[str, Any]] = []
+    for path in sorted(scenes_dir.iterdir()):
+        if not path.is_dir():
+            continue
+        launch_file = path / "launch" / "demo.launch.py"
+        discovered.append({
+            "scene": path.name,
+            "scene_path": path,
+            "launch_file": launch_file,
+            "supported": launch_file.is_file(),
+        })
+    return discovered
+
+
+def collect_evidence(blob: str) -> tuple[list[str], list[str], list[str]]:
+    low = blob.lower()
+    evidence: list[str] = []
+    warnings: list[str] = []
+    blockers: list[str] = []
+
+    for key, patterns in PASS_EVIDENCE_PATTERNS.items():
+        if all(p in low for p in patterns):
+            evidence.append(key)
+
+    for key, patterns in WARN_EVIDENCE_PATTERNS.items():
+        if all(p in low for p in patterns):
+            evidence.append(key)
+
+    for key, patterns in BLOCKER_PATTERNS.items():
+        if all(p in low for p in patterns):
+            blockers.append(key)
+
+    if "rviz" not in low:
+        warnings.append("rviz_not_seen_in_logs")
+
+    return evidence, blockers, warnings
+
+
+def safety_violations(command: str) -> list[str]:
+    lower = command.lower()
+    return [token for token in REAL_HARDWARE_TOKENS if token in lower]
+
+
+def run_scene(scene_name: str, launch_file: Path, timeout_sec: int, launch_rviz: bool, dry_run: bool) -> dict[str, Any]:
+    command = f"ros2 launch {scene_name} demo.launch.py use_fake_hardware:=true launch_rviz:={'true' if launch_rviz else 'false'}"
+    print(command)
+
+    result: dict[str, Any] = {
+        "scene": scene_name,
+        "command": command,
+        "status": "SKIP",
+        "timeout": timeout_sec,
+        "launch_file_path": str(launch_file),
+        "use_fake_hardware": True,
+        "launch_rviz": launch_rviz,
+        "evidence": [],
+        "blockers": [],
+        "warnings": [],
+        "stdout_tail": "",
+        "stderr_tail": "",
+    }
+
+    if not launch_file.is_file():
+        result["status"] = "SKIP"
+        result["warnings"].append("unsupported_metadata: missing launch/demo.launch.py")
+        return result
+
+    violations = safety_violations(command)
+    if violations:
+        result["status"] = "FAIL"
+        result["blockers"].append(f"safety_rejected: {', '.join(violations)}")
+        return result
+
+    if dry_run:
+        result["status"] = "SKIP"
+        result["warnings"].append("dry_run")
+        return result
+
+    try:
+        proc = subprocess.Popen(
+            shlex.split(command),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            preexec_fn=os.setsid,
+        )
+        try:
+            stdout, stderr = proc.communicate(timeout=max(1, timeout_sec))
+            timed_out = False
+        except subprocess.TimeoutExpired:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            stdout, stderr = proc.communicate(timeout=5)
+            timed_out = True
+
+        combined = f"{stdout}\n{stderr}"
+        evidence, blockers, warnings = collect_evidence(combined)
+        result["evidence"] = evidence
+        result["blockers"] = blockers
+        result["warnings"] = warnings
+        result["stdout_tail"] = stdout[-TAIL_CHARS:]
+        result["stderr_tail"] = stderr[-TAIL_CHARS:]
+
+        if timed_out and {"robot_description", "robot_state_publisher", "move_group", "fake_controller"}.issubset(set(evidence)) and not blockers:
+            result["status"] = "PASS"
+        elif proc.returncode == 0 and {"robot_description", "robot_state_publisher", "move_group"}.issubset(set(evidence)) and not blockers:
+            result["status"] = "PASS"
+        elif evidence and not blockers:
+            result["status"] = "WARN"
+            if timed_out:
+                result["warnings"].append("timeout_before_full_readiness_confirmation")
+        else:
+            result["status"] = "FAIL"
+            if proc.returncode not in (0, None):
+                result["blockers"].append(f"early_exit_code:{proc.returncode}")
+            if timed_out and not evidence:
+                result["blockers"].append("timeout_no_readiness_evidence")
+
+    except FileNotFoundError:
+        result["status"] = "FAIL"
+        result["blockers"].append("missing ros2 executable / environment not sourced")
+    except Exception as exc:  # broad catch for robust reporting
+        result["status"] = "FAIL"
+        result["blockers"].append(f"launch_execution_exception: {exc}")
+
+    return result
+
+
+def main() -> int:
+    args = parse_args()
+
+    if bool(args.scene) == bool(args.run_all):
+        raise SystemExit("Exactly one of --scene or --all must be provided")
+
+    launch_rviz = True if args.launch_rviz else False
+    if args.headless:
+        launch_rviz = False
+
+    repo_root = Path(__file__).resolve().parents[1]
+    scenes = discover_scenes(repo_root)
+    scene_map = {item["scene"]: item for item in scenes}
+
+    targets: list[dict[str, Any]]
+    if args.scene:
+        if args.scene not in scene_map:
+            raise SystemExit(f"Unknown scene: {args.scene}")
+        targets = [scene_map[args.scene]]
+    else:
+        targets = scenes
+
+    results = [
+        run_scene(
+            scene_name=item["scene"],
+            launch_file=item["launch_file"],
+            timeout_sec=args.timeout_sec,
+            launch_rviz=launch_rviz,
+            dry_run=args.dry_run,
+        )
+        for item in targets
+    ]
+
+    args.json_output.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": "rviz_moveit_simulation_launch_report/v1",
+        "dry_run": args.dry_run,
+        "timeout_sec": args.timeout_sec,
+        "launch_rviz": launch_rviz,
+        "results": results,
+    }
+    args.json_output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    statuses = {entry["status"] for entry in results}
+    if "FAIL" in statuses:
+        return 1
+    if statuses == {"SKIP"}:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide an automated validator to verify that scene demo launches start in a safe, fake-hardware simulation configuration and to detect readiness evidence or blockers from captured logs.
- Make it easy to run targeted or bulk checks against the repository `scenes/*` so CI or developers can detect launch/URDF/controller/driver problems early.

### Description
- Add `scripts/validate_rviz_moveit_simulation_launches.py` which supports `--scene`, `--all`, `--timeout-sec`, `--headless`, `--launch-rviz`, `--json-output` (default `build/workcell_studio/rviz_moveit_simulation_launch_report.json`), and `--dry-run` CLI options.
- Discover scenes from `scenes/*` and require `launch/demo.launch.py` presence per scene; construct and print the exact command `ros2 launch <scene> demo.launch.py use_fake_hardware:=true launch_rviz:=<true|false>` for each target.
- Enforce hard safety checks rejecting known real-hardware intent tokens (e.g. `use_fake_hardware:=false`, `fake_hardware:=false`, `ur_robot_driver`, `ethercat`, etc.) and mark violations as blockers/FAIL.
- When not in dry-run, execute the launch command with a timeout, capture `stdout`/`stderr`, extract evidence/warnings/blockers from logs, classify each scene as `PASS`/`WARN`/`FAIL`/`SKIP`, and emit a per-scene structured JSON entry including tails of output.

### Testing
- Ran `python3 scripts/validate_rviz_moveit_simulation_launches.py --all --dry-run --headless --timeout-sec 5` which executed in dry-run mode and printed the constructed `ros2 launch ...` commands for all discovered scenes (exit 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ed610c2cc833182464cc3694e6c1f)