### PR TITLE
Guard Scene3D drag commit callback with XYZ/id validation

### DIFF
--- a/tests/test_scene3d_drag_commit_guard.py
+++ b/tests/test_scene3d_drag_commit_guard.py
@@ -15,7 +15,24 @@ def test_drag_preview_updates_item_pose_without_commit_write_on_mousemove():
 def test_drag_commit_happens_on_mouse_release_via_transform_callback():
     assert 'void Scene3DViewportWidget::mouseReleaseEvent(QMouseEvent * e)' in VIEW_CPP
     assert 'if (drag_in_progress_ && !drag_cancelled_ && transform_changed_cb)' in VIEW_CPP
+    assert "const bool finite_xyz = std::isfinite(it.x) && std::isfinite(it.y) && std::isfinite(it.z);" in VIEW_CPP
+    assert 'const bool bounded_xyz = qAbs(it.x) <= kWorkspaceLimitMeters' in VIEW_CPP
+    assert "const bool id_valid = !it.id.trimmed().isEmpty() && !drag_start_pose_.item_id.trimmed().isEmpty() && it.id == selected_id;" in VIEW_CPP
     assert 'transform_changed_cb(it.id, it.x, it.y, it.z, it.roll, it.pitch, it.yaw);' in VIEW_CPP
+
+
+def test_drag_commit_rejects_invalid_xyz_and_reverts_without_write():
+    assert "if (!id_valid || !finite_xyz || !bounded_xyz) {" in VIEW_CPP
+    for token in ['it.x = drag_start_pose_.x;', 'it.y = drag_start_pose_.y;', 'it.z = drag_start_pose_.z;']:
+        assert token in VIEW_CPP
+    assert "Rejected gizmo drag commit for '%1': invalid final XYZ or mismatched drag source; pose reverted." in VIEW_CPP
+    assert 'if (status_message_cb) status_message_cb(message);' in VIEW_CPP
+    assert 'update();' in VIEW_CPP
+
+
+def test_drag_commit_mismatch_source_emits_discard_message_without_callback_write():
+    assert 'No valid drag source found for commit; change discarded.' in VIEW_CPP
+    assert 'if (!committed && status_message_cb) {' in VIEW_CPP
 
 
 def test_drag_cancel_restores_previous_pose_and_keeps_selection_path_alive():

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -21,11 +21,13 @@
 #include <QtMath>
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <sstream>
 
 namespace {
 constexpr int kMeshTriangleLimit = 100000;
+constexpr double kWorkspaceLimitMeters = 1000.0;
 
 QString snap_mode_label(Scene3DViewportWidget::SnapMode mode)
 {
@@ -1432,10 +1434,35 @@ void Scene3DViewportWidget::mouseReleaseEvent(QMouseEvent * e)
 {
   if (e->button() == Qt::LeftButton) {
     if (drag_in_progress_ && !drag_cancelled_ && transform_changed_cb) {
-      for (const auto & it : items) {
+      bool committed = false;
+      for (auto & it : items) {
         if (it.id != drag_start_pose_.item_id) continue;
+        const bool id_valid = !it.id.trimmed().isEmpty() && !drag_start_pose_.item_id.trimmed().isEmpty() && it.id == selected_id;
+        const bool finite_xyz = std::isfinite(it.x) && std::isfinite(it.y) && std::isfinite(it.z);
+        const bool bounded_xyz = qAbs(it.x) <= kWorkspaceLimitMeters &&
+                                 qAbs(it.y) <= kWorkspaceLimitMeters &&
+                                 qAbs(it.z) <= kWorkspaceLimitMeters;
+        if (!id_valid || !finite_xyz || !bounded_xyz) {
+          it.x = drag_start_pose_.x;
+          it.y = drag_start_pose_.y;
+          it.z = drag_start_pose_.z;
+          it.roll = drag_start_pose_.roll;
+          it.pitch = drag_start_pose_.pitch;
+          it.yaw = drag_start_pose_.yaw;
+          const QString message = QStringLiteral(
+            "Rejected gizmo drag commit for '%1': invalid final XYZ or mismatched drag source; pose reverted.")
+                                    .arg(drag_start_pose_.item_id);
+          qWarning().noquote() << message;
+          if (status_message_cb) status_message_cb(message);
+          update();
+          break;
+        }
         transform_changed_cb(it.id, it.x, it.y, it.z, it.roll, it.pitch, it.yaw);
+        committed = true;
         break;
+      }
+      if (!committed && status_message_cb) {
+        status_message_cb(QStringLiteral("No valid drag source found for commit; change discarded."));
       }
     }
     dragging_gizmo_ = false;


### PR DESCRIPTION
### Motivation
- Prevent invalid or unintended writes when a gizmo drag finishes by validating the final pose before invoking the external transform callback.
- Ensure the final XYZ is numeric and within a sane workspace prior to committing changes to avoid NaNs/inf or wildly out-of-range coordinates.

### Description
- Added a workspace limit constant `kWorkspaceLimitMeters` and commit-time checks in `Scene3DViewportWidget::mouseReleaseEvent` to validate `it.x`, `it.y`, `it.z` using `std::isfinite` and bounding via `qAbs(... ) <= kWorkspaceLimitMeters`.
- Require non-empty IDs and that the dragged item matches the active selection via `it.id == selected_id` before committing.
- On invalid final pose or mismatched drag source revert the item to `drag_start_pose_`, call `update()`, emit a clear status via `status_message_cb`, log a `qWarning`, and skip calling `transform_changed_cb`.
- Add a fallback status message when no valid drag source was committed, and update tests to assert presence of these guards.

### Testing
- Added assertions in `tests/test_scene3d_drag_commit_guard.py` to cover finite/bounded/id validation, revert/no-write behavior, and discard messaging paths.
- Ran the new test module with `pytest -q tests/test_scene3d_drag_commit_guard.py` and observed `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f079769cc8331bfa69d358b1c1037)