### PR TITLE
Handle stale resolved_source_path during visual preview ingestion

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -5521,7 +5521,9 @@ void MainWindow::populate_scene_hierarchy()
   int non_mesh_geometry_added = 0;
   int non_mesh_geometry_unsupported = 0;
   int package_uri_resolved_by_loader = 0;
+  int package_uri_resolved_after_stale_resolved_source_path = 0;
   int source_path_from_resolved_path = 0;
+  int stale_resolved_source_path_count = 0;
   int unresolved_package_uri_count = 0;
   int stale_or_absolute_only_mesh_index_count = 0;
   int mesh_item_count = 0;
@@ -5593,25 +5595,45 @@ void MainWindow::populate_scene_hierarchy()
           const QString resolved_path = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "resolved_path"));
           const QString resolved_source_path = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "resolved_source_path"));
           const QString package_uri = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "package_uri"));
+          p.resolved_source_path_original = resolved_source_path;
+          p.package_uri = package_uri;
           bool unresolved_package_uri = false;
           if (p.source_path.trimmed().isEmpty() && !resolved_path.trimmed().isEmpty()) {
             p.source_path = resolved_path;
             ++source_path_from_resolved_path;
           }
-          if (!resolved_source_path.trimmed().isEmpty() && fs::exists(fs::path(resolved_source_path.toStdString()))) {
+          const bool has_resolved_source_path = !resolved_source_path.trimmed().isEmpty();
+          const bool resolved_source_path_exists =
+            has_resolved_source_path && fs::exists(fs::path(resolved_source_path.toStdString()));
+          if (resolved_source_path_exists) {
             p.source_path = resolved_source_path;
             p.mesh_path = resolved_source_path;
             p.mesh_available = true;
             p.has_mesh_metadata = true;
             p.active_visual_source = QStringLiteral("mesh_preview");
+            p.source_path_resolution_outcome = QStringLiteral("resolved_source_path_exists");
             ++source_path_from_resolved_path;
+          } else if (has_resolved_source_path) {
+            p.resolved_source_path_stale = true;
+            p.source_path_resolution_outcome = QStringLiteral("resolved_source_path_missing");
+            ++stale_resolved_source_path_count;
+            append_studio_log(QString(
+              "URDF visual stale resolved_source_path for %1: resolved_source_path=%2 package_uri=%3")
+              .arg(p.id, resolved_source_path, package_uri));
           }
           if (p.source_path.trimmed().isEmpty() && (package_uri.startsWith("file://") || package_uri.startsWith("/"))) {
             QString candidate = package_uri;
             if (candidate.startsWith("file://")) candidate = candidate.mid(7);
             if (fs::exists(fs::path(candidate.toStdString()))) {
               p.source_path = candidate;
+              p.source_path_resolution_outcome = p.resolved_source_path_stale
+                ? QStringLiteral("resolved_via_package_uri_after_stale_resolved_source_path")
+                : QStringLiteral("resolved_via_package_uri");
               ++package_uri_resolved_by_loader;
+              if (p.resolved_source_path_stale) ++package_uri_resolved_after_stale_resolved_source_path;
+              append_studio_log(QString(
+                "URDF visual resolution outcome for %1: resolved_source_path=%2 package_uri=%3 outcome=%4 source_path=%5")
+                .arg(p.id, resolved_source_path, package_uri, p.source_path_resolution_outcome, p.source_path));
             }
           }
           p.locked = true;
@@ -5681,9 +5703,19 @@ void MainWindow::populate_scene_hierarchy()
                 mesh_fallback = true;
               } else if (resolved_mesh_path.trimmed().isEmpty()) {
                 mesh_fallback = true;
+                if (p.resolved_source_path_stale &&
+                    p.source_path_resolution_outcome == QStringLiteral("resolved_source_path_missing")) {
+                  p.source_path_resolution_outcome = QStringLiteral("stale_resolved_source_path_unresolved_after_package_uri_attempt");
+                  append_studio_log(QString(
+                    "URDF visual resolution outcome for %1: resolved_source_path=%2 package_uri=%3 outcome=%4")
+                    .arg(p.id, resolved_source_path, package_uri, p.source_path_resolution_outcome));
+                }
               } else {
                 p.mesh_path = resolved_mesh_path;
                 p.source_path = resolved_mesh_path;
+                if (p.source_path_resolution_outcome.trimmed().isEmpty()) {
+                  p.source_path_resolution_outcome = QStringLiteral("resolved_via_mesh_source_resolution");
+                }
               }
               if (mesh_fallback && !tried_candidates.isEmpty()) {
                 append_studio_log(QString("URDF visual mesh unresolved for %1: raw=%2 package=%3 tried=[%4]")
@@ -5710,6 +5742,9 @@ void MainWindow::populate_scene_hierarchy()
             p.selectable = true;
             p.lock_reason = QStringLiteral("generated URDF visual");
             p.warnings << QStringLiteral("Preview warning: URDF visual mesh unavailable; using primitive fallback");
+            if (p.resolved_source_path_stale) {
+              p.warnings << QStringLiteral("Preview warning: resolved_source_path is stale; package_uri fallback was attempted");
+            }
             if (!render_expected) {
               p.warnings << QStringLiteral("Preview warning: xacro-expanded visual kept as generated primitive fallback");
             }
@@ -5759,6 +5794,9 @@ void MainWindow::populate_scene_hierarchy()
         .arg(skipped_other));
       append_studio_log(QString("Loader fallbacks: package_uri_resolved_by_loader=%1 source_path_from_resolved_path=%2 non_mesh_geometry_added=%3 non_mesh_geometry_unsupported=%4")
         .arg(package_uri_resolved_by_loader).arg(source_path_from_resolved_path).arg(non_mesh_geometry_added).arg(non_mesh_geometry_unsupported));
+      append_studio_log(QString("Resolved source path diagnostics: stale_resolved_source_path=%1 package_uri_resolved_after_stale=%2")
+        .arg(stale_resolved_source_path_count)
+        .arg(package_uri_resolved_after_stale_resolved_source_path));
       if (visual_index_loaded_count != (visual_preview_added_count + visual_skipped_total)) {
         append_studio_log(
           QString("Preview warning: visual ingestion mismatch loaded=%1 added=%2 skipped_sum=%3")

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -56,6 +56,10 @@ public:
     QString tracking_id;
     QString snapshot_source_file;
     QString alignment_warning;
+    bool resolved_source_path_stale{ false };
+    QString resolved_source_path_original;
+    QString package_uri;
+    QString source_path_resolution_outcome;
   };
   struct CameraOverlayModel
   {


### PR DESCRIPTION
### Motivation
- Ensure the visual ingestion path uses an existing `resolved_source_path` directly so preview items with valid generated paths remain resolved in the GUI.
- Detect and surface cases where `resolved_source_path` is present in the index but missing on disk so the loader can attempt a `package_uri` fallback.
- Provide per-item and aggregate diagnostics so stale/redo resolution outcomes are available for auditing and runtime debugging.
- Avoid silently overriding a valid `resolved_source_path` later in GUI handling so preview stability is preserved.

### Description
- Extend `ScenePreviewWidget::PreviewItem` with `resolved_source_path_stale`, `resolved_source_path_original`, `package_uri`, and `source_path_resolution_outcome` to carry per-item resolution diagnostics.
- Update visual index ingestion in `MainWindow::populate_scene_hierarchy()` to prefer `resolved_source_path` when it exists and the file is present, and to set both `source_path` and `mesh_path` from it.
- When `resolved_source_path` is present but the file is missing, set `resolved_source_path_stale=true`, attempt resolution from `package_uri`, record a human-readable `source_path_resolution_outcome`, and emit studio logs containing both paths and the final outcome.
- Add counters and summary logs for stale-path diagnostics and successful package-uri recoveries so overall loader diagnostics include stale resolution statistics.

### Testing
- Ran `python3 -m pytest -q tests/test_scene3d_generated_mesh_index_contract.py`, which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11cf4f73748331abb9308beefe9751)