### PR TITLE
Stabilize Scene3D canvas contract with checker & regression tests

### DIFF
--- a/docs/architecture/SCENE3D_CANVAS_CONTRACT.md
+++ b/docs/architecture/SCENE3D_CANVAS_CONTRACT.md
@@ -1,0 +1,86 @@
+# Scene3D Canvas Contract
+
+This document defines the non-optional stability contract for Workcell Builder Scene3D.
+
+## Required Layers
+
+1. `editable_layout`
+   - Owns: authoring objects from `environment.yaml`, `layout/workcell_studio_layout.yaml`, and in-memory layout model.
+   - Must never own: generated URDF visual source-of-truth.
+   - Editability: editable (`editable=true`).
+
+2. `mesh_preview`
+   - Owns: mesh-backed visual preview loaded from `generated/scene_visual_mesh_index.json` when safe.
+   - Must never own: authoring state unless explicitly mapped by user workflow.
+   - Editability: selectable/inspectable, not authoring source.
+
+3. `locked_generated_urdf_visual`
+   - Owns: xacro-expanded URDF visual extraction preview for robot/tool/camera/table/fixtures.
+   - Must never own: editable layout authoring state.
+   - Editability: locked/read-only by default (`editable=false`).
+
+4. `primitive_fallback`
+   - Owns: primitive/bounding-box/simple-shape fallback visuals.
+   - Must never own: generated mesh authority.
+   - Editability: follows originating layout item policy.
+
+5. `overlay`
+   - Owns: visualization overlays only (FOV/zones/safety guidance).
+   - Must never own: scene generation data.
+   - Editability: non-authoring guidance visuals.
+
+## Source-of-Truth Rules
+
+- Authoring source-of-truth is `editable_layout` only.
+- `mesh_preview` and `locked_generated_urdf_visual` are preview layers and must not mutate layout YAML/environment YAML implicitly.
+- `overlay` is visual-only and cannot become data ownership.
+
+## Fallback Rules
+
+- Primitive fallback must remain available whenever mesh preview is missing, unsafe, or disabled.
+- If xacro expansion fails, attempt safe mesh preview and retain primitive fallback.
+- If mesh index is unsafe, logs must report unsafe mesh preview and confirm fallback retained.
+
+## Refresh Rules
+
+- Existing open/refresh/generate scene flows must preserve layer counts and not silently drop items.
+- No-silent-disappearance: items cannot disappear across refresh without diagnostics indicating reason and replacement path.
+
+## Stable Item Schema (contract fields)
+
+Scene3D items expose/track:
+
+- `id`, `label`, `source_layer`, `active_visual_source`, `editable`, `locked_reason`
+- `transform_source`, `source_scene`, `source_file`, `parent_link`
+- `mesh_uri`, `resolved_mesh_path`, `primitive_geometry`
+- `pose_xyz`, `pose_rpy`, `scale`, `diagnostics`
+
+Allowed `source_layer` values:
+
+- `editable_layout`
+- `mesh_preview`
+- `locked_generated_urdf_visual`
+- `primitive_fallback`
+- `overlay`
+
+Allowed `active_visual_source` values:
+
+- `mesh`
+- `expanded_urdf_mesh`
+- `primitive`
+- `placeholder`
+- `overlay`
+
+Additional invariants:
+
+- IDs must be stable across repeated loads.
+- IDs must not contain unresolved `${...}` placeholders when safe xacro-expanded extraction is available.
+- Locked generated URDF items default `editable=false`.
+- Editable layout items remain `editable=true`.
+- Primitive fallback cannot be deleted solely because mesh index exists.
+- If a higher-fidelity visual supersedes fallback rendering, diagnostics must retain fallback relationship metadata.
+
+## Additive Change Rule
+
+**Future 3D canvas PRs must add capabilities as layers or extend existing layers. They must not remove primitive fallback, mesh preview, xacro-expanded preview, or refresh behavior unless the Scene3D contract is intentionally updated and all regression tests are updated.**
+

--- a/docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md
+++ b/docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md
@@ -160,3 +160,12 @@ Audit:
 ```bash
 python3 scripts/run_workcell_studio_scene_readiness_gate.py --dry-run-launches --include-visual-assets
 ```
+
+## Scene3D preview stability
+
+- `editable_layout` is the authoring layer for user-editable items.
+- `locked_generated_urdf_visual` is generated preview from xacro-expanded URDF and remains read-only.
+- `mesh_preview` improves fidelity but does not own authoring state.
+- `primitive_fallback` remains available when meshes are missing/unsafe.
+- Refresh/generate actions should not silently remove visual items.
+- Contract reports are produced by `scripts/check_scene3d_canvas_contract.py` (JSON + Markdown outputs).

--- a/scenes/suction_test/generated/scene_visual_mesh_index.json
+++ b/scenes/suction_test/generated/scene_visual_mesh_index.json
@@ -1,6 +1,9 @@
 {
   "scene_name": "suction_test",
-  "generated_at": "2026-05-21T12:22:39.496839+00:00",
+  "visual_count": 0,
+  "resolved": 0,
+  "unresolved": 0,
+  "generated_at": "2026-05-21T12:38:56.232365+00:00",
   "extractor_version": "2.1",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,

--- a/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json
@@ -1,6 +1,9 @@
 {
   "scene_name": "ur10_2f_test",
-  "generated_at": "2026-05-21T12:22:39.502388+00:00",
+  "visual_count": 0,
+  "resolved": 0,
+  "unresolved": 0,
+  "generated_at": "2026-05-21T12:38:56.479251+00:00",
   "extractor_version": "2.1",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,

--- a/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json
@@ -1,6 +1,9 @@
 {
   "scene_name": "ur3_suction_test",
-  "generated_at": "2026-05-21T12:22:39.508027+00:00",
+  "visual_count": 0,
+  "resolved": 0,
+  "unresolved": 0,
+  "generated_at": "2026-05-21T12:38:56.728725+00:00",
   "extractor_version": "2.1",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,

--- a/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json
@@ -1,6 +1,9 @@
 {
   "scene_name": "ur5_2f_builder_pick_place_demo",
-  "generated_at": "2026-05-21T12:22:39.526349+00:00",
+  "visual_count": 0,
+  "resolved": 0,
+  "unresolved": 0,
+  "generated_at": "2026-05-21T12:38:56.987501+00:00",
   "extractor_version": "2.1",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,

--- a/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json
@@ -1,6 +1,9 @@
 {
   "scene_name": "ur5_2f_sorting_test",
-  "generated_at": "2026-05-21T12:22:39.545253+00:00",
+  "visual_count": 0,
+  "resolved": 0,
+  "unresolved": 0,
+  "generated_at": "2026-05-21T12:38:57.217608+00:00",
   "extractor_version": "2.1",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,

--- a/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
@@ -1,6 +1,9 @@
 {
   "scene_name": "ur5_2f_test",
-  "generated_at": "2026-05-21T12:22:39.561115+00:00",
+  "visual_count": 0,
+  "resolved": 0,
+  "unresolved": 0,
+  "generated_at": "2026-05-21T12:38:57.462226+00:00",
   "extractor_version": "2.1",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,

--- a/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json
@@ -1,6 +1,9 @@
 {
   "scene_name": "ur5_3f_test",
-  "generated_at": "2026-05-21T12:22:39.576370+00:00",
+  "visual_count": 0,
+  "resolved": 0,
+  "unresolved": 0,
+  "generated_at": "2026-05-21T12:38:57.689368+00:00",
   "extractor_version": "2.1",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,

--- a/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json
@@ -1,6 +1,9 @@
 {
   "scene_name": "ur5_airpick4_test",
-  "generated_at": "2026-05-21T12:22:39.591140+00:00",
+  "visual_count": 0,
+  "resolved": 0,
+  "unresolved": 0,
+  "generated_at": "2026-05-21T12:38:57.919842+00:00",
   "extractor_version": "2.1",
   "extraction_mode": "best_effort_recursive",
   "xacro_available": false,

--- a/scripts/check_scene3d_canvas_contract.py
+++ b/scripts/check_scene3d_canvas_contract.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, re
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLACEHOLDER_RE = re.compile(r"\$\{[^}]+\}")
+
+
+def _load_json(path: Path):
+    try:
+        return json.loads(path.read_text(encoding='utf-8'))
+    except Exception:
+        return None
+
+
+def check_scene(scene_dir: Path) -> dict:
+    scene = scene_dir.name
+    layout_path = scene_dir / 'layout' / 'workcell_studio_layout.yaml'
+    has_layout = layout_path.exists()
+    idx = _load_json(scene_dir / 'generated' / 'scene_visual_mesh_index.json') or {}
+    items = idx.get('items', []) if isinstance(idx, dict) else []
+
+    layer_counts = Counter()
+    visual_counts = Counter()
+    unresolved = 0
+    unsafe_reasons = 0
+    locked_generated = 0
+    editable_layout = 0
+    blockers, fixes = [], []
+
+    for i in items:
+        layer = i.get('source_layer') or i.get('item_source') or ('primitive_fallback' if i.get('geometry_type') in {'box','cylinder','sphere'} else 'mesh_preview')
+        visual = i.get('active_visual_source') or ('expanded_urdf_mesh' if i.get('extraction_mode') == 'xacro_expanded' else ('mesh' if i.get('mesh_path') else 'primitive'))
+        layer_counts[layer] += 1
+        visual_counts[visual] += 1
+        item_id = str(i.get('id', ''))
+        unresolved += 1 if PLACEHOLDER_RE.search(item_id) else 0
+        if i.get('unsafe_visual_reason'):
+            unsafe_reasons += 1
+        if layer == 'locked_generated_urdf_visual':
+            if i.get('editable') is not False:
+                blockers.append(f"locked item editable: {item_id}")
+            locked_generated += 1
+        if layer == 'editable_layout':
+            if i.get('editable') is not True:
+                blockers.append(f"editable layout locked: {item_id}")
+            editable_layout += 1
+
+    primitive_count = layer_counts['primitive_fallback']
+    mesh_count = layer_counts['mesh_preview']
+    urdf_count = layer_counts['locked_generated_urdf_visual']
+
+    if not has_layout:
+        blockers.append('missing layout/workcell_studio_layout.yaml')
+    if primitive_count == 0:
+        blockers.append('primitive_fallback layer missing')
+        fixes.append('retain primitive_fallback visuals even when mesh/urdf previews exist')
+    if mesh_count == 0:
+        fixes.append('if safe mesh index exists, map items into mesh_preview layer')
+    if unresolved > 0 and bool(idx.get('safe_for_preview', False)):
+        blockers.append('unresolved placeholders remain in IDs during safe preview')
+
+    status = 'PASS'
+    if blockers:
+        status = 'FAIL'
+    elif mesh_count == 0 or urdf_count == 0:
+        status = 'WARN'
+
+    return {
+        'scene': scene,
+        'editable_layout_count': editable_layout,
+        'mesh_preview_count': mesh_count,
+        'locked_generated_urdf_visual_count': urdf_count,
+        'primitive_fallback_count': primitive_count,
+        'overlay_count': layer_counts['overlay'],
+        'unsafe_visual_reason_count': unsafe_reasons,
+        'unresolved_placeholder_count': unresolved,
+        'contract_status': status,
+        'blockers': blockers,
+        'suggested_fixes': fixes,
+        'source_layer_counts': dict(layer_counts),
+        'active_visual_source_counts': dict(visual_counts),
+    }
+
+
+def markdown(report: list[dict]) -> str:
+    lines = ['# Scene3D Canvas Contract Report', '']
+    for r in report:
+        lines += [f"## {r['scene']} - {r['contract_status']}",
+                  f"- editable_layout_count: {r['editable_layout_count']}",
+                  f"- mesh_preview_count: {r['mesh_preview_count']}",
+                  f"- locked_generated_urdf_visual_count: {r['locked_generated_urdf_visual_count']}",
+                  f"- primitive_fallback_count: {r['primitive_fallback_count']}",
+                  f"- overlay_count: {r['overlay_count']}",
+                  f"- unsafe_visual_reason_count: {r['unsafe_visual_reason_count']}",
+                  f"- unresolved_placeholder_count: {r['unresolved_placeholder_count']}"]
+        if r['blockers']:
+            lines.append('- blockers:'); lines += [f"  - {b}" for b in r['blockers']]
+        if r['suggested_fixes']:
+            lines.append('- suggested_fixes:'); lines += [f"  - {s}" for s in r['suggested_fixes']]
+        lines.append('')
+    return '\n'.join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--scene', action='append')
+    ap.add_argument('--all', action='store_true')
+    ap.add_argument('--json')
+    ap.add_argument('--markdown')
+    args = ap.parse_args()
+
+    scenes = []
+    if args.all:
+        scenes = sorted([p for p in (ROOT / 'scenes').iterdir() if p.is_dir()])
+    elif args.scene:
+        scenes = [ROOT / 'scenes' / s for s in args.scene]
+    else:
+        ap.error('use --all or --scene <name>')
+
+    report = [check_scene(s) for s in scenes if s.exists()]
+    overall = 'PASS' if all(r['contract_status'] == 'PASS' for r in report) else ('FAIL' if any(r['contract_status']=='FAIL' for r in report) else 'WARN')
+    payload = {'overall_status': overall, 'scenes': report}
+
+    if args.json:
+        Path(args.json).write_text(json.dumps(payload, indent=2), encoding='utf-8')
+    if args.markdown:
+        Path(args.markdown).write_text(markdown(report), encoding='utf-8')
+    print(f"Scene3D Contract: {overall}")
+    for r in report:
+        print(f"Layers: editable_layout={r['editable_layout_count']} mesh_preview={r['mesh_preview_count']} locked_generated_urdf_visual={r['locked_generated_urdf_visual_count']} primitive_fallback={r['primitive_fallback_count']} overlay={r['overlay_count']}")
+    raise SystemExit(1 if overall == 'FAIL' else 0)
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_scene3d_canvas_contract.py
+++ b/tests/test_scene3d_canvas_contract.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import json, subprocess
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_contract_document_exists_and_contains_required_rule():
+    text = (ROOT / 'docs' / 'architecture' / 'SCENE3D_CANVAS_CONTRACT.md').read_text(encoding='utf-8')
+    for token in ['editable_layout','mesh_preview','locked_generated_urdf_visual','primitive_fallback','overlay']:
+        assert token in text
+    assert 'must not remove primitive fallback, mesh preview, xacro-expanded preview, or refresh behavior' in text
+
+
+def test_contract_checker_generates_json_and_markdown(tmp_path):
+    out_json = tmp_path / 'report.json'
+    out_md = tmp_path / 'report.md'
+    proc = subprocess.run(['python3', str(ROOT / 'scripts' / 'check_scene3d_canvas_contract.py'), '--scene', 'suction_test', '--json', str(out_json), '--markdown', str(out_md)], capture_output=True, text=True)
+    assert out_json.exists()
+    assert out_md.exists()
+    data = json.loads(out_json.read_text(encoding='utf-8'))
+    assert 'overall_status' in data
+    assert data['scenes']

--- a/tests/test_scene3d_feature_regression_guard.py
+++ b/tests/test_scene3d_feature_regression_guard.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import subprocess, json
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_checker_has_pass_warn_fail_fields(tmp_path):
+    out_json = tmp_path / 'contract.json'
+    subprocess.run(['python3', str(ROOT / 'scripts' / 'check_scene3d_canvas_contract.py'), '--scene', 'suction_test', '--json', str(out_json)], check=False)
+    payload = json.loads(out_json.read_text(encoding='utf-8'))
+    scene = payload['scenes'][0]
+    required = ['scene','editable_layout_count','mesh_preview_count','locked_generated_urdf_visual_count','primitive_fallback_count','overlay_count','unsafe_visual_reason_count','unresolved_placeholder_count','contract_status','blockers','suggested_fixes']
+    for k in required:
+        assert k in scene
+    assert scene['contract_status'] in {'PASS','WARN','FAIL'}
+
+
+def test_no_disallowed_real_hardware_tokens_in_new_contract_assets():
+    banned = ['use_fake_hardware:=false','fake_hardware:=false','ur_robot_driver','ethercat','canopen']
+    targets = [
+        ROOT / 'scripts' / 'check_scene3d_canvas_contract.py',
+        ROOT / 'docs' / 'architecture' / 'SCENE3D_CANVAS_CONTRACT.md',
+    ]
+    for t in targets:
+        text = t.read_text(encoding='utf-8').lower()
+        for b in banned:
+            assert b not in text


### PR DESCRIPTION
### Motivation
- Codify a stable Scene3D canvas contract so future PRs cannot accidentally remove primitive fallback, mesh preview, xacro-expanded URDF preview, or refresh behavior. 
- Provide a machine-checkable regression guard to ensure future changes are additive (layers/extensions) and do not silently drop preview or authoring visuals.

### Description
- Add `docs/architecture/SCENE3D_CANVAS_CONTRACT.md` documenting the five mandatory layers (`editable_layout`, `mesh_preview`, `locked_generated_urdf_visual`, `primitive_fallback`, `overlay`), layer ownership boundaries, fallback/refresh rules, stable item schema, and the additive-change rule. 
- Add `scripts/check_scene3d_canvas_contract.py` which inspects `scenes/*/generated/scene_visual_mesh_index.json`, computes layer/visual counts, checks invariants (IDs, placeholders, editable/locked rules), and emits JSON/Markdown reports and an exit code (PASS/WARN/FAIL). 
- Add regression tests `tests/test_scene3d_canvas_contract.py` and `tests/test_scene3d_feature_regression_guard.py` that verify the contract doc presence and that the checker produces required fields and outputs, and that new assets do not contain disallowed real-hardware tokens. 
- Update `docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md` with a short "Scene3D preview stability" section linking to the checker. 
- Regenerated portable `scenes/*/generated/scene_visual_mesh_index.json` artifacts so the repository includes the portable mesh-index outputs used by the checker.

### Testing
- Compiled key scripts successfully with `python3 -m py_compile scripts/check_scene3d_canvas_contract.py scripts/extract_scene_urdf_visual_mesh_index.py scripts/regenerate_scene_visual_mesh_indexes.py scripts/run_workcell_studio_scene_readiness_gate.py` (success). 
- Ran the full pytest matrix requested with `pytest -q ...`; most tests passed but 6 existing, xacro/visual-dependent tests failed (failures due to empty/partially-generated `visual_items` and strict xacro expectations in this environment). 
- Ran the contract checker across scenes with `python3 scripts/check_scene3d_canvas_contract.py --all --json /tmp/report.json --markdown /tmp/report.md`, which produced JSON/Markdown outputs but returned `FAIL` because the current generated artifacts do not yet satisfy the new contract invariants (this is intentional guard behavior). 
- Regenerated mesh indexes with `python3 scripts/regenerate_scene_visual_mesh_indexes.py --all --portable` (succeeded and updated `scenes/*/generated/scene_visual_mesh_index.json`). 
- `scripts/run_workcell_studio_scene_readiness_gate.py --dry-run-launches --include-visual-assets` returned non-zero in this environment and `colcon build` was not executed due to `colcon` not being available here; these are environment limitations unrelated to the contract code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0efc5c13188331b8aeea30e98d7a50)