### PR TITLE
Restore preview pose on gizmo Esc without calling commit callback

### DIFF
--- a/tests/test_3d_canvas_selection_transform_roundtrip.py
+++ b/tests/test_3d_canvas_selection_transform_roundtrip.py
@@ -61,3 +61,10 @@ def test_locked_item_edit_rejected_and_no_real_hardware_banned_tokens():
     scan = '\n'.join([PREVIEW_H, CANVAS_MODEL_CPP]).lower()
     for token in banned:
         assert token not in scan
+
+
+def test_escape_cancel_path_does_not_save_layout_or_commit_transform():
+    esc_shortcut_block = MAIN_CPP.split('auto * esc_sc = new QShortcut(QKeySequence(Qt::Key_Escape), scene_builder);', 1)[1].split('; });', 1)[0]
+    assert 'save_layout_changes' not in esc_shortcut_block
+    assert 'mark_layout_dirty' not in esc_shortcut_block
+

--- a/tests/test_scene3d_drag_commit_guard.py
+++ b/tests/test_scene3d_drag_commit_guard.py
@@ -18,10 +18,21 @@ def test_drag_commit_happens_on_mouse_release_via_transform_callback():
     assert 'transform_changed_cb(it.id, it.x, it.y, it.z, it.roll, it.pitch, it.yaw);' in VIEW_CPP
 
 
-def test_drag_cancel_restores_previous_pose_and_keeps_selection_path_alive():
-    for token in ['it.x = drag_start_pose_.x;', 'it.y = drag_start_pose_.y;', 'it.z = drag_start_pose_.z;']:
+def test_drag_cancel_restores_previous_pose_without_commit_callback():
+    for token in [
+        'it.x = drag_start_pose_.x;',
+        'it.y = drag_start_pose_.y;',
+        'it.z = drag_start_pose_.z;',
+        'it.roll = drag_start_pose_.roll;',
+        'it.pitch = drag_start_pose_.pitch;',
+        'it.yaw = drag_start_pose_.yaw;',
+    ]:
         assert token in VIEW_CPP
-    assert 'QStringLiteral("Gizmo drag cancelled.")' in VIEW_CPP
+    esc_block = VIEW_CPP.split('if (e->key() == Qt::Key_Escape) {', 1)[1].split('QOpenGLWidget::keyPressEvent(e);', 1)[0]
+    assert 'transform_changed_cb(it.id, it.x, it.y, it.z, it.roll, it.pitch, it.yaw);' not in esc_block
+    assert 'drag_cancelled_ = true;' in esc_block
+    assert 'update();' in esc_block
+    assert 'QStringLiteral("Gizmo drag cancelled.")' in esc_block
 
 
 def test_transform_editing_guard_and_generated_locked_rejection_tokens():

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1478,7 +1478,7 @@ void Scene3DViewportWidget::keyPressEvent(QKeyEvent * e)
       it.roll = drag_start_pose_.roll;
       it.pitch = drag_start_pose_.pitch;
       it.yaw = drag_start_pose_.yaw;
-      if (transform_changed_cb) transform_changed_cb(it.id, it.x, it.y, it.z, it.roll, it.pitch, it.yaw);
+      // Cancel restores the in-memory preview pose only; commit/save callback is release-only.
       break;
     }
     dragging_gizmo_ = false;


### PR DESCRIPTION
### Motivation
- Canceling a gizmo drag should revert the in-memory preview pose and update the viewport/inspector without triggering the commit/save path. 
- Existing Esc handling restored pose but also invoked the transform commit callback, causing unintended save/dirty side effects.

### Description
- Changed `Scene3DViewportWidget::keyPressEvent` so Esc restores `drag_start_pose_` into the selected preview item and updates the view but does not call `transform_changed_cb`. 
- Preserved existing commit semantics on mouse release (commit remains guarded by `drag_cancelled_`/`drag_in_progress_`).
- Verified there is no other Esc route in `MainWindow` that indirectly triggers a layout save or marks the layout dirty. 
- Updated tests in `tests/test_scene3d_drag_commit_guard.py` and `tests/test_3d_canvas_selection_transform_roundtrip.py` to assert that cancel restores xyz+rpy, sets the cancel state, updates the preview, and does not call the commit/save path.

### Testing
- Ran `pytest -q tests/test_scene3d_drag_commit_guard.py tests/test_3d_canvas_selection_transform_roundtrip.py` and all tests passed (`10 passed`).
- The updated tests assert absence of `transform_changed_cb` invocation in the Esc branch and absence of `save_layout_changes`/`mark_layout_dirty` in the Esc shortcut block. 
- Verified runtime behavior in the widget code: Esc now updates preview state and calls `update()` without invoking the transform commit callback.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f079537f88331bb73dad9bc11f941)