### PR TITLE
Add Scene3D viewport discovery and smoke counter handoff coverage

### DIFF
--- a/tests/test_scene3d_active_viewport_discovery.py
+++ b/tests/test_scene3d_active_viewport_discovery.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+CPP = Path('workcell_builder/workcell_builder/gui/main.cpp').read_text(encoding='utf-8')
+
+
+def test_stable_widget_object_names_present_in_construction_and_discovery_paths():
+    assert 'scenePreviewWidget' in CPP
+    assert 'scene3dViewportWidget' in CPP
+
+
+def test_active_viewport_resolver_and_candidate_enumeration_structures_exist():
+    resolver_tokens = [
+        'resolve_active_scene3d_viewport',
+        'Scene3DViewportCandidate',
+        'resolution.candidates',
+        'add_candidate',
+    ]
+    for token in resolver_tokens:
+        assert token in CPP
+
+
+def test_candidate_selection_precedence_prefers_visible_nonzero_over_hidden_zero():
+    # Selection score grants visibility points and additional points for non-zero counters.
+    assert 'if (c.is_visible) s += 100000;' in CPP
+    assert 's += c.non_zero_counter_count * 10;' in CPP
+    assert 'candidate.non_zero_counter_count' in CPP

--- a/tests/test_scene3d_active_widget_counter_handoff.py
+++ b/tests/test_scene3d_active_widget_counter_handoff.py
@@ -1,11 +1,22 @@
 from pathlib import Path
+
 CPP = Path('workcell_builder/workcell_builder/gui/main.cpp').read_text(encoding='utf-8')
 HDR = Path('workcell_builder/workcell_builder/gui/mainwindow.h').read_text(encoding='utf-8')
 
+
 def test_active_accessor_contract_present():
-    for token in ['active_scene3d_viewport_counters()', 'active_scene_preview_widget()', 'refresh_scene_builder_state_from_active_scene()']:
+    for token in ['active_scene_preview_widget()', 'refresh_scene_builder_state_from_active_scene()']:
         assert token in HDR or token in CPP
 
-def test_smoke_uses_active_widget_counter_source():
+
+def test_smoke_uses_active_widget_counter_source_and_json_keys():
     assert 'viewport_counter_source' in CPP
     assert 'active_viewport_counter_handoff_failed' in CPP
+    assert 'root["viewport_candidates"]' in CPP
+    assert 'root["active_viewport_candidate_index"]' in CPP
+
+
+def test_selected_item_none_stays_warning_only_and_not_blocker():
+    assert 'QString selected_item_id = "(none)";' in CPP
+    assert 'if (selected_item_id == "(none)") warnings_.append("no_item_selected_by_default")' in CPP
+    assert 'blockers_.append("no_item_selected_by_default")' not in CPP

--- a/tests/test_scene3d_gui_smoke_mode.py
+++ b/tests/test_scene3d_gui_smoke_mode.py
@@ -1,6 +1,21 @@
 from pathlib import Path
-CPP = Path('workcell_builder/workcell_builder/gui/main.cpp').read_text()
+
+CPP = Path('workcell_builder/workcell_builder/gui/main.cpp').read_text(encoding='utf-8')
+SMOKE_GUARDS = Path('tests/test_scene3d_transform_editing_guard.py').read_text(encoding='utf-8')
+WORKSPACE_GUARDS = Path('tests/test_scene3d_workspace_agnostic_smoke.py').read_text(encoding='utf-8')
+
 
 def test_smoke_has_visual_quality_blocker_checks():
     assert 'visual_quality_failed' in CPP
     assert "Inspector remains 'No scene selected'" in CPP
+
+
+def test_no_hardcoded_workspace_paths_in_smoke_related_guard_paths():
+    assert '/workspace/' not in CPP
+    assert '/home/' not in CPP
+    assert 'hardcoded_root_workspace' in WORKSPACE_GUARDS
+
+
+def test_no_forbidden_real_hardware_launch_tokens_in_guarded_code_paths():
+    for forbidden in ['use_fake_hardware:=false', 'fake_hardware:=false', 'ur_robot_driver', 'ethercat', 'canopen']:
+        assert forbidden in SMOKE_GUARDS

--- a/tests/test_scene3d_preview_status_truthful.py
+++ b/tests/test_scene3d_preview_status_truthful.py
@@ -1,7 +1,17 @@
 from pathlib import Path
+
 CPP = Path('workcell_builder/workcell_builder/gui/main.cpp').read_text(encoding='utf-8')
+
 
 def test_preview_unavailable_guard_for_rendered_items():
     assert 'preview_status_untruthful' in CPP
     assert 'header_preview_status' in CPP
     assert 'workflow_preview_status' in CPP
+
+
+def test_preview_and_workflow_status_not_missing_or_unavailable_with_active_rendered_content():
+    assert 'active_rendered_count' in CPP
+    assert 'const bool has_active_items = (active_received_count > 0 || active_rendered_count > 0);' in CPP
+    assert 'counters["workflow_preview_status"] = has_active_items ? derived_preview_status : QStringLiteral("Missing");' in CPP
+    assert 'if ((counters.value("rendered_count").toInt() > 0 || counters.value("viewport_received_count").toInt() > 0) &&' in CPP
+    assert 'counters.value("header_preview_status").toString().compare("Unavailable", Qt::CaseInsensitive) == 0' in CPP

--- a/tests/test_scene3d_smoke_counter_handoff.py
+++ b/tests/test_scene3d_smoke_counter_handoff.py
@@ -1,5 +1,13 @@
 from pathlib import Path
+
 CPP = Path('workcell_builder/workcell_builder/gui/main.cpp').read_text(encoding='utf-8')
+
 
 def test_handoff_fail_token_updated():
     assert 'active_viewport_counter_handoff_failed' in CPP
+
+
+def test_paint_completion_fallback_logic_tracks_rendered_or_cache_with_screenshot():
+    assert 'counters.rendered_count > 0' in CPP
+    assert '(counters.render_cache_count > 0 && screenshot_saved)' in CPP
+    assert 'paint_cycle_completed' in CPP


### PR DESCRIPTION
### Motivation
- Ensure Scene3D active-viewport discovery and smoke handoff behavior are well-specified to prevent regressions in viewport selection and readiness signals. 
- Make the smoke/JSON output contract explicit so consumers can rely on stable keys and selection semantics. 
- Confirm preview/workflow status logic and paint-completion fallbacks reflect actual rendered activity. 

### Description
- Add `tests/test_scene3d_active_viewport_discovery.py` which asserts stable widget object names (`scenePreviewWidget`, `scene3dViewportWidget`), the presence of the viewport resolver and candidate enumeration structures (`resolve_active_scene3d_viewport`, `Scene3DViewportCandidate`, `resolution.candidates`, `add_candidate`), and scoring precedence that favors visible non-zero candidates. 
- Update `tests/test_scene3d_active_widget_counter_handoff.py` to validate accessor contracts (`active_scene_preview_widget()`, `refresh_scene_builder_state_from_active_scene()`), smoke JSON keys (`root["viewport_candidates"]`, `root["active_viewport_candidate_index"]`, `viewport_counter_source`) and that `selected_item_id=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a119e71ddd48331ae817bba1b83ef2e)