### PR TITLE
Add per-item Scene3D render counters to smoke diagnostics

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -602,6 +602,9 @@ void Scene3DViewportWidget::paintGL()
     }
   }
   overlay_count = static_cast<int>(overlay_items.size());
+  last_render_counters = RenderDebugCounters{};
+  last_render_counters.overlay_count = overlay_count;
+  last_render_counters.hierarchy_child_row_count = static_cast<int>(items.size());
 
   auto draw_item_batch = [&](const std::vector<const ScenePreviewWidget::PreviewItem *> & batch, bool count_in_stats) {
     for (const auto * it : batch) {
@@ -634,7 +637,12 @@ void Scene3DViewportWidget::paintGL()
            << "skipped=" << skipped_item_count
            << "mesh_backed=" << mesh_backed_count
            << "placeholder=" << placeholder_count
-           << "overlay=" << overlay_count;
+           << "overlay=" << overlay_count
+           << "mesh_rendered_count=" << last_render_counters.mesh_rendered_count
+           << "generated_fallback_count=" << last_render_counters.generated_fallback_count
+           << "labels_drawn=" << last_render_counters.labels_drawn
+           << "labels_suppressed=" << last_render_counters.labels_suppressed
+           << "hierarchy_child_row_count=" << last_render_counters.hierarchy_child_row_count;
   qDebug() << kPaintGLCacheOnlyGuard;
   qDebug() << "Scene3D diagnostics {viewport_received_count=" << received_item_count
            << ", render_cache_count=" << mesh_cache_.size()
@@ -715,6 +723,8 @@ void Scene3DViewportWidget::paintGL()
 
   QVector<QRectF> placed_label_boxes;
   QVector<QPointF> placed_label_points;
+  int labels_drawn = 0;
+  int labels_suppressed = 0;
   for (const auto & candidate : label_candidates) {
     const QPointF label_pos = apply_label_overlap_offset(candidate.anchor, placed_label_points, robot_base_points, candidate.critical);
     const QRectF label_rect = painter.boundingRect(QRectF(label_pos.x() - 2.0, label_pos.y() - 14.0, 220.0, 18.0), Qt::AlignLeft | Qt::AlignVCenter, candidate.text);
@@ -727,13 +737,16 @@ void Scene3DViewportWidget::paintGL()
       }
     }
     // LABEL_OVERLAP_SUPPRESS_LOWER_PRIORITY: keep high priority, suppress lower when overlap remains.
-    if (overlaps) continue;
+    if (overlaps) { ++labels_suppressed; continue; }
 
     placed_label_points.push_back(label_pos);
     placed_label_boxes.push_back(label_rect);
     painter.setPen(candidate.color);
     painter.drawText(label_pos, candidate.text);
+    ++labels_drawn;
   }
+  last_render_counters.labels_drawn = labels_drawn;
+  last_render_counters.labels_suppressed = labels_suppressed;
   painter.setPen(Qt::NoPen);
   painter.setBrush(QColor(15, 23, 42, 190));
   painter.drawRoundedRect(QRectF(12.0, 12.0, 360.0, 74.0), 6.0, 6.0);
@@ -793,12 +806,14 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
   // Always try mesh-backed draw first for physical items.
   if (draw_mesh_preview_if_available(it, item_color(it), true)) {
     if (out_mesh_count) ++(*out_mesh_count);
+    ++last_render_counters.mesh_rendered_count;
     return true;
   }
   const QString missing_reason = placeholder_reason_for_item(it);
   if (!missing_reason.isEmpty()) {
     draw_missing_geometry_marker(it);
     if (out_placeholder_count) ++(*out_placeholder_count);
+    ++last_render_counters.generated_fallback_count;
     if (show_warning_labels) warn_mesh_fallback_once(it.id, QStringLiteral("missing geometry"), it.source_path);
     return false;
   }
@@ -810,6 +825,7 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
   }
   draw_missing_geometry_marker(it);
   if (out_placeholder_count) ++(*out_placeholder_count);
+  ++last_render_counters.generated_fallback_count;
   return false;
 }
 

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -74,6 +74,17 @@ public:
   void set_isometric_view();
   void invalidate_mesh_cache();
 
+  struct RenderDebugCounters
+  {
+    int mesh_rendered_count{ 0 };
+    int generated_fallback_count{ 0 };
+    int overlay_count{ 0 };
+    int labels_drawn{ 0 };
+    int labels_suppressed{ 0 };
+    int hierarchy_child_row_count{ 0 };
+  };
+  RenderDebugCounters last_render_counters;
+
   static bool parse_stl_bytes_for_test(const QByteArray & bytes, const QString & source_hint,
                                        InternalTriangleMesh & out_mesh, QString & out_error,
                                        int triangle_limit = 100000);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -370,11 +370,17 @@ void ScenePreviewWidget::refresh_info_chip()
          lock_reason.contains("robotmodel") || lock_reason.contains("urdf visual"))) ++locked_urdf_count;
   }
 
+  const auto * viewport = static_cast<Scene3DViewportWidget *>(simple_3d_view_);
+  const auto counters = viewport ? viewport->last_render_counters : Scene3DViewportWidget::RenderDebugCounters{};
   const QString compact_stats = QString("Items %1 M%2 B%3 Miss%4 Ov%5 L-URDF%6")
                                   .arg(physical_count).arg(mesh_count).arg(box_count).arg(missing_count).arg(overlay_count).arg(locked_urdf_count);
+  const QString smoke_stats = QString("mesh_rendered_count=%1 fallback_count=%2 overlay_count=%3 labels=%4/%5 hierarchy_child_row_count=%6")
+                                  .arg(counters.mesh_rendered_count).arg(counters.generated_fallback_count)
+                                  .arg(counters.overlay_count).arg(counters.labels_drawn).arg(counters.labels_suppressed)
+                                  .arg(counters.hierarchy_child_row_count);
   info_chip_label_->setText(QString("Scene: %1\nMode: %2\n%3\n%4  Warn: %5  Task: %6")
                               .arg(preview_scene_name_).arg(render_mode).arg(summary).arg(compact_stats)
-                              .arg(total_warning_count()).arg(task_is_ready() ? "Ready" : "Missing"));
+                              .arg(total_warning_count()).arg(task_is_ready() ? "Ready" : "Missing") + QString("\n") + smoke_stats);
   info_chip_label_->adjustSize();
   if (fallback_info_chip_proxy_) fallback_info_chip_proxy_->setPos(12.0, 12.0);
   if (toolbar_status_chip_) {


### PR DESCRIPTION
### Motivation

- Provide per-frame, per-item smoke/debug diagnostics for the 3D preview so callers and tests can observe mesh vs fallback rendering, overlay counts, label behavior, and hierarchy size without instrumenting the render loop further.
- Surface those diagnostics into existing UI smoke artifacts so automated checks and telemetry can read `mesh_rendered_count`, `generated_fallback_count`, `overlay_count`, label draw/suppress counters, and a simple hierarchy count.

### Description

- Added a `RenderDebugCounters` struct and a `last_render_counters` instance to `Scene3DViewportWidget` to hold `mesh_rendered_count`, `generated_fallback_count`, `overlay_count`, `labels_drawn`, `labels_suppressed`, and `hierarchy_child_row_count` (`workcell_builder/.../scene3d_viewport_widget.h`).
- In `paintGL()` the counters are reset and seeded (`overlay_count`, `hierarchy_child_row_count`) and the render diagnostics log now prints the counter values (`workcell_builder/.../scene3d_viewport_widget.cpp`).
- Increment per-item counters where geometry decisions are made: on successful mesh draw in `draw_truthful_item_geometry` we increment `mesh_rendered_count`, and on per-item fallback marker generation we increment `generated_fallback_count`; label draw/suppress counts are tracked while placing labels and saved to the counters at frame end (`workcell_builder/.../scene3d_viewport_widget.cpp`).
- Exposed the counters to the preview info chip by reading `last_render_counters` from `ScenePreviewWidget::refresh_info_chip()` and appending a compact `smoke_stats` line to the info chip text so smoke artifacts can capture them (`workcell_builder/.../scene_preview_widget.cpp`).
- No changes were made to mesh path resolution, mesh cache population, or STL/DAE parsing logic; mesh loading remains handled by `ensure_mesh_cached()` and `parse_stl_bytes_for_test`/`parse_collada_bytes_for_test`, and `paintGL()` continues to consume cached triangle data only.

### Testing

- Ran repository inspection and diff commands to validate the edits: `rg`, `sed`, `nl`, `git diff`, and `git status` (all succeeded).
- Committed the changes locally (`git commit`) and generated the PR metadata with `make_pr` (succeeded); the patch was reviewed via local diffs (`git diff` / `nl`) to confirm the counter wiring.
- No full build or runtime unit test was executed in this environment (no compile/run tests performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10210aa6888331bcf21d6d8ad8071c)