### PR TITLE
Refine Scene3D label prioritization and smoke diagnostics

### DIFF
--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -33,6 +33,7 @@
 
 #include "gui/mainwindow.h"
 #include "gui/scene_select.h"
+#include "gui/scene3d_viewport_widget.h"
 #include "gui/startup_dialog.h"
 #include "workcell_builder_ui_utils.hpp"
 
@@ -189,6 +190,10 @@ private:
     counters["hierarchy_top_level_count"] = tree ? tree->topLevelItemCount() : 0;
     counters["log_line_count"] = log ? log->toPlainText().split('\n', Qt::SkipEmptyParts).size() : 0;
     counters["log_has_scene3d_diagnostics"] = log ? log->toPlainText().contains("Scene3D diagnostics") : false;
+    auto * viewport = window_->findChild<Scene3DViewportWidget *>();
+    const auto render_counters = viewport ? viewport->last_render_counters : Scene3DViewportWidget::RenderDebugCounters{};
+    counters["labels_drawn"] = render_counters.labels_drawn;
+    counters["labels_suppressed_overlap"] = render_counters.labels_suppressed_overlap;
     root["counters"] = counters;
     root["warnings"] = warnings_;
     root["blockers"] = blockers_;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -481,6 +481,7 @@ QPointF apply_label_overlap_offset(const QPointF & anchor, const QVector<QPointF
   }
 
   return candidates.back();
+}
 
 int label_priority_bucket(bool selected, bool has_warnings, NormalizedRole role)
 {
@@ -488,6 +489,7 @@ int label_priority_bucket(bool selected, bool has_warnings, NormalizedRole role)
   if (selected) return 0;
   if (has_warnings) return 1;
   if (is_critical_label_role(role)) return 2;
+  if (role == NormalizedRole::WarningAnchor) return 2;
   return 3;
 }
 
@@ -665,6 +667,7 @@ void Scene3DViewportWidget::paintGL()
   const bool crowded = items.size() > 30;
   const bool zoomed_far = zoom_factor > 5.2;
   const bool suppress_dense_non_critical_labels = crowded || zoomed_far;
+  label_mode = ScenePreviewWidget::LabelMode::Selected;
   QVector<QPointF> robot_base_points;
   for (const auto & it : items) {
     if (classify_item_role(it) != NormalizedRole::RobotBase) continue;
@@ -678,16 +681,12 @@ void Scene3DViewportWidget::paintGL()
     const QPointF p = project_to_screen(bounds.x + (bounds.sx * 0.5), bounds.y + (bounds.sy * 0.5), bounds.z + (bounds.sz * 0.5));
     const bool selected = (it.id == selected_id);
     const NormalizedRole role = classify_item_role(it);
-    bool draw_label = false;
-    switch (label_mode) {
-      case ScenePreviewWidget::LabelMode::Off: draw_label = selected; break;
-      case ScenePreviewWidget::LabelMode::Important: draw_label = selected || is_critical_label_role(role); break;
-      case ScenePreviewWidget::LabelMode::Selected: draw_label = selected; break;
-      case ScenePreviewWidget::LabelMode::All: draw_label = true; break;
-    }
     const bool is_urdf_visual = it.locked && !it.editable && it.lock_reason.contains("URDF visual", Qt::CaseInsensitive);
+    const bool overlay_only = is_overlay_only_item(it);
+    bool draw_label = selected;
+    if (!selected && overlay_only) draw_label = false;
+    if (!selected && is_urdf_visual) draw_label = false;
     if (suppress_dense_non_critical_labels && !selected && !is_critical_label_role(role)) draw_label = false;
-    if (is_urdf_visual && !selected && label_mode != ScenePreviewWidget::LabelMode::All) draw_label = false;
     if (show_warning_labels && !it.warnings.isEmpty()) {
       if (debug_overlays_mode && show_warning_labels && !it.warnings.isEmpty()) {
         const QString debug_warning_text = warning_debug_text(it.warnings);
@@ -702,7 +701,7 @@ void Scene3DViewportWidget::paintGL()
     if (!draw_label) continue;
     const QString missing_reason = placeholder_reason_for_item(it);
     const bool is_critical_scene_anchor = (role == NormalizedRole::RobotBase || role == NormalizedRole::Table || role == NormalizedRole::Camera);
-    if (!selected && is_urdf_visual && missing_reason.isEmpty() && !is_critical_scene_anchor && label_mode != ScenePreviewWidget::LabelMode::All) continue;
+    if (!selected && is_urdf_visual && missing_reason.isEmpty() && !is_critical_scene_anchor) continue;
 
     const QString compact_text = clean_label_from_item(it);
     const QString text = selected ? compact_text : (missing_reason.isEmpty() ? compact_text : QString("%1 missing").arg(compact_role(it.role)));
@@ -725,6 +724,8 @@ void Scene3DViewportWidget::paintGL()
   QVector<QPointF> placed_label_points;
   int labels_drawn = 0;
   int labels_suppressed = 0;
+  int labels_suppressed_overlap = 0;
+  int overlap_budget = 6;
   for (const auto & candidate : label_candidates) {
     const QPointF label_pos = apply_label_overlap_offset(candidate.anchor, placed_label_points, robot_base_points, candidate.critical);
     const QRectF label_rect = painter.boundingRect(QRectF(label_pos.x() - 2.0, label_pos.y() - 14.0, 220.0, 18.0), Qt::AlignLeft | Qt::AlignVCenter, candidate.text);
@@ -737,7 +738,13 @@ void Scene3DViewportWidget::paintGL()
       }
     }
     // LABEL_OVERLAP_SUPPRESS_LOWER_PRIORITY: keep high priority, suppress lower when overlap remains.
-    if (overlaps) { ++labels_suppressed; continue; }
+    if (overlaps) {
+      ++labels_suppressed;
+      ++labels_suppressed_overlap;
+      if (candidate.priority >= 2) --overlap_budget;
+      if (overlap_budget <= 0 && candidate.priority >= 2) break;
+      continue;
+    }
 
     placed_label_points.push_back(label_pos);
     placed_label_boxes.push_back(label_rect);
@@ -747,6 +754,7 @@ void Scene3DViewportWidget::paintGL()
   }
   last_render_counters.labels_drawn = labels_drawn;
   last_render_counters.labels_suppressed = labels_suppressed;
+  last_render_counters.labels_suppressed_overlap = labels_suppressed_overlap;
   painter.setPen(Qt::NoPen);
   painter.setBrush(QColor(15, 23, 42, 190));
   painter.drawRoundedRect(QRectF(12.0, 12.0, 360.0, 74.0), 6.0, 6.0);

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -81,6 +81,7 @@ public:
     int overlay_count{ 0 };
     int labels_drawn{ 0 };
     int labels_suppressed{ 0 };
+    int labels_suppressed_overlap{ 0 };
     int hierarchy_child_row_count{ 0 };
   };
   RenderDebugCounters last_render_counters;

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -235,8 +235,8 @@ void ScenePreviewWidget::set_task_overlay_visibility(bool task_route, bool pick_
   v->show_task_route = task_route;
   v->show_pick_place = pick_place_zones;
   v->show_approach_retreat = approach_retreat;
-  if (labels) v->label_mode = LabelMode::All;
-  else if (v->label_mode == LabelMode::All) v->label_mode = LabelMode::Important;
+  Q_UNUSED(labels);
+  v->label_mode = LabelMode::Selected;
   // else if (v->label_mode == LabelMode::All) v->label_mode = LabelMode::SelectedOnly;
   v->update();
 }
@@ -374,9 +374,9 @@ void ScenePreviewWidget::refresh_info_chip()
   const auto counters = viewport ? viewport->last_render_counters : Scene3DViewportWidget::RenderDebugCounters{};
   const QString compact_stats = QString("Items %1 M%2 B%3 Miss%4 Ov%5 L-URDF%6")
                                   .arg(physical_count).arg(mesh_count).arg(box_count).arg(missing_count).arg(overlay_count).arg(locked_urdf_count);
-  const QString smoke_stats = QString("mesh_rendered_count=%1 fallback_count=%2 overlay_count=%3 labels=%4/%5 hierarchy_child_row_count=%6")
+  const QString smoke_stats = QString("mesh_rendered_count=%1 fallback_count=%2 overlay_count=%3 labels_drawn=%4 labels_suppressed_overlap=%5 hierarchy_child_row_count=%6")
                                   .arg(counters.mesh_rendered_count).arg(counters.generated_fallback_count)
-                                  .arg(counters.overlay_count).arg(counters.labels_drawn).arg(counters.labels_suppressed)
+                                  .arg(counters.overlay_count).arg(counters.labels_drawn).arg(counters.labels_suppressed_overlap)
                                   .arg(counters.hierarchy_child_row_count);
   info_chip_label_->setText(QString("Scene: %1\nMode: %2\n%3\n%4  Warn: %5  Task: %6")
                               .arg(preview_scene_name_).arg(render_mode).arg(summary).arg(compact_stats)


### PR DESCRIPTION
### Motivation

- Make 3D label rendering deterministic and conservative so generated/overlay labels do not clutter the view by default and diagnostics reflect overlap suppression.

### Description

- Enforce default label mode to `Selected` in the viewport render path by pinning `label_mode = ScenePreviewWidget::LabelMode::Selected` and using `selected`-only drawing rules for overlay and generated URDF/link visuals. (changes in `scene3d_viewport_widget.cpp` and `scene_preview_widget.cpp`)
- Only draw labels for the selected item by default and keep overlay/generated visual labels suppressed unless the item is selected. (changes in `scene3d_viewport_widget.cpp`)
- Apply the same selection-based rules to overlay labels by setting the label mode before collecting overlay candidates. (changes in `scene3d_viewport_widget.cpp` and `scene_preview_widget.cpp`)
- Implement deterministic priority buckets: `selected (0) > warnings (1) > critical/anchor/WarningAnchor (2) > others (3)` by updating `label_priority_bucket`. (changes in `scene3d_viewport_widget.cpp`)
- Add overlap-budget logic to stop drawing low-priority labels once the overlap budget is exceeded and increment a new counter `labels_suppressed_overlap`. (changes in `scene3d_viewport_widget.cpp`)
- Expose `labels_drawn` and `labels_suppressed_overlap` to smoke diagnostics consumed by JSON by adding them to the smoke counters and info chip text, and add the new counter to `RenderDebugCounters`. (changes in `scene3d_viewport_widget.h`, `main.cpp`, and `scene_preview_widget.cpp`)

### Testing

- No automated build or unit tests were executed for this patch; changes were limited to label selection, priority and diagnostic reporting logic only.
- Basic repository checks were performed (status/diff) and the edit/commit cycle completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a102b716b308331b22db8631bda8a43)