### PR TITLE
docs: add Scene3D camera/FOV overlay contract and New Cell guidance

### DIFF
--- a/docs/architecture/SCENE3D_CANVAS_CONTRACT.md
+++ b/docs/architecture/SCENE3D_CANVAS_CONTRACT.md
@@ -80,6 +80,17 @@ Additional invariants:
 - Primitive fallback cannot be deleted solely because mesh index exists.
 - If a higher-fidelity visual supersedes fallback rendering, diagnostics must retain fallback relationship metadata.
 
+
+## Camera, FOV, and perception overlay contract
+
+- Camera markers may appear in Scene3D from either editable layout metadata or generated preview sources.
+- When camera marker source is `editable_layout`, pose/metadata edits are allowed through existing authoring controls.
+- When camera marker source is generated preview (`locked_generated_urdf_visual` or `mesh_preview` without explicit mapping), the marker is inspectable only and remains locked/read-only.
+- Camera FOV frustum must render on the `overlay` layer as read-only guidance visuals and must not become an authoring transform owner.
+- Detection snapshot overlays (for example projected detections, historical perception frames, and similar snapshot annotations) must render on the `overlay` layer as read-only visuals.
+- Overlay visuals are preview-only and non-authoritative for scene generation: they must not mutate `environment.yaml`, `layout/workcell_studio_layout.yaml`, task intent files, or generated URDF/mesh artifacts.
+- This feature scope excludes live perception-device launches. No live EPD/RealSense startup, streaming session creation, or hardware bring-up is triggered from Scene3D camera/FOV/detection overlays.
+
 ## Additive Change Rule
 
 **Future 3D canvas PRs must add capabilities as layers or extend existing layers. They must not remove primitive fallback, mesh preview, xacro-expanded preview, or refresh behavior unless the Scene3D contract is intentionally updated and all regression tests are updated.**

--- a/docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md
+++ b/docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md
@@ -38,6 +38,21 @@ When conveyor options are configured, New Cell includes conveyor placeholder/spa
 - Optional missing mesh/asset: WARN + primitive fallback.
 - Missing required robot/tool package: FAIL with clear blocker.
 
+
+## Side-pick camera metadata, Scene3D visualization, and preview warnings
+
+- Side-pick workflows can store camera metadata (camera pose and FOV/frustum parameters) alongside layout/task metadata.
+- `pick_zone` targeting remains authoritative for task intent; camera metadata is supportive context for preview and adapter handoff.
+- In Scene3D, camera and FOV appear as:
+  - camera marker item in canvas/hierarchy (editable only when sourced from `editable_layout`),
+  - FOV frustum guidance on the overlay layer (read-only),
+  - inspector details showing source/editable/locked state and metadata fields.
+- Optional detection snapshot overlays may appear as read-only preview annotations; these represent captured/recorded perception context and not live device state.
+- Warning semantics:
+  - If an indicated detection region is outside configured `pick_zone`, UI/reporting should emit a warning for operator review.
+  - Missing camera metadata or missing FOV/frustum metadata should emit warning-level diagnostics (not implicit hardware failure) so authoring can continue with reduced preview confidence.
+- Preview-only safety note: camera/FOV/detection overlays support visualization and planning context only. They are not hardware approval, not runtime sensor validation, and not authorization to execute on real hardware.
+
 ## Fake-hardware-first safety note
 Generated New Cell scenes are simulation/fake-hardware-first and **must not be treated as real-hardware approval**.
 

--- a/tests/test_workcell_studio_docs.py
+++ b/tests/test_workcell_studio_docs.py
@@ -21,3 +21,31 @@ def test_workcell_studio_docs_positioning() -> None:
     assert "Gazebo Sim" in roadmap_text
     assert "Isaac Sim" in roadmap_text
     assert "Streamlit" in roadmap_text
+
+
+
+def test_scene3d_camera_fov_overlay_contract_docs() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    contract_doc = repo_root / "docs" / "architecture" / "SCENE3D_CANVAS_CONTRACT.md"
+    contract_text = contract_doc.read_text(encoding="utf-8")
+
+    assert "## Camera, FOV, and perception overlay contract" in contract_text
+    assert "camera marker source is `editable_layout`" in contract_text
+    assert "FOV frustum must render on the `overlay` layer as read-only guidance visuals" in contract_text
+    assert "Detection snapshot overlays" in contract_text
+    assert "preview-only and non-authoritative for scene generation" in contract_text
+    assert "No live EPD/RealSense startup" in contract_text
+
+
+def test_new_cell_manual_camera_fov_overlay_guidance() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    manual_doc = repo_root / "docs" / "manuals" / "WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md"
+    manual_text = manual_doc.read_text(encoding="utf-8")
+
+    assert "## Side-pick camera metadata, Scene3D visualization, and preview warnings" in manual_text
+    assert "`pick_zone` targeting remains authoritative" in manual_text
+    assert "FOV frustum guidance on the overlay layer (read-only)" in manual_text
+    assert "Optional detection snapshot overlays may appear as read-only preview annotations" in manual_text
+    assert "outside configured `pick_zone`" in manual_text
+    assert "Missing camera metadata or missing FOV/frustum metadata" in manual_text
+    assert "They are not hardware approval" in manual_text


### PR DESCRIPTION
### Motivation

- Clarify how camera markers, FOV/frustum visuals, and perception snapshot overlays should be rendered and owned by Scene3D preview layers to avoid accidental mutation of authoring data.\n- Make explicit that overlays are preview-only and non-authoritative for scene generation and that this feature will not trigger live perception-device launches.\n- Provide user-facing guidance in the New Cell manual about how camera metadata relates to `pick_zone` semantics and what warnings operators should expect.\n
### Description

- Add a new `## Camera, FOV, and perception overlay contract` section to `docs/architecture/SCENE3D_CANVAS_CONTRACT.md` documenting editable-vs-locked camera marker source rules, FOV frustum and detection snapshots as `overlay`/read-only visuals, preview-only semantics, and an explicit note that no live EPD/RealSense launches occur from this feature.\n- Add `## Side-pick camera metadata, Scene3D visualization, and preview warnings` to `docs/manuals/WORKCELL_STUDIO_NEW_CELL_FROM_SCRATCH.md` describing side-pick camera metadata storage, `pick_zone` authority, how camera/FOV appears in the canvas/hierarchy/inspector, interpretation of optional detection snapshot overlays, and warning semantics for out-of-zone or missing metadata.\n- Update `tests/test_workcell_studio_docs.py` to assert the presence of the new headings and key tokens that validate the contract and user guidance text.\n
### Testing

- Ran `pytest -q tests/test_workcell_studio_docs.py` and the suite completed successfully.\n- New assertions verify `## Camera, FOV, and perception overlay contract` and `## Side-pick camera metadata, Scene3D visualization, and preview warnings` exist and that the docs include the expected tokens about read-only overlays, `pick_zone` authority, warning semantics, and lack of live EPD/RealSense startup.\n

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f20e684808331be80833a6be4e985)