### PR TITLE
Add missing rviz_preview_runner include to mainwindow.cpp

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -117,6 +117,7 @@
 #include "workcell_studio_id_utils.hpp"
 #include "gui/new_cell_wizard.h"
 #include "include/workcell_builder_command_builders.hpp"
+#include "include/rviz_preview_runner.hpp"
 #include "gui/asset_catalog_discovery.h"
 #include "gui/transform_clipboard_utils.h"
 


### PR DESCRIPTION
### Motivation
- Ensure `mainwindow.cpp` can resolve calls to `build_command`, `validate_readiness`, and `dry_run` (used by `selected_scene_launch_command()`, `selected_scene_preview_ready()`, and `run_fake_hardware_preview()`), preventing unresolved-member errors at compile time.

### Description
- Added `#include "include/rviz_preview_runner.hpp"` to `workcell_builder/workcell_builder/gui/mainwindow.cpp` alongside other project headers so the declarations for the preview helper functions are available.
- Committed the change with message `Fix mainwindow include for rviz preview runner helpers`.

### Testing
- Ran `rg -n "selected_scene_launch_command|selected_scene_preview_ready|run_fake_hardware_preview|build_command|validate_readiness|dry_run"` to confirm the header declares the expected functions and call sites are present, which succeeded.
- Attempted to build with `colcon build --packages-select workcell_builder`, but the command could not be executed in this environment because `colcon` is not installed (`colcon: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1202a936a48331b9c892973ed4d36e)