### PR TITLE
Strengthen Scene3D runtime regression guard contracts

### DIFF
--- a/tests/test_scene3d_feature_regression_guard.py
+++ b/tests/test_scene3d_feature_regression_guard.py
@@ -72,3 +72,73 @@ def test_feature_regression_behavior_successful_drag_writes_once_cancel_and_read
     assert ro.pose["x"] == 0.0
     assert ro.release() is False
     assert ro.saved == 0
+
+
+MAIN_CPP = (ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+PREVIEW_CPP = (ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.cpp").read_text(encoding="utf-8")
+VIEWPORT_CPP = (ROOT / "workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp").read_text(encoding="utf-8")
+
+
+def test_feature_regression_static_runtime_scene3d_hierarchy_and_layer_contract_tokens_present():
+    for tok in [
+        'p.source_layer = QStringLiteral("editable_layout")',
+        'p.source_layer = QStringLiteral("primitive_fallback")',
+        'p.active_visual_source = QStringLiteral("mesh_preview")',
+        'p.active_visual_source = QStringLiteral("generated_preview")',
+        'p.linked_to_editable_layout_state = true',
+    ]:
+        assert tok in MAIN_CPP
+
+
+def test_feature_regression_static_layer_visibility_toggle_handlers_present():
+    for tok in [
+        'show_warnings_action',
+        'show_labels_action',
+        'set_task_overlay_visibility(',
+        'set_perception_overlay_visibility(',
+        'append_studio_log("overlay toggled")',
+        'v->show_task_route = task_route;',
+        'v->show_pick_place = pick_place_zones;',
+        'v->show_approach_retreat = approach_retreat;',
+    ]:
+        assert tok in MAIN_CPP or tok in PREVIEW_CPP
+
+
+def test_feature_regression_static_selection_sync_stable_id_bidirectional_tokens_present():
+    for tok in [
+        'preview_item_selected',
+        'select_preview_item(id); emit preview_item_selected(id, role);',
+        'it.id == selected_preview_item_id_',
+        'selected_preview_item_id_ = id; static_cast<Scene3DViewportWidget *>(simple_3d_view_)->selected_id = id;',
+        'it.id == selected_id',
+        'find_tree_item_by_id(selected_id)',
+        'find_canvas_item_by_id(selected_id)',
+    ]:
+        assert tok in MAIN_CPP or tok in PREVIEW_CPP or tok in VIEWPORT_CPP
+
+
+def test_feature_regression_static_read_only_enforcement_log_path_present():
+    for tok in [
+        'Locked/generated item edit rejected',
+        'Locked: %1',
+        'generated_robot_visual',
+        'if (generated_robot_visual) return false;',
+    ]:
+        assert tok in MAIN_CPP or tok in VIEWPORT_CPP
+
+
+def test_feature_regression_static_no_generated_artifact_mutation_in_toggle_or_readonly_handlers():
+    relevant_toggle_lines = [line for line in PREVIEW_CPP.splitlines() if 'set_task_overlay_visibility' in line or 'set_perception_overlay_visibility' in line or 'on_clear_selection_clicked' in line]
+    relevant_toggle_lines += [line for line in MAIN_CPP.splitlines() if 'overlay toggled' in line or 'show_warnings_action' in line or 'show_labels_action' in line]
+    relevant_readonly_lines = [line for line in VIEWPORT_CPP.splitlines() if 'generated_robot_visual' in line or 'Locked:' in line or 'item_is_editable_for_gizmo' in line]
+    relevant = '\n'.join(relevant_toggle_lines + relevant_readonly_lines).lower()
+    for forbidden in [
+        'generated_workcell_summary.json',
+        'scene_manifest.yaml',
+        'write',
+        'save_layout',
+        'yaml',
+        'qsavefile',
+        'ofstream',
+    ]:
+        assert forbidden not in relevant

--- a/tests/test_scene3d_transform_editing_guard.py
+++ b/tests/test_scene3d_transform_editing_guard.py
@@ -40,3 +40,15 @@ def test_safety_tokens_absent_in_docs_and_tests_fixture_scope():
     ]).lower()
     for forbidden in ['use_fake_hardware:=false', 'fake_hardware:=false', 'ur_robot_driver', 'ethercat', 'canopen']:
         assert forbidden not in corpus
+
+
+def test_scene3d_contract_runtime_files_not_docs_only():
+    runtime_symbols = [
+        'set_task_overlay_visibility(',
+        'select_preview_item(const QString & id)',
+        'item_is_editable_for_gizmo',
+        'Locked/generated item edit rejected',
+    ]
+    corpus = '\n'.join([MAIN_CPP, (ROOT / 'workcell_builder/workcell_builder/gui/scene_preview_widget.cpp').read_text(encoding='utf-8'), (ROOT / 'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp').read_text(encoding='utf-8')])
+    for symbol in runtime_symbols:
+        assert symbol in corpus


### PR DESCRIPTION
### Motivation
- Ensure regression guards fail when changes are only to docs/tests and do not modify runtime scene3d hierarchy, layer, or selection code paths.
- Make static checks deterministic and tied to concrete runtime symbols to prevent silent contract regressions from documentation-only edits.

### Description
- Added a new static runtime contract test in `tests/test_scene3d_feature_regression_guard.py` that asserts presence of concrete tokens in `mainwindow.cpp`, `scene_preview_widget.cpp`, and `scene3d_viewport_widget.cpp` for layer/source assignments and selection sync paths.
- Added checks for layer visibility toggle handlers and their wiring by asserting tokens such as `set_task_overlay_visibility(`, `set_perception_overlay_visibility(` and `append_studio_log("overlay toggled")` appear in the runtime sources.
- Added read-only enforcement presence checks targeting `Locked/generated item edit rejected`, `generated_robot_visual`, and the `if (generated_robot_visual) return false;` guard in runtime code.
- Added deterministic negative checks that scan toggle/read-only handler slices to ensure no generated-artifact mutation tokens (e.g. `generated_workcell_summary.json`, `scene_manifest.yaml`, `write`, `save_layout`, `yaml`, `qsavefile`, `ofstream`) are introduced in those handlers, and added a companion runtime-symbol gate in `tests/test_scene3d_transform_editing_guard.py`.

### Testing
- Ran `pytest -q tests/test_scene3d_feature_regression_guard.py tests/test_scene3d_transform_editing_guard.py`.
- Result: all tests passed (`13 tests`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f154e08d88331b8cba48b5a33ae61)