### PR TITLE
Fix Scene3D GUI smoke setup crashes and emit structured FAIL JSON

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -8,9 +8,8 @@ import shutil
 import subprocess
 import sys
 import time
+import traceback
 from pathlib import Path
-
-import sys
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
@@ -215,18 +214,61 @@ def main() -> int:
     blockers: list[str] = []
     warnings: list[str] = []
     artifacts = {"json": str(args.output), "screenshot": str(args.screenshot) if args.screenshot else None}
-    extra_resolution = {"repo_root": None, "workspace_root": None}
+    repo_root: Path | None = None
+    workspace_root: Path | None = None
+    exe: Path | None = None
+    searched_candidates: list[Path] = []
 
-    repo_root = resolve_repo_root(explicit_repo_root=args.repo_root)
-    extra_resolution["repo_root"] = str(repo_root)
-    extra_resolution["workspace_root"] = str(workspace_root) if workspace_root else None
-    workspace_root = resolve_workspace_root(repo_root, args.workspace_root)
-    if args.executable is not None:
-        exe = args.executable
-        searched_candidates: list[Path] = [args.executable]
-    else:
-        exe = resolve_workcell_builder_executable(workspace_root)
-        searched_candidates = _resolve_executable_candidates(workspace_root or repo_root)
+    def _write_fail_output(
+        *,
+        blocker: str,
+        warning_list: list[str] | None = None,
+        exc: Exception | None = None,
+    ) -> None:
+        payload = {
+            "schema": EXPECTED_SCHEMA,
+            "status": "FAIL",
+            "scene": args.scene,
+            "repo_root": str(repo_root) if repo_root else None,
+            "workspace_root": str(workspace_root) if workspace_root else None,
+            "executable": str(exe) if exe else None,
+            "blockers": [blocker],
+            "warnings": warning_list or [],
+            "searched_paths": [str(p) for p in searched_candidates],
+            "exception_type": type(exc).__name__ if exc else None,
+            "exception_message": str(exc) if exc else None,
+            "traceback_tail": "\n".join(traceback.format_exception(exc)[-3:]) if exc else None,
+            "screenshot_path": str(args.screenshot) if args.screenshot else None,
+            "screenshot_available": bool(args.screenshot and args.screenshot.is_file()),
+        }
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    try:
+        repo_root = resolve_repo_root(explicit_repo_root=args.repo_root)
+        workspace_root = resolve_workspace_root(repo_root, args.workspace_root)
+        if args.executable is not None:
+            exe = args.executable
+            searched_candidates = [args.executable]
+        elif workspace_root is not None:
+            exe = resolve_workcell_builder_executable(workspace_root)
+            searched_candidates = _resolve_executable_candidates(workspace_root)
+        else:
+            exe = None
+            searched_candidates = []
+    except Exception as exc:
+        _write_fail_output(blocker=f"smoke_setup_exception: {type(exc).__name__}: {exc}", exc=exc)
+        print(f"status=FAIL; blockers=[smoke_setup_exception: {type(exc).__name__}: {exc}]")
+        return 2
+
+    extra_resolution = {"repo_root": str(repo_root) if repo_root else None, "workspace_root": str(workspace_root) if workspace_root else None}
+
+    if workspace_root is None:
+        blocker = "workspace_root_unresolved"
+        warnings.append("screenshot missing")
+        _write_fail_output(blocker=blocker, warning_list=warnings)
+        print(f"status=FAIL; blockers=[{blocker}]")
+        return 2
 
     if exe is None or not Path(exe).is_file():
         searched = " | ".join(str(p) for p in searched_candidates)
@@ -240,6 +282,7 @@ def main() -> int:
             print("warning_list=" + " | ".join(str(w) for w in warnings))
             print("artifacts=" + json.dumps({**artifacts, **extra_resolution}, sort_keys=True))
             return 0
+        _write_fail_output(blocker=message, warning_list=warnings)
         print(f"status=FAIL; blockers=[{message}]")
         return 2
 

--- a/scripts/run_workcell_studio_local_validation.py
+++ b/scripts/run_workcell_studio_local_validation.py
@@ -82,12 +82,22 @@ def main() -> int:
             if rc!=0:
                 blockers.append(f"GUI smoke failed for {s}")
                 blockers.append(f"returncode={rc}")
-                if not sj.exists():
+                smoke_payload = None
+                if sj.exists():
+                    try:
+                        smoke_payload = json.loads(sj.read_text(encoding="utf-8"))
+                    except Exception as exc:
+                        blockers.append(f"invalid smoke JSON for {s}: {exc}")
+                else:
                     blockers.append("smoke JSON missing")
-                if not sp.exists():
+                if isinstance(smoke_payload, dict):
+                    for b in smoke_payload.get("blockers", []):
+                        blockers.append(f"gui_smoke[{s}] blocker: {b}")
+                    if not smoke_payload.get("screenshot_available", False):
+                        blockers.append(f"gui_smoke[{s}] screenshot missing")
+                    blockers.append(f"gui_smoke[{s}] json={sj}")
+                elif not sp.exists():
                     blockers.append("screenshot missing")
-                if not s:
-                    blockers.append("selected_scene_name empty")
 
     if args.include_readiness:
         cmd=["python3", str(repo_root / "scripts/run_workcell_studio_scene_readiness_gate.py"), "--repo-root", str(repo_root)]

--- a/tests/test_scene3d_gui_smoke_runner_setup_errors.py
+++ b/tests/test_scene3d_gui_smoke_runner_setup_errors.py
@@ -1,0 +1,56 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_gui_smoke_missing_workspace_writes_fail_json(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    out = tmp_path / "smoke.json"
+    shot = tmp_path / "smoke.png"
+    cmd = [
+        "python3",
+        str(repo / "scripts/run_workcell_builder_scene3d_gui_smoke.py"),
+        "--repo-root",
+        str(repo),
+        "--workspace-root",
+        str(tmp_path / "missing_ws"),
+        "--scene",
+        "ur5_2f_test",
+        "--output",
+        str(out),
+        "--screenshot",
+        str(shot),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert out.exists()
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema"] == "workcell_studio_scene3d_gui_smoke/v1"
+    assert payload["status"] == "FAIL"
+    assert isinstance(payload.get("blockers"), list) and payload["blockers"]
+    assert payload.get("repo_root")
+    assert "workspace_root" in payload
+    assert "executable" in payload
+    assert "searched_paths" in payload
+    assert payload.get("screenshot_available") is False
+
+
+def test_gui_smoke_explicit_workspace_no_unboundlocalerror(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    out = tmp_path / "smoke.json"
+    cmd = [
+        "python3",
+        str(repo / "scripts/run_workcell_builder_scene3d_gui_smoke.py"),
+        "--repo-root",
+        str(repo),
+        "--workspace-root",
+        str(repo),
+        "--scene",
+        "ur5_2f_test",
+        "--output",
+        str(out),
+        "--dry-run",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    combined = (proc.stdout or "") + (proc.stderr or "")
+    assert "UnboundLocalError" not in combined

--- a/tests/test_workcell_studio_local_validation_runner.py
+++ b/tests/test_workcell_studio_local_validation_runner.py
@@ -15,3 +15,19 @@ def test_local_validation_fail_when_required_missing(tmp_path):
     out = tmp_path / 'out2'
     rc = subprocess.run(['python3', str(repo/'scripts/run_workcell_studio_local_validation.py'), '--repo-root', str(repo), '--output-dir', str(out), '--include-gui-smoke', '--require-gui-smoke', '--workspace-root', str(tmp_path/'ws')], capture_output=True, text=True)
     assert rc.returncode != 0
+
+
+def test_local_validation_consumes_smoke_fail_json_blockers(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    out = tmp_path / 'out3'
+    cmd = [
+        'python3', str(repo/'scripts/run_workcell_studio_local_validation.py'),
+        '--repo-root', str(repo), '--output-dir', str(out), '--include-gui-smoke', '--require-gui-smoke',
+        '--workspace-root', str(tmp_path/'missing_ws'), '--executable', '/bin/true', '--scenes', 'ur5_2f_test'
+    ]
+    rc = subprocess.run(cmd, capture_output=True, text=True)
+    assert rc.returncode != 0
+    payload = json.loads((out / 'workcell_studio_local_validation.json').read_text(encoding='utf-8'))
+    joined = '\n'.join(payload.get('blockers', []))
+    assert 'GUI smoke failed for ur5_2f_test' in joined
+    assert 'returncode=' in joined


### PR DESCRIPTION
### Motivation

- Prevent the GUI smoke runner from crashing with `UnboundLocalError` when `workspace_root` is not initialized so local validation can reach the Workcell Builder GUI.
- Ensure the smoke runner always writes a structured FAIL JSON on pre-launch/setup failures so local validation sees real blockers instead of only missing-artifact errors.
- Surface the real setup exception as the primary blocker and keep missing screenshot as a secondary consequence so diagnostics point to the root cause.

### Description

- Initialize `repo_root`, `workspace_root`, `exe`, and `searched_candidates` before use and wrap resolution in a guarded flow in `scripts/run_workcell_builder_scene3d_gui_smoke.py` to avoid unbound variables.
- Add `_write_fail_output(...)` to the smoke runner to write a structured FAIL JSON with `schema`, `status`, `scene`, `repo_root`, `workspace_root`, `executable`, `blockers`, `warnings`, `searched_paths`, exception diagnostics, `traceback_tail`, and `screenshot_available` when setup fails before launch.
- Treat an unresolved `workspace_root` as a structured FAIL and write the failure JSON instead of raising; likewise ensure missing executable failures write JSON before exiting.
- Update `scripts/run_workcell_studio_local_validation.py` to parse smoke JSON even when the smoke command exits non-zero, propagate smoke JSON `blockers` into top-level `blockers`, include the smoke JSON path, and report screenshot missing as secondary when the smoke payload indicates it.
- Add regression tests in `tests/test_scene3d_gui_smoke_runner_setup_errors.py` and extend `tests/test_workcell_studio_local_validation_runner.py` to cover explicit `--workspace-root` behavior and consumption of smoke FAIL JSON by local validation.

### Testing

- Successfully compiled runtime scripts with `python3 -m py_compile` for `scripts/run_workcell_builder_scene3d_gui_smoke.py`, `scripts/run_workcell_studio_local_validation.py`, and resolver/bootstrap scripts.
- Ran the test suite with `pytest` covering smoke setup errors, smoke mode, local validation, script direct-exec imports, and hardcoded-path checks; all tests passed (`10 passed`).
- Added targeted tests that confirm `--workspace-root` execution does not raise `UnboundLocalError`, missing-`workspace_root` writes FAIL JSON with expected fields, and local validation includes the smoke-runner blockers rather than collapsing to only “smoke JSON missing”.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10b27ad41c8331b5bb2407820c8688)