### PR TITLE
Use actual Scene3D viewport render counters for GUI smoke readiness

### DIFF
--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -16,3 +16,13 @@ def test_wrapper_writes_fail_json_with_child_diagnostics(tmp_path):
     payload = json.loads(out.read_text(encoding='utf-8'))
     assert payload['status'] == 'FAIL'
     assert 'blockers' in payload and 'app_smoke_json_missing' in payload['blockers']
+
+
+def test_main_cpp_contract_contains_scene3d_counter_keys():
+    repo = Path(__file__).resolve().parents[1]
+    main_cpp = (repo / 'workcell_builder/workcell_builder/gui/main.cpp').read_text(encoding='utf-8')
+    for key in [
+        'viewport_received_count', 'render_cache_count', 'visible_count', 'rendered_count',
+        'unique_visible_item_count', 'selected_scene_name', 'selected_item_id', 'log_line_count'
+    ]:
+        assert f'counters["{key}"]' in main_cpp

--- a/tests/test_scene3d_gui_smoke_mode.py
+++ b/tests/test_scene3d_gui_smoke_mode.py
@@ -14,3 +14,4 @@ def test_cpp_handles_scene3d_smoke_flags_and_output_write():
     for token in ["--scene3d-smoke", "--smoke-output", "--smoke-screenshot", "--exit-after-smoke"]:
         assert token in MAIN_CPP
     assert "QFile out(opts_.smoke_output)" in MAIN_CPP
+    assert "visual_quality_failed" in MAIN_CPP

--- a/tests/test_scene3d_smoke_readiness_markers.py
+++ b/tests/test_scene3d_smoke_readiness_markers.py
@@ -15,3 +15,8 @@ def test_readiness_markers_present_and_item_optional():
 
 def test_no_generic_timeout_message_when_markers_false():
     assert 'Scene3D readiness failed' in MAIN_CPP
+    assert 'viewport_received_count=%1 visible_count=%2 rendered_count=%3 render_cache_count=%4 skipped_count=%5' in MAIN_CPP
+
+
+def test_hierarchy_readiness_uses_child_row_count_consistently():
+    assert 'const bool hierarchy_ready = (tree != nullptr && hierarchy_child_rows > 0);' in MAIN_CPP

--- a/tests/test_scene3d_smoke_render_counters.py
+++ b/tests/test_scene3d_smoke_render_counters.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MAIN_CPP = (ROOT / 'workcell_builder/workcell_builder/gui/main.cpp').read_text(encoding='utf-8')
+VIEWPORT_H = (ROOT / 'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h').read_text(encoding='utf-8')
+
+
+def test_smoke_json_includes_runtime_render_counter_fields():
+    required = [
+        'preview_items_count', 'viewport_received_count', 'render_cache_count',
+        'visible_count', 'rendered_count', 'skipped_count', 'unique_visible_item_count',
+        'mesh_backed_count', 'placeholder_count', 'mesh_rendered_count',
+        'generated_fallback_count', 'editable_layout_count', 'primitive_fallback_count',
+        'locked_generated_urdf_visual_count', 'labels_drawn', 'labels_suppressed_overlap',
+    ]
+    for token in required:
+        assert f'counters["{token}"]' in MAIN_CPP
+
+
+def test_viewport_has_render_debug_counters_accessor_and_fields():
+    for token in [
+        'render_debug_counters() const',
+        'viewport_received_count', 'render_cache_count', 'visible_count',
+        'rendered_count', 'skipped_count', 'unique_visible_item_count',
+    ]:
+        assert token in VIEWPORT_H

--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -82,6 +82,7 @@ private:
   QJsonArray warnings_;
   QJsonArray blockers_;
   QDateTime start_time_;
+  QJsonObject latest_counters_;
 
   void step_begin()
   {
@@ -183,15 +184,16 @@ private:
         if (line.startsWith("Scene: ")) selected_scene_name = line.mid(QString("Scene: ").size()).trimmed();
       }
     }
-    const bool hierarchy_ready = (tree != nullptr && hierarchy_child_rows > 0 && !hierarchy_has_only_headings);
+    const bool hierarchy_ready = (tree != nullptr && hierarchy_child_rows > 0);
     const bool selected_scene_ready = !selected_scene_name.trimmed().isEmpty() && selected_scene_name != "(none)" && selected_scene_name != "none";
     const bool inspector_ready = (inspector != nullptr && !inspector_no_scene_selected && selected_scene_ready);
     const bool log_ready = (log != nullptr && log->toPlainText().contains("Scene3D diagnostics"));
+    const auto rc = viewport ? viewport->render_debug_counters() : Scene3DViewportWidget::RenderDebugCounters{};
+    const bool screenshot_available = !opts_.screenshot_path.trimmed().isEmpty();
     const bool render_ready = viewport != nullptr &&
-      (viewport->last_render_counters.mesh_rendered_count > 0 ||
-       viewport->last_render_counters.generated_fallback_count > 0 ||
-       viewport->last_render_counters.overlay_count > 0 ||
-       viewport->last_render_counters.labels_drawn > 0);
+      rc.viewport_received_count > 0 &&
+      rc.visible_count > 0 &&
+      (rc.rendered_count > 0 || (rc.render_cache_count > 0 && screenshot_available));
     markers["hierarchy_ready"] = hierarchy_ready;
     markers["inspector_ready"] = inspector_ready;
     markers["log_ready"] = log_ready;
@@ -209,6 +211,14 @@ private:
     for (const QString key : {QStringLiteral("hierarchy_ready"), QStringLiteral("inspector_ready"), QStringLiteral("log_ready"),
       QStringLiteral("screenshot_ready"), QStringLiteral("render_ready"), QStringLiteral("selected_scene_ready")}) {
       if (!markers.value(key).toBool(false)) failed.append(key + "=false");
+    }
+    if (!markers.value("render_ready").toBool(false)) {
+      return QString("Scene3D readiness failed: render_ready=false viewport_received_count=%1 visible_count=%2 rendered_count=%3 render_cache_count=%4 skipped_count=%5")
+        .arg(latest_counters_.value("viewport_received_count").toInt())
+        .arg(latest_counters_.value("visible_count").toInt())
+        .arg(latest_counters_.value("rendered_count").toInt())
+        .arg(latest_counters_.value("render_cache_count").toInt())
+        .arg(latest_counters_.value("skipped_count").toInt());
     }
     return failed.isEmpty() ? QString("Scene3D readiness failed") : QString("Scene3D readiness failed: %1").arg(failed.join(", "));
   }
@@ -277,42 +287,49 @@ private:
     const QJsonObject readiness_markers = collect_readiness_markers();
     auto * viewport = window_->findChild<Scene3DViewportWidget *>("scene3dViewportWidget");
     if (viewport) {
-      const auto & rc = viewport->last_render_counters;
-
+      const auto rc = viewport->render_debug_counters();
+      counters["preview_items_count"] = rc.preview_items_count;
+      counters["viewport_received_count"] = rc.viewport_received_count;
+      counters["render_cache_count"] = rc.render_cache_count;
+      counters["visible_count"] = rc.visible_count;
+      counters["rendered_count"] = rc.rendered_count;
+      counters["skipped_count"] = rc.skipped_count;
+      counters["unique_visible_item_count"] = rc.unique_visible_item_count;
+      counters["mesh_backed_count"] = rc.mesh_backed_count;
+      counters["placeholder_count"] = rc.placeholder_count;
       counters["mesh_rendered_count"] = rc.mesh_rendered_count;
       counters["generated_fallback_count"] = rc.generated_fallback_count;
+      counters["editable_layout_count"] = rc.editable_layout_count;
+      counters["primitive_fallback_count"] = rc.primitive_fallback_count;
+      counters["locked_generated_urdf_visual_count"] = rc.locked_generated_urdf_visual_count;
       counters["overlay_count"] = rc.overlay_count;
       counters["labels_drawn"] = rc.labels_drawn;
       counters["labels_suppressed_overlap"] = rc.labels_suppressed_overlap;
-      counters["hierarchy_child_row_count"] = rc.hierarchy_child_row_count;
-
-      // Backward-compatible JSON fields no longer tracked by RenderDebugCounters.
-      counters["preview_items_count"] = 0;
-      counters["viewport_received_count"] = 0;
-      counters["render_cache_count"] = 0;
-      counters["rendered_count"] = rc.mesh_rendered_count + rc.generated_fallback_count + rc.overlay_count;
-      counters["visible_count"] = 0;
-      counters["skipped_count"] = 0;
-      counters["unique_visible_item_count"] = 0;
-      counters["mesh_backed_count"] = rc.mesh_rendered_count;
-      counters["placeholder_count"] = rc.generated_fallback_count;
-      counters["editable_layout_count"] = 0;
-      counters["primitive_fallback_count"] = rc.generated_fallback_count;
-      counters["locked_generated_urdf_visual_count"] = 0;
     } else {
-      counters["mesh_rendered_count"] = 0;
-      counters["generated_fallback_count"] = 0;
-      counters["overlay_count"] = 0;
-      counters["labels_drawn"] = 0;
-      counters["labels_suppressed_overlap"] = 0;
-      counters["hierarchy_child_row_count"] = 0;
+      for (const QString & key : {QStringLiteral("preview_items_count"), QStringLiteral("viewport_received_count"), QStringLiteral("render_cache_count"),
+                                  QStringLiteral("visible_count"), QStringLiteral("rendered_count"), QStringLiteral("skipped_count"),
+                                  QStringLiteral("unique_visible_item_count"), QStringLiteral("mesh_backed_count"), QStringLiteral("placeholder_count"),
+                                  QStringLiteral("mesh_rendered_count"), QStringLiteral("generated_fallback_count"), QStringLiteral("editable_layout_count"),
+                                  QStringLiteral("primitive_fallback_count"), QStringLiteral("locked_generated_urdf_visual_count"),
+                                  QStringLiteral("overlay_count"), QStringLiteral("labels_drawn"), QStringLiteral("labels_suppressed_overlap")}) {
+        counters[key] = 0;
+      }
     }
+    latest_counters_ = counters;
     if (hierarchy_has_only_headings) blockers_.append("Hierarchy has headings only (no child rows)");
     if (selected_scene_name.trimmed().isEmpty() || selected_scene_name == "(none)" || selected_scene_name == "none") {
       blockers_.append("Inspector scene name is empty");
     }
     if (inspector_no_scene_selected) blockers_.append("Inspector remains 'No scene selected'");
     if (selected_item_id == "(none)") warnings_.append("no_item_selected_by_default");
+    const bool render_ready = readiness_markers.value("render_ready").toBool(false);
+    if (render_ready) {
+      const int rendered_count = counters.value("rendered_count").toInt();
+      const int unique_visible = counters.value("unique_visible_item_count").toInt();
+      const int classified = counters.value("mesh_rendered_count").toInt() + counters.value("generated_fallback_count").toInt() +
+        counters.value("editable_layout_count").toInt() + counters.value("overlay_count").toInt();
+      if ((rendered_count > 0 && classified == 0) || unique_visible <= 1) blockers_.append("visual_quality_failed");
+    }
     root["readiness_markers"] = readiness_markers;
     root["counters"] = counters;
     root["warnings"] = warnings_;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -588,13 +588,17 @@ void Scene3DViewportWidget::paintGL()
   int overlay_count = 0;
   int locked_urdf_count = 0;
   int physical_item_count = 0;
+  QSet<QString> unique_visible_ids;
+  int editable_layout_count = 0;
   std::vector<const ScenePreviewWidget::PreviewItem *> overlay_items;
   std::vector<const ScenePreviewWidget::PreviewItem *> physical_items;
   for (const auto * it : draw_items) {
     const NormalizedRole role = classify_item_role(*it);
     if (!show_safety && role == NormalizedRole::SafetyZone) { ++skipped_item_count; continue; }
     ++visible_item_count;
+    unique_visible_ids.insert(it->id);
     if (is_locked_urdf_item(*it)) ++locked_urdf_count;
+    if (it->linked_to_editable_layout_state) ++editable_layout_count;
     if (is_overlay_visual_role(role)) overlay_items.push_back(it);
     else {
       physical_items.push_back(it);
@@ -603,7 +607,15 @@ void Scene3DViewportWidget::paintGL()
   }
   overlay_count = static_cast<int>(overlay_items.size());
   last_render_counters = RenderDebugCounters{};
+  last_render_counters.preview_items_count = items.size();
+  last_render_counters.viewport_received_count = received_item_count;
+  last_render_counters.render_cache_count = mesh_cache_.size();
+  last_render_counters.visible_count = visible_item_count;
+  last_render_counters.skipped_count = skipped_item_count;
+  last_render_counters.unique_visible_item_count = unique_visible_ids.size();
   last_render_counters.overlay_count = overlay_count;
+  last_render_counters.locked_generated_urdf_visual_count = locked_urdf_count;
+  last_render_counters.editable_layout_count = editable_layout_count;
   int visible_hierarchy_items = 0;
   for (const auto * it : draw_items) {
     if (!it) continue;
@@ -635,6 +647,10 @@ void Scene3DViewportWidget::paintGL()
   };  // draw_item_batch
   draw_item_batch(overlay_items, false);  // draw translucent overlays before solids to keep physical meshes legible.
   draw_item_batch(physical_items, true);
+  last_render_counters.rendered_count = rendered_item_count;
+  last_render_counters.mesh_backed_count = mesh_backed_count;
+  last_render_counters.placeholder_count = placeholder_count;
+  last_render_counters.primitive_fallback_count = placeholder_count;
 
   glDisable(GL_BLEND);
 
@@ -787,6 +803,11 @@ void Scene3DViewportWidget::paintGL()
     draw_box(x, y, 0.0, 0.35, 0.35, 0.35, QColor(56, 189, 248, 120), true);
     QToolTip::showText(mapToGlobal(drag_asset_screen_pos_), drag_asset_drop_status_, this);
   }
+}
+
+Scene3DViewportWidget::RenderDebugCounters Scene3DViewportWidget::render_debug_counters() const
+{
+  return last_render_counters;
 }
 
 bool Scene3DViewportWidget::scene_bounds_from_visible_items(QVector3D & out_min, QVector3D & out_max, bool include_overlays) const

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -76,14 +76,27 @@ public:
 
   struct RenderDebugCounters
   {
+    int preview_items_count{ 0 };
+    int viewport_received_count{ 0 };
+    int render_cache_count{ 0 };
+    int visible_count{ 0 };
+    int rendered_count{ 0 };
+    int skipped_count{ 0 };
+    int unique_visible_item_count{ 0 };
+    int mesh_backed_count{ 0 };
+    int placeholder_count{ 0 };
     int mesh_rendered_count{ 0 };
     int generated_fallback_count{ 0 };
+    int editable_layout_count{ 0 };
+    int primitive_fallback_count{ 0 };
+    int locked_generated_urdf_visual_count{ 0 };
     int overlay_count{ 0 };
     int labels_drawn{ 0 };
     int labels_suppressed_overlap{ 0 };
     int hierarchy_child_row_count{ 0 };
   };
   RenderDebugCounters last_render_counters;
+  RenderDebugCounters render_debug_counters() const;
 
   static bool parse_stl_bytes_for_test(const QByteArray & bytes, const QString & source_hint,
                                        InternalTriangleMesh & out_mesh, QString & out_error,

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -332,6 +332,32 @@ void ScenePreviewWidget::set_collision_overlay_model(const CollisionOverlayModel
 
 void ScenePreviewWidget::set_label_mode(LabelMode mode){ Q_UNUSED(mode); auto *v=static_cast<Scene3DViewportWidget *>(simple_3d_view_); v->label_mode = LabelMode::Selected; if (labels_selector_) labels_selector_->setCurrentText("Selected"); v->update(); }
 
+ScenePreviewWidget::RenderDebugCounters ScenePreviewWidget::render_debug_counters() const
+{
+  const auto * viewport = static_cast<Scene3DViewportWidget *>(simple_3d_view_);
+  const auto counters = viewport ? viewport->render_debug_counters() : Scene3DViewportWidget::RenderDebugCounters{};
+  RenderDebugCounters out;
+  out.preview_items_count = counters.preview_items_count;
+  out.viewport_received_count = counters.viewport_received_count;
+  out.render_cache_count = counters.render_cache_count;
+  out.visible_count = counters.visible_count;
+  out.rendered_count = counters.rendered_count;
+  out.skipped_count = counters.skipped_count;
+  out.unique_visible_item_count = counters.unique_visible_item_count;
+  out.mesh_backed_count = counters.mesh_backed_count;
+  out.placeholder_count = counters.placeholder_count;
+  out.overlay_count = counters.overlay_count;
+  out.mesh_rendered_count = counters.mesh_rendered_count;
+  out.generated_fallback_count = counters.generated_fallback_count;
+  out.editable_layout_count = counters.editable_layout_count;
+  out.primitive_fallback_count = counters.primitive_fallback_count;
+  out.locked_generated_urdf_visual_count = counters.locked_generated_urdf_visual_count;
+  out.labels_drawn = counters.labels_drawn;
+  out.labels_suppressed_overlap = counters.labels_suppressed_overlap;
+  out.hierarchy_child_row_count = counters.hierarchy_child_row_count;
+  return out;
+}
+
 int ScenePreviewWidget::total_warning_count() const { int count = 0; for (const auto & item : preview_items_) count += item.warnings.size(); count += overlay_model_.warnings.size() + reachability_overlay_model_.warnings.size() + collision_overlay_model_.warnings.size() + camera_overlay_model_.warnings.size(); for (const auto & det : epd_detections_) count += det.warnings.size(); return count; }
 bool ScenePreviewWidget::task_is_ready() const { return overlay_model_.has_intent_metadata && overlay_model_.pick_source_id != "unknown" && overlay_model_.place_target_id != "unknown"; }
 void ScenePreviewWidget::refresh_info_chip()

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -17,6 +17,7 @@ class ScenePreviewWidget : public QWidget
 {
   Q_OBJECT
 public:
+  struct RenderDebugCounters;
   struct PreviewItem
   {
     QString id;
@@ -168,6 +169,28 @@ public:
   QString selected_preview_item_id() const;
   MeshPreviewMode mesh_preview_mode() const;
   void reload_meshes();
+  struct RenderDebugCounters
+  {
+    int preview_items_count{ 0 };
+    int viewport_received_count{ 0 };
+    int render_cache_count{ 0 };
+    int visible_count{ 0 };
+    int rendered_count{ 0 };
+    int skipped_count{ 0 };
+    int unique_visible_item_count{ 0 };
+    int mesh_backed_count{ 0 };
+    int placeholder_count{ 0 };
+    int overlay_count{ 0 };
+    int mesh_rendered_count{ 0 };
+    int generated_fallback_count{ 0 };
+    int editable_layout_count{ 0 };
+    int primitive_fallback_count{ 0 };
+    int locked_generated_urdf_visual_count{ 0 };
+    int labels_drawn{ 0 };
+    int labels_suppressed_overlap{ 0 };
+    int hierarchy_child_row_count{ 0 };
+  };
+  RenderDebugCounters render_debug_counters() const;
 
 signals:
   void studio_log_requested(const QString & message);


### PR DESCRIPTION
### Motivation
- The Scene3D GUI smoke was reporting `render_ready=false` because it relied on incomplete/stale model-only counters instead of the viewport's live render/cache metrics.
- Smoke JSON lacked key runtime counters (viewport/render-cache/visible/rendered/etc.) and showed inconsistent hierarchy readiness (`hierarchy_child_row_count == 0` while `hierarchy_ready == true`).
- The change aims to expose truthful viewport diagnostics to the smoke runner so `render_ready` reflects actual viewport activity while keeping visual-quality checks separate.

### Description
- Expanded `RenderDebugCounters` and added `Scene3DViewportWidget::render_debug_counters() const` to `scene3d_viewport_widget.h`/`.cpp`, and populated all runtime counters in `paintGL()` from the live draw pipeline (received/visible/rendered/skipped/cache/unique-visible/mesh/fallback/overlay/labels/etc.).
- Added `ScenePreviewWidget::render_debug_counters()` passthrough so higher-level code can obtain viewport diagnostics without duplicating render logic (`scene_preview_widget.h`/`.cpp`).
- Reworked smoke collection in `workcell_builder/workcell_builder/gui/main.cpp` to write the full `counters` contract from the viewport diagnostics, compute `render_ready` using the new rule (viewport_received_count>0, visible_count>0, and rendered_count>0 OR render_cache_count>0 with screenshot available), include exact counter values in render-readiness failure messages, and make `hierarchy_ready` consistent with `hierarchy_child_row_count`.
- Kept `selected_item_id=(none)` as a warning-only condition and added separate `visual_quality_failed` logic when render readiness passes but quality/classification checks fail.
- Added/updated tests: `tests/test_scene3d_smoke_render_counters.py`, `tests/test_scene3d_smoke_readiness_markers.py`, `tests/test_scene3d_gui_smoke_mode.py`, and `tests/test_scene3d_gui_smoke_json_output_contract.py` to assert presence of counters, readiness behavior, hierarchy consistency, and visual-quality separation.

### Testing
- Compiled smoke wrapper scripts with `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py scripts/run_workcell_studio_local_validation.py scripts/workcell_studio_path_resolver.py` and the compile succeeded.
- Ran unit/contract tests with `pytest -q tests/test_scene3d_smoke_render_counters.py tests/test_scene3d_smoke_readiness_markers.py tests/test_scene3d_gui_smoke_mode.py tests/test_scene3d_gui_smoke_json_output_contract.py tests/test_no_hardcoded_workspace_paths.py` and all tests passed (`10 passed`).
- Attempted the full local workspace smoke run (colcon build + smoke runner) but the workspace path `/home/user/workcell_ws` was not present in this environment, so the end-to-end smoke run was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a118682db388331962293bee931ed0f)