### PR TITLE
Fix Scene3D validation CLI contracts to match documented all-scenes commands

### DIFF
--- a/scripts/run_scene3d_generated_canvas_acceptance.py
+++ b/scripts/run_scene3d_generated_canvas_acceptance.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import argparse, json, subprocess, sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = DEFAULT_REPO_ROOT
 
 
 def _run(cmd: list[str], cwd: Path) -> tuple[int, str, str]:
@@ -19,11 +20,14 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--scene-name", default="scene3d_generated_canvas_acceptance")
     ap.add_argument("--output-dir", default="build/workcell_studio/local_validation")
+    ap.add_argument("--repo-root", default=str(DEFAULT_REPO_ROOT))
     ap.add_argument("--workspace-root", default=None)
     ap.add_argument("--workcell-builder-executable", "--executable", dest="executable", default=None)
+    ap.add_argument("--timeout-sec", type=float, default=30)
     args = ap.parse_args()
 
-    out_dir = (REPO_ROOT / args.output_dir).resolve()
+    repo_root = Path(args.repo_root).resolve()
+    out_dir = (repo_root / args.output_dir).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
     generated_root = out_dir / "generated_scenes"
     generated_root.mkdir(parents=True, exist_ok=True)
@@ -31,7 +35,7 @@ def main() -> int:
     acceptance_json = out_dir / f"{args.scene_name}_generation.json"
     generation_cmd = [
         sys.executable,
-        str(REPO_ROOT / "scripts" / "generate_scratch_cell_acceptance.py"),
+        str(repo_root / "scripts" / "generate_scratch_cell_acceptance.py"),
         "--scene-name",
         args.scene_name,
         "--output-root",
@@ -39,7 +43,7 @@ def main() -> int:
         "--json-out",
         str(acceptance_json),
     ]
-    rc, so, se = _run(generation_cmd, REPO_ROOT)
+    rc, so, se = _run(generation_cmd, repo_root)
     if rc != 0:
         print(json.dumps({"status": "FAIL", "step": "generation", "stdout": so, "stderr": se}, indent=2))
         return rc
@@ -62,11 +66,11 @@ def main() -> int:
     smoke_png = out_dir / f"scene3d_gui_smoke_{args.scene_name}.png"
     smoke_cmd = [
         sys.executable,
-        str(REPO_ROOT / "scripts" / "run_workcell_builder_scene3d_gui_smoke.py"),
+        str(repo_root / "scripts" / "run_workcell_builder_scene3d_gui_smoke.py"),
         "--repo-root",
-        str(REPO_ROOT),
+        str(repo_root),
         "--workspace-root",
-        str(Path(args.workspace_root).resolve() if args.workspace_root else REPO_ROOT),
+        str(Path(args.workspace_root).resolve() if args.workspace_root else repo_root),
         "--scene",
         args.scene_name,
         "--output",
@@ -76,17 +80,18 @@ def main() -> int:
     ]
     if args.executable:
         smoke_cmd.extend(["--executable", str(Path(args.executable).resolve())])
-    smoke_rc, smoke_so, smoke_se = _run(smoke_cmd, REPO_ROOT)
+    smoke_cmd.extend(["--timeout-sec", str(args.timeout_sec)])
+    smoke_rc, smoke_so, smoke_se = _run(smoke_cmd, repo_root)
 
     runtime_json = out_dir / f"scene3d_runtime_acceptance_{args.scene_name}.json"
     runtime_md = out_dir / f"scene3d_runtime_acceptance_{args.scene_name}.md"
     runtime_cmd = [
         sys.executable,
-        str(REPO_ROOT / "scripts" / "validate_scene3d_runtime_acceptance.py"),
+        str(repo_root / "scripts" / "validate_scene3d_runtime_acceptance.py"),
         "--scene",
         args.scene_name,
         "--repo-root",
-        str(REPO_ROOT),
+        str(repo_root),
         "--output-dir",
         str(out_dir),
         "--json",
@@ -100,7 +105,7 @@ def main() -> int:
         runtime_cmd.extend(["--workspace-root", str(Path(args.workspace_root).resolve())])
     if args.executable:
         runtime_cmd.extend(["--workcell-builder-executable", str(Path(args.executable).resolve())])
-    runtime_rc, runtime_so, runtime_se = _run(runtime_cmd, REPO_ROOT)
+    runtime_rc, runtime_so, runtime_se = _run(runtime_cmd, repo_root)
 
     smoke_payload = _json(smoke_json) if smoke_json.exists() else {}
     counters = smoke_payload.get("counters", {}) if isinstance(smoke_payload, dict) else {}

--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -72,7 +72,7 @@ def main() -> int:
     ap.add_argument("--all-scenes", action="store_true")
     ap.add_argument("--output-dir", type=Path, default=None)
     ap.add_argument("--new-cell-recommended-layout-smoke", action="store_true")
-    ap.add_argument("--output", type=Path, required=True)
+    ap.add_argument("--output", type=Path, default=None)
     ap.add_argument("--screenshot", type=Path, default=None)
     ap.add_argument("--timeout-sec", type=float, default=30.0)
     ap.add_argument("--xvfb", action="store_true")
@@ -82,8 +82,14 @@ def main() -> int:
         raise SystemExit("Choose only one of --scene or --all-scenes")
     if not args.all_scenes and not args.scene and not args.new_cell_recommended_layout_smoke:
         raise SystemExit("Provide one of --scene, --all-scenes, or --new-cell-recommended-layout-smoke")
+    if args.all_scenes and args.output is not None:
+        raise SystemExit("--output is only valid for single-scene mode")
+    if args.all_scenes and args.new_cell_recommended_layout_smoke:
+        raise SystemExit("--new-cell-recommended-layout-smoke cannot be combined with --all-scenes")
     if args.all_scenes and args.output_dir is None:
         raise SystemExit("--output-dir is required with --all-scenes")
+    if not args.all_scenes and args.output is None:
+        raise SystemExit("--output is required unless --all-scenes is used")
 
     repo_root = resolve_repo_root(explicit_repo_root=args.repo_root)
     workspace_root = resolve_workspace_root(repo_root, args.workspace_root)
@@ -113,6 +119,7 @@ def main() -> int:
             ]
             if exe:
                 cmd += ["--executable", str(exe)]
+            cmd += ["--timeout-sec", str(args.timeout_sec)]
             if args.xvfb:
                 cmd.append("--xvfb")
             proc = subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True, check=False)

--- a/scripts/validate_scene3d_runtime_acceptance.py
+++ b/scripts/validate_scene3d_runtime_acceptance.py
@@ -295,6 +295,7 @@ def main() -> int:
     ap.add_argument("--json", default=None)
     ap.add_argument("--markdown", default=None)
     ap.add_argument("--smoke-json", default=None, help="path to GUI smoke evidence JSON (workcell_studio_scene3d_gui_smoke/v1)")
+    ap.add_argument("--smoke-dir", default=None, help="directory containing per-scene smoke JSONs named scene3d_gui_smoke_<scene>.json")
     args = ap.parse_args()
 
     repo_root = Path(args.repo_root).resolve()
@@ -308,6 +309,8 @@ def main() -> int:
 
     discovered = discover_scene3d_scenes(scenes_root)
     discovered_map = {d["scene"]: d for d in discovered}
+    if args.all_scenes and args.smoke_json:
+        ap.error("--smoke-json is only valid for single-scene mode; use --smoke-dir with --all-scenes")
     if args.all_scenes:
         scenes = [d["scene"] for d in discovered if d["status"] != "IGNORED_NON_SCENE"]
     else:
@@ -344,7 +347,10 @@ def main() -> int:
                 }
             )
             continue
-        evaluated = evaluate_scene(repo_root, scenes_root, main_path, preview_path, viewport_path, s, args.smoke_json)
+        smoke_json_path = args.smoke_json
+        if args.all_scenes and args.smoke_dir:
+            smoke_json_path = str(Path(args.smoke_dir) / f"scene3d_gui_smoke_{s}.json")
+        evaluated = evaluate_scene(repo_root, scenes_root, main_path, preview_path, viewport_path, s, smoke_json_path)
         if discovery:
             evaluated["detected_files"] = discovery["detected_files"]
             evaluated["source_layers_found"] = discovery["source_layers_found"]

--- a/tests/test_scene3d_cli_contracts_pr2042.py
+++ b/tests/test_scene3d_cli_contracts_pr2042.py
@@ -1,0 +1,96 @@
+import argparse
+from pathlib import Path
+
+import pytest
+
+import scripts.run_scene3d_generated_canvas_acceptance as generated
+import scripts.run_workcell_builder_scene3d_gui_smoke as smoke
+import scripts.validate_scene3d_runtime_acceptance as runtime
+
+
+def test_gui_smoke_all_scenes_output_dir_without_output_parses(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(smoke.sys, "argv", ["prog", "--all-scenes", "--output-dir", str(tmp_path)])
+
+    def fake_discover(_repo_root):
+        return []
+
+    monkeypatch.setattr(smoke, "_discover_scene_targets", fake_discover)
+    assert smoke.main() == 0
+
+
+def test_gui_smoke_single_scene_requires_output(monkeypatch):
+    monkeypatch.setattr(smoke.sys, "argv", ["prog", "--scene", "ur5_2f_test"])
+    with pytest.raises(SystemExit, match="--output is required unless --all-scenes is used"):
+        smoke.main()
+
+
+def test_runtime_acceptance_all_scenes_smoke_dir_parses(monkeypatch, tmp_path: Path):
+    out_json = tmp_path / "out.json"
+    out_md = tmp_path / "out.md"
+    monkeypatch.setattr(
+        runtime.sys,
+        "argv",
+        ["prog", "--all-scenes", "--smoke-dir", str(tmp_path), "--json", str(out_json), "--markdown", str(out_md)],
+    )
+    assert runtime.main() in (0, 1)
+    assert out_json.exists()
+
+
+def test_runtime_acceptance_all_scenes_smoke_json_fails_clearly(monkeypatch):
+    parser_errors = []
+
+    def fake_error(msg):
+        parser_errors.append(msg)
+        raise SystemExit(2)
+
+    monkeypatch.setattr(argparse.ArgumentParser, "error", lambda self, msg: fake_error(msg))
+    monkeypatch.setattr(runtime.sys, "argv", ["prog", "--all-scenes", "--smoke-json", "x.json"])
+    with pytest.raises(SystemExit):
+        runtime.main()
+    assert parser_errors[-1] == "--smoke-json is only valid for single-scene mode; use --smoke-dir with --all-scenes"
+
+
+def test_generated_canvas_acceptance_accepts_repo_root_and_forwards_timeout(monkeypatch, tmp_path: Path):
+    calls = []
+    out_dir = tmp_path / "out"
+
+    def fake_run(cmd, cwd):
+        calls.append((cmd, cwd))
+        cmd_s = " ".join(cmd)
+        if "generate_scratch_cell_acceptance.py" in cmd_s:
+            scene_name = cmd[cmd.index("--scene-name") + 1]
+            scene_dir = out_dir / "generated_scenes" / scene_name
+            (scene_dir / "config").mkdir(parents=True, exist_ok=True)
+            (scene_dir / "urdf").mkdir(parents=True, exist_ok=True)
+            (scene_dir / "launch").mkdir(parents=True, exist_ok=True)
+            for rel in [
+                "scene_manifest.yaml",
+                "environment_layout.yaml",
+                "config/scene3d_mesh_index.json",
+                "urdf/scene.urdf.xacro",
+                "launch/demo.launch.py",
+                "package.xml",
+                "CMakeLists.txt",
+            ]:
+                (scene_dir / rel).write_text("x", encoding="utf-8")
+            gen_json = Path(cmd[cmd.index("--json-out") + 1])
+            gen_json.parent.mkdir(parents=True, exist_ok=True)
+            gen_json.write_text('{"scene_dir": "%s"}' % scene_dir, encoding="utf-8")
+            return 0, "", ""
+        if "run_workcell_builder_scene3d_gui_smoke.py" in cmd_s:
+            Path(cmd[cmd.index("--output") + 1]).write_text('{"counters":{"visible_count":1,"rendered_count":1,"selectable_count":1,"hierarchy_rows":1}}', encoding="utf-8")
+            Path(cmd[cmd.index("--screenshot") + 1]).write_bytes(b"png")
+            return 0, "", ""
+        if "validate_scene3d_runtime_acceptance.py" in cmd_s:
+            Path(cmd[cmd.index("--json") + 1]).write_text("{}", encoding="utf-8")
+            Path(cmd[cmd.index("--markdown") + 1]).write_text("# ok\n", encoding="utf-8")
+            return 0, "", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(generated, "_run", fake_run)
+    monkeypatch.setattr(generated.sys, "argv", ["prog", "--repo-root", str(tmp_path), "--output-dir", str(out_dir), "--timeout-sec", "45"])
+    assert generated.main() == 0
+
+    smoke_call = next(cmd for cmd, _ in calls if "run_workcell_builder_scene3d_gui_smoke.py" in " ".join(cmd))
+    assert "--timeout-sec" in smoke_call
+    assert smoke_call[smoke_call.index("--timeout-sec") + 1] == "45.0"


### PR DESCRIPTION
## Summary
- make `scripts/run_workcell_builder_scene3d_gui_smoke.py` accept `--all-scenes --output-dir` without requiring `--output`
- keep `--output` required for single-scene/new-cell smoke modes via post-parse validation
- forward `--timeout-sec` in all-scenes subprocess fanout and preserve existing forwarded flags
- add `--smoke-dir` to `scripts/validate_scene3d_runtime_acceptance.py` and wire per-scene smoke evidence paths in `--all-scenes` mode
- add explicit conflict error when `--all-scenes` is combined with `--smoke-json`
- add `--repo-root` and `--timeout-sec` to `scripts/run_scene3d_generated_canvas_acceptance.py`, use explicit repo root for script path resolution, and forward timeout to GUI smoke command
- preserve compatibility by keeping `REPO_ROOT` alias in generated-canvas script

## Tests
- added `tests/test_scene3d_cli_contracts_pr2042.py` covering:
  - all-scenes smoke parse without `--output`
  - single-scene still requiring `--output`
  - runtime acceptance all-scenes parse with `--smoke-dir`
  - clear failure for `--all-scenes` + `--smoke-json`
  - generated canvas acceptance accepting `--repo-root` and forwarding `--timeout-sec`
- ran:
  - `pytest -q tests/test_scene3d_cli_contracts_pr2042.py tests/test_scene3d_generated_canvas_acceptance.py`
  - help-surface checks for new/updated flags on all three scripts

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f1525018833190f19ce477c0c691)