### PR TITLE
Fix Scene3D compile breaks in workcell_builder

### DIFF
--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include <QApplication>
+#include <QAction>
 #include <QDateTime>
 #include <QFile>
 #include <QJsonArray>

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -200,8 +200,8 @@ Scene3DDetectionSnapshotLoadResult load_scene3d_detection_snapshot_preview(const
   return out;
 }
 [[maybe_unused]] static const char * kSceneBuilderGuidedWorkflowLegacyContractTokens =
-  "{"Scene selected"} {"Assets placed"} {"Layout saved"} {"YAML generated"} "
-  "{"Validation passed"} {"Scene package generated"} {"Plan / Simulate ready"} {"Export ready"} "
+  "{Scene selected} {Assets placed} {Layout saved} {YAML generated}"
+  "{Validation passed} {Scene package generated} {Plan / Simulate ready} {Export ready} "
   "Blocked: Scene changed since last validation. Run Offline Validation first. "
   "Blocked: Missing smoke/offline_smoke_report.json. Run Offline Validation first. "
   "Blocked: Missing launch/demo.launch.py. Generate Scene Package first. "
@@ -5110,7 +5110,7 @@ void MainWindow::populate_scene_hierarchy()
   QMap<QString, QTreeWidgetItem*> hierarchy_groups;
   auto group_for_item = [&](const ScenePreviewWidget::PreviewItem & p) {
     const QString lower = (p.role + " " + p.category + " " + p.source_layer + " " + p.active_visual_source).toLower();
-    if (p.status.contains("warning", Qt::CaseInsensitive) || p.visual_warning_status.contains("missing", Qt::CaseInsensitive)) return QString("Warnings / Missing Assets");
+    if (p.status.contains("warning", Qt::CaseInsensitive) || p.mesh_load_warning.contains("missing", Qt::CaseInsensitive)) return QString("Warnings / Missing Assets");
     if (lower.contains("editable_layout")) return QString("Editable Layout");
     if (lower.contains("camera") || lower.contains("sensor")) return QString("Cameras");
     if (lower.contains("robot") || lower.contains("tool") || lower.contains("gripper") || lower.contains("end_effector")) return QString("Robot / Tooling");

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -36,6 +36,7 @@
 #include "attributes/workcell.h"
 #include "workcell_studio_scene_browser.hpp"
 #include "workcell_studio_layout_merge.hpp"
+#include "gui/scene_preview_widget.h"
 
 namespace fs = boost::filesystem;
 
@@ -55,7 +56,6 @@ class QCheckBox;
 class QPushButton;
 class QDoubleSpinBox;
 class QGraphicsSceneMouseEvent;
-class ScenePreviewWidget;
 class QTreeWidget;
 class QTreeWidgetItem;
 class QComboBox;

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -471,30 +471,3 @@ YAML::Node build_starter_layout_entries_from_preview(const WorkcellStudioCanvasM
   return root;
 }
 }
-
-struct RuntimeVisualDiagnosticsCounts {
-  int editable_layout_items_loaded{0};
-  int locked_preview_items_loaded{0};
-  int mesh_backed_items_loaded{0};
-  int primitive_fallback_items_loaded{0};
-  int missing_mesh_items{0};
-  int unsupported_mesh_items{0};
-  int unresolved_placeholder_items{0};
-};
-
-static RuntimeVisualDiagnosticsCounts compute_runtime_visual_diagnostics_counts(const WorkcellStudioCanvasModel & model)
-{
-  // mesh-backed items loaded
-  // primitive fallback items loaded
-  // missing mesh items
-  // unsupported mesh items
-  RuntimeVisualDiagnosticsCounts c;
-  for (const auto & item : model.items) {
-    if (!item.locked) c.editable_layout_items_loaded++; else c.locked_preview_items_loaded++;
-    if (item.has_mesh_metadata && item.mesh_available) c.mesh_backed_items_loaded++;
-    else c.primitive_fallback_items_loaded++;
-    if (item.has_mesh_metadata && !item.mesh_available) c.missing_mesh_items++;
-    if (item.mesh_type == "unsupported") c.unsupported_mesh_items++;
-  }
-  return c;
-}


### PR DESCRIPTION
### Motivation
- Recent Scene3D runtime/GUI changes introduced C++ compile breaks due to incomplete-type use of `ScenePreviewWidget::PreviewItem`, a malformed string literal in the workflow tokens, missing Qt includes, and an out-of-place diagnostics helper referencing `WorkcellStudioCanvasModel` before it was visible. 
- The intent is to perform targeted build-repair only so the `workcell_builder` package compiles again without adding features, UI controls, or changing hardware behavior. 

### Description
- Make `ScenePreviewWidget::PreviewItem` a concrete compile-time type in the header by including `gui/scene_preview_widget.h` from `mainwindow.h`, removing the unsafe forward declaration. 
- Add the missing Qt include `#include <QAction>` to `gui/main.cpp` so `QAction` use and `findChildren<QAction*>()` compile. 
- Fix the malformed legacy workflow token string in `gui/mainwindow.cpp` by replacing the invalid nested-quote literal with a valid C++ string. 
- Replace uses of the non-existent `visual_warning_status` with the existing `PreviewItem::mesh_load_warning` field to restore the warning grouping logic. 
- Remove the dead out-of-namespace diagnostics helper (`RuntimeVisualDiagnosticsCounts` and `compute_runtime_visual_diagnostics_counts`) from `src_workcell_studio_canvas_model.cpp` to resolve the `WorkcellStudioCanvasModel does not name a type` compilation failure. 
- Changes are strictly build-repair only and do not add Scene3D features, UI buttons, hardware behavior changes, or touch `epd_Improved`.

### Testing
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but the environment here could not run `colcon` (not installed) and an earlier `cd` to `/root/workcell_ws` failed, so a local package build was not executed in this environment. 
- Ran `python3 -m py_compile` for the smoke/validation scripts with `scripts/run_workcell_builder_scene3d_gui_smoke.py`, `scripts/validate_scene3d_runtime_acceptance.py`, `scripts/check_scene3d_canvas_contract.py`, and `scripts/run_workcell_studio_scene_readiness_gate.py`, and the byte-compile step succeeded. 
- Ran `pytest -q` against the listed Scene3D test files but the invocation failed here because the explicit test file paths were not present in this checkout, so those pytest runs did not execute in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6a0b85448331bd187f9924ab4e4a)