### PR TITLE
Document blocked workcell_builder scene validation attempt (2026-05-22)

### DIFF
--- a/docs/manuals/latest_workcell_builder_scene_validation_attempt_2026-05-22.md
+++ b/docs/manuals/latest_workcell_builder_scene_validation_attempt_2026-05-22.md
@@ -1,0 +1,45 @@
+# Workcell Builder scene validation attempt (2026-05-22)
+
+## Commands requested
+- `colcon build --symlink-install --packages-select workcell_builder`
+- `source install/setup.bash`
+- Scene runtime acceptance + scene contract checks for:
+  - `ur5_2f_test`
+  - `ur5_2f_sorting_test`
+- GUI smoke screenshots:
+  - `build/workcell_studio/scene3d_gui_smoke_ur5_2f_test.png`
+  - `build/workcell_studio/scene3d_gui_smoke_ur5_2f_sorting_test.png`
+  - `build/workcell_studio/scene3d_gui_smoke_new_cell.png` (if supported)
+
+## Environment blockers
+1. `colcon` is not installed in this runner (`/bin/bash: colcon: command not found`).
+2. `install/setup.bash` is not present because build did not run.
+3. `workcell_builder` executable cannot be resolved by GUI smoke (`status=FAIL; blockers=[unable to resolve workcell_builder executable: checked install/workcell_builder first, then PATH]`).
+4. ROS package discovery is unavailable for contract checks (`RESULT: SKIP` with E1 requesting sourced ROS + workspace overlays).
+
+## Produced artifacts
+- Runtime acceptance summary was still generated and captured missing smoke evidence:
+  - `build/workcell_studio/scene3d_runtime_acceptance.json`
+  - `build/workcell_studio/scene3d_runtime_acceptance.md`
+
+## Requested screenshot paths
+The following paths are the expected reviewer targets, but screenshots were **not** generated in this environment due blockers above:
+- `build/workcell_studio/scene3d_gui_smoke_ur5_2f_test.png`
+- `build/workcell_studio/scene3d_gui_smoke_ur5_2f_sorting_test.png`
+- `build/workcell_studio/scene3d_gui_smoke_new_cell.png`
+
+## Smoke JSON snippets
+### `build/workcell_studio/scene3d_runtime_acceptance.json`
+```json
+{
+  "schema": "workcell_studio_scene3d_runtime_acceptance/v1",
+  "scenes": [
+    {
+      "scene": "ur5_2f_test",
+      "blockers": [
+        "missing runtime smoke evidence JSON: /workspace/Easy_Manipulator_Improved/build/workcell_studio/scene3d_gui_smoke_ur5_2f_test.json"
+      ]
+    }
+  ]
+}
+```


### PR DESCRIPTION
### Motivation
- Capture a writable Code-mode attempt to run workcell_builder build, scene runtime acceptance, contract checks, and GUI smoke for `ur5_2f_test` and `ur5_2f_sorting_test`, and record precise environment blockers so reviewers understand why visual evidence could not be produced.

### Description
- Add `docs/manuals/latest_workcell_builder_scene_validation_attempt_2026-05-22.md` which records the requested commands, environment blockers (`colcon` missing, missing `install/setup.bash`, unresolved `workcell_builder`, ROS package discovery unavailable), produced artifacts, expected screenshot paths, and an embedded smoke JSON snippet for reviewer verification.

### Testing
- Executed the requested workflow as far as possible: `colcon build --symlink-install --packages-select workcell_builder` failed due to `colcon: command not found`, `source install/setup.bash` failed due to missing file, `python3 scripts/validate_scene3d_runtime_acceptance.py --scene ur5_2f_test --scene ur5_2f_sorting_test` produced `build/workcell_studio/scene3d_runtime_acceptance.json` and `.md` (reporting missing GUI smoke evidence), `python3 scripts/validate_scene_contract.py ur5_2f_test` was skipped (`RESULT: SKIP`) because ROS package discovery was unavailable, and `python3 scripts/run_workcell_builder_scene3d_gui_smoke.py ... --xvfb` failed due to being unable to resolve the `workcell_builder` executable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a102114f6688331831753de0ed84001)