### PR TITLE
Make Scene3D smoke loading deterministic and add assembly diagnostics

### DIFF
--- a/scripts/generate_scratch_cell_acceptance.py
+++ b/scripts/generate_scratch_cell_acceptance.py
@@ -13,7 +13,7 @@ def _safe_scene_dir(root:Path,name:str)->Path:
 
 def _run(cmd:list[str]):
  p=subprocess.run(cmd,capture_output=True,text=True,check=False); return p.returncode,(p.stdout+'\n'+p.stderr).strip()
-CELL_TMPL='''cell:\n  id: {scene}\n  name: {scene}\nrobot:\n  model: ur5\nend_effector:\n  id: robotiq_2f\nenvironment:\n  layout: environment_layout.yaml\ntask:\n  type: pick_place\n  pick:\n    source: pick_zone\n  place:\n    destination: place_bin\n  destinations:\n    - id: place_bin\n      frame: world\n      pose_xyz: [0.65, -0.25, 0.75]\n      pose_rpy: [0.0, 0.0, 0.0]\nassets:\n  - id: table_support\n    kind: table\n  - id: pick_zone\n    kind: pick_zone\n  - id: place_bin\n    kind: bin\n'''
+CELL_TMPL='''cell:\n  id: {scene}\n  name: {scene}\nrobot:\n  model: ur5\n  safe_joint_state: []\n  home_named_target: home\nend_effector:\n  id: robotiq_2f\nenvironment:\n  layout: environment_layout.yaml\ntask:\n  type: pick_place\n  pick:\n    source: pick_zone\n  place:\n    destination: place_bin\n  destinations:\n    - id: place_bin\n      frame: world\n      pose_xyz: [0.65, -0.25, 0.75]\n      pose_rpy: [0.0, 0.0, 0.0]\nassets:\n  - id: table_support\n    kind: table\n  - id: pick_zone\n    kind: pick_zone\n  - id: place_bin\n    kind: bin\n'''
 
 def main():
  ap=argparse.ArgumentParser(); ap.add_argument('--scene-name',default=DEFAULT_SCENE); ap.add_argument('--output-root',type=Path,default=Path('/tmp/workcell_studio_scratch_acceptance')); ap.add_argument('--json-out',type=Path); a=ap.parse_args()

--- a/tests/test_generate_scratch_cell_acceptance_schema.py
+++ b/tests/test_generate_scratch_cell_acceptance_schema.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import importlib.util
+
+
+def test_scratch_cell_template_includes_safe_joint_state_key() -> None:
+    path = Path('scripts/generate_scratch_cell_acceptance.py')
+    spec = importlib.util.spec_from_file_location('gsca', path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    tmpl = mod.CELL_TMPL
+    assert 'robot:' in tmpl
+    assert 'safe_joint_state: []' in tmpl

--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -336,6 +336,7 @@ private:
   QJsonArray blockers_;
   QDateTime start_time_;
   QJsonObject latest_counters_;
+  QJsonObject scene_load_diagnostics_;
   int render_ready_attempts_{0};
 
   void step_begin()
@@ -351,25 +352,13 @@ private:
       return;
     }
     if (!opts_.scene_name.trimmed().isEmpty()) {
-      auto * table = window_->findChild<QTableWidget *>("studioHomeSceneTable");
-      if (table == nullptr) {
-        blockers_.append("Scene table not found");
-      } else {
-        bool found = false;
-        for (int row = 0; row < table->rowCount(); ++row) {
-          auto * item = table->item(row, 0);
-          if (item && item->text().trimmed() == opts_.scene_name.trimmed()) {
-            table->selectRow(row);
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          blockers_.append(QString("Requested scene not found: %1").arg(opts_.scene_name));
-        }
+      QStringList load_blockers;
+      if (!window_->load_scene_for_scene3d_smoke(opts_.scene_name, &load_blockers, &scene_load_diagnostics_)) {
+        for (const auto & b : load_blockers) blockers_.append(b);
       }
+    } else {
+      trigger_by_text("Open Selected Scene");
     }
-    trigger_by_text("Open Selected Scene");
     QTimer::singleShot(300, this, &Scene3DSmokeRunner::step_wait_scene3d_ready);
   }
 
@@ -558,6 +547,7 @@ private:
     root["timestamp"] = QDateTime::currentDateTimeUtc().toString(Qt::ISODate);
     root["scene"] = opts_.scene_name;
     root["new_cell_recommended_layout_smoke"] = opts_.new_cell_recommended_layout_smoke;
+    root["scene_load_diagnostics"] = scene_load_diagnostics_;
     root["duration_ms"] = start_time_.msecsTo(QDateTime::currentDateTimeUtc());
 
     auto * tree = window_->findChild<QTreeWidget *>("studioSceneHierarchyTree");
@@ -745,7 +735,14 @@ private:
     }
     const int active_received_count = counters.value("active_viewport_received_count").toInt();
     counters["render_ready_attempts"] = render_ready_attempts_;
-    counters["static_candidate_count"] = counters.value("preview_items_count").toInt();
+    counters["source_layout_item_count"] = scene_load_diagnostics_.value("source_layout_item_count").toInt();
+    counters["source_mesh_index_item_count"] = scene_load_diagnostics_.value("source_mesh_index_item_count").toInt();
+    counters["source_generated_layout_item_count"] = scene_load_diagnostics_.value("source_generated_layout_item_count").toInt();
+    counters["source_preview_metadata_item_count"] = scene_load_diagnostics_.value("source_preview_metadata_item_count").toInt();
+    counters["assembled_preview_item_count"] = scene_load_diagnostics_.value("assembled_preview_item_count").toInt(counters.value("preview_items_count").toInt());
+    counters["forwarded_to_preview_widget_count"] = counters.value("preview_items_count").toInt();
+    counters["forwarded_to_viewport_count"] = counters.value("viewport_received_count").toInt();
+    counters["static_candidate_count"] = counters.value("assembled_preview_item_count").toInt();
     counters["filtered_visible_candidate_count"] = counters.value("visible_count").toInt();
     counters["viewport_items_after_ingest"] = counters.value("viewport_received_count").toInt();
     counters["hierarchy_rows_after_ingest"] = counters.value("hierarchy_rows_count").toInt();

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -904,6 +904,66 @@ bool MainWindow::open_scene_builder_for_selected_scene(const QString & source_ac
   return true;
 }
 
+bool MainWindow::load_scene_for_scene3d_smoke(const QString & scene_name, QStringList * blockers, QJsonObject * diagnostics)
+{
+  auto add_blocker = [&](const QString & b) {
+    if (blockers) blockers->append(b);
+  };
+  if (diagnostics) diagnostics->insert("requested_scene_name", scene_name);
+  sync_selected_scene_state();
+  int scene_idx = -1;
+  for (int i = 0; i < static_cast<int>(scene_browser_result_.scenes.size()); ++i) {
+    if (QString::fromStdString(scene_browser_result_.scenes[static_cast<size_t>(i)].scene_name).trimmed() == scene_name.trimmed()) {
+      scene_idx = i;
+      break;
+    }
+  }
+  if (scene_idx < 0) {
+    add_blocker(QString("scene_not_found:%1").arg(scene_name));
+    return false;
+  }
+  select_scene_by_row(scene_idx);
+  if (!open_scene_builder_for_selected_scene(QStringLiteral("Scene3D smoke deterministic load"))) {
+    add_blocker("open_scene_builder_for_selected_scene_failed");
+    return false;
+  }
+  QApplication::processEvents(QEventLoop::AllEvents, 250);
+  populate_scene_hierarchy();
+  apply_scene3d_preview_layer_filters(false);
+  if (scene_preview_widget_) {
+    scene_preview_widget_->show();
+    scene_preview_widget_->raise();
+    scene_preview_widget_->update();
+    if (auto * viewport = scene_preview_widget_->findChild<Scene3DViewportWidget *>()) {
+      if (viewport->objectName().trimmed().isEmpty()) viewport->setObjectName("scene3dViewportWidget");
+      viewport->show();
+      viewport->resize(qMax(viewport->width(), 400), qMax(viewport->height(), 300));
+      viewport->fit_scene();
+      viewport->update();
+      viewport->repaint();
+    }
+  }
+  QApplication::processEvents(QEventLoop::AllEvents, 250);
+  if (diagnostics) {
+    const fs::path d = scene_browser_result_.scenes[static_cast<size_t>(scene_idx)].scene_dir;
+    diagnostics->insert("resolved_scene_path", QString::fromStdString(d.string()));
+    diagnostics->insert("source_layout_item_count", fs::exists(d / "layout" / "workcell_studio_layout.yaml") ? 1 : 0);
+    diagnostics->insert("source_mesh_index_item_count", fs::exists(d / "generated" / "scene_visual_mesh_index.json") ? 1 : 0);
+    diagnostics->insert("source_generated_layout_item_count", fs::exists(d / "layout" / "workcell_studio_layout.generated.yaml") ? 1 : 0);
+    diagnostics->insert("source_preview_metadata_item_count", fs::exists(d / "generated" / "scene_preview_metadata.json") ? 1 : 0);
+    diagnostics->insert("assembled_preview_item_count", all_scene_preview_items_.size());
+  }
+  if (all_scene_preview_items_.isEmpty()) {
+    add_blocker("scene3d_candidate_assembly_failed");
+    add_blocker("checked:layout/workcell_studio_layout.yaml");
+    add_blocker("checked:generated/scene_visual_mesh_index.json");
+    add_blocker("checked:layout/workcell_studio_layout.generated.yaml");
+    add_blocker("checked:generated/scene_preview_metadata.json");
+    return false;
+  }
+  return true;
+}
+
 void MainWindow::open_new_scene_creation_flow()
 {
   const QString workspace_root = detect_workspace_root();

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -85,6 +85,7 @@ public:
   explicit MainWindow(const QString & startup_workspace = QString(), const QString & startup_ros_distro = QString(), QWidget * parent = nullptr);
   ~MainWindow();
   ScenePreviewWidget * active_scene_preview_widget() const;
+  bool load_scene_for_scene3d_smoke(const QString & scene_name, QStringList * blockers = nullptr, QJsonObject * diagnostics = nullptr);
   void refresh_scene_builder_state_from_active_scene();
   static bool parse_transform_clipboard_text(
     const QString & text, double * x, double * y, double * z, double * r, double * p, double * yaw, QString * error = nullptr);


### PR DESCRIPTION
## Summary
- Added a deterministic smoke/test loading path in `MainWindow` via `load_scene_for_scene3d_smoke(...)`.
- Updated Scene3D smoke runner to call this deterministic loader instead of relying only on UI button text/selection.
- Added pre-viewport smoke counters and scene-load diagnostics to distinguish assembled candidates from viewport runtime counters.
- Ensured active scene preview viewport is explicitly shown/fit/updated during smoke load and assigned `scene3dViewportWidget` objectName when missing.
- Updated scratch acceptance template to include required `robot.safe_joint_state` (with `home_named_target`) for schema compliance.
- Added a regression test verifying generated scratch template includes `safe_joint_state`.

## Files
- `workcell_builder/workcell_builder/gui/mainwindow.h`
- `workcell_builder/workcell_builder/gui/mainwindow.cpp`
- `workcell_builder/workcell_builder/gui/main.cpp`
- `scripts/generate_scratch_cell_acceptance.py`
- `tests/test_generate_scratch_cell_acceptance_schema.py`

## Notes
- This change avoids hardcoded scene names and does not fake runtime counters.
- Validation/build commands were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12fd6d7a38833185e6682586dc8cf5)