### PR TITLE
Fix RViz Truth Preview gating and fake-hardware safety guard handling

### DIFF
--- a/tests/test_rviz_truth_preview_gating_and_safety.py
+++ b/tests/test_rviz_truth_preview_gating_and_safety.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+
+RUNNER_CPP = Path("workcell_builder/workcell_builder/src_rviz_preview_runner.cpp").read_text(encoding="utf-8")
+MAIN_CPP = Path("workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+
+
+def test_safe_direct_command_accepted():
+    assert "use_fake_hardware:=true" in RUNNER_CPP
+    assert "launch_rviz:=true" in RUNNER_CPP
+    assert "ros2\\s+launch\\s+\\S+\\s+demo\\.launch\\.py" in RUNNER_CPP
+
+
+def test_safe_bash_wrapper_accepted():
+    assert "build_shell_command" in RUNNER_CPP
+    assert "bash -lc 'source /opt/ros/humble/setup.bash && source %1 && %2'" in RUNNER_CPP
+    assert "expected_launch_re.match(trimmed).hasMatch()" in RUNNER_CPP
+
+
+def test_unsafe_false_command_rejected():
+    for token in ["use_fake_hardware:=false", "fake_hardware:=false", "ur_robot_driver", "ethercat", "canopen"]:
+        assert token in RUNNER_CPP
+
+
+def test_rviz_truth_preview_not_blocked_by_stale_layout_when_package_present():
+    assert "Layout changed since last generation. Run Generate Scene / Layout Merge before preview." not in RUNNER_CPP
+    assert "RViz Truth Preview readiness: WARN stale layout detected; continuing with generated package." in MAIN_CPP
+
+
+def test_missing_package_launch_and_setup_still_block():
+    for token in ["package.xml missing", "launch/demo.launch.py missing", "install/setup.bash missing under workspace root"]:
+        assert token in RUNNER_CPP
+
+
+def test_studio_log_pass_before_launch():
+    assert "RViz Truth Preview readiness: PASS" in MAIN_CPP
+    assert "RViz Truth Preview dry run: " in MAIN_CPP
+    assert "RViz Truth Preview launch started" in MAIN_CPP

--- a/tests/test_workcell_studio_preview_stale_layout_gate.py
+++ b/tests/test_workcell_studio_preview_stale_layout_gate.py
@@ -1,6 +1,0 @@
-from pathlib import Path
-
-MAIN_CPP = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
-
-def test_preview_gate_warns_on_stale_layout_merge():
-    assert 'Layout changed since last generation. Run Generate Scene / Layout Merge before preview.' in MAIN_CPP

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -3617,25 +3617,32 @@ void MainWindow::run_fake_hardware_preview(){
 
   const auto & scene = scene_browser_result_.scenes[static_cast<size_t>(selected_scene_index_)];
   const std::string workspace_root = detect_workspace_root().toStdString();
-  append_studio_log(QString("Plan & Simulate selection: scene=%1 workspace_root=%2")
+  append_studio_log(QString("RViz Truth Preview selection: scene=%1 workspace_root=%2")
       .arg(QString::fromStdString(scene.scene_name), QString::fromStdString(workspace_root)));
+  append_studio_log(QString("RViz Truth Preview package: %1").arg(QString::fromStdString(scene.scene_name)));
+  const boost::filesystem::path layout_file = scene.scene_dir / "layout" / "workcell_studio_layout.yaml";
+  const boost::filesystem::path merge_report = scene.scene_dir / "generated" / "workcell_studio_layout_merge_report.json";
+  if (boost::filesystem::exists(layout_file) &&
+    (!boost::filesystem::exists(merge_report) || boost::filesystem::last_write_time(layout_file) > boost::filesystem::last_write_time(merge_report))) {
+    append_studio_log("RViz Truth Preview readiness: WARN stale layout detected; continuing with generated package.");
+  }
   const auto readiness = workcell_builder::validate_readiness(scene, workspace_root);
   if (!readiness.ready) {
-    QMessageBox::warning(this, "Plan & Simulate", readiness.blocker_reason);
-    append_studio_log("Plan & Simulate launch blocked: " + readiness.blocker_reason);
+    QMessageBox::warning(this, "RViz Truth Preview", readiness.blocker_reason);
+    append_studio_log("RViz Truth Preview readiness: BLOCKED - " + readiness.blocker_reason);
     return;
   }
-  append_studio_log("Plan & Simulate readiness: PASS");
+  append_studio_log("RViz Truth Preview readiness: PASS");
 
   QString command;
   const auto dry_run_status = workcell_builder::dry_run(scene, workspace_root, &command);
   if (!dry_run_status.ready) {
-    QMessageBox::warning(this, "Plan & Simulate", dry_run_status.blocker_reason);
-    append_studio_log("Plan & Simulate dry-run blocked: " + dry_run_status.blocker_reason);
+    QMessageBox::warning(this, "RViz Truth Preview", dry_run_status.blocker_reason);
+    append_studio_log("RViz Truth Preview dry-run blocked: " + dry_run_status.blocker_reason);
     return;
   }
-
-  append_studio_log("Plan & Simulate dry-run command: " + command);
+  append_studio_log("RViz Truth Preview fake-hardware safety: PASS");
+  append_studio_log("RViz Truth Preview dry run: " + command);
   auto rc = QMessageBox::question(
     this, "Confirm Fake-Hardware Preview",
     "Command:\n" + command + "\n\nFake hardware only. No real hardware. No runtime execution. No robot motion commanded.");
@@ -3644,9 +3651,9 @@ void MainWindow::run_fake_hardware_preview(){
   const QString selected_scene_key = QString::fromStdString(scene.scene_name);
   if (preview_process_ && preview_process_->state() != QProcess::NotRunning) {
     if (preview_running_scene_key_ == selected_scene_key) {
-      append_studio_log("WARN Plan & Simulate launch ignored: preview already running for selected scene.");
+      append_studio_log("WARN RViz Truth Preview launch ignored: preview already running for selected scene.");
     } else {
-      append_studio_log(QString("WARN Plan & Simulate launch ignored: another preview is running for scene '%1'.").arg(preview_running_scene_key_));
+      append_studio_log(QString("WARN RViz Truth Preview launch ignored: another preview is running for scene '%1'.").arg(preview_running_scene_key_));
     }
     return;
   }
@@ -3654,18 +3661,18 @@ void MainWindow::run_fake_hardware_preview(){
   active_preview_command_ = command;
   preview_running_scene_key_ = selected_scene_key;
   if (preview_log_) preview_log_->appendPlainText("$ " + command);
-  append_studio_log("Plan & Simulate launch started");
+  append_studio_log("RViz Truth Preview launch started");
   set_preview_state("PREVIEW_RUNNING");
   write_preview_launch_transcript(true, command, "preview_started");
-  preview_process_->start("/bin/bash", {"-lc", command});
+  preview_process_->start("bash", {"-lc", command});
   refresh_new_cell_checklist();
 }
 void MainWindow::stop_preview_process(){ if(!preview_process_ || preview_process_->state()==QProcess::NotRunning) return; set_preview_state("PREVIEW_STOPPING"); if(preview_log_) preview_log_->appendPlainText("Stopping preview process..."); preview_process_->terminate(); QTimer::singleShot(2000, this, [this]() { if(preview_process_ && preview_process_->state()!=QProcess::NotRunning){ if(preview_log_) preview_log_->appendPlainText("Terminate timeout, forcing kill."); preview_process_->kill(); } }); refresh_new_cell_checklist(); }
 void MainWindow::handle_preview_stdout(){ if(!preview_process_) return; const QString out = QString::fromUtf8(preview_process_->readAllStandardOutput()); if(preview_log_) preview_log_->appendPlainText(out); if(!out.trimmed().isEmpty()) append_studio_log("[preview stdout] " + out.trimmed()); }
 void MainWindow::handle_preview_stderr(){ if(!preview_process_) return; const QString err = QString::fromUtf8(preview_process_->readAllStandardError()); if(preview_log_) preview_log_->appendPlainText(err); if(!err.trimmed().isEmpty()) append_studio_log("[preview stderr] " + err.trimmed()); }
 void MainWindow::handle_preview_started(){ if(!preview_process_) return; const qint64 pid = preview_process_->processId(); const QString state = QString::number(static_cast<int>(preview_process_->state())); append_studio_log(QString("Plan & Simulate process started: pid=%1 state=%2").arg(pid).arg(state)); }
-void MainWindow::handle_preview_error(QProcess::ProcessError error){ const QString msg = preview_process_ ? preview_process_->errorString() : QStringLiteral("unknown error"); append_studio_log(QString("ERROR Plan & Simulate process error: code=%1 message=%2").arg(static_cast<int>(error)).arg(msg)); append_studio_log("Plan & Simulate launch blocked: ros2 launch failed"); if(preview_state_=="PREVIEW_RUNNING" || preview_state_=="BUILD_RUNNING") set_preview_state("PREVIEW_FAILED"); }
-void MainWindow::handle_preview_finished(int exit_code, QProcess::ExitStatus exit_status){ if(preview_state_=="BUILD_RUNNING") set_preview_state(exit_code==0?"BUILD_PASSED":"BUILD_FAILED"); else if(preview_state_=="PREVIEW_STOPPING") set_preview_state("PREVIEW_STOPPED"); else set_preview_state(exit_code==0?"PREVIEW_EXITED":"PREVIEW_FAILED"); if (preview_state_ == "PREVIEW_FAILED") append_studio_log("Plan & Simulate launch blocked: ros2 launch failed"); append_studio_log(QString("Plan & Simulate launch exit: exit_code=%1 exit_status=%2 state=%3").arg(exit_code).arg(static_cast<int>(exit_status)).arg(preview_state_)); preview_running_scene_key_.clear(); write_preview_launch_transcript(true, active_preview_command_, "process_finished", exit_code); refresh_new_cell_checklist(); }
+void MainWindow::handle_preview_error(QProcess::ProcessError error){ const QString msg = preview_process_ ? preview_process_->errorString() : QStringLiteral("unknown error"); append_studio_log(QString("ERROR RViz Truth Preview process error: code=%1 message=%2").arg(static_cast<int>(error)).arg(msg)); append_studio_log("RViz Truth Preview launch blocked: ros2 launch failed"); if(preview_state_=="PREVIEW_RUNNING" || preview_state_=="BUILD_RUNNING") set_preview_state("PREVIEW_FAILED"); }
+void MainWindow::handle_preview_finished(int exit_code, QProcess::ExitStatus exit_status){ if(preview_state_=="BUILD_RUNNING") set_preview_state(exit_code==0?"BUILD_PASSED":"BUILD_FAILED"); else if(preview_state_=="PREVIEW_STOPPING") set_preview_state("PREVIEW_STOPPED"); else set_preview_state(exit_code==0?"PREVIEW_EXITED":"PREVIEW_FAILED"); if (preview_state_ == "PREVIEW_FAILED") append_studio_log("RViz Truth Preview launch blocked: ros2 launch failed"); append_studio_log(QString("RViz Truth Preview launch exit: exit_code=%1 exit_status=%2 state=%3").arg(exit_code).arg(static_cast<int>(exit_status)).arg(preview_state_)); preview_running_scene_key_.clear(); write_preview_launch_transcript(true, active_preview_command_, "process_finished", exit_code); refresh_new_cell_checklist(); }
 
 void MainWindow::write_preview_launch_transcript(bool ran_process, const QString & command, const QString & event, int exit_code)
 {
@@ -3696,7 +3703,13 @@ void MainWindow::run_layout_merge_for_selected_scene(bool from_generate_scene)
   append_studio_log(from_generate_scene ? "Generate Scene: running layout merge" : "Run Layout Merge");
   auto result = workcell_builder::merge_workcell_studio_layout(s.scene_dir);
   append_studio_log(QString::fromStdString(result.status ? "Layout merge completed" : "Layout merge blocked"));
-  append_studio_log("Merge report: " + QString::fromStdString(result.report_path));
+  if (!result.report_path.empty()) {
+    append_studio_log("Merge report: " + QString::fromStdString(result.report_path));
+  } else if (!result.error.empty()) {
+    append_studio_log("Merge report blocker: " + QString::fromStdString(result.error));
+  } else {
+    append_studio_log("Merge report blocker: layout merge failed without report path");
+  }
   refresh_scene_browser_ui();
   refresh_scene_builder_left_explorer();
 }

--- a/workcell_builder/workcell_builder/src_rviz_preview_runner.cpp
+++ b/workcell_builder/workcell_builder/src_rviz_preview_runner.cpp
@@ -50,7 +50,7 @@ bool launch_command_is_safe(const QString & command, QString * reason)
 
   const QString trimmed = command.trimmed();
   const QRegularExpression expected_launch_re(
-    R"(^ros2\s+launch\s+\S+\s+demo\.launch\.py(?:\s+.*)?$)");
+    R"(\bros2\s+launch\s+\S+\s+demo\.launch\.py(?:\s+.*)?$)");
   if (!expected_launch_re.match(trimmed).hasMatch()) {
     return reject();
   }
@@ -86,13 +86,6 @@ PreviewReadinessStatus validate_readiness(
 
   const boost::filesystem::path workspace_setup = workspace_root / "install" / "setup.bash";
   if (!boost::filesystem::exists(workspace_setup)) return blocked("install/setup.bash missing under workspace root");
-
-  const boost::filesystem::path layout_file = scene_info.scene_dir / "layout" / "workcell_studio_layout.yaml";
-  const boost::filesystem::path merge_report = scene_info.scene_dir / "generated" / "workcell_studio_layout_merge_report.json";
-  if (boost::filesystem::exists(layout_file) &&
-    (!boost::filesystem::exists(merge_report) || boost::filesystem::last_write_time(layout_file) > boost::filesystem::last_write_time(merge_report))) {
-    return blocked("Layout changed since last generation. Run Generate Scene / Layout Merge before preview.");
-  }
 
   PreviewReadinessStatus ok;
   ok.ready = true;


### PR DESCRIPTION
## Summary
- decoupled RViz Truth Preview readiness from layout freshness so stale layout is warning-only for preview launch
- fixed fake-hardware safety guard matching so sourced `bash -lc` launch wrappers are accepted when they contain the safe `ros2 launch ... demo.launch.py use_fake_hardware:=true launch_rviz:=true` command
- kept blocking checks for missing `package.xml`, missing `launch/demo.launch.py`, missing workspace `install/setup.bash`, and unsafe real-hardware tokens
- switched preview process launch invocation to `bash` with `-lc` args and improved RViz Truth Preview logging labels and sequencing
- improved layout merge failure logging to report real blocker details when merge report path is empty

## Files changed
- `workcell_builder/workcell_builder/src_rviz_preview_runner.cpp`
  - removed stale-layout hard blocker from readiness
  - expanded safe launch regex handling to allow wrapped sourced commands
- `workcell_builder/workcell_builder/gui/mainwindow.cpp`
  - updated RViz Truth Preview log messages and readiness/warn paths
  - added stale-layout warning-only log line
  - updated QProcess launch program to `bash`
  - improved merge failure log fallback (`result.error` / explicit fallback message)
- `tests/test_rviz_truth_preview_gating_and_safety.py`
  - added coverage for safe direct command tokens, safe bash wrapper acceptance path, unsafe false-token rejection, stale-layout non-blocking behavior, required file blockers, and PASS log before launch
- removed obsolete stale-layout blocker test:
  - `tests/test_workcell_studio_preview_stale_layout_gate.py`

## Notes
- Per task constraints, no runtime execution/tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a120915a8e88331843cc9a45e946a6e)