### PR TITLE
Add smoke-mode Scene3D layer reset and renderable fallback pass

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -929,6 +929,61 @@ bool MainWindow::load_scene_for_scene3d_smoke(const QString & scene_name, QStrin
   }
   QApplication::processEvents(QEventLoop::AllEvents, 250);
   populate_scene_hierarchy();
+  const bool has_renderable_editable_mesh_or_primitive = [&]() {
+      for (const auto & item : all_scene_preview_items_) {
+        const QString source_layer = item.source_layer.trimmed().toLower();
+        const QString active_visual_source = item.active_visual_source.trimmed().toLower();
+        if (source_layer == QStringLiteral("editable_layout")) return true;
+        if (active_visual_source == QStringLiteral("mesh_preview")) return true;
+        if (source_layer == QStringLiteral("primitive_fallback") || active_visual_source == QStringLiteral("primitive_fallback")) return true;
+      }
+      return false;
+    }();
+  if (preview_layer_editable_layout_box_) preview_layer_editable_layout_box_->setChecked(true);
+  if (preview_layer_mesh_preview_box_) preview_layer_mesh_preview_box_->setChecked(true);
+  if (preview_layer_primitive_fallback_box_) preview_layer_primitive_fallback_box_->setChecked(true);
+  if (preview_layer_overlays_helpers_box_) preview_layer_overlays_helpers_box_->setChecked(
+      blockers == nullptr || blockers->isEmpty());
+  if (preview_layer_generated_urdf_visual_box_) {
+    preview_layer_generated_urdf_visual_box_->setChecked(!has_renderable_editable_mesh_or_primitive);
+  }
+
+  const auto count_visible_for_layers = [&](const QSet<QString> & enabled_layers) {
+      int count = 0;
+      for (const auto & item : all_scene_preview_items_) {
+        if (workcell_builder::include_preview_item_for_scene3d(item, enabled_layers)) {
+          ++count;
+        }
+      }
+      return count;
+    };
+  const QSet<QString> normal_enabled_layers = {
+    preview_layer_editable_layout_box_ && preview_layer_editable_layout_box_->isChecked() ? "editable_layout" : "",
+    preview_layer_generated_urdf_visual_box_ && preview_layer_generated_urdf_visual_box_->isChecked() ? "locked_generated_urdf_visual" : "",
+    preview_layer_mesh_preview_box_ && preview_layer_mesh_preview_box_->isChecked() ? "mesh_preview" : "",
+    preview_layer_primitive_fallback_box_ && preview_layer_primitive_fallback_box_->isChecked() ? "primitive_fallback" : "",
+    preview_layer_overlays_helpers_box_ && preview_layer_overlays_helpers_box_->isChecked() ? "overlay" : "",
+    preview_layer_warnings_missing_assets_box_ && preview_layer_warnings_missing_assets_box_->isChecked() ? "warning" : ""
+  };
+  int visible_count = count_visible_for_layers(normal_enabled_layers);
+  if (visible_count == 0 && !all_scene_preview_items_.isEmpty()) {
+    const QSet<QString> fallback_enabled_layers = {
+      "editable_layout",
+      "mesh_preview",
+      "primitive_fallback",
+      "locked_generated_urdf_visual"
+    };
+    visible_count = count_visible_for_layers(fallback_enabled_layers);
+    if (visible_count > 0) {
+      append_studio_log("default_filter_fallback_kept_renderable_items_visible");
+      if (preview_layer_editable_layout_box_) preview_layer_editable_layout_box_->setChecked(true);
+      if (preview_layer_mesh_preview_box_) preview_layer_mesh_preview_box_->setChecked(true);
+      if (preview_layer_primitive_fallback_box_) preview_layer_primitive_fallback_box_->setChecked(true);
+      if (preview_layer_generated_urdf_visual_box_) preview_layer_generated_urdf_visual_box_->setChecked(true);
+    } else {
+      add_blocker("scene3d_default_filter_hid_all_renderable_candidates");
+    }
+  }
   apply_scene3d_preview_layer_filters(false);
   if (scene_preview_widget_) {
     scene_preview_widget_->show();


### PR DESCRIPTION
### Motivation
- Ensure smoke-mode loads produce deterministic visible Scene3D previews by resetting layer visibility to safe defaults before filtering. 
- Prevent prior UI checkbox state from hiding all renderable candidates during smoke tests by treating smoke mode as authoritative. 
- Provide a conservative fallback that keeps renderable safe candidates visible and surface a clear diagnostic when nothing remains visible.

### Description
- Added an unconditional reset in `MainWindow::load_scene_for_scene3d_smoke(...)` that explicitly sets preview layer checkboxes for `editable_layout`, `mesh_preview`, and `primitive_fallback` to visible and `overlay` to visible only when non-blocking, and sets `locked_generated_urdf_visual` visible only when no editable/mesh/primitive renderable candidates exist. 
- Implemented a `has_renderable_editable_mesh_or_primitive` detection and a `count_visible_for_layers` helper to evaluate normal vs fallback layer sets before calling `apply_scene3d_preview_layer_filters(false)`. 
- Added a generic fallback pass that enables safe renderable layers (`editable_layout`, `mesh_preview`, `primitive_fallback`, `locked_generated_urdf_visual`) when the normal reset+filtering yields zero visible items while assembled candidates exist. 
- Emit log token `default_filter_fallback_kept_renderable_items_visible` when fallback restores visibility and append blocker `scene3d_default_filter_hid_all_renderable_candidates` only if fallback still yields zero. 
- Change is scene-agnostic and contained to `workcell_builder/workcell_builder/gui/mainwindow.cpp` in the `load_scene_for_scene3d_smoke` flow.

### Testing
- No automated tests were executed locally for this change; only the code change was committed (`workcell_builder/workcell_builder/gui/mainwindow.cpp`).
- CI/unit tests (if present) should run after push/PR to validate runtime behavior and catch regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131b57e3fc8331bda81832cfcac213)