### PR TITLE
Clarify scene3d generated-canvas required outputs and optional geometry fallback

### DIFF
--- a/scripts/run_scene3d_generated_canvas_acceptance.py
+++ b/scripts/run_scene3d_generated_canvas_acceptance.py
@@ -117,13 +117,17 @@ def main() -> int:
     required_outputs = [
         "scene_manifest.yaml",
         "environment_layout.yaml",
-        "config/scene3d_mesh_index.json",
-        "urdf/scene.urdf.xacro",
         "launch/demo.launch.py",
         "package.xml",
         "CMakeLists.txt",
+        "cell_definition.yaml",
+    ]
+    optional_geometry_outputs = [
+        "config/scene3d_mesh_index.json",
+        "urdf/scene.urdf.xacro",
     ]
     missing_outputs = [r for r in required_outputs if not (scene_dir / r).exists()]
+    missing_optional_geometry_outputs = [r for r in optional_geometry_outputs if not (scene_dir / r).exists()]
 
     smoke_json = out_dir / f"scene3d_gui_smoke_{args.scene_name}.json"
     smoke_png = out_dir / f"scene3d_gui_smoke_{args.scene_name}.png"
@@ -224,6 +228,13 @@ def main() -> int:
             if not failing_step:
                 failing_step = "runtime_acceptance"
                 failing_command = " ".join(runtime_cmd)
+    if missing_optional_geometry_outputs and any(v <= 0 for v in key_counts.values()):
+        blockers.append(
+            "optional geometry outputs missing while runtime/render counters do not prove primitive/layout fallback path"
+        )
+        if not failing_step:
+            failing_step = "runtime_acceptance"
+            failing_command = " ".join(runtime_cmd)
 
     artifact = {
         "schema": "scene3d_generated_canvas_acceptance/v1",
@@ -237,7 +248,9 @@ def main() -> int:
         },
         "generation": generation_payload,
         "required_outputs": required_outputs,
+        "optional_geometry_outputs": optional_geometry_outputs,
         "missing_outputs": missing_outputs,
+        "missing_optional_geometry_outputs": missing_optional_geometry_outputs,
         "gui_smoke": {
             "returncode": smoke_rc,
             "json": str(smoke_json),

--- a/tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py
+++ b/tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py
@@ -172,3 +172,13 @@ def test_audit_failure_recorded_not_crashed(tmp_path, monkeypatch):
 def test_cell_template_yaml_has_top_level_objects():
     doc = yaml.safe_load(target.CELL_TMPL.format(scene="demo"))
     assert "objects" in doc
+
+
+def test_required_contract_files_include_core_package_contract():
+    required = set(target.REQUIRED)
+    assert "package.xml" in required
+    assert "CMakeLists.txt" in required
+    assert "scene_manifest.yaml" in required
+    assert "environment_layout.yaml" in required
+    assert "launch/demo.launch.py" in required
+    assert "cell_definition.yaml" in required

--- a/tests/test_scene3d_generated_canvas_acceptance.py
+++ b/tests/test_scene3d_generated_canvas_acceptance.py
@@ -23,6 +23,7 @@ def test_generated_canvas_acceptance_exports_artifacts(monkeypatch, tmp_path: Pa
             (scene_dir / "launch/demo.launch.py").write_text("x", encoding="utf-8")
             (scene_dir / "package.xml").write_text("x", encoding="utf-8")
             (scene_dir / "CMakeLists.txt").write_text("x", encoding="utf-8")
+            (scene_dir / "cell_definition.yaml").write_text("x", encoding="utf-8")
             gen_json = Path(cmd[cmd.index("--json-out") + 1])
             gen_json.parent.mkdir(parents=True, exist_ok=True)
             gen_json.write_text(json.dumps({"scene_dir": str(scene_dir), "run_id": cmd[cmd.index("--run-id") + 1]}), encoding="utf-8")
@@ -57,6 +58,48 @@ def test_generated_canvas_acceptance_exports_artifacts(monkeypatch, tmp_path: Pa
     assert artifact["key_counts"]["selectable_count"] > 0
     assert artifact["key_counts"]["hierarchy_rows_count"] > 0
     assert Path(artifact["gui_smoke"]["screenshot"]).stat().st_size > 0
+    assert artifact["missing_optional_geometry_outputs"] == []
+
+
+def test_generated_canvas_acceptance_allows_optional_geometry_outputs_when_runtime_counters_pass(monkeypatch, tmp_path: Path):
+    scene_name = "scene3d_generated_canvas_acceptance"
+    out_dir = tmp_path / "out"
+    scene_dir = out_dir / "generated_scenes" / scene_name
+
+    def fake_run(cmd, cwd):
+        cmd_s = " ".join(cmd)
+        if "generate_scratch_cell_acceptance.py" in cmd_s:
+            (scene_dir / "launch").mkdir(parents=True, exist_ok=True)
+            (scene_dir / "scene_manifest.yaml").write_text("x", encoding="utf-8")
+            (scene_dir / "environment_layout.yaml").write_text("x", encoding="utf-8")
+            (scene_dir / "launch/demo.launch.py").write_text("x", encoding="utf-8")
+            (scene_dir / "package.xml").write_text("x", encoding="utf-8")
+            (scene_dir / "CMakeLists.txt").write_text("x", encoding="utf-8")
+            (scene_dir / "cell_definition.yaml").write_text("x", encoding="utf-8")
+            gen_json = Path(cmd[cmd.index("--json-out") + 1])
+            gen_json.parent.mkdir(parents=True, exist_ok=True)
+            gen_json.write_text(json.dumps({"scene_dir": str(scene_dir), "run_id": cmd[cmd.index("--run-id") + 1]}), encoding="utf-8")
+            return 0, "ok", ""
+        if "run_workcell_builder_scene3d_gui_smoke.py" in cmd_s:
+            smoke_json = Path(cmd[cmd.index("--output") + 1])
+            smoke_png = Path(cmd[cmd.index("--screenshot") + 1])
+            smoke_json.write_text(json.dumps({"counters": {"assembled_preview_item_count": 2, "filtered_visible_candidate_count": 2, "forwarded_to_viewport_count": 2, "viewport_received_count": 2, "rendered_count": 2, "selectable_count": 2, "hierarchy_rows": 2}}), encoding="utf-8")
+            smoke_png.write_bytes(b"png")
+            return 0, "ok", ""
+        if "validate_scene3d_runtime_acceptance.py" in cmd_s:
+            runtime_json = Path(cmd[cmd.index("--json") + 1])
+            runtime_md = Path(cmd[cmd.index("--markdown") + 1])
+            runtime_json.write_text("{}", encoding="utf-8")
+            runtime_md.write_text("# runtime", encoding="utf-8")
+            return 0, "ok", ""
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(target, "_run", fake_run)
+    monkeypatch.setattr(target.sys, "argv", ["prog", "--output-dir", str(out_dir), "--scene-name", scene_name])
+    rc = target.main()
+    assert rc == 0
+    artifact = json.loads((out_dir / f"{scene_name}_acceptance.json").read_text(encoding="utf-8"))
+    assert sorted(artifact["missing_optional_geometry_outputs"]) == sorted(["config/scene3d_mesh_index.json", "urdf/scene.urdf.xacro"])
 
 
 def test_generated_canvas_acceptance_failure_reports_schema_blockers(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
### Motivation
- Enforce a strict core package contract for generated scene packages so essential files are always present at generation time. 
- Allow geometry artifacts (`config/scene3d_mesh_index.json`, `urdf/scene.urdf.xacro`) to be optional when the runtime/viewer proves a primitive/layout fallback path. 
- Make the acceptance artifact explicit about which geometry files are optional and which are missing to aid downstream diagnostics.

### Description
- Updated `scripts/run_scene3d_generated_canvas_acceptance.py` to require core package contract files and add `cell_definition.yaml` to the strict `required_outputs` list. 
- Introduced `optional_geometry_outputs` for `config/scene3d_mesh_index.json` and `urdf/scene.urdf.xacro` and computed `missing_optional_geometry_outputs`. 
- Added logic that only treats missing optional geometry files as a blocker when runtime/render counters do not demonstrate the primitive/layout fallback (i.e., counters are non-positive). 
- Exported `optional_geometry_outputs` and `missing_optional_geometry_outputs` in the generated acceptance artifact JSON, and updated acceptance tests to cover both full-output and optional-geometry fallback scenarios. 
- Added a preflight test asserting the scratch generator's `REQUIRED` list contains core package contract members (`package.xml`, `CMakeLists.txt`, `scene_manifest.yaml`, `environment_layout.yaml`, `launch/demo.launch.py`, `cell_definition.yaml`).

### Testing
- Ran `pytest -q tests/test_scene3d_generated_canvas_acceptance.py tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py` and observed all tests passing. 
- Result: `14 passed` (covers updated generated-canvas acceptance tests and added preflight contract test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a135f2edda88331a79997051e1b43ed)