### PR TITLE
Add --repo-root support to Scene3D contract/acceptance scripts

### DIFF
--- a/scripts/check_scene3d_canvas_contract.py
+++ b/scripts/check_scene3d_canvas_contract.py
@@ -9,8 +9,6 @@ try:
 except ModuleNotFoundError:
     from scene_root_resolver import resolve_scene_root
 
-ROOT = Path(__file__).resolve().parents[1]
-SCENES_ROOT = resolve_scene_root(ROOT)
 PLACEHOLDER_RE = re.compile(r"\$\{[^}]+\}")
 CANONICAL_LAYERS = {"editable_layout", "mesh_preview", "locked_generated_urdf_visual", "primitive_fallback", "overlay"}
 
@@ -59,8 +57,8 @@ def _count_preview_items_from_generated_metadata(scene_dir: Path) -> int:
     return count
 
 
-def _runtime_scene_diagnostics(scene: str) -> dict:
-    diag_path = ROOT / 'build' / 'workcell_studio_scene3d_visual_diagnostics.json'
+def _runtime_scene_diagnostics(repo_root: Path, scene: str) -> dict:
+    diag_path = repo_root / 'build' / 'workcell_studio_scene3d_visual_diagnostics.json'
     payload = _load_json(diag_path)
     if not isinstance(payload, dict):
         return {}
@@ -73,7 +71,7 @@ def _runtime_scene_diagnostics(scene: str) -> dict:
     return {}
 
 
-def check_scene(scene_dir: Path) -> dict:
+def check_scene(repo_root: Path, scene_dir: Path) -> dict:
     scene = scene_dir.name
     layout_path = scene_dir / 'layout' / 'workcell_studio_layout.yaml'
     has_layout = layout_path.exists()
@@ -89,7 +87,7 @@ def check_scene(scene_dir: Path) -> dict:
         scene_dir / 'config/epd_snapshot.json',
         scene_dir / 'config/readiness_overlay_metadata.json',
         scene_dir / 'generated/workcell_studio_runtime_acceptance.json',
-        ROOT / 'build/workcell_studio/scene3d_runtime_acceptance.json',
+        repo_root / 'build/workcell_studio/scene3d_runtime_acceptance.json',
     ]
 
     layer_counts = Counter()
@@ -133,7 +131,7 @@ def check_scene(scene_dir: Path) -> dict:
     overlay_count = max(layer_counts['overlay'], overlay_preview_count, overlay_file_count)
     visible_after_filters_count = max(visible_mesh_index_items, editable_layout + mesh_count + primitive_count)
     filtered_hidden_count = max(0, len(items) - visible_after_filters_count)
-    diag_scene = _runtime_scene_diagnostics(scene)
+    diag_scene = _runtime_scene_diagnostics(repo_root, scene)
     render_cache_received_count = None
     if diag_scene:
         render_cache_received_count = diag_scene.get('render_cache_received_count', diag_scene.get('render_cache_received'))
@@ -213,27 +211,33 @@ def markdown(report: list[dict]) -> str:
 
 def main():
     ap = argparse.ArgumentParser()
+    ap.add_argument('--repo-root', default=str(Path(__file__).resolve().parents[1]))
     ap.add_argument('--scene', action='append')
     ap.add_argument('--all', action='store_true')
     ap.add_argument('--json')
     ap.add_argument('--markdown')
     args = ap.parse_args()
 
+    repo_root = Path(args.repo_root).resolve()
+    scenes_root = resolve_scene_root(repo_root)
+    if not scenes_root.exists():
+        ap.error(f"scenes root does not exist: {scenes_root}")
+
     scenes = []
     if args.all:
-        scenes = sorted([p for p in SCENES_ROOT.iterdir() if p.is_dir()]) if SCENES_ROOT.exists() else []
+        scenes = sorted([p for p in scenes_root.iterdir() if p.is_dir()]) if scenes_root.exists() else []
     elif args.scene:
-        scenes = [SCENES_ROOT / s for s in args.scene]
+        scenes = [scenes_root / s for s in args.scene]
     else:
         ap.error('use --all or --scene <name>')
 
     missing = [str(s) for s in scenes if not s.exists()]
     if missing:
-        ap.error(f"requested scene path is missing: {', '.join(missing)}")
+        ap.error(f"requested scene path is missing under scenes root {scenes_root}: {', '.join(missing)}")
 
-    report = [check_scene(s) for s in scenes]
+    report = [check_scene(repo_root, s) for s in scenes]
     overall = 'PASS' if all(r['contract_status'] == 'PASS' for r in report) else ('FAIL' if any(r['contract_status']=='FAIL' for r in report) else 'WARN')
-    payload = {'overall_status': overall, 'scenes': report}
+    payload = {'overall_status': overall, 'repo_root': str(repo_root), 'scenes_root': str(scenes_root), 'scenes': report}
 
     if args.json:
         Path(args.json).write_text(json.dumps(payload, indent=2), encoding='utf-8')

--- a/scripts/validate_scene3d_runtime_acceptance.py
+++ b/scripts/validate_scene3d_runtime_acceptance.py
@@ -13,11 +13,6 @@ except ModuleNotFoundError:
     from scene_root_resolver import resolve_scene_root
 
 SCHEMA = "workcell_studio_scene3d_runtime_acceptance/v1"
-ROOT = Path(__file__).resolve().parents[1]
-SCENES_ROOT = resolve_scene_root(ROOT)
-MAIN = ROOT / "workcell_builder/workcell_builder/gui/mainwindow.cpp"
-PREVIEW = ROOT / "workcell_builder/workcell_builder/gui/scene_preview_widget.cpp"
-VIEWPORT = ROOT / "workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp"
 CANONICAL_LAYERS = {"editable_layout", "mesh_preview", "locked_generated_urdf_visual", "primitive_fallback", "overlay"}
 
 
@@ -32,8 +27,8 @@ def normalize_layer_token(value: str | None) -> str:
     return token
 
 
-def scene_dir(scene: str) -> Path:
-    return SCENES_ROOT / scene
+def scene_dir(scenes_root: Path, scene: str) -> Path:
+    return scenes_root / scene
 
 
 def load_yaml(path: Path) -> dict:
@@ -46,11 +41,11 @@ def load_json(path: Path) -> dict:
     return data if isinstance(data, dict) else {}
 
 
-def runtime_smoke_json_default(scene: str) -> Path:
+def runtime_smoke_json_default(repo_root: Path, scenes_root: Path, scene: str) -> Path:
     candidates = [
-        ROOT / "build/workcell_studio/scene3d_gui_smoke.json",
-        ROOT / f"build/workcell_studio/scene3d_gui_smoke_{scene}.json",
-        scene_dir(scene) / "generated/scene3d_gui_smoke.json",
+        repo_root / "build/workcell_studio/scene3d_gui_smoke.json",
+        repo_root / f"build/workcell_studio/scene3d_gui_smoke_{scene}.json",
+        scene_dir(scenes_root, scene) / "generated/scene3d_gui_smoke.json",
     ]
     for candidate in candidates:
         if candidate.exists():
@@ -58,8 +53,8 @@ def runtime_smoke_json_default(scene: str) -> Path:
     return candidates[0]
 
 
-def evaluate_scene(scene: str, smoke_json_path: str | None) -> dict:
-    sdir = scene_dir(scene)
+def evaluate_scene(repo_root: Path, scenes_root: Path, main_path: Path, preview_path: Path, viewport_path: Path, scene: str, smoke_json_path: str | None) -> dict:
+    sdir = scene_dir(scenes_root, scene)
     blockers: list[str] = []
 
     if not sdir.exists():
@@ -139,7 +134,7 @@ def evaluate_scene(scene: str, smoke_json_path: str | None) -> dict:
     if not blockers and visible_after_default_filters == 0:
         blockers.append("no visible scene items after default filters")
 
-    smoke_path = Path(smoke_json_path) if smoke_json_path else runtime_smoke_json_default(scene)
+    smoke_path = Path(smoke_json_path) if smoke_json_path else runtime_smoke_json_default(repo_root, scenes_root, scene)
     runtime_evidence: dict = {"path": str(smoke_path), "valid": False}
     required_runtime_fields = [
         "viewport_received_count",
@@ -184,14 +179,14 @@ def evaluate_scene(scene: str, smoke_json_path: str | None) -> dict:
             runtime_evidence["counts"] = {k: runtime_payload.get(k) for k in required_runtime_fields if k != "status"}
 
     secondary_checks = {
-        "grid_axes_enabled": ("draw_ground_grid_pass" in VIEWPORT.read_text(encoding="utf-8") and "draw_world_axes_pass" in VIEWPORT.read_text(encoding="utf-8")),
-        "orbit_pan_zoom_handlers_exist": all(t in VIEWPORT.read_text(encoding="utf-8") for t in ["mouseMoveEvent", "wheelEvent", "pan_mode"]),
-        "selection_callback_wired": "select_cb" in PREVIEW.read_text(encoding="utf-8"),
-        "inspector_callback_wired": "update_scene_builder_inspector_for_selected_item" in MAIN.read_text(encoding="utf-8"),
-        "drag_commit_callback_wired": "transform_changed_cb" in VIEWPORT.read_text(encoding="utf-8"),
-        "hierarchy_selection_sync_wired": "apply_scene_selection(" in MAIN.read_text(encoding="utf-8"),
-        "layer_toggles_not_default_hide_all": "visible item count after filters" in MAIN.read_text(encoding="utf-8"),
-        "viewport_diagnostics_summary_present": "Scene3D runtime render: received=" in VIEWPORT.read_text(encoding="utf-8"),
+        "grid_axes_enabled": ("draw_ground_grid_pass" in viewport_path.read_text(encoding="utf-8") and "draw_world_axes_pass" in viewport_path.read_text(encoding="utf-8")),
+        "orbit_pan_zoom_handlers_exist": all(t in viewport_path.read_text(encoding="utf-8") for t in ["mouseMoveEvent", "wheelEvent", "pan_mode"]),
+        "selection_callback_wired": "select_cb" in preview_path.read_text(encoding="utf-8"),
+        "inspector_callback_wired": "update_scene_builder_inspector_for_selected_item" in main_path.read_text(encoding="utf-8"),
+        "drag_commit_callback_wired": "transform_changed_cb" in viewport_path.read_text(encoding="utf-8"),
+        "hierarchy_selection_sync_wired": "apply_scene_selection(" in main_path.read_text(encoding="utf-8"),
+        "layer_toggles_not_default_hide_all": "visible item count after filters" in main_path.read_text(encoding="utf-8"),
+        "viewport_diagnostics_summary_present": "Scene3D runtime render: received=" in viewport_path.read_text(encoding="utf-8"),
     }
 
     return {
@@ -234,14 +229,24 @@ def evaluate_scene(scene: str, smoke_json_path: str | None) -> dict:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--scene", action="append", default=[])
-    ap.add_argument("--json", default=str(ROOT / "build/workcell_studio/scene3d_runtime_acceptance.json"))
-    ap.add_argument("--markdown", default=str(ROOT / "build/workcell_studio/scene3d_runtime_acceptance.md"))
+    ap.add_argument("--repo-root", default=str(Path(__file__).resolve().parents[1]))
+    ap.add_argument("--json", default=None)
+    ap.add_argument("--markdown", default=None)
     ap.add_argument("--smoke-json", default=None, help="path to GUI smoke evidence JSON (workcell_studio_scene3d_gui_smoke/v1)")
     args = ap.parse_args()
 
+    repo_root = Path(args.repo_root).resolve()
+    scenes_root = resolve_scene_root(repo_root)
+    main_path = repo_root / "workcell_builder/workcell_builder/gui/mainwindow.cpp"
+    preview_path = repo_root / "workcell_builder/workcell_builder/gui/scene_preview_widget.cpp"
+    viewport_path = repo_root / "workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp"
+
+    if not scenes_root.exists():
+        ap.error(f"scenes root does not exist: {scenes_root}")
+
     scenes = args.scene or ["ur5_2f_test"]
-    if SCENES_ROOT.exists():
-        maybe = sorted(p.name for p in SCENES_ROOT.iterdir() if p.is_dir() and "new_cell" in p.name)
+    if scenes_root.exists():
+        maybe = sorted(p.name for p in scenes_root.iterdir() if p.is_dir() and "new_cell" in p.name)
         if maybe:
             scenes.append(maybe[0])
 
@@ -250,17 +255,19 @@ def main() -> int:
         if s not in unique_scenes:
             unique_scenes.append(s)
 
-    results = [evaluate_scene(s, args.smoke_json) for s in unique_scenes]
+    results = [evaluate_scene(repo_root, scenes_root, main_path, preview_path, viewport_path, s, args.smoke_json) for s in unique_scenes]
     blockers = [f"{r['scene']}: {b}" for r in results for b in r.get("blockers", [])]
 
     payload = {
         "schema": SCHEMA,
+        "repo_root": str(repo_root),
+        "scenes_root": str(scenes_root),
         "scenes": results,
         "blockers": blockers,
         "pass": not blockers,
     }
 
-    out_json = Path(args.json)
+    out_json = Path(args.json) if args.json else repo_root / "build/workcell_studio/scene3d_runtime_acceptance.json"
     out_json.parent.mkdir(parents=True, exist_ok=True)
     out_json.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
@@ -294,7 +301,7 @@ def main() -> int:
         for k, v in r["secondary_checks"].items():
             lines.append(f"- {k}: {'PASS' if v else 'FAIL'}")
 
-    out_md = Path(args.markdown)
+    out_md = Path(args.markdown) if args.markdown else repo_root / "build/workcell_studio/scene3d_runtime_acceptance.md"
     out_md.parent.mkdir(parents=True, exist_ok=True)
     out_md.write_text("\n".join(lines) + "\n", encoding="utf-8")
 


### PR DESCRIPTION
### Motivation
- Make scene and build path resolution deterministic by resolving from an explicit repository root instead of the process CWD or module-level constants.
- Allow callers to invoke validation utilities for different checkouts or CI workspaces by passing a `--repo-root` argument.
- Surface the resolved repository and scenes roots in machine-readable outputs and make missing-scenes errors include the exact searched path.

### Description
- Added a `--repo-root` CLI argument to `scripts/validate_scene3d_runtime_acceptance.py` and `scripts/check_scene3d_canvas_contract.py` and moved path resolution to runtime after argument parsing. 
- Reworked helper signatures (`scene_dir`, `runtime_smoke_json_default`, `evaluate_scene`, `_runtime_scene_diagnostics`, `check_scene`) to accept `repo_root`/`scenes_root`/`*_path` parameters so resolution is not locked at import time. 
- Included `repo_root` and `scenes_root` fields in the JSON payloads produced by both scripts. 
- Made missing-scenes failures explicit by returning or exiting with error messages that include the exact resolved `scenes_root` path, and adjusted runtime-smoke/default paths to prefer the provided repo root.

### Testing
- Ran a bytecode/compile check with `python -m py_compile scripts/validate_scene3d_runtime_acceptance.py scripts/check_scene3d_canvas_contract.py scripts/scene_root_resolver.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1031394ad883319a03a21431e67cf4)