### PR TITLE
Handle malformed layout YAML with warning fallback and mark Preview as Warning

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -5943,6 +5943,7 @@ std::vector<MainWindow::SceneWorkflowStep> MainWindow::scene_workflow_steps() co
   const bool scene_selected = has_selected_scene();
   const bool editable_layout_ready = !workcell_builder::build_workcell_studio_canvas_model(s.scene_dir, s.scene_name).items.empty();
   const bool has_warnings = !readiness_warning_details_.isEmpty();
+  const bool preview_fallback_visible = preview_fallback_item_count_ > 0;
   const bool validation_gate_ready = validation_report_ready && !validation_stale_;
   const bool export_ready = yaml_ready && launch_ready;
   const bool fake_hardware_ready = launch_artifacts_ready_ && validation_gate_ready;
@@ -5988,9 +5989,12 @@ std::vector<MainWindow::SceneWorkflowStep> MainWindow::scene_workflow_steps() co
   steps.push_back(compute_scene_workflow_step(
     "Preview",
     fake_hardware_ready,
-    "Ready (Safety: fake hardware only, no robot motion).",
+    preview_fallback_visible ?
+      "Ready with fallback visible (Safety: fake hardware only, no robot motion)." :
+      "Ready (Safety: fake hardware only, no robot motion).",
     "Blocked until scene package and validation gates are satisfied. Safety gate remains enforced: fake hardware only.",
-    {"scene_package", "validation"}, gates, fake_hardware_ready ? SceneWorkflowStepStatus::Done : SceneWorkflowStepStatus::Blocked));
+    {"scene_package", "validation"}, gates,
+    fake_hardware_ready ? (preview_fallback_visible ? SceneWorkflowStepStatus::Warning : SceneWorkflowStepStatus::Done) : SceneWorkflowStepStatus::Blocked));
   steps.push_back(compute_scene_workflow_step(
     "Export",
     export_ready, "Export prerequisites are satisfied.",

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -8,7 +8,22 @@
 namespace fs = boost::filesystem;
 namespace workcell_builder {
 
-static bool read_yaml(const fs::path & p, YAML::Node * out){ try{ if(!fs::exists(p)) return false; *out = YAML::LoadFile(p.string()); return true;}catch(...){ workcell_builder::log_warning_once_per_context_path_reason("task_metadata_summary_loader", p, "scene YAML parse failed"); return false;} }
+static bool read_yaml(const fs::path & p, YAML::Node * out, std::string * parse_error = nullptr)
+{
+  try {
+    if (!fs::exists(p)) return false;
+    *out = YAML::LoadFile(p.string());
+    return true;
+  } catch (const YAML::Exception & ex) {
+    if (parse_error) *parse_error = ex.what();
+    workcell_builder::log_warning_once_per_context_path_reason("task_metadata_summary_loader", p, std::string("scene YAML parse failed: ") + ex.what());
+    return false;
+  } catch (const std::exception & ex) {
+    if (parse_error) *parse_error = ex.what();
+    workcell_builder::log_warning_once_per_context_path_reason("task_metadata_summary_loader", p, std::string("scene YAML parse failed: ") + ex.what());
+    return false;
+  }
+}
 
 static void add_mesh_candidate(const YAML::Node & node, std::vector<std::string> * out)
 {
@@ -124,18 +139,22 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   };
 
   YAML::Node env, manifest, task, layout;
-  const bool env_ok = read_yaml(scene_dir / "environment.yaml", &env);
-  const bool manifest_ok = read_yaml(scene_dir / "scene_manifest.yaml", &manifest);
-  const bool task_ok = read_yaml(scene_dir / "config" / "task_recipe.yaml", &task);
-  const bool layout_ok = read_yaml(scene_dir / "layout" / "workcell_studio_layout.yaml", &layout);
+  std::string env_parse_error, manifest_parse_error, task_parse_error, layout_parse_error;
+  const bool env_ok = read_yaml(scene_dir / "environment.yaml", &env, &env_parse_error);
+  const bool manifest_ok = read_yaml(scene_dir / "scene_manifest.yaml", &manifest, &manifest_parse_error);
+  const bool task_ok = read_yaml(scene_dir / "config" / "task_recipe.yaml", &task, &task_parse_error);
+  const bool layout_ok = read_yaml(scene_dir / "layout" / "workcell_studio_layout.yaml", &layout, &layout_parse_error);
   if (!layout_ok) {
     if (fs::exists(scene_dir / "layout" / "workcell_studio_layout.yaml")) enable_deterministic_fallback("layout/workcell_studio_layout.yaml is malformed");
     else enable_deterministic_fallback("layout/workcell_studio_layout.yaml is missing");
   }
-  if (!env_ok) m.warnings.push_back("Malformed or missing environment.yaml");
-  if (!manifest_ok) m.warnings.push_back("Missing scene_manifest.yaml");
-  if (!task_ok) m.warnings.push_back("Task intent missing");
-  if (!layout_ok && fs::exists(scene_dir / "layout" / "workcell_studio_layout.yaml")) m.warnings.push_back("Malformed layout/workcell_studio_layout.yaml; falling back safely");
+  if (!env_ok) m.warnings.push_back(env_parse_error.empty() ? "Malformed or missing environment.yaml" : ("Malformed environment.yaml: " + env_parse_error));
+  if (!manifest_ok) m.warnings.push_back(manifest_parse_error.empty() ? "Missing scene_manifest.yaml" : ("Malformed scene_manifest.yaml: " + manifest_parse_error));
+  if (!task_ok) m.warnings.push_back(task_parse_error.empty() ? "Task intent missing" : ("Malformed config/task_recipe.yaml: " + task_parse_error));
+  if (!layout_ok && fs::exists(scene_dir / "layout" / "workcell_studio_layout.yaml")) {
+    m.warnings.push_back("Malformed layout/workcell_studio_layout.yaml; falling back safely. Parse reason: " + (layout_parse_error.empty() ? std::string("unknown parse error") : layout_parse_error));
+    m.warnings.push_back("Repair guidance: Validate " + (scene_dir / "layout" / "workcell_studio_layout.yaml").string() + " with yamllint or python yaml.safe_load and fix syntax/indentation issues.");
+  }
 
   m.template_name = manifest_ok ? yaml_map_value_or_empty(manifest, "template_name") : "";
   if (m.template_name.empty()) m.template_name = "unknown_template";
@@ -397,16 +416,17 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   if (!m.warnings.empty()) { m.has_warnings = true; m.status = "WARNINGS"; { WorkcellStudioCanvasItem w; w.id="warning"; w.type="warning"; w.role="warning"; w.label="warning"; w.source_file="environment.yaml"; w.x=-1.2; w.y=1.2; w.width=0.1; w.depth=0.1; w.height=0.0; w.warnings=m.warnings; m.items.push_back(w); } }
   else { m.status = "READY"; }
   return m;
-  } catch (const YAML::Exception &) {
-    workcell_builder::log_warning_once_per_context_path_reason("task_metadata_summary_loader", scene_dir / "layout" / "workcell_studio_layout.yaml", "YAML parse exception in preview loader");
-  } catch (const std::exception &) {
-    workcell_builder::log_warning_once_per_context_path_reason("task_metadata_summary_loader", scene_dir / "layout" / "workcell_studio_layout.yaml", "std exception in preview loader");
+  } catch (const YAML::Exception & ex) {
+    workcell_builder::log_warning_once_per_context_path_reason("task_metadata_summary_loader", scene_dir / "layout" / "workcell_studio_layout.yaml", std::string("YAML parse exception in preview loader: ") + ex.what());
+  } catch (const std::exception & ex) {
+    workcell_builder::log_warning_once_per_context_path_reason("task_metadata_summary_loader", scene_dir / "layout" / "workcell_studio_layout.yaml", std::string("std exception in preview loader: ") + ex.what());
   }
   WorkcellStudioCanvasModel fallback;
   fallback.scene_name = scene_name;
   fallback.status = "WARNINGS";
   fallback.has_warnings = true;
   fallback.warnings.push_back("mesh metadata missing or legacy; using primitive preview");
+  fallback.warnings.push_back("Repair guidance: Validate layout/workcell_studio_layout.yaml syntax and regenerate preview metadata.");
   fallback.provenance_status.summary = provenance_summary_text(fallback.provenance_status);
   return fallback;
 }


### PR DESCRIPTION
### Motivation

- Keep Workcell Studio usable when layout YAML is malformed by surfacing actionable diagnostics instead of hard-failing the preview pipeline.
- Provide exact parse error text in logs so operators can locate and fix YAML issues quickly.
- Ensure preview generation continues using scene metadata and URDF mesh-index fallbacks when `layout/workcell_studio_layout.yaml` is invalid.

### Description

- Update `read_yaml` to catch `YAML::Exception` and `std::exception`, capture `ex.what()` into an optional `parse_error` string, and log the exact failure reason with `task_metadata_summary_loader` context.
- Propagate parse-error strings from environment/manifest/task/layout loads and convert generic failures into structured Studio warnings that include the parse reason and file path (e.g., `layout/workcell_studio_layout.yaml`).
- Add Studio-facing repair guidance warnings instructing to validate the layout file (examples include `yamllint` or Python `yaml.safe_load`) so operators know next steps.
- Preserve the deterministic/primitive preview fallback and make the global fallback model include the repair guidance; update workflow UI mapping so the `Preview` step is marked as `Warning` when fallback preview content is visible.

### Testing

- Ran `ctest -R workcell_studio_canvas_model_mesh_test --output-on-failure` which executed successfully but reported "No tests were found!!!" in this environment.
- Verified diffs for `workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp` and `workcell_builder/workcell_builder/gui/mainwindow.cpp` to confirm logging, warning text, and workflow-status changes were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f734acf188331bfda883ca7392bfb)