### PR TITLE
Use runtime smoke evidence for Scene3D default-filter acceptance

### DIFF
--- a/scripts/validate_scene3d_runtime_acceptance.py
+++ b/scripts/validate_scene3d_runtime_acceptance.py
@@ -65,6 +65,15 @@ def _runtime_counter(payload: dict, key: str) -> int:
     return 0
 
 
+def _runtime_warnings(payload: dict) -> list[str]:
+    if not isinstance(payload, dict):
+        return []
+    warnings = payload.get("warnings")
+    if not isinstance(warnings, list):
+        return []
+    return [str(w).strip() for w in warnings if str(w).strip()]
+
+
 def runtime_smoke_json_default(repo_root: Path, scenes_root: Path, scene: str) -> Path:
     candidates = [
         repo_root / "build/workcell_studio/scene3d_gui_smoke.json",
@@ -95,6 +104,7 @@ def evaluate_scene(repo_root: Path, scenes_root: Path, main_path: Path, preview_
             },
             "layers": {},
             "sources": {},
+            "default_filter_visibility_evidence": {},
             "pass": False,
         }
 
@@ -227,6 +237,21 @@ def evaluate_scene(repo_root: Path, scenes_root: Path, main_path: Path, preview_
     ):
         blockers.append("visible candidates exist but runtime counters are all zero")
 
+    assembled_preview_item_count = _runtime_counter(runtime_payload, "assembled_preview_item_count")
+    filtered_visible_candidate_count = _runtime_counter(runtime_payload, "filtered_visible_candidate_count")
+    smoke_warnings = set(_runtime_warnings(runtime_payload))
+    fallback_warning = "default_filter_fallback_kept_renderable_items_visible"
+    fallback_engaged = fallback_warning in smoke_warnings
+    default_filter_pass_mode = "not_required"
+    if assembled_preview_item_count > 0:
+        if filtered_visible_candidate_count > 0 and not fallback_engaged:
+            default_filter_pass_mode = "default_pass"
+        elif filtered_visible_candidate_count > 0 and fallback_engaged:
+            default_filter_pass_mode = "fallback_pass"
+        else:
+            default_filter_pass_mode = "failed"
+            blockers.append("scene3d_default_filter_hid_all_renderable_candidates")
+
     secondary_checks = {
         "grid_axes_enabled": ("draw_ground_grid_pass" in viewport_path.read_text(encoding="utf-8") and "draw_world_axes_pass" in viewport_path.read_text(encoding="utf-8")),
         "orbit_pan_zoom_handlers_exist": all(t in viewport_path.read_text(encoding="utf-8") for t in ["mouseMoveEvent", "wheelEvent", "pan_mode"]),
@@ -237,10 +262,8 @@ def evaluate_scene(repo_root: Path, scenes_root: Path, main_path: Path, preview_
         ),
         "drag_commit_callback_wired": "transform_changed_cb" in viewport_path.read_text(encoding="utf-8"),
         "hierarchy_selection_sync_wired": "apply_scene_selection(" in main_path.read_text(encoding="utf-8"),
-        "layer_toggles_not_default_hide_all": (
-            "apply_scene3d_preview_layer_filters" in main_path.read_text(encoding="utf-8")
-            and "visible item count after filters" in main_path.read_text(encoding="utf-8")
-        ),
+        "layer_toggles_not_default_hide_all": default_filter_pass_mode in {"default_pass", "fallback_pass", "not_required"},
+        "layer_toggles_default_filter_pass_mode": default_filter_pass_mode,
         "viewport_diagnostics_summary_present": "Scene3D runtime render: received=" in viewport_path.read_text(encoding="utf-8"),
     }
 
@@ -263,6 +286,8 @@ def evaluate_scene(repo_root: Path, scenes_root: Path, main_path: Path, preview_
             "selectable_count": _runtime_counter(runtime_counts, "selectable_count"),
             "hierarchy_rows_count": _runtime_counter(runtime_counts, "hierarchy_rows_count"),
             "mesh_rendered_count": _runtime_counter(runtime_counts, "mesh_rendered_count"),
+            "assembled_preview_item_count": assembled_preview_item_count,
+            "filtered_visible_candidate_count": filtered_visible_candidate_count,
         },
         "visibility_contract": {
             "input_items_count": input_items_count,
@@ -284,6 +309,13 @@ def evaluate_scene(repo_root: Path, scenes_root: Path, main_path: Path, preview_
         },
         "source_layer_counts": source_layer_counts,
         "runtime_evidence": runtime_evidence,
+        "default_filter_visibility_evidence": {
+            "assembled_preview_item_count": assembled_preview_item_count,
+            "filtered_visible_candidate_count": filtered_visible_candidate_count,
+            "fallback_warning_present": fallback_engaged,
+            "fallback_warning_token": fallback_warning,
+            "pass_mode": default_filter_pass_mode,
+        },
         "secondary_checks": secondary_checks,
         "status": "PASS" if not blockers else "FAIL",
         "pass": not blockers,
@@ -347,6 +379,7 @@ def main() -> int:
                     "visibility_contract": {},
                     "layers": {},
                     "sources": {},
+                    "default_filter_visibility_evidence": {},
                     "runtime_evidence": {"valid": False, "skipped": True},
                     "secondary_checks": {},
                     "pass": False,
@@ -418,9 +451,15 @@ def main() -> int:
         lines.append("### Runtime smoke evidence")
         for k, v in r["runtime_evidence"].items():
             lines.append(f"- {k}: {v}")
+        lines.append("### Default-filter visibility evidence")
+        for k, v in r.get("default_filter_visibility_evidence", {}).items():
+            lines.append(f"- {k}: {v}")
         lines.append("### Secondary diagnostics")
         for k, v in r["secondary_checks"].items():
-            lines.append(f"- {k}: {'PASS' if v else 'FAIL'}")
+            if isinstance(v, bool):
+                lines.append(f"- {k}: {'PASS' if v else 'FAIL'}")
+            else:
+                lines.append(f"- {k}: {v}")
 
     out_md = Path(args.markdown) if args.markdown else repo_root / "build/workcell_studio/scene3d_runtime_acceptance.md"
     out_md.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_scene3d_runtime_acceptance.py
+++ b/tests/test_scene3d_runtime_acceptance.py
@@ -2,6 +2,8 @@ import json
 import subprocess
 from pathlib import Path
 
+import scripts.validate_scene3d_runtime_acceptance as runtime
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -144,3 +146,100 @@ def test_runtime_acceptance_reads_hierarchy_child_row_count_alias(tmp_path):
     ], check=False)
     payload = json.loads(out_json.read_text(encoding="utf-8"))
     assert payload["scenes"][0]["counts"]["hierarchy_rows_count"] == 7
+
+
+def _write_scene_fixture(tmp_path: Path, smoke_payload: dict) -> tuple[Path, Path, Path, Path, Path, Path]:
+    repo = tmp_path / "repo"
+    scene_root = repo / "scenes"
+    scene = "demo_scene"
+    sdir = scene_root / scene
+    (sdir / "layout").mkdir(parents=True, exist_ok=True)
+    (sdir / "generated").mkdir(parents=True, exist_ok=True)
+    (repo / "cpp").mkdir(parents=True, exist_ok=True)
+
+    (sdir / "layout/workcell_studio_layout.yaml").write_text("items:\n  - id: a\n", encoding="utf-8")
+    (sdir / "generated/scene_visual_mesh_index.json").write_text(json.dumps({"safe_for_preview": True, "visual_items": [{"id": "m1"}], "items": []}), encoding="utf-8")
+    (sdir / "layout/workcell_studio_layout.generated.yaml").write_text("items: []\n", encoding="utf-8")
+
+    main_path = repo / "cpp/mainwindow.cpp"
+    main_path.write_text("select_cb\napply_scene_selection(\nupdate_scene_builder_inspector_for_selected_item\n", encoding="utf-8")
+    preview_path = repo / "cpp/scene_preview_widget.cpp"
+    preview_path.write_text("select_cb\n", encoding="utf-8")
+    viewport_path = repo / "cpp/scene3d_viewport_widget.cpp"
+    viewport_path.write_text("draw_ground_grid_pass\ndraw_world_axes_pass\nmouseMoveEvent\nwheelEvent\npan_mode\ntransform_changed_cb\nScene3D runtime render: received=\n", encoding="utf-8")
+
+    smoke = sdir / "generated/scene3d_gui_smoke.json"
+    smoke.write_text(json.dumps(smoke_payload), encoding="utf-8")
+    return repo, scene_root, main_path, preview_path, viewport_path, scene
+
+
+def test_runtime_acceptance_default_filter_default_pass_from_runtime_smoke(tmp_path):
+    repo, scene_root, main_path, preview_path, viewport_path, scene = _write_scene_fixture(
+        tmp_path,
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "counters": {
+                "viewport_received_count": 3,
+                "render_cache_count": 3,
+                "rendered_count": 3,
+                "selectable_count": 3,
+                "hierarchy_rows_count": 3,
+                "mesh_rendered_count": 3,
+                "assembled_preview_item_count": 2,
+                "filtered_visible_candidate_count": 2,
+            },
+        },
+    )
+    result = runtime.evaluate_scene(repo, scene_root, main_path, preview_path, viewport_path, scene, None)
+    assert result["default_filter_visibility_evidence"]["pass_mode"] == "default_pass"
+    assert result["secondary_checks"]["layer_toggles_not_default_hide_all"] is True
+    assert "scene3d_default_filter_hid_all_renderable_candidates" not in result["blockers"]
+
+
+def test_runtime_acceptance_default_filter_fallback_pass_requires_warning(tmp_path):
+    repo, scene_root, main_path, preview_path, viewport_path, scene = _write_scene_fixture(
+        tmp_path,
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "counters": {
+                "viewport_received_count": 3,
+                "render_cache_count": 3,
+                "rendered_count": 3,
+                "selectable_count": 3,
+                "hierarchy_rows_count": 3,
+                "mesh_rendered_count": 3,
+                "assembled_preview_item_count": 2,
+                "filtered_visible_candidate_count": 1,
+            },
+            "warnings": ["default_filter_fallback_kept_renderable_items_visible"],
+        },
+    )
+    result = runtime.evaluate_scene(repo, scene_root, main_path, preview_path, viewport_path, scene, None)
+    assert result["default_filter_visibility_evidence"]["pass_mode"] == "fallback_pass"
+    assert result["secondary_checks"]["layer_toggles_not_default_hide_all"] is True
+
+
+def test_runtime_acceptance_default_filter_zero_visible_is_blocker(tmp_path):
+    repo, scene_root, main_path, preview_path, viewport_path, scene = _write_scene_fixture(
+        tmp_path,
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "counters": {
+                "viewport_received_count": 3,
+                "render_cache_count": 3,
+                "rendered_count": 3,
+                "selectable_count": 3,
+                "hierarchy_rows_count": 3,
+                "mesh_rendered_count": 3,
+                "assembled_preview_item_count": 2,
+                "filtered_visible_candidate_count": 0,
+            },
+        },
+    )
+    result = runtime.evaluate_scene(repo, scene_root, main_path, preview_path, viewport_path, scene, None)
+    assert result["default_filter_visibility_evidence"]["pass_mode"] == "failed"
+    assert "scene3d_default_filter_hid_all_renderable_candidates" in result["blockers"]
+    assert result["secondary_checks"]["layer_toggles_not_default_hide_all"] is False


### PR DESCRIPTION
### Motivation
- The prior check for `layer_toggles_not_default_hide_all` relied on source-code substring detection and did not use runtime evidence from GUI smoke tests.
- The goal is to make default-filter acceptance decisions based on actual runtime smoke JSON counters/warnings so the gate reflects real app behaviour.

### Description
- Replace source-substring gating with runtime checks using `assembled_preview_item_count` and `filtered_visible_candidate_count`, and treat `default_filter_fallback_kept_renderable_items_visible` as the required warning token when fallback is used.
- Emit blocker `scene3d_default_filter_hid_all_renderable_candidates` when assembled preview items exist but `filtered_visible_candidate_count` remains zero, and add pass-mode reporting with values `default_pass`, `fallback_pass`, `not_required`, or `failed`.
- Add helper `_runtime_warnings`, include `default_filter_visibility_evidence` in the JSON output, expose `layer_toggles_default_filter_pass_mode` in `secondary_checks`, and make markdown rendering include the new evidence and non-boolean secondary diagnostics.
- Remove string-parsing reliance in tests and add runtime-focused tests that exercise `evaluate_scene` with smoke fixtures to validate `default_pass`, `fallback_pass` (requires warning), and the zero-visible blocker.

### Testing
- Added tests in `tests/test_scene3d_runtime_acceptance.py` that create scene fixtures and smoke JSONs and assert the new `default_filter_visibility_evidence` and `secondary_checks` behaviour.
- Ran `pytest -q tests/test_scene3d_runtime_acceptance.py` and received `8 passed` (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131b5609f08331827e75470d7b77af)