### PR TITLE
Add shared Workcell Studio path resolver and refactor scripts

### DIFF
--- a/scripts/check_workcell_builder_gui_acceptance.py
+++ b/scripts/check_workcell_builder_gui_acceptance.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 import json, os, subprocess
 from pathlib import Path
 
+from scripts.workcell_studio_path_resolver import resolve_repo_root, resolve_workspace_root, resolve_workcell_builder_executable
+
 def main() -> int:
-    exe = os.environ.get("WORKCELL_BUILDER_EXE", "workcell_builder")
+    repo_root = resolve_repo_root()
+    workspace_root = resolve_workspace_root(repo_root)
+    resolved = resolve_workcell_builder_executable(workspace_root, repo_root)
+    exe = os.environ.get("WORKCELL_BUILDER_EXE") or (str(resolved) if resolved else "workcell_builder")
     env = dict(os.environ)
     env.setdefault("QT_QPA_PLATFORM", "offscreen")
     cmd = [exe, "--self-test-gui"]

--- a/scripts/report_workcell_builder_paths.py
+++ b/scripts/report_workcell_builder_paths.py
@@ -8,6 +8,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from scripts.workcell_studio_path_resolver import resolve_repo_root
+
 MESH_EXTS = {".stl", ".dae", ".obj"}
 
 
@@ -60,7 +62,7 @@ def build_report(repo_root: Path) -> dict[str, Any]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--repo-root", type=Path, default=resolve_repo_root())
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args()
 

--- a/scripts/scene_root_resolver.py
+++ b/scripts/scene_root_resolver.py
@@ -2,19 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from scripts.workcell_studio_path_resolver import resolve_scenes_root
+
 
 def resolve_scene_root(repo_root: Path) -> Path:
-    """Resolve the canonical scene root for script utilities.
-
-    Priority:
-    1) <repo>/scenes
-    2) <repo>/workcell_builder/scenes (legacy fallback) only when canonical does not exist.
-    """
-
-    canonical = repo_root / "scenes"
-    legacy = repo_root / "workcell_builder" / "scenes"
-    if canonical.exists():
-        return canonical
-    if legacy.exists():
-        return legacy
-    return canonical
+    """Backward-compatible scene root resolver."""
+    return resolve_scenes_root(repo_root)

--- a/scripts/workcell_builder_gui_workflow.py
+++ b/scripts/workcell_builder_gui_workflow.py
@@ -6,6 +6,8 @@ from typing import Any
 import re
 import yaml
 
+from scripts.workcell_studio_path_resolver import resolve_repo_root
+
 DEFAULTS={
     "robot":{"role":"robot_base","pose":{"x":0,"y":0,"z":0,"roll":0,"pitch":0,"yaw":0},"collision_mode":"mesh_collision","support_status":"supported"},
     "end_effector":{"role":"end_effector","pose":{"x":0,"y":0,"z":0,"roll":0,"pitch":0,"yaw":0},"collision_mode":"mesh_collision","support_status":"supported"},
@@ -110,7 +112,7 @@ def import_custom_stl(state:dict[str,Any], filepath:str, collision_mode:str="vis
 
 
 def repo_root() -> Path:
-    return Path(__file__).resolve().parents[1]
+    return resolve_repo_root()
 
 
 def _run(cmd:list[str], cwd:Path|None=None)->dict[str,Any]:

--- a/scripts/workcell_studio_path_resolver.py
+++ b/scripts/workcell_studio_path_resolver.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Optional
+
+REPO_MARKERS = ("scripts", "workcell_builder", "scenes", "assets", "package.xml")
+
+
+def _looks_like_repo_root(path: Path) -> bool:
+    return all((path / marker).exists() for marker in REPO_MARKERS)
+
+
+def resolve_repo_root(start: Path | None = None) -> Path:
+    """Resolve repository root by walking upward from start (or this file)."""
+    origin = (start or Path(__file__).resolve()).resolve()
+    scan_from = origin if origin.is_dir() else origin.parent
+
+    for candidate in (scan_from, *scan_from.parents):
+        if _looks_like_repo_root(candidate):
+            return candidate
+
+    # Conservative fallback for script-in-repo execution.
+    return Path(__file__).resolve().parents[1]
+
+
+def resolve_workspace_root(repo_root: Path) -> Optional[Path]:
+    """Find a colcon-style workspace root without assuming workspace name."""
+    env_candidates = [
+        os.environ.get("WORKCELL_WS"),
+        os.environ.get("WORKSPACE"),
+        os.environ.get("COLCON_CURRENT_PREFIX"),
+    ]
+    for raw in env_candidates:
+        if not raw:
+            continue
+        p = Path(raw).expanduser().resolve()
+        root = p if (p / "src").is_dir() else p.parent
+        if (root / "src").is_dir():
+            return root
+
+    cwd = Path.cwd().resolve()
+    for candidate in (cwd, *cwd.parents):
+        if (candidate / "src").is_dir():
+            return candidate
+
+    for candidate in (repo_root.parent, *repo_root.parent.parents):
+        if (candidate / "src").is_dir():
+            return candidate
+
+    return None
+
+
+def resolve_install_setup(workspace_root: Path | None, repo_root: Path) -> Optional[Path]:
+    candidates = []
+    if workspace_root is not None:
+        candidates.append(workspace_root / "install" / "setup.bash")
+    candidates += [
+        repo_root / "install" / "setup.bash",
+        repo_root.parent / "install" / "setup.bash",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def resolve_workcell_builder_executable(workspace_root: Path | None, repo_root: Path) -> Optional[Path]:
+    """Resolve workcell_builder executable and emit searched-path diagnostics."""
+    candidates: list[Path] = []
+    if workspace_root is not None:
+        candidates.extend(
+            [
+                workspace_root / "install" / "workcell_builder" / "lib" / "workcell_builder" / "workcell_builder",
+                workspace_root / "build" / "workcell_builder" / "workcell_builder",
+            ]
+        )
+
+    candidates.extend(
+        [
+            repo_root / "install" / "workcell_builder" / "lib" / "workcell_builder" / "workcell_builder",
+            repo_root / "build" / "workcell_builder" / "workcell_builder",
+        ]
+    )
+
+    system_exe = shutil.which("workcell_builder")
+    if system_exe:
+        candidates.append(Path(system_exe))
+
+    for candidate in candidates:
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return candidate
+
+    search_log = "\n".join(f"- {p}" for p in candidates) if candidates else "- <none>"
+    print("workcell_builder executable not found. searched:\n" + search_log)
+    return None
+
+
+def resolve_scenes_root(repo_root: Path) -> Path:
+    canonical = repo_root / "scenes"
+    legacy = repo_root / "workcell_builder" / "scenes"
+    if canonical.exists():
+        return canonical
+    if legacy.exists():
+        return legacy
+    return canonical

--- a/scripts/workcell_studio_preview_launch.py
+++ b/scripts/workcell_studio_preview_launch.py
@@ -4,6 +4,8 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+from scripts.workcell_studio_path_resolver import resolve_workspace_root
+
 DENYLIST = [
     'use_fake_hardware:=false',
     'real_hardware:=true',
@@ -14,14 +16,9 @@ DENYLIST = [
 ]
 
 def detect_workspace_root(scene_dir: Path | None = None) -> str:
-    cwd = Path.cwd()
-    if (cwd / 'src').is_dir():
-        return str(cwd)
-    if scene_dir:
-        for parent in [scene_dir, *scene_dir.parents]:
-            if (parent / 'src').is_dir():
-                return str(parent)
-    return ''
+    start = scene_dir.resolve() if scene_dir else Path.cwd().resolve()
+    ws = resolve_workspace_root(start)
+    return str(ws) if ws else ''
 
 def build_preview_commands(scene_name: str, workspace_root: str = '') -> dict[str, str]:
     ws = workspace_root or '<workspace_root>'


### PR DESCRIPTION
### Motivation

- Centralize duplicate path-discovery logic used across scripts to make workspace/repo/scene resolution consistent and easier to maintain.
- Provide robust upward-walk marker heuristics and environment-variable fallbacks to avoid assumptions about workspace naming or layout.
- Surface diagnostics when resolving the `workcell_builder` executable so callers can understand where resolution failed.

### Description

- Added `scripts/workcell_studio_path_resolver.py` implementing `resolve_repo_root(start: Path | None = None) -> Path`, `resolve_workspace_root(repo_root: Path) -> Optional[Path]`, `resolve_install_setup(workspace_root: Path | None, repo_root: Path) -> Optional[Path]`, `resolve_workcell_builder_executable(workspace_root, repo_root) -> Optional[Path]` (with searched-path diagnostics), and `resolve_scenes_root(repo_root: Path) -> Path`, using upward-walk marker logic and environment fallbacks.
- Replaced duplicated heuristics with imports from the new module in `scripts/scene_root_resolver.py`, `scripts/workcell_studio_preview_launch.py` (replaced `detect_workspace_root`), `scripts/report_workcell_builder_paths.py` (default `--repo-root` now from `resolve_repo_root()`), `scripts/check_workcell_builder_gui_acceptance.py` (resolve repo/workspace/executable before launching), and `scripts/workcell_builder_gui_workflow.py` (use `resolve_repo_root()` for `repo_root()`).
- `resolve_workcell_builder_executable` searches workspace/install/build locations and `shutil.which` and prints a compact searched-path log when not found.

### Testing

- Ran byte-compile check: `python -m py_compile scripts/workcell_studio_path_resolver.py scripts/scene_root_resolver.py scripts/workcell_studio_preview_launch.py scripts/report_workcell_builder_paths.py scripts/check_workcell_builder_gui_acceptance.py scripts/workcell_builder_gui_workflow.py`, which succeeded.
- Verified repository state after changes with `git status --short` showing the intended modifications and the new file was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10313372548331963c37934393d805)