### PR TITLE
Add Scene3D translate gizmo docs and guard tests

### DIFF
--- a/docs/architecture/SCENE3D_CANVAS_CONTRACT.md
+++ b/docs/architecture/SCENE3D_CANVAS_CONTRACT.md
@@ -92,3 +92,13 @@ Additional invariants:
 - `mesh_preview` is a visual aid and does not become authoring state by selection.
 - `primitive_fallback` must remain available even when mesh/URDF preview is present.
 - Inspector transform writes must target authoring layout sources only and must not mutate generated artifacts (`scene.urdf.xacro`, expanded preview data, mesh index JSON, or generated preview files).
+
+## Translate gizmo and drag editing rules
+
+- Drag translation is available only for editable authoring-backed items.
+- Generated visuals remain inspectable/selectable but locked (no drag gizmo).
+- `mesh_preview` remains a visual aid by default and only participates in editing when explicitly mapped to editable layout state.
+- `primitive_fallback` can be editable only when linked to editable layout state.
+- Dragging provides preview movement only; authoring YAML is not written on every mouse move.
+- Drag commit writes only authoring layout XYZ transforms and preserves other transform fields.
+- Drag editing must not mutate generated artifacts (`generated/scene.urdf.xacro`, expanded URDF preview data, mesh index files, generated preview artifacts).

--- a/docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md
+++ b/docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md
@@ -169,3 +169,14 @@ python3 scripts/run_workcell_studio_scene_readiness_gate.py --dry-run-launches -
 - `primitive_fallback` remains available when meshes are missing/unsafe.
 - Refresh/generate actions should not silently remove visual items.
 - Contract reports are produced by `scripts/check_scene3d_canvas_contract.py` (JSON + Markdown outputs).
+
+## Dragging editable 3D items
+
+- Select an editable layout item in Scene3D.
+- Use the Scene3D move gizmo/drag affordance to translate the selected item.
+- Inspector XYZ fields track the preview pose while dragging.
+- Releasing the drag commits/saves the final transform back to authoring layout YAML.
+- Generated robot/tool/camera visuals remain locked/read-only even when selected.
+- `mesh_preview` visuals are read-only by default unless explicitly linked to editable layout state.
+- `primitive_fallback` remains available when mesh preview is unavailable.
+- Drag editing does not directly edit generated artifacts.

--- a/tests/test_scene3d_drag_commit_guard.py
+++ b/tests/test_scene3d_drag_commit_guard.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEW_CPP = (ROOT / 'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp').read_text(encoding='utf-8')
+MAIN_CPP = (ROOT / 'workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+
+
+def test_drag_preview_updates_item_pose_without_commit_write_on_mousemove():
+    assert 'if (dragging_gizmo_ && (e->buttons() & Qt::LeftButton) && !selected_id.isEmpty()) {' in VIEW_CPP
+    assert 'it.x = drag_start_pose_.x + snapped' in VIEW_CPP
+    assert 'it.y = drag_start_pose_.y + snapped' in VIEW_CPP
+    assert 'update();' in VIEW_CPP
+
+
+def test_drag_commit_happens_on_mouse_release_via_transform_callback():
+    assert 'void Scene3DViewportWidget::mouseReleaseEvent(QMouseEvent * e)' in VIEW_CPP
+    assert 'if (drag_in_progress_ && !drag_cancelled_ && transform_changed_cb)' in VIEW_CPP
+    assert 'transform_changed_cb(it.id, it.x, it.y, it.z, it.roll, it.pitch, it.yaw);' in VIEW_CPP
+
+
+def test_drag_cancel_restores_previous_pose_and_keeps_selection_path_alive():
+    for token in ['it.x = drag_start_pose_.x;', 'it.y = drag_start_pose_.y;', 'it.z = drag_start_pose_.z;']:
+        assert token in VIEW_CPP
+    assert 'QStringLiteral("Gizmo drag cancelled.")' in VIEW_CPP
+
+
+def test_transform_editing_guard_and_generated_locked_rejection_tokens():
+    assert 'Locked/generated item edit rejected' in MAIN_CPP

--- a/tests/test_scene3d_translate_gizmo.py
+++ b/tests/test_scene3d_translate_gizmo.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEW_CPP = (ROOT / 'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp').read_text(encoding='utf-8')
+
+
+def test_translate_gizmo_editability_gate_tokens_present():
+    assert 'bool item_is_editable_for_gizmo(const ScenePreviewWidget::PreviewItem & it)' in VIEW_CPP
+    assert 'if (it.locked) return false;' in VIEW_CPP
+    assert 'return it.editable;' in VIEW_CPP
+
+
+def test_translate_gizmo_available_for_editable_and_not_for_locked_generated_visuals():
+    assert 'if (!item_is_editable_for_gizmo(it)) {' in VIEW_CPP
+    assert 'status_message_cb(QStringLiteral("Locked: %1").arg(item_locked_reason(it)));' in VIEW_CPP
+
+
+def test_gizmo_pick_move_axis_and_drag_handle_tokens_present():
+    assert 'pick_gizmo_axis_at_screen' in VIEW_CPP
+    assert 'drag_active_handle_ = (axis == "x") ? GizmoHandle::MoveX' in VIEW_CPP
+    assert 'if (gizmo_mode == GizmoMode::Move)' in VIEW_CPP
+
+
+def test_overlay_items_never_show_translate_affordance_rule_documented():
+    assert 'bool is_overlay_only_item(const ScenePreviewWidget::PreviewItem & it)' in VIEW_CPP
+    assert 'role_text.contains("overlay")' in VIEW_CPP


### PR DESCRIPTION
### Motivation

- Make the Scene3D canvas explicitly support safe translate-only drag editing for authoring-backed items by documenting rules and adding regression guards. 
- Ensure editable vs preview/locked layer semantics are enforced and preserved (no mutation of generated artifacts) and that drag preview vs commit semantics are clear. 

### Description

- Added a new contract section `Translate gizmo and drag editing rules` to `docs/architecture/SCENE3D_CANVAS_CONTRACT.md` documenting editable vs locked layers, preview/commit semantics, and prohibition on mutating generated artifacts. 
- Added a new user manual subsection `Dragging editable 3D items` in `docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md` describing operator workflow and inspector integration during drag. 
- Added two guard tests: `tests/test_scene3d_translate_gizmo.py` to validate gizmo editability gating and pick/handle tokens, and `tests/test_scene3d_drag_commit_guard.py` to validate preview-on-drag, commit-on-release, and cancel/restore behavior. 

### Testing

- Ran Python syntax checks with `python3 -m py_compile scripts/check_scene3d_canvas_contract.py scripts/extract_scene_urdf_visual_mesh_index.py scripts/regenerate_scene_visual_mesh_indexes.py scripts/run_workcell_studio_scene_readiness_gate.py` which completed successfully. 
- Ran the full pytest subset with `pytest -q tests/test_scene3d_translate_gizmo.py tests/test_scene3d_drag_commit_guard.py tests/test_scene3d_selection_inspector.py tests/test_scene3d_transform_editing_guard.py tests/test_scene3d_canvas_contract.py tests/test_scene3d_feature_regression_guard.py tests/test_scene3d_true_viewport_contract.py tests/test_expanded_urdf_visual_preview_pipeline.py tests/test_visual_mesh_index_portability.py tests/test_workcell_studio_visual_asset_pipeline.py tests/test_scene_urdf_visual_mesh_index.py` which produced 38 passed and 6 failed tests (failures are in existing mesh-index/xacro-related pipelines and scene indexing in this environment). 
- Ran the contract checker `python3 scripts/check_scene3d_canvas_contract.py --all --json /tmp/scene3d_canvas_contract_report.json --markdown /tmp/scene3d_canvas_contract_report.md` which reported a contract failure (zero layer counts in the current environment). 
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but it failed in this environment because `colcon` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f046d12b88331a5bfc8b5a00e9cb7)