### PR TITLE
Add actionable generator failure diagnostics to Scene3D acceptance outputs

### DIFF
--- a/scripts/generate_scratch_cell_acceptance.py
+++ b/scripts/generate_scratch_cell_acceptance.py
@@ -12,7 +12,7 @@ def _safe_scene_dir(root:Path,name:str)->Path:
  return d
 
 def _run(cmd:list[str]):
- p=subprocess.run(cmd,capture_output=True,text=True,check=False); return p.returncode,(p.stdout+'\n'+p.stderr).strip()
+ p=subprocess.run(cmd,capture_output=True,text=True,check=False); return p.returncode,p.stdout,p.stderr
 CELL_TMPL='''schema_version: cell_definition/v1
 cell:
   id: {scene}
@@ -88,7 +88,7 @@ commissioning:
 
 def main():
  ap=argparse.ArgumentParser(); ap.add_argument('--scene-name',default=DEFAULT_SCENE); ap.add_argument('--output-root',type=Path,default=Path('/tmp/workcell_studio_scratch_acceptance')); ap.add_argument('--json-out',type=Path); a=ap.parse_args()
- r={'scene_name':a.scene_name,'scene_dir':'','messages_format':'standard_v1','generated_files':[],'missing_files':[],'validation_status':'BLOCKED','blockers':[],'warnings':[],'build_command':'','source_command':'source install/setup.bash','launch_command':'','ready_for_plan_simulate':False,'failure_step':'generation','schema_preflight':{}}
+ r={'scene_name':a.scene_name,'scene_dir':'','messages_format':'standard_v1','generated_files':[],'missing_files':[],'validation_status':'BLOCKED','blockers':[],'warnings':[],'build_command':'','source_command':'source install/setup.bash','launch_command':'','ready_for_plan_simulate':False,'failure_step':'generation','failure_summary':'','schema_preflight':{},'generator':{}}
  if not re.fullmatch(r'[a-z][a-z0-9_]*', a.scene_name): r['blockers'].append(get_message('INVALID_SCENE_NAME'))
  try: a.output_root.mkdir(parents=True,exist_ok=True)
  except Exception as exc: r['blockers'].append(get_message('MISSING_WORKSPACE',detail=f'invalid output root: {a.output_root} ({exc})')); print(json.dumps(r,indent=2)); return 1
@@ -96,7 +96,8 @@ def main():
  if sd.name!=a.scene_name: r['warnings'].append(get_message('SCENE_ALREADY_EXISTS',detail=f'Scene already existed; using {sd.name}'))
  cell=sd/'cell_definition.yaml'; cell.write_text(CELL_TMPL.format(scene=sd.name),encoding='utf-8')
  preflight_cmd=[sys.executable,str(SCRIPTS/'validate_cell_definition.py'),str(cell),'--json']
- preflight_rc,preflight_out=_run(preflight_cmd)
+ preflight_rc,preflight_stdout,preflight_stderr=_run(preflight_cmd)
+ preflight_out=(preflight_stdout+'\n'+preflight_stderr).strip()
  preflight_json={}
  try:
   preflight_json=json.loads(preflight_out)
@@ -118,8 +119,17 @@ def main():
   out=json.dumps(r,indent=2)
   if a.json_out: a.json_out.parent.mkdir(parents=True,exist_ok=True); a.json_out.write_text(out+'\n',encoding='utf-8')
   print(out); return 1
- rc,out=_run([sys.executable,str(SCRIPTS/'generate_workcell_from_cell_definition.py'),str(cell),'--output-dir',str(a.output_root),'--package-name',sd.name,'--force'])
- if rc!=0: r['blockers'].append(get_message('VALIDATION_BLOCKED',title='Generate Scene Package failed',detail=out.splitlines()[-1] if out else 'Generator failed.'))
+ generator_cmd=[sys.executable,str(SCRIPTS/'generate_workcell_from_cell_definition.py'),str(cell),'--output-dir',str(a.output_root),'--package-name',sd.name,'--force']
+ rc,generator_stdout,generator_stderr=_run(generator_cmd)
+ generator_stdout_tail='\n'.join(generator_stdout.splitlines()[-120:])
+ generator_stderr_tail='\n'.join(generator_stderr.splitlines()[-120:])
+ r['generator']={'command':' '.join(generator_cmd),'returncode':rc,'stdout_tail':generator_stdout_tail,'stderr_tail':generator_stderr_tail}
+ if rc!=0:
+  summary=(generator_stderr or generator_stdout).splitlines()[-1] if (generator_stderr or generator_stdout) else 'Generator failed.'
+  r['failure_step']='generation'
+  r['failure_summary']=f'generation failed (rc={rc}): {summary}'
+  r['generator']['failure_summary']=r['failure_summary']
+  r['blockers'].append(get_message('VALIDATION_BLOCKED',title='Generate Scene Package failed',detail=f"{summary} (see JSON: generator.returncode/stdout_tail/stderr_tail/failure_summary)"))
  for rel,txt in [('environment_layout.yaml','schema_version: environment_layout/v1\nassets: []\n'),('config/workcell_builder_task_intent.yaml','task:\n  type: pick_place\n'),('environment.yaml',f'scene_name: {sd.name}\n')]:
   p=sd/rel; p.parent.mkdir(parents=True,exist_ok=True)
   if not p.exists(): p.write_text(txt,encoding='utf-8')

--- a/scripts/run_scene3d_generated_canvas_acceptance.py
+++ b/scripts/run_scene3d_generated_canvas_acceptance.py
@@ -15,6 +15,9 @@ def _run(cmd: list[str], cwd: Path) -> tuple[int, str, str]:
 def _json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
+def _tail(text: str, lines: int = 20) -> str:
+    return "\n".join(text.splitlines()[-lines:])
+
 
 def main() -> int:
     ap = argparse.ArgumentParser()
@@ -47,14 +50,16 @@ def main() -> int:
     if rc != 0:
         step = "generation"
         blockers: list[str] = []
+        failure_summary = "generation command failed"
         if acceptance_json.exists():
             try:
                 generation_payload = _json(acceptance_json)
                 step = str(generation_payload.get("failure_step") or "generation")
                 blockers = list(generation_payload.get("blockers", []))
+                failure_summary = str(generation_payload.get("failure_summary") or failure_summary)
             except Exception:
                 pass
-        print(json.dumps({"status": "FAIL", "step": step, "blockers": blockers, "stdout": so, "stderr": se}, indent=2))
+        print(json.dumps({"status": "FAIL", "step": step, "command": " ".join(generation_cmd), "failure_summary": failure_summary, "blockers": blockers, "stdout_tail": _tail(so), "stderr_tail": _tail(se)}, indent=2))
         return rc
 
     generation_payload = _json(acceptance_json)
@@ -145,17 +150,31 @@ def main() -> int:
     }
 
     blockers: list[str] = []
+    failing_step = ""
+    failing_command = ""
     if missing_outputs:
         blockers.append(f"missing generated outputs: {', '.join(missing_outputs)}")
     if smoke_rc != 0:
         blockers.append("gui smoke command failed")
+        if not failing_step:
+            failing_step = "gui_smoke"
+            failing_command = " ".join(smoke_cmd)
     if not smoke_png.exists() or smoke_png.stat().st_size <= 0:
         blockers.append("gui smoke screenshot missing or empty")
+        if not failing_step:
+            failing_step = "gui_smoke"
+            failing_command = " ".join(smoke_cmd)
     if runtime_rc != 0:
         blockers.append("runtime acceptance validation failed")
+        if not failing_step:
+            failing_step = "runtime_acceptance"
+            failing_command = " ".join(runtime_cmd)
     for k, v in key_counts.items():
         if v <= 0:
             blockers.append(f"runtime counter must be > 0: {k}={v}")
+            if not failing_step:
+                failing_step = "runtime_acceptance"
+                failing_command = " ".join(runtime_cmd)
 
     artifact = {
         "schema": "scene3d_generated_canvas_acceptance/v1",
@@ -175,11 +194,13 @@ def main() -> int:
             "json": str(smoke_json),
             "screenshot": str(smoke_png),
             "screenshot_size": smoke_png.stat().st_size if smoke_png.exists() else 0,
-            "stdout_tail": "\n".join(so.splitlines()[-20:]),
-            "stderr_tail": "\n".join(se.splitlines()[-20:]),
+            "stdout_tail": "\n".join(smoke_so.splitlines()[-20:]),
+            "stderr_tail": "\n".join(smoke_se.splitlines()[-20:]),
         },
         "runtime_acceptance": {"returncode": runtime_rc, "json": str(runtime_json), "markdown": str(runtime_md), "stdout_tail": "\n".join(runtime_so.splitlines()[-20:]), "stderr_tail": "\n".join(runtime_se.splitlines()[-20:])},
         "key_counts": key_counts,
+        "failing_step": failing_step,
+        "failing_command": failing_command,
         "blockers": blockers,
     }
     out_json = out_dir / f"{args.scene_name}_acceptance.json"
@@ -201,6 +222,10 @@ def main() -> int:
             "",
             "## Blockers",
             *([f"- {b}" for b in blockers] or ["- none"]),
+            "",
+            "## Failure diagnostics",
+            (f"- failing_step: `{failing_step}`" if failing_step else "- failing_step: none"),
+            (f"- failing_command: `{failing_command}`" if failing_command else "- failing_command: none"),
             "",
             "## Artifacts",
             f"- `{out_json}`",


### PR DESCRIPTION
### Motivation
- Make scene-generation failures easier to triage by persisting the full generator command and structured diagnostic fields so callers can act on failures without rerunning. 
- Surface concise, actionable failure context in top-level failure prints and final acceptance artifacts so CI / automation consumers know the failing step and exact command.

### Description
- Change `_run` in `scripts/generate_scratch_cell_acceptance.py` to return `(returncode, stdout, stderr)` so stdout and stderr can be recorded separately. 
- Persist a `generator` object in the generator JSON payload that includes the full `command`, `returncode`, `stdout_tail`, `stderr_tail`, and a concise `failure_summary` when the generator exits non-zero, and keep blocker text concise while pointing to these JSON fields. 
- Update `scripts/run_scene3d_generated_canvas_acceptance.py` to print an immediate failing `step`, the failing `command`, `failure_summary`, and `stdout_tail`/`stderr_tail` when generation fails so failures are actionable without reruns. 
- Add `failing_step` and `failing_command` to the final acceptance JSON and include a short "Failure diagnostics" section in the acceptance Markdown; also ensure GUI smoke stdout/stderr tails are taken from the smoke step outputs.

### Testing
- Ran `python -m py_compile scripts/generate_scratch_cell_acceptance.py scripts/run_scene3d_generated_canvas_acceptance.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a134c58662c8331b3768a45f6ccdcee)