### PR TITLE
Fix Scene3D smoke viewport/render-cache handoff and readiness staging

### DIFF
--- a/tests/test_scene3d_viewport_render_cache_handoff.py
+++ b/tests/test_scene3d_viewport_render_cache_handoff.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PREVIEW_CPP = (ROOT / 'workcell_builder/workcell_builder/gui/scene_preview_widget.cpp').read_text(encoding='utf-8')
+VIEWPORT_CPP = (ROOT / 'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp').read_text(encoding='utf-8')
+VIEWPORT_H = (ROOT / 'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h').read_text(encoding='utf-8')
+
+
+def test_preview_widget_delegates_render_counters_to_viewport():
+    assert 'viewport->render_debug_counters()' in PREVIEW_CPP
+    assert 'out.last_paint_completed = counters.last_paint_completed;' in PREVIEW_CPP
+
+
+def test_setting_preview_items_updates_viewport_handoff_counters_before_paint():
+    assert 'void Scene3DViewportWidget::ingest_preview_items' in VIEWPORT_CPP
+    for token in ['viewport_received_count = items.size()', 'visible_count = visible_item_count', 'render_cache_count = mesh_cache_.size()']:
+        assert token in VIEWPORT_CPP
+
+
+def test_viewport_debug_counters_include_paint_marker():
+    assert 'bool last_paint_completed{ false };' in VIEWPORT_H
+    assert 'last_render_counters.last_paint_completed = true;' in VIEWPORT_CPP

--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -132,6 +132,11 @@ private:
     auto * timer = new QTimer(this);
     const qint64 start_ms = QDateTime::currentMSecsSinceEpoch();
     connect(timer, &QTimer::timeout, this, [this, timer, start_ms, timeout_ms]() {
+      if (auto * viewport = window_->findChild<Scene3DViewportWidget *>("scene3dViewportWidget")) {
+        viewport->update();
+        viewport->repaint();
+        app_->processEvents();
+      }
       if (scene3d_ready()) {
         timer->stop();
         timer->deleteLater();
@@ -199,6 +204,7 @@ private:
     markers["log_ready"] = log_ready;
     markers["screenshot_ready"] = true;
     markers["render_ready"] = render_ready;
+    markers["paint_completed"] = rc.last_paint_completed;
     markers["selected_scene_ready"] = selected_scene_ready;
     markers["selected_item_required"] = false;
     return markers;
@@ -213,6 +219,18 @@ private:
       if (!markers.value(key).toBool(false)) failed.append(key + "=false");
     }
     if (!markers.value("render_ready").toBool(false)) {
+      if (latest_counters_.value("preview_items_count").toInt() <= 0 && latest_counters_.value("hierarchy_child_row_count").toInt() > 0) {
+        return QString("preview_items_not_handed_to_scene_preview_widget");
+      }
+      if (latest_counters_.value("preview_items_count").toInt() > 0 && latest_counters_.value("viewport_received_count").toInt() <= 0) {
+        return QString("scene_preview_items_not_forwarded_to_viewport");
+      }
+      if (latest_counters_.value("viewport_received_count").toInt() > 0 && latest_counters_.value("render_cache_count").toInt() <= 0) {
+        return QString("viewport_render_cache_empty");
+      }
+      if (!markers.value("paint_completed").toBool(false)) {
+        return QString("paint_cycle_not_completed");
+      }
       return QString("Scene3D readiness failed: render_ready=false viewport_received_count=%1 visible_count=%2 rendered_count=%3 render_cache_count=%4 skipped_count=%5")
         .arg(latest_counters_.value("viewport_received_count").toInt())
         .arg(latest_counters_.value("visible_count").toInt())
@@ -305,6 +323,7 @@ private:
       counters["overlay_count"] = rc.overlay_count;
       counters["labels_drawn"] = rc.labels_drawn;
       counters["labels_suppressed_overlap"] = rc.labels_suppressed_overlap;
+      counters["last_paint_completed"] = rc.last_paint_completed;
     } else {
       for (const QString & key : {QStringLiteral("preview_items_count"), QStringLiteral("viewport_received_count"), QStringLiteral("render_cache_count"),
                                   QStringLiteral("visible_count"), QStringLiteral("rendered_count"), QStringLiteral("skipped_count"),
@@ -314,6 +333,7 @@ private:
                                   QStringLiteral("overlay_count"), QStringLiteral("labels_drawn"), QStringLiteral("labels_suppressed_overlap")}) {
         counters[key] = 0;
       }
+      counters["last_paint_completed"] = false;
     }
     latest_counters_ = counters;
     if (hierarchy_has_only_headings) blockers_.append("Hierarchy has headings only (no child rows)");
@@ -349,6 +369,10 @@ private:
       root["warnings"] = warnings_;
       root["screenshot_path"] = opts_.screenshot_path;
       root["screenshot_saved"] = screenshot_ok;
+      if (screenshot_ok && counters.value("render_cache_count").toInt() <= 0) {
+        warnings_.append("screenshot_saved_without_render_cache");
+        blockers_.append("screenshot_saved_without_render_cache");
+      }
     }
 
     const bool pass = blockers_.isEmpty();

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -526,6 +526,31 @@ void Scene3DViewportWidget::invalidate_mesh_cache()
   warned_mesh_fallbacks_.clear();
   update();
 }
+void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidget::PreviewItem> & preview_items)
+{
+  items = preview_items;
+  int visible_item_count = 0;
+  int skipped_item_count = 0;
+  QSet<QString> unique_visible_ids;
+  std::vector<const ScenePreviewWidget::PreviewItem *> overlay_items;
+  for (const auto & it : items) {
+    const NormalizedRole role = classify_item_role(it);
+    if (!show_safety && role == NormalizedRole::SafetyZone) { ++skipped_item_count; continue; }
+    ++visible_item_count;
+    unique_visible_ids.insert(it.id);
+    if (is_overlay_visual_role(role)) overlay_items.push_back(&it);
+  }
+  last_render_counters.preview_items_count = items.size();
+  last_render_counters.viewport_received_count = items.size();
+  last_render_counters.render_cache_count = mesh_cache_.size();
+  last_render_counters.visible_count = visible_item_count;
+  last_render_counters.skipped_count = skipped_item_count;
+  last_render_counters.unique_visible_item_count = unique_visible_ids.size();
+  last_render_counters.overlay_count = static_cast<int>(overlay_items.size());
+  last_render_counters.hierarchy_child_row_count = visible_item_count;
+  last_render_counters.last_paint_completed = false;
+  update();
+}
 void Scene3DViewportWidget::fit_scene() {
   QVector3D bmin, bmax;
   // if (!include_in_fit_bounds_physical_only(it)) continue;
@@ -651,6 +676,7 @@ void Scene3DViewportWidget::paintGL()
   last_render_counters.mesh_backed_count = mesh_backed_count;
   last_render_counters.placeholder_count = placeholder_count;
   last_render_counters.primitive_fallback_count = placeholder_count;
+  last_render_counters.last_paint_completed = true;
 
   glDisable(GL_BLEND);
 

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -73,6 +73,7 @@ public:
   void set_side_view();
   void set_isometric_view();
   void invalidate_mesh_cache();
+  void ingest_preview_items(const QVector<ScenePreviewWidget::PreviewItem> & preview_items);
 
   struct RenderDebugCounters
   {
@@ -94,6 +95,7 @@ public:
     int labels_drawn{ 0 };
     int labels_suppressed_overlap{ 0 };
     int hierarchy_child_row_count{ 0 };
+    bool last_paint_completed{ false };
   };
   RenderDebugCounters last_render_counters;
   RenderDebugCounters render_debug_counters() const;

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -226,7 +226,7 @@ void ScenePreviewWidget::set_3d_available(bool available, const QString & reason
   refresh_mode_and_state();
 }
 void ScenePreviewWidget::on_mode_changed(int){ refresh_mode_and_state(); }
-void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items){ preview_items_ = items; static_cast<Scene3DViewportWidget *>(simple_3d_view_)->items = preview_items_; emit studio_log_requested(QString("Scene3D diagnostics {preview_items_count=%1, viewport_received_count=%2}").arg(preview_items_.size()).arg(static_cast<Scene3DViewportWidget *>(simple_3d_view_)->items.size())); const bool has_selected = std::any_of(preview_items_.cbegin(), preview_items_.cend(), [this](const PreviewItem & it){ return it.id == selected_preview_item_id_; }); if (!has_selected && !selected_preview_item_id_.isEmpty()) { emit studio_log_requested(QString("Preview selection cleared after refresh (id missing): %1").arg(selected_preview_item_id_)); selected_preview_item_id_.clear(); static_cast<Scene3DViewportWidget *>(simple_3d_view_)->selected_id.clear(); emit preview_item_selected(QString(), QStringLiteral("unknown")); } else { static_cast<Scene3DViewportWidget *>(simple_3d_view_)->selected_id = selected_preview_item_id_; if (!selected_preview_item_id_.isEmpty()) emit studio_log_requested(QString("Preview selection restored after refresh: %1").arg(selected_preview_item_id_)); } emit studio_log_requested(preview_status_summary_.isEmpty() ? QString("Preview items loaded: %1.").arg(preview_items_.size()) : preview_status_summary_); fit_fallback_scene_to_items(); refresh_info_chip(); update(); }
+void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items){ preview_items_ = items; auto * viewport = static_cast<Scene3DViewportWidget *>(simple_3d_view_); viewport->ingest_preview_items(preview_items_); emit studio_log_requested(QString("Scene3D diagnostics {preview_items_count=%1, viewport_received_count=%2}").arg(preview_items_.size()).arg(viewport->render_debug_counters().viewport_received_count)); const bool has_selected = std::any_of(preview_items_.cbegin(), preview_items_.cend(), [this](const PreviewItem & it){ return it.id == selected_preview_item_id_; }); if (!has_selected && !selected_preview_item_id_.isEmpty()) { emit studio_log_requested(QString("Preview selection cleared after refresh (id missing): %1").arg(selected_preview_item_id_)); selected_preview_item_id_.clear(); static_cast<Scene3DViewportWidget *>(simple_3d_view_)->selected_id.clear(); emit preview_item_selected(QString(), QStringLiteral("unknown")); } else { static_cast<Scene3DViewportWidget *>(simple_3d_view_)->selected_id = selected_preview_item_id_; if (!selected_preview_item_id_.isEmpty()) emit studio_log_requested(QString("Preview selection restored after refresh: %1").arg(selected_preview_item_id_)); } emit studio_log_requested(preview_status_summary_.isEmpty() ? QString("Preview items loaded: %1.").arg(preview_items_.size()) : preview_status_summary_); fit_fallback_scene_to_items(); refresh_info_chip(); update(); }
 void ScenePreviewWidget::set_preview_scene_name(const QString & scene_name){ preview_scene_name_ = scene_name.trimmed().isEmpty() ? "No scene" : scene_name.trimmed(); auto * v = static_cast<Scene3DViewportWidget *>(simple_3d_view_); v->scene_name = preview_scene_name_; refresh_info_chip(); v->update(); }
 void ScenePreviewWidget::set_preview_status_summary(const QString & summary){ preview_status_summary_ = summary.trimmed(); refresh_info_chip(); }
 void ScenePreviewWidget::set_task_overlay_model(const TaskOverlayModel & model){ overlay_model_ = model; static_cast<Scene3DViewportWidget *>(simple_3d_view_)->task_overlay = model; refresh_info_chip(); simple_3d_view_->update(); }
@@ -337,7 +337,7 @@ ScenePreviewWidget::RenderDebugCounters ScenePreviewWidget::render_debug_counter
   const auto * viewport = static_cast<Scene3DViewportWidget *>(simple_3d_view_);
   const auto counters = viewport ? viewport->render_debug_counters() : Scene3DViewportWidget::RenderDebugCounters{};
   RenderDebugCounters out;
-  out.preview_items_count = counters.preview_items_count;
+  out.preview_items_count = preview_items_.size();
   out.viewport_received_count = counters.viewport_received_count;
   out.render_cache_count = counters.render_cache_count;
   out.visible_count = counters.visible_count;
@@ -355,6 +355,7 @@ ScenePreviewWidget::RenderDebugCounters ScenePreviewWidget::render_debug_counter
   out.labels_drawn = counters.labels_drawn;
   out.labels_suppressed_overlap = counters.labels_suppressed_overlap;
   out.hierarchy_child_row_count = counters.hierarchy_child_row_count;
+  out.last_paint_completed = counters.last_paint_completed;
   return out;
 }
 

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -189,6 +189,7 @@ public:
     int labels_drawn{ 0 };
     int labels_suppressed_overlap{ 0 };
     int hierarchy_child_row_count{ 0 };
+    bool last_paint_completed{ false };
   };
   RenderDebugCounters render_debug_counters() const;
 


### PR DESCRIPTION
### Motivation
- The GUI smoke runner was reporting zero Scene3D viewport/render-cache counters despite the hierarchy and inspector being ready, indicating the smoke logic was reading stale or pre-paint state. 
- The goal is to ensure smoke JSON reflects the actual viewport handoff and paint progress without adding new UI, 3D features, or launching hardware.

### Description
- Add an explicit handoff API `Scene3DViewportWidget::ingest_preview_items(...)` that updates `last_render_counters` (received/visible/render_cache counts) immediately when preview items are set, and mark paint state separately. 
- Make `ScenePreviewWidget::set_preview_items()` call the new `ingest_preview_items()` and make `render_debug_counters()` return the widget's `preview_items_count` while delegating viewport counters (including `last_paint_completed`) to the contained `Scene3DViewportWidget`. 
- Extend `RenderDebugCounters` with `last_paint_completed` and set it to `true` at the end of `paintGL()` and to `false` when ingesting preview items. 
- Strengthen the smoke wait loop to force viewport rendering (`update()`, `repaint()`, `QApplication::processEvents()`), publish a `paint_completed` readiness marker, and surface stage-specific timeout blockers (`preview_items_not_handed_to_scene_preview_widget`, `scene_preview_items_not_forwarded_to_viewport`, `viewport_render_cache_empty`, `paint_cycle_not_completed`) plus a `screenshot_saved_without_render_cache` warning/blocker when a screenshot is saved but the render cache is empty. 
- Add a focused test `tests/test_scene3d_viewport_render_cache_handoff.py` and adjust smoke JSON counter handling to include `last_paint_completed` and the updated counters.

### Testing
- Compiled smoke runner scripts via `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py scripts/run_workcell_studio_local_validation.py scripts/workcell_studio_path_resolver.py` with no errors. 
- Ran the smoke-related test suite with `pytest -q` including `tests/test_scene3d_viewport_render_cache_handoff.py`, `tests/test_scene3d_smoke_render_counters.py`, `tests/test_scene3d_smoke_readiness_markers.py`, `tests/test_scene3d_gui_smoke_mode.py`, `tests/test_scene3d_gui_smoke_json_output_contract.py`, and `tests/test_no_hardcoded_workspace_paths.py`, and all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1189a927a0833192277d42bc869df8)