### PR TITLE
Fix Scene3D smoke runtime readiness gating to block zero-counter PASSes

### DIFF
--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -393,6 +393,10 @@ private:
         viewport->repaint();
         app_->processEvents();
       }
+      qInfo() << "Scene3D smoke render-ready: received=" << (viewport ? viewport->render_debug_counters().viewport_received_count : 0)
+              << "rendered=" << (viewport ? viewport->render_debug_counters().rendered_count : 0)
+              << "selectable=" << (viewport ? qMax(0, viewport->render_debug_counters().visible_count - viewport->render_debug_counters().overlay_count) : 0)
+              << "hierarchy=" << (viewport ? viewport->render_debug_counters().hierarchy_child_row_count : 0);
       if (scene3d_ready()) {
         timer->stop();
         timer->deleteLater();
@@ -455,7 +459,8 @@ private:
     const bool paint_completed = paint_cycle_completed(rc, screenshot_saved);
     const bool render_ready =
       rc.viewport_received_count > 0 &&
-      rc.visible_count > 0 &&
+      rc.rendered_count > 0 &&
+      rc.hierarchy_child_row_count > 0 &&
       paint_completed;
     markers["hierarchy_ready"] = hierarchy_ready;
     markers["inspector_ready"] = inspector_ready;
@@ -555,6 +560,7 @@ private:
       hierarchy_has_only_headings = (tree->topLevelItemCount() > 0 && hierarchy_child_rows == 0);
     }
     counters["hierarchy_child_row_count"] = hierarchy_child_rows;
+    counters["hierarchy_rows_count"] = hierarchy_child_rows;
     counters["hierarchy_has_only_headings"] = hierarchy_has_only_headings;
     counters["log_line_count"] = log_text.split('\n', Qt::SkipEmptyParts).size();
     counters["log_has_scene3d_diagnostics"] = log_text.contains("Scene3D diagnostics");
@@ -683,6 +689,8 @@ private:
       counters["primitive_fallback_count"] = rc.primitive_fallback_count;
       counters["locked_generated_urdf_visual_count"] = rc.locked_generated_urdf_visual_count;
       counters["overlay_count"] = rc.overlay_count;
+      counters["selectable_count"] = qMax(0, rc.visible_count - rc.overlay_count);
+      counters["hierarchy_rows_count"] = rc.hierarchy_child_row_count;
       counters["labels_drawn"] = rc.labels_drawn;
       counters["labels_suppressed_overlap"] = rc.labels_suppressed_overlap;
       counters["last_paint_completed"] = rc.last_paint_completed;
@@ -714,6 +722,8 @@ private:
       if (text.startsWith("Preview:")) preview_status = text.mid(QString("Preview:").size()).trimmed();
     }
     const int active_received_count = counters.value("active_viewport_received_count").toInt();
+    const int active_selectable_count = counters.value("selectable_count").toInt();
+    const int active_hierarchy_rows = counters.value("hierarchy_rows_count").toInt();
     const int active_rendered_count = counters.value("active_rendered_count").toInt();
     const bool has_active_items = (active_received_count > 0 || active_rendered_count > 0);
     if (parsed_runtime_diagnostics_total > 0 && !has_active_items) {
@@ -805,6 +815,10 @@ private:
         warnings_.append("active_viewport_counter_handoff_failed");
         blockers_.append("active_viewport_counter_handoff_failed");
       }
+    }
+    if (active_received_count > 0 &&
+        (active_rendered_count <= 0 || active_selectable_count <= 0 || active_hierarchy_rows <= 0)) {
+      blockers_.append("scene3d_runtime_not_rendered_after_candidate_ingestion");
     }
 
     const bool pass = blockers_.isEmpty();


### PR DESCRIPTION
## Summary
- Tightened Scene3D smoke readiness in GUI smoke mode to require actual runtime rendering signals before success.
- Added/propagated runtime counters for `selectable_count` and `hierarchy_rows_count` in smoke JSON output.
- Added explicit blocker `scene3d_runtime_not_rendered_after_candidate_ingestion` when candidate ingestion occurs but runtime render/select/hierarchy counters do not become positive.
- Added smoke-loop render diagnostics logging for received/rendered/selectable/hierarchy counts.

## Why
Supported scenes can have static candidate visibility but still fail to ingest/render in native Scene3D at runtime. This change prevents false PASS outcomes with zero runtime counters and surfaces the intended blocker.

## Files changed
- `workcell_builder/workcell_builder/gui/main.cpp`

## Manual validation commands
```bash
cd /home/user/workcell_ws
source /opt/ros/humble/setup.bash
colcon build --symlink-install --packages-select workcell_builder
source install/setup.bash

OUT="$PWD/src/easy_manipulation_deployment/build/workcell_studio/local_validation"
mkdir -p "$OUT"

python3 src/easy_manipulation_deployment/scripts/run_workcell_builder_scene3d_gui_smoke.py \
  --repo-root "$PWD/src/easy_manipulation_deployment" \
  --workspace-root "$PWD" \
  --all-scenes \
  --output-dir "$OUT" \
  --executable "$PWD/install/workcell_builder/bin/workcell_builder" \
  --timeout-sec 30

python3 src/easy_manipulation_deployment/scripts/validate_scene3d_runtime_acceptance.py \
  --repo-root "$PWD/src/easy_manipulation_deployment" \
  --all-scenes \
  --smoke-dir "$OUT" \
  --json "$OUT/scene3d_runtime_acceptance_all_scenes.json" \
  --markdown "$OUT/scene3d_runtime_acceptance_all_scenes.md"

python3 src/easy_manipulation_deployment/scripts/run_scene3d_generated_canvas_acceptance.py \
  --repo-root "$PWD/src/easy_manipulation_deployment" \
  --workspace-root "$PWD" \
  --output-dir "$OUT" \
  --executable "$PWD/install/workcell_builder/bin/workcell_builder" \
  --timeout-sec 30
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f45e704083319b119bf93b98b722)