### PR TITLE
Wire existing New Cell layout/task actions to persist scene artifacts

### DIFF
--- a/docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md
+++ b/docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md
@@ -80,3 +80,13 @@ The **existing New Cell flow** now drives runtime scene-contract generation dire
   - `python3 scripts/run_workcell_studio_scene_readiness_gate.py --dry-run-launches`
 
 > Safety policy: generated New Cell scenes are simulation/fake-hardware-first scaffolds and are **not** real-hardware execution approval.
+
+## Existing New Cell action wiring
+
+The existing **New Cell** flow now wires runtime actions directly:
+- **Use Recommended Layout** populates starter layout items from current preview metadata.
+- **Save Layout** writes both `layout/workcell_studio_layout.yaml` and `environment.yaml` metadata (including pick/place task zones).
+- **Generate/Update Task Intent** writes task-intent artifacts under `task/` and creates an offline plan preview request.
+- The existing canvas refresh path reads saved layout metadata so editable items show up without manual YAML repair.
+
+This remains the existing New Cell workflow and does **not** introduce a separate generator workflow.

--- a/tests/test_existing_new_cell_layout_action_wiring.py
+++ b/tests/test_existing_new_cell_layout_action_wiring.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+import subprocess
+import yaml
+
+MAIN = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+
+
+def test_new_cell_actions_are_wired_to_runtime_file_outputs():
+    for token in [
+        'Use Recommended Layout: wrote',
+        'workcell_studio_layout.yaml',
+        'existing_new_cell_flow',
+        'task/workcell_builder_task_intent.yaml',
+        'task/task_recipe_from_builder_intent.yaml',
+        'offline_plan_preview_request.yaml',
+    ]:
+        assert token in MAIN
+
+
+def test_save_layout_contract_tokens_present():
+    for token in [
+        'schema_version"] = "workcell_studio_layout/v1"',
+        'schema"] = "workcell_studio_layout/v1"',
+        'fake_hardware_first',
+        'task_zones',
+    ]:
+        assert token in MAIN
+
+
+def test_task_intent_script_writes_zone_bound_intent(tmp_path: Path):
+    scene = tmp_path / 'scene_a'
+    (scene / 'generated').mkdir(parents=True)
+    (scene / 'environment.yaml').write_text(yaml.safe_dump({
+        'scene_name': 'scene_a',
+        'task_zones': [
+            {'id': 'pick_zone', 'type': 'pick'},
+            {'id': 'place_zone', 'type': 'place'},
+        ],
+    }, sort_keys=False), encoding='utf-8')
+    out = scene / 'generated' / 'workcell_builder_task_intent.yaml'
+    cmd = [
+        'python3', 'scripts/create_or_update_builder_task_intent.py',
+        '--scene-package', str(scene),
+        '--task-id', 'scene_a_pick_place',
+        '--task-type', 'pick_place',
+        '--task-template', 'pick_place',
+        '--pick-source', 'pick_zone',
+        '--place-target', 'place_zone',
+        '--grasp-strategy', 'top_grasp_2f',
+        '--output', str(out),
+        '--json',
+    ]
+    subprocess.run(cmd, check=True)
+    payload = yaml.safe_load(out.read_text(encoding='utf-8'))
+    assert payload['task']['pick']['source']['id'] == 'pick_zone'
+    assert payload['task']['place']['target']['id'] == 'place_zone'
+    text = out.read_text(encoding='utf-8').lower()
+    for banned in ['use_fake_hardware:=false', 'fake_hardware:=false', 'ur_robot_driver', 'ethercat', 'canopen']:
+        assert banned not in text

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -2001,7 +2001,7 @@ void MainWindow::refresh_task_intent_panel()
 }
 
 void MainWindow::validate_task_intent_for_selected_scene(){ refresh_task_intent_panel(); append_studio_log("Task intent validation completed (Fake Hardware | No Robot Motion | Preview Only)"); }
-void MainWindow::generate_or_update_task_intent_for_selected_scene(){ if (selected_scene_index_ < 0) return; const auto & sc = scene_browser_result_.scenes[(size_t)selected_scene_index_]; QString script; helper_script_exists("create_or_update_builder_task_intent.py", &script); workcell_builder::TaskIntentCommandInput input; input.scene_package = QString::fromStdString(sc.scene_dir.string()); input.task_id = QString::fromStdString(sc.scene_name) + "_pick_place"; input.task_type = "pick_place"; input.task_template = "pick_place"; input.grasp_strategy = "finger_top"; const auto resolved_input = workcell_builder::resolve_task_intent_command_input_defaults(input); const auto plan = workcell_builder::build_task_intent_command_plan(script, resolved_input); if (!plan.ready()) { append_studio_log("Generate/Update Task Intent: " + plan.missing_fields_message()); return; } QProcess process; process.start("python3", QStringList() << plan.script_path << plan.arguments); if (!process.waitForFinished(120000)) { append_studio_log("Generate/Update Task Intent: timed out while waiting for helper script."); return; } const int exit_code = process.exitCode(); const QString stdout_text = QString::fromUtf8(process.readAllStandardOutput()).trimmed(); const QString stderr_text = QString::fromUtf8(process.readAllStandardError()).trimmed(); if (exit_code != 0) { append_studio_log(QString("Generate/Update Task Intent failed (exit=%1).").arg(exit_code)); if (!stderr_text.isEmpty()) append_studio_log("stderr: " + stderr_text.left(400)); if (!stdout_text.isEmpty()) append_studio_log("stdout: " + stdout_text.left(400)); return; } append_studio_log("Generate/Update Task Intent: " + plan.display_command() + " (Preview Only)"); if (!stdout_text.isEmpty()) append_studio_log("stdout: " + stdout_text.left(400)); refresh_task_intent_panel(); refresh_new_cell_checklist(); }
+void MainWindow::generate_or_update_task_intent_for_selected_scene(){ if (selected_scene_index_ < 0) return; const auto & sc = scene_browser_result_.scenes[(size_t)selected_scene_index_]; QString script; helper_script_exists("create_or_update_builder_task_intent.py", &script); workcell_builder::TaskIntentCommandInput input; input.scene_package = QString::fromStdString(sc.scene_dir.string()); input.task_id = QString::fromStdString(sc.scene_name) + "_pick_place"; input.task_type = "pick_place"; input.task_template = "pick_place"; input.grasp_strategy = "finger_top"; const auto resolved_input = workcell_builder::resolve_task_intent_command_input_defaults(input); const auto plan = workcell_builder::build_task_intent_command_plan(script, resolved_input); if (!plan.ready()) { append_studio_log("Generate/Update Task Intent: " + plan.missing_fields_message()); return; } QProcess process; process.start("python3", QStringList() << plan.script_path << plan.arguments); if (!process.waitForFinished(120000)) { append_studio_log("Generate/Update Task Intent: timed out while waiting for helper script."); return; } const int exit_code = process.exitCode(); const QString stdout_text = QString::fromUtf8(process.readAllStandardOutput()).trimmed(); const QString stderr_text = QString::fromUtf8(process.readAllStandardError()).trimmed(); if (exit_code != 0) { append_studio_log(QString("Generate/Update Task Intent failed (exit=%1).").arg(exit_code)); if (!stderr_text.isEmpty()) append_studio_log("stderr: " + stderr_text.left(400)); if (!stdout_text.isEmpty()) append_studio_log("stdout: " + stdout_text.left(400)); return; } append_studio_log("Generate/Update Task Intent: " + plan.display_command() + " (Preview Only)"); if (!stdout_text.isEmpty()) append_studio_log("stdout: " + stdout_text.left(400)); const fs::path task_dir = sc.scene_dir / "task"; boost::system::error_code ec; fs::create_directories(task_dir, ec); fs::create_directories(sc.scene_dir / "plan_preview", ec); const fs::path config_path = sc.scene_dir / "config" / "workcell_builder_task_intent.yaml"; const fs::path generated_path = sc.scene_dir / "generated" / "workcell_builder_task_intent.yaml"; const fs::path source_path = fs::exists(config_path) ? config_path : generated_path; if (fs::exists(source_path)) { fs::copy_file(source_path, task_dir / "workcell_builder_task_intent.yaml", fs::copy_option::overwrite_if_exists, ec); if (ec) append_studio_log(QString("WARN Generate/Update Task Intent: failed writing task/workcell_builder_task_intent.yaml (%1)").arg(QString::fromStdString(ec.message()))); ec.clear(); fs::copy_file(source_path, task_dir / "task_recipe_from_builder_intent.yaml", fs::copy_option::overwrite_if_exists, ec); if (ec) append_studio_log(QString("WARN Generate/Update Task Intent: failed writing task/task_recipe_from_builder_intent.yaml (%1)").arg(QString::fromStdString(ec.message()))); std::ofstream preview((sc.scene_dir / "plan_preview" / "offline_plan_preview_request.yaml").string()); preview << "schema: offline_plan_preview_request/v1\nscene_name: " << sc.scene_name << "\nsource: existing_new_cell_flow\n"; preview.close(); } else { append_studio_log("WARN Generate/Update Task Intent: helper succeeded but no generated/config task intent file was found."); } refresh_task_intent_panel(); refresh_new_cell_checklist(); }
 void MainWindow::generate_yaml_draft_for_selected_scene()
 {
   if (selected_scene_index_ < 0) return;
@@ -4141,6 +4141,17 @@ void MainWindow::save_layout_changes()
   if (!digital_twin_scene_) return;
   const fs::path layout_path = selected_scene_environment_layout_path(scene_browser_result_, selected_scene_index_);
   if (layout_path.empty()) return;
+  const fs::path scene_dir = layout_path.parent_path().parent_path();
+  const std::array<const char *, 4> required_dirs = {"layout", "task", "generated", "plan_preview"};
+  for (const char * dir_name : required_dirs) {
+    boost::system::error_code mk_ec;
+    fs::create_directories(scene_dir / dir_name, mk_ec);
+    if (mk_ec) {
+      append_studio_log(QString("Save Layout failed: cannot create %1/ (%2)")
+        .arg(dir_name, QString::fromStdString(mk_ec.message())));
+      return;
+    }
+  }
   const std::string scene_name = (selected_scene_index_ >= 0 && selected_scene_index_ < static_cast<int>(scene_browser_result_.scenes.size())) ?
     scene_browser_result_.scenes[static_cast<size_t>(selected_scene_index_)].scene_name : "unknown";
   YAML::Node root;
@@ -4254,6 +4265,46 @@ void MainWindow::save_layout_changes()
   launch_artifacts_ready_ = false;
   if (layout_state_label_) layout_state_label_->setText("Unsaved Layout Edits: none");
   append_studio_log(QString("Saved scene layout metadata to %1").arg(QString::fromStdString(layout_path.string())));
+  const fs::path workcell_layout_path = scene_dir / "layout" / "workcell_studio_layout.yaml";
+  YAML::Node workcell_layout(YAML::NodeType::Map);
+  workcell_layout["schema_version"] = "workcell_studio_layout/v1";
+  workcell_layout["schema"] = "workcell_studio_layout/v1";
+  workcell_layout["scene_name"] = scene_name;
+  YAML::Node items(YAML::NodeType::Sequence);
+  for (const auto & node : updated_placed) {
+    YAML::Node item = YAML::Clone(node);
+    item["source"] = "existing_new_cell_flow";
+    items.push_back(item);
+  }
+  workcell_layout["items"] = items;
+  std::ofstream workcell_out(workcell_layout_path.string());
+  workcell_out << workcell_layout;
+  workcell_out.close();
+  append_studio_log(QString("Save Layout: wrote editable layout items to %1")
+    .arg(QString::fromStdString(workcell_layout_path.string())));
+
+  YAML::Node environment(YAML::NodeType::Map);
+  environment["scene_name"] = scene_name;
+  environment["fake_hardware_first"] = true;
+  environment["safety_note"] = "Preview metadata only. Not approval for real-hardware execution.";
+  YAML::Node task_zones(YAML::NodeType::Sequence);
+  for (const auto & node : updated_placed) {
+    const std::string type = workcell_builder::yaml_map_value_or_empty(node, "type");
+    if (type == "pick_zone" || type == "place_zone") {
+      YAML::Node zone(YAML::NodeType::Map);
+      zone["id"] = workcell_builder::yaml_map_value_or_empty(node, "id");
+      zone["type"] = type == "pick_zone" ? "pick" : "place";
+      zone["source"] = "existing_new_cell_flow";
+      task_zones.push_back(zone);
+    }
+  }
+  environment["task_zones"] = task_zones;
+  const fs::path environment_path = scene_dir / "environment.yaml";
+  std::ofstream env_out(environment_path.string());
+  env_out << environment;
+  env_out.close();
+  append_studio_log(QString("Save Layout: wrote environment metadata to %1")
+    .arg(QString::fromStdString(environment_path.string())));
   refresh_scene_builder_left_explorer();
   if (scene_preview_widget_) {
     if (!selected_preview_id.isEmpty()) {
@@ -4312,7 +4363,8 @@ void MainWindow::create_starter_layout_from_preview()
     append_studio_log("Create Starter Layout failed: write error while saving starter layout.");
     return;
   }
-  append_studio_log(QString("Create Starter Layout success: wrote %1 item(s) to %2").arg(model.items.size()).arg(QString::fromStdString(layout_file.string())));
+  append_studio_log(QString("Use Recommended Layout: wrote %1 item(s) to %2").arg(model.items.size()).arg(QString::fromStdString(layout_file.string())));
+  append_studio_log("Use Recommended Layout: added recommended editable layout items from current preview metadata.");
   rebuild_digital_twin_canvas();
   refresh_scene_builder_left_explorer();
   refresh_scene_builder_selected_scene_ui();


### PR DESCRIPTION
## Summary
- Wired existing New Cell runtime path so **Save Layout** now ensures required output folders and writes:
  - `layout/workcell_studio_layout.yaml` with `workcell_studio_layout/v1` schema markers and `existing_new_cell_flow` source tag
  - `environment.yaml` with `scene_name`, `task_zones`, and fake-hardware-first safety metadata
- Updated **Use Recommended Layout** logging to explicitly report starter item generation via the existing action path.
- Extended **Generate/Update Task Intent** post-processing to mirror generated intent into:
  - `task/workcell_builder_task_intent.yaml`
  - `task/task_recipe_from_builder_intent.yaml`
  - `plan_preview/offline_plan_preview_request.yaml`
  while emitting WARN logs instead of crashing when artifacts are unavailable.
- Added focused test coverage in `tests/test_existing_new_cell_layout_action_wiring.py` for action wiring tokens and task-intent artifact content behavior.
- Added docs section in `docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md` describing the existing New Cell action wiring behavior.

## Validation
- `python3 -m py_compile scripts/run_workcell_studio_scene_readiness_gate.py`
- `pytest -q tests/test_existing_new_cell_layout_action_wiring.py tests/test_existing_new_cell_contract_writer.py tests/test_existing_new_cell_workflow_contract.py tests/test_workcell_studio_new_cell_flow.py tests/test_workcell_studio_new_cell_button_audit.py tests/test_scene_builder_guided_workflow.py tests/test_workcell_studio_scene_readiness_gate.py`
- `python3 scripts/run_workcell_studio_scene_readiness_gate.py --dry-run-launches`
- `colcon build --symlink-install --packages-select workcell_builder` *(not available in this environment: `colcon: command not found`)*

## Notes
- Changes stay within the existing New Cell UI flow and do not introduce a new workflow, new buttons, or a separate generator path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee41aa380833184ea8cd32cb534a4)