### PR TITLE
Use LayoutMergeResult blockers/stderr in layout merge logging

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -3705,8 +3705,10 @@ void MainWindow::run_layout_merge_for_selected_scene(bool from_generate_scene)
   append_studio_log(QString::fromStdString(result.status ? "Layout merge completed" : "Layout merge blocked"));
   if (!result.report_path.empty()) {
     append_studio_log("Merge report: " + QString::fromStdString(result.report_path));
-  } else if (!result.error.empty()) {
-    append_studio_log("Merge report blocker: " + QString::fromStdString(result.error));
+  } else if (!result.blockers.empty()) {
+    append_studio_log("Merge report blocker: " + QString::fromStdString(result.blockers.front()));
+  } else if (!result.stderr_log.empty()) {
+    append_studio_log("Merge report stderr: " + QString::fromStdString(result.stderr_log).left(400));
   } else {
     append_studio_log("Merge report blocker: layout merge failed without report path");
   }


### PR DESCRIPTION
### Motivation
- The layout-merge logging used `result.error` which is not part of the `LayoutMergeResult` failure/report contract, so prefer the fields actually produced by the merge implementation to surface useful diagnostics.

### Description
- Replace the `else if (!result.error.empty())` branch in `MainWindow::run_layout_merge_for_selected_scene` to first log the first entry of `result.blockers` when present.
- Add a secondary fallback that logs a truncated `result.stderr_log` (left 400 chars) when no blockers exist and no `report_path` is available.
- Keep the existing generic fallback message `"layout merge failed without report path"` when none of the fields are set.

### Testing
- Searched and inspected `workcell_builder/workcell_builder/gui/mainwindow.cpp` to confirm the merge-path branch no longer references `result.error` and now uses `result.blockers`/`result.stderr_log`.
- Confirmed compatibility with `workcell_builder/workcell_builder/src_workcell_studio_layout_merge.cpp`, which populates `blockers` (including a default `"Layout merge failed"`) when appropriate.
- Attempted to run `colcon build --packages-select workcell_builder` but the build could not be executed in this environment because `colcon` is not installed (`colcon: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a120aae0cf4833185a4a3a2f7e70a54)