### PR TITLE
Silence unused-symbol warnings in GUI code

### DIFF
--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -417,13 +417,11 @@ private:
     const auto viewport_resolution = resolve_active_scene3d_viewport(window_, active_preview_widget);
     auto * viewport = viewport_resolution.selected;
     int hierarchy_child_rows = 0;
-    bool hierarchy_has_only_headings = false;
     if (tree) {
       for (int i = 0; i < tree->topLevelItemCount(); ++i) {
         auto * top = tree->topLevelItem(i);
         if (top) hierarchy_child_rows += top->childCount();
       }
-      hierarchy_has_only_headings = (tree->topLevelItemCount() > 0 && hierarchy_child_rows == 0);
     }
     QString selected_scene_name = "(none)";
     bool inspector_no_scene_selected = true;
@@ -461,7 +459,7 @@ private:
   {
     const QJsonObject markers = collect_readiness_markers();
     QStringList failed;
-    for (const QString key : {QStringLiteral("hierarchy_ready"), QStringLiteral("inspector_ready"), QStringLiteral("log_ready"),
+    for (const QString & key : {QStringLiteral("hierarchy_ready"), QStringLiteral("inspector_ready"), QStringLiteral("log_ready"),
       QStringLiteral("screenshot_ready"), QStringLiteral("render_ready"), QStringLiteral("selected_scene_ready")}) {
       if (!markers.value(key).toBool(false)) failed.append(key + "=false");
     }

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1597,7 +1597,7 @@ void MainWindow::setup_studio_shell()
   auto * generate_actions = make_action_section("Generate");
   auto * validate_actions = make_action_section("Validate");
   auto * simulate_actions = make_action_section("Simulate");
-  auto * export_actions = make_action_section("Export");
+  make_action_section("Export");
   auto * diagnostics_actions = make_action_section("Diagnostics");
 
   create_action_button(layout_actions, "layout.save");
@@ -4058,12 +4058,10 @@ void MainWindow::refresh_scene_builder_left_explorer()
 
 void MainWindow::refresh_scene_builder_view_chips()
 {
-  bool preview_available = false;
   bool launch_ready = false;
   QString preview_chip_status = QStringLiteral("Unavailable");
   if (has_selected_scene()) {
     const auto & s = scene_browser_result_.scenes[static_cast<size_t>(selected_scene_index_)];
-    preview_available = s.has_static_preview_svg || s.has_static_preview_html || s.has_smoke_report_json;
     launch_ready = s.has_launch_demo && s.has_package_xml;
     if (scene_preview_widget_) {
       const auto counters = scene_preview_widget_->render_debug_counters();
@@ -5884,7 +5882,7 @@ void MainWindow::populate_scene_hierarchy()
   if (!task_summary.perception_legacy_source.isEmpty()) perception_line += QString(" mapped from legacy mode: %1.").arg(task_summary.perception_legacy_source);
 
   const QString camera_line = has_camera_metadata ? QString("Camera: %1 configured.").arg(camera_id) : "Camera: no camera metadata in this scene.";
-  const int urdf_visual_locked_count = visual_preview_added_count;
+  [[maybe_unused]] const int urdf_visual_locked_count = visual_preview_added_count;
   int scene3d_editable_count = 0;
   int scene3d_mesh_count = 0;
   int scene3d_generated_count = 0;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -29,7 +29,7 @@ namespace {
 constexpr int kMeshTriangleLimit = 100000;
 constexpr double kWorkspaceLimitMeters = 1000.0;
 
-QString snap_mode_label(Scene3DViewportWidget::SnapMode mode)
+[[maybe_unused]] QString snap_mode_label(Scene3DViewportWidget::SnapMode mode)
 {
   switch (mode) {
     case Scene3DViewportWidget::SnapMode::Off: return "Off";
@@ -449,7 +449,7 @@ double distance_to_polyline_2d(const QPointF & p, const QVector<QPointF> & polyl
   return best;
 }
 
-double wrap_angle_pi(double angle)
+[[maybe_unused]] double wrap_angle_pi(double angle)
 {
   constexpr double kTwoPi = 2.0 * M_PI;
   double wrapped = std::fmod(angle + M_PI, kTwoPi);


### PR DESCRIPTION
### Motivation
- Reduce compiler warning noise by addressing symbols that were reported as unused while preserving existing behavior.
- Use project-consistent annotations or remove unused locals to make intent explicit and avoid misleading dead-code signals.

### Description
- Marked `snap_mode_label` and `wrap_angle_pi` as intentionally unused with `[[maybe_unused]]` in `scene3d_viewport_widget.cpp` so they remain available but do not emit warnings.
- Removed the redundant `hierarchy_has_only_headings` local from `collect_readiness_markers()` in `main.cpp` to eliminate an unused variable.
- Changed the readiness-key loop in `readiness_failure_message()` to iterate by `const QString &` to avoid unnecessary copies.
- Removed unused locals `export_actions` and `preview_available` in `mainwindow.cpp` while keeping the side-effect (section creation and logic) intact, and annotated `urdf_visual_locked_count` with `[[maybe_unused]]` to indicate intentional retention.

### Testing
- Verified occurrences and edits with `rg -n "wrap_angle_pi|snap_mode_label|hierarchy_has_only_headings|export_actions|preview_available|urdf_visual_locked_count|for \(const QString key"` which completed successfully.
- Inspected file regions with `sed`/`nl` to confirm the intended annotations and removals were applied successfully.
- Added and committed the modified files with `git` which succeeded, indicating a clean working-tree update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11c87697488331bce37168a8781a86)