### PR TITLE
Unify Scene3D scripts on canonical scene-root resolution

### DIFF
--- a/scripts/check_scene3d_canvas_contract.py
+++ b/scripts/check_scene3d_canvas_contract.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 import argparse, json, re
 from collections import Counter
 from pathlib import Path
+try:
+    from scripts.scene_root_resolver import resolve_scene_root
+except ModuleNotFoundError:
+    from scene_root_resolver import resolve_scene_root
 
 ROOT = Path(__file__).resolve().parents[1]
+SCENES_ROOT = resolve_scene_root(ROOT)
 PLACEHOLDER_RE = re.compile(r"\$\{[^}]+\}")
 
 
@@ -114,13 +119,17 @@ def main():
 
     scenes = []
     if args.all:
-        scenes = sorted([p for p in (ROOT / 'scenes').iterdir() if p.is_dir()])
+        scenes = sorted([p for p in SCENES_ROOT.iterdir() if p.is_dir()]) if SCENES_ROOT.exists() else []
     elif args.scene:
-        scenes = [ROOT / 'scenes' / s for s in args.scene]
+        scenes = [SCENES_ROOT / s for s in args.scene]
     else:
         ap.error('use --all or --scene <name>')
 
-    report = [check_scene(s) for s in scenes if s.exists()]
+    missing = [str(s) for s in scenes if not s.exists()]
+    if missing:
+        ap.error(f"requested scene path is missing: {', '.join(missing)}")
+
+    report = [check_scene(s) for s in scenes]
     overall = 'PASS' if all(r['contract_status'] == 'PASS' for r in report) else ('FAIL' if any(r['contract_status']=='FAIL' for r in report) else 'WARN')
     payload = {'overall_status': overall, 'scenes': report}
 

--- a/scripts/scene_root_resolver.py
+++ b/scripts/scene_root_resolver.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_scene_root(repo_root: Path) -> Path:
+    """Resolve the canonical scene root for script utilities.
+
+    Priority:
+    1) <repo>/scenes
+    2) <repo>/workcell_builder/scenes (legacy fallback) only when canonical does not exist.
+    """
+
+    canonical = repo_root / "scenes"
+    legacy = repo_root / "workcell_builder" / "scenes"
+    if canonical.exists():
+        return canonical
+    if legacy.exists():
+        return legacy
+    return canonical

--- a/scripts/validate_scene3d_runtime_acceptance.py
+++ b/scripts/validate_scene3d_runtime_acceptance.py
@@ -2,16 +2,21 @@
 from __future__ import annotations
 import argparse, json
 from pathlib import Path
+try:
+    from scripts.scene_root_resolver import resolve_scene_root
+except ModuleNotFoundError:
+    from scene_root_resolver import resolve_scene_root
 
 SCHEMA = "workcell_studio_scene3d_runtime_acceptance/v1"
 ROOT = Path(__file__).resolve().parents[1]
+SCENES_ROOT = resolve_scene_root(ROOT)
 MAIN = ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp"
 PREVIEW = ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.cpp"
 VIEWPORT = ROOT / "workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp"
 
 
 def scene_dir(scene: str) -> Path:
-    return ROOT / "workcell_builder" / "scenes" / scene
+    return SCENES_ROOT / scene
 
 
 def has_snapshot_overlay(scene_path: Path) -> bool:
@@ -42,8 +47,8 @@ def main() -> int:
     ap.add_argument("--markdown", default=str(ROOT / "build/workcell_studio/scene3d_runtime_acceptance.md"))
     args = ap.parse_args()
     scenes = args.scene or ["ur5_2f_test"]
-    if (ROOT / "workcell_builder/scenes").exists():
-      scenes_dir = ROOT / "workcell_builder/scenes"
+    if SCENES_ROOT.exists():
+      scenes_dir = SCENES_ROOT
       maybe = sorted(p.name for p in scenes_dir.iterdir() if p.is_dir() and "new_cell" in p.name)
       if maybe:
           scenes.append(maybe[0])
@@ -51,6 +56,11 @@ def main() -> int:
     for s in scenes:
         if s not in unique_scenes:
             unique_scenes.append(s)
+
+    missing = [str(scene_dir(s)) for s in unique_scenes if not scene_dir(s).exists()]
+    if missing:
+        ap.error(f"requested scene path is missing: {', '.join(missing)}")
+
     results = [evaluate_scene(s) for s in unique_scenes]
 
     root_checks = {

--- a/tests/test_scene_root_resolver_regression.py
+++ b/tests/test_scene_root_resolver_regression.py
@@ -1,0 +1,38 @@
+import subprocess
+from pathlib import Path
+
+from scripts.scene_root_resolver import resolve_scene_root
+from scripts import check_scene3d_canvas_contract as canvas_contract
+from scripts import validate_scene3d_runtime_acceptance as runtime_acceptance
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_both_scripts_resolve_ur5_2f_test_from_same_root():
+    shared_root = resolve_scene_root(ROOT)
+    canvas_path = canvas_contract.SCENES_ROOT / "ur5_2f_test"
+    runtime_path = runtime_acceptance.scene_dir("ur5_2f_test")
+
+    assert canvas_contract.SCENES_ROOT == runtime_acceptance.SCENES_ROOT == shared_root
+    assert canvas_path == runtime_path
+    assert canvas_path.exists()
+
+
+def test_missing_scene_error_message_is_explicit_for_both_scripts(tmp_path):
+    missing_scene = "scene_does_not_exist_for_contract_test"
+
+    canvas_proc = subprocess.run(
+        ["python3", str(ROOT / "scripts" / "check_scene3d_canvas_contract.py"), "--scene", missing_scene],
+        capture_output=True,
+        text=True,
+    )
+    assert canvas_proc.returncode != 0
+    assert "requested scene path is missing:" in canvas_proc.stderr
+
+    runtime_proc = subprocess.run(
+        ["python3", str(ROOT / "scripts" / "validate_scene3d_runtime_acceptance.py"), "--scene", missing_scene, "--json", str(tmp_path / "r.json"), "--markdown", str(tmp_path / "r.md")],
+        capture_output=True,
+        text=True,
+    )
+    assert runtime_proc.returncode != 0
+    assert "requested scene path is missing:" in runtime_proc.stderr


### PR DESCRIPTION
### Motivation
- Provide a single canonical resolver for locating scene assets to avoid duplicated path logic across Scene3D utilities.
- Prefer the repository-root `scenes` directory but fall back to the legacy `workcell_builder/scenes` only when the canonical path is absent.
- Replace hardcoded scene path usages and make missing-scene failures explicit to improve user feedback and avoid silent mis-resolution regressions.

### Description
- Added `scripts/scene_root_resolver.py` which implements `resolve_scene_root(repo_root: Path)` with canonical-first precedence (`<repo>/scenes`, then legacy `<repo>/workcell_builder/scenes`).
- Updated `scripts/check_scene3d_canvas_contract.py` to import the resolver, set `SCENES_ROOT = resolve_scene_root(ROOT)`, use `SCENES_ROOT` for `--all` and `--scene` handling, and fail with `ap.error("requested scene path is missing: ...")` for missing scenes.
- Updated `scripts/validate_scene3d_runtime_acceptance.py` to import the resolver, set `SCENES_ROOT = resolve_scene_root(ROOT)`, use `SCENES_ROOT` in `scene_dir()` and discovery, and fail with the same explicit missing-scene error.
- Added `tests/test_scene_root_resolver_regression.py` to assert both scripts resolve `ur5_2f_test` from the same root and that both emit the explicit missing-scene error for nonexistent scene requests.

### Testing
- Ran `pytest -q tests/test_scene3d_canvas_contract.py tests/test_scene3d_runtime_acceptance.py tests/test_scene_root_resolver_regression.py` which resulted in all tests passing.
- Test summary: `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f2d6c1e888331a64599173b72c09e)