### PR TITLE
Harden RViz preview fake-hardware safety guard

### DIFF
--- a/workcell_builder/workcell_builder/src_rviz_preview_runner.cpp
+++ b/workcell_builder/workcell_builder/src_rviz_preview_runner.cpp
@@ -1,6 +1,7 @@
 #include "rviz_preview_runner.hpp"
 
 #include <QProcess>
+#include <QRegularExpression>
 
 namespace workcell_builder
 {
@@ -18,22 +19,42 @@ PreviewReadinessStatus blocked(const QString & reason)
 
 bool launch_command_is_safe(const QString & command, QString * reason)
 {
-  if (!command.contains("use_fake_hardware:=true") || command.contains("use_fake_hardware:=false")) {
-    if (reason) {
-      *reason = "Missing required use_fake_hardware:=true";
-    }
-    return false;
-  }
-  const QStringList deny{
-    "real_hardware:=true", "runtime_execution_enabled:=true", "execute:=true", "command_robot:=true", "send_motion:=true"};
-  for (const auto & token : deny) {
-    if (command.contains(token)) {
+  auto reject = [reason]() {
       if (reason) {
-        *reason = "Unsafe launch argument detected: " + token;
+        *reason = "command rejected by fake-hardware safety guard";
       }
       return false;
+    };
+
+  if (!command.contains("use_fake_hardware:=true") || command.contains("use_fake_hardware:=false")) {
+    return reject();
+  }
+  if (!command.contains("launch_rviz:=true")) {
+    return reject();
+  }
+  const QStringList deny{
+    "real_hardware:=true",
+    "runtime_execution_enabled:=true",
+    "execute:=true",
+    "command_robot:=true",
+    "send_motion:=true",
+    "fake_hardware:=false",
+    "ur_robot_driver",
+    "ethercat",
+    "canopen"};
+  for (const auto & token : deny) {
+    if (command.contains(token)) {
+      return reject();
     }
   }
+
+  const QString trimmed = command.trimmed();
+  const QRegularExpression expected_launch_re(
+    R"(^ros2\s+launch\s+\S+\s+demo\.launch\.py(?:\s+.*)?$)");
+  if (!expected_launch_re.match(trimmed).hasMatch()) {
+    return reject();
+  }
+
   return true;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent preview launches from accidentally running against real hardware or unsafe drivers by tightening command validation in the RViz preview runner.
- Ensure preview commands always request simulated hardware and RViz via `use_fake_hardware:=true` and `launch_rviz:=true`.
- Normalize UI feedback so any safety guard failure reports the exact blocker message expected by the UI.

### Description
- Introduced a centralized reject lambda that returns the exact blocker reason `command rejected by fake-hardware safety guard` on any validation failure.
- Enforced presence of `use_fake_hardware:=true` and `launch_rviz:=true`, and explicitly reject `use_fake_hardware:=false` and `fake_hardware:=false` tokens.
- Extended the deny-list to reject runtime/execute flags and driver/runtime tokens including `ur_robot_driver`, `ethercat`, and `canopen`.
- Added a launch-form regex (`^ros2\s+launch\s+\S+\s+demo\.launch\.py(?:\s+.*)?$`) and included `QRegularExpression` to require the expected `ros2 launch <pkg> demo.launch.py ...` shape.

### Testing
- No automated tests were executed in this environment; the change is isolated to command validation logic and should be covered by unit/integration tests that exercise `launch_command_is_safe` in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f270f2888331bd7a6d7adbc4e64a)