### PR TITLE
Guard Scene3D mesh previews against unreasonable bounds

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1098,6 +1098,17 @@ const Scene3DViewportWidget::MeshCacheEntry & Scene3DViewportWidget::ensure_mesh
     entry.warning = QStringLiteral("%1 (%2)").arg(entry.oversized ? QStringLiteral("mesh oversized") : QStringLiteral("mesh invalid"), parse_error);
   }
   entry.has_bounds = compute_mesh_bounds_for_test(entry.mesh, entry.local_min, entry.local_max);
+  if (entry.valid && entry.has_bounds) {
+    const QVector3D span = entry.local_max - entry.local_min;
+    const bool finite_bounds = qIsFinite(entry.local_min.x()) && qIsFinite(entry.local_min.y()) && qIsFinite(entry.local_min.z()) &&
+                               qIsFinite(entry.local_max.x()) && qIsFinite(entry.local_max.y()) && qIsFinite(entry.local_max.z()) &&
+                               qIsFinite(span.x()) && qIsFinite(span.y()) && qIsFinite(span.z());
+    const float max_span = qMax(span.x(), qMax(span.y(), span.z()));
+    if (!finite_bounds || max_span > 100.0f) {
+      entry.valid = false;
+      entry.warning = QStringLiteral("mesh invalid (unreasonable bounds)");
+    }
+  }
   return mesh_cache_.insert(canonical, entry).value();
 }
 


### PR DESCRIPTION
## Summary
- add a mesh-cache validation guard in `Scene3DViewportWidget::ensure_mesh_cached`
- reject meshes with non-finite bounds or extremely large extents (>100m)
- surface a clear fallback warning (`mesh invalid (unreasonable bounds)`) so the 3D canvas falls back to primitives instead of rendering corrupt/stretching geometry

## Why
The 3D canvas can display severely stretched/corrupt triangles when a parsed mesh has invalid or unrealistic bounds. This patch prevents those meshes from being treated as valid render geometry.

## Validation
- Static inspection of the Scene3D mesh-load path and fallback handling.
- No runtime tests executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11cdc41b388331a768dee9685d820a)