### PR TITLE
Fix MainWindow Scene3D helper API regression

### DIFF
--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -193,7 +193,7 @@ private:
     const bool selected_scene_ready = !selected_scene_name.trimmed().isEmpty() && selected_scene_name != "(none)" && selected_scene_name != "none";
     const bool inspector_ready = (inspector != nullptr && !inspector_no_scene_selected && selected_scene_ready);
     const bool log_ready = (log != nullptr && log->toPlainText().contains("Scene3D diagnostics"));
-    const auto rc = window_->active_scene3d_viewport_counters();
+    const auto rc = viewport ? viewport->render_debug_counters() : Scene3DViewportWidget::RenderDebugCounters{};
     const bool screenshot_available = !opts_.screenshot_path.trimmed().isEmpty();
     const bool render_ready =
       rc.viewport_received_count > 0 &&
@@ -319,7 +319,7 @@ private:
       viewport->update();
       viewport->repaint();
       QApplication::processEvents(QEventLoop::AllEvents, 250);
-      const auto rc = window_->active_scene3d_viewport_counters();
+      const auto rc = viewport ? viewport->render_debug_counters() : Scene3DViewportWidget::RenderDebugCounters{};
       counters["preview_items_count"] = rc.preview_items_count;
       counters["viewport_received_count"] = rc.viewport_received_count;
       counters["render_cache_count"] = rc.render_cache_count;

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -3712,20 +3712,9 @@ void MainWindow::refresh_scene_builder_selection_state_ui()
   refresh_task_intent_panel();
 }
 
-MainWindow::SelectedSceneState MainWindow::active_scene_builder_state() const
-{
-  return selected_scene_state_;
-}
-
 ScenePreviewWidget * MainWindow::active_scene_preview_widget() const
 {
   return scene_preview_widget_;
-}
-
-Scene3DViewportWidget::RenderDebugCounters MainWindow::active_scene3d_viewport_counters() const
-{
-  auto * preview = active_scene_preview_widget();
-  return preview ? preview->render_debug_counters() : Scene3DViewportWidget::RenderDebugCounters{};
 }
 
 void MainWindow::refresh_scene_builder_state_from_active_scene()

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -84,9 +84,7 @@ public:
 
   explicit MainWindow(const QString & startup_workspace = QString(), const QString & startup_ros_distro = QString(), QWidget * parent = nullptr);
   ~MainWindow();
-  SelectedSceneState active_scene_builder_state() const;
   ScenePreviewWidget * active_scene_preview_widget() const;
-  Scene3DViewportWidget::RenderDebugCounters active_scene3d_viewport_counters() const;
   void refresh_scene_builder_state_from_active_scene();
   static bool parse_transform_clipboard_text(
     const QString & text, double * x, double * y, double * z, double * r, double * p, double * yaw, QString * error = nullptr);


### PR DESCRIPTION
## Summary
- removed the recently-added `MainWindow` helper declarations that exposed Scene3D smoke internals:
  - `active_scene_builder_state()`
  - `active_scene3d_viewport_counters()`
- removed their corresponding implementations from `mainwindow.cpp`
- updated Scene3D smoke logic in `gui/main.cpp` to read counters directly from the existing viewport child lookup (`scene3dViewportWidget`) instead of calling `MainWindow` helpers

## Why
This restores build stability for `workcell_builder` by eliminating invalid/fragile `MainWindow` API additions that referenced types in problematic declaration order and unnecessary cross-component exposure.

## Scope
- No new UI/runtime behavior introduced.
- Scene3D smoke validation remains in place using direct `findChild<Scene3DViewportWidget*>` access.

## Files
- `workcell_builder/workcell_builder/gui/mainwindow.h`
- `workcell_builder/workcell_builder/gui/mainwindow.cpp`
- `workcell_builder/workcell_builder/gui/main.cpp`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11963971d4833198510d5f1f38d2b2)