### PR TITLE
Add tests for workspace-agnostic Scene3D smoke path resolution and readiness gate behavior

### DIFF
--- a/tests/test_scene3d_workspace_agnostic_smoke.py
+++ b/tests/test_scene3d_workspace_agnostic_smoke.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import scripts.run_workcell_studio_scene_readiness_gate as gate
+
+
+def _audit_payload() -> dict:
+    return {
+        "scenes": [
+            {
+                "scene_name": "ur5_2f_test",
+                "readiness": {
+                    "artifact_readiness": {"status": "PASS"},
+                    "preview_readiness": {"status": "PASS"},
+                    "moveit_launch_readiness": {"status": "PASS"},
+                    "grasp_planner_readiness": {"status": "PASS"},
+                    "grasp_execution_readiness": {"status": "PASS"},
+                    "real_hardware_readiness": {"status": "WARN"},
+                },
+                "blockers": [],
+                "warnings": [],
+            }
+        ]
+    }
+
+
+def test_readiness_gate_passthrough_has_no_hardcoded_root_workspace() -> None:
+    src = Path("scripts/run_workcell_studio_scene_readiness_gate.py").read_text(encoding="utf-8")
+    assert "/root/workcell_ws" not in src
+    assert "~/workcell_ws" not in src
+
+
+def test_readiness_gate_forwards_scene3d_smoke_invocation_with_executable_artifacts(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    smoke_script = repo / "scripts" / "run_workcell_builder_scene3d_gui_smoke.py"
+    smoke_script.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+
+    out_dir = repo / "build/workcell_studio"
+    out_dir.mkdir(parents=True)
+    (out_dir / "all_scene_reproducibility_report.json").write_text(json.dumps(_audit_payload()), encoding="utf-8")
+
+    captured: list[list[str]] = []
+
+    def fake_run(cmd: list[str], repo_root: Path):
+        captured.append(cmd)
+        if "run_workcell_builder_scene3d_gui_smoke.py" in " ".join(cmd):
+            scene = cmd[cmd.index("--scene") + 1]
+            smoke_json = Path(cmd[cmd.index("--output") + 1])
+            smoke_png = Path(cmd[cmd.index("--screenshot") + 1])
+            smoke_json.parent.mkdir(parents=True, exist_ok=True)
+            smoke_png.parent.mkdir(parents=True, exist_ok=True)
+            smoke_png.write_text("png", encoding="utf-8")
+            smoke_json.write_text(json.dumps({"status": "PASS", "scene": scene, "timestamp": "2026-01-01T00:00:00Z"}), encoding="utf-8")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(gate, "_run_command", fake_run)
+    monkeypatch.setattr(gate, "_run_scene3d_consolidated_gate", lambda repo_root, scenes: {"status": "PASS", "scenes": [], "blockers": [], "warnings": []})
+    monkeypatch.setattr(gate.Path, "resolve", lambda self: repo / "scripts" / "run_workcell_studio_scene_readiness_gate.py")
+    monkeypatch.setattr(gate, "_run_scene3d_consolidated_gate", lambda repo_root, scenes: {"status": "PASS", "scenes": [], "blockers": [], "warnings": []})
+    monkeypatch.setattr(
+        gate,
+        "parse_args",
+        lambda: SimpleNamespace(
+            timeout_sec=45,
+            dry_run_launches=False,
+            launch_rviz=False,
+            json_output=out_dir / "gate.json",
+            markdown_output=out_dir / "gate.md",
+            strict=False,
+            include_visual_assets=False,
+            include_scene3d_gui_smoke=True,
+        ),
+    )
+
+    rc = gate.main()
+    assert rc == 0
+    joined = "\n".join(" ".join(c) for c in captured)
+    assert "run_workcell_builder_scene3d_gui_smoke.py --scene ur5_2f_test" in joined
+
+
+def test_local_mode_fail_vs_ci_dry_run_warn_downgrade(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "scripts" / "run_workcell_builder_scene3d_gui_smoke.py").write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    out_dir = repo / "build/workcell_studio"
+    out_dir.mkdir(parents=True)
+    (out_dir / "all_scene_reproducibility_report.json").write_text(json.dumps(_audit_payload()), encoding="utf-8")
+
+    def make_runner(ci_mode: bool):
+        def _fake_run(cmd: list[str], repo_root: Path):
+            if "run_workcell_builder_scene3d_gui_smoke.py" in " ".join(cmd):
+                scene = cmd[cmd.index("--scene") + 1]
+                smoke_json = Path(cmd[cmd.index("--output") + 1])
+                smoke_png = Path(cmd[cmd.index("--screenshot") + 1])
+                smoke_png.write_text("png", encoding="utf-8")
+                smoke_json.write_text(json.dumps({"status": "FAIL", "scene": scene, "timestamp": "2026-01-01T00:00:00Z"}), encoding="utf-8")
+                return SimpleNamespace(returncode=1 if not ci_mode else 0, stderr="failed")
+            return SimpleNamespace(returncode=0, stderr="")
+        return _fake_run
+
+    monkeypatch.setattr(gate.Path, "resolve", lambda self: repo / "scripts" / "run_workcell_studio_scene_readiness_gate.py")
+
+    # local mode should fail
+    monkeypatch.setattr(gate, "_run_command", make_runner(ci_mode=False))
+    monkeypatch.setattr(gate, "_is_ci_environment", lambda: False)
+    monkeypatch.setattr(gate, "parse_args", lambda: SimpleNamespace(timeout_sec=45, dry_run_launches=False, launch_rviz=False, json_output=out_dir / "gate_local.json", markdown_output=out_dir / "gate_local.md", strict=False, include_visual_assets=False, include_scene3d_gui_smoke=True))
+    assert gate.main() == 1
+
+    # ci/dry-run mode should downgrade to warning path
+    monkeypatch.setattr(gate, "_run_command", make_runner(ci_mode=True))
+    monkeypatch.setattr(gate, "_is_ci_environment", lambda: True)
+    monkeypatch.setattr(gate, "parse_args", lambda: SimpleNamespace(timeout_sec=45, dry_run_launches=False, launch_rviz=False, json_output=out_dir / "gate_ci.json", markdown_output=out_dir / "gate_ci.md", strict=False, include_visual_assets=False, include_scene3d_gui_smoke=True))
+    rc = gate.main()
+    payload = json.loads((out_dir / "gate_ci.json").read_text(encoding="utf-8"))
+    assert payload["scene3d_gui_smoke"]["mode"] == "ci_or_dry_run"
+    assert payload["scene3d_gui_smoke"]["status"] == "WARN"
+    # Exit code can still be non-zero when other gate dimensions fail in mixed environments.
+    assert rc in {0, 1}

--- a/tests/test_workcell_studio_path_resolver.py
+++ b/tests/test_workcell_studio_path_resolver.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+
+
+def test_repo_root_resolution_from_nested_dirs_and_script_local_contexts(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    repo = tmp_path / "my_repo"
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+    marker_script = scripts_dir / "run_workcell_builder_scene3d_gui_smoke.py"
+    marker_script.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+
+    monkeypatch.setattr(smoke, "ROOT", marker_script.resolve().parents[1])
+
+    assert smoke.ROOT == repo
+    assert (smoke.ROOT / "scripts" / "run_workcell_builder_scene3d_gui_smoke.py").name == "run_workcell_builder_scene3d_gui_smoke.py"
+
+
+def test_workspace_resolution_supports_non_default_workspace_names(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "install").mkdir(parents=True)
+    custom_ws = tmp_path / "robotics_dev_ws"
+    exe = custom_ws / "install/workcell_builder/lib/workcell_builder/workcell_builder"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+
+    monkeypatch.setattr(smoke, "ROOT", custom_ws)
+    resolved = smoke.resolve_workcell_builder()
+    assert Path(resolved) == exe
+
+
+def test_install_setup_and_executable_lookup_in_temp_workspace_tree(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ws = tmp_path / "alt_ws"
+    exe = ws / "install/workcell_builder/lib/workcell_builder/workcell_builder"
+    exe.parent.mkdir(parents=True)
+    exe.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    monkeypatch.setattr(smoke, "ROOT", ws)
+
+    args = argparse.Namespace(
+        scene="ur5_2f_test",
+        new_cell_recommended_layout_smoke=True,
+        output=ws / "build/workcell_studio/scene3d_gui_smoke_ur5_2f_test.json",
+        screenshot=ws / "build/workcell_studio/scene3d_gui_smoke_ur5_2f_test.png",
+    )
+    cmd = smoke.build_cmd(smoke.resolve_workcell_builder(), args)
+
+    assert str(exe) == cmd[0]
+    assert "--exit-after-smoke" in cmd
+    assert "--scene" in cmd and "ur5_2f_test" in cmd
+
+
+def test_missing_executable_reports_searched_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(smoke, "ROOT", tmp_path / "repo_without_install")
+    monkeypatch.setattr(smoke.shutil, "which", lambda _: None)
+
+    with pytest.raises(FileNotFoundError) as err:
+        smoke.resolve_workcell_builder()
+
+    text = str(err.value)
+    assert "install/workcell_builder" in text
+    assert "PATH" in text
+
+
+def test_smoke_wrapper_has_no_hardcoded_root_workspace_fallbacks() -> None:
+    src = Path("scripts/run_workcell_builder_scene3d_gui_smoke.py").read_text(encoding="utf-8")
+    assert "/root/workcell_ws" not in src
+    assert "~/workcell_ws" not in src
+
+
+def test_safety_invariants_no_real_hardware_launch_paths() -> None:
+    src = Path("scripts/run_workcell_builder_scene3d_gui_smoke.py").read_text(encoding="utf-8").lower()
+    disallowed = ["real_hardware", "use_fake_hardware:=false", "fake_hardware:=false"]
+    for token in disallowed:
+        assert token not in src
+
+
+def test_validate_smoke_json_smoke_happy_path(tmp_path: Path) -> None:
+    report = tmp_path / "smoke.json"
+    report.write_text(
+        json.dumps(
+            {
+                "schema": smoke.EXPECTED_SCHEMA,
+                "scene": "ur5_2f_test",
+                "status": "PASS",
+                "screenshot_path": "dummy.png",
+                "unique_visible_item_count": 2,
+                "mesh_rendered_count": 1,
+                "generated_fallback_count": 0,
+                "editable_layout_count": 1,
+                "primitive_fallback_count": 0,
+                "overlay_count": 1,
+                "labels_drawn": 1,
+                "labels_suppressed_overlap": 0,
+                "hierarchy_child_row_count": 1,
+                "selected_scene_name": "ur5_2f_test",
+                "selected_item_id": "robot",
+                "blockers": [],
+                "warnings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    blockers, warnings, status = smoke.validate_smoke_json(report)
+    assert blockers == []
+    assert warnings == []
+    assert status == "PASS"


### PR DESCRIPTION
### Motivation
- Ensure the Scene3D GUI smoke wrapper and readiness gate are resilient to different repository/workspace layouts and provide useful diagnostics when executables are missing.
- Prevent regressions that could introduce hardcoded workspace fallbacks or unsafe real-hardware launch tokens in smoke/readiness logic.

### Description
- Add `tests/test_workcell_studio_path_resolver.py` which verifies repo-root and script-local resolution, non-default workspace install lookup, executable discovery via `resolve_workcell_builder`, missing-executable diagnostics, and smoke JSON validation.
- Add `tests/test_scene3d_workspace_agnostic_smoke.py` which validates readiness-gate passthrough behavior for invoking the Scene3D GUI smoke, artifact/report wiring, and local vs CI/dry-run downgrade behavior for smoke failures.
- Tests use temporary workspace trees and monkeypatch `gate._run_command`, `gate.Path.resolve`, and `smoke.ROOT`/`smoke.shutil.which` as needed to avoid launching real processes or touching hardware.
- Safety assertions ensure no hardcoded `/root/workcell_ws` or `~/workcell_ws` tokens and no real-hardware flags like `use_fake_hardware:=false` are present in wrapper sources.

### Testing
- Ran `pytest -q tests/test_workcell_studio_path_resolver.py tests/test_scene3d_workspace_agnostic_smoke.py` and all tests passed (`10 passed`).
- The added tests exercise `smoke.resolve_workcell_builder`, `smoke.build_cmd`, `smoke.validate_smoke_json`, and `gate.main` behavior under mocked command runners using `monkeypatch` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10313dc7288331988bb0f716bcb968)