### PR TITLE
Add Scene3D GUI smoke CLI runner and JSON reporting

### DIFF
--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -20,6 +20,13 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QPushButton>
+#include <QTableWidget>
+#include <QTimer>
+#include <QTreeWidget>
+#include <QLabel>
+#include <QTextEdit>
+#include <QImage>
+#include <QWidget>
 #include <iostream>
 #include <vector>
 
@@ -34,6 +41,186 @@ bool has_cli_flag(const QStringList & args, const QString & flag)
 {
   return args.contains(flag);
 }
+
+QString cli_value(const QStringList & args, const QString & flag)
+{
+  const int idx = args.indexOf(flag);
+  if (idx >= 0 && (idx + 1) < args.size()) {
+    return args.at(idx + 1);
+  }
+  return QString();
+}
+
+QJsonObject run_gui_self_test();
+
+struct Scene3DSmokeOptions
+{
+  bool enabled{ false };
+  QString scene_name;
+  QString smoke_output;
+  QString screenshot_path;
+  bool exit_after_smoke{ false };
+  bool new_cell_recommended_layout_smoke{ false };
+};
+
+class Scene3DSmokeRunner : public QObject
+{
+public:
+  Scene3DSmokeRunner(QApplication * app, MainWindow * window, const Scene3DSmokeOptions & opts)
+  : app_(app), window_(window), opts_(opts) {}
+
+  void start() { QTimer::singleShot(0, this, &Scene3DSmokeRunner::step_begin); }
+
+private:
+  QApplication * app_;
+  MainWindow * window_;
+  Scene3DSmokeOptions opts_;
+  QJsonArray warnings_;
+  QJsonArray blockers_;
+  QDateTime start_time_;
+
+  void step_begin()
+  {
+    start_time_ = QDateTime::currentDateTimeUtc();
+    if (!window_) {
+      blockers_.append("MainWindow instance is null");
+      return finalize();
+    }
+    if (opts_.new_cell_recommended_layout_smoke) {
+      trigger_by_text("New Cell");
+      QTimer::singleShot(300, this, &Scene3DSmokeRunner::step_trigger_recommended_layout);
+      return;
+    }
+    if (!opts_.scene_name.trimmed().isEmpty()) {
+      auto * table = window_->findChild<QTableWidget *>("studioHomeSceneTable");
+      if (table == nullptr) {
+        blockers_.append("Scene table not found");
+      } else {
+        bool found = false;
+        for (int row = 0; row < table->rowCount(); ++row) {
+          auto * item = table->item(row, 0);
+          if (item && item->text().trimmed() == opts_.scene_name.trimmed()) {
+            table->selectRow(row);
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          blockers_.append(QString("Requested scene not found: %1").arg(opts_.scene_name));
+        }
+      }
+    }
+    trigger_by_text("Open Selected Scene");
+    QTimer::singleShot(300, this, &Scene3DSmokeRunner::step_wait_scene3d_ready);
+  }
+
+  void step_trigger_recommended_layout()
+  {
+    trigger_by_text("Use Recommended Layout");
+    QTimer::singleShot(300, this, &Scene3DSmokeRunner::step_wait_scene3d_ready);
+  }
+
+  void step_wait_scene3d_ready()
+  {
+    const int timeout_ms = 20000;
+    const int poll_ms = 250;
+    auto * timer = new QTimer(this);
+    const qint64 start_ms = QDateTime::currentMSecsSinceEpoch();
+    connect(timer, &QTimer::timeout, this, [this, timer, start_ms, timeout_ms]() {
+      if (scene3d_ready()) {
+        timer->stop();
+        timer->deleteLater();
+        finalize();
+        return;
+      }
+      if ((QDateTime::currentMSecsSinceEpoch() - start_ms) > timeout_ms) {
+        blockers_.append("Scene3D readiness timeout waiting for hierarchy/inspector/log markers");
+        timer->stop();
+        timer->deleteLater();
+        finalize();
+      }
+    });
+    timer->start(poll_ms);
+  }
+
+  bool scene3d_ready()
+  {
+    auto * tree = window_->findChild<QTreeWidget *>("studioSceneHierarchyTree");
+    auto * inspector = window_->findChild<QLabel *>();
+    auto * log = window_->findChild<QTextEdit *>("studioHomeLog");
+    const bool hierarchy_ok = (tree != nullptr && tree->topLevelItemCount() > 0);
+    const bool inspector_ok = (inspector != nullptr && !inspector->text().contains("Selected item: (none)"));
+    const bool log_ok = (log != nullptr && log->toPlainText().contains("Scene3D diagnostics"));
+    return hierarchy_ok && inspector_ok && log_ok;
+  }
+
+  void trigger_by_text(const QString & text)
+  {
+    const auto buttons = window_->findChildren<QPushButton *>();
+    for (auto * b : buttons) {
+      if (b && b->text().trimmed() == text && b->isEnabled()) {
+        b->click();
+        return;
+      }
+    }
+    const auto actions = window_->findChildren<QAction *>();
+    for (auto * a : actions) {
+      if (a && a->text().trimmed() == text && a->isEnabled()) {
+        a->trigger();
+        return;
+      }
+    }
+    warnings_.append(QString("Unable to trigger action: %1").arg(text));
+  }
+
+  void finalize()
+  {
+    QJsonObject root;
+    root["schema"] = "workcell_studio_scene3d_gui_smoke/v1";
+    root["timestamp"] = QDateTime::currentDateTimeUtc().toString(Qt::ISODate);
+    root["scene"] = opts_.scene_name;
+    root["new_cell_recommended_layout_smoke"] = opts_.new_cell_recommended_layout_smoke;
+    root["duration_ms"] = start_time_.msecsTo(QDateTime::currentDateTimeUtc());
+
+    auto * tree = window_->findChild<QTreeWidget *>("studioSceneHierarchyTree");
+    auto * log = window_->findChild<QTextEdit *>("studioHomeLog");
+    QJsonObject counters;
+    counters["hierarchy_top_level_count"] = tree ? tree->topLevelItemCount() : 0;
+    counters["log_line_count"] = log ? log->toPlainText().split('\n', Qt::SkipEmptyParts).size() : 0;
+    counters["log_has_scene3d_diagnostics"] = log ? log->toPlainText().contains("Scene3D diagnostics") : false;
+    root["counters"] = counters;
+    root["warnings"] = warnings_;
+    root["blockers"] = blockers_;
+
+    if (!opts_.screenshot_path.trimmed().isEmpty()) {
+      bool screenshot_ok = false;
+      auto * viewport = window_->findChild<QWidget *>("scene3dViewportWidget");
+      QWidget * source = viewport ? viewport : window_;
+      if (source) {
+        QImage img = source->grab().toImage();
+        screenshot_ok = img.save(opts_.screenshot_path);
+      }
+      if (!screenshot_ok) {
+        warnings_.append(QString("Failed to capture screenshot to: %1").arg(opts_.screenshot_path));
+      }
+      root["warnings"] = warnings_;
+      root["screenshot_path"] = opts_.screenshot_path;
+      root["screenshot_saved"] = screenshot_ok;
+    }
+
+    const bool pass = blockers_.isEmpty();
+    root["result"] = pass ? "PASS" : "FAIL";
+    QFile out(opts_.smoke_output);
+    if (!out.open(QIODevice::WriteOnly | QIODevice::Text)) {
+      std::cerr << "Unable to write smoke report: " << opts_.smoke_output.toStdString() << std::endl;
+      app_->exit(2);
+      return;
+    }
+    out.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+    out.close();
+    app_->exit(pass ? 0 : 1);
+  }
+};
 
 QJsonObject run_gui_self_test()
 {
@@ -123,7 +310,6 @@ QJsonObject run_gui_self_test()
 }
 }  // namespace
 
-
 int main(int argc, char * argv[])
 {
   QApplication a(argc, argv);
@@ -142,6 +328,27 @@ int main(int argc, char * argv[])
 
   a.setStyleSheet(workcell_builder::workcellStudioStyleSheet());
 
+  Scene3DSmokeOptions smoke_opts;
+  smoke_opts.enabled = has_cli_flag(args, "--scene3d-smoke");
+  smoke_opts.scene_name = cli_value(args, "--scene");
+  smoke_opts.smoke_output = cli_value(args, "--smoke-output");
+  smoke_opts.screenshot_path = cli_value(args, "--smoke-screenshot");
+  smoke_opts.exit_after_smoke = has_cli_flag(args, "--exit-after-smoke");
+  smoke_opts.new_cell_recommended_layout_smoke = has_cli_flag(args, "--new-cell-recommended-layout-smoke");
+
+  if (smoke_opts.enabled) {
+    if (smoke_opts.smoke_output.trimmed().isEmpty()) {
+      std::cerr << "Missing required --smoke-output <path> for --scene3d-smoke" << std::endl;
+      return 2;
+    }
+    const QString workspace = cli_value(args, "--workspace");
+    const QString ros_distro = cli_value(args, "--ros-distro");
+    MainWindow w(workspace, ros_distro);
+    w.show();
+    auto * runner = new Scene3DSmokeRunner(&a, &w, smoke_opts);
+    runner->start();
+    return a.exec();
+  }
 
   StartupDialog startup;
   if (startup.exec() != QDialog::Accepted) {


### PR DESCRIPTION
### Motivation
- Provide an internal, automatable smoke test flow for the Scene3D GUI that can be invoked from CI/developer tooling via CLI flags to validate the Scene3D ingest/display pipeline and produce machine-readable diagnostics.

### Description
- Added CLI parsing in `main.cpp` for `--scene3d-smoke`, `--scene`, `--smoke-output`, `--smoke-screenshot`, `--exit-after-smoke`, and `--new-cell-recommended-layout-smoke` and lightweight `cli_value` helper to read flag values.
- Introduced `Scene3DSmokeOptions` and an internal `Scene3DSmokeRunner` that launches `MainWindow`, drives either an explicit dashboard-selected scene or the New Cell + "Use Recommended Layout" flow, and polls for Scene3D readiness via existing UI widgets (hierarchy, inspector text, and diagnostics log).
- Collected runtime counters and state into the schema `workcell_studio_scene3d_gui_smoke/v1`, appended `warnings` and `blockers`, optionally attempted a Scene3D viewport screenshot (non-fatal on failure), wrote a JSON report to `--smoke-output`, and exited with `0` for PASS and non-zero for FAIL/write errors.
- Kept behavior strictly internal behind CLI flags with no new visible GUI buttons or parallel viewers; added necessary includes (`QTableWidget`, `QTimer`, `QTreeWidget`, `QLabel`, `QTextEdit`, `QImage`, `QWidget`) and wiring in `main()` to start smoke flow when requested.

### Testing
- Ran static checklist: `git diff --check` to ensure no whitespace/diff issues and validated the diff contents were produced without conflicts.
- No full build or runtime GUI test was executed in this environment, so binary compilation and live smoke execution remain unverified here; smoke flow is designed to run headful and should be validated in the target CI/developer environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f32785b048331a4a460cfd9759df1)