### PR TITLE
Enhance Scene3D canvas contract checker with runtime semantic counts

### DIFF
--- a/scripts/check_scene3d_canvas_contract.py
+++ b/scripts/check_scene3d_canvas_contract.py
@@ -15,6 +15,38 @@ def _load_json(path: Path):
         return None
 
 
+def _count_preview_items_from_generated_metadata(scene_dir: Path) -> int:
+    generated_layout = scene_dir / 'layout' / 'workcell_studio_layout.generated.yaml'
+    if not generated_layout.exists():
+        return 0
+    in_preview_items = False
+    count = 0
+    for raw in generated_layout.read_text(encoding='utf-8').splitlines():
+        line = raw.rstrip()
+        if line.strip() == 'preview_items:':
+            in_preview_items = True
+            continue
+        if in_preview_items and line and not line.startswith(' '):
+            break
+        if in_preview_items and line.lstrip().startswith('- id:'):
+            count += 1
+    return count
+
+
+def _runtime_scene_diagnostics(scene: str) -> dict:
+    diag_path = ROOT / 'build' / 'workcell_studio_scene3d_visual_diagnostics.json'
+    payload = _load_json(diag_path)
+    if not isinstance(payload, dict):
+        return {}
+    scenes = payload.get('scenes', [])
+    if not isinstance(scenes, list):
+        return {}
+    for item in scenes:
+        if isinstance(item, dict) and item.get('scene') == scene:
+            return item
+    return {}
+
+
 def check_scene(scene_dir: Path) -> dict:
     scene = scene_dir.name
     layout_path = scene_dir / 'layout' / 'workcell_studio_layout.yaml'
@@ -51,6 +83,15 @@ def check_scene(scene_dir: Path) -> dict:
     primitive_count = layer_counts['primitive_fallback']
     mesh_count = layer_counts['mesh_preview']
     urdf_count = layer_counts['locked_generated_urdf_visual']
+    meaningful_total = primitive_count + mesh_count + urdf_count
+
+    preview_items_count = _count_preview_items_from_generated_metadata(scene_dir)
+    visible_after_filters_count = sum(1 for i in items if i.get('hidden_by_filters') is not True)
+    filtered_hidden_count = max(0, len(items) - visible_after_filters_count)
+    diag_scene = _runtime_scene_diagnostics(scene)
+    render_cache_received_count = None
+    if diag_scene:
+        render_cache_received_count = diag_scene.get('render_cache_received_count', diag_scene.get('render_cache_received'))
 
     if not has_layout:
         blockers.append('missing layout/workcell_studio_layout.yaml')
@@ -61,6 +102,12 @@ def check_scene(scene_dir: Path) -> dict:
         fixes.append('if safe mesh index exists, map items into mesh_preview layer')
     if unresolved > 0 and bool(idx.get('safe_for_preview', False)):
         blockers.append('unresolved placeholders remain in IDs during safe preview')
+    if meaningful_total == 0:
+        blockers.append('meaningful layer counts are all zero')
+    if visible_after_filters_count == 0:
+        blockers.append('visible_after_filters_count is zero by default')
+    if mesh_count == 0 and primitive_count > 0 and visible_after_filters_count > 0:
+        fixes.append('optional mesh assets missing; primitive fallback is present and visible')
 
     status = 'PASS'
     if blockers:
@@ -77,6 +124,10 @@ def check_scene(scene_dir: Path) -> dict:
         'overlay_count': layer_counts['overlay'],
         'unsafe_visual_reason_count': unsafe_reasons,
         'unresolved_placeholder_count': unresolved,
+        'preview_items_count': preview_items_count,
+        'visible_after_filters_count': visible_after_filters_count,
+        'filtered_hidden_count': filtered_hidden_count,
+        'render_cache_received_count': render_cache_received_count,
         'contract_status': status,
         'blockers': blockers,
         'suggested_fixes': fixes,
@@ -95,7 +146,11 @@ def markdown(report: list[dict]) -> str:
                   f"- primitive_fallback_count: {r['primitive_fallback_count']}",
                   f"- overlay_count: {r['overlay_count']}",
                   f"- unsafe_visual_reason_count: {r['unsafe_visual_reason_count']}",
-                  f"- unresolved_placeholder_count: {r['unresolved_placeholder_count']}"]
+                  f"- unresolved_placeholder_count: {r['unresolved_placeholder_count']}",
+                  f"- preview_items_count: {r['preview_items_count']}",
+                  f"- visible_after_filters_count: {r['visible_after_filters_count']}",
+                  f"- filtered_hidden_count: {r['filtered_hidden_count']}",
+                  f"- render_cache_received_count: {r['render_cache_received_count']}"]
         if r['blockers']:
             lines.append('- blockers:'); lines += [f"  - {b}" for b in r['blockers']]
         if r['suggested_fixes']:

--- a/tests/test_scene3d_canvas_contract.py
+++ b/tests/test_scene3d_canvas_contract.py
@@ -29,3 +29,9 @@ def test_contract_checker_generates_json_and_markdown(tmp_path):
     data = json.loads(out_json.read_text(encoding='utf-8'))
     assert 'overall_status' in data
     assert data['scenes']
+    scene = data['scenes'][0]
+    for key in ['preview_items_count', 'visible_after_filters_count', 'filtered_hidden_count', 'render_cache_received_count']:
+        assert key in scene
+    assert isinstance(scene['preview_items_count'], int)
+    assert isinstance(scene['visible_after_filters_count'], int)
+    assert isinstance(scene['filtered_hidden_count'], int)

--- a/tests/test_scene3d_feature_regression_guard.py
+++ b/tests/test_scene3d_feature_regression_guard.py
@@ -46,7 +46,11 @@ def test_feature_regression_static_sentinel_contract_checker_has_status_field(tm
     out_json = tmp_path / 'contract.json'
     subprocess.run(['python3', str(ROOT / 'scripts' / 'check_scene3d_canvas_contract.py'), '--scene', 'suction_test', '--json', str(out_json)], check=False)
     payload = json.loads(out_json.read_text(encoding='utf-8'))
-    assert 'contract_status' in payload['scenes'][0]
+    scene = payload['scenes'][0]
+    assert 'contract_status' in scene
+    for key in ['preview_items_count', 'visible_after_filters_count', 'filtered_hidden_count', 'render_cache_received_count']:
+        assert key in scene
+    assert isinstance(scene['visible_after_filters_count'], int)
 
 
 def test_feature_regression_behavior_successful_drag_writes_once_cancel_and_read_only_write_never():


### PR DESCRIPTION
### Motivation
- The existing contract checker relied largely on source-layer token counts and did not validate end-to-end runtime/preview semantics.
- Contract validation should reflect runtime diagnostics and generated preview metadata to ensure what the UI would actually render and show.
- Strengthen the contract to detect empty/meaningless previews and missing-visible content early, while still allowing primitive fallbacks where appropriate.

### Description
- Added helpers to read generated metadata and runtime diagnostics: `_count_preview_items_from_generated_metadata()` reads `layout/workcell_studio_layout.generated.yaml` and `_runtime_scene_diagnostics()` reads `build/workcell_studio_scene3d_visual_diagnostics.json`.
- Expose new scene fields in JSON/markdown output: `preview_items_count`, `visible_after_filters_count`, `filtered_hidden_count`, and `render_cache_received_count` (when diagnostics exist).
- Introduced end-to-end gate checks that `FAIL` when meaningful layer counts are all zero or when `visible_after_filters_count == 0`, and added a `WARN`-style suggested fix when optional mesh assets are missing but primitive fallback items are present and visible.
- Preserved strict blockers and semantics for editability and safety: locked generated URDF visuals must remain non-editable, editable layout items must remain editable, and unresolved placeholder IDs remain a blocker in safe-preview mode.

### Testing
- Updated tests `tests/test_scene3d_canvas_contract.py` and `tests/test_scene3d_feature_regression_guard.py` to assert presence and types of the new fields.
- Ran the contract/regression tests with `pytest -q tests/test_scene3d_canvas_contract.py tests/test_scene3d_feature_regression_guard.py` and all tests passed (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f2d6ea058833183c4cf210e8e242d)