### PR TITLE
Canonicalize Scene3D/New Cell camera metadata modes and legacy mapping

### DIFF
--- a/tests/test_existing_new_cell_layout_action_wiring.py
+++ b/tests/test_existing_new_cell_layout_action_wiring.py
@@ -57,3 +57,16 @@ def test_task_intent_script_writes_zone_bound_intent(tmp_path: Path):
     text = out.read_text(encoding='utf-8').lower()
     for banned in ['use_fake_hardware:=false', 'fake_hardware:=false', 'ur_robot_driver', 'ethercat', 'canopen']:
         assert banned not in text
+
+
+def test_new_cell_camera_metadata_canonical_and_legacy_traceability_tokens_present():
+    txt = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+    for token in [
+        'Detection mode: %6',
+        'mapped from legacy: %2',
+        'perception_legacy_source',
+        'snapshot_overlay',
+        'epd_optional',
+        'none (camera metadata only)',
+    ]:
+        assert token in txt

--- a/tests/test_scene3d_camera_fov_overlay.py
+++ b/tests/test_scene3d_camera_fov_overlay.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+MAIN_CPP = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+YAML_UTILS_CPP = Path('workcell_builder/workcell_builder/src_workcell_yaml_utils.cpp').read_text(encoding='utf-8')
+
+
+def test_scene3d_camera_mode_uses_canonical_values_and_legacy_mappers():
+    for token in [
+        'none',
+        'epd_optional',
+        'snapshot_overlay',
+        'live_epd',
+        'saved_snapshot',
+        'manual_simulated',
+        'canonicalize_scene3d_camera_mode',
+    ]:
+        assert token in YAML_UTILS_CPP
+
+
+def test_scene3d_overlay_generation_does_not_require_live_launch_for_snapshot_modes():
+    for token in [
+        'snapshot overlay loaded (no live launch required)',
+        'EPD optional (live runtime launch not required for preview overlays)',
+        'Detection snapshot overlays are preview-only and do not require launching live runtime nodes.',
+    ]:
+        assert token in MAIN_CPP

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -275,6 +275,7 @@ struct SceneTaskIntentSummary
   QString allowed_roll_yaw{"unknown"};
   QString tool_id{"unknown"};
   QString perception_mode{"unknown"};
+  QString perception_legacy_source{""};
   QString clearance{"unknown"};
   QStringList searched_paths;
 };
@@ -419,6 +420,7 @@ static SceneTaskIntentSummary load_scene_task_intent_summary(const fs::path & sc
   if (s.tool_id == "unknown") s.tool_id = scalar_path(task, {"end_effector"});
   const auto perception = workcell_builder::parse_perception_contract_summary(task);
   s.perception_mode = QString::fromStdString(perception.mode);
+  s.perception_legacy_source = QString::fromStdString(perception.legacy_source_mode);
   if (!perception.warning.empty()) {
     static QSet<QString> warned_scene_paths;
     const QString canonical_scene = canonical_scene_path_string(scene_dir);
@@ -1992,7 +1994,8 @@ void MainWindow::refresh_task_intent_panel()
   task_intent_details_label_->setText(QString("Scene: %1\nTask type: %2\nSource task file: %3\nPick source: %4\nPlace target: %5\nObject/class: %6\nStatus badge: %7%8").arg(QString::fromStdString(sc.scene_name), ti.task_type, ti.source_basename, ti.pick_source, ti.place_target, ti.object_class, ti.status, missing));
   pick_place_details_label_->setText(QString("Pick source: %1\nPlace target: %2\nReject/bin target: %3\nLinked hierarchy item status: unknown").arg(ti.pick_source, ti.place_target, ti.reject_target));
   grasp_details_label_->setText(QString("Strategy/ref: %1\nTool/End Effector: %2\nApproach axis: %3\nOrientation mode: %4\nAllowed roll/yaw: %5").arg(ti.grasp_strategy, ti.tool_id, ti.approach_axis, ti.orientation_mode, ti.allowed_roll_yaw));
-  approach_retreat_details_label_->setText(QString("Approach distance: %1\nRetreat distance: %2\nApproach frame/axis: %3\nRetreat frame/axis: %4\nClearance: %5\nDetection mode: %6\nDetection status: %7\nDetails: %8").arg(ti.approach_distance, ti.retreat_distance, ti.approach_axis, ti.retreat_axis, ti.clearance, "Live EPD / RealSense", "Configured", "Live EPD/RealSense uses runtime camera and EPD topics. Saved snapshots are only for offline preview."));
+  const QString detection_mode_line = ti.perception_legacy_source.isEmpty() ? ti.perception_mode : QString("%1 (mapped from legacy: %2)").arg(ti.perception_mode, ti.perception_legacy_source);
+  approach_retreat_details_label_->setText(QString("Approach distance: %1\nRetreat distance: %2\nApproach frame/axis: %3\nRetreat frame/axis: %4\nClearance: %5\nDetection mode: %6\nDetection status: %7\nDetails: %8").arg(ti.approach_distance, ti.retreat_distance, ti.approach_axis, ti.retreat_axis, ti.clearance, detection_mode_line, "Configured", "Detection snapshot overlays are preview-only and do not require launching live runtime nodes."));
   if (!overlay_warnings.isEmpty()) {
     approach_retreat_details_label_->setText(approach_retreat_details_label_->text() + QString("\nOverlay warnings: %1").arg(overlay_warnings.join(" | ")));
   }
@@ -5559,9 +5562,7 @@ void MainWindow::populate_scene_hierarchy()
   preview_warning_details_ = preview_warning_details;
 
   const bool snapshot_available = fs::exists(d / "preview" / "epd_detection_snapshot.png");
-  const bool live_selected = task_summary.perception_mode.compare("live_epd", Qt::CaseInsensitive) == 0;
-  const bool manual_selected = task_summary.perception_mode.compare("manual_simulated", Qt::CaseInsensitive) == 0;
-  const QString perception_mode = snapshot_available ? "saved_snapshot" : (live_selected ? "live_epd" : (manual_selected ? "manual_simulated" : "not_configured"));
+  const QString perception_mode = snapshot_available ? "snapshot_overlay" : task_summary.perception_mode;
 
   QString camera_id;
   for (const auto & p : preview_items) {
@@ -5570,10 +5571,10 @@ void MainWindow::populate_scene_hierarchy()
   const bool has_camera_metadata = !camera_id.trimmed().isEmpty();
 
   QString perception_line;
-  if (perception_mode == "saved_snapshot") perception_line = "Perception: saved snapshot loaded.";
-  else if (perception_mode == "live_epd") perception_line = "Perception: Live EPD/RealSense selected; saved snapshot not required.";
-  else if (perception_mode == "manual_simulated") perception_line = "Perception: manual/simulated mode selected.";
-  else perception_line = "Perception: not configured.";
+  if (perception_mode == "snapshot_overlay") perception_line = "Perception: snapshot overlay loaded (no live launch required).";
+  else if (perception_mode == "epd_optional") perception_line = "Perception: EPD optional (live runtime launch not required for preview overlays).";
+  else perception_line = "Perception: none (camera metadata only).";
+  if (!task_summary.perception_legacy_source.isEmpty()) perception_line += QString(" mapped from legacy mode: %1.").arg(task_summary.perception_legacy_source);
 
   const QString camera_line = has_camera_metadata ? QString("Camera: %1 configured.").arg(camera_id) : "Camera: no camera metadata in this scene.";
   const int urdf_visual_locked_count = visual_preview_added_count;

--- a/workcell_builder/workcell_builder/include/workcell_yaml_utils.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_yaml_utils.hpp
@@ -11,6 +11,7 @@ struct PerceptionContractSummary
   bool enabled{false};
   std::string mode{"legacy_disabled"};
   std::string warning;
+  std::string legacy_source_mode;
 };
 
 std::string yaml_scalar_or_empty(const YAML::Node & node);

--- a/workcell_builder/workcell_builder/src_workcell_yaml_utils.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_yaml_utils.cpp
@@ -3,6 +3,38 @@
 
 namespace workcell_builder
 {
+static std::string to_lower_copy(std::string value)
+{
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c){ return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+static std::string canonicalize_scene3d_camera_mode(const std::string & raw_mode, std::string * legacy_source)
+{
+  const std::string raw_lower = to_lower_copy(raw_mode);
+  if (legacy_source) legacy_source->clear();
+  if (raw_lower.empty()) return "none";
+  if (raw_lower == "none") return "none";
+  if (raw_lower == "epd_optional") return "epd_optional";
+  if (raw_lower == "snapshot_overlay") return "snapshot_overlay";
+
+  if (raw_lower == "live_epd" || raw_lower == "live_epd_realsense" || raw_lower == "live") {
+    if (legacy_source) *legacy_source = raw_mode;
+    return "epd_optional";
+  }
+  if (raw_lower == "saved_snapshot" || raw_lower == "epd_replay") {
+    if (legacy_source) *legacy_source = raw_mode;
+    return "snapshot_overlay";
+  }
+  if (raw_lower == "manual_simulated" || raw_lower == "not_configured" || raw_lower == "disabled") {
+    if (legacy_source) *legacy_source = raw_mode;
+    return "none";
+  }
+
+  if (legacy_source) *legacy_source = raw_mode;
+  return "none";
+}
+
 std::string yaml_scalar_or_empty(const YAML::Node & node)
 {
   if (!node || !node.IsScalar()) return "";
@@ -148,11 +180,13 @@ PerceptionContractSummary parse_perception_contract_summary(const YAML::Node & t
     return out;
   }
   out.enabled = true;
-  out.mode = yaml_map_value_or_empty(perception, "mode");
-  if (out.mode.empty()) {
-    out.mode = "enabled_partial";
-    out.warning = "perception map present but mode missing";
+  const std::string raw_mode = yaml_map_value_or_empty(perception, "mode");
+  if (raw_mode.empty()) {
+    out.mode = "epd_optional";
+    out.warning = "perception map present but mode missing; defaulted to epd_optional";
+    return out;
   }
+  out.mode = canonicalize_scene3d_camera_mode(raw_mode, &out.legacy_source_mode);
   return out;
 }
 }


### PR DESCRIPTION
### Motivation
- Standardize Scene3D / New Cell camera metadata into canonical modes `none`, `epd_optional`, and `snapshot_overlay` so downstream UI/overlay logic is unambiguous.
- Maintain compatibility with existing scenes that use legacy tokens (`live_epd`, `saved_snapshot`, `manual_simulated`, etc.) by mapping them to canonical modes and preserving the original value for traceability.
- Ensure snapshot-based overlay generation is treated as preview-only and does not require launching live runtime nodes, and surface mapping information in the inspector for debugging.

### Description
- Add `canonicalize_scene3d_camera_mode` and helper `to_lower_copy` in `workcell_builder/workcell_builder/src_workcell_yaml_utils.cpp` to map legacy mode strings to canonical modes and capture the legacy source string.
- Extend `PerceptionContractSummary` (header) with `legacy_source_mode` and make `parse_perception_contract_summary` return canonical `mode` (default `epd_optional` when mode missing) while filling `legacy_source_mode` when applicable.
- Propagate the mapped legacy source into `SceneTaskIntentSummary` as `perception_legacy_source` and update `load_scene_task_intent_summary` to use the canonical `perception.mode` and legacy source.
- Update New Cell / Scene inspector and preview summary text in `workcell_builder/workcell_builder/gui/mainwindow.cpp` to display the canonical detection mode and, when present, the legacy source `(mapped from legacy: ...)`, and change perception-summary logic so `snapshot_overlay` and `epd_optional` do not require a live runtime launch.
- Add/extend regression tests: append a token-check test to `tests/test_existing_new_cell_layout_action_wiring.py` and add `tests/test_scene3d_camera_fov_overlay.py` to verify canonical tokens, legacy mapping function presence, and overlay messaging about no live launch requirement.

### Testing
- Ran the new/modified Python tests with `pytest -q tests/test_existing_new_cell_layout_action_wiring.py tests/test_scene3d_camera_fov_overlay.py` and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f20e33a208331bc944350d9f5f7b6)