### PR TITLE
Refine Scene3D and RViz truth preview guidance copy

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -2105,10 +2105,17 @@ void MainWindow::build_studio_header_actions()
   auto * run_next_menu = new QMenu(run_next_button);
   run_next_menu->addAction(action_validate_offline_);
   run_next_menu->addAction(action_validate_generated_scene_);
+  action_simulate_plan_preview_->setText("Open RViz Truth Preview");
   run_next_menu->addAction(action_simulate_plan_preview_);
   run_next_menu->addAction(action_export_open_page_);
   run_next_button->setMenu(run_next_menu);
   top_bar->addWidget(run_next_button);
+  auto * native_scene3d_help_label = new QLabel(
+    "Native Scene3D: lightweight editable layout preview; not guaranteed RViz-equivalent.",
+    this);
+  native_scene3d_help_label->setWordWrap(true);
+  native_scene3d_help_label->setObjectName("studioNativeScene3DHelpLabel");
+  top_bar->addWidget(native_scene3d_help_label);
   auto * more_button = new QToolButton(this);
   more_button->setText("More");
   more_button->setPopupMode(QToolButton::InstantPopup);
@@ -2125,6 +2132,12 @@ void MainWindow::build_studio_header_actions()
   more_menu->addAction(action_diagnostics_copy_build_launch_commands_);
   more_button->setMenu(more_menu);
   top_bar->addWidget(more_button);
+  auto * rviz_truth_preview_help_label = new QLabel(
+    "RViz Truth Preview: authoritative generated scene preview using ROS/MoveIt/RViz stack.",
+    this);
+  rviz_truth_preview_help_label->setWordWrap(true);
+  rviz_truth_preview_help_label->setObjectName("studioRvizTruthPreviewHelpLabel");
+  top_bar->addWidget(rviz_truth_preview_help_label);
 }
 
 void MainWindow::refresh_scene_bundle_export_panel()


### PR DESCRIPTION
### Motivation
- Clarify the difference between the lightweight native Scene3D editable preview and the authoritative RViz/MoveIt-generated preview. 
- Surface concise guidance text adjacent to existing header actions (under Run Next / More) without adding new top-level home-page actions.

### Description
- Rename the Plan/Simulate header action by setting `action_simulate_plan_preview_->setText("Open RViz Truth Preview")` to better indicate that it opens the RViz-based truth preview. 
- Add a compact `QLabel` for Native Scene3D with the text "Native Scene3D: lightweight editable layout preview; not guaranteed RViz-equivalent." and set `setWordWrap(true)` and object name `studioNativeScene3DHelpLabel`, then add it to the top toolbar. 
- Add a compact `QLabel` for RViz Truth Preview with the text "RViz Truth Preview: authoritative generated scene preview using ROS/MoveIt/RViz stack." and set `setWordWrap(true)` and object name `studioRvizTruthPreviewHelpLabel`, then add it to the top toolbar. 
- All changes are localized to `workcell_builder/workcell_builder/gui/mainwindow.cpp` and keep placement under existing Scene Builder / Run Next / More areas.

### Testing
- Verified repository status with `git -C /workspace/Easy_Manipulator_Improved status --short` and inspected the modified region with `nl -ba workcell_builder/workcell_builder/gui/mainwindow.cpp | sed -n '2088,2165p'`, both commands completed successfully. 
- Staged and committed the change with `git -C /workspace/Easy_Manipulator_Improved commit` which succeeded and recorded the update. 
- Manual code inspection confirms the new labels and object names are inserted and connected to the existing top toolbar UI flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e97c37508331877d59cfbf26bb63)