### PR TITLE
Wire existing 3D canvas selection to inspector transform editing and deterministic save-back

### DIFF
--- a/docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md
+++ b/docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md
@@ -103,3 +103,13 @@ This remains the existing New Cell workflow and does **not** introduce a separat
 - When mesh files are missing or unsupported, preview logs warnings and uses primitive fallback geometry so canvas inspection remains usable.
 - Camera FOV and conveyor metadata are represented with placeholder/frustum/primitive visuals when available.
 - This canvas is for layout/preview only: it is not physics simulation and not real-hardware approval.
+
+## 3D selection and transform editing
+
+- Click an item in the existing Scene3D canvas to select it and highlight it.
+- The existing inspector/details area shows ID, type, source, editable/locked status, XYZ/RPY, and dimensions where applicable.
+- Editable layout items can be changed via inspector XYZ/RPY and dimensions fields.
+- Locked/generated preview items remain selectable for inspection but are read-only in the inspector.
+- Use the existing **Save Layout** action to persist edits to `layout/workcell_studio_layout.yaml`.
+- Pick/place zone edits are propagated to `environment.yaml` task-zone metadata.
+- This remains preview/layout editing only (no physics and no real-hardware approval).

--- a/tests/test_3d_canvas_selection_transform_roundtrip.py
+++ b/tests/test_3d_canvas_selection_transform_roundtrip.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MAIN_CPP = (ROOT / 'workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+MAIN_H = (ROOT / 'workcell_builder/workcell_builder/gui/mainwindow.h').read_text(encoding='utf-8')
+PREVIEW_H = (ROOT / 'workcell_builder/workcell_builder/gui/scene_preview_widget.h').read_text(encoding='utf-8')
+CANVAS_MODEL_CPP = (ROOT / 'workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp').read_text(encoding='utf-8')
+
+
+def test_layout_item_model_supports_required_types():
+    for token in ['robot_base', 'pick_zone', 'place_zone', 'camera', 'camera_fov', 'conveyor', 'spawn_line']:
+        assert token in CANVAS_MODEL_CPP or token in PREVIEW_H or token in MAIN_CPP
+
+
+def test_selection_sync_and_inspector_editability_contract_present():
+    for token in [
+        'preview_item_selected',
+        'apply_scene_selection',
+        'scene_hierarchy_tree_->setCurrentItem',
+        'setReadOnly(locked)',
+        'inspector_dim_x_',
+        'inspector_dim_y_',
+        'inspector_dim_z_',
+    ]:
+        assert token in MAIN_CPP or token in MAIN_H
+
+
+def test_transform_and_dimensions_update_selected_item_only_contract_present():
+    for token in [
+        'digital_twin_scene_->selectedItems().front()',
+        'setData(RolePoseZ',
+        'setData(RoleRoll',
+        'setData(RolePitch',
+        'setData(RoleYaw',
+        'setData(RoleWidth',
+        'setData(RoleDepth',
+        'setData(RoleHeight',
+    ]:
+        assert token in MAIN_CPP
+
+
+def test_save_roundtrip_preserves_metadata_and_updates_task_zones_contract_present():
+    for token in [
+        'workcell_studio_layout.yaml',
+        'item["id"]',
+        'item["type"]',
+        'item["source_path"]',
+        'item["editable"]',
+        'item["locked"]',
+        'pose["xyz"]',
+        'pose["rpy"]',
+        'item["dimensions"]',
+        'environment["task_zones"]',
+    ]:
+        assert token in MAIN_CPP
+
+
+def test_locked_item_edit_rejected_and_no_real_hardware_banned_tokens():
+    assert 'Locked/generated item edit rejected' in MAIN_CPP
+    banned = ['use_fake_hardware:=false', 'fake_hardware:=false', 'ur_robot_driver', 'ethercat', 'canopen']
+    scan = '\n'.join([PREVIEW_H, CANVAS_MODEL_CPP]).lower()
+    for token in banned:
+        assert token not in scan

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1470,6 +1470,11 @@ void MainWindow::setup_studio_shell()
   inspector_roll_ = new QDoubleSpinBox(scene_builder); inspector_roll_->setPrefix("r "); pose_grid->addWidget(inspector_roll_, 1, 0);
   inspector_pitch_ = new QDoubleSpinBox(scene_builder); inspector_pitch_->setPrefix("p "); pose_grid->addWidget(inspector_pitch_, 1, 1);
   inspector_yaw_ = new QDoubleSpinBox(scene_builder); inspector_yaw_->setPrefix("yaw "); pose_grid->addWidget(inspector_yaw_, 1, 2);
+  auto * dim_grid = new QGridLayout();
+  inspector_dim_x_ = new QDoubleSpinBox(scene_builder); inspector_dim_x_->setPrefix("dx "); dim_grid->addWidget(inspector_dim_x_, 0, 0);
+  inspector_dim_y_ = new QDoubleSpinBox(scene_builder); inspector_dim_y_->setPrefix("dy "); dim_grid->addWidget(inspector_dim_y_, 0, 1);
+  inspector_dim_z_ = new QDoubleSpinBox(scene_builder); inspector_dim_z_->setPrefix("dz "); dim_grid->addWidget(inspector_dim_z_, 0, 2);
+  selection_tab_layout->addLayout(dim_grid);
   selected_item_card_layout->addLayout(pose_grid);
   inspector_live_update_box_ = new QCheckBox("Live update", scene_builder); inspector_live_update_box_->setChecked(false); selection_tab_layout->addWidget(inspector_live_update_box_);
   auto * transform_actions = new QHBoxLayout();
@@ -1735,12 +1740,14 @@ connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo
   connect(duplicate_layout_button_, &QPushButton::clicked, this, &MainWindow::duplicate_selected_item);
   connect(delete_layout_button_, &QPushButton::clicked, this, &MainWindow::delete_selected_item);
   for (auto *sb : {inspector_x_, inspector_y_, inspector_z_, inspector_roll_, inspector_pitch_, inspector_yaw_}) connect(sb, qOverload<double>(&QDoubleSpinBox::valueChanged), this, [this](double){ if (inspector_live_update_box_ && inspector_live_update_box_->isChecked()) apply_selection_transform_from_editor(); });
+  for (auto *sb : {inspector_dim_x_, inspector_dim_y_, inspector_dim_z_}) connect(sb, qOverload<double>(&QDoubleSpinBox::valueChanged), this, [this](double){ if (inspector_live_update_box_ && inspector_live_update_box_->isChecked()) apply_selection_transform_from_editor(); });
   connect(inspector_apply_button_, &QPushButton::clicked, this, &MainWindow::apply_selection_transform_from_editor);
   connect(inspector_revert_button_, &QPushButton::clicked, this, &MainWindow::revert_selection_transform_editor);
   connect(inspector_copy_transform_button_, &QPushButton::clicked, this, &MainWindow::copy_selection_transform_to_clipboard);
   connect(inspector_paste_transform_button_, &QPushButton::clicked, this, &MainWindow::paste_selection_transform_from_clipboard);
   inspector_x_->setToolTip("X position in metres"); inspector_y_->setToolTip("Y position in metres"); inspector_z_->setToolTip("Z position in metres");
   inspector_roll_->setToolTip("Roll in radians"); inspector_pitch_->setToolTip("Pitch in radians"); inspector_yaw_->setToolTip("Yaw in radians");
+  inspector_dim_x_->setToolTip("Dimension X in metres"); inspector_dim_y_->setToolTip("Dimension Y in metres"); inspector_dim_z_->setToolTip("Dimension Z in metres");
   connect(save_layout_button_, &QPushButton::clicked, this, &MainWindow::save_layout_changes);
   connect(create_starter_layout_button_, &QPushButton::clicked, this, &MainWindow::create_starter_layout_from_preview);
   connect(select_mode_button, &QPushButton::clicked, this, [this](){ set_canvas_interaction_mode(CanvasInteractionMode::Select); });
@@ -4061,7 +4068,10 @@ void MainWindow::apply_scene_selection(const QString & id, const QString & role,
     sync_selected_item_state();
     refresh_selected_scene_item_labels(selected_item_state_);
   }
-  append_studio_log(QString("Selected item: %1 (%2)").arg(selected_id, selected_role));
+  const auto selected_state = current_selected_scene_item();
+  append_studio_log(QString("Selected item: %1 (%2) type=%3 source=%4 editable=%5 locked=%6")
+    .arg(selected_id, selected_role, selected_state.role_or_category, selected_state.source_path,
+      selected_state.editable ? "true" : "false", selected_state.locked ? "true" : "false"));
 }
 
 void MainWindow::mark_layout_dirty(const QString & reason)
@@ -4419,7 +4429,13 @@ void MainWindow::refresh_selection_transform_editor_from_item(QGraphicsItem * it
   inspector_update_guard_ = true;
   inspector_x_->setValue(item->pos().x() / 100.0); inspector_y_->setValue(item->pos().y() / 100.0); inspector_z_->setValue(item->data(RolePoseZ).toDouble());
   inspector_roll_->setValue(item->data(RoleRoll).toDouble()); inspector_pitch_->setValue(item->data(RolePitch).toDouble()); inspector_yaw_->setValue(item->data(RoleYaw).toDouble());
+  inspector_dim_x_->setValue(item->data(RoleWidth).toDouble());
+  inspector_dim_y_->setValue(item->data(RoleDepth).toDouble());
+  inspector_dim_z_->setValue(item->data(RoleHeight).toDouble());
   for (auto * sb : {inspector_x_, inspector_y_, inspector_z_, inspector_roll_, inspector_pitch_, inspector_yaw_}) {
+    if (sb) sb->setReadOnly(locked);
+  }
+  for (auto * sb : {inspector_dim_x_, inspector_dim_y_, inspector_dim_z_}) {
     if (sb) sb->setReadOnly(locked);
   }
   if (inspector_apply_button_) inspector_apply_button_->setEnabled(!locked);
@@ -4430,7 +4446,7 @@ void MainWindow::refresh_selection_transform_editor_from_item(QGraphicsItem * it
 
 void MainWindow::apply_selection_transform_from_editor() { apply_inspector_pose_to_item(); }
 
-void MainWindow::apply_inspector_pose_to_item(){ if(inspector_update_guard_ || !digital_twin_scene_ || digital_twin_scene_->selectedItems().isEmpty()) return; auto *i=digital_twin_scene_->selectedItems().front(); if (i->data(RoleLocked).toBool()) return; QPointF old=i->pos(); i->setPos(inspector_x_->value()*100.0, inspector_y_->value()*100.0); i->setData(RolePoseZ, inspector_z_->value()); i->setData(RoleRoll, inspector_roll_->value()); i->setData(RolePitch, inspector_pitch_->value()); i->setData(RoleYaw, inspector_yaw_->value()); undo_stack_.push_back({"pose_edit", i->data(RoleId).toString(), old, i->pos(), false, false}); redo_stack_.clear(); mark_layout_dirty("Inspector Pose Edit"); refresh_selection_transform_editor_from_item(i); }
+void MainWindow::apply_inspector_pose_to_item(){ if(inspector_update_guard_ || !digital_twin_scene_ || digital_twin_scene_->selectedItems().isEmpty()) return; auto *i=digital_twin_scene_->selectedItems().front(); if (i->data(RoleLocked).toBool()) { append_studio_log(QString("Locked/generated item edit rejected: %1").arg(i->data(RoleId).toString())); return; } QPointF old=i->pos(); i->setPos(inspector_x_->value()*100.0, inspector_y_->value()*100.0); i->setData(RolePoseZ, inspector_z_->value()); i->setData(RoleRoll, inspector_roll_->value()); i->setData(RolePitch, inspector_pitch_->value()); i->setData(RoleYaw, inspector_yaw_->value()); i->setData(RoleWidth, inspector_dim_x_->value()); i->setData(RoleDepth, inspector_dim_y_->value()); i->setData(RoleHeight, inspector_dim_z_->value()); undo_stack_.push_back({"pose_edit", i->data(RoleId).toString(), old, i->pos(), false, false}); redo_stack_.clear(); mark_layout_dirty("Inspector Pose/Dimensions Edit"); append_studio_log(QString("item updated: %1 type=%2 source=%3 editable=%4 locked=%5").arg(i->data(RoleId).toString(), i->data(RoleType).toString(), i->data(RoleSource).toString(), i->data(RoleLocked).toBool() ? "false":"true", i->data(RoleLocked).toBool() ? "true":"false")); refresh_selection_transform_editor_from_item(i); if (scene_preview_widget_) scene_preview_widget_->update(); }
 
 void MainWindow::revert_selection_transform_editor()
 {

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -399,6 +399,9 @@ private:
   QDoubleSpinBox * inspector_roll_{ nullptr };
   QDoubleSpinBox * inspector_pitch_{ nullptr };
   QDoubleSpinBox * inspector_yaw_{ nullptr };
+  QDoubleSpinBox * inspector_dim_x_{ nullptr };
+  QDoubleSpinBox * inspector_dim_y_{ nullptr };
+  QDoubleSpinBox * inspector_dim_z_{ nullptr };
   QCheckBox * inspector_live_update_box_{ nullptr };
   QPushButton * inspector_apply_button_{ nullptr };
   QPushButton * inspector_revert_button_{ nullptr };


### PR DESCRIPTION
## Summary
Implements runtime behavior to make the existing Scene3D/inspector surfaces usable for editing (no new panel/workflow/buttons):

- Reused existing `ScenePreviewWidget::preview_item_selected -> MainWindow::apply_scene_selection` path for 3D selection sync.
- Extended inspector transform editor to include dimension fields (dx/dy/dz) inside the existing Selection inspector tab.
- Enabled manual pose + dimension edits on editable items and blocked edits for locked/generated items with explicit log messages.
- Kept save path on existing **Save Layout** action; persisted edited pose/dimensions through existing serialization to:
  - `layout/workcell_studio_layout.yaml`
  - `environment.yaml` task-zone metadata for pick/place.
- Added selection/update logs including selected item id/type/source/editable/locked status.
- Added documentation section for “3D selection and transform editing”.

## Files changed
- `workcell_builder/workcell_builder/gui/mainwindow.h`
- `workcell_builder/workcell_builder/gui/mainwindow.cpp`
- `tests/test_3d_canvas_selection_transform_roundtrip.py` (new)
- `docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md`

## Test coverage
Added/updated static contract coverage to verify:
- required item-type/layout metadata tokens
- selection→inspector synchronization hooks
- editable vs locked behavior
- selected-item-only pose/dimension mutation path
- save-roundtrip metadata/token contracts
- banned real-hardware runtime token absence in preview/model-scoped files

## Validation run
- `pytest -q tests/test_3d_canvas_selection_transform_roundtrip.py tests/test_scene3d_true_viewport_contract.py tests/test_existing_new_cell_layout_action_wiring.py tests/test_scene_builder_guided_workflow.py tests/test_workcell_studio_new_cell_flow.py` ✅ (26 passed)
- `colcon build --symlink-install --packages-select workcell_builder` ⚠️ (`colcon` not installed in environment)
- `python3 scripts/run_workcell_studio_scene_readiness_gate.py --dry-run-launches` ✅ (completed with exit 0)

## Notes
- This keeps ROS 2 Humble/Qt5 compatibility and avoids introducing Gazebo/Isaac/physics or new UI surfaces.
- No `epd_Improved` changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee819d8a48331961faad9c41d72a8)