### PR TITLE
Scene3D: canonical generated-URDF classification, distinct views, and visual acceptance gate

### DIFF
--- a/scripts/validate_scene3d_visual_acceptance.py
+++ b/scripts/validate_scene3d_visual_acceptance.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json
+from pathlib import Path
+
+
+def _get(d: dict, *keys, default=0):
+    for k in keys:
+        if isinstance(d, dict) and k in d:
+            return d[k]
+    return default
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--smoke-json", required=True, type=Path)
+    ap.add_argument("--screenshot", required=True, type=Path)
+    args = ap.parse_args()
+
+    smoke = json.loads(args.smoke_json.read_text(encoding="utf-8"))
+    counters = smoke.get("render_debug_counters", {}) if isinstance(smoke, dict) else {}
+
+    blockers: list[str] = []
+    status = str(_get(smoke, "status", default="")).upper()
+    if status and status == "FAIL":
+      blockers.append("scene3d smoke reported FAIL")
+
+    if str(_get(smoke, "schema", default="")) != "workcell_studio_scene3d_gui_smoke/v1":
+      blockers.append("unexpected smoke schema")
+
+    if not bool(_get(smoke, "scene3d_rendered", "last_paint_completed", default=counters.get("last_paint_completed", False))):
+      blockers.append("scene3d not rendered")
+
+    mesh_rendered = int(_get(smoke, "mesh_rendered_count", default=counters.get("mesh_rendered_count", 0)))
+    if mesh_rendered <= 0:
+      blockers.append("mesh_rendered_count <= 0")
+
+    generated_count = int(_get(smoke, "generated_urdf_visual_count", "locked_generated_urdf_visual_count", default=counters.get("locked_generated_urdf_visual_count", 0)))
+    if generated_count <= 0:
+      blockers.append("generated URDF visual count <= 0")
+
+    overlay_count = int(_get(smoke, "overlay_count", default=counters.get("overlay_count", 0)))
+    visible_count = max(1, int(_get(smoke, "visible_count", default=counters.get("visible_count", 0))))
+    if overlay_count > int(visible_count * 0.7):
+      blockers.append("helper overlays dominate visible set")
+
+    placeholder_count = int(_get(smoke, "placeholder_count", "primitive_fallback_count", default=counters.get("placeholder_count", 0)))
+    rendered_count = max(1, int(_get(smoke, "rendered_count", default=counters.get("rendered_count", 0))))
+    if placeholder_count > int(rendered_count * 0.5):
+      blockers.append("fallback placeholders dominate rendered solids")
+
+    viewport_source = str(_get(smoke, "active_viewport_source", "viewport_source", default="")).lower()
+    if viewport_source and ("scene3d" not in viewport_source or "visible" not in viewport_source):
+      blockers.append("active viewport source is not the visible Scene3D viewport")
+
+    if not args.screenshot.exists() or args.screenshot.stat().st_size <= 0:
+      blockers.append("screenshot missing or empty")
+
+    out = {
+      "status": "PASS" if not blockers else "FAIL",
+      "blockers": blockers,
+      "smoke_json": str(args.smoke_json),
+      "screenshot": str(args.screenshot),
+      "mesh_rendered_count": mesh_rendered,
+      "generated_urdf_visual_count": generated_count,
+      "overlay_count": overlay_count,
+      "placeholder_count": placeholder_count,
+    }
+    print(json.dumps(out, indent=2))
+    return 0 if not blockers else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -242,14 +242,21 @@ QString normalized_token(const QString & value)
 QString normalized_scene3d_layer_token(const QString & value)
 {
   const QString normalized = normalized_token(value);
-  if (normalized == QStringLiteral("generated_preview") ||
-      normalized == QStringLiteral("generated_urdf_visual") ||
-      normalized == QStringLiteral("locked_generated_urdf")) {
-    return QStringLiteral("locked_generated_urdf_visual");
-  }
+  if (normalized == QStringLiteral("generated_preview")) return QStringLiteral("generated_urdf_visual");
+  if (normalized == QStringLiteral("locked_generated_urdf")) return QStringLiteral("locked_generated_urdf_visual");
   if (normalized == QStringLiteral("legacy_static_fallback")) return QStringLiteral("primitive_fallback");
   if (normalized == QStringLiteral("overlays") || normalized == QStringLiteral("helper_overlay")) return QStringLiteral("overlay");
   return normalized;
+}
+
+bool is_generated_urdf_visual_item(const ScenePreviewWidget::PreviewItem & it)
+{
+  const QString source_layer = normalized_scene3d_layer_token(it.source_layer);
+  const QString visual_source = normalized_scene3d_layer_token(it.active_visual_source);
+  if (source_layer == "generated_urdf_visual" || source_layer == "locked_generated_urdf_visual") return true;
+  if (visual_source == "generated_urdf_visual" || visual_source == "locked_generated_urdf_visual") return true;
+  if (it.locked && it.lock_reason.contains("URDF visual", Qt::CaseInsensitive)) return true;
+  return false;
 }
 
 QString clean_label_from_item(const ScenePreviewWidget::PreviewItem & it)
@@ -295,7 +302,8 @@ bool item_is_editable_for_gizmo(const ScenePreviewWidget::PreviewItem & it)
                                  lock_reason.contains("overlay") || lock_reason.contains("helper");
   if (overlay_or_helper) return false;
 
-  const bool generated_robot_visual = source_layer.contains("generated") || source_layer.contains("urdf") ||
+  const bool generated_robot_visual = is_generated_urdf_visual_item(it) ||
+                                      source_layer.contains("generated") || source_layer.contains("urdf") ||
                                       visual_source.contains("generated") || lock_reason.contains("urdf") ||
                                       lock_reason.contains("robot model") || lock_reason.contains("camera generated") ||
                                       lock_reason.contains("tool generated");
@@ -343,11 +351,14 @@ bool include_in_fit_bounds(const ScenePreviewWidget::PreviewItem & it, bool incl
   const QString source_layer = normalized_scene3d_layer_token(it.source_layer);
   const QString visual_source = normalized_scene3d_layer_token(it.active_visual_source);
   const bool helper_overlay = is_overlay_only_item(it) || source_layer == "overlay" || visual_source == "overlay";
-  const bool generated_urdf_visual = source_layer == "locked_generated_urdf_visual" || visual_source == "locked_generated_urdf_visual" ||
-                                     is_locked_urdf_item(it);
+  const bool generated_urdf_visual = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
   const bool mesh_backed = it.mesh_available || it.has_mesh_metadata || !it.mesh_path.trimmed().isEmpty() || !it.source_path.trimmed().isEmpty();
   const bool explicit_primitive = it.sx > 0.001 && it.sy > 0.001 && it.sz > 0.001;
+  const bool missing_geometry = !mesh_backed && !explicit_primitive;
+  const bool missing_mesh_fallback = missing_geometry && !it.linked_to_editable_layout_state && !generated_urdf_visual;
   if (helper_overlay) return false;
+  if (missing_mesh_fallback) return false;
+  if (generated_urdf_visual && mesh_backed) return true;
   if (generated_urdf_visual) return true;
   if (it.linked_to_editable_layout_state) return true;
   return mesh_backed || explicit_primitive;
@@ -512,7 +523,7 @@ void Scene3DViewportWidget::set_isometric_view()
   update();
 }
 void Scene3DViewportWidget::set_top_view() { yaw_ = 0.0; pitch_ = -M_PI_2; update(); }
-void Scene3DViewportWidget::set_front_view() { yaw_ = -M_PI_2; pitch_ = 0.0; update(); }
+void Scene3DViewportWidget::set_front_view() { yaw_ = M_PI; pitch_ = 0.0; update(); }
 void Scene3DViewportWidget::set_side_view() { yaw_ = -M_PI_2; pitch_ = 0.0; update(); }
 void Scene3DViewportWidget::invalidate_mesh_cache()
 {
@@ -619,7 +630,7 @@ void Scene3DViewportWidget::paintGL()
     if (!show_safety && role == NormalizedRole::SafetyZone) { ++skipped_item_count; continue; }
     ++visible_item_count;
     unique_visible_ids.insert(it->id);
-    if (is_locked_urdf_item(*it)) ++locked_urdf_count;
+    if (is_generated_urdf_visual_item(*it) || is_locked_urdf_item(*it)) ++locked_urdf_count;
     if (it->linked_to_editable_layout_state) ++editable_layout_count;
     if (is_overlay_visual_role(role)) overlay_items.push_back(it);
     else {
@@ -732,7 +743,7 @@ void Scene3DViewportWidget::paintGL()
       case ScenePreviewWidget::LabelMode::Selected: draw_label = selected; break;
       case ScenePreviewWidget::LabelMode::All: draw_label = true; break;
     }
-    const bool is_urdf_visual = it.locked && !it.editable && it.lock_reason.contains("URDF visual", Qt::CaseInsensitive);
+    const bool is_urdf_visual = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
     if (suppress_dense_non_critical_labels && !selected && !is_critical_label_role(role)) draw_label = false;
     if (is_urdf_visual && !selected && effective_label_mode != ScenePreviewWidget::LabelMode::All) draw_label = false;
     if (show_warning_labels && !it.warnings.isEmpty()) {
@@ -881,7 +892,7 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
   }
   // Always try mesh-backed draw first for physical items.
   QColor visual_color = item_color(it);
-  if (source_layer == "locked_generated_urdf_visual" || visual_source == "locked_generated_urdf_visual" || is_locked_urdf_item(it)) {
+  if (is_generated_urdf_visual_item(it) || is_locked_urdf_item(it)) {
     visual_color = QColor("#cfd4da");
   }
   if (draw_mesh_preview_if_available(it, visual_color, true)) {
@@ -979,7 +990,7 @@ QString Scene3DViewportWidget::render_role_for_test(const ScenePreviewWidget::Pr
   const QString source_layer = normalized_scene3d_layer_token(item.source_layer);
   const QString visual_source = normalized_scene3d_layer_token(item.active_visual_source);
   if (is_overlay_only_item(item) || source_layer == "overlay" || visual_source == "overlay") return QStringLiteral("helper_overlay");
-  if (source_layer == "locked_generated_urdf_visual" || visual_source == "locked_generated_urdf_visual" || is_locked_urdf_item(item)) {
+  if (is_generated_urdf_visual_item(item) || is_locked_urdf_item(item)) {
     return item.mesh_available ? QStringLiteral("generated_urdf_mesh") : QStringLiteral("generated_urdf_primitive");
   }
   if (item.linked_to_editable_layout_state) return QStringLiteral("physical_layout_item");

--- a/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
@@ -60,3 +60,16 @@ TEST(Scene3DRenderRoleClassifier, MeshesModeDoesNotDrawFallbackSolid)
   EXPECT_FALSE(Scene3DViewportWidget::should_draw_as_solid_for_test(missing, ScenePreviewWidget::MeshPreviewMode::Meshes));
   EXPECT_TRUE(Scene3DViewportWidget::should_draw_as_wireframe_for_test(missing, ScenePreviewWidget::MeshPreviewMode::Meshes));
 }
+
+TEST(Scene3DRenderRoleClassifier, AcceptsCanonicalAndLegacyGeneratedUrdfTokens)
+{
+  auto canonical = make_item("canonical");
+  canonical.source_layer = "generated_urdf_visual";
+  canonical.mesh_available = true;
+  EXPECT_EQ(Scene3DViewportWidget::render_role_for_test(canonical), "generated_urdf_mesh");
+
+  auto legacy = make_item("legacy");
+  legacy.active_visual_source = "locked_generated_urdf_visual";
+  legacy.mesh_available = true;
+  EXPECT_EQ(Scene3DViewportWidget::render_role_for_test(legacy), "generated_urdf_mesh");
+}


### PR DESCRIPTION
### Motivation
- Generated URDF visuals were emitted with `source_layer == "generated_urdf_visual"` but code still relied on `locked_generated_urdf_visual` and lock_reason text, causing fragile classification; this broke fit/visibility behavior for scenes like `ur5_2f_test`.
- Camera presets made Front and Side effectively identical after a prior change, and the default top/debug view produced an unreadable, tiny robot on open.
- Missing-mesh fallback primitives were visually dominating the default scene and biasing fit bounds, so default rendering/fitting should prefer mesh-backed generated visuals.
- Add a screenshot+JSON acceptance gate so local smoke runs can assert that the visible Scene3D output is reasonable.

### Description
- Introduced a centralized helper `is_generated_urdf_visual_item(const PreviewItem &)` that accepts canonical `generated_urdf_visual`, legacy `locked_generated_urdf_visual`, `active_visual_source` variants, and the `lock_reason` fallback containing "URDF visual"; replaced scattered checks to use this helper (`workcell_builder/.../scene3d_viewport_widget.cpp`).
- Normalized layer mapping: treat `generated_preview` as canonical `generated_urdf_visual` and preserve legacy `locked_generated_urdf` mapping; canonical token is `generated_urdf_visual`.
- Made Front and Side camera presets distinct (`Front: yaw = M_PI`, `Side: yaw = -M_PI_2`) and kept Isometric as the default readable perspective view.
- Adjusted fit/include logic to de-emphasize non-meaningful missing-geometry fallback placeholders by default and prefer mesh-backed generated URDF visuals and editable physical items when computing fit bounds.
- Updated rendering/color/label logic and runtime counters to use the canonical generated-URDF helper so generated meshes are classified and framed reliably.
- Added a local visual acceptance validator script `scripts/validate_scene3d_visual_acceptance.py` that inspects the GUI smoke JSON and screenshot for signals such as `mesh_rendered_count > 0`, generated URDF visual count, overlay/placeholder dominance, and screenshot existence.
- Extended unit tests to cover canonical and legacy generated-URDF tokens (`workcell_builder/.../test/scene3d_render_role_classifier_test.cpp`).

### Testing
- Compiled the new Python validator: `python3 -m py_compile scripts/validate_scene3d_visual_acceptance.py` — passed.
- Added a C++ classifier test exercising canonical and legacy tokens (`scene3d_render_role_classifier_test.cpp`) but an integrated C++/ROS build could not be executed in this environment because `source /opt/ros/humble/setup.bash` is not available; `colcon build --packages-select workcell_builder` was attempted and blocked by the missing ROS setup. 
- All code changes were committed and unit-test additions are present for CI to run in a proper ROS-enabled environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11af72c4508331ac1d53090117e432)