### PR TITLE
Add New Cell contract writer tests and document runtime generation behavior

### DIFF
--- a/docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md
+++ b/docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md
@@ -59,3 +59,24 @@ Choose Workspace → New Cell → New Scene → Use Recommended Layout → Add t
 ```bash
 python3 scripts/run_workcell_studio_scene_readiness_gate.py --dry-run-launches
 ```
+
+
+## Runtime generation behavior
+
+The **existing New Cell flow** now drives runtime scene-contract generation directly from UI state (no parallel generator path).
+
+- **Use Recommended Layout** populates starter environment/layout metadata (workbench or primitive fallback, pick/place zones, robot base marker, camera marker/FOV when configured, and conveyor placeholder/spawn line when configured in the existing layout step).
+- **Save Layout / Generate Task Intent / Generate Scene Package** update the scene contract files used by Workcell Studio, including:
+  - `environment.yaml`
+  - `cell_definition.yaml`
+  - `scene_manifest.yaml`
+  - `layout/workcell_studio_layout.yaml`
+  - `task/workcell_builder_task_intent.yaml`
+  - `task/task_recipe_from_builder_intent.yaml` (where supported)
+  - `plan_preview/offline_plan_preview_request.yaml` (where supported)
+  - `launch/demo.launch.py` (or explicit blockers)
+- Primitive fallback behavior is recorded as warning metadata so preview stays usable even when optional meshes are unavailable.
+- Validation path remains the same existing readiness workflow. Recommended command:
+  - `python3 scripts/run_workcell_studio_scene_readiness_gate.py --dry-run-launches`
+
+> Safety policy: generated New Cell scenes are simulation/fake-hardware-first scaffolds and are **not** real-hardware execution approval.

--- a/tests/test_existing_new_cell_contract_writer.py
+++ b/tests/test_existing_new_cell_contract_writer.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import yaml
+from scripts.export_builder_scene_to_cell_definition import export_scene
+
+def _seed_scene(scene: Path) -> None:
+    (scene / "layout").mkdir(parents=True, exist_ok=True)
+    (scene / "generated").mkdir(parents=True, exist_ok=True)
+    (scene / "environment.yaml").write_text(yaml.safe_dump({"scene_name": scene.name, "robot": {"name": "ur5", "base_link": "base_link"}, "end_effector": {"name": "robotiq_85"}, "task_zones": [{"id": "pick_zone_01", "type": "pick_zone", "frame": "world", "dimensions": [0.3,0.2,0.15]}, {"id": "place_zone_01", "type": "place_zone", "frame": "world", "dimensions": [0.3,0.2,0.15]}], "objects": {}, "metadata": {}, "fake_hardware_first": True}, sort_keys=False), encoding="utf-8")
+    (scene / "layout" / "workcell_studio_layout.yaml").write_text(yaml.safe_dump({"schema": "workcell_studio_layout/v1", "items": [{"id": "pick_zone_01", "type": "pick_zone", "editable": True}, {"id": "place_zone_01", "type": "place_zone", "editable": True}], "zones": [{"id": "pick_zone_01", "type": "pick_zone"}, {"id": "place_zone_01", "type": "place_zone"}], "targets": [{"id": "place_zone_01", "type": "bin"}]}, sort_keys=False), encoding="utf-8")
+
+def test_minimal_new_cell_export_writes_core_contract_files(tmp_path: Path):
+    scene = tmp_path / "src" / "scenes" / "demo_cell"; scene.mkdir(parents=True); _seed_scene(scene)
+    result = export_scene(scene, scene / "generated", validate=False)
+    assert (scene / "generated" / "cell_definition.yaml").is_file()
+    assert (scene / "generated" / "environment_layout.yaml").is_file()
+    assert result["generated_by"] == "workcell_builder"
+
+def test_generated_contract_is_fake_hardware_first_and_zone_bound(tmp_path: Path):
+    scene = tmp_path / "src" / "scenes" / "safe_cell"; scene.mkdir(parents=True); _seed_scene(scene)
+    result = export_scene(scene, scene / "generated", validate=False)
+    cell_text = (scene / "generated" / "cell_definition.yaml").read_text(encoding="utf-8").lower()
+    assert "pick_zone_01" in cell_text and "place_zone_01" in cell_text
+    assert "use_fake_hardware:=false" not in cell_text and "fake_hardware:=false" not in cell_text
+    assert "ur_robot_driver" not in cell_text and "ethercat" not in cell_text and "canopen" not in cell_text
+    assert any("incomplete" in w.lower() for w in result.get("warnings", []))


### PR DESCRIPTION
### Motivation
- Make the existing New Cell flow concrete by exercising the export-based contract writer path and ensuring generated scenes are simulation-safe and contain required layout/task tokens. 
- Provide runtime guidance in the New Cell docs so users know the UI-driven file outputs and recommended validation command.

### Description
- Added `tests/test_existing_new_cell_contract_writer.py` to seed a minimal New Cell scene and assert that `generated/cell_definition.yaml` and `generated/environment_layout.yaml` are produced and include pick/place zone bindings and fake-hardware safety tokens. 
- Updated `docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md` with a `## Runtime generation behavior` section describing that the existing New Cell UI flows drive scene-contract generation, recommended layout behavior, primitive fallback semantics, and the recommended readiness-gate command. 
- The change leaves the existing New Cell UI and generator paths intact and focuses on coverage and documentation of the runtime writer behavior.

### Testing
- Ran `python3 -m py_compile scripts/run_workcell_studio_scene_readiness_gate.py` which succeeded. 
- Ran the pytest suite for the affected areas with `pytest -q tests/test_existing_new_cell_contract_writer.py tests/test_existing_new_cell_workflow_contract.py tests/test_workcell_studio_new_cell_button_audit.py tests/test_scene_builder_guided_workflow.py tests/test_workcell_studio_scene_readiness_gate.py` and all tests passed (`19 passed`). 
- Attempted `colcon build --symlink-install --packages-select workcell_builder` in this environment but it failed due to `colcon` not being available; this is an environment limitation and not a change regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee1fe39508331a51854fd377c898f)