### PR TITLE
Set stable object names on active ScenePreviewWidget and Scene3DViewportWidget; expose smoke counters

### DIFF
--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -35,6 +35,7 @@
 
 #include "gui/mainwindow.h"
 #include "gui/scene3d_viewport_widget.h"
+#include "gui/scene_preview_widget.h"
 #include "gui/scene_select.h"
 #include "gui/startup_dialog.h"
 #include "workcell_builder_ui_utils.hpp"
@@ -132,10 +133,12 @@ private:
     auto * timer = new QTimer(this);
     const qint64 start_ms = QDateTime::currentMSecsSinceEpoch();
     connect(timer, &QTimer::timeout, this, [this, timer, start_ms, timeout_ms]() {
-      if (auto * viewport = window_->findChild<Scene3DViewportWidget *>("scene3dViewportWidget")) {
+      if (auto * preview = window_->active_scene_preview_widget()) {
+        if (auto * viewport = preview->findChild<Scene3DViewportWidget *>("scene3dViewportWidget")) {
         viewport->update();
         viewport->repaint();
         app_->processEvents();
+        }
       }
       if (scene3d_ready()) {
         timer->stop();
@@ -169,7 +172,8 @@ private:
     auto * tree = window_->findChild<QTreeWidget *>("studioSceneHierarchyTree");
     auto * inspector = window_->findChild<QLabel *>("sceneBuilderInspectorLabel");
     auto * log = window_->findChild<QTextEdit *>("studioHomeLog");
-    auto * viewport = window_->findChild<Scene3DViewportWidget *>("scene3dViewportWidget");
+    auto * active_preview_widget = window_->active_scene_preview_widget();
+    auto * viewport = active_preview_widget ? active_preview_widget->findChild<Scene3DViewportWidget *>("scene3dViewportWidget") : nullptr;
     int hierarchy_child_rows = 0;
     bool hierarchy_has_only_headings = false;
     if (tree) {
@@ -314,7 +318,18 @@ private:
     counters["inspector_scene_path"] = inspector_scene_path;
     counters["inspector_scene_status"] = inspector_scene_status;
     const QJsonObject readiness_markers = collect_readiness_markers();
-    auto * viewport = window_->findChild<Scene3DViewportWidget *>("scene3dViewportWidget");
+    auto * active_preview_widget = window_->active_scene_preview_widget();
+    auto * resolver_preview_widget = window_->findChild<ScenePreviewWidget *>("scenePreviewWidget");
+    auto * viewport = active_preview_widget ? active_preview_widget->findChild<Scene3DViewportWidget *>("scene3dViewportWidget") : nullptr;
+    const auto preview_widget_matches_resolver = (active_preview_widget != nullptr && active_preview_widget == resolver_preview_widget);
+    const auto preview_widget_count = window_->findChildren<ScenePreviewWidget *>("scenePreviewWidget").size();
+    const auto viewport_widget_count = window_->findChildren<Scene3DViewportWidget *>("scene3dViewportWidget").size();
+    counters["scene_preview_widget_object_name"] = active_preview_widget ? active_preview_widget->objectName() : QString();
+    counters["scene_preview_widget_count"] = preview_widget_count;
+    counters["scene_preview_widget_matches_resolver"] = preview_widget_matches_resolver;
+    counters["scene3d_viewport_widget_object_name"] = viewport ? viewport->objectName() : QString();
+    counters["scene3d_viewport_widget_found"] = (viewport != nullptr);
+    counters["scene3d_viewport_widget_count"] = viewport_widget_count;
     if (viewport) {
       viewport->update();
       viewport->repaint();
@@ -397,8 +412,7 @@ private:
 
     if (!opts_.screenshot_path.trimmed().isEmpty()) {
       bool screenshot_ok = false;
-      auto * viewport = window_->findChild<QWidget *>("scene3dViewportWidget");
-      QWidget * source = viewport ? viewport : window_;
+      QWidget * source = viewport ? static_cast<QWidget *>(viewport) : window_;
       if (source) {
         QImage img = source->grab().toImage();
         screenshot_ok = img.save(opts_.screenshot_path);

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1151,6 +1151,7 @@ void MainWindow::setup_studio_shell()
   //   2) locked/generated visual metadata (generated/scene_visual_mesh_index.json)
   // and forwards them to Scene3DViewportWidget for perspective/depth/orbit-pan-zoom rendering.
   scene_preview_widget_ = new ScenePreviewWidget(scene_builder);
+  scene_preview_widget_->setObjectName("scenePreviewWidget");
   scene_preview_widget_->set_label_mode(ScenePreviewWidget::LabelMode::Selected);
   connect(scene_preview_widget_, &ScenePreviewWidget::studio_log_requested, this, [this](const QString &m){
     append_studio_log(m);
@@ -1164,6 +1165,7 @@ void MainWindow::setup_studio_shell()
   });
   auto * scene3d_viewport = scene_preview_widget_->findChild<Scene3DViewportWidget *>();
   if (scene3d_viewport) {
+    scene3d_viewport->setObjectName("scene3dViewportWidget");
     scene3d_viewport->transform_changed_cb = [this](const QString &id, double x, double y, double z, double r, double p, double yaw){
       if (!digital_twin_scene_) return;
       for (auto * item : digital_twin_scene_->items()) {

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -108,7 +108,9 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   root->addLayout(controls);
   stack_ = new QStackedWidget(this);
   view3d_container_ = new QWidget(this); auto * v3 = new QVBoxLayout(view3d_container_);
-  simple_3d_view_ = new Scene3DViewportWidget(view3d_container_); v3->addWidget(simple_3d_view_);
+  simple_3d_view_ = new Scene3DViewportWidget(view3d_container_);
+  simple_3d_view_->setObjectName("scene3dViewportWidget");
+  v3->addWidget(simple_3d_view_);
   empty_state_label_ = new QLabel("No scene selected\nOpen a scene or create a new cell to preview it.", view3d_container_);
   empty_state_label_->setAlignment(Qt::AlignCenter); v3->addWidget(empty_state_label_);
   error_state_label_ = new QLabel("3D Layout Preview unavailable", view3d_container_); error_state_label_->setAlignment(Qt::AlignCenter); v3->addWidget(error_state_label_);


### PR DESCRIPTION
### Motivation
- Ensure the UI instance added to layouts has stable, queryable object names so runtime/self-test logic can reliably locate the active preview and viewport widgets. 
- Avoid reporting counters from detached or temporary widget instances by resolving counters from the resolver-selected active preview widget. 
- Provide additional smoke-run metrics for diagnosing preview/viewport handoff and presence.

### Description
- In `ScenePreviewWidget` constructor set the 3D viewport instance name with `simple_3d_view_->setObjectName("scene3dViewportWidget")` so the actual visible viewport carries the name. 
- In `MainWindow::setup_studio_shell()` set `scene_preview_widget_->setObjectName("scenePreviewWidget")` on the UI instance and, when the child viewport is found, reinforce `scene3d_viewport->setObjectName("scene3dViewportWidget")`. 
- In the smoke runner and `finalize()` logic (`main.cpp`) resolve the viewport from `window_->active_scene_preview_widget()` (the resolver-selected active widget) rather than global detached lookups, and use that pointer for updates, repaint and screenshot capture. 
- Added smoke counters populated from the active widgets: `scene_preview_widget_object_name`, `scene3d_viewport_widget_object_name`, `scene3d_viewport_widget_found`, `scene3d_viewport_widget_count`, and `scene_preview_widget_count`, and added `scene_preview_widget_matches_resolver` to help detect mismatches.

### Testing
- No automated unit or integration tests were executed for this change; validation was performed by code inspection and targeted source searches/diff to confirm object-name placements and updated counter keys.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a119985448c83319ab8bbbc10ad82e5)