### PR TITLE
Fix Scene3D smoke readiness diagnostics and generated destination schema

### DIFF
--- a/scripts/generate_scratch_cell_acceptance.py
+++ b/scripts/generate_scratch_cell_acceptance.py
@@ -13,7 +13,7 @@ def _safe_scene_dir(root:Path,name:str)->Path:
 
 def _run(cmd:list[str]):
  p=subprocess.run(cmd,capture_output=True,text=True,check=False); return p.returncode,(p.stdout+'\n'+p.stderr).strip()
-CELL_TMPL='''cell:\n  id: {scene}\n  name: {scene}\nrobot:\n  model: ur5\nend_effector:\n  id: robotiq_2f\nenvironment:\n  layout: environment_layout.yaml\ntask:\n  type: pick_place\n  pick:\n    source: pick_zone\n  place:\n    destination: place_bin\n  destinations:\n    - id: place_bin\n      frame: world\n      pose:\n        xyz: [0.65, -0.25, 0.75]\n        rpy: [0.0, 0.0, 0.0]\nassets:\n  - id: table_support\n    kind: table\n  - id: pick_zone\n    kind: pick_zone\n  - id: place_bin\n    kind: bin\n'''
+CELL_TMPL='''cell:\n  id: {scene}\n  name: {scene}\nrobot:\n  model: ur5\nend_effector:\n  id: robotiq_2f\nenvironment:\n  layout: environment_layout.yaml\ntask:\n  type: pick_place\n  pick:\n    source: pick_zone\n  place:\n    destination: place_bin\n  destinations:\n    - id: place_bin\n      frame: world\n      pose_xyz: [0.65, -0.25, 0.75]\n      pose_rpy: [0.0, 0.0, 0.0]\nassets:\n  - id: table_support\n    kind: table\n  - id: pick_zone\n    kind: pick_zone\n  - id: place_bin\n    kind: bin\n'''
 
 def main():
  ap=argparse.ArgumentParser(); ap.add_argument('--scene-name',default=DEFAULT_SCENE); ap.add_argument('--output-root',type=Path,default=Path('/tmp/workcell_studio_scratch_acceptance')); ap.add_argument('--json-out',type=Path); a=ap.parse_args()

--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -336,6 +336,7 @@ private:
   QJsonArray blockers_;
   QDateTime start_time_;
   QJsonObject latest_counters_;
+  int render_ready_attempts_{0};
 
   void step_begin()
   {
@@ -385,19 +386,29 @@ private:
     auto * timer = new QTimer(this);
     const qint64 start_ms = QDateTime::currentMSecsSinceEpoch();
     connect(timer, &QTimer::timeout, this, [this, timer, start_ms, timeout_ms]() {
+      ++render_ready_attempts_;
       const auto preview_resolution = resolve_active_scene_preview_widget(window_);
       ScenePreviewWidget * active_preview_widget = preview_resolution.selected;
       const auto viewport_resolution = resolve_active_scene3d_viewport(window_, active_preview_widget);
       auto * viewport = viewport_resolution.selected;
+      auto * tree = window_->findChild<QTreeWidget *>("studioSceneHierarchyTree");
+      int hierarchy_rows = 0;
+      if (tree) {
+        for (int i = 0; i < tree->topLevelItemCount(); ++i) {
+          if (auto * top = tree->topLevelItem(i)) hierarchy_rows += top->childCount();
+        }
+      }
       if (viewport) {
+        viewport->show();
         viewport->update();
         viewport->repaint();
         app_->processEvents();
       }
-      qInfo() << "Scene3D smoke render-ready: received=" << (viewport ? viewport->render_debug_counters().viewport_received_count : 0)
+      qInfo() << "Scene3D smoke render-ready: scene=" << opts_.scene_name
+              << "received=" << (viewport ? viewport->render_debug_counters().viewport_received_count : 0)
               << "rendered=" << (viewport ? viewport->render_debug_counters().rendered_count : 0)
               << "selectable=" << (viewport ? qMax(0, viewport->render_debug_counters().visible_count - viewport->render_debug_counters().overlay_count) : 0)
-              << "hierarchy=" << (viewport ? viewport->render_debug_counters().hierarchy_child_row_count : 0);
+              << "hierarchy=" << hierarchy_rows;
       if (scene3d_ready()) {
         timer->stop();
         timer->deleteLater();
@@ -461,6 +472,7 @@ private:
     const bool render_ready =
       rc.viewport_received_count > 0 &&
       rc.rendered_count > 0 &&
+      qMax(0, rc.visible_count - rc.overlay_count) > 0 &&
       rc.hierarchy_child_row_count > 0 &&
       paint_completed;
     markers["hierarchy_ready"] = hierarchy_ready;
@@ -488,6 +500,11 @@ private:
       }
       if (latest_counters_.value("preview_items_count").toInt() > 0 && latest_counters_.value("viewport_received_count").toInt() <= 0) {
         return QString("scene_preview_items_not_forwarded_to_viewport");
+      }
+      if (latest_counters_.value("preview_items_count").toInt() > 0 &&
+          latest_counters_.value("viewport_received_count").toInt() > 0 &&
+          latest_counters_.value("rendered_count").toInt() <= 0) {
+        return QString("scene3d_runtime_not_rendered_after_candidate_ingestion");
       }
       if (latest_counters_.value("viewport_received_count").toInt() > 0 && latest_counters_.value("render_cache_count").toInt() <= 0) {
         return QString("viewport_render_cache_empty");
@@ -701,6 +718,10 @@ private:
       counters["active_rendered_count"] = rc.rendered_count;
       counters["active_render_cache_count"] = rc.render_cache_count;
       counters["active_viewport_object_name"] = viewport->objectName();
+      qInfo() << "Scene3D smoke viewport ingest: scene=" << opts_.scene_name
+              << "viewport_items=" << rc.viewport_received_count;
+      qInfo() << "Scene3D smoke hierarchy ingest: scene=" << opts_.scene_name
+              << "hierarchy_rows=" << rc.hierarchy_child_row_count;
     } else {
       for (const QString & key : {QStringLiteral("preview_items_count"), QStringLiteral("viewport_received_count"), QStringLiteral("render_cache_count"),
                                   QStringLiteral("visible_count"), QStringLiteral("rendered_count"), QStringLiteral("skipped_count"),
@@ -723,6 +744,14 @@ private:
       if (text.startsWith("Preview:")) preview_status = text.mid(QString("Preview:").size()).trimmed();
     }
     const int active_received_count = counters.value("active_viewport_received_count").toInt();
+    counters["render_ready_attempts"] = render_ready_attempts_;
+    counters["static_candidate_count"] = counters.value("preview_items_count").toInt();
+    counters["filtered_visible_candidate_count"] = counters.value("visible_count").toInt();
+    counters["viewport_items_after_ingest"] = counters.value("viewport_received_count").toInt();
+    counters["hierarchy_rows_after_ingest"] = counters.value("hierarchy_rows_count").toInt();
+    qInfo() << "Scene3D smoke load: scene=" << opts_.scene_name
+            << "static_candidates=" << counters.value("static_candidate_count").toInt()
+            << "filtered=" << counters.value("filtered_visible_candidate_count").toInt();
     const int active_selectable_count = counters.value("selectable_count").toInt();
     const int active_hierarchy_rows = counters.value("hierarchy_rows_count").toInt();
     const int active_rendered_count = counters.value("active_rendered_count").toInt();


### PR DESCRIPTION
## Summary
- strengthened Scene3D smoke-mode runtime readiness checks to require non-zero selectable content in addition to received/rendered/hierarchy counters
- added smoke diagnostics fields and logs for candidate/load/ingest/render-ready visibility in the smoke JSON/reporting path
- ensured smoke path actively shows and repaints viewport during readiness polling to improve QOpenGLWidget paint initialization in smoke runs
- fixed generated scratch cell task destination schema to emit `pose_xyz` and `pose_rpy` fields expected by validators

## Details
### Scene3D smoke diagnostics and readiness
- `workcell_builder/workcell_builder/gui/main.cpp`
  - added `render_ready_attempts` tracking
  - logs now include:
    - `Scene3D smoke load: scene=<name> static_candidates=<n> filtered=<n>`
    - `Scene3D smoke viewport ingest: scene=<name> viewport_items=<n>`
    - `Scene3D smoke hierarchy ingest: scene=<name> hierarchy_rows=<n>`
    - `Scene3D smoke render-ready: scene=<name> received=<n> rendered=<n> selectable=<n> hierarchy=<n>`
  - readiness now also requires `selectable_count > 0`
  - added explicit blocker message `scene3d_runtime_not_rendered_after_candidate_ingestion` when candidates ingest but rendering remains zero
  - exported smoke counters:
    - `static_candidate_count`
    - `filtered_visible_candidate_count`
    - `viewport_items_after_ingest`
    - `hierarchy_rows_after_ingest`
    - `render_ready_attempts`

### Generated-scene destination schema
- `scripts/generate_scratch_cell_acceptance.py`
  - changed generated task destination pose block from nested `pose: {xyz, rpy}` to flat keys:
    - `pose_xyz: [...]`
    - `pose_rpy: [...]`

## Manual validation commands
```bash
cd /home/user/workcell_ws
source /opt/ros/humble/setup.bash
colcon build --symlink-install --packages-select workcell_builder
source install/setup.bash

OUT="$PWD/src/easy_manipulation_deployment/build/workcell_studio/local_validation"
mkdir -p "$OUT"

python3 src/easy_manipulation_deployment/scripts/run_workcell_builder_scene3d_gui_smoke.py \
  --repo-root "$PWD/src/easy_manipulation_deployment" \
  --workspace-root "$PWD" \
  --all-scenes \
  --output-dir "$OUT" \
  --executable "$PWD/install/workcell_builder/bin/workcell_builder" \
  --timeout-sec 30

python3 src/easy_manipulation_deployment/scripts/validate_scene3d_runtime_acceptance.py \
  --repo-root "$PWD/src/easy_manipulation_deployment" \
  --all-scenes \
  --smoke-dir "$OUT" \
  --json "$OUT/scene3d_runtime_acceptance_all_scenes.json" \
  --markdown "$OUT/scene3d_runtime_acceptance_all_scenes.md"

python3 src/easy_manipulation_deployment/scripts/run_scene3d_generated_canvas_acceptance.py \
  --repo-root "$PWD/src/easy_manipulation_deployment" \
  --workspace-root "$PWD" \
  --output-dir "$OUT" \
  --executable "$PWD/install/workcell_builder/bin/workcell_builder" \
  --timeout-sec 30
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f8872ea083318406eb7dc338067d)