### PR TITLE
Apply DAE unit scaling during parse and expand mesh diagnostics

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -204,13 +204,14 @@ bool parse_collada_bytes(const QByteArray & bytes, Scene3DViewportWidget::Intern
       const QStringList idxs = ptext.split(QRegExp("\\s+"), Qt::SkipEmptyParts);
       QVector<int> all; all.reserve(idxs.size());
       for (const auto & t : idxs) all.push_back(t.toInt());
+      const double unit_meter = (out_unit_meter && *out_unit_meter > 0.0 && qIsFinite(*out_unit_meter)) ? *out_unit_meter : 1.0;
       auto addTri=[&](int a,int b,int c){
         const int na=a*3, nb=b*3, nc=c*3;
         if (na+2>=positions.size()||nb+2>=positions.size()||nc+2>=positions.size()) return;
         Scene3DViewportWidget::InternalTriangleMesh::Triangle tri;
-        tri.vertices[0]=QVector3D(positions[na],positions[na+1],positions[na+2]);
-        tri.vertices[1]=QVector3D(positions[nb],positions[nb+1],positions[nb+2]);
-        tri.vertices[2]=QVector3D(positions[nc],positions[nc+1],positions[nc+2]);
+        tri.vertices[0]=QVector3D(positions[na],positions[na+1],positions[na+2]) * static_cast<float>(unit_meter);
+        tri.vertices[1]=QVector3D(positions[nb],positions[nb+1],positions[nb+2]) * static_cast<float>(unit_meter);
+        tri.vertices[2]=QVector3D(positions[nc],positions[nc+1],positions[nc+2]) * static_cast<float>(unit_meter);
         tri.normal = QVector3D::crossProduct(tri.vertices[1]-tri.vertices[0], tri.vertices[2]-tri.vertices[0]);
         out_mesh.triangles.push_back(tri);
       };
@@ -1123,6 +1124,15 @@ const Scene3DViewportWidget::MeshCacheEntry & Scene3DViewportWidget::ensure_mesh
     entry.oversized = parse_error.contains("exceeds limit");
     entry.warning = QStringLiteral("%1 (%2)").arg(entry.oversized ? QStringLiteral("mesh oversized") : QStringLiteral("mesh invalid"), parse_error);
   }
+  if (entry.valid && entry.parser_type == QStringLiteral("dae") && entry.dae_unit_meter > 0.0 && qIsFinite(entry.dae_unit_meter)) {
+    Scene3DViewportWidget::InternalTriangleMesh pre_unit_mesh = entry.mesh;
+    const float inv_unit = static_cast<float>(1.0 / entry.dae_unit_meter);
+    for (auto & tri : pre_unit_mesh.triangles) {
+      for (int i = 0; i < 3; ++i) tri.vertices[i] *= inv_unit;
+    }
+    entry.dae_has_pre_unit_bounds = compute_mesh_bounds_for_test(pre_unit_mesh, entry.dae_pre_unit_min, entry.dae_pre_unit_max);
+    if (entry.dae_has_pre_unit_bounds) entry.dae_pre_unit_span = entry.dae_pre_unit_max - entry.dae_pre_unit_min;
+  }
   entry.has_bounds = compute_mesh_bounds_for_test(entry.mesh, entry.local_min, entry.local_max);
   if (entry.has_bounds) entry.local_span = entry.local_max - entry.local_min;
   return mesh_cache_.insert(canonical, entry).value();
@@ -1141,13 +1151,10 @@ bool Scene3DViewportWidget::validate_mesh_final_span(const ScenePreviewWidget::P
 {
   if (!entry.has_bounds) return true;
   constexpr double kFinalSpanThresholdMeters = 50.0;
-  const double unit = (entry.parser_type == QStringLiteral("dae") && entry.dae_unit_meter > 0.0 && qIsFinite(entry.dae_unit_meter))
-    ? entry.dae_unit_meter
-    : 1.0;
   const QVector3D raw_span = entry.local_span;
-  const QVector3D final_span(raw_span.x() * unit * it.mesh_scale_x,
-                             raw_span.y() * unit * it.mesh_scale_y,
-                             raw_span.z() * unit * it.mesh_scale_z);
+  const QVector3D final_span(raw_span.x() * it.mesh_scale_x,
+                             raw_span.y() * it.mesh_scale_y,
+                             raw_span.z() * it.mesh_scale_z);
   if (out_raw_span) *out_raw_span = raw_span;
   if (out_final_span) *out_final_span = final_span;
   const QVector3D abs_final(qAbs(final_span.x()), qAbs(final_span.y()), qAbs(final_span.z()));
@@ -1185,6 +1192,14 @@ QJsonArray Scene3DViewportWidget::mesh_diagnostics_export() const
     row["local_min"] = QJsonArray{e.local_min.x(), e.local_min.y(), e.local_min.z()};
     row["local_max"] = QJsonArray{e.local_max.x(), e.local_max.y(), e.local_max.z()};
     row["span"] = QJsonArray{e.local_span.x(), e.local_span.y(), e.local_span.z()};
+    row["dae_unit_meter"] = e.dae_unit_meter;
+    row["dae_has_pre_unit_bounds"] = e.dae_has_pre_unit_bounds;
+    row["dae_pre_unit_min"] = QJsonArray{e.dae_pre_unit_min.x(), e.dae_pre_unit_min.y(), e.dae_pre_unit_min.z()};
+    row["dae_pre_unit_max"] = QJsonArray{e.dae_pre_unit_max.x(), e.dae_pre_unit_max.y(), e.dae_pre_unit_max.z()};
+    row["dae_pre_unit_span"] = QJsonArray{e.dae_pre_unit_span.x(), e.dae_pre_unit_span.y(), e.dae_pre_unit_span.z()};
+    row["dae_post_unit_min"] = QJsonArray{e.local_min.x(), e.local_min.y(), e.local_min.z()};
+    row["dae_post_unit_max"] = QJsonArray{e.local_max.x(), e.local_max.y(), e.local_max.z()};
+    row["dae_post_unit_span"] = QJsonArray{e.local_span.x(), e.local_span.y(), e.local_span.z()};
 
     QJsonArray guard_details;
     for (const auto & item : items) {

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -200,6 +200,10 @@ private:
     QVector3D local_max;
     QVector3D local_span;
     double dae_unit_meter{ 1.0 };
+    bool dae_has_pre_unit_bounds{ false };
+    QVector3D dae_pre_unit_min;
+    QVector3D dae_pre_unit_max;
+    QVector3D dae_pre_unit_span;
   };
   QHash<QString, MeshCacheEntry> mesh_cache_;
   QSet<QString> warned_mesh_fallbacks_;


### PR DESCRIPTION
### Motivation
- Collada (`.dae`) files can declare a modeling unit via `<asset><unit meter="...">` and parsed geometry must be scaled into meters for consistent runtime behavior. 
- Applying the unit at parse time avoids duplicated/misordered scaling later and makes span/guard logic operate on unit-correct coordinates. 
- Recording both pre-unit and post-unit bounds improves diagnostics for troubleshooting scale-related issues.

### Description
- Parse the DAE unit meter value (default `1.0`) and apply the unit factor when creating triangle vertices in `parse_collada_bytes` by multiplying parsed positions before triangle insertion. 
- Add pre-unit bounds fields to `MeshCacheEntry` (`dae_has_pre_unit_bounds`, `dae_pre_unit_min`, `dae_pre_unit_max`, `dae_pre_unit_span`) and compute cached pre-unit bounds by deriving an unscaled copy of the mesh. 
- Stop applying a second DAE unit multiplication in `validate_mesh_final_span` so the final span is computed from already unit-correct `local_span`. 
- Expand `mesh_diagnostics_export()` to include `dae_unit_meter` plus pre-unit and post-unit min/max/span fields for each cached mesh.

### Testing
- Ran `pytest -q tests/test_scene3d_viewport_mesh_preview_static.py` and it passed (`3 passed`).
- A separate test invocation for `tests/test_scene3d_mesh_preview_static.py` failed to run due to a missing file path (no tests executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11d1530b6c833189e2f7d5cc0feed8)