### PR TITLE
Build workspace-aware shell launch command in rviz_preview_runner

### DIFF
--- a/workcell_builder/workcell_builder/include/rviz_preview_runner.hpp
+++ b/workcell_builder/workcell_builder/include/rviz_preview_runner.hpp
@@ -20,6 +20,7 @@ struct PreviewReadinessStatus
 };
 
 QString build_command(const QString & scene_pkg);
+QString build_shell_command(const QString & scene_pkg, const boost::filesystem::path & workspace_root);
 PreviewReadinessStatus validate_readiness(
   const WorkcellStudioSceneInfo & scene_info,
   const boost::filesystem::path & workspace_root);

--- a/workcell_builder/workcell_builder/src_rviz_preview_runner.cpp
+++ b/workcell_builder/workcell_builder/src_rviz_preview_runner.cpp
@@ -44,6 +44,13 @@ QString build_command(const QString & scene_pkg)
   return QString("ros2 launch %1 demo.launch.py use_fake_hardware:=true launch_rviz:=true").arg(scene_pkg);
 }
 
+QString build_shell_command(const QString & scene_pkg, const boost::filesystem::path & workspace_root)
+{
+  const QString workspace_setup = QString::fromStdString((workspace_root / "install" / "setup.bash").string());
+  return QString("bash -lc 'source /opt/ros/humble/setup.bash && source %1 && %2'")
+    .arg(workspace_setup, build_command(scene_pkg));
+}
+
 PreviewReadinessStatus validate_readiness(
   const WorkcellStudioSceneInfo & scene_info,
   const boost::filesystem::path & workspace_root)
@@ -77,9 +84,17 @@ PreviewReadinessStatus run(
     return blocked(reason);
   }
 
+  QString shell_command = command;
+  if (shell_command.startsWith("bash -lc ")) {
+    shell_command = shell_command.mid(QString("bash -lc ").size());
+    if (shell_command.size() >= 2 && shell_command.startsWith("'") && shell_command.endsWith("'")) {
+      shell_command = shell_command.mid(1, shell_command.size() - 2);
+    }
+  }
+
   QProcess process;
   process.setProgram("/bin/bash");
-  process.setArguments({"-lc", command});
+  process.setArguments({"-lc", shell_command});
   process.start();
   if (!process.waitForStarted()) {
     return blocked("Failed to start preview process");
@@ -112,7 +127,7 @@ PreviewReadinessStatus dry_run(
 {
   const PreviewReadinessStatus readiness = validate_readiness(scene_info, workspace_root);
   if (!readiness.ready) return readiness;
-  const QString generated = build_command(QString::fromStdString(scene_info.scene_name));
+  const QString generated = build_shell_command(QString::fromStdString(scene_info.scene_name), workspace_root);
   if (command) {
     *command = generated;
   }


### PR DESCRIPTION
### Motivation
- Ensure the preview runner emits a fully-resolved shell invocation that sources ROS and the selected workspace before launching the demo so runtime environment is correct.
- Keep command assembly centralized in the runner rather than duplicating logic in UI code.
- Make the dry-run output show the exact final shell command that will be executed for clearer user feedback.

### Description
- Added `build_shell_command(const QString & scene_pkg, const boost::filesystem::path & workspace_root)` declaration in `rviz_preview_runner.hpp`.
- Implemented `build_shell_command(...)` to return the full invocation: `bash -lc 'source /opt/ros/humble/setup.bash && source <workspace_root>/install/setup.bash && ros2 launch <scene_pkg> demo.launch.py use_fake_hardware:=true launch_rviz:=true'` in `src_rviz_preview_runner.cpp`.
- Updated `run(...)` to accept the full `bash -lc '...'` formatted command by normalizing/extracting the inner shell payload and still launching via `QProcess` with `/bin/bash -lc`.
- Updated `dry_run(...)` to use `build_shell_command(...)` so the dry-run output now contains the final shell command string that will be executed.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f26bc5308331bd26e95021587b5f)