### PR TITLE
Fix workcell_builder Scene3D render-role classifier test CMake registration

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -359,6 +359,15 @@ if(BUILD_TESTING)
     target_include_directories(workcell_scene3d_stl_parser_test PRIVATE gui)
   endif()
 
+  if(TARGET workcell_scene3d_render_role_classifier_test)
+    target_link_libraries(workcell_scene3d_render_role_classifier_test
+      Qt5::Widgets
+      Qt5::OpenGL
+      OpenGL::GL
+    )
+    target_include_directories(workcell_scene3d_render_role_classifier_test PRIVATE gui)
+  endif()
+
   if(TARGET workcell_command_builders_test)
     target_link_libraries(workcell_command_builders_test
       Qt5::Core
@@ -548,6 +557,7 @@ if(BUILD_TESTING)
     workspace_validation_test.cpp
     placed_object_preview_writer_test.cpp
     scene3d_stl_parser_test.cpp
+    scene3d_render_role_classifier_test.cpp
     command_builders_test.cpp
     scene_preview_widget_ui_test.cpp
     workcell_studio_canvas_model_mesh_test.cpp


### PR DESCRIPTION
### Motivation
- A recently added test `test/scene3d_render_role_classifier_test.cpp` and its gtest target were not added to the CMake test registration list, causing a CMake configure-time "Orphan or unregistered test sources" failure.
- The new test builds `gui/scene3d_viewport_widget.cpp` and therefore requires the same link/include setup as the existing Scene3D STL parser test.

### Description
- Add `scene3d_render_role_classifier_test.cpp` to `set(workcell_builder_registered_cpp_tests ...)` in `workcell_builder/workcell_builder/CMakeLists.txt` so the registered list matches discovered test sources.
- Add an `if(TARGET workcell_scene3d_render_role_classifier_test)` block to link `Qt5::Widgets`, `Qt5::OpenGL`, and `OpenGL::GL` and to add `gui` to the target include directories, mirroring the existing STL parser test configuration.
- This is a CMake-only change and does not touch rendering logic, UI, inspector/workflow, or smoke counters.

### Testing
- Attempted to build with `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder`, which failed in this environment because `/opt/ros/humble/setup.bash` is not present.
- Attempted to run `colcon build --symlink-install --packages-select workcell_builder` without ROS setup, which failed because `colcon` is not installed in this environment.
- In a correctly provisioned environment the change resolves the orphan/unregistered test-sources validation by ensuring the discovered test file is registered and the test target is linked and includedd as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11b204216083318e99804210181052)