### PR TITLE
Unify Scene3D candidate assembly and fallback visibility behavior

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -60,6 +60,8 @@ add_executable(workcell_builder
     gui/scene_preview_widget.h
     gui/scene3d_viewport_widget.cpp
     gui/scene3d_viewport_widget.h
+    gui/scene3d_candidate_assembly.cpp
+    gui/scene3d_candidate_assembly.h
     src_scene3d_visual_backend.cpp
     include/scene3d_visual_backend.hpp
 

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -113,6 +113,7 @@
 #include "workcell_studio_canvas_model.hpp"
 #include "scene_preview_widget.h"
 #include "scene3d_viewport_widget.h"
+#include "scene3d_candidate_assembly.h"
 #include "workcell_studio_layout_editor.hpp"
 #include "workcell_studio_id_utils.hpp"
 #include "gui/new_cell_wizard.h"
@@ -5396,24 +5397,19 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
     return;
   }
   QVector<ScenePreviewWidget::PreviewItem> filtered_items;
-  auto include_item = [this](const ScenePreviewWidget::PreviewItem & p) {
-      const QString source_layer = canonical_scene3d_token(p.source_layer);
-      const QString visual_source = canonical_scene3d_token(p.active_visual_source);
-      const QString role = p.role.trimmed().toLower();
-      const QString category = p.category.trimmed().toLower();
-      const QString combined = role + "|" + category + "|" + p.status.trimmed().toLower() + "|" + p.warnings.join("|").toLower();
-      const bool is_warning_or_missing = combined.contains("warning") || combined.contains("missing") || !p.mesh_load_warning.trimmed().isEmpty();
-      const bool is_overlay_or_helper = combined.contains("overlay") || combined.contains("helper") || combined.contains("safety zone");
-      if (source_layer == "editable_layout") return preview_layer_editable_layout_box_ ? preview_layer_editable_layout_box_->isChecked() : true;
-      if (source_layer == "locked_generated_urdf_visual") return preview_layer_generated_urdf_visual_box_ ? preview_layer_generated_urdf_visual_box_->isChecked() : true;
-      if (source_layer == "primitive_fallback") return preview_layer_primitive_fallback_box_ ? preview_layer_primitive_fallback_box_->isChecked() : true;
-      if (visual_source == "mesh_preview") return preview_layer_mesh_preview_box_ ? preview_layer_mesh_preview_box_->isChecked() : true;
-      if (is_overlay_or_helper) return preview_layer_overlays_helpers_box_ ? preview_layer_overlays_helpers_box_->isChecked() : true;
-      if (is_warning_or_missing) return preview_layer_warnings_missing_assets_box_ ? preview_layer_warnings_missing_assets_box_->isChecked() : true;
-      return true;
-    };
+  const QSet<QString> enabled_layers = {
+    preview_layer_editable_layout_box_ && preview_layer_editable_layout_box_->isChecked() ? "editable_layout" : "",
+    preview_layer_generated_urdf_visual_box_ && preview_layer_generated_urdf_visual_box_->isChecked() ? "locked_generated_urdf_visual" : "",
+    preview_layer_mesh_preview_box_ && preview_layer_mesh_preview_box_->isChecked() ? "mesh_preview" : "",
+    preview_layer_primitive_fallback_box_ && preview_layer_primitive_fallback_box_->isChecked() ? "primitive_fallback" : "",
+    preview_layer_overlays_helpers_box_ && preview_layer_overlays_helpers_box_->isChecked() ? "overlay" : "",
+    preview_layer_warnings_missing_assets_box_ && preview_layer_warnings_missing_assets_box_->isChecked() ? "warning" : ""
+  };
   for (const auto & p : all_scene_preview_items_) {
-    if (include_item(p)) filtered_items.push_back(p);
+    if (workcell_builder::include_preview_item_for_scene3d(p, enabled_layers)) filtered_items.push_back(p);
+  }
+  if (filtered_items.isEmpty() && !all_scene_preview_items_.isEmpty()) {
+    append_studio_log("Scene3D blocker: current layer filters hide all items. Re-enable editable layout, mesh preview, primitive fallback, or locked generated URDF visuals.");
   }
   scene_preview_widget_->set_preview_items(filtered_items);
   append_studio_log(
@@ -5601,20 +5597,14 @@ void MainWindow::populate_scene_hierarchy()
   };
 
   auto include_preview_item_in_hierarchy = [this](const ScenePreviewWidget::PreviewItem & p) {
-    const QString source_layer = canonical_scene3d_token(p.source_layer);
-    const QString visual_source = canonical_scene3d_token(p.active_visual_source);
-    const QString role = p.role.trimmed().toLower();
-    const QString category = p.category.trimmed().toLower();
-    const QString combined = role + "|" + category + "|" + p.status.trimmed().toLower() + "|" + p.warnings.join("|").toLower();
-    const bool is_warning_or_missing = combined.contains("warning") || combined.contains("missing") || !p.mesh_load_warning.trimmed().isEmpty();
-    const bool is_overlay_or_helper = combined.contains("overlay") || combined.contains("helper") || combined.contains("safety zone");
-    if (source_layer == "editable_layout") return preview_layer_editable_layout_box_ ? preview_layer_editable_layout_box_->isChecked() : true;
-    if (source_layer == "locked_generated_urdf_visual") return preview_layer_generated_urdf_visual_box_ ? preview_layer_generated_urdf_visual_box_->isChecked() : true;
-    if (source_layer == "primitive_fallback") return preview_layer_primitive_fallback_box_ ? preview_layer_primitive_fallback_box_->isChecked() : true;
-    if (visual_source == "mesh_preview") return preview_layer_mesh_preview_box_ ? preview_layer_mesh_preview_box_->isChecked() : true;
-    if (is_overlay_or_helper) return preview_layer_overlays_helpers_box_ ? preview_layer_overlays_helpers_box_->isChecked() : true;
-    if (is_warning_or_missing) return preview_layer_warnings_missing_assets_box_ ? preview_layer_warnings_missing_assets_box_->isChecked() : true;
-    return true;
+    QSet<QString> enabled_layers;
+    if (!preview_layer_editable_layout_box_ || preview_layer_editable_layout_box_->isChecked()) enabled_layers.insert("editable_layout");
+    if (!preview_layer_generated_urdf_visual_box_ || preview_layer_generated_urdf_visual_box_->isChecked()) enabled_layers.insert("locked_generated_urdf_visual");
+    if (!preview_layer_mesh_preview_box_ || preview_layer_mesh_preview_box_->isChecked()) enabled_layers.insert("mesh_preview");
+    if (!preview_layer_primitive_fallback_box_ || preview_layer_primitive_fallback_box_->isChecked()) enabled_layers.insert("primitive_fallback");
+    if (!preview_layer_overlays_helpers_box_ || preview_layer_overlays_helpers_box_->isChecked()) enabled_layers.insert("overlay");
+    if (!preview_layer_warnings_missing_assets_box_ || preview_layer_warnings_missing_assets_box_->isChecked()) enabled_layers.insert("warning");
+    return workcell_builder::include_preview_item_for_scene3d(p, enabled_layers);
   };
 
   auto add_preview_item = [&](const QString & id,
@@ -6220,6 +6210,11 @@ void MainWindow::populate_scene_hierarchy()
       : QString("%1 | %2").arg(preview_provenance_summary_, visual_diagnostics_summary);
   }
   all_scene_preview_items_ = preview_items;
+  const auto defaults = workcell_builder::compute_scene3d_default_layer_visibility(all_scene_preview_items_);
+  if (preview_layer_editable_layout_box_) preview_layer_editable_layout_box_->setChecked(defaults.editable_layout);
+  if (preview_layer_mesh_preview_box_) preview_layer_mesh_preview_box_->setChecked(defaults.mesh_preview);
+  if (preview_layer_primitive_fallback_box_) preview_layer_primitive_fallback_box_->setChecked(defaults.primitive_fallback);
+  if (preview_layer_generated_urdf_visual_box_) preview_layer_generated_urdf_visual_box_->setChecked(defaults.locked_generated_urdf_visual);
   if (scene_preview_widget_) {
     scene_preview_widget_->set_scene_selected(true);
     scene_preview_widget_->set_preview_scene_name(selected_scene_state_.name);

--- a/workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp
@@ -1,0 +1,46 @@
+#include "scene3d_candidate_assembly.h"
+
+namespace {
+QString token(QString s) { return s.trimmed().toLower(); }
+}
+
+namespace workcell_builder {
+
+bool include_preview_item_for_scene3d(
+  const ScenePreviewWidget::PreviewItem & item,
+  const QSet<QString> & enabled_layers)
+{
+  const QString source_layer = token(item.source_layer);
+  const QString visual_source = token(item.active_visual_source);
+  const QString role = token(item.role);
+  const QString category = token(item.category);
+  const QString combined = role + "|" + category + "|" + token(item.status) + "|" + item.warnings.join("|").toLower();
+  const bool is_warning_or_missing = combined.contains("warning") || combined.contains("missing") || !item.mesh_load_warning.trimmed().isEmpty();
+  const bool is_overlay_or_helper = combined.contains("overlay") || combined.contains("helper") || combined.contains("safety zone");
+
+  if (source_layer == "editable_layout") return enabled_layers.contains("editable_layout");
+  if (source_layer == "locked_generated_urdf_visual" || source_layer == "generated_urdf_visual") return enabled_layers.contains("locked_generated_urdf_visual");
+  if (source_layer == "primitive_fallback") return enabled_layers.contains("primitive_fallback");
+  if (visual_source == "mesh_preview") return enabled_layers.contains("mesh_preview");
+  if (is_overlay_or_helper) return enabled_layers.contains("overlay");
+  if (is_warning_or_missing) return enabled_layers.contains("warning");
+  return true;
+}
+
+Scene3DLayerVisibilityDefaults compute_scene3d_default_layer_visibility(
+  const QVector<ScenePreviewWidget::PreviewItem> & all_items)
+{
+  bool has_editable = false, has_mesh = false, has_primitive = false;
+  for (const auto & item : all_items) {
+    const QString source_layer = token(item.source_layer);
+    const QString visual_source = token(item.active_visual_source);
+    if (source_layer == "editable_layout") has_editable = true;
+    if (visual_source == "mesh_preview") has_mesh = true;
+    if (source_layer == "primitive_fallback" || visual_source == "primitive_fallback") has_primitive = true;
+  }
+  Scene3DLayerVisibilityDefaults out;
+  out.locked_generated_urdf_visual = !(has_editable || has_mesh || has_primitive);
+  return out;
+}
+
+}  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "scene_preview_widget.h"
+
+#include <QSet>
+#include <QVector>
+
+namespace workcell_builder {
+
+struct Scene3DLayerVisibilityDefaults
+{
+  bool editable_layout{ true };
+  bool mesh_preview{ true };
+  bool primitive_fallback{ true };
+  bool locked_generated_urdf_visual{ false };
+};
+
+bool include_preview_item_for_scene3d(
+  const ScenePreviewWidget::PreviewItem & item,
+  const QSet<QString> & enabled_layers);
+
+Scene3DLayerVisibilityDefaults compute_scene3d_default_layer_visibility(
+  const QVector<ScenePreviewWidget::PreviewItem> & all_items);
+
+}  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -755,6 +755,14 @@ void Scene3DViewportWidget::paintGL()
 
   QPainter painter(this);
   painter.setRenderHint(QPainter::Antialiasing, true);
+  if (visible_item_count == 0) {
+    painter.setPen(QColor("#f8fafc"));
+    painter.drawText(rect(), Qt::AlignCenter,
+      "Scene3D empty state\nNo visible candidate visuals.\nCheck preview layer visibility and scene source files.");
+    if (status_message_cb) {
+      status_message_cb("Scene3D blocker: no visible candidate visuals after ingestion and layer filtering.");
+    }
+  }
   const auto compact_role = [](const QString & role) {
     const QString r = role.trimmed().toLower();
     if (r.contains("pick")) return QStringLiteral("Pick");


### PR DESCRIPTION
### Motivation
- Centralize Scene3D candidate assembly so both `MainWindow` and the viewport use the same layer/priority rules and avoid divergent behavior.
- Ensure that missing higher-priority sources do not produce a silent-empty canvas when lower-priority valid sources exist.
- Apply sensible default visible layers (`editable_layout`, `mesh_preview`, `primitive_fallback`) and enable `locked_generated_urdf_visual` by default only when other meaningful visual layers are absent.
- Surface explicit empty-state UI and Studio Log blockers when no visuals remain visible instead of leaving an ambiguous blank viewport.

### Description
- Added `workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.h/.cpp` with `include_preview_item_for_scene3d` and `compute_scene3d_default_layer_visibility` to encapsulate layer eligibility and default visibility decisions.
- Replaced inline filtering logic in `MainWindow::apply_scene3d_preview_layer_filters()` and hierarchy inclusion with the shared `include_preview_item_for_scene3d` so both hierarchy and viewport ingestion share the same rules.
- Wire computed defaults from `compute_scene3d_default_layer_visibility` to initial preview-layer checkbox states (`editable_layout`, `mesh_preview`, `primitive_fallback`, `locked_generated_urdf_visual`).
- Emit a Studio Log blocker when layer filters hide all items and draw an explicit empty-state overlay in `Scene3DViewportWidget::paintGL()` while invoking `status_message_cb` to report the blocker.
- Added the new files to the GUI target in `CMakeLists.txt`.

### Testing
- Applied patches and committed the changes successfully (`git add` / `git commit`) and added the new sources to `CMakeLists.txt` (commit succeeded).
- All `apply_patch` steps completed without error and updated source files as intended (no failures reported by patch tooling).
- No automated unit/CI build was executed in this rollout; compilation/CI should be run in the normal pipeline to verify integration and catch build issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e84b761883319c5adc4dd9604174)