### PR TITLE
Set stable scene preview/viewport object names and report active-widget smoke counters

### DIFF
--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -72,6 +72,24 @@ struct Scene3DViewportCandidate
   int non_zero_counter_count{ 0 };
 };
 
+
+struct ScenePreviewCandidate
+{
+  ScenePreviewWidget * widget{ nullptr };
+  bool is_visible{ false };
+  bool under_active_scene_builder_panel{ false };
+  QString object_name;
+  QString pointer_address;
+};
+
+struct ActiveScenePreviewResolution
+{
+  ScenePreviewWidget * selected{ nullptr };
+  QVector<ScenePreviewCandidate> candidates;
+  int selected_index{ -1 };
+  QString source_label{ "missing" };
+};
+
 struct ActiveScene3DViewportResolution
 {
   Scene3DViewportWidget * selected{ nullptr };
@@ -102,7 +120,53 @@ bool has_active_scene_builder_ancestor(QWidget * widget)
   return false;
 }
 
-ActiveScene3DViewportResolution resolve_active_scene3d_viewport(MainWindow * mw)
+ActiveScenePreviewResolution resolve_active_scene_preview_widget(MainWindow * mw)
+{
+  ActiveScenePreviewResolution resolution;
+  if (!mw) return resolution;
+
+  const QList<ScenePreviewWidget *> previews = mw->findChildren<ScenePreviewWidget *>();
+  ScenePreviewWidget * active_preview = mw->active_scene_preview_widget();
+
+  auto score = [&](ScenePreviewWidget * preview) {
+    if (!preview) return std::numeric_limits<int>::min();
+    int s = 0;
+    if (preview == active_preview) s += 100000;
+    if (preview->isVisible()) s += 10000;
+    if (has_active_scene_builder_ancestor(preview)) s += 1000;
+    if (preview->objectName() == QStringLiteral("scenePreviewWidget")) s += 100;
+    return s;
+  };
+
+  int best_score = std::numeric_limits<int>::min();
+  for (auto * preview : previews) {
+    if (!preview) continue;
+    ScenePreviewCandidate candidate;
+    candidate.widget = preview;
+    candidate.is_visible = preview->isVisible();
+    candidate.under_active_scene_builder_panel = has_active_scene_builder_ancestor(preview);
+    candidate.object_name = preview->objectName();
+    candidate.pointer_address = QStringLiteral("0x%1").arg(reinterpret_cast<quintptr>(preview), 0, 16);
+    resolution.candidates.push_back(candidate);
+    const int s = score(preview);
+    if (s > best_score) {
+      best_score = s;
+      resolution.selected = preview;
+      resolution.selected_index = resolution.candidates.size() - 1;
+    }
+  }
+
+  if (resolution.selected) {
+    const auto & selected = resolution.candidates[resolution.selected_index];
+    if (resolution.selected == active_preview) resolution.source_label = QStringLiteral("active_scene_preview_widget");
+    else if (selected.is_visible) resolution.source_label = QStringLiteral("visible_scene_preview_widget");
+    else resolution.source_label = QStringLiteral("fallback_scene_preview_widget");
+  }
+
+  return resolution;
+}
+
+ActiveScene3DViewportResolution resolve_active_scene3d_viewport(MainWindow * mw, ScenePreviewWidget * active_preview)
 {
   ActiveScene3DViewportResolution resolution;
   if (!mw) {
@@ -141,7 +205,12 @@ ActiveScene3DViewportResolution resolve_active_scene3d_viewport(MainWindow * mw)
     resolution.candidates.push_back(candidate);
   };
 
+  if (active_preview) {
+    const auto preview_viewports = active_preview->findChildren<Scene3DViewportWidget *>();
+    for (auto * viewport : preview_viewports) add_candidate(viewport);
+  }
   for (auto * preview : previews) {
+    if (preview == active_preview) continue;
     if (!preview) continue;
     const auto preview_viewports = preview->findChildren<Scene3DViewportWidget *>();
     for (auto * viewport : preview_viewports) add_candidate(viewport);
@@ -258,7 +327,9 @@ private:
     auto * timer = new QTimer(this);
     const qint64 start_ms = QDateTime::currentMSecsSinceEpoch();
     connect(timer, &QTimer::timeout, this, [this, timer, start_ms, timeout_ms]() {
-      const auto viewport_resolution = resolve_active_scene3d_viewport(window_);
+      const auto preview_resolution = resolve_active_scene_preview_widget(window_);
+      ScenePreviewWidget * active_preview_widget = preview_resolution.selected;
+      const auto viewport_resolution = resolve_active_scene3d_viewport(window_, active_preview_widget);
       if (auto * viewport = viewport_resolution.selected) {
         viewport->update();
         viewport->repaint();
@@ -296,7 +367,9 @@ private:
     auto * tree = window_->findChild<QTreeWidget *>("studioSceneHierarchyTree");
     auto * inspector = window_->findChild<QLabel *>("sceneBuilderInspectorLabel");
     auto * log = window_->findChild<QTextEdit *>("studioHomeLog");
-    const auto viewport_resolution = resolve_active_scene3d_viewport(window_);
+    const auto preview_resolution = resolve_active_scene_preview_widget(window_);
+    ScenePreviewWidget * active_preview_widget = preview_resolution.selected;
+    const auto viewport_resolution = resolve_active_scene3d_viewport(window_, active_preview_widget);
     auto * viewport = viewport_resolution.selected;
     int hierarchy_child_rows = 0;
     bool hierarchy_has_only_headings = false;
@@ -441,9 +514,17 @@ private:
     counters["inspector_scene_display_name"] = inspector_scene_display_name;
     counters["inspector_scene_path"] = inspector_scene_path;
     counters["inspector_scene_status"] = inspector_scene_status;
-    const QJsonObject readiness_markers = collect_readiness_markers();
-    const auto viewport_resolution = resolve_active_scene3d_viewport(window_);
+    const auto preview_resolution = resolve_active_scene_preview_widget(window_);
+    ScenePreviewWidget * active_preview_widget = preview_resolution.selected;
+    const auto viewport_resolution = resolve_active_scene3d_viewport(window_, active_preview_widget);
     auto * viewport = viewport_resolution.selected;
+    counters["scene_preview_widget_found"] = (active_preview_widget != nullptr);
+    counters["scene_preview_widget_count"] = preview_resolution.candidates.size();
+    counters["scene_preview_widget_object_name"] = active_preview_widget ? active_preview_widget->objectName() : QString();
+    counters["scene3d_viewport_widget_found"] = (viewport != nullptr);
+    counters["scene3d_viewport_widget_count"] = viewport_resolution.candidates.size();
+    counters["scene3d_viewport_widget_object_name"] = viewport ? viewport->objectName() : QString();
+    const QJsonObject readiness_markers = collect_readiness_markers();
     if (viewport) {
       viewport->update();
       viewport->repaint();
@@ -552,7 +633,9 @@ private:
 
     if (!opts_.screenshot_path.trimmed().isEmpty()) {
       bool screenshot_ok = false;
-      const auto viewport_resolution = resolve_active_scene3d_viewport(window_);
+      const auto preview_resolution = resolve_active_scene_preview_widget(window_);
+      ScenePreviewWidget * active_preview_widget = preview_resolution.selected;
+      const auto viewport_resolution = resolve_active_scene3d_viewport(window_, active_preview_widget);
       QWidget * source = viewport_resolution.selected ? static_cast<QWidget *>(viewport_resolution.selected) : window_;
       if (source) {
         QImage img = source->grab().toImage();

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1151,6 +1151,7 @@ void MainWindow::setup_studio_shell()
   //   2) locked/generated visual metadata (generated/scene_visual_mesh_index.json)
   // and forwards them to Scene3DViewportWidget for perspective/depth/orbit-pan-zoom rendering.
   scene_preview_widget_ = new ScenePreviewWidget(scene_builder);
+  scene_preview_widget_->setObjectName("scenePreviewWidget");
   scene_preview_widget_->set_label_mode(ScenePreviewWidget::LabelMode::Selected);
   connect(scene_preview_widget_, &ScenePreviewWidget::studio_log_requested, this, [this](const QString &m){
     append_studio_log(m);
@@ -1164,6 +1165,7 @@ void MainWindow::setup_studio_shell()
   });
   auto * scene3d_viewport = scene_preview_widget_->findChild<Scene3DViewportWidget *>();
   if (scene3d_viewport) {
+    scene3d_viewport->setObjectName("scene3dViewportWidget");
     scene3d_viewport->transform_changed_cb = [this](const QString &id, double x, double y, double z, double r, double p, double yaw){
       if (!digital_twin_scene_) return;
       for (auto * item : digital_twin_scene_->items()) {

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -55,6 +55,7 @@ QString scene_preview_mouse_help_tooltip(const QString & unavailable_reason)
 
 ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
 {
+  setObjectName("scenePreviewWidget");
   auto * root = new QVBoxLayout(this);
   auto * controls = new QHBoxLayout();
   controls->addWidget(new QLabel("View mode", this));
@@ -108,7 +109,9 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   root->addLayout(controls);
   stack_ = new QStackedWidget(this);
   view3d_container_ = new QWidget(this); auto * v3 = new QVBoxLayout(view3d_container_);
-  simple_3d_view_ = new Scene3DViewportWidget(view3d_container_); v3->addWidget(simple_3d_view_);
+  simple_3d_view_ = new Scene3DViewportWidget(view3d_container_);
+  simple_3d_view_->setObjectName("scene3dViewportWidget");
+  v3->addWidget(simple_3d_view_);
   empty_state_label_ = new QLabel("No scene selected\nOpen a scene or create a new cell to preview it.", view3d_container_);
   empty_state_label_->setAlignment(Qt::AlignCenter); v3->addWidget(empty_state_label_);
   error_state_label_ = new QLabel("3D Layout Preview unavailable", view3d_container_); error_state_label_->setAlignment(Qt::AlignCenter); v3->addWidget(error_state_label_);


### PR DESCRIPTION
### Motivation
- Ensure the widgets created and shown in the Scene Builder UI have stable object names so external tooling can reliably identify them (`scenePreviewWidget` and `scene3dViewportWidget`).
- Improve smoke-test diagnostics by reporting object names and counts for the actual active UI widgets rather than detached/temporary instances.
- Make smoke readiness/screenshot capture resolve metrics from resolver-selected active widgets to avoid inconsistent counters.

### Description
- Set `ScenePreviewWidget` object name to `scenePreviewWidget` in the widget constructor and also on the `MainWindow` instance when it is created (`scene_preview_widget_`).
- Set the internal 3D viewport object name to `scene3dViewportWidget` on the actual visible viewport instance (`simple_3d_view_`) and reinforce it where `MainWindow` wires callbacks.
- Add `ActiveScenePreviewResolution` and update `resolve_active_scene3d_viewport` to accept a resolver-selected active preview widget so viewport candidates under the active preview are prioritized.
- Extend smoke `finalize()` counters JSON to include `scene_preview_widget_object_name`, `scene3d_viewport_widget_object_name`, `scene3d_viewport_widget_found`, `scene3d_viewport_widget_count`, and `scene_preview_widget_count`, and populate them from the resolver-selected active widgets.

### Testing
- Ran `git -C /workspace/Easy_Manipulator_Improved diff --check` to validate no patch formatting issues and it passed.
- Created a commit (confirmed via `git commit`) successfully which includes the changes to `main.cpp`, `mainwindow.cpp`, and `scene_preview_widget.cpp`.
- No automated unit tests were run as part of this change (only repository-level checks and the commit were performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a119af04e3c83319f7ecfebb5d9c1e5)