### PR TITLE
Fix Scene3D runtime acceptance parsing and scratch cell schema version

### DIFF
--- a/scripts/generate_scratch_cell_acceptance.py
+++ b/scripts/generate_scratch_cell_acceptance.py
@@ -13,7 +13,7 @@ def _safe_scene_dir(root:Path,name:str)->Path:
 
 def _run(cmd:list[str]):
  p=subprocess.run(cmd,capture_output=True,text=True,check=False); return p.returncode,(p.stdout+'\n'+p.stderr).strip()
-CELL_TMPL='''cell:\n  id: {scene}\n  name: {scene}\nrobot:\n  model: ur5\n  safe_joint_state: []\n  home_named_target: home\nend_effector:\n  id: robotiq_2f\nenvironment:\n  layout: environment_layout.yaml\ntask:\n  type: pick_place\n  pick:\n    source: pick_zone\n  place:\n    destination: place_bin\n  destinations:\n    - id: place_bin\n      frame: world\n      pose_xyz: [0.65, -0.25, 0.75]\n      pose_rpy: [0.0, 0.0, 0.0]\nassets:\n  - id: table_support\n    kind: table\n  - id: pick_zone\n    kind: pick_zone\n  - id: place_bin\n    kind: bin\n'''
+CELL_TMPL='''schema_version: cell_definition/v1\ncell:\n  id: {scene}\n  name: {scene}\nrobot:\n  model: ur5\n  safe_joint_state: []\n  home_named_target: home\nend_effector:\n  id: robotiq_2f\nenvironment:\n  layout: environment_layout.yaml\ntask:\n  type: pick_place\n  pick:\n    source: pick_zone\n  place:\n    destination: place_bin\n  destinations:\n    - id: place_bin\n      frame: world\n      pose_xyz: [0.65, -0.25, 0.75]\n      pose_rpy: [0.0, 0.0, 0.0]\nassets:\n  - id: table_support\n    kind: table\n  - id: pick_zone\n    kind: pick_zone\n  - id: place_bin\n    kind: bin\n'''
 
 def main():
  ap=argparse.ArgumentParser(); ap.add_argument('--scene-name',default=DEFAULT_SCENE); ap.add_argument('--output-root',type=Path,default=Path('/tmp/workcell_studio_scratch_acceptance')); ap.add_argument('--json-out',type=Path); a=ap.parse_args()

--- a/scripts/validate_scene3d_runtime_acceptance.py
+++ b/scripts/validate_scene3d_runtime_acceptance.py
@@ -56,8 +56,12 @@ def _runtime_counter(payload: dict, key: str) -> int:
         return int(payload.get(key) or 0)
     counters = payload.get("counters")
     if isinstance(counters, dict):
-        alias = {"hierarchy_rows_count": "hierarchy_rows"}.get(key, key)
-        return int(counters.get(alias) or 0)
+        if key == "hierarchy_rows_count":
+            for alias in ("hierarchy_rows_count", "hierarchy_rows", "hierarchy_child_row_count"):
+                if alias in counters:
+                    return int(counters.get(alias) or 0)
+            return 0
+        return int(counters.get(key) or 0)
     return 0
 
 
@@ -193,12 +197,14 @@ def evaluate_scene(repo_root: Path, scenes_root: Path, main_path: Path, preview_
                     invalid_fields.append(field)
         if invalid_fields:
             blockers.append(f"runtime smoke evidence missing/invalid fields: {', '.join(invalid_fields)}")
-        elif runtime_payload.get("status") not in {"ok", "pass", "passed"}:
-            blockers.append(f"runtime smoke evidence status is not passing: {runtime_payload.get('status')!r}")
         else:
-            runtime_evidence["valid"] = True
-            runtime_evidence["status"] = runtime_payload.get("status")
-            runtime_evidence["counts"] = {k: runtime_payload.get(k) for k in required_runtime_fields if k != "status"}
+            status_value = str(runtime_payload.get("status") or "").strip().upper()
+            if status_value not in {"PASS", "OK"}:
+                blockers.append(f"runtime smoke evidence status is not passing: {runtime_payload.get('status')!r}")
+            else:
+                runtime_evidence["valid"] = True
+                runtime_evidence["status"] = runtime_payload.get("status")
+                runtime_evidence["counts"] = {k: _runtime_counter(runtime_payload, k) for k in required_runtime_fields if k != "status"}
 
     required_positive_counts = {
         "viewport_received_count": _runtime_counter(runtime_payload, "viewport_received_count"),

--- a/tests/test_generate_scratch_cell_acceptance_schema.py
+++ b/tests/test_generate_scratch_cell_acceptance_schema.py
@@ -1,13 +1,8 @@
 from pathlib import Path
-import importlib.util
 
 
 def test_scratch_cell_template_includes_safe_joint_state_key() -> None:
-    path = Path('scripts/generate_scratch_cell_acceptance.py')
-    spec = importlib.util.spec_from_file_location('gsca', path)
-    mod = importlib.util.module_from_spec(spec)
-    assert spec and spec.loader
-    spec.loader.exec_module(mod)
-    tmpl = mod.CELL_TMPL
-    assert 'robot:' in tmpl
-    assert 'safe_joint_state: []' in tmpl
+    text = Path('scripts/generate_scratch_cell_acceptance.py').read_text(encoding='utf-8')
+    assert 'CELL_TMPL' in text
+    assert 'schema_version: cell_definition/v1' in text
+    assert 'safe_joint_state: []' in text

--- a/tests/test_scene3d_runtime_acceptance.py
+++ b/tests/test_scene3d_runtime_acceptance.py
@@ -91,3 +91,56 @@ def test_runtime_acceptance_preview_warn_done_semantics_for_fixture_scenes(tmp_p
         assert scene['counts']['editable_layout_count'] > 0
         # Preview can still be considered done for visuals even with warning/blocker metadata.
         assert scene['visibility_contract']['visible_after_default_filters'] > 0
+
+
+def test_runtime_acceptance_accepts_pass_status_and_hierarchy_counter_aliases(tmp_path):
+    smoke = tmp_path / "smoke.json"
+    smoke.write_text(json.dumps({
+        "schema": "workcell_studio_scene3d_gui_smoke/v1",
+        "status": "PASS",
+        "counters": {
+            "viewport_received_count": 10,
+            "render_cache_count": 10,
+            "rendered_count": 10,
+            "selectable_count": 10,
+            "hierarchy_rows_count": 10,
+            "mesh_rendered_count": 8
+        }
+    }), encoding="utf-8")
+    out_json = tmp_path / "acceptance.json"
+    subprocess.run([
+        "python3",
+        str(ROOT / "scripts" / "validate_scene3d_runtime_acceptance.py"),
+        "--scene", "ur5_2f_test",
+        "--smoke-json", str(smoke),
+        "--json", str(out_json),
+    ], check=False)
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    scene = payload["scenes"][0]
+    assert "runtime smoke evidence status is not passing" not in "\n".join(scene["blockers"])
+    assert scene["counts"]["hierarchy_rows_count"] == 10
+
+
+def test_runtime_acceptance_reads_hierarchy_child_row_count_alias(tmp_path):
+    smoke = tmp_path / "smoke_alias.json"
+    smoke.write_text(json.dumps({
+        "schema": "workcell_studio_scene3d_gui_smoke/v1",
+        "status": "OK",
+        "counters": {
+            "viewport_received_count": 4,
+            "render_cache_count": 4,
+            "rendered_count": 4,
+            "selectable_count": 4,
+            "hierarchy_child_row_count": 7
+        }
+    }), encoding="utf-8")
+    out_json = tmp_path / "acceptance_alias.json"
+    subprocess.run([
+        "python3",
+        str(ROOT / "scripts" / "validate_scene3d_runtime_acceptance.py"),
+        "--scene", "ur5_2f_test",
+        "--smoke-json", str(smoke),
+        "--json", str(out_json),
+    ], check=False)
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["scenes"][0]["counts"]["hierarchy_rows_count"] == 7


### PR DESCRIPTION
### Motivation
- The runtime acceptance validator treated valid smoke `status` values like `PASS` as failing and did not reliably read `hierarchy_rows_count` from nested/legacy fields, causing false blockers in Scene3D runtime acceptance. 
- Generated scratch cell output omitted the required `schema_version: cell_definition/v1` so generated-scene acceptance failed schema validation. 
- Tests needed to assert the corrected parsing behavior and the scratch template schema token to prevent regressions. 

### Description
- Treat smoke `status` values `PASS` and `OK` as passing by normalizing and comparing the `status` string before gating acceptance, and emit the same structured `runtime_evidence["counts"]` using the parsed-counter helper. (modified `scripts/validate_scene3d_runtime_acceptance.py`) 
- Extend `_runtime_counter` to resolve `hierarchy_rows_count` from `counters.hierarchy_rows_count`, legacy `counters.hierarchy_rows`, and `counters.hierarchy_child_row_count` aliases so hierarchy counters are read correctly. (modified `scripts/validate_scene3d_runtime_acceptance.py`) 
- Add the exact schema token `schema_version: cell_definition/v1` to the top of the scratch `CELL_TMPL` to satisfy the schema validator. (modified `scripts/generate_scratch_cell_acceptance.py`) 
- Add/adjust unit tests validating `PASS` acceptance and the hierarchy counter aliases, and update the scratch-template test to check for the `schema_version` token without importing the script module. (modified `tests/test_scene3d_runtime_acceptance.py` and `tests/test_generate_scratch_cell_acceptance_schema.py`) 

### Testing
- Compiled the modified scripts with `python3 -m py_compile scripts/validate_scene3d_runtime_acceptance.py scripts/generate_scratch_cell_acceptance.py` and the check succeeded. 
- Ran the targeted test suite with `pytest -q tests/test_scene3d_runtime_acceptance.py tests/test_generate_scratch_cell_acceptance_schema.py` and all tests passed (`6 passed`). 
- The new tests exercise acceptance of `status: PASS` and reading `hierarchy_rows_count` from `counters.hierarchy_rows_count` and `counters.hierarchy_child_row_count` aliases and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1316163bfc8331a3ac3b972d422e97)