### PR TITLE
Add scratch-cell acceptance preflight tests and tighten Scene3D generated-canvas assertions

### DIFF
--- a/tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py
+++ b/tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py
@@ -1,0 +1,96 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+spec = importlib.util.spec_from_file_location("scratch_acceptance", SCRIPTS / "generate_scratch_cell_acceptance.py")
+target = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(target)
+
+
+def test_generated_scratch_schema_preflight_zero_errors_and_generation_attempt(tmp_path, monkeypatch):
+    report = tmp_path / "acceptance.json"
+    monkeypatch.setattr(target.sys, "argv", ["prog", "--scene-name", "scratchacceptancetest", "--output-root", str(tmp_path / "out"), "--json-out", str(report)])
+
+    calls = []
+
+    def fake_run(cmd):
+        calls.append(" ".join(cmd))
+        cmd_s = " ".join(cmd)
+        if "validate_cell_definition.py" in cmd_s:
+            return 0, json.dumps({"errors": [], "warnings": []}), ""
+        if "generate_workcell_from_cell_definition.py" in cmd_s:
+            scene_name = cmd[cmd.index("--package-name") + 1]
+            scene_dir = (tmp_path / "out" / scene_name)
+            for rel in ("scene_manifest.yaml", "config/scene3d_mesh_index.json", "urdf/scene.urdf.xacro", "launch/demo.launch.py", "package.xml", "CMakeLists.txt"):
+                p = scene_dir / rel
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text("x", encoding="utf-8")
+            return 0, "ok", ""
+        if "audit_new_cell_file_outputs.py" in cmd_s:
+            return 0, "ok"
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(target, "_run", fake_run)
+    rc = target.main()
+    payload = json.loads(report.read_text(encoding="utf-8"))
+
+    assert rc == 0
+    assert payload["schema_preflight"]["schema_blockers"] == []
+    assert payload["schema_preflight"]["returncode"] == 0
+    assert any("generate_workcell_from_cell_definition.py" in c for c in calls)
+    assert "generate_workcell_from_cell_definition.py" in payload["generator"]["command"]
+
+
+def test_generated_template_objects_pose_and_task_binding_integrity():
+    doc = target.CELL_TMPL.format(scene="demo")
+    assert "objects:" in doc
+    assert "- id: pick_part" in doc
+    assert "- id: place_bin" in doc
+    assert "pose_xyz:" in doc and "pose_rpy:" in doc
+    assert "source_object: pick_part" in doc
+    assert "destination: place_bin" in doc
+
+
+def test_intentionally_broken_definition_reports_multiple_missing_keys(tmp_path):
+    broken = tmp_path / "broken_cell.yaml"
+    broken.write_text("schema_version: cell_definition/v1\ncell:\n  id: broken\n  name: broken\n", encoding="utf-8")
+    proc = __import__("subprocess").run(["python3", str(SCRIPTS / "validate_cell_definition.py"), str(broken), "--json"], capture_output=True, text=True, check=False)
+    payload = json.loads((proc.stdout or proc.stderr).strip())
+    assert proc.returncode != 0
+    assert len(payload.get("errors", [])) >= 2
+
+
+def test_acceptance_artifact_records_package_generation_command(tmp_path, monkeypatch):
+    report = tmp_path / "acceptance.json"
+    monkeypatch.setattr(target.sys, "argv", ["prog", "--scene-name", "scratchcmdtest", "--output-root", str(tmp_path / "out"), "--json-out", str(report)])
+
+    def fake_run(cmd):
+        cmd_s = " ".join(cmd)
+        if "validate_cell_definition.py" in cmd_s:
+            return 0, json.dumps({"errors": [], "warnings": []}), ""
+        if "generate_workcell_from_cell_definition.py" in cmd_s:
+            scene_name = cmd[cmd.index("--package-name") + 1]
+            scene_dir = (tmp_path / "out" / scene_name)
+            (scene_dir / "launch").mkdir(parents=True, exist_ok=True)
+            for rel in target.REQUIRED:
+                p = scene_dir / rel
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text("x", encoding="utf-8")
+            return 0, "ok", ""
+        if "audit_new_cell_file_outputs.py" in cmd_s:
+            return 0, "ok"
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(target, "_run", fake_run)
+    rc = target.main()
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert rc == 0
+    assert "generator" in payload and "command" in payload["generator"]
+    assert "--package-name" in payload["generator"]["command"]

--- a/tests/test_scene3d_generated_canvas_acceptance.py
+++ b/tests/test_scene3d_generated_canvas_acceptance.py
@@ -30,7 +30,7 @@ def test_generated_canvas_acceptance_exports_artifacts(monkeypatch, tmp_path: Pa
         if "run_workcell_builder_scene3d_gui_smoke.py" in cmd_s:
             smoke_json = Path(cmd[cmd.index("--output") + 1])
             smoke_png = Path(cmd[cmd.index("--screenshot") + 1])
-            smoke_json.write_text(json.dumps({"counters": {"visible_count": 1, "rendered_count": 1, "selectable_count": 1, "hierarchy_rows": 1}}), encoding="utf-8")
+            smoke_json.write_text(json.dumps({"counters": {"assembled_preview_item_count": 1, "filtered_visible_candidate_count": 1, "forwarded_to_viewport_count": 1, "viewport_received_count": 1, "rendered_count": 1, "selectable_count": 1, "hierarchy_rows": 1}}), encoding="utf-8")
             smoke_png.write_bytes(b"png")
             return 0, "ok", ""
         if "validate_scene3d_runtime_acceptance.py" in cmd_s:
@@ -49,5 +49,11 @@ def test_generated_canvas_acceptance_exports_artifacts(monkeypatch, tmp_path: Pa
     assert rc == 0
     artifact = json.loads((out_dir / f"{scene_name}_acceptance.json").read_text(encoding="utf-8"))
     assert artifact["status"] == "PASS"
-    assert artifact["key_counts"]["visible"] > 0
+    assert artifact["key_counts"]["assembled_preview_item_count"] > 0
+    assert artifact["key_counts"]["filtered_visible_candidate_count"] > 0
+    assert artifact["key_counts"]["forwarded_to_viewport_count"] > 0
+    assert artifact["key_counts"]["viewport_received_count"] > 0
+    assert artifact["key_counts"]["rendered_count"] > 0
+    assert artifact["key_counts"]["selectable_count"] > 0
+    assert artifact["key_counts"]["hierarchy_rows_count"] > 0
     assert Path(artifact["gui_smoke"]["screenshot"]).stat().st_size > 0


### PR DESCRIPTION
### Motivation
- Increase automated coverage for the scratch acceptance flow by verifying the generated scratch `cell_definition` template passes schema preflight and that generated artifacts record generator invocations. 
- Validate that the scratch template contains `objects` entries with required `pose_xyz`/`pose_rpy` fields and that task bindings reference real object IDs. 
- Ensure validator behavior surfaces multiple schema errors in a single preflight result instead of stopping at the first failure. 
- Strengthen Scene3D generated-canvas acceptance expectations by asserting all required positive runtime counter keys are present in artifacts.

### Description
- Added `tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py` which imports the `scripts/generate_scratch_cell_acceptance.py` module via an importlib spec and adds tests for schema preflight success, object/pose and task-binding integrity, multi-error preflight reporting, and package-generation command recording in the generated artifact. 
- Tests use a `fake_run`/monkeypatch strategy that stubs calls to the schema validator, package generator, and file-audit scripts to provide deterministic responses and to assert generator invocation was recorded in the artifact. 
- Updated `tests/test_scene3d_generated_canvas_acceptance.py` to require the full set of Scene3D positive counters (`assembled_preview_item_count`, `filtered_visible_candidate_count`, `forwarded_to_viewport_count`, `viewport_received_count`, `rendered_count`, `selectable_count`, and `hierarchy_rows_count`) when validating the generated acceptance artifact. 
- Test code checks generated JSON artifacts written by the scripts and asserts command strings include `--package-name` and that generator commands are present in the `generator` field when generation proceeds.

### Testing
- Ran the targeted pytest suite with `pytest -q tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py tests/test_scene3d_generated_canvas_acceptance.py -q`, and the tests completed successfully. 
- The added tests exercise the acceptance flow paths via monkeypatched command runners and validate recorded artifact fields (all assertions passed in the targeted run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a134d14f7388331bbda0f0ac52e16af)