### PR TITLE
Fix direct-execution imports for Workcell Studio validation scripts

### DIFF
--- a/scripts/check_scene3d_canvas_contract.py
+++ b/scripts/check_scene3d_canvas_contract.py
@@ -4,10 +4,18 @@ import argparse, json, re
 from collections import Counter
 from pathlib import Path
 import yaml
-try:
-    from scripts.scene_root_resolver import resolve_scene_root
-except ModuleNotFoundError:
-    from scene_root_resolver import resolve_scene_root
+
+import sys
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.workcell_studio_script_bootstrap import ensure_repo_root_on_sys_path
+
+ensure_repo_root_on_sys_path(__file__)
+
+from scripts.scene_root_resolver import resolve_scene_root
 
 PLACEHOLDER_RE = re.compile(r"\$\{[^}]+\}")
 CANONICAL_LAYERS = {"editable_layout", "mesh_preview", "locked_generated_urdf_visual", "primitive_fallback", "overlay"}

--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -10,8 +10,18 @@ import sys
 import time
 from pathlib import Path
 
+import sys
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.workcell_studio_script_bootstrap import ensure_repo_root_on_sys_path
+
+ensure_repo_root_on_sys_path(__file__)
+
 from scripts.workcell_studio_path_resolver import resolve_repo_root, resolve_workspace_root, resolve_workcell_builder_executable
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = _REPO_ROOT
 EXPECTED_SCHEMA = "workcell_studio_scene3d_gui_smoke/v1"
 PASS_STATES = {"ok", "pass", "passed"}
 

--- a/scripts/run_workcell_studio_local_validation.py
+++ b/scripts/run_workcell_studio_local_validation.py
@@ -2,12 +2,18 @@
 from __future__ import annotations
 import argparse, json, subprocess, os
 from pathlib import Path
-try:
-    from scripts.workcell_studio_path_resolver import resolve_repo_root, resolve_workspace_root, resolve_install_setup, resolve_workcell_builder_executable, resolve_scenes_root, describe_resolution
-except ModuleNotFoundError:
-    import sys
-    sys.path.insert(0, str(Path(__file__).resolve().parent))
-    from workcell_studio_path_resolver import resolve_repo_root, resolve_workspace_root, resolve_install_setup, resolve_workcell_builder_executable, resolve_scenes_root, describe_resolution
+
+import sys
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.workcell_studio_script_bootstrap import ensure_repo_root_on_sys_path
+
+ensure_repo_root_on_sys_path(__file__)
+
+from scripts.workcell_studio_path_resolver import resolve_repo_root, resolve_workspace_root, resolve_install_setup, resolve_workcell_builder_executable, resolve_scenes_root, describe_resolution
 
 
 def main() -> int:

--- a/scripts/run_workcell_studio_scene_readiness_gate.py
+++ b/scripts/run_workcell_studio_scene_readiness_gate.py
@@ -8,6 +8,17 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+import sys
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.workcell_studio_script_bootstrap import ensure_repo_root_on_sys_path
+
+ensure_repo_root_on_sys_path(__file__)
+
 from scripts.workcell_studio_path_resolver import (
     resolve_install_setup,
     resolve_repo_root,

--- a/scripts/validate_scene3d_runtime_acceptance.py
+++ b/scripts/validate_scene3d_runtime_acceptance.py
@@ -7,10 +7,17 @@ from pathlib import Path
 
 import yaml
 
-try:
-    from scripts.scene_root_resolver import resolve_scene_root
-except ModuleNotFoundError:
-    from scene_root_resolver import resolve_scene_root
+import sys
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.workcell_studio_script_bootstrap import ensure_repo_root_on_sys_path
+
+ensure_repo_root_on_sys_path(__file__)
+
+from scripts.scene_root_resolver import resolve_scene_root
 
 SCHEMA = "workcell_studio_scene3d_runtime_acceptance/v1"
 CANONICAL_LAYERS = {"editable_layout", "mesh_preview", "locked_generated_urdf_visual", "primitive_fallback", "overlay"}

--- a/scripts/workcell_studio_script_bootstrap.py
+++ b/scripts/workcell_studio_script_bootstrap.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def ensure_repo_root_on_sys_path(current_file: str | Path) -> Path:
+    current_path = Path(current_file).resolve()
+    repo_root = current_path.parents[1]
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+    return repo_root

--- a/tests/test_script_direct_execution_imports.py
+++ b/tests/test_script_direct_execution_imports.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+SCRIPTS = [
+    "run_workcell_builder_scene3d_gui_smoke.py",
+    "run_workcell_studio_scene_readiness_gate.py",
+    "run_workcell_studio_local_validation.py",
+    "validate_scene3d_runtime_acceptance.py",
+    "check_scene3d_canvas_contract.py",
+]
+
+
+def test_scripts_support_direct_execution_help_without_import_errors():
+    repo_root = Path(__file__).resolve().parents[1]
+    for script in SCRIPTS:
+        proc = subprocess.run(
+            ["python3", str(repo_root / "scripts" / script), "--help"],
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+        )
+        assert proc.returncode == 0, f"{script} failed: stdout={proc.stdout}\nstderr={proc.stderr}"
+        combined = f"{proc.stdout}\n{proc.stderr}"
+        assert "No module named 'scripts.workcell_studio_path_resolver'" not in combined
+        assert "ModuleNotFoundError" not in combined
+
+
+def test_runtime_scripts_do_not_hardcode_workspace_paths():
+    repo_root = Path(__file__).resolve().parents[1]
+    forbidden = ["/root/workcell_ws", "~/workcell_ws"]
+    for script in SCRIPTS:
+        text = (repo_root / "scripts" / script).read_text(encoding="utf-8")
+        for token in forbidden:
+            assert token not in text, f"{script} contains forbidden path token: {token}"


### PR DESCRIPTION
## Summary
- Added `scripts/workcell_studio_script_bootstrap.py` with `ensure_repo_root_on_sys_path(current_file)` to normalize direct script execution imports.
- Updated direct-execution runtime scripts to bootstrap `sys.path` before any `from scripts...` imports:
  - `scripts/run_workcell_builder_scene3d_gui_smoke.py`
  - `scripts/run_workcell_studio_scene_readiness_gate.py`
  - `scripts/run_workcell_studio_local_validation.py`
  - `scripts/validate_scene3d_runtime_acceptance.py`
  - `scripts/check_scene3d_canvas_contract.py`
- Removed fallback import patterns that depended on script-local imports and made import behavior consistent.
- Added `tests/test_script_direct_execution_imports.py` to assert `--help` direct execution works and does not raise `ModuleNotFoundError`, and to verify no hardcoded `/root/workcell_ws` or `~/workcell_ws` in these scripts.

## Why
Local validation child scripts were failing under direct path execution with:
`ModuleNotFoundError: No module named 'scripts.workcell_studio_path_resolver'`.
This blocked Scene3D GUI smoke/readiness from reaching real runtime blockers.

## Validation
- `python3 -m py_compile scripts/workcell_studio_script_bootstrap.py scripts/workcell_studio_path_resolver.py scripts/run_workcell_studio_local_validation.py scripts/run_workcell_builder_scene3d_gui_smoke.py scripts/run_workcell_studio_scene_readiness_gate.py scripts/validate_scene3d_runtime_acceptance.py scripts/check_scene3d_canvas_contract.py`
- `pytest -q tests/test_script_direct_execution_imports.py tests/test_workcell_studio_local_validation_runner.py tests/test_no_hardcoded_workspace_paths.py`

(One requested test file path appears absent in this checkout: `tests/test_workcell_studio_local_validation_report_detail.py`.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10aca815248331808d28d11d12e4da)