### PR TITLE
Prevent generator clobbering of cell_definition and add file-output regression test

### DIFF
--- a/scripts/generate_scratch_cell_acceptance.py
+++ b/scripts/generate_scratch_cell_acceptance.py
@@ -100,7 +100,9 @@ def main():
  except Exception as exc: r['blockers'].append(get_message('MISSING_WORKSPACE',detail=f'invalid output root: {a.output_root} ({exc})')); print(json.dumps(r,indent=2)); return 1
  sd=_safe_scene_dir(a.output_root,a.scene_name); sd.mkdir(parents=True,exist_ok=True); r['scene_dir']=str(sd)
  if sd.name!=a.scene_name: r['warnings'].append(get_message('SCENE_ALREADY_EXISTS',detail=f'Scene already existed; using {sd.name}'))
- cell=sd/'cell_definition.yaml'; cell.write_text(CELL_TMPL.format(scene=sd.name),encoding='utf-8')
+ cell_input=a.output_root/f'.{sd.name}.cell_definition.input.yaml'
+ cell_input.write_text(CELL_TMPL.format(scene=sd.name),encoding='utf-8')
+ cell=cell_input
  cell_text=cell.read_text(encoding='utf-8')
  cell_sha256=hashlib.sha256(cell_text.encode('utf-8')).hexdigest()
  cell_doc=yaml.safe_load(cell_text) if cell_text.strip() else {}

--- a/tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py
+++ b/tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py
@@ -29,7 +29,7 @@ def test_generated_scratch_schema_preflight_zero_errors_and_generation_attempt(t
         if "generate_workcell_from_cell_definition.py" in cmd_s:
             scene_name = cmd[cmd.index("--package-name") + 1]
             scene_dir = (tmp_path / "out" / scene_name)
-            for rel in ("scene_manifest.yaml", "config/scene3d_mesh_index.json", "urdf/scene.urdf.xacro", "launch/demo.launch.py", "package.xml", "CMakeLists.txt"):
+            for rel in ("scene_manifest.yaml", "config/scene3d_mesh_index.json", "urdf/scene.urdf.xacro", "launch/demo.launch.py", "package.xml", "CMakeLists.txt", "cell_definition.yaml"):
                 p = scene_dir / rel
                 p.parent.mkdir(parents=True, exist_ok=True)
                 p.write_text("x", encoding="utf-8")
@@ -46,7 +46,7 @@ def test_generated_scratch_schema_preflight_zero_errors_and_generation_attempt(t
     assert payload["schema_preflight"]["schema_blockers"] == []
     assert payload["schema_preflight"]["validator_returncode"] == 0
     assert "validate_cell_definition.py" in payload["schema_preflight"]["validator_command"]
-    assert payload["schema_preflight"]["cell_definition_path"].endswith("cell_definition.yaml")
+    assert payload["schema_preflight"]["cell_definition_path"].endswith(".cell_definition.input.yaml")
     assert "objects" in payload["schema_preflight"]["cell_definition_top_level_keys"]
     assert payload["schema_preflight"]["object_count"] > 0
     assert payload["schema_preflight"]["next_failed_step"] == "generation"
@@ -172,3 +172,35 @@ def test_audit_failure_recorded_not_crashed(tmp_path, monkeypatch):
 def test_cell_template_yaml_has_top_level_objects():
     doc = yaml.safe_load(target.CELL_TMPL.format(scene="demo"))
     assert "objects" in doc
+
+
+def test_generated_package_contains_core_files_before_file_output_audit(tmp_path, monkeypatch):
+    report = tmp_path / "acceptance.json"
+    monkeypatch.setattr(target.sys, "argv", ["prog", "--scene-name", "scratchcorefiles", "--output-root", str(tmp_path / "out"), "--json-out", str(report)])
+    seen = {"cell_input_path": None}
+
+    def fake_run(cmd):
+        cmd_s = " ".join(cmd)
+        if "validate_cell_definition.py" in cmd_s:
+            seen["cell_input_path"] = Path(cmd[2])
+            return 0, json.dumps({"errors": [], "warnings": []}), ""
+        if "generate_workcell_from_cell_definition.py" in cmd_s:
+            scene_name = cmd[cmd.index("--package-name") + 1]
+            scene_dir = tmp_path / "out" / scene_name
+            for rel in target.REQUIRED:
+                p = scene_dir / rel
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text("x", encoding="utf-8")
+            return 0, "ok", ""
+        if "audit_new_cell_file_outputs.py" in cmd_s:
+            scene_dir = Path(cmd[cmd.index("--scene-dir") + 1])
+            assert (scene_dir / "cell_definition.yaml").exists()
+            assert (scene_dir / "launch" / "demo.launch.py").exists()
+            return 0, "ok", ""
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(target, "_run", fake_run)
+    rc = target.main()
+    assert rc == 0
+    assert seen["cell_input_path"] is not None
+    assert seen["cell_input_path"].name.endswith(".cell_definition.input.yaml")


### PR DESCRIPTION
### Motivation
- The generator could remove the package directory when invoked with `--force`, which caused the seed `cell_definition.yaml` written inside the package tree to be lost and produced a `FileNotFoundError` during package generation.  
- Add a regression guard so the workflow asserts core generated outputs exist before running the `file_output_audit` step.

### Description
- Change `scripts/generate_scratch_cell_acceptance.py` to write the seed cell definition to a stable input file outside the package root at `--output-root/.<scene>.cell_definition.input.yaml` and use that file as the generator input.  
- Keep generator invocation the same but point it at the new stable input file so the generator can safely remove/recreate the package directory.  
- Add `test_generated_package_contains_core_files_before_file_output_audit` to `tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py` to assert that `cell_definition.yaml` and `launch/demo.launch.py` exist in the generated package directory before `audit_new_cell_file_outputs.py` runs.  
- Update an existing test expectation to match the new explicit input-file suffix (`.cell_definition.input.yaml`) and add `cell_definition.yaml` to the fake generator outputs where needed.

### Testing
- Ran `python -m pytest -q tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py` and all tests in that file passed (`9 passed`).  
- Ran the full acceptance flow via `python scripts/run_scene3d_generated_canvas_acceptance.py`; the generation step and `file_output_audit` now complete successfully (no longer blocked by the missing `cell_definition.yaml`/`launch/demo.launch.py`).  
- The end-to-end acceptance still fails later in the runtime/GUI checks due to missing runtime-generated artifacts (`config/scene3d_mesh_index.json`, `urdf/scene.urdf.xacro`) and GUI smoke/runtime counters, which are outside the scope of this path-fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a135f2c74008331b02947a5671abf39)