### PR TITLE
Fix Scene3D smoke inspector/preview state handoff and truthfulness checks

### DIFF
--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -289,19 +289,28 @@ private:
     auto * inspector = window_->findChild<QLabel *>("sceneBuilderInspectorLabel");
     QString selected_scene_name = "(none)";
     QString selected_item_id = "(none)";
+    QString inspector_scene_display_name = "";
+    QString inspector_scene_path = "";
+    QString inspector_scene_status = "";
+    QString preview_status = "Unavailable";
     bool inspector_no_scene_selected = true;
     if (inspector) {
       const QString text = inspector->text();
       inspector_no_scene_selected = text.contains("No scene selected", Qt::CaseInsensitive);
       const QStringList lines = text.split('\n');
       for (const QString & line : lines) {
-        if (line.startsWith("Scene: ")) selected_scene_name = line.mid(QString("Scene: ").size()).trimmed();
+        if (line.startsWith("Scene: ")) { selected_scene_name = line.mid(QString("Scene: ").size()).trimmed(); inspector_scene_display_name = selected_scene_name; }
+        if (line.startsWith("Scene path: ")) inspector_scene_path = line.mid(QString("Scene path: ").size()).trimmed();
+        if (line.startsWith("Scene status: ")) inspector_scene_status = line.mid(QString("Scene status: ").size()).trimmed();
         if (line.startsWith("Selected item ID: ")) selected_item_id = line.mid(QString("Selected item ID: ").size()).trimmed();
       }
     }
     counters["selected_scene_name"] = selected_scene_name;
     counters["selected_item_id"] = selected_item_id;
     counters["inspector_no_scene_selected"] = inspector_no_scene_selected;
+    counters["inspector_scene_display_name"] = inspector_scene_display_name;
+    counters["inspector_scene_path"] = inspector_scene_path;
+    counters["inspector_scene_status"] = inspector_scene_status;
     const QJsonObject readiness_markers = collect_readiness_markers();
     auto * viewport = window_->findChild<Scene3DViewportWidget *>("scene3dViewportWidget");
     if (viewport) {
@@ -338,12 +347,23 @@ private:
       }
       counters["last_paint_completed"] = false;
     }
+    auto * preview_chip = window_->findChild<QLabel *>("sceneStatusChip");
+    if (preview_chip) {
+      const QString text = preview_chip->text();
+      if (text.startsWith("Preview:")) preview_status = text.mid(QString("Preview:").size()).trimmed();
+    }
+    counters["preview_status"] = preview_status;
+    counters["workflow_preview_status"] = readiness_markers.value("render_ready").toBool(false) ? QString("Ready") : QString("Fallback");
     latest_counters_ = counters;
     if (hierarchy_has_only_headings) blockers_.append("Hierarchy has headings only (no child rows)");
     if (selected_scene_name.trimmed().isEmpty() || selected_scene_name == "(none)" || selected_scene_name == "none") {
       blockers_.append("Inspector scene name is empty");
     }
     if (inspector_no_scene_selected) blockers_.append("Inspector remains 'No scene selected'");
+    if (!selected_scene_name.trimmed().isEmpty() && selected_scene_name != "(none)" &&
+        (inspector_scene_display_name.trimmed().isEmpty() || inspector_no_scene_selected)) {
+      blockers_.append("inspector_scene_state_mismatch");
+    }
     if (selected_item_id == "(none)") warnings_.append("no_item_selected_by_default");
     const bool render_ready = readiness_markers.value("render_ready").toBool(false);
     if (render_ready) {
@@ -357,6 +377,12 @@ private:
     root["counters"] = counters;
     root["warnings"] = warnings_;
     root["blockers"] = blockers_;
+
+    if ((counters.value("rendered_count").toInt() > 0 || counters.value("viewport_received_count").toInt() > 0) &&
+        counters.value("preview_status").toString().compare("Unavailable", Qt::CaseInsensitive) == 0) {
+      warnings_.append("preview_status_untruthful");
+      blockers_.append("preview_status_untruthful");
+    }
 
     if (!opts_.screenshot_path.trimmed().isEmpty()) {
       bool screenshot_ok = false;


### PR DESCRIPTION
### Motivation
- The GUI smoke output and readiness markers were reporting stale or empty inspector fields while the 3D viewport showed rendered items, causing false negatives (Preview: Unavailable, Inspector: No scene selected).
- Smoke JSON lacked direct preview status and inspector fields needed to validate runtime truthfulness against Scene3D diagnostics.
- Additional smoke-level blockers were required to catch mismatches between rendered counters and displayed preview state so automated validation fails correctly when GUI is inconsistent.

### Description
- Parse the right-side inspector label (`sceneBuilderInspectorLabel`) and emit `inspector_scene_display_name`, `inspector_scene_path`, and `inspector_scene_status` into the smoke `counters` JSON. (modified `workcell_builder/workcell_builder/gui/main.cpp`)
- Read the preview status chip (`sceneStatusChip`) and export `preview_status` plus a `workflow_preview_status` derived from readiness markers so smoke has explicit preview state fields.
- Add smoke blockers when the inspector is inconsistent with a selected scene (`inspector_scene_state_mismatch`) and when the preview chip reports `Unavailable` while render counters are non-zero (`preview_status_untruthful`).
- Wire viewport debug counters into smoke collection (unchanged access point) and include the new counters into `latest_counters_` so smoke JSON better reflects the visible Scene3D diagnostics.

### Testing
- Compiled smoke/validation scripts with `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py scripts/run_workcell_studio_local_validation.py scripts/check_scene3d_canvas_contract.py` which succeeded.
- Ran the focused pytest suite: `pytest -q tests/test_scene3d_inspector_scene_state.py tests/test_scene3d_preview_status_truthful.py tests/test_scene3d_layout_yaml_compatibility.py tests/test_scene3d_giant_blob_regression.py tests/test_scene3d_smoke_counter_handoff.py tests/test_scene3d_generated_fallback_shapes.py tests/test_scene3d_gui_smoke_mode.py tests/test_no_hardcoded_workspace_paths.py` and all tests passed (8 passed).
- Changes committed to `workcell_builder/workcell_builder/gui/main.cpp` and packaged as this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1191e831b4833183776fd0a7fd4e2e)