### PR TITLE
Refactor RViz preview launch logic into shared runner API

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -181,7 +181,9 @@ add_executable(workcell_builder
     include/external_asset_import_dialog.hpp
     include/workspace_validation.hpp
     src_workspace_validation.cpp
-    src_workcell_builder_command_builders.cpp)
+    src_workcell_builder_command_builders.cpp
+    src_rviz_preview_runner.cpp
+    include/rviz_preview_runner.hpp)
 target_sources(workcell_builder PRIVATE src_workcell_yaml_utils.cpp)
 
 ament_target_dependencies(workcell_builder

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -2900,7 +2900,13 @@ void MainWindow::refresh_selected_scene_details_card()
 }
 
 
-QString MainWindow::selected_scene_launch_command() const { if (selected_scene_index_ < 0 || selected_scene_index_ >= (int)scene_browser_result_.scenes.size()) return ""; const auto & scene = scene_browser_result_.scenes[(size_t)selected_scene_index_]; QString command = QString("ros2 launch %1 demo.launch.py use_fake_hardware:=true launch_rviz:=true").arg(QString::fromStdString(scene.scene_name)); const fs::path launch_file = scene.scene_dir / "launch" / "demo.launch.py"; std::ifstream ifs(launch_file.string()); if (ifs) { std::string launch_text((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>()); if (launch_text.find("launch_task_preview") != std::string::npos) { command += " launch_task_preview:=true"; } } return command; }
+QString MainWindow::selected_scene_launch_command() const
+{
+  if (selected_scene_index_ < 0 || selected_scene_index_ >= static_cast<int>(scene_browser_result_.scenes.size())) return "";
+  const auto & scene = scene_browser_result_.scenes[static_cast<size_t>(selected_scene_index_)];
+  return workcell_builder::build_command(QString::fromStdString(scene.scene_name));
+}
+
 
 void MainWindow::open_selected_scene_artifact(const QString & artifact)
 { if (selected_scene_index_ < 0 || selected_scene_index_ >= (int)scene_browser_result_.scenes.size()) { QMessageBox::information(this,"Workcell Studio","No scene selected."); return; }
@@ -3354,24 +3360,36 @@ QString MainWindow::selected_scene_preview_command_block() const { return select
 
 bool MainWindow::selected_scene_preview_ready(QStringList * blockers) const
 {
-  if (selected_scene_index_ < 0) { if (blockers) blockers->append("No scene selected"); return false; }
-  const auto & s = scene_browser_result_.scenes[(size_t)selected_scene_index_];
-  if (QString::fromStdString(s.status).contains("BLOCKED")) { if (blockers) blockers->append("BLOCKED acceptance scene"); return false; }
-  if (QString::fromStdString(s.status).contains("PREVIEW_ONLY")) { if (blockers) blockers->append("PREVIEW_ONLY scenes cannot run"); return false; }
-  const fs::path layout_file = s.scene_dir / "layout" / "workcell_studio_layout.yaml";
-  const fs::path merge_report = s.scene_dir / "generated" / "workcell_studio_layout_merge_report.json";
-  if (fs::exists(layout_file) && (!fs::exists(merge_report) || fs::last_write_time(layout_file) > fs::last_write_time(merge_report))) {
-    if (blockers) blockers->append("Layout changed since last generation. Run Generate Scene / Layout Merge before preview.");
+  if (selected_scene_index_ < 0 || selected_scene_index_ >= static_cast<int>(scene_browser_result_.scenes.size())) {
+    if (blockers) blockers->append("No scene selected");
     return false;
   }
-  return true;
+  const auto & scene = scene_browser_result_.scenes[static_cast<size_t>(selected_scene_index_)];
+  const auto status = workcell_builder::validate_readiness(scene, detect_workspace_root().toStdString());
+  if (!status.ready && blockers) blockers->append(status.blocker_reason);
+  return status.ready;
 }
+
 bool MainWindow::preview_command_is_safe(const QString & command, QStringList * blockers) const
-{ bool ok = command.contains("use_fake_hardware:=true") && !command.contains("use_fake_hardware:=false");
-  const QStringList deny{ "real_hardware:=true", "runtime_execution_enabled:=true", "execute:=true", "command_robot:=true", "send_motion:=true"};
-  for (const auto & d : deny) if (command.contains(d)) { ok=false; if (blockers) blockers->append("Unsafe launch argument detected: "+d); }
-  if (!command.contains("use_fake_hardware:=true") && blockers) blockers->append("Missing required use_fake_hardware:=true");
-  return ok; }
+{
+  if (selected_scene_index_ < 0 || selected_scene_index_ >= static_cast<int>(scene_browser_result_.scenes.size())) {
+    if (blockers) blockers->append("No scene selected");
+    return false;
+  }
+  QString dry_command;
+  const auto status = workcell_builder::dry_run(
+    scene_browser_result_.scenes[static_cast<size_t>(selected_scene_index_)],
+    detect_workspace_root().toStdString(),
+    &dry_command);
+  if (!status.ready) {
+    if (blockers) blockers->append(status.blocker_reason);
+    return false;
+  }
+  const QString expected = "cd " + detect_workspace_root() + " && source install/setup.bash && " + dry_command;
+  const bool safe = (command.trimmed() == dry_command.trimmed()) || (command.trimmed() == expected.trimmed());
+  if (!safe && blockers) blockers->append("Unsafe launch argument detected: command does not match expected fake-hardware preview command");
+  return safe;
+}
 
 void MainWindow::set_preview_state(const QString & state){ preview_state_=state; refresh_preview_launch_ui(); }
 

--- a/workcell_builder/workcell_builder/include/rviz_preview_runner.hpp
+++ b/workcell_builder/workcell_builder/include/rviz_preview_runner.hpp
@@ -1,0 +1,37 @@
+#ifndef EASY_MANIPULATION_DEPLOYMENT__WORKCELL_BUILDER__WORKCELL_BUILDER__INCLUDE__RVIZ_PREVIEW_RUNNER_HPP_
+#define EASY_MANIPULATION_DEPLOYMENT__WORKCELL_BUILDER__WORKCELL_BUILDER__INCLUDE__RVIZ_PREVIEW_RUNNER_HPP_
+
+#include <QString>
+
+#include <boost/filesystem.hpp>
+
+#include <functional>
+#include <string>
+
+#include "workcell_studio_scene_browser.hpp"
+
+namespace workcell_builder
+{
+
+struct PreviewReadinessStatus
+{
+  bool ready{false};
+  QString blocker_reason;
+};
+
+QString build_command(const QString & scene_pkg);
+PreviewReadinessStatus validate_readiness(
+  const WorkcellStudioSceneInfo & scene_info,
+  const boost::filesystem::path & workspace_root);
+PreviewReadinessStatus run(
+  const QString & command,
+  const std::function<void(const QString &)> & stdout_callback,
+  const std::function<void(const QString &)> & stderr_callback);
+PreviewReadinessStatus dry_run(
+  const WorkcellStudioSceneInfo & scene_info,
+  const boost::filesystem::path & workspace_root,
+  QString * command);
+
+}  // namespace workcell_builder
+
+#endif

--- a/workcell_builder/workcell_builder/src_rviz_preview_runner.cpp
+++ b/workcell_builder/workcell_builder/src_rviz_preview_runner.cpp
@@ -1,0 +1,128 @@
+#include "rviz_preview_runner.hpp"
+
+#include <QProcess>
+
+namespace workcell_builder
+{
+
+namespace
+{
+
+PreviewReadinessStatus blocked(const QString & reason)
+{
+  PreviewReadinessStatus result;
+  result.ready = false;
+  result.blocker_reason = reason;
+  return result;
+}
+
+bool launch_command_is_safe(const QString & command, QString * reason)
+{
+  if (!command.contains("use_fake_hardware:=true") || command.contains("use_fake_hardware:=false")) {
+    if (reason) {
+      *reason = "Missing required use_fake_hardware:=true";
+    }
+    return false;
+  }
+  const QStringList deny{
+    "real_hardware:=true", "runtime_execution_enabled:=true", "execute:=true", "command_robot:=true", "send_motion:=true"};
+  for (const auto & token : deny) {
+    if (command.contains(token)) {
+      if (reason) {
+        *reason = "Unsafe launch argument detected: " + token;
+      }
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+QString build_command(const QString & scene_pkg)
+{
+  return QString("ros2 launch %1 demo.launch.py use_fake_hardware:=true launch_rviz:=true").arg(scene_pkg);
+}
+
+PreviewReadinessStatus validate_readiness(
+  const WorkcellStudioSceneInfo & scene_info,
+  const boost::filesystem::path & workspace_root)
+{
+  if (scene_info.scene_name.empty()) return blocked("No scene selected");
+  if (!boost::filesystem::exists(workspace_root)) return blocked("Workspace root does not exist");
+  if (scene_info.status.find("BLOCKED") != std::string::npos) return blocked("BLOCKED acceptance scene");
+  if (scene_info.status.find("PREVIEW_ONLY") != std::string::npos) return blocked("PREVIEW_ONLY scenes cannot run");
+  if (!scene_info.has_launch_demo) return blocked("Missing launch/demo.launch.py");
+  if (!scene_info.has_task_intent) return blocked("Missing config/workcell_builder_task_intent.yaml");
+
+  const boost::filesystem::path layout_file = scene_info.scene_dir / "layout" / "workcell_studio_layout.yaml";
+  const boost::filesystem::path merge_report = scene_info.scene_dir / "generated" / "workcell_studio_layout_merge_report.json";
+  if (boost::filesystem::exists(layout_file) &&
+    (!boost::filesystem::exists(merge_report) || boost::filesystem::last_write_time(layout_file) > boost::filesystem::last_write_time(merge_report))) {
+    return blocked("Layout changed since last generation. Run Generate Scene / Layout Merge before preview.");
+  }
+
+  PreviewReadinessStatus ok;
+  ok.ready = true;
+  return ok;
+}
+
+PreviewReadinessStatus run(
+  const QString & command,
+  const std::function<void(const QString &)> & stdout_callback,
+  const std::function<void(const QString &)> & stderr_callback)
+{
+  QString reason;
+  if (!launch_command_is_safe(command, &reason)) {
+    return blocked(reason);
+  }
+
+  QProcess process;
+  process.setProgram("/bin/bash");
+  process.setArguments({"-lc", command});
+  process.start();
+  if (!process.waitForStarted()) {
+    return blocked("Failed to start preview process");
+  }
+  while (process.state() != QProcess::NotRunning) {
+    process.waitForReadyRead(100);
+    const QString out = QString::fromUtf8(process.readAllStandardOutput());
+    if (!out.isEmpty() && stdout_callback) stdout_callback(out);
+    const QString err = QString::fromUtf8(process.readAllStandardError());
+    if (!err.isEmpty() && stderr_callback) stderr_callback(err);
+  }
+  const QString out = QString::fromUtf8(process.readAllStandardOutput());
+  if (!out.isEmpty() && stdout_callback) stdout_callback(out);
+  const QString err = QString::fromUtf8(process.readAllStandardError());
+  if (!err.isEmpty() && stderr_callback) stderr_callback(err);
+
+  if (process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0) {
+    return blocked(QString("Preview command failed with exit code %1").arg(process.exitCode()));
+  }
+
+  PreviewReadinessStatus ok;
+  ok.ready = true;
+  return ok;
+}
+
+PreviewReadinessStatus dry_run(
+  const WorkcellStudioSceneInfo & scene_info,
+  const boost::filesystem::path & workspace_root,
+  QString * command)
+{
+  const PreviewReadinessStatus readiness = validate_readiness(scene_info, workspace_root);
+  if (!readiness.ready) return readiness;
+  const QString generated = build_command(QString::fromStdString(scene_info.scene_name));
+  if (command) {
+    *command = generated;
+  }
+  QString reason;
+  if (!launch_command_is_safe(generated, &reason)) {
+    return blocked(reason);
+  }
+  PreviewReadinessStatus ok;
+  ok.ready = true;
+  return ok;
+}
+
+}  // namespace workcell_builder


### PR DESCRIPTION
### Motivation
- Centralize construction, validation, and safety checks for fake-hardware RViz preview launches so all UI paths share a single source of truth.
- Provide a narrow, testable API for building the exact launch command, validating scene/workspace readiness with explicit blocker reasons, performing dry-runs, and running the command with stdout/stderr forwarding hooks.

### Description
- Added `include/rviz_preview_runner.hpp` and implementation `src_rviz_preview_runner.cpp` which expose `build_command(scene_pkg)`, `validate_readiness(scene_info, workspace_root)`, `dry_run(scene_info, workspace_root, command_out)`, and `run(command, stdout_cb, stderr_cb)`.
- Implemented readiness checks that return structured `PreviewReadinessStatus` containing `ready` and `blocker_reason` and centralized command safety checks (deny-list + required `use_fake_hardware:=true`).
- Updated `MainWindow` to delegate preview responsibilities to the runner: `selected_scene_launch_command()` -> `workcell_builder::build_command(...)`, `selected_scene_preview_ready()` -> `workcell_builder::validate_readiness(...)`, and `preview_command_is_safe()` -> `workcell_builder::dry_run(...)` with exact-command matching.
- Registered the new source/header in `workcell_builder/CMakeLists.txt` so the GUI target is aware of the new files.

### Testing
- No automated tests were executed as part of this change; CI should perform a full build and run the existing test suite that depends on the `workcell_builder` target.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e970b7148331bc440a74a5114165)