### PR TITLE
Document blocked Scene3D validation attempt (missing ~/workcell_ws)

### DIFF
--- a/SCENE3D_VALIDATION_ATTEMPT.md
+++ b/SCENE3D_VALIDATION_ATTEMPT.md
@@ -1,0 +1,24 @@
+# Scene3D Runtime Acceptance Attempt (2026-05-22 UTC)
+
+Requested workspace: `~/workcell_ws`
+
+## Command 1
+`colcon build --symlink-install --packages-select workcell_builder`
+
+### stderr/stdout
+```text
+/bin/bash: line 1: cd: /root/workcell_ws: No such file or directory
+```
+
+## Result
+Blocked immediately because `~/workcell_ws` does not exist in this environment.
+
+Because step 1 failed at workspace discovery, steps 2-9 could not be executed here:
+- source install/setup.bash
+- runtime acceptance for both scenes
+- contract checks producing /tmp/*.json and /tmp/*.md
+- GUI smoke outputs json/png files
+- readiness gate
+- manual GUI checks and screenshots
+
+No PR readiness claim is made.


### PR DESCRIPTION
### Motivation
- Record and communicate that the requested Scene3D runtime acceptance workflow could not be executed because the expected workspace path did not exist, preventing accidental PR readiness claims.

### Description
- Add `SCENE3D_VALIDATION_ATTEMPT.md` at the repository root which documents the attempted `colcon build --symlink-install --packages-select workcell_builder` run, includes the stderr (`/bin/bash: line 1: cd: /root/workcell_ws: No such file or directory`), and lists the downstream steps and artifacts that were not produced.

### Testing
- Ran `cd ~/workcell_ws && colcon build --symlink-install --packages-select workcell_builder` which failed due to the missing workspace path, and repository operations to add/inspect the documentation file completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a102b73beac8331abf7e01ac3e9c0aa)