### PR TITLE
Improve actionable failure diagnostics for Scene3D acceptance pipeline

### DIFF
--- a/scripts/generate_scratch_cell_acceptance.py
+++ b/scripts/generate_scratch_cell_acceptance.py
@@ -12,20 +12,27 @@ def _safe_scene_dir(root:Path,name:str)->Path:
  return d
 
 def _run(cmd:list[str]):
- p=subprocess.run(cmd,capture_output=True,text=True,check=False); return p.returncode,(p.stdout+'\n'+p.stderr).strip()
+ p=subprocess.run(cmd,capture_output=True,text=True,check=False); return p.returncode,p.stdout,p.stderr
 CELL_TMPL='''schema_version: cell_definition/v1\ncell:\n  id: {scene}\n  name: {scene}\nrobot:\n  model: ur5\n  safe_joint_state: []\n  home_named_target: home\nend_effector:\n  id: robotiq_2f\nenvironment:\n  layout: environment_layout.yaml\ntask:\n  type: pick_place\n  pick:\n    source: pick_zone\n  place:\n    destination: place_bin\n  destinations:\n    - id: place_bin\n      frame: world\n      pose_xyz: [0.65, -0.25, 0.75]\n      pose_rpy: [0.0, 0.0, 0.0]\nassets:\n  - id: table_support\n    kind: table\n  - id: pick_zone\n    kind: pick_zone\n  - id: place_bin\n    kind: bin\ncommissioning:\n  self_test_enabled: true\n  export_bundle: true\n  require_operator_review: true\n  fake_hardware_default: true\n  demo_template_id: scratch_ur5_2f_acceptance\n'''
 
 def main():
  ap=argparse.ArgumentParser(); ap.add_argument('--scene-name',default=DEFAULT_SCENE); ap.add_argument('--output-root',type=Path,default=Path('/tmp/workcell_studio_scratch_acceptance')); ap.add_argument('--json-out',type=Path); a=ap.parse_args()
- r={'scene_name':a.scene_name,'scene_dir':'','messages_format':'standard_v1','generated_files':[],'missing_files':[],'validation_status':'BLOCKED','blockers':[],'warnings':[],'build_command':'','source_command':'source install/setup.bash','launch_command':'','ready_for_plan_simulate':False}
+ generator_cmd=[sys.executable,str(SCRIPTS/'generate_workcell_from_cell_definition.py'),'','--output-dir',str(a.output_root),'--package-name','','--force']
+ r={'scene_name':a.scene_name,'scene_dir':'','messages_format':'standard_v1','generated_files':[],'missing_files':[],'validation_status':'BLOCKED','blockers':[],'warnings':[],'build_command':'','source_command':'source install/setup.bash','launch_command':'','ready_for_plan_simulate':False,'generator_command':'','generator_failure':{}}
  if not re.fullmatch(r'[a-z][a-z0-9_]*', a.scene_name): r['blockers'].append(get_message('INVALID_SCENE_NAME'))
  try: a.output_root.mkdir(parents=True,exist_ok=True)
  except Exception as exc: r['blockers'].append(get_message('MISSING_WORKSPACE',detail=f'invalid output root: {a.output_root} ({exc})')); print(json.dumps(r,indent=2)); return 1
  sd=_safe_scene_dir(a.output_root,a.scene_name); sd.mkdir(parents=True,exist_ok=True); r['scene_dir']=str(sd)
  if sd.name!=a.scene_name: r['warnings'].append(get_message('SCENE_ALREADY_EXISTS',detail=f'Scene already existed; using {sd.name}'))
  cell=sd/'cell_definition.yaml'; cell.write_text(CELL_TMPL.format(scene=sd.name),encoding='utf-8')
- rc,out=_run([sys.executable,str(SCRIPTS/'generate_workcell_from_cell_definition.py'),str(cell),'--output-dir',str(a.output_root),'--package-name',sd.name,'--force'])
- if rc!=0: r['blockers'].append(get_message('VALIDATION_BLOCKED',title='Generate Scene Package failed',detail=out.splitlines()[-1] if out else 'Generator failed.'))
+ generator_cmd[2]=str(cell); generator_cmd[7]=sd.name
+ r['generator_command']=' '.join(generator_cmd)
+ rc,so,se=_run(generator_cmd)
+ if rc!=0:
+  combined_lines=(so+'\n'+se).splitlines()
+  summary=combined_lines[-1] if combined_lines else 'Generator failed.'
+  r['generator_failure']={'returncode':rc,'stdout_tail':'\n'.join(so.splitlines()[-20:]),'stderr_tail':'\n'.join(se.splitlines()[-20:]),'summary':summary}
+  r['blockers'].append(get_message('VALIDATION_BLOCKED',title='Generate Scene Package failed',detail='See generator_failure.{returncode,summary,stdout_tail,stderr_tail} and generator_command in this JSON payload.'))
  for rel,txt in [('environment_layout.yaml','schema_version: environment_layout/v1\nassets: []\n'),('config/workcell_builder_task_intent.yaml','task:\n  type: pick_place\n'),('environment.yaml',f'scene_name: {sd.name}\n')]:
   p=sd/rel; p.parent.mkdir(parents=True,exist_ok=True)
   if not p.exists(): p.write_text(txt,encoding='utf-8')

--- a/scripts/run_scene3d_generated_canvas_acceptance.py
+++ b/scripts/run_scene3d_generated_canvas_acceptance.py
@@ -12,6 +12,10 @@ def _run(cmd: list[str], cwd: Path) -> tuple[int, str, str]:
     return p.returncode, p.stdout, p.stderr
 
 
+def _tail(text: str, lines: int = 20) -> str:
+    return "\n".join(text.splitlines()[-lines:])
+
+
 def _json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -44,8 +48,21 @@ def main() -> int:
         str(acceptance_json),
     ]
     rc, so, se = _run(generation_cmd, repo_root)
+    generation_summary = (se.strip().splitlines() or so.strip().splitlines() or ["generation command failed"])[-1]
     if rc != 0:
-        print(json.dumps({"status": "FAIL", "step": "generation", "stdout": so, "stderr": se}, indent=2))
+        print(
+            json.dumps(
+                {
+                    "status": "FAIL",
+                    "step": "generation",
+                    "command": " ".join(generation_cmd),
+                    "failure_summary": generation_summary,
+                    "stdout_tail": _tail(so),
+                    "stderr_tail": _tail(se),
+                },
+                indent=2,
+            )
+        )
         return rc
 
     generation_payload = _json(acceptance_json)
@@ -82,6 +99,7 @@ def main() -> int:
         smoke_cmd.extend(["--executable", str(Path(args.executable).resolve())])
     smoke_cmd.extend(["--timeout-sec", str(args.timeout_sec)])
     smoke_rc, smoke_so, smoke_se = _run(smoke_cmd, repo_root)
+    smoke_summary = (smoke_se.strip().splitlines() or smoke_so.strip().splitlines() or ["gui smoke command failed"])[-1]
 
     runtime_json = out_dir / f"scene3d_runtime_acceptance_{args.scene_name}.json"
     runtime_md = out_dir / f"scene3d_runtime_acceptance_{args.scene_name}.md"
@@ -106,6 +124,7 @@ def main() -> int:
     if args.executable:
         runtime_cmd.extend(["--workcell-builder-executable", str(Path(args.executable).resolve())])
     runtime_rc, runtime_so, runtime_se = _run(runtime_cmd, repo_root)
+    runtime_summary = (runtime_se.strip().splitlines() or runtime_so.strip().splitlines() or ["runtime acceptance failed"])[-1]
 
     smoke_payload = _json(smoke_json) if smoke_json.exists() else {}
     counters = smoke_payload.get("counters", {}) if isinstance(smoke_payload, dict) else {}
@@ -123,23 +142,42 @@ def main() -> int:
     }
 
     blockers: list[str] = []
+    failing_step = ""
+    failing_command = ""
     if missing_outputs:
         blockers.append(f"missing generated outputs: {', '.join(missing_outputs)}")
+        if not failing_step:
+            failing_step = "output_validation"
+            failing_command = "generated output existence checks"
     if smoke_rc != 0:
         blockers.append("gui smoke command failed")
+        if not failing_step:
+            failing_step = "gui_smoke"
+            failing_command = " ".join(smoke_cmd)
     if not smoke_png.exists() or smoke_png.stat().st_size <= 0:
         blockers.append("gui smoke screenshot missing or empty")
+        if not failing_step:
+            failing_step = "gui_smoke"
+            failing_command = " ".join(smoke_cmd)
     if runtime_rc != 0:
         blockers.append("runtime acceptance validation failed")
+        if not failing_step:
+            failing_step = "runtime_acceptance"
+            failing_command = " ".join(runtime_cmd)
     for k, v in key_counts.items():
         if v <= 0:
             blockers.append(f"runtime counter not > 0: {k}={v}")
+            if not failing_step:
+                failing_step = "runtime_counters"
+                failing_command = "scene3d runtime counter checks"
 
     artifact = {
         "schema": "scene3d_generated_canvas_acceptance/v1",
         "scene": args.scene_name,
         "scene_dir": str(scene_dir),
         "status": "PASS" if not blockers else "FAIL",
+        "failing_step": failing_step if blockers else "",
+        "failing_command": failing_command if blockers else "",
         "commands": {
             "generation": " ".join(generation_cmd),
             "gui_smoke": " ".join(smoke_cmd),
@@ -153,10 +191,11 @@ def main() -> int:
             "json": str(smoke_json),
             "screenshot": str(smoke_png),
             "screenshot_size": smoke_png.stat().st_size if smoke_png.exists() else 0,
-            "stdout_tail": "\n".join(so.splitlines()[-20:]),
-            "stderr_tail": "\n".join(se.splitlines()[-20:]),
+            "stdout_tail": "\n".join(smoke_so.splitlines()[-20:]),
+            "stderr_tail": "\n".join(smoke_se.splitlines()[-20:]),
+            "failure_summary": smoke_summary,
         },
-        "runtime_acceptance": {"returncode": runtime_rc, "json": str(runtime_json), "markdown": str(runtime_md), "stdout_tail": "\n".join(runtime_so.splitlines()[-20:]), "stderr_tail": "\n".join(runtime_se.splitlines()[-20:])},
+        "runtime_acceptance": {"returncode": runtime_rc, "json": str(runtime_json), "markdown": str(runtime_md), "stdout_tail": "\n".join(runtime_so.splitlines()[-20:]), "stderr_tail": "\n".join(runtime_se.splitlines()[-20:]), "failure_summary": runtime_summary},
         "key_counts": key_counts,
         "blockers": blockers,
     }
@@ -179,6 +218,11 @@ def main() -> int:
             "",
             "## Blockers",
             *([f"- {b}" for b in blockers] or ["- none"]),
+            "",
+            "## Failure context",
+            f"- failing_step: `{artifact['failing_step'] or 'none'}`",
+            f"- failing_command: `{artifact['failing_command'] or 'none'}`",
+            "- detailed diagnostics: `generation.generator_failure`, `gui_smoke.{returncode,stdout_tail,stderr_tail}`, `runtime_acceptance.{returncode,stdout_tail,stderr_tail}`",
             "",
             "## Artifacts",
             f"- `{out_json}`",


### PR DESCRIPTION
### Motivation

- Make scene generation failures actionable without rerunning by persisting the exact generator command and structured diagnostics. 
- Surface concise failure pointers in top-level blocker messages while keeping detailed logs in machine-readable fields. 
- Provide consistent short summaries for GUI smoke and runtime acceptance failures so triage can quickly identify the failing step and command. 

### Description

- In `scripts/generate_scratch_cell_acceptance.py` the generator command is persisted to `generator_command` and on non-zero exit `generator_failure` now contains `returncode`, `stdout_tail`, `stderr_tail`, and `summary`, and `_run` now returns `(rc, stdout, stderr)`. 
- The generator invocation captures the last 20 lines of `stdout`/`stderr` and the blocker message is kept concise while pointing to `generator_failure` and `generator_command` in the JSON payload. 
- In `scripts/run_scene3d_generated_canvas_acceptance.py` added `_tail()` helper and emit a failure JSON for generation failures that includes `step`, `command`, `failure_summary`, `stdout_tail`, and `stderr_tail`. 
- The final acceptance artifact now includes top-level `failing_step` and `failing_command`, and per-step `failure_summary` fields were added for GUI smoke and runtime acceptance; the markdown output includes a "Failure context" section pointing to structured diagnostics. 

### Testing

- Ran `python -m py_compile scripts/generate_scratch_cell_acceptance.py scripts/run_scene3d_generated_canvas_acceptance.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131e5bbd6c8331838653dcbc72ca01)