### PR TITLE
Derive Scene3D preview statuses from active viewport counters

### DIFF
--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -362,9 +362,33 @@ private:
       const QString text = preview_chip->text();
       if (text.startsWith("Preview:")) preview_status = text.mid(QString("Preview:").size()).trimmed();
     }
+    const int active_received_count = counters.value("active_viewport_received_count").toInt();
+    const int active_rendered_count = counters.value("active_rendered_count").toInt();
+    const bool has_active_items = (active_received_count > 0 || active_rendered_count > 0);
+    const bool fallback_render_path_active =
+      counters.value("generated_fallback_count").toInt() > 0 ||
+      counters.value("primitive_fallback_count").toInt() > 0 ||
+      counters.value("editable_layout_count").toInt() > 0;
+    const bool has_mesh_or_meaningful_fallback =
+      counters.value("mesh_rendered_count").toInt() > 0 || fallback_render_path_active;
+    const bool has_layout_mesh_warning_with_visible_fallback =
+      counters.value("visible_count").toInt() > 0 && fallback_render_path_active &&
+      (counters.value("placeholder_count").toInt() > 0 ||
+       counters.value("locked_generated_urdf_visual_count").toInt() > 0 ||
+       (counters.value("mesh_backed_count").toInt() > 0 && counters.value("mesh_rendered_count").toInt() <= 0));
+
+    QString derived_preview_status = QStringLiteral("Unavailable");
+    if (has_layout_mesh_warning_with_visible_fallback) {
+      derived_preview_status = QStringLiteral("Warning");
+    } else if (has_mesh_or_meaningful_fallback) {
+      derived_preview_status = fallback_render_path_active ? QStringLiteral("Fallback") : QStringLiteral("Available");
+    } else if (has_active_items) {
+      derived_preview_status = QStringLiteral("Fallback");
+    }
+
     counters["preview_status"] = preview_status;
-    counters["header_preview_status"] = preview_status;
-    counters["workflow_preview_status"] = (counters.value("rendered_count").toInt() > 0 || counters.value("viewport_received_count").toInt() > 0) ? (preview_status.compare("Unavailable", Qt::CaseInsensitive) == 0 ? QString("Fallback") : preview_status) : QString("Missing");
+    counters["header_preview_status"] = derived_preview_status;
+    counters["workflow_preview_status"] = has_active_items ? derived_preview_status : QStringLiteral("Missing");
     latest_counters_ = counters;
     if (hierarchy_has_only_headings) blockers_.append("Hierarchy has headings only (no child rows)");
     if (selected_scene_name.trimmed().isEmpty() || selected_scene_name == "(none)" || selected_scene_name == "none") {


### PR DESCRIPTION
### Motivation
- Ensure header and workflow preview states reflect actual active viewport rendering activity rather than only the status chip text.
- Prevent reporting the header as `Unavailable` when the active viewport has received or rendered items.
- Provide explicit mapping for `Fallback`, `Warning`, and `Available` based on fallback-path usage and mesh/layout indicators.
- Keep visual-quality blockers separate from counter handoff / paint-cycle blocker logic.

### Description
- Compute `active_viewport_received_count` and `active_rendered_count` and derive `has_active_items`, `fallback_render_path_active`, `has_mesh_or_meaningful_fallback`, and `has_layout_mesh_warning_with_visible_fallback` from the collected counters.
- Derive `derived_preview_status` with the requested mapping: `Warning` for layout/mesh warnings with visible fallback, `Fallback` when fallback render path or active items are present, and `Available` when mesh rendering exists without fallback dominance.
- Set `counters["header_preview_status"]` to the derived status and set `counters["workflow_preview_status"]` to the derived status when active items exist otherwise `Missing`.
- Preserve the original `preview_status` captured from the UI chip and leave existing `visual_quality_failed` and other readiness/blocker logic unchanged.

### Testing
- Applied the change with `apply_patch` and performed an in-repo edit via a short `python` script, both of which completed successfully.
- Verified modifications via `rg -n` and inspected file regions with `sed -n` and `nl -ba`, which showed the new derived-status logic in `workcell_builder/workcell_builder/gui/main.cpp`.
- Committed the change with `git` (`git add` / `git commit`) which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11998a38d88331ab4501ea72c8c347)