### PR TITLE
Scene3D: emit mesh-ingestion diagnostics and add loader/fallback contract tests

### DIFF
--- a/scripts/check_scene3d_canvas_contract.py
+++ b/scripts/check_scene3d_canvas_contract.py
@@ -86,6 +86,21 @@ def check_scene(repo_root: Path, scene_dir: Path) -> dict:
     layout = _load_yaml(layout_path) if has_layout else {}
     idx = _load_json(scene_dir / 'generated' / 'scene_visual_mesh_index.json') or {}
     items = idx.get('items', []) if isinstance(idx, dict) else []
+
+    def _ext_of(i):
+        ext = str(i.get('extension') or '').strip().lower()
+        if not ext:
+            mesh_path = str(i.get('resolved_source_path') or i.get('resolved_path') or i.get('source_path') or i.get('mesh_path') or '')
+            ext = Path(mesh_path).suffix.lower()
+        return ext
+
+    mesh_uri_count = sum(1 for i in items if str(i.get('original_uri') or i.get('mesh_uri') or i.get('package_uri') or '').strip())
+    mesh_resolved_count = sum(1 for i in items if i.get('resolved') is True or str(i.get('resolved_source_path') or i.get('resolved_path') or '').strip())
+    stl_count = sum(1 for i in items if _ext_of(i) == '.stl')
+    dae_count = sum(1 for i in items if _ext_of(i) == '.dae')
+    obj_count = sum(1 for i in items if _ext_of(i) == '.obj')
+    supported_mesh_count = stl_count
+    unsupported_extension_count = dae_count + obj_count
     preview_metadata_path = scene_dir / 'generated' / 'scene_preview_metadata.json'
     preview_metadata = _load_json(preview_metadata_path) if preview_metadata_path.exists() else {}
 
@@ -191,6 +206,14 @@ def check_scene(repo_root: Path, scene_dir: Path) -> dict:
         'source_layer_counts': dict(layer_counts),
         'overlay_sources_present': [str(p) for p in overlay_sources if p.exists()],
         'active_visual_source_counts': dict(visual_counts),
+        'visual_mesh_index_total': len(items),
+        'mesh_uri_count': mesh_uri_count,
+        'mesh_resolved_count': mesh_resolved_count,
+        'stl_count': stl_count,
+        'dae_count': dae_count,
+        'obj_count': obj_count,
+        'supported_mesh_count': supported_mesh_count,
+        'unsupported_extension_count': unsupported_extension_count,
     }
 
 

--- a/tests/test_scene3d_dae_obj_fallback_contract.py
+++ b/tests/test_scene3d_dae_obj_fallback_contract.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CPP = (ROOT / "workcell_builder" / "workcell_builder" / "gui" / "scene3d_viewport_widget.cpp").read_text(encoding="utf-8")
+MAIN = (ROOT / "workcell_builder" / "workcell_builder" / "gui" / "mainwindow.cpp").read_text(encoding="utf-8")
+
+
+def test_collada_parser_exists_and_unsupported_mesh_message_exists():
+    assert "parse_collada_bytes" in CPP
+    assert "unsupported mesh format" in CPP
+
+
+def test_unsupported_mesh_falls_back_with_warning():
+    assert "URDF visual mesh unavailable; using primitive fallback" in MAIN
+    assert "unsupported_extension" in MAIN or "unsupported_format" in MAIN

--- a/tests/test_scene3d_mesh_asset_resolver.py
+++ b/tests/test_scene3d_mesh_asset_resolver.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import json
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_visual_mesh_index_has_resolution_fields():
+    for scene in ["ur5_2f_test", "ur5_2f_sorting_test"]:
+        p = ROOT / "scenes" / scene / "generated" / "scene_visual_mesh_index.json"
+        data = json.loads(p.read_text(encoding="utf-8"))
+        assert "safe_for_preview" in data
+        assert any(k in data for k in ["visual_items", "items"])
+
+
+def test_contract_checker_emits_mesh_resolution_counters():
+    src = (ROOT / "scripts" / "check_scene3d_canvas_contract.py").read_text(encoding="utf-8")
+    for token in [
+        "mesh_uri_count",
+        "mesh_resolved_count",
+        "stl_count",
+        "dae_count",
+        "obj_count",
+        "supported_mesh_count",
+        "unsupported_extension_count",
+    ]:
+        assert token in src

--- a/tests/test_scene3d_stl_mesh_loader_runtime.py
+++ b/tests/test_scene3d_stl_mesh_loader_runtime.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CPP = (ROOT / "workcell_builder" / "workcell_builder" / "gui" / "scene3d_viewport_widget.cpp").read_text(encoding="utf-8")
+
+
+def test_ascii_and_binary_stl_parsers_present():
+    assert "parse_ascii_stl" in CPP
+    assert "parse_binary_stl" in CPP
+    assert "looks_like_ascii_stl" in CPP
+
+
+def test_stl_loader_reports_errors_and_triangle_limit():
+    for token in ["mesh triangle count exceeds limit", "ascii STL contains no triangles", "binary STL truncated"]:
+        assert token in CPP


### PR DESCRIPTION
### Motivation
- Surface precise mesh-resolution diagnostics so GUI/smoke logs can explain why Scene3D shows `Mesh 0` (URI absent, unresolved, unsupported extension, loader failure, or not expected to render). 
- Provide measurable counters used by smoke/contract checks to guide subsequent STL loader and fallback improvements. 
- Lock runtime loader and DAE/OBJ fallback contracts with tests to prevent regressions while implementing real-mesh rendering work.

### Description
- Extended `scripts/check_scene3d_canvas_contract.py` to compute and emit mesh ingestion diagnostics including `visual_mesh_index_total`, `mesh_uri_count`, `mesh_resolved_count`, `stl_count`, `dae_count`, `obj_count`, `supported_mesh_count`, and `unsupported_extension_count`. 
- Added a small helper to infer extension from `extension`, `resolved_source_path`, `resolved_path`, `source_path`, or `mesh_path` when `extension` is missing. 
- Added targeted tests: `tests/test_scene3d_mesh_asset_resolver.py`, `tests/test_scene3d_stl_mesh_loader_runtime.py`, and `tests/test_scene3d_dae_obj_fallback_contract.py` to validate index schema expectations, presence of STL parsers, key STL failure messages, and DAE/unsupported-mesh fallback warning tokens.

### Testing
- Verified Python syntax with `python3 -m py_compile` on the relevant scripts and the compile step succeeded. 
- Ran `pytest` for the new and related Scene3D tests (including `tests/test_scene3d_mesh_asset_resolver.py`, `tests/test_scene3d_stl_mesh_loader_runtime.py`, `tests/test_scene3d_dae_obj_fallback_contract.py` plus the existing Scene3D smoke/contract tests) and the suite passed. 
- Confirmed the modified contract output now contains the new mesh counters so downstream smoke and reporting tools can clearly diagnose `Mesh 0` reasons.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1193579b188331ac3ea9377e23fbaa)