### PR TITLE
Archive scene validation attempt docs as non-authoritative history

### DIFF
--- a/docs/manuals/validation_attempts/README.md
+++ b/docs/manuals/validation_attempts/README.md
@@ -1,0 +1,8 @@
+# Validation Attempts Archive (Historical / Non-Authoritative)
+
+Files in this folder are archived troubleshooting attempts and may include blocked or partial runs.
+
+## Policy
+- **Do not** treat these files as validation pass evidence.
+- **Do not** use these files as readiness gate inputs.
+- For go/no-go decisions, use canonical readiness outputs produced by current automation under `scripts/` and tested flows.

--- a/docs/manuals/validation_attempts/historical_non_authoritative_scene3d_validation_attempt_2026-05-22.md
+++ b/docs/manuals/validation_attempts/historical_non_authoritative_scene3d_validation_attempt_2026-05-22.md
@@ -1,3 +1,7 @@
+# ⚠️ Historical Record Only (Non-Authoritative)
+
+This document is retained only as a historical troubleshooting log. It is **not** evidence of successful validation, release readiness, or runtime acceptance. Readiness tooling and release decisions must rely on canonical readiness artifacts and automated checks instead.
+
 # Scene3D Runtime Acceptance Attempt (2026-05-22 UTC)
 
 Requested workspace: `~/workcell_ws`

--- a/docs/manuals/validation_attempts/historical_non_authoritative_workcell_builder_scene_validation_attempt_2026-05-22.md
+++ b/docs/manuals/validation_attempts/historical_non_authoritative_workcell_builder_scene_validation_attempt_2026-05-22.md
@@ -1,3 +1,7 @@
+# ⚠️ Historical Record Only (Non-Authoritative)
+
+This document is retained only as a historical troubleshooting log. It is **not** evidence of successful validation, release readiness, or runtime acceptance. Readiness tooling and release decisions must rely on canonical readiness artifacts and automated checks instead.
+
 # Workcell Builder scene validation attempt (2026-05-22)
 
 ## Commands requested


### PR DESCRIPTION
### Motivation

- Prevent historical troubleshooting outputs from being misinterpreted as evidence of successful scene validation or release readiness.
- Remove the `latest_...` naming that could be mistaken for an authoritative/current validation artifact.

### Description

- Move `SCENE3D_VALIDATION_ATTEMPT.md` to `docs/manuals/validation_attempts/historical_non_authoritative_scene3d_validation_attempt_2026-05-22.md` and `docs/manuals/latest_workcell_builder_scene_validation_attempt_2026-05-22.md` to `docs/manuals/validation_attempts/historical_non_authoritative_workcell_builder_scene_validation_attempt_2026-05-22.md`.
- Prepend a clear historical/non-authoritative disclaimer header to both archived documents stating they are not evidence of successful validation or readiness.
- Add `docs/manuals/validation_attempts/README.md` documenting archive policy that these files must not be used as readiness gate inputs or validation evidence.
- Ensure tooling/readers reference the new `validation_attempts/` archive location instead of authoritative paths.

### Testing

- Located relevant files with `rg --files` and confirmed matches using `rg` search patterns, which succeeded.
- Prepended headers using a short Python script and validated their presence with `sed` and `nl`, which showed the disclaimer at the top of both files.
- Verified the archive `README.md` contents with `nl`, confirming the policy text was written as expected.
- Generated PR metadata via `make_pr` to summarize the change for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10313b94788331ba51aead4906e0c7)