### PR TITLE
Add end-to-end generated Scene3D canvas acceptance runner and pytest coverage

### DIFF
--- a/scripts/run_scene3d_generated_canvas_acceptance.py
+++ b/scripts/run_scene3d_generated_canvas_acceptance.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, json, subprocess, sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run(cmd: list[str], cwd: Path) -> tuple[int, str, str]:
+    p = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=False)
+    return p.returncode, p.stdout, p.stderr
+
+
+def _json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scene-name", default="scene3d_generated_canvas_acceptance")
+    ap.add_argument("--output-dir", default="build/workcell_studio/local_validation")
+    ap.add_argument("--workspace-root", default=None)
+    ap.add_argument("--workcell-builder-executable", "--executable", dest="executable", default=None)
+    args = ap.parse_args()
+
+    out_dir = (REPO_ROOT / args.output_dir).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    generated_root = out_dir / "generated_scenes"
+    generated_root.mkdir(parents=True, exist_ok=True)
+
+    acceptance_json = out_dir / f"{args.scene_name}_generation.json"
+    generation_cmd = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "generate_scratch_cell_acceptance.py"),
+        "--scene-name",
+        args.scene_name,
+        "--output-root",
+        str(generated_root),
+        "--json-out",
+        str(acceptance_json),
+    ]
+    rc, so, se = _run(generation_cmd, REPO_ROOT)
+    if rc != 0:
+        print(json.dumps({"status": "FAIL", "step": "generation", "stdout": so, "stderr": se}, indent=2))
+        return rc
+
+    generation_payload = _json(acceptance_json)
+    scene_dir = Path(generation_payload["scene_dir"]).resolve()
+
+    required_outputs = [
+        "scene_manifest.yaml",
+        "environment_layout.yaml",
+        "config/scene3d_mesh_index.json",
+        "urdf/scene.urdf.xacro",
+        "launch/demo.launch.py",
+        "package.xml",
+        "CMakeLists.txt",
+    ]
+    missing_outputs = [r for r in required_outputs if not (scene_dir / r).exists()]
+
+    smoke_json = out_dir / f"scene3d_gui_smoke_{args.scene_name}.json"
+    smoke_png = out_dir / f"scene3d_gui_smoke_{args.scene_name}.png"
+    smoke_cmd = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "run_workcell_builder_scene3d_gui_smoke.py"),
+        "--repo-root",
+        str(REPO_ROOT),
+        "--workspace-root",
+        str(Path(args.workspace_root).resolve() if args.workspace_root else REPO_ROOT),
+        "--scene",
+        args.scene_name,
+        "--output",
+        str(smoke_json),
+        "--screenshot",
+        str(smoke_png),
+    ]
+    if args.executable:
+        smoke_cmd.extend(["--executable", str(Path(args.executable).resolve())])
+    smoke_rc, smoke_so, smoke_se = _run(smoke_cmd, REPO_ROOT)
+
+    runtime_json = out_dir / f"scene3d_runtime_acceptance_{args.scene_name}.json"
+    runtime_md = out_dir / f"scene3d_runtime_acceptance_{args.scene_name}.md"
+    runtime_cmd = [
+        sys.executable,
+        str(REPO_ROOT / "scripts" / "validate_scene3d_runtime_acceptance.py"),
+        "--scene",
+        args.scene_name,
+        "--repo-root",
+        str(REPO_ROOT),
+        "--output-dir",
+        str(out_dir),
+        "--json",
+        str(runtime_json),
+        "--markdown",
+        str(runtime_md),
+        "--smoke-json",
+        str(smoke_json),
+    ]
+    if args.workspace_root:
+        runtime_cmd.extend(["--workspace-root", str(Path(args.workspace_root).resolve())])
+    if args.executable:
+        runtime_cmd.extend(["--workcell-builder-executable", str(Path(args.executable).resolve())])
+    runtime_rc, runtime_so, runtime_se = _run(runtime_cmd, REPO_ROOT)
+
+    smoke_payload = _json(smoke_json) if smoke_json.exists() else {}
+    counters = smoke_payload.get("counters", {}) if isinstance(smoke_payload, dict) else {}
+    key_counts = {
+        "visible": int(counters.get("visible_count", 0) or 0),
+        "rendered": int(counters.get("rendered_count", 0) or 0),
+        "selectable": int(counters.get("selectable_count", 0) or 0),
+        "hierarchy_rows": int(counters.get("hierarchy_rows", 0) or 0),
+    }
+
+    blockers: list[str] = []
+    if missing_outputs:
+        blockers.append(f"missing generated outputs: {', '.join(missing_outputs)}")
+    if smoke_rc != 0:
+        blockers.append("gui smoke command failed")
+    if not smoke_png.exists() or smoke_png.stat().st_size <= 0:
+        blockers.append("gui smoke screenshot missing or empty")
+    if runtime_rc != 0:
+        blockers.append("runtime acceptance validation failed")
+    for k, v in key_counts.items():
+        if v <= 0:
+            blockers.append(f"runtime counter not > 0: {k}={v}")
+
+    artifact = {
+        "schema": "scene3d_generated_canvas_acceptance/v1",
+        "scene": args.scene_name,
+        "scene_dir": str(scene_dir),
+        "status": "PASS" if not blockers else "FAIL",
+        "commands": {
+            "generation": " ".join(generation_cmd),
+            "gui_smoke": " ".join(smoke_cmd),
+            "runtime_acceptance": " ".join(runtime_cmd),
+        },
+        "generation": generation_payload,
+        "required_outputs": required_outputs,
+        "missing_outputs": missing_outputs,
+        "gui_smoke": {
+            "returncode": smoke_rc,
+            "json": str(smoke_json),
+            "screenshot": str(smoke_png),
+            "screenshot_size": smoke_png.stat().st_size if smoke_png.exists() else 0,
+            "stdout_tail": "\n".join(so.splitlines()[-20:]),
+            "stderr_tail": "\n".join(se.splitlines()[-20:]),
+        },
+        "runtime_acceptance": {"returncode": runtime_rc, "json": str(runtime_json), "markdown": str(runtime_md), "stdout_tail": "\n".join(runtime_so.splitlines()[-20:]), "stderr_tail": "\n".join(runtime_se.splitlines()[-20:])},
+        "key_counts": key_counts,
+        "blockers": blockers,
+    }
+    out_json = out_dir / f"{args.scene_name}_acceptance.json"
+    out_md = out_dir / f"{args.scene_name}_acceptance.md"
+    out_json.write_text(json.dumps(artifact, indent=2) + "\n", encoding="utf-8")
+    out_md.write_text(
+        "\n".join([
+            "# Scene3D Generated Canvas Acceptance",
+            "",
+            f"- scene: `{args.scene_name}`",
+            f"- status: **{artifact['status']}**",
+            f"- scene_dir: `{scene_dir}`",
+            "",
+            "## Missing outputs",
+            *([f"- {m}" for m in missing_outputs] or ["- none"]),
+            "",
+            "## Key runtime counts",
+            *[f"- {k}: {v}" for k, v in key_counts.items()],
+            "",
+            "## Blockers",
+            *([f"- {b}" for b in blockers] or ["- none"]),
+            "",
+            "## Artifacts",
+            f"- `{out_json}`",
+            f"- `{runtime_json}`",
+            f"- `{smoke_json}`",
+            f"- `{smoke_png}`",
+        ]) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps({"status": artifact["status"], "artifact_json": str(out_json), "artifact_md": str(out_md)}, indent=2))
+    return 0 if not blockers else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_scene3d_generated_canvas_acceptance.py
+++ b/tests/test_scene3d_generated_canvas_acceptance.py
@@ -1,0 +1,53 @@
+import json
+from pathlib import Path
+
+import scripts.run_scene3d_generated_canvas_acceptance as target
+
+
+def test_generated_canvas_acceptance_exports_artifacts(monkeypatch, tmp_path: Path):
+    scene_name = "scene3d_generated_canvas_acceptance"
+    out_dir = tmp_path / "out"
+    gen_root = out_dir / "generated_scenes"
+    scene_dir = gen_root / scene_name
+
+    def fake_run(cmd, cwd):
+        cmd_s = " ".join(cmd)
+        if "generate_scratch_cell_acceptance.py" in cmd_s:
+            (scene_dir / "config").mkdir(parents=True, exist_ok=True)
+            (scene_dir / "urdf").mkdir(parents=True, exist_ok=True)
+            (scene_dir / "launch").mkdir(parents=True, exist_ok=True)
+            (scene_dir / "scene_manifest.yaml").write_text("x", encoding="utf-8")
+            (scene_dir / "environment_layout.yaml").write_text("x", encoding="utf-8")
+            (scene_dir / "config/scene3d_mesh_index.json").write_text("{}", encoding="utf-8")
+            (scene_dir / "urdf/scene.urdf.xacro").write_text("x", encoding="utf-8")
+            (scene_dir / "launch/demo.launch.py").write_text("x", encoding="utf-8")
+            (scene_dir / "package.xml").write_text("x", encoding="utf-8")
+            (scene_dir / "CMakeLists.txt").write_text("x", encoding="utf-8")
+            gen_json = Path(cmd[cmd.index("--json-out") + 1])
+            gen_json.parent.mkdir(parents=True, exist_ok=True)
+            gen_json.write_text(json.dumps({"scene_dir": str(scene_dir)}), encoding="utf-8")
+            return 0, "ok", ""
+        if "run_workcell_builder_scene3d_gui_smoke.py" in cmd_s:
+            smoke_json = Path(cmd[cmd.index("--output") + 1])
+            smoke_png = Path(cmd[cmd.index("--screenshot") + 1])
+            smoke_json.write_text(json.dumps({"counters": {"visible_count": 1, "rendered_count": 1, "selectable_count": 1, "hierarchy_rows": 1}}), encoding="utf-8")
+            smoke_png.write_bytes(b"png")
+            return 0, "ok", ""
+        if "validate_scene3d_runtime_acceptance.py" in cmd_s:
+            runtime_json = Path(cmd[cmd.index("--json") + 1])
+            runtime_md = Path(cmd[cmd.index("--markdown") + 1])
+            runtime_json.write_text("{}", encoding="utf-8")
+            runtime_md.write_text("# runtime", encoding="utf-8")
+            return 0, "ok", ""
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(target, "_run", fake_run)
+    monkeypatch.setattr(target, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(target.sys, "argv", ["prog", "--output-dir", str(out_dir), "--scene-name", scene_name])
+
+    rc = target.main()
+    assert rc == 0
+    artifact = json.loads((out_dir / f"{scene_name}_acceptance.json").read_text(encoding="utf-8"))
+    assert artifact["status"] == "PASS"
+    assert artifact["key_counts"]["visible"] > 0
+    assert Path(artifact["gui_smoke"]["screenshot"]).stat().st_size > 0


### PR DESCRIPTION
### Motivation
- Provide an automated end-to-end acceptance path that generates a new Scene3D workspace package and validates the generated canvas and runtime evidence so regressions are caught by CI.
- Reuse existing generation flow rather than duplicating logic so the same generator is exercised by the acceptance path.
- Validate both GUI-side smoke evidence (screenshot + visual counters) and runtime acceptance artifacts to ensure generated scenes are usable for preview and planning.

### Description
- Add `scripts/run_scene3d_generated_canvas_acceptance.py` which invokes `generate_scratch_cell_acceptance.py` to create `scene3d_generated_canvas_acceptance`, validates presence of generated outputs (`scene_manifest.yaml`, `environment_layout.yaml`, `config/scene3d_mesh_index.json`, `urdf/scene.urdf.xacro`, `launch/demo.launch.py`, `package.xml`, `CMakeLists.txt`), runs the Scene3D GUI smoke script, and runs the runtime acceptance validator.
- The script collects GUI smoke counters (`visible_count`, `rendered_count`, `selectable_count`, `hierarchy_rows`), enforces they are > 0, checks that the screenshot file exists and is non-empty, and emits both a JSON and Markdown acceptance artifact under `build/workcell_studio/local_validation/`.
- Add `tests/test_scene3d_generated_canvas_acceptance.py` which monkeypatches the orchestration steps to deterministically exercise the script and assert that artifacts are exported, the acceptance status is `PASS`, runtime key counts are > 0, and the screenshot file size > 0.
- The change deliberately reuses existing generator and validator scripts (`generate_scratch_cell_acceptance.py`, `run_workcell_builder_scene3d_gui_smoke.py`, `validate_scene3d_runtime_acceptance.py`) so no generation logic is duplicated.

### Testing
- Executed `pytest -q tests/test_scene3d_generated_canvas_acceptance.py` which ran the new integration-style unit test and it passed (`1 passed`).
- The test exercises the full orchestration path via controlled monkeypatches and verifies exported artifacts, runtime counters, and screenshot size, and therefore is suitable for automated regression coverage in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e8505ad483318f909583e496152a)