### PR TITLE
Add shared runtime resolver and tighten Scene3D GUI smoke gating

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -14,16 +14,17 @@ EXPECTED_SCHEMA = "workcell_studio_scene3d_gui_smoke/v1"
 PASS_STATES = {"ok", "pass", "passed"}
 
 
-def resolve_workcell_builder() -> Path | str:
-    install_bin = ROOT / "install/workcell_builder/lib/workcell_builder/workcell_builder"
-    if install_bin.is_file():
-        return install_bin
-    fallback = shutil.which("workcell_builder")
-    if fallback:
-        return fallback
-    raise FileNotFoundError(
-        "unable to resolve workcell_builder executable: checked install/workcell_builder first, then PATH"
+from scripts.workcell_builder_runtime_resolver import resolve_runtime_paths
+
+
+def resolve_workcell_builder(args: argparse.Namespace) -> tuple[Path | None, dict[str, object]]:
+    resolved = resolve_runtime_paths(
+        script_path=Path(__file__),
+        repo_root_arg=args.repo_root,
+        workspace_root_arg=args.workspace_root,
+        workcell_builder_executable_arg=args.workcell_builder_executable,
     )
+    return resolved.get("executable_path"), resolved
 
 
 def build_cmd(exe: Path | str, args: argparse.Namespace) -> list[str]:
@@ -169,16 +170,19 @@ def main() -> int:
     ap.add_argument("--screenshot", type=Path, default=None)
     ap.add_argument("--timeout-sec", type=float, default=30.0)
     ap.add_argument("--xvfb", action="store_true")
+    ap.add_argument("--repo-root", type=Path, default=None)
+    ap.add_argument("--workspace-root", type=Path, default=None)
+    ap.add_argument("--workcell-builder-executable", default=None)
     args = ap.parse_args()
 
     blockers: list[str] = []
     warnings: list[str] = []
     artifacts = {"json": str(args.output), "screenshot": str(args.screenshot) if args.screenshot else None}
 
-    try:
-        exe = resolve_workcell_builder()
-    except FileNotFoundError as exc:
-        print(f"status=FAIL; blockers=[{exc}]")
+    exe, resolved = resolve_workcell_builder(args)
+    if exe is None:
+        searched = ", ".join(str(p) for p in resolved.get("searched_executable_paths", []))
+        print(f"status=FAIL; blockers=[unable to resolve workcell_builder executable; searched: {searched}]")
         return 2
 
     cmd = build_cmd(exe, args)

--- a/scripts/run_workcell_studio_scene_readiness_gate.py
+++ b/scripts/run_workcell_studio_scene_readiness_gate.py
@@ -9,6 +9,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from scripts.workcell_builder_runtime_resolver import resolve_runtime_paths
+
 PASS = "PASS"
 WARN = "WARN"
 FAIL = "FAIL"
@@ -39,6 +41,9 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--strict", action="store_true", help="Exit non-zero if any supported scene has FAIL readiness")
     p.add_argument("--include-visual-assets", action="store_true", help="Run visual asset inventory and include report links")
     p.add_argument("--include-scene3d-gui-smoke", action="store_true", help="Run Scene3D GUI smoke for ur5_2f_test and include result")
+    p.add_argument("--repo-root", type=Path, default=None)
+    p.add_argument("--workspace-root", type=Path, default=None)
+    p.add_argument("--workcell-builder-executable", default=None)
     return p.parse_args()
 
 
@@ -252,7 +257,13 @@ def write_markdown(path: Path, report: dict[str, Any]) -> None:
 
 def main() -> int:
     args = parse_args()
-    repo_root = Path(__file__).resolve().parents[1]
+    resolved_runtime = resolve_runtime_paths(
+        script_path=Path(__file__),
+        repo_root_arg=args.repo_root,
+        workspace_root_arg=args.workspace_root,
+        workcell_builder_executable_arg=args.workcell_builder_executable,
+    )
+    repo_root = Path(resolved_runtime["repo_root"])
 
     sim_report_path = args.json_output.parent / "rviz_moveit_simulation_launch_report.json"
     sim_report_path = DEFAULT_SIM_REPORT if sim_report_path != DEFAULT_SIM_REPORT else sim_report_path
@@ -306,6 +317,10 @@ def main() -> int:
         smoke_script = repo_root / "scripts/run_workcell_builder_scene3d_gui_smoke.py"
         smoke_scenes = ("ur5_2f_test", "ur5_2f_sorting_test")
         mode = "ci_or_dry_run" if (args.dry_run_launches or _is_ci_environment()) else "local_validation"
+        setup_path = resolved_runtime.get("setup_path")
+        executable_path = resolved_runtime.get("executable_path")
+        searched_setup = resolved_runtime.get("searched_setup_paths", [])
+        searched_exe = resolved_runtime.get("searched_executable_paths", [])
         scene3d_gui_smoke = {
             "mode": mode,
             "status": WARN if mode == "ci_or_dry_run" else PASS,
@@ -314,6 +329,27 @@ def main() -> int:
             "warnings": [],
             "blockers": [],
         }
+        if mode == "local_validation":
+            if not setup_path:
+                scene3d_gui_smoke["status"] = FAIL
+                scene3d_gui_smoke["blockers"].append(
+                    "LOCAL_VALIDATION_REQUIRED: missing setup.bash; searched: " + ", ".join(str(p) for p in searched_setup)
+                )
+            if not executable_path:
+                scene3d_gui_smoke["status"] = FAIL
+                scene3d_gui_smoke["blockers"].append(
+                    "LOCAL_VALIDATION_REQUIRED: missing workcell_builder executable; searched: " + ", ".join(str(p) for p in searched_exe)
+                )
+        else:
+            if not setup_path:
+                scene3d_gui_smoke["warnings"].append(
+                    "CI_OR_DRY_RUN_DOWNGRADE: missing setup.bash; searched: " + ", ".join(str(p) for p in searched_setup)
+                )
+            if not executable_path:
+                scene3d_gui_smoke["warnings"].append(
+                    "CI_OR_DRY_RUN_DOWNGRADE: missing workcell_builder executable; searched: " + ", ".join(str(p) for p in searched_exe)
+                )
+
         if not smoke_script.exists():
             marker = "CI_OR_DRY_RUN_DOWNGRADE" if mode == "ci_or_dry_run" else "LOCAL_VALIDATION_REQUIRED"
             msg = f"{marker}: GUI smoke script missing: {smoke_script}"
@@ -331,7 +367,9 @@ def main() -> int:
                     "json_path_abs": str(smoke_json.resolve()),
                     "screenshot_path_abs": str(smoke_png.resolve()),
                 }
-                smoke_cmd = ["python3", str(smoke_script), "--scene", scene_name, "--output", str(smoke_json), "--screenshot", str(smoke_png)]
+                smoke_cmd = ["python3", str(smoke_script), "--scene", scene_name, "--output", str(smoke_json), "--screenshot", str(smoke_png), "--repo-root", str(repo_root), "--workspace-root", str(resolved_runtime["workspace_root"])]
+                if executable_path:
+                    smoke_cmd.extend(["--workcell-builder-executable", str(executable_path)])
                 smoke_proc = _run_command(smoke_cmd, repo_root)
                 scene_result: dict[str, Any] = {"scene": scene_name, "returncode": smoke_proc.returncode}
                 scene3d_gui_smoke["scenes"].append(scene_result)
@@ -385,14 +423,19 @@ def main() -> int:
     final_report["scene3d_consolidated_gate"] = scene3d_consolidated_gate
     args.json_output.parent.mkdir(parents=True, exist_ok=True)
     args.json_output.write_text(json.dumps(final_report, indent=2) + "\n", encoding="utf-8")
-    write_markdown(args.markdown_output, final_report)
 
     strict_fail = args.strict and any(scene["artifact_readiness"] == FAIL or scene["preview_readiness"] == FAIL or scene["moveit_launch_readiness"] == FAIL for scene in final_report["scenes"])
 
     scene3d_fail = args.include_scene3d_gui_smoke and bool(scene3d_gui_smoke) and scene3d_gui_smoke.get("status") == FAIL
     scene3d_consolidated_fail = scene3d_consolidated_gate.get("status") == FAIL
+    failed = sim_proc.returncode != 0 or audit_proc.returncode != 0 or strict_fail or scene3d_fail or scene3d_consolidated_fail
 
-    if sim_proc.returncode != 0 or audit_proc.returncode != 0 or strict_fail or scene3d_fail or scene3d_consolidated_fail:
+    if not failed:
+        write_markdown(args.markdown_output, final_report)
+    elif args.markdown_output.exists():
+        args.markdown_output.unlink()
+
+    if failed:
         return 1
     return 0
 

--- a/scripts/workcell_builder_runtime_resolver.py
+++ b/scripts/workcell_builder_runtime_resolver.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+
+def _uniq(paths: list[Path]) -> list[Path]:
+    out: list[Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(path)
+    return out
+
+
+def resolve_runtime_paths(
+    *,
+    script_path: Path,
+    repo_root_arg: Path | None,
+    workspace_root_arg: Path | None,
+    workcell_builder_executable_arg: str | None,
+) -> dict[str, object]:
+    repo_root = (repo_root_arg or script_path.resolve().parents[1]).resolve()
+    workspace_root = (workspace_root_arg or repo_root).resolve()
+
+    searched_setup_paths = _uniq([
+        workspace_root / "install/setup.bash",
+        repo_root / "install/setup.bash",
+    ])
+    setup_path = next((p for p in searched_setup_paths if p.is_file()), None)
+
+    searched_executable_paths = _uniq([
+        Path(workcell_builder_executable_arg).expanduser() if workcell_builder_executable_arg else workspace_root / "install/workcell_builder/lib/workcell_builder/workcell_builder",
+        repo_root / "install/workcell_builder/lib/workcell_builder/workcell_builder",
+    ])
+
+    executable_path: Path | None = None
+    executable_source = "searched_paths"
+    for candidate in searched_executable_paths:
+        if candidate.is_file():
+            executable_path = candidate.resolve()
+            break
+
+    if executable_path is None and workcell_builder_executable_arg:
+        which_match = shutil.which(workcell_builder_executable_arg)
+        if which_match:
+            executable_path = Path(which_match).resolve()
+            executable_source = "path_lookup"
+
+    if executable_path is None and not workcell_builder_executable_arg:
+        which_match = shutil.which("workcell_builder")
+        if which_match:
+            executable_path = Path(which_match).resolve()
+            executable_source = "path_lookup"
+
+    return {
+        "repo_root": repo_root,
+        "workspace_root": workspace_root,
+        "setup_path": setup_path,
+        "executable_path": executable_path,
+        "executable_source": executable_source,
+        "searched_setup_paths": [str(p) for p in searched_setup_paths],
+        "searched_executable_paths": [str(p) for p in searched_executable_paths],
+        "ci": str(os.environ.get("CI", "")).strip().lower() in {"1", "true", "yes", "on"},
+    }


### PR DESCRIPTION
### Motivation
- Provide a single resolver for repo/workspace/setup/executable resolution and surfaced searched-path diagnostics for reproducible smoke runs.
- Invoke the Scene3D GUI smoke wrapper with explicit repo/workspace/executable arguments so wrapper runs deterministically and honors user/CI overrides.
- Enforce stricter local validation (fail on missing setup/executable) while downgrading those errors to warnings in CI or when `--dry-run-launches` is used, and avoid producing success-style markdown when the gate is blocked.

### Description
- Add `scripts/workcell_builder_runtime_resolver.py` which resolves and returns `repo_root`, `workspace_root`, `setup_path`, `executable_path`, `searched_setup_paths`, `searched_executable_paths`, and `ci` diagnostics.
- Add CLI args `--repo-root`, `--workspace-root`, and `--workcell-builder-executable` to `scripts/run_workcell_studio_scene_readiness_gate.py` and switch its path handling to use the shared resolver.
- Enforce local vs CI/dry-run semantics so missing `setup.bash` or `workcell_builder` becomes `LOCAL_VALIDATION_REQUIRED` blockers in local mode or `CI_OR_DRY_RUN_DOWNGRADE` warnings in CI/dry-run mode, and include searched-path diagnostics in messages.
- Update smoke invocation to pass `--repo-root`, `--workspace-root`, and the resolved executable to `scripts/run_workcell_builder_scene3d_gui_smoke.py`, and update that wrapper to use the resolver and emit searched-path diagnostics and an explicit failure when the executable cannot be resolved.
- Prevent generation of success-style blocked validation docs by only writing the markdown report when the gate succeeds and removing any stale markdown when the gate fails.

### Testing
- Ran `python3 -m py_compile` on `scripts/run_workcell_studio_scene_readiness_gate.py`, `scripts/run_workcell_builder_scene3d_gui_smoke.py`, and `scripts/workcell_builder_runtime_resolver.py`, which completed without syntax errors.
- No other automated tests were executed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a103137342483319809d5c14922cdc7)