### PR TITLE
Fix generated Scene3D acceptance crash, stale JSON reuse, and preflight diagnostics

### DIFF
--- a/scripts/generate_scratch_cell_acceptance.py
+++ b/scripts/generate_scratch_cell_acceptance.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import argparse, json, subprocess, sys, re
+import argparse, json, subprocess, sys, re, hashlib
+from datetime import datetime, timezone
 from pathlib import Path
+import yaml
 from workcell_studio_error_messages import get_message
 REPO_ROOT=Path(__file__).resolve().parents[1]; SCRIPTS=REPO_ROOT/'scripts'; DEFAULT_SCENE='scratch_ur5_2f_acceptance'
 REQUIRED=['environment.yaml','environment_layout.yaml','config/workcell_builder_task_intent.yaml','cell_definition.yaml','scene_manifest.yaml','package.xml','CMakeLists.txt','launch/demo.launch.py']
@@ -90,14 +92,21 @@ commissioning:
 '''
 
 def main():
- ap=argparse.ArgumentParser(); ap.add_argument('--scene-name',default=DEFAULT_SCENE); ap.add_argument('--output-root',type=Path,default=Path('/tmp/workcell_studio_scratch_acceptance')); ap.add_argument('--json-out',type=Path); a=ap.parse_args()
- r={'scene_name':a.scene_name,'scene_dir':'','messages_format':'standard_v1','generated_files':[],'missing_files':[],'validation_status':'BLOCKED','blockers':[],'warnings':[],'build_command':'','source_command':'source install/setup.bash','launch_command':'','ready_for_plan_simulate':False,'failure_step':'generation','failure_summary':'','next_failed_step':'generation','schema_preflight':{},'generator':{}}
+ ap=argparse.ArgumentParser(); ap.add_argument('--scene-name',default=DEFAULT_SCENE); ap.add_argument('--output-root',type=Path,default=Path('/tmp/workcell_studio_scratch_acceptance')); ap.add_argument('--json-out',type=Path); ap.add_argument('--run-id',default=''); a=ap.parse_args()
+ run_id=a.run_id or datetime.now(timezone.utc).isoformat()
+ r={'run_id':run_id,'scene_name':a.scene_name,'scene_dir':'','messages_format':'standard_v1','generated_files':[],'missing_files':[],'validation_status':'BLOCKED','blockers':[],'warnings':[],'build_command':'','source_command':'source install/setup.bash','launch_command':'','ready_for_plan_simulate':False,'failure_step':'generation','failure_summary':'','next_failed_step':'generation','schema_preflight':{},'generator':{},'file_output_audit':{}}
  if not re.fullmatch(r'[a-z][a-z0-9_]*', a.scene_name): r['blockers'].append(get_message('INVALID_SCENE_NAME'))
  try: a.output_root.mkdir(parents=True,exist_ok=True)
  except Exception as exc: r['blockers'].append(get_message('MISSING_WORKSPACE',detail=f'invalid output root: {a.output_root} ({exc})')); print(json.dumps(r,indent=2)); return 1
  sd=_safe_scene_dir(a.output_root,a.scene_name); sd.mkdir(parents=True,exist_ok=True); r['scene_dir']=str(sd)
  if sd.name!=a.scene_name: r['warnings'].append(get_message('SCENE_ALREADY_EXISTS',detail=f'Scene already existed; using {sd.name}'))
  cell=sd/'cell_definition.yaml'; cell.write_text(CELL_TMPL.format(scene=sd.name),encoding='utf-8')
+ cell_text=cell.read_text(encoding='utf-8')
+ cell_sha256=hashlib.sha256(cell_text.encode('utf-8')).hexdigest()
+ cell_doc=yaml.safe_load(cell_text) if cell_text.strip() else {}
+ top_level_keys=sorted(list(cell_doc.keys())) if isinstance(cell_doc,dict) else []
+ objects=cell_doc.get('objects',[]) if isinstance(cell_doc,dict) else []
+ task_destinations=((cell_doc.get('task') or {}).get('destinations') or []) if isinstance(cell_doc,dict) else []
  preflight_cmd=[sys.executable,str(SCRIPTS/'validate_cell_definition.py'),str(cell),'--json']
  preflight_rc,preflight_stdout,preflight_stderr=_run(preflight_cmd)
  preflight_out=(preflight_stdout+'\n'+preflight_stderr).strip()
@@ -109,8 +118,13 @@ def main():
  preflight_errors=list(preflight_json.get('errors',[])) if isinstance(preflight_json,dict) else []
  preflight_warnings=list(preflight_json.get('warnings',[])) if isinstance(preflight_json,dict) else []
  r['schema_preflight']={
-  'command':' '.join(preflight_cmd),
-  'returncode':preflight_rc,
+  'validator_command':' '.join(preflight_cmd),
+  'validator_returncode':preflight_rc,
+  'cell_definition_path':str(cell.resolve()),
+  'cell_definition_sha256':cell_sha256,
+  'cell_definition_top_level_keys':top_level_keys,
+  'object_count':len(objects) if isinstance(objects,list) else 0,
+  'task_destination_count':len(task_destinations) if isinstance(task_destinations,list) else 0,
   'stdout_stderr':preflight_out,
   'stdout_stderr_tail':'\n'.join(preflight_out.splitlines()[-120:]),
   'schema_blockers':preflight_errors,
@@ -147,7 +161,12 @@ def main():
  if 'use_fake_hardware:=false' in r['launch_command']: r['blockers'].append(get_message('MISSING_FAKE_HARDWARE_ARG', detail='Unsafe launch command includes use_fake_hardware:=false'))
  if not list(REPO_ROOT.rglob('*ur5*')): r['warnings'].append(get_message('VALIDATION_BLOCKED', title='Missing UR5 assets', detail='Repository search did not find ur5 tokens.'))
  if not (list(REPO_ROOT.rglob('*robotiq*2f*'))+list(REPO_ROOT.rglob('*2f_85*'))): r['warnings'].append(get_message('VALIDATION_BLOCKED', title='Missing Robotiq 2F assets', detail='Repository search did not find robotiq 2f tokens.'))
- _rc,_out=_run([sys.executable,str(SCRIPTS/'audit_new_cell_file_outputs.py'),'--scene-dir',str(sd),'--scene-name',sd.name,'--json-out',str(sd/'file_output_audit.json')])
+ audit_cmd=[sys.executable,str(SCRIPTS/'audit_new_cell_file_outputs.py'),'--scene-dir',str(sd),'--scene-name',sd.name,'--json-out',str(sd/'file_output_audit.json')]
+ audit_rc,audit_stdout,audit_stderr=_run(audit_cmd)
+ r['file_output_audit']={'command':' '.join(audit_cmd),'returncode':audit_rc,'stdout_tail':'\n'.join(audit_stdout.splitlines()[-120:]),'stderr_tail':'\n'.join(audit_stderr.splitlines()[-120:])}
+ if audit_rc!=0:
+  r['blockers'].append(f'file_output_audit failed (rc={audit_rc})')
+  r['next_failed_step']='file_output_audit'
  r['validation_status']='PASS' if not r['blockers'] and not r['missing_files'] else 'BLOCKED'; r['ready_for_plan_simulate']=r['validation_status']=='PASS'
  out=json.dumps(r,indent=2)
  if a.json_out: a.json_out.parent.mkdir(parents=True,exist_ok=True); a.json_out.write_text(out+'\n',encoding='utf-8')

--- a/scripts/run_scene3d_generated_canvas_acceptance.py
+++ b/scripts/run_scene3d_generated_canvas_acceptance.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import argparse, json, subprocess, sys
+import argparse, json, subprocess, sys, uuid
 from pathlib import Path
 
 DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -36,6 +36,9 @@ def main() -> int:
     generated_root.mkdir(parents=True, exist_ok=True)
 
     acceptance_json = out_dir / f"{args.scene_name}_generation.json"
+    if acceptance_json.exists():
+        acceptance_json.unlink()
+    run_id = str(uuid.uuid4())
     generation_cmd = [
         sys.executable,
         str(repo_root / "scripts" / "generate_scratch_cell_acceptance.py"),
@@ -45,6 +48,8 @@ def main() -> int:
         str(generated_root),
         "--json-out",
         str(acceptance_json),
+        "--run-id",
+        run_id,
     ]
     rc, so, se = _run(generation_cmd, repo_root)
     if rc != 0:
@@ -55,9 +60,11 @@ def main() -> int:
         schema_preflight: dict = {}
         generated_files: list[str] = []
         missing_files: list[str] = []
+        stale_or_missing = True
         if acceptance_json.exists():
             try:
                 generation_payload = _json(acceptance_json)
+                stale_or_missing = generation_payload.get("run_id") != run_id
                 step = str(generation_payload.get("failure_step") or generation_payload.get("next_failed_step") or "generation")
                 blockers = list(generation_payload.get("blockers", []))
                 failure_summary = str(generation_payload.get("failure_summary") or failure_summary)
@@ -66,14 +73,20 @@ def main() -> int:
                 missing_files = list(generation_payload.get("missing_files", []))
             except Exception:
                 pass
+        if stale_or_missing:
+            blockers = [*blockers, "generation_report_missing_or_stale"]
         print(json.dumps({
             "status": "FAIL",
-            "step": step,
+            "step": "generation" if stale_or_missing else step,
             "command": " ".join(generation_cmd),
+            "returncode": rc,
             "failure_summary": failure_summary,
             "blockers": blockers,
+            "generation_json_path": str(acceptance_json),
+            "generation_json_exists": acceptance_json.exists(),
+            "generation_json_run_id_matches": (generation_payload.get("run_id") == run_id) if generation_payload else False,
             "schema_preflight": {
-                "validator_command": schema_preflight.get("command", ""),
+                "validator_command": schema_preflight.get("validator_command", schema_preflight.get("command", "")),
                 "schema_blockers": schema_preflight.get("schema_blockers", []),
                 "next_failed_step": schema_preflight.get("next_failed_step", step),
             },
@@ -85,6 +98,20 @@ def main() -> int:
         return rc
 
     generation_payload = _json(acceptance_json)
+    if generation_payload.get("run_id") != run_id:
+        print(json.dumps({
+            "status": "FAIL",
+            "step": "generation",
+            "command": " ".join(generation_cmd),
+            "returncode": rc,
+            "blockers": ["generation_report_missing_or_stale"],
+            "generation_json_path": str(acceptance_json),
+            "generation_json_exists": acceptance_json.exists(),
+            "generation_json_run_id_matches": False,
+            "stdout_tail": _tail(so),
+            "stderr_tail": _tail(se),
+        }, indent=2))
+        return 1
     scene_dir = Path(generation_payload["scene_dir"]).resolve()
 
     required_outputs = [

--- a/tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py
+++ b/tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py
@@ -2,6 +2,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / "scripts"
@@ -34,7 +35,7 @@ def test_generated_scratch_schema_preflight_zero_errors_and_generation_attempt(t
                 p.write_text("x", encoding="utf-8")
             return 0, "ok", ""
         if "audit_new_cell_file_outputs.py" in cmd_s:
-            return 0, "ok"
+            return 0, "ok", ""
         raise AssertionError(cmd)
 
     monkeypatch.setattr(target, "_run", fake_run)
@@ -43,8 +44,11 @@ def test_generated_scratch_schema_preflight_zero_errors_and_generation_attempt(t
 
     assert rc == 0
     assert payload["schema_preflight"]["schema_blockers"] == []
-    assert payload["schema_preflight"]["returncode"] == 0
-    assert "validate_cell_definition.py" in payload["schema_preflight"]["command"]
+    assert payload["schema_preflight"]["validator_returncode"] == 0
+    assert "validate_cell_definition.py" in payload["schema_preflight"]["validator_command"]
+    assert payload["schema_preflight"]["cell_definition_path"].endswith("cell_definition.yaml")
+    assert "objects" in payload["schema_preflight"]["cell_definition_top_level_keys"]
+    assert payload["schema_preflight"]["object_count"] > 0
     assert payload["schema_preflight"]["next_failed_step"] == "generation"
     assert any("generate_workcell_from_cell_definition.py" in c for c in calls)
     assert "generate_workcell_from_cell_definition.py" in payload["generator"]["command"]
@@ -89,7 +93,7 @@ def test_acceptance_artifact_records_package_generation_command(tmp_path, monkey
                 p.write_text("x", encoding="utf-8")
             return 0, "ok", ""
         if "audit_new_cell_file_outputs.py" in cmd_s:
-            return 0, "ok"
+            return 0, "ok", ""
         raise AssertionError(cmd)
 
     monkeypatch.setattr(target, "_run", fake_run)
@@ -126,7 +130,7 @@ def test_generated_file_and_missing_file_lists_recorded(tmp_path, monkeypatch):
                 p.write_text('x', encoding='utf-8')
             return 0, 'ok', ''
         if 'audit_new_cell_file_outputs.py' in cmd_s:
-            return 0, 'ok'
+            return 0, 'ok', ''
         raise AssertionError(cmd)
 
     monkeypatch.setattr(target, '_run', fake_run)
@@ -135,3 +139,36 @@ def test_generated_file_and_missing_file_lists_recorded(tmp_path, monkeypatch):
     assert isinstance(payload['generated_files'], list)
     assert isinstance(payload['missing_files'], list)
     assert payload['schema_preflight']['missing_package_files'] == payload['missing_files']
+
+
+def test_audit_failure_recorded_not_crashed(tmp_path, monkeypatch):
+    report = tmp_path / "acceptance.json"
+    monkeypatch.setattr(target.sys, "argv", ["prog", "--scene-name", "scratchauditfail", "--output-root", str(tmp_path / "out"), "--json-out", str(report)])
+
+    def fake_run(cmd):
+        cmd_s = " ".join(cmd)
+        if "validate_cell_definition.py" in cmd_s:
+            return 0, json.dumps({"errors": [], "warnings": []}), ""
+        if "generate_workcell_from_cell_definition.py" in cmd_s:
+            scene_name = cmd[cmd.index("--package-name") + 1]
+            scene_dir = (tmp_path / "out" / scene_name)
+            for rel in target.REQUIRED:
+                p = scene_dir / rel
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text("x", encoding="utf-8")
+            return 0, "ok", ""
+        if "audit_new_cell_file_outputs.py" in cmd_s:
+            return 9, "", "audit fail"
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(target, "_run", fake_run)
+    rc = target.main()
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert rc == 1
+    assert payload["file_output_audit"]["returncode"] == 9
+    assert payload["next_failed_step"] == "file_output_audit"
+
+
+def test_cell_template_yaml_has_top_level_objects():
+    doc = yaml.safe_load(target.CELL_TMPL.format(scene="demo"))
+    assert "objects" in doc

--- a/tests/test_scene3d_generated_canvas_acceptance.py
+++ b/tests/test_scene3d_generated_canvas_acceptance.py
@@ -25,7 +25,7 @@ def test_generated_canvas_acceptance_exports_artifacts(monkeypatch, tmp_path: Pa
             (scene_dir / "CMakeLists.txt").write_text("x", encoding="utf-8")
             gen_json = Path(cmd[cmd.index("--json-out") + 1])
             gen_json.parent.mkdir(parents=True, exist_ok=True)
-            gen_json.write_text(json.dumps({"scene_dir": str(scene_dir)}), encoding="utf-8")
+            gen_json.write_text(json.dumps({"scene_dir": str(scene_dir), "run_id": cmd[cmd.index("--run-id") + 1]}), encoding="utf-8")
             return 0, "ok", ""
         if "run_workcell_builder_scene3d_gui_smoke.py" in cmd_s:
             smoke_json = Path(cmd[cmd.index("--output") + 1])
@@ -72,10 +72,11 @@ def test_generated_canvas_acceptance_failure_reports_schema_blockers(monkeypatch
                 'failure_summary': 'schema invalid',
                 'blockers': ['schema_preflight: Missing required top-level key: objects', 'schema_preflight: Missing required top-level key: commissioning'],
                 'schema_preflight': {
-                    'command': 'python3 scripts/validate_cell_definition.py /tmp/cell.yaml --json',
+                    'validator_command': 'python3 scripts/validate_cell_definition.py /tmp/cell.yaml --json',
                     'schema_blockers': ['Missing required top-level key: objects', 'Missing required top-level key: commissioning'],
                     'next_failed_step': 'schema_preflight'
                 },
+                'run_id': cmd[cmd.index("--run-id") + 1],
                 'generated_files': ['cell_definition.yaml'],
                 'missing_files': ['scene_manifest.yaml', 'package.xml', 'CMakeLists.txt', 'launch/demo.launch.py']
             }), encoding='utf-8')
@@ -86,3 +87,39 @@ def test_generated_canvas_acceptance_failure_reports_schema_blockers(monkeypatch
     monkeypatch.setattr(target.sys, 'argv', ['prog', '--output-dir', str(out_dir), '--scene-name', scene_name])
     rc = target.main()
     assert rc == 1
+
+
+def test_generation_crash_reports_missing_or_stale(monkeypatch, tmp_path: Path, capsys):
+    out_dir = tmp_path / "out"
+
+    def fake_run(cmd, cwd):
+        if "generate_scratch_cell_acceptance.py" in " ".join(cmd):
+            return 2, "", "traceback"
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(target, "_run", fake_run)
+    monkeypatch.setattr(target.sys, "argv", ["prog", "--output-dir", str(out_dir)])
+    rc = target.main()
+    assert rc == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert "generation_report_missing_or_stale" in payload["blockers"]
+    assert payload["step"] == "generation"
+
+
+def test_stale_generation_json_not_reused(monkeypatch, tmp_path: Path, capsys):
+    out_dir = tmp_path / "out"
+
+    def fake_run(cmd, cwd):
+        if "generate_scratch_cell_acceptance.py" in " ".join(cmd):
+            gen_json = Path(cmd[cmd.index("--json-out") + 1])
+            gen_json.parent.mkdir(parents=True, exist_ok=True)
+            gen_json.write_text(json.dumps({"scene_dir": str(out_dir / "x"), "run_id": "old-run"}), encoding="utf-8")
+            return 0, "ok", ""
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(target, "_run", fake_run)
+    monkeypatch.setattr(target.sys, "argv", ["prog", "--output-dir", str(out_dir)])
+    rc = target.main()
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["blockers"] == ["generation_report_missing_or_stale"]


### PR DESCRIPTION
### Motivation

- The generated-scene acceptance run was crashing during audit due to inconsistent `_run()` unpacking and then reading stale generation JSON, producing misleading "Missing required top-level key: objects" diagnostics. 
- The wrapper must refuse to consume stale or partial generation reports and instead surface a clear, actionable blocker when generation crashes or fails to write a current report. 
- Schema preflight evidence must include exact file context so missing-top-level-key errors are diagnosable (which file was validated and what keys it contained).

### Description

- Fixed all `_run` usage so subprocess results are consistently unpacked as `(returncode, stdout, stderr)` and the remaining 2-value unpack in `scripts/generate_scratch_cell_acceptance.py` was corrected to record audit returncode/stdout/stderr instead of crashing. 
- Enhanced `scripts/generate_scratch_cell_acceptance.py` to emit `run_id`, compute `cell_definition_sha256`, parse the `CELL_TMPL` YAML and record `cell_definition_path`, `cell_definition_top_level_keys`, `object_count`, `task_destination_count`, `validator_command`, and `validator_returncode` in `schema_preflight`; added durable `file_output_audit` fields (`command`, `returncode`, `stdout_tail`, `stderr_tail`) and record audit failures as blockers without raising. 
- Updated `scripts/run_scene3d_generated_canvas_acceptance.py` to remove any prior generation JSON before invoking the generator, pass a unique `--run-id` to the generator, validate the `run_id` on read, and refuse to consume stale/mismatched generation JSON by returning an explicit `generation_report_missing_or_stale` blocker and current subprocess diagnostics. 
- Added and updated tests in `tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py` and `tests/test_scene3d_generated_canvas_acceptance.py` to cover `_run` unpacking, audit failure recording, propagation of `run_id`, stale/missing generation JSON handling, schema preflight diagnostics, and that `CELL_TMPL` YAML includes top-level `objects`.

### Testing

- Ran the updated unit tests `pytest -q tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py tests/test_scene3d_generated_canvas_acceptance.py`, and all tests passed (`12 passed`).
- New/updated tests cover: `_run` 3-value unpacking sites, audit failure recorded (not crashed), wrapper refusing stale generation JSON, generation-crash -> `generation_report_missing_or_stale` blocker, and `schema_preflight` recording of `cell_definition_path`, top-level keys and object counts. 
- No manual ROS/colcon runtime validation was executed in this environment (automated tests only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13576352ac8331a7cd36d13fd5b5e9)