### PR TITLE
Add RViz truth-preview command safety validator and integrate into launch gate

### DIFF
--- a/scripts/validate_rviz_moveit_simulation_launches.py
+++ b/scripts/validate_rviz_moveit_simulation_launches.py
@@ -7,6 +7,7 @@ import os
 import shlex
 import signal
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -106,7 +107,35 @@ def safety_violations(command: str) -> list[str]:
     return [token for token in REAL_HARDWARE_TOKENS if token in lower]
 
 
-def run_scene(scene_name: str, launch_file: Path, timeout_sec: int, launch_rviz: bool, dry_run: bool) -> dict[str, Any]:
+def _run_truth_preview_guard(scene_name: str, repo_root: Path, workspace_root: Path) -> tuple[bool, dict[str, Any]]:
+    cmd = [
+        sys.executable,
+        str(repo_root / "scripts" / "validate_rviz_truth_preview_command.py"),
+        scene_name,
+        "--repo-root",
+        str(repo_root),
+        "--workspace-root",
+        str(workspace_root),
+        "--check-ros2-prefix",
+        "--json",
+    ]
+    proc = subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True)
+    payload: dict[str, Any] = {
+        "status": "FAIL",
+        "blockers": [f"truth_preview_guard_invocation_failed: exit={proc.returncode}"],
+        "stdout": proc.stdout.strip(),
+        "stderr": proc.stderr.strip(),
+    }
+    if proc.stdout.strip():
+        try:
+            payload = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            payload["blockers"].append("truth_preview_guard_invalid_json")
+    ok = proc.returncode == 0 and str(payload.get("status", "")).upper() == "PASS"
+    return ok, payload
+
+
+def run_scene(scene_name: str, launch_file: Path, timeout_sec: int, launch_rviz: bool, dry_run: bool, repo_root: Path, workspace_root: Path) -> dict[str, Any]:
     command = f"ros2 launch {scene_name} demo.launch.py use_fake_hardware:=true launch_rviz:={'true' if launch_rviz else 'false'}"
     print(command)
 
@@ -123,6 +152,7 @@ def run_scene(scene_name: str, launch_file: Path, timeout_sec: int, launch_rviz:
         "warnings": [],
         "stdout_tail": "",
         "stderr_tail": "",
+        "truth_preview_guard": {},
     }
 
     if not launch_file.is_file():
@@ -134,6 +164,17 @@ def run_scene(scene_name: str, launch_file: Path, timeout_sec: int, launch_rviz:
     if violations:
         result["status"] = "FAIL"
         result["blockers"].append(f"safety_rejected: {', '.join(violations)}")
+        return result
+
+    guard_ok, guard_payload = _run_truth_preview_guard(scene_name, repo_root, workspace_root)
+    result["truth_preview_guard"] = guard_payload
+    if not guard_ok:
+        result["status"] = "FAIL"
+        guard_blockers = guard_payload.get("blockers", [])
+        if isinstance(guard_blockers, list):
+            result["blockers"].extend([f"truth_preview_guard: {str(item)}" for item in guard_blockers])
+        else:
+            result["blockers"].append("truth_preview_guard: failed")
         return result
 
     if dry_run:
@@ -201,6 +242,7 @@ def main() -> int:
         launch_rviz = False
 
     repo_root = Path(__file__).resolve().parents[1]
+    workspace_root = repo_root
     scenes = discover_scenes(repo_root)
     scene_map = {item["scene"]: item for item in scenes}
 
@@ -219,6 +261,8 @@ def main() -> int:
             timeout_sec=args.timeout_sec,
             launch_rviz=launch_rviz,
             dry_run=args.dry_run,
+            repo_root=repo_root,
+            workspace_root=workspace_root,
         )
         for item in targets
     ]

--- a/scripts/validate_rviz_truth_preview_command.py
+++ b/scripts/validate_rviz_truth_preview_command.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+REQUIRED_TOKEN = "use_fake_hardware:=true"
+FORBIDDEN_TOKENS = [
+    "use_fake_hardware:=false",
+    "fake_hardware:=false",
+    "real_hardware:=true",
+    "use_real_hardware:=true",
+    "hardware_mode:=real",
+    "driver_mode:=real",
+    "use_mock_hardware:=false",
+    "mock_hardware:=false",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Validate scene RViz truth preview launch command safety")
+    p.add_argument("scene_name", help="Scene/package name")
+    p.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    p.add_argument("--workspace-root", type=Path, default=None)
+    p.add_argument("--check-ros2-prefix", action="store_true", help="Run 'ros2 pkg prefix <scene_pkg>' for visibility diagnostics")
+    p.add_argument("--json", action="store_true", help="Emit compact JSON only")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    workspace_root = args.workspace_root.resolve() if args.workspace_root else repo_root
+    scene_pkg = args.scene_name
+    scene_dir = workspace_root / "scenes" / scene_pkg
+
+    launch_command = f"ros2 launch {scene_pkg} demo.launch.py use_fake_hardware:=true launch_rviz:=true"
+
+    blockers: list[str] = []
+    warnings: list[str] = []
+
+    package_xml = scene_dir / "package.xml"
+    launch_file = scene_dir / "launch" / "demo.launch.py"
+    if not package_xml.is_file():
+        blockers.append(f"missing required artifact: {package_xml}")
+    if not launch_file.is_file():
+        blockers.append(f"missing required artifact: {launch_file}")
+
+    lowered_command = launch_command.lower()
+    if REQUIRED_TOKEN not in lowered_command:
+        blockers.append(f"required token missing: {REQUIRED_TOKEN}")
+
+    present_forbidden = [token for token in FORBIDDEN_TOKENS if token in lowered_command]
+    if present_forbidden:
+        blockers.append("forbidden token(s) present: " + ", ".join(present_forbidden))
+
+    ros2_visible: dict[str, Any] | None = None
+    if args.check_ros2_prefix:
+        if shutil.which("ros2") is None:
+            ros2_visible = {"checked": True, "visible": False, "reason": "ros2 executable not found"}
+            warnings.append("ros2 executable not found; package visibility could not be checked")
+        else:
+            proc = subprocess.run(["ros2", "pkg", "prefix", scene_pkg], cwd=repo_root, capture_output=True, text=True)
+            prefix = proc.stdout.strip()
+            ros2_visible = {
+                "checked": True,
+                "visible": proc.returncode == 0 and bool(prefix),
+                "returncode": proc.returncode,
+                "prefix": prefix,
+                "stderr": proc.stderr.strip(),
+            }
+            if proc.returncode != 0:
+                warnings.append("scene package not visible to ros2 package index")
+
+    payload: dict[str, Any] = {
+        "schema": "rviz_truth_preview_command_validation/v1",
+        "scene_pkg": scene_pkg,
+        "repo_root": str(repo_root),
+        "workspace_root": str(workspace_root),
+        "scene_dir": str(scene_dir),
+        "required_artifacts": {
+            "package_xml": str(package_xml),
+            "launch_demo": str(launch_file),
+            "exists": package_xml.is_file() and launch_file.is_file(),
+        },
+        "launch_command": launch_command,
+        "required_tokens": [REQUIRED_TOKEN],
+        "forbidden_tokens": FORBIDDEN_TOKENS,
+        "status": "PASS" if not blockers else "FAIL",
+        "blockers": blockers,
+        "warnings": warnings,
+    }
+    if ros2_visible is not None:
+        payload["ros2_package_visibility"] = ros2_visible
+
+    if args.json:
+        print(json.dumps(payload, separators=(",", ":")))
+    else:
+        print(json.dumps(payload, indent=2))
+
+    return 0 if not blockers else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Ensure Scene Builder RViz/MoveIt preview launches preserve the fake-hardware-first safety pattern (`use_fake_hardware:=true`) before any `ros2 launch` is executed.
- Prevent unsafe launch-argument drift and ambiguous aliases that could accidentally enable real hardware access during preview runs.
- Provide an explicit, machine-readable check and visibility diagnostics so the readiness gate can fail-fast on unsafe or missing artifacts.

### Description
- Add `scripts/validate_rviz_truth_preview_command.py` which accepts a `scene_name` and optional `--repo-root`/`--workspace-root`, verifies `package.xml` and `launch/demo.launch.py` exist, builds the command `ros2 launch <scene_pkg> demo.launch.py use_fake_hardware:=true launch_rviz:=true`, enforces the required token and rejects forbidden tokens, optionally runs `ros2 pkg prefix <scene_pkg>`, emits JSON, and exits non-zero on blockers.
- Integrate the new guard into `scripts/validate_rviz_moveit_simulation_launches.py` by adding `_run_truth_preview_guard` and invoking it in `run_scene` prior to executing the launch, and by including the guard response in each scene result under the `truth_preview_guard` field.
- Pass repository/workspace context when invoking the guard so the script can resolve scene paths and optionally run `ros2` visibility checks.
- Update `run_scene` signature and call sites to forward `repo_root` and `workspace_root` to the guard.

### Testing
- Compiled the updated scripts successfully with `python3 -m py_compile scripts/validate_rviz_truth_preview_command.py scripts/validate_rviz_moveit_simulation_launches.py` (succeeded).
- Ran `python3 scripts/validate_rviz_truth_preview_command.py ur5_2f_test --json` to exercise the new validator and confirmed it emits valid JSON (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e985bfd083318a6fd683bf6e37c1)