### PR TITLE
Add forward declarations for overlay/locked URDF helper predicates

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -344,6 +344,9 @@ NormalizedRole classify_item_role(const ScenePreviewWidget::PreviewItem & it)
 }
 
 
+bool is_overlay_only_item(const ScenePreviewWidget::PreviewItem & it);
+bool is_locked_urdf_item(const ScenePreviewWidget::PreviewItem & it);
+
 
 bool include_in_fit_bounds(const ScenePreviewWidget::PreviewItem & it, bool include_overlays)
 {


### PR DESCRIPTION
### Motivation
- Ensure the helper predicates are visible before `include_in_fit_bounds(...)` so the compiler sees their prototypes and to make it easier to move or refactor their full definitions without introducing duplicate/implicit-declaration issues.

### Description
- Added forward declarations for `bool is_overlay_only_item(const ScenePreviewWidget::PreviewItem & it);` and `bool is_locked_urdf_item(const ScenePreviewWidget::PreviewItem & it);` in the anonymous namespace immediately before `include_in_fit_bounds(...)` in `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`, leaving the existing definitions intact and keeping a single definition per helper.

### Testing
- Searched the file with `rg` to confirm there is only one definition of each helper and that call sites (including `include_in_fit_bounds`, render-role classification, and the `locked_urdf_count` / `helper_overlay` logic) use matching signatures, which succeeded.
- Inspected the file with `nl`/`sed` and committed the change with `git commit`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11c87552948331b49557ac481af4b8)