### PR TITLE
Unify Scene3D layer/source naming to canonical tokens

### DIFF
--- a/scripts/check_scene3d_canvas_contract.py
+++ b/scripts/check_scene3d_canvas_contract.py
@@ -11,6 +11,18 @@ except ModuleNotFoundError:
 ROOT = Path(__file__).resolve().parents[1]
 SCENES_ROOT = resolve_scene_root(ROOT)
 PLACEHOLDER_RE = re.compile(r"\$\{[^}]+\}")
+CANONICAL_LAYERS = {"editable_layout", "mesh_preview", "locked_generated_urdf_visual", "primitive_fallback", "overlay"}
+
+
+def normalize_layer_token(value: str | None) -> str:
+    token = (value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    if token in {"generated_preview", "generated_urdf_visual", "locked_generated_urdf"}:
+        return "locked_generated_urdf_visual"
+    if token == "legacy_static_fallback":
+        return "primitive_fallback"
+    if token in {"overlays", "helper_overlay"}:
+        return "overlay"
+    return token
 
 
 def _load_json(path: Path):
@@ -68,7 +80,7 @@ def check_scene(scene_dir: Path) -> dict:
     blockers, fixes = [], []
 
     for i in items:
-        layer = i.get('source_layer') or i.get('item_source') or ('primitive_fallback' if i.get('geometry_type') in {'box','cylinder','sphere'} else 'mesh_preview')
+        layer = normalize_layer_token(i.get('source_layer') or i.get('item_source') or ('primitive_fallback' if i.get('geometry_type') in {'box','cylinder','sphere'} else 'mesh_preview'))
         visual = i.get('active_visual_source') or ('expanded_urdf_mesh' if i.get('extraction_mode') == 'xacro_expanded' else ('mesh' if i.get('mesh_path') else 'primitive'))
         layer_counts[layer] += 1
         visual_counts[visual] += 1
@@ -127,6 +139,7 @@ def check_scene(scene_dir: Path) -> dict:
         'locked_generated_urdf_visual_count': urdf_count,
         'primitive_fallback_count': primitive_count,
         'overlay_count': layer_counts['overlay'],
+        'missing_count': sum(count for key, count in layer_counts.items() if key not in CANONICAL_LAYERS),
         'unsafe_visual_reason_count': unsafe_reasons,
         'unresolved_placeholder_count': unresolved,
         'preview_items_count': preview_items_count,

--- a/scripts/validate_scene3d_runtime_acceptance.py
+++ b/scripts/validate_scene3d_runtime_acceptance.py
@@ -18,6 +18,18 @@ SCENES_ROOT = resolve_scene_root(ROOT)
 MAIN = ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp"
 PREVIEW = ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.cpp"
 VIEWPORT = ROOT / "workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp"
+CANONICAL_LAYERS = {"editable_layout", "mesh_preview", "locked_generated_urdf_visual", "primitive_fallback", "overlay"}
+
+
+def normalize_layer_token(value: str | None) -> str:
+    token = (value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    if token in {"generated_preview", "generated_urdf_visual", "locked_generated_urdf"}:
+        return "locked_generated_urdf_visual"
+    if token == "legacy_static_fallback":
+        return "primitive_fallback"
+    if token in {"overlays", "helper_overlay"}:
+        return "overlay"
+    return token
 
 
 def scene_dir(scene: str) -> Path:
@@ -101,7 +113,9 @@ def evaluate_scene(scene: str, smoke_json_path: str | None) -> dict:
     primitive_fallback_count = int(mesh_index.get("unresolved_placeholder_count") or 0)
 
     generated_items = generated_layout.get("items") or []
-    locked_generated_urdf_visual_count = sum(1 for item in generated_items if item.get("source") == "generated_urdf_visual")
+    locked_generated_urdf_visual_count = sum(
+        1 for item in generated_items if normalize_layer_token(item.get("source")) == "locked_generated_urdf_visual"
+    )
 
     overlay_count = 0
     if preview_metadata:
@@ -111,7 +125,14 @@ def evaluate_scene(scene: str, smoke_json_path: str | None) -> dict:
     if overlay_count == 0:
         overlay_count = sum(1 for p in overlay_sources if p.exists())
 
-    input_items_count = editable_layout_count + primitive_fallback_count + mesh_preview_count + locked_generated_urdf_visual_count + overlay_count
+    source_layer_counts: dict[str, int] = {}
+    for item in (mesh_index.get("items") or []):
+        layer = normalize_layer_token(item.get("source_layer") or item.get("item_source"))
+        if layer:
+            source_layer_counts[layer] = source_layer_counts.get(layer, 0) + 1
+    missing_count = sum(count for layer, count in source_layer_counts.items() if layer not in CANONICAL_LAYERS)
+
+    input_items_count = editable_layout_count + primitive_fallback_count + mesh_preview_count + locked_generated_urdf_visual_count + overlay_count + missing_count
     visible_after_default_filters = editable_layout_count + mesh_preview_count
     hidden_by_filters_count = max(input_items_count - visible_after_default_filters, 0)
 
@@ -183,6 +204,7 @@ def evaluate_scene(scene: str, smoke_json_path: str | None) -> dict:
             "mesh_preview_count": mesh_preview_count,
             "locked_generated_urdf_visual_count": locked_generated_urdf_visual_count,
             "overlay_count": overlay_count,
+            "missing_count": missing_count,
         },
         "visibility_contract": {
             "input_items_count": input_items_count,
@@ -202,6 +224,7 @@ def evaluate_scene(scene: str, smoke_json_path: str | None) -> dict:
             "generated_layout": str(urdf_generated_layout_path) if urdf_generated_layout_path.exists() else None,
             "overlay_files": [str(p) for p in overlay_sources if p.exists()],
         },
+        "source_layer_counts": source_layer_counts,
         "runtime_evidence": runtime_evidence,
         "secondary_checks": secondary_checks,
         "pass": not blockers,

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -249,6 +249,20 @@ enum SceneTreeRoles {
 };
 enum AssetCatalogRoles { CatalogRoleIndex = Qt::UserRole, CatalogRolePlaceable = Qt::UserRole + 10, CatalogRoleSourcePath = Qt::UserRole + 11 };
 
+QString canonical_scene3d_token(const QString & value)
+{
+  const QString normalized = value.trimmed().toLower().replace('-', '_').replace(' ', '_');
+  if (normalized == QStringLiteral("generated_preview") ||
+      normalized == QStringLiteral("generated_urdf_visual") ||
+      normalized == QStringLiteral("locked_generated_urdf") ||
+      normalized == QStringLiteral("locked_generated_urdf_visual")) {
+    return QStringLiteral("locked_generated_urdf_visual");
+  }
+  if (normalized == QStringLiteral("legacy_static_fallback")) return QStringLiteral("primitive_fallback");
+  if (normalized == QStringLiteral("overlays") || normalized == QStringLiteral("helper_overlay")) return QStringLiteral("overlay");
+  return normalized;
+}
+
 class DraggableCanvasItem : public QGraphicsRectItem {
 public:
   explicit DraggableCanvasItem(const QRectF & r): QGraphicsRectItem(r) {}
@@ -4987,15 +5001,15 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
   }
   QVector<ScenePreviewWidget::PreviewItem> filtered_items;
   auto include_item = [this](const ScenePreviewWidget::PreviewItem & p) {
-      const QString source_layer = p.source_layer.trimmed().toLower();
-      const QString visual_source = p.active_visual_source.trimmed().toLower();
+      const QString source_layer = canonical_scene3d_token(p.source_layer);
+      const QString visual_source = canonical_scene3d_token(p.active_visual_source);
       const QString role = p.role.trimmed().toLower();
       const QString category = p.category.trimmed().toLower();
       const QString combined = role + "|" + category + "|" + p.status.trimmed().toLower() + "|" + p.warnings.join("|").toLower();
       const bool is_warning_or_missing = combined.contains("warning") || combined.contains("missing") || !p.mesh_load_warning.trimmed().isEmpty();
       const bool is_overlay_or_helper = combined.contains("overlay") || combined.contains("helper") || combined.contains("safety zone");
       if (source_layer == "editable_layout") return preview_layer_editable_layout_box_ ? preview_layer_editable_layout_box_->isChecked() : true;
-      if (source_layer == "generated_urdf_visual") return preview_layer_generated_urdf_visual_box_ ? preview_layer_generated_urdf_visual_box_->isChecked() : true;
+      if (source_layer == "locked_generated_urdf_visual") return preview_layer_generated_urdf_visual_box_ ? preview_layer_generated_urdf_visual_box_->isChecked() : true;
       if (source_layer == "primitive_fallback") return preview_layer_primitive_fallback_box_ ? preview_layer_primitive_fallback_box_->isChecked() : true;
       if (visual_source == "mesh_preview") return preview_layer_mesh_preview_box_ ? preview_layer_mesh_preview_box_->isChecked() : true;
       if (is_overlay_or_helper) return preview_layer_overlays_helpers_box_ ? preview_layer_overlays_helpers_box_->isChecked() : true;
@@ -5195,13 +5209,11 @@ void MainWindow::populate_scene_hierarchy()
     p.role = normalize_role(role_hint, category + " " + display_name);
     p.status = status;
     p.source_path = source_path;
-    p.source_layer = QStringLiteral("generated_preview");
-    p.active_visual_source = QStringLiteral("generated_preview");
+    p.source_layer = QStringLiteral("overlay");
+    p.active_visual_source = QStringLiteral("overlay");
     p.linked_to_editable_layout_state = false;
-          p.source_layer = QStringLiteral("overlay");
-          p.active_visual_source = QStringLiteral("overlay");
-          p.editable = false;
-          p.selectable = true;
+    p.editable = false;
+    p.selectable = true;
     p.metadata_complete = metadata_complete;
     if (!metadata_complete) {
       p.warnings << "metadata incomplete";
@@ -5274,20 +5286,12 @@ void MainWindow::populate_scene_hierarchy()
         p.source_layer = QStringLiteral("primitive_fallback");
         p.active_visual_source = QStringLiteral("primitive_fallback");
         p.linked_to_editable_layout_state = false;
-          p.source_layer = QStringLiteral("overlay");
-          p.active_visual_source = QStringLiteral("overlay");
-          p.editable = false;
-          p.selectable = true;
         break;
       case workcell_builder::WorkcellStudioItemProvenance::GeneratedOrLegacyPreview:
       default:
-        p.source_layer = QStringLiteral("generated_preview");
+        p.source_layer = QStringLiteral("locked_generated_urdf_visual");
         p.active_visual_source = QStringLiteral("mesh_preview");
         p.linked_to_editable_layout_state = false;
-          p.source_layer = QStringLiteral("overlay");
-          p.active_visual_source = QStringLiteral("overlay");
-          p.editable = false;
-          p.selectable = true;
         break;
     }
     if (item.locked) {
@@ -5458,12 +5462,10 @@ void MainWindow::populate_scene_hierarchy()
           p.editable = false;
           p.selectable = true;
           p.lock_reason = "URDF visual preview-only item (locked)";
-          p.source_layer = QStringLiteral("generated_urdf_visual");
+          p.source_layer = QStringLiteral("locked_generated_urdf_visual");
           p.active_visual_source = (geometry_type == "mesh") ? QStringLiteral("mesh_preview")
                                                               : QStringLiteral("primitive_fallback");
           p.linked_to_editable_layout_state = false;
-          p.source_layer = QStringLiteral("overlay");
-          p.active_visual_source = QStringLiteral("overlay");
           p.editable = false;
           p.selectable = true;
           const YAML::Node pose = workcell_builder::yaml_map_key(v, "pose");
@@ -5706,11 +5708,19 @@ void MainWindow::populate_scene_hierarchy()
   int scene3d_missing_count = 0;
   int scene3d_locked_count = 0;
   for (const auto & item : preview_items) {
-    if (item.editable) ++scene3d_editable_count;
-    if (item.active_visual_source == "mesh_preview") ++scene3d_mesh_count;
-    if (item.source_layer == "generated_urdf_visual") ++scene3d_generated_count;
-    if (item.active_visual_source == "primitive_fallback" || item.source_layer == "legacy_static_fallback") ++scene3d_fallback_count;
-    if (!item.mesh_available) ++scene3d_missing_count;
+    const QString source_layer = canonical_scene3d_token(item.source_layer);
+    const QString visual_source = canonical_scene3d_token(item.active_visual_source);
+    if (source_layer == "editable_layout") ++scene3d_editable_count;
+    if (visual_source == "mesh_preview") ++scene3d_mesh_count;
+    if (source_layer == "locked_generated_urdf_visual") ++scene3d_generated_count;
+    if (visual_source == "primitive_fallback" || source_layer == "primitive_fallback") ++scene3d_fallback_count;
+    if (source_layer != "editable_layout" &&
+        source_layer != "mesh_preview" &&
+        source_layer != "locked_generated_urdf_visual" &&
+        source_layer != "primitive_fallback" &&
+        source_layer != "overlay") {
+      ++scene3d_missing_count;
+    }
     if (item.locked) ++scene3d_locked_count;
   }
   const QString scene3d_diagnostics_line = QString("Scene3D: editable=%1, mesh=%2, generated=%3, fallback=%4, missing=%5, locked=%6")

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -239,6 +239,19 @@ QString normalized_token(const QString & value)
   return value.trimmed().toLower().replace('-', '_').replace(' ', '_');
 }
 
+QString normalized_scene3d_layer_token(const QString & value)
+{
+  const QString normalized = normalized_token(value);
+  if (normalized == QStringLiteral("generated_preview") ||
+      normalized == QStringLiteral("generated_urdf_visual") ||
+      normalized == QStringLiteral("locked_generated_urdf")) {
+    return QStringLiteral("locked_generated_urdf_visual");
+  }
+  if (normalized == QStringLiteral("legacy_static_fallback")) return QStringLiteral("primitive_fallback");
+  if (normalized == QStringLiteral("overlays") || normalized == QStringLiteral("helper_overlay")) return QStringLiteral("overlay");
+  return normalized;
+}
+
 QString clean_label_from_item(const ScenePreviewWidget::PreviewItem & it)
 {
   QString label = it.display_name.trimmed();
@@ -271,8 +284,8 @@ QString warning_debug_text(const QStringList & warnings)
 bool item_is_editable_for_gizmo(const ScenePreviewWidget::PreviewItem & it)
 {
   if (it.locked) return false;
-  const QString source_layer = normalized_token(it.source_layer);
-  const QString visual_source = normalized_token(it.active_visual_source);
+  const QString source_layer = normalized_scene3d_layer_token(it.source_layer);
+  const QString visual_source = normalized_scene3d_layer_token(it.active_visual_source);
   const QString role = normalized_token(it.role);
   const QString category = normalized_token(it.category);
   const QString lock_reason = normalized_token(it.lock_reason);


### PR DESCRIPTION
### Motivation
- Historical code and scene artifacts used ad-hoc layer/source tokens (e.g. `generated_preview`, `generated_urdf_visual`, `legacy_static_fallback`), causing inconsistent classification and diagnostics across GUI and validation tooling. 
- Establish a single canonical set of tokens (`editable_layout`, `mesh_preview`, `locked_generated_urdf_visual`, `primitive_fallback`, `overlay`) so runtime, editor, and offline validators classify items consistently.

### Description
- Added canonical token normalization in the C++ GUI via `canonical_scene3d_token()` and `normalized_scene3d_layer_token()` and replaced ad-hoc assignments at preview-item creation and URDF visual insertion so new items use canonical layer names. 
- Updated visibility/filtering and gizmo/editability decisions to consult canonicalized `source_layer` and `active_visual_source` values before making UI decisions. 
- Extended Python validation scripts (`check_scene3d_canvas_contract.py` and `validate_scene3d_runtime_acceptance.py`) with a `normalize_layer_token()` helper and `CANONICAL_LAYERS` so legacy aliases are mapped at read-time and source-layer distributions are reported canonically. 
- Changed diagnostics/counting to increment editable/mesh/generated/fallback from canonicalized fields only and introduced `missing`/`missing_count` to capture truly unclassified (non-canonical) items.

### Testing
- Ran `python3 -m py_compile scripts/check_scene3d_canvas_contract.py scripts/validate_scene3d_runtime_acceptance.py`, and compilation succeeded. 
- Performed automated text searches (`rg`) to verify legacy tokens are replaced or normalized and canonical tokens are present across modified files. 
- No automated C++ build was run in this patch; changes were limited to normalization/assignment logic and script outputs and validated via the above checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f7342ad28833182bb9028968eb984)