### PR TITLE
Fix Scene3D smoke viewport pointer scope in GUI build

### DIFF
--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -388,7 +388,8 @@ private:
       const auto preview_resolution = resolve_active_scene_preview_widget(window_);
       ScenePreviewWidget * active_preview_widget = preview_resolution.selected;
       const auto viewport_resolution = resolve_active_scene3d_viewport(window_, active_preview_widget);
-      if (auto * viewport = viewport_resolution.selected) {
+      auto * viewport = viewport_resolution.selected;
+      if (viewport) {
         viewport->update();
         viewport->repaint();
         app_->processEvents();


### PR DESCRIPTION
## Summary
- Fix a compile failure in `workcell_builder/gui/main.cpp` where `viewport` was referenced outside its declaration scope in the Scene3D smoke readiness timer lambda.
- Hoist the `viewport` pointer declaration out of the `if` initializer and keep the existing null-guarded logic.

## Why
`colcon build --symlink-install --packages-select workcell_builder` failed with:
- `error: ‘viewport’ was not declared in this scope`

This change restores valid C++ scope rules while preserving behavior.

## Files changed
- `workcell_builder/workcell_builder/gui/main.cpp`

## Validation
- Static inspection of the lambda now shows `viewport` is in scope for both the update block and subsequent debug logging expression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f5ec00208331bf4196cb1c7791a5)