### PR TITLE
Add deterministic New Cell recommended-layout Scene3D fixture acceptance coverage

### DIFF
--- a/tests/fixtures/new_cell_recommended_layout/environment.yaml
+++ b/tests/fixtures/new_cell_recommended_layout/environment.yaml
@@ -1,0 +1,8 @@
+scene_name: new_cell_recommended_layout
+task_zones:
+  - id: pick_zone
+    type: pick
+  - id: place_zone
+    type: place
+support_surfaces:
+  - id: workbench

--- a/tests/fixtures/new_cell_recommended_layout/generated/scene_visual_mesh_index.json
+++ b/tests/fixtures/new_cell_recommended_layout/generated/scene_visual_mesh_index.json
@@ -1,0 +1,10 @@
+{
+  "scene": "new_cell_recommended_layout",
+  "visible_after_filters": 4,
+  "items": [
+    {"id": "robot_base", "type": "robot_base", "source_layer": "editable_layout", "active_visual_source": "primitive_fallback", "editable": true, "locked": false},
+    {"id": "workbench", "type": "table", "source_layer": "editable_layout", "active_visual_source": "primitive_fallback", "editable": true, "locked": false},
+    {"id": "pick_zone", "type": "zone", "source_layer": "editable_layout", "active_visual_source": "primitive_fallback", "editable": true, "locked": false},
+    {"id": "place_zone", "type": "zone", "source_layer": "editable_layout", "active_visual_source": "primitive_fallback", "editable": true, "locked": false}
+  ]
+}

--- a/tests/fixtures/new_cell_recommended_layout/layout/workcell_studio_layout.yaml
+++ b/tests/fixtures/new_cell_recommended_layout/layout/workcell_studio_layout.yaml
@@ -1,0 +1,26 @@
+schema_version: workcell_studio_layout/v1
+items:
+  - id: robot_base
+    type: robot_base
+    source_layer: editable_layout
+    active_visual_source: primitive_fallback
+    editable: true
+    locked: false
+  - id: workbench
+    type: table
+    source_layer: editable_layout
+    active_visual_source: primitive_fallback
+    editable: true
+    locked: false
+  - id: pick_zone
+    type: zone
+    source_layer: editable_layout
+    active_visual_source: primitive_fallback
+    editable: true
+    locked: false
+  - id: place_zone
+    type: zone
+    source_layer: editable_layout
+    active_visual_source: primitive_fallback
+    editable: true
+    locked: false

--- a/tests/test_existing_new_cell_layout_action_wiring.py
+++ b/tests/test_existing_new_cell_layout_action_wiring.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import json
+import shutil
 import subprocess
 import yaml
 
@@ -70,3 +72,36 @@ def test_new_cell_camera_metadata_canonical_and_legacy_traceability_tokens_prese
         'none (camera metadata only)',
     ]:
         assert token in txt
+
+
+def test_use_recommended_layout_fixture_populates_scene3d_data_immediately(tmp_path: Path):
+    fixture = Path('tests/fixtures/new_cell_recommended_layout')
+    scene = tmp_path / 'new_cell_recommended_layout'
+    shutil.copytree(fixture, scene)
+
+    subprocess.run([
+        'python3',
+        'scripts/generate_workcell_studio_scene_artifacts.py',
+        '--root', str(tmp_path),
+        '--scene', scene.name,
+        '--overwrite',
+    ], check=True)
+
+    layout_preview = yaml.safe_load((scene / 'layout' / 'workcell_studio_layout.generated.yaml').read_text(encoding='utf-8'))
+    preview_items = layout_preview.get('preview_items', [])
+    assert len(preview_items) > 0
+
+    mesh_index = json.loads((scene / 'generated' / 'scene_visual_mesh_index.json').read_text(encoding='utf-8'))
+    items = mesh_index.get('items', [])
+    by_id = {str(i.get('id')): i for i in items if isinstance(i, dict)}
+    for required in ['robot_base', 'workbench', 'pick_zone', 'place_zone']:
+        assert required in by_id
+
+    for required in ['robot_base', 'workbench', 'pick_zone', 'place_zone']:
+        item = by_id[required]
+        assert item.get('id')
+        assert item.get('source_layer')
+        assert item.get('active_visual_source')
+        assert item.get('editable') is (not item.get('locked'))
+
+    assert int(mesh_index.get('visible_after_filters', 0)) > 0


### PR DESCRIPTION
### Motivation
- Provide a deterministic, fake-hardware-first fixture to validate that the "Use Recommended Layout" flow populates Scene3D preview data immediately. 
- Ensure automated tests can exercise the same layout-generation path used by the New Cell flow without launching any GUI or real hardware.

### Description
- Added a fixture scene under `tests/fixtures/new_cell_recommended_layout` containing `environment.yaml`, `layout/workcell_studio_layout.yaml`, and `generated/scene_visual_mesh_index.json` with canonical starter items (`robot_base`, `workbench`, `pick_zone`, `place_zone`).
- Extended `tests/test_existing_new_cell_layout_action_wiring.py` with `test_use_recommended_layout_fixture_populates_scene3d_data_immediately` which copies the fixture to a temp scene root and invokes the canonical layout artifact generator.
- The new test runs `scripts/generate_workcell_studio_scene_artifacts.py` (non-GUI) and asserts that preview items are non-empty, that `robot_base`, `workbench` (table/workbench), `pick_zone`, and `place_zone` exist, that each required item contains `id`, `source_layer`, and `active_visual_source` and that `editable` equals `not locked`, and that `visible_after_filters > 0`.
- No UI controls or real hardware/perception launch strings were introduced; fixture and test are fake-hardware-first and offline-only.

### Testing
- Ran `pytest -q tests/test_existing_new_cell_layout_action_wiring.py` and it passed: `5 passed in 0.76s`.
- The added test executes the generation script with `--scene` and `--overwrite` to exercise the same artifact-generation path used by the New Cell/Recommended Layout flow and validated the expected Scene3D preview outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f2d73280c8331a5452bbdf726d68f)