### PR TITLE
Tighten Scene3D generated canvas acceptance counter gates

### DIFF
--- a/scripts/run_scene3d_generated_canvas_acceptance.py
+++ b/scripts/run_scene3d_generated_canvas_acceptance.py
@@ -108,18 +108,31 @@ def main() -> int:
     runtime_rc, runtime_so, runtime_se = _run(runtime_cmd, repo_root)
 
     smoke_payload = _json(smoke_json) if smoke_json.exists() else {}
-    counters = smoke_payload.get("counters", {}) if isinstance(smoke_payload, dict) else {}
-    def _count(key: str, nested_alias: str | None = None) -> int:
-        if isinstance(smoke_payload, dict) and key in smoke_payload:
-            return int(smoke_payload.get(key) or 0)
-        if isinstance(counters, dict):
-            return int(counters.get(nested_alias or key) or 0)
+    runtime_payload = _json(runtime_json) if runtime_json.exists() else {}
+    smoke_counters = smoke_payload.get("counters", {}) if isinstance(smoke_payload, dict) else {}
+    runtime_counters = runtime_payload.get("counters", {}) if isinstance(runtime_payload, dict) else {}
+
+    def _count(primary_key: str, *aliases: str) -> int:
+        candidate_keys = (primary_key, *aliases)
+        for payload, nested in ((smoke_payload, smoke_counters), (runtime_payload, runtime_counters)):
+            if isinstance(payload, dict):
+                for key in candidate_keys:
+                    if key in payload:
+                        return int(payload.get(key) or 0)
+            if isinstance(nested, dict):
+                for key in candidate_keys:
+                    if key in nested:
+                        return int(nested.get(key) or 0)
         return 0
+
     key_counts = {
-        "visible": _count("visible_count"),
-        "rendered": _count("rendered_count"),
-        "selectable": _count("selectable_count"),
-        "hierarchy_rows": _count("hierarchy_rows_count", "hierarchy_rows"),
+        "assembled_preview_item_count": _count("assembled_preview_item_count"),
+        "filtered_visible_candidate_count": _count("filtered_visible_candidate_count"),
+        "forwarded_to_viewport_count": _count("forwarded_to_viewport_count"),
+        "viewport_received_count": _count("viewport_received_count"),
+        "rendered_count": _count("rendered_count"),
+        "selectable_count": _count("selectable_count"),
+        "hierarchy_rows_count": _count("hierarchy_rows_count", "hierarchy_rows"),
     }
 
     blockers: list[str] = []
@@ -133,7 +146,7 @@ def main() -> int:
         blockers.append("runtime acceptance validation failed")
     for k, v in key_counts.items():
         if v <= 0:
-            blockers.append(f"runtime counter not > 0: {k}={v}")
+            blockers.append(f"runtime counter must be > 0: {k}={v}")
 
     artifact = {
         "schema": "scene3d_generated_canvas_acceptance/v1",


### PR DESCRIPTION
### Motivation
- Ensure all mandated runtime/smoke counters are strictly positive before accepting a generated Scene3D canvas. 
- Read counters from both smoke JSON and runtime JSON and only apply alias fallbacks where necessary to avoid missing values. 
- Make failures actionable by recording all counter values and emitting explicit blocker messages for each missing/zero counter.

### Description
- Read both the smoke JSON and the runtime JSON into `smoke_payload` and `runtime_payload`, and expose nested `counters` from each file. 
- Add a unified `_count` helper that checks keys (and aliases) first in the top-level payload, then in the nested `counters`, searching smoke JSON first then runtime JSON. 
- Populate a single `key_counts` map with the mandated counters: `assembled_preview_item_count`, `filtered_visible_candidate_count`, `forwarded_to_viewport_count`, `viewport_received_count`, `rendered_count`, `selectable_count`, and `hierarchy_rows_count` (with alias fallback to `hierarchy_rows`). 
- Add an explicit blocker per counter when a value is missing/zero via `runtime counter must be > 0: <name>=<value>` and retain existing screenshot and command return-code checks, while persisting `key_counts` in the acceptance artifact for debugging. 

### Testing
- Ran `python -m py_compile scripts/run_scene3d_generated_canvas_acceptance.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131e5cac0c8331911000b5712a0dd7)