### PR TITLE
Add RViz/MoveIt launch validation tests and synthetic smoke-launch report handling

### DIFF
--- a/scripts/validate_all_workcell_studio_scenes.py
+++ b/scripts/validate_all_workcell_studio_scenes.py
@@ -164,6 +164,27 @@ def _fake_hardware_command_available(scene_dir: Path) -> bool:
     return (scene_dir / "launch" / "demo.launch.py").exists()
 
 
+def _load_launch_simulation_report(scene_dir: Path) -> tuple[str | None, list[str]]:
+    report_path = scene_dir / "generated" / "fake_hardware_smoke_launch_report.json"
+    if not report_path.exists():
+        return None, []
+    try:
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        return FAIL, [f"launch simulation report unreadable: {exc.__class__.__name__}: {exc}"]
+    if payload.get("schema") != "fake_hardware_smoke_launch_report/v1":
+        return SKIP, ["launch simulation report schema unsupported"]
+    status = str((payload.get("result") or {}).get("status") or "").upper()
+    if status not in {PASS, WARN, FAIL, SKIP}:
+        return WARN, [f"launch simulation report returned unknown status: {status or '(missing)'}"]
+    reasons: list[str] = []
+    for key in ("warnings", "errors"):
+        for msg in (payload.get("result") or {}).get(key, []) or []:
+            if isinstance(msg, str) and msg.strip():
+                reasons.append(f"launch simulation report {key[:-1]}: {msg}")
+    return status, reasons
+
+
 def audit_scene(repo_root: Path, scene_dir: Path) -> SceneAudit:
     files = {k: (scene_dir / rel).exists() for k, rel in REQUIRED_FILES.items()}
     optional = {k: (scene_dir / rel).exists() for k, rel in OPTIONAL_FILES.items()}
@@ -255,10 +276,17 @@ def audit_scene(repo_root: Path, scene_dir: Path) -> SceneAudit:
     preview_status = FAIL if any("mesh index" in b or "visual mesh" in b for b in blockers) else (WARN if preview_reasons or preview_readiness == "degraded" else PASS)
 
     moveit_reasons: list[str] = []
+    launch_report_status, launch_report_reasons = _load_launch_simulation_report(scene_dir)
     if not smoke_available:
         moveit_reasons.append("launch/demo.launch.py missing; fake-hardware smoke command unavailable")
+    moveit_reasons.extend(launch_report_reasons)
     moveit_reasons.extend(_with_prefix("launch warning", launch_warnings))
-    moveit_status = FAIL if not smoke_available else (WARN if moveit_reasons else PASS)
+    if not smoke_available:
+        moveit_status = FAIL
+    elif launch_report_status in {PASS, WARN, FAIL, SKIP}:
+        moveit_status = launch_report_status
+    else:
+        moveit_status = WARN if moveit_reasons else PASS
 
     grasp_planner_reasons: list[str] = []
     if not optional["task_recipe"]:

--- a/tests/test_all_scene_reproducibility.py
+++ b/tests/test_all_scene_reproducibility.py
@@ -79,3 +79,29 @@ def test_scene_warnings_are_grouped_and_non_ambiguous():
         for warning in scene.get("warnings", []):
             assert warning.strip()
             assert any(token in warning.lower() for token in ("missing", "issue", "degraded", "failed", "unreadable", "not in known-scenes"))
+
+
+def test_moveit_launch_readiness_uses_synthetic_launch_report_statuses(tmp_path):
+    from scripts.validate_all_workcell_studio_scenes import audit_scene
+
+    def _mk_scene(name: str, report_status: str):
+        scene = tmp_path / name
+        (scene / "layout").mkdir(parents=True)
+        (scene / "generated").mkdir(parents=True)
+        (scene / "launch").mkdir(parents=True)
+        (scene / "urdf").mkdir(parents=True)
+        (scene / "scene_manifest.yaml").write_text("schema_version: x\n", encoding="utf-8")
+        (scene / "environment.yaml").write_text("schema_version: y\nsupport_surfaces: []\ntask_zones: []\n", encoding="utf-8")
+        (scene / "layout/workcell_studio_layout.yaml").write_text("schema_version: workcell_studio_layout/v1\nitems: [{id: i1, type: marker}]\n", encoding="utf-8")
+        (scene / "launch/demo.launch.py").write_text("# launch\n", encoding="utf-8")
+        (scene / "urdf/scene.urdf").write_text("<robot/>\n", encoding="utf-8")
+        (scene / "generated/scene_visual_mesh_index.json").write_text(json.dumps({"items": [{"render_expected": True}]}), encoding="utf-8")
+        (scene / "generated/fake_hardware_smoke_launch_report.json").write_text(
+            json.dumps({"schema": "fake_hardware_smoke_launch_report/v1", "result": {"status": report_status, "warnings": [], "errors": []}}),
+            encoding="utf-8",
+        )
+        return scene
+
+    assert audit_scene(repo_root=Path(__file__).resolve().parents[1], scene_dir=_mk_scene("s1", "PASS")).readiness["moveit_launch_readiness"].status == "PASS"
+    assert audit_scene(repo_root=Path(__file__).resolve().parents[1], scene_dir=_mk_scene("s2", "WARN")).readiness["moveit_launch_readiness"].status == "WARN"
+    assert audit_scene(repo_root=Path(__file__).resolve().parents[1], scene_dir=_mk_scene("s3", "FAIL")).readiness["moveit_launch_readiness"].status == "FAIL"

--- a/tests/test_rviz_moveit_simulation_launch_validation.py
+++ b/tests/test_rviz_moveit_simulation_launch_validation.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "generate_rviz_moveit_plan_preview_session.py"
+KNOWN_SCENES = ["ur5_2f_test", "ur5_3f_test", "suction_test"]
+
+
+def _request(path: Path) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "offline_plan_preview_request/v1",
+                "request": {
+                    "waypoints": [{"name": "w1"}],
+                    "pick": {"source_id": "pick_zone"},
+                    "place": {"target_id": "place_zone"},
+                    "tool": {"grasp_strategy": "top"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _run(scene: str, out: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    req = _request(out / "req.json")
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--scene-package", str(ROOT / "scenes" / scene), "--plan-preview-request", str(req), "--output-dir", str(out), "--json", *extra],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _session(out: Path) -> dict:
+    return json.loads((out / "rviz_moveit_plan_preview_session.json").read_text(encoding="utf-8"))
+
+
+def test_all_dry_run_like_generation_emits_expected_commands_for_known_scenes(tmp_path):
+    for scene in KNOWN_SCENES:
+        out = tmp_path / scene
+        out.mkdir(parents=True)
+        proc = _run(scene, out, "--allow-missing-launch")
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        cmd = (((_session(out).get("rviz_moveit") or {}).get("suggested_launch") or {}).get("command") or "")
+        assert cmd.startswith("ros2 launch ")
+        assert "demo.launch.py" in cmd
+
+
+def test_use_fake_hardware_true_always_included_and_false_tokens_rejected(tmp_path):
+    out = tmp_path / "ok"
+    out.mkdir()
+    proc = _run("ur5_2f_test", out, "--allow-missing-launch")
+    assert proc.returncode == 0
+    text = (out / "suggested_commands.sh").read_text(encoding="utf-8") + "\n" + json.dumps(_session(out))
+    assert "use_fake_hardware:=true" in text
+    assert "use_fake_hardware:=false" not in text
+    assert "fake_hardware:=false" not in text
+
+
+def test_json_output_schema_and_required_scene_keys(tmp_path):
+    out = tmp_path / "schema"
+    out.mkdir()
+    proc = _run("ur5_2f_test", out, "--allow-missing-launch")
+    assert proc.returncode == 0
+    payload = _session(out)
+    assert payload.get("schema") == "rviz_moveit_plan_preview_session/v1"
+    for key in ("source", "session", "rviz_moveit", "plan_preview", "safety", "readiness", "next_manual_steps"):
+        assert key in payload
+
+
+def test_missing_launch_file_is_fail_without_allow_missing_launch(tmp_path):
+    scene = tmp_path / "scene_no_launch"
+    (scene / "config").mkdir(parents=True)
+    req = _request(tmp_path / "req.json")
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--scene-package", str(scene), "--plan-preview-request", str(req), "--output-dir", str(tmp_path / "out"), "--json"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode != 0
+    summary = json.loads(proc.stdout)
+    assert any("demo.launch.py not found" in b for b in summary.get("blockers", []))
+
+
+def test_unsupported_metadata_classified_as_skip_in_scene_audit(tmp_path):
+    from scripts.validate_all_workcell_studio_scenes import audit_scene
+
+    scene = tmp_path / "ur5_2f_test"
+    (scene / "layout").mkdir(parents=True)
+    (scene / "generated").mkdir(parents=True)
+    (scene / "launch").mkdir(parents=True)
+    (scene / "urdf").mkdir(parents=True)
+    (scene / "scene_manifest.yaml").write_text("schema_version: x\n", encoding="utf-8")
+    (scene / "environment.yaml").write_text("schema_version: y\nsupport_surfaces: []\ntask_zones: []\n", encoding="utf-8")
+    (scene / "layout/workcell_studio_layout.yaml").write_text("schema_version: workcell_studio_layout/v1\nitems: [{id: a, type: marker}]\n", encoding="utf-8")
+    (scene / "launch/demo.launch.py").write_text("# launch\n", encoding="utf-8")
+    (scene / "urdf/scene.urdf").write_text("<robot/>\n", encoding="utf-8")
+    (scene / "generated/scene_visual_mesh_index.json").write_text(json.dumps({"items": [{"render_expected": True}]}), encoding="utf-8")
+    (scene / "generated/fake_hardware_smoke_launch_report.json").write_text(json.dumps({"schema": "unsupported/v0", "result": {"status": "PASS"}}), encoding="utf-8")
+
+    audit = audit_scene(ROOT, scene)
+    assert audit.readiness["moveit_launch_readiness"].status == "SKIP"


### PR DESCRIPTION
### Motivation
- Improve confidence that RViz/MoveIt preview guidance is fake-hardware-only and enable scene-audit readiness to reflect synthetic fake-hardware smoke-launch evidence without requiring a ROS runtime.

### Description
- Add `tests/test_rviz_moveit_simulation_launch_validation.py` to validate generated launch commands for known scenes, require `use_fake_hardware:=true`, reject `use_fake_hardware:=false` and `fake_hardware:=false`, assert session JSON schema and required top-level keys, classify missing launch files as FAIL, and classify unsupported launch-report metadata as SKIP in the scene audit.
- Extend `tests/test_all_scene_reproducibility.py` with a synthetic launch-report consumption test that verifies `moveit_launch_readiness` maps to PASS/WARN/FAIL according to the report's reported status.
- Update `scripts/validate_all_workcell_studio_scenes.py` to optionally read `generated/fake_hardware_smoke_launch_report.json`, return SKIP for unsupported schemas and FAIL for unreadable reports, and incorporate report-derived reasons/status into `moveit_launch_readiness`.

### Testing
- Ran `pytest -q tests/test_rviz_moveit_simulation_launch_validation.py tests/test_all_scene_reproducibility.py` and received `8 passed`.
- The new tests follow existing subprocess/mocking patterns so they run offline and do not require ROS runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ed618c8448331b854d8a0da06b4d4)