### PR TITLE
Fix Workcell Builder compile break in scene workflow provenance classification

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -6024,10 +6024,20 @@ std::vector<MainWindow::SceneWorkflowStep> MainWindow::scene_workflow_steps() co
   int classified_fallback_count = 0;
   int classified_other_count = 0;
   for (const auto & item : canvas_model.items) {
-    if (item.source_layer == "editable_layout") ++classified_editable_count;
-    else if (item.source_layer == "generated_urdf_visual") ++classified_generated_count;
-    else if (item.source_layer == "primitive_fallback") ++classified_fallback_count;
-    else ++classified_other_count;
+    switch (item.provenance) {
+      case workcell_builder::WorkcellStudioItemProvenance::EditableLayout:
+        ++classified_editable_count;
+        break;
+      case workcell_builder::WorkcellStudioItemProvenance::GeneratedOrLegacyPreview:
+        ++classified_generated_count;
+        break;
+      case workcell_builder::WorkcellStudioItemProvenance::StaticFallbackPreview:
+        ++classified_fallback_count;
+        break;
+      default:
+        ++classified_other_count;
+        break;
+    }
   }
 
   const int preview_received_count = all_scene_preview_items_.size();


### PR DESCRIPTION
### Motivation
- A recent change removed the `source_layer` string from `WorkcellStudioCanvasItem`, causing a compile error in `MainWindow::scene_workflow_steps()` where code still referenced `item.source_layer` and attempted string comparisons. 
- The canvas model exposes a `provenance` enum (`WorkcellStudioItemProvenance`) which must be used instead to classify items as editable/generated/fallback.

### Description
- Replaced the `source_layer` string comparisons in `MainWindow::scene_workflow_steps()` with an enum `switch` on `item.provenance` that increments `classified_editable_count`, `classified_generated_count`, `classified_fallback_count`, or `classified_other_count` as appropriate. 
- The change is localized to `workcell_builder/workcell_builder/gui/mainwindow.cpp` inside `MainWindow::scene_workflow_steps()` and preserves the existing `classified_other_count` via a `default` branch for forward compatibility. 
- No other files, UI elements, scene generation, mesh/EPD/safety logic, or runtime behavior were modified.

### Testing
- Attempted the requested automated build `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder`, but the build could not be executed in this environment because `/opt/ros/humble/setup.bash` is not present and the expected workspace path was unavailable, so the automated build failed to run here. 
- Local static checks (search/patch and a commit) were performed and the offending `item.source_layer` usage at the reported lines was removed and replaced with the enum-based classification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a0ade52c8331baa408b1b97e2378)