### PR TITLE
Fix malformed helper scope/bracing in scene3d_viewport_widget.cpp

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -481,6 +481,7 @@ QPointF apply_label_overlap_offset(const QPointF & anchor, const QVector<QPointF
   }
 
   return candidates.back();
+}
 
 int label_priority_bucket(bool selected, bool has_warnings, NormalizedRole role)
 {
@@ -503,7 +504,6 @@ struct LabelDrawCandidate
 };
 
 
-}
 }
 
 


### PR DESCRIPTION
### Motivation
- Restore compilation of the Workcell Builder by fixing a missing closing brace in the anonymous helper block that caused `label_priority_bucket` and `LabelDrawCandidate` to be parsed inside `apply_label_overlap_offset`, producing a function-definition-inside-function and undeclared-symbol errors.

### Description
- Insert the missing `}` immediately after `return candidates.back();` to properly close `apply_label_overlap_offset`, ensure `label_priority_bucket` and `LabelDrawCandidate` remain at anonymous-namespace scope, and remove the extra namespace-closing brace so there is exactly one anonymous-namespace close before the `Scene3DViewportWidget` method definitions; no behavioral or UI logic was changed.

### Testing
- Attempted the requested build commands (`colcon build --symlink-install --packages-select workcell_builder` and `cd ~/workcell_ws && source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder`), but both could not complete in this environment because the ROS Humble setup script or the expected workspace path is not present, so no local build verification was possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a109e8ee1a483318bc13cab40e8a68c)