### PR TITLE
Add workcell_builder compile smoke test for MainWindow + rviz preview API

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -351,6 +351,8 @@ if(BUILD_TESTING)
   ament_add_gtest(workcell_studio_layout_editor_test
     test/workcell_studio_layout_editor_test.cpp
     src_workcell_studio_layout_editor.cpp)
+  ament_add_gtest(workcell_mainwindow_rviz_preview_compile_test
+    test/mainwindow_rviz_preview_compile_test.cpp)
   if(TARGET workcell_scene_preview_widget_ui_test)
     target_link_libraries(workcell_scene_preview_widget_ui_test Qt5::Widgets Qt5::OpenGL OpenGL::GL)
   endif()
@@ -547,6 +549,16 @@ if(BUILD_TESTING)
     target_include_directories(workcell_studio_layout_editor_test PRIVATE ${Boost_INCLUDE_DIRS} include)
   endif()
 
+  if(TARGET workcell_mainwindow_rviz_preview_compile_test)
+    target_link_libraries(workcell_mainwindow_rviz_preview_compile_test Qt5::Widgets)
+    target_include_directories(workcell_mainwindow_rviz_preview_compile_test
+      PRIVATE
+        ${Boost_INCLUDE_DIRS}
+        include
+        gui
+    )
+  endif()
+
   set(workcell_builder_registered_cpp_tests
     link_deletion_test.cpp
     workcell_directory_inspection_test.cpp
@@ -574,6 +586,7 @@ if(BUILD_TESTING)
     transform_clipboard_utils_test.cpp
     layout_serialization_contract_test.cpp
     workcell_studio_layout_editor_test.cpp
+    mainwindow_rviz_preview_compile_test.cpp
   )
 
   file(GLOB workcell_builder_discovered_cpp_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/test ${CMAKE_CURRENT_SOURCE_DIR}/test/*.cpp)

--- a/workcell_builder/workcell_builder/test/mainwindow_rviz_preview_compile_test.cpp
+++ b/workcell_builder/workcell_builder/test/mainwindow_rviz_preview_compile_test.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+
+#include "gui/mainwindow.h"
+#include "rviz_preview_runner.hpp"
+
+namespace
+{
+
+TEST(WorkcellBuilderCompileCoverage, MainWindowAndRvizPreviewRunnerHeadersCompileTogether)
+{
+  workcell_builder::PreviewReadinessStatus status;
+  status.ready = false;
+  EXPECT_FALSE(status.ready);
+}
+
+}  // namespace


### PR DESCRIPTION
### Motivation
- Add a lightweight compile-focused check to catch missing declarations/namespace drift between the GUI entrypoint and the rviz preview runner API before a full build.

### Description
- Add a minimal gtest TU at `workcell_builder/workcell_builder/test/mainwindow_rviz_preview_compile_test.cpp` that includes `gui/mainwindow.h` and `include/rviz_preview_runner.hpp` and references `workcell_builder::PreviewReadinessStatus`.
- Register the test in `workcell_builder/workcell_builder/CMakeLists.txt` via `ament_add_gtest(...)`, wire minimal link/include settings (Qt5::Widgets and `include`/`gui` directories), and add the source to the `workcell_builder_registered_cpp_tests` list so the package’s existing test-registration parity check stays satisfied.

### Testing
- Attempted to run the new test with `colcon test --packages-select workcell_builder --ctest-args -R workcell_mainwindow_rviz_preview_compile_test`, but the command could not be executed here because `colcon` is not available (`/bin/bash: colcon: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1202ac08c08331b85cd4b6a1c47113)