### PR TITLE
Clarify generated-canvas acceptance contract for core vs optional artifacts

### DIFF
--- a/scripts/run_scene3d_generated_canvas_acceptance.py
+++ b/scripts/run_scene3d_generated_canvas_acceptance.py
@@ -117,13 +117,17 @@ def main() -> int:
     required_outputs = [
         "scene_manifest.yaml",
         "environment_layout.yaml",
-        "config/scene3d_mesh_index.json",
-        "urdf/scene.urdf.xacro",
         "launch/demo.launch.py",
         "package.xml",
         "CMakeLists.txt",
+        "cell_definition.yaml",
+    ]
+    optional_generated_outputs = [
+        "config/scene3d_mesh_index.json",
+        "urdf/scene.urdf.xacro",
     ]
     missing_outputs = [r for r in required_outputs if not (scene_dir / r).exists()]
+    missing_optional_outputs = [r for r in optional_generated_outputs if not (scene_dir / r).exists()]
 
     smoke_json = out_dir / f"scene3d_gui_smoke_{args.scene_name}.json"
     smoke_png = out_dir / f"scene3d_gui_smoke_{args.scene_name}.png"
@@ -237,7 +241,9 @@ def main() -> int:
         },
         "generation": generation_payload,
         "required_outputs": required_outputs,
+        "optional_generated_outputs": optional_generated_outputs,
         "missing_outputs": missing_outputs,
+        "missing_optional_outputs": missing_optional_outputs,
         "gui_smoke": {
             "returncode": smoke_rc,
             "json": str(smoke_json),

--- a/tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py
+++ b/tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py
@@ -270,3 +270,13 @@ def test_regression_audit_does_not_point_to_stale_existing_folder(tmp_path, monk
     assert payload["scene_dir"].endswith(f"{scene_name}_1")
     assert Path(seen["audit_scene_dir"]) == Path(payload["scene_dir"])
     assert Path(seen["audit_scene_dir"]) != stale_scene
+
+
+def test_required_contract_files_remain_strict_for_scratch_generation():
+    required = set(target.REQUIRED)
+    assert "package.xml" in required
+    assert "CMakeLists.txt" in required
+    assert "scene_manifest.yaml" in required
+    assert "environment_layout.yaml" in required
+    assert "launch/demo.launch.py" in required
+    assert "cell_definition.yaml" in required

--- a/tests/test_scene3d_generated_canvas_acceptance.py
+++ b/tests/test_scene3d_generated_canvas_acceptance.py
@@ -23,6 +23,7 @@ def test_generated_canvas_acceptance_exports_artifacts(monkeypatch, tmp_path: Pa
             (scene_dir / "launch/demo.launch.py").write_text("x", encoding="utf-8")
             (scene_dir / "package.xml").write_text("x", encoding="utf-8")
             (scene_dir / "CMakeLists.txt").write_text("x", encoding="utf-8")
+            (scene_dir / "cell_definition.yaml").write_text("x", encoding="utf-8")
             gen_json = Path(cmd[cmd.index("--json-out") + 1])
             gen_json.parent.mkdir(parents=True, exist_ok=True)
             gen_json.write_text(json.dumps({"scene_dir": str(scene_dir), "run_id": cmd[cmd.index("--run-id") + 1]}), encoding="utf-8")
@@ -49,6 +50,8 @@ def test_generated_canvas_acceptance_exports_artifacts(monkeypatch, tmp_path: Pa
     assert rc == 0
     artifact = json.loads((out_dir / f"{scene_name}_acceptance.json").read_text(encoding="utf-8"))
     assert artifact["status"] == "PASS"
+    assert artifact["missing_outputs"] == []
+    assert artifact["missing_optional_outputs"] == []
     assert artifact["key_counts"]["assembled_preview_item_count"] > 0
     assert artifact["key_counts"]["filtered_visible_candidate_count"] > 0
     assert artifact["key_counts"]["forwarded_to_viewport_count"] > 0
@@ -57,6 +60,51 @@ def test_generated_canvas_acceptance_exports_artifacts(monkeypatch, tmp_path: Pa
     assert artifact["key_counts"]["selectable_count"] > 0
     assert artifact["key_counts"]["hierarchy_rows_count"] > 0
     assert Path(artifact["gui_smoke"]["screenshot"]).stat().st_size > 0
+
+
+def test_generated_canvas_acceptance_allows_optional_geometry_when_runtime_counters_pass(monkeypatch, tmp_path: Path):
+    scene_name = "scene3d_generated_canvas_acceptance"
+    out_dir = tmp_path / "out"
+    gen_root = out_dir / "generated_scenes"
+    scene_dir = gen_root / scene_name
+
+    def fake_run(cmd, cwd):
+        cmd_s = " ".join(cmd)
+        if "generate_scratch_cell_acceptance.py" in cmd_s:
+            (scene_dir / "launch").mkdir(parents=True, exist_ok=True)
+            (scene_dir / "scene_manifest.yaml").write_text("x", encoding="utf-8")
+            (scene_dir / "environment_layout.yaml").write_text("x", encoding="utf-8")
+            (scene_dir / "launch/demo.launch.py").write_text("x", encoding="utf-8")
+            (scene_dir / "package.xml").write_text("x", encoding="utf-8")
+            (scene_dir / "CMakeLists.txt").write_text("x", encoding="utf-8")
+            (scene_dir / "cell_definition.yaml").write_text("x", encoding="utf-8")
+            gen_json = Path(cmd[cmd.index("--json-out") + 1])
+            gen_json.parent.mkdir(parents=True, exist_ok=True)
+            gen_json.write_text(json.dumps({"scene_dir": str(scene_dir), "run_id": cmd[cmd.index("--run-id") + 1]}), encoding="utf-8")
+            return 0, "ok", ""
+        if "run_workcell_builder_scene3d_gui_smoke.py" in cmd_s:
+            smoke_json = Path(cmd[cmd.index("--output") + 1])
+            smoke_png = Path(cmd[cmd.index("--screenshot") + 1])
+            smoke_json.write_text(json.dumps({"counters": {"assembled_preview_item_count": 1, "filtered_visible_candidate_count": 1, "forwarded_to_viewport_count": 1, "viewport_received_count": 1, "rendered_count": 1, "selectable_count": 1, "hierarchy_rows": 1}}), encoding="utf-8")
+            smoke_png.write_bytes(b"png")
+            return 0, "ok", ""
+        if "validate_scene3d_runtime_acceptance.py" in cmd_s:
+            runtime_json = Path(cmd[cmd.index("--json") + 1])
+            runtime_md = Path(cmd[cmd.index("--markdown") + 1])
+            runtime_json.write_text("{}", encoding="utf-8")
+            runtime_md.write_text("# runtime", encoding="utf-8")
+            return 0, "ok", ""
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(target, "_run", fake_run)
+    monkeypatch.setattr(target, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(target.sys, "argv", ["prog", "--output-dir", str(out_dir), "--scene-name", scene_name])
+    rc = target.main()
+    artifact = json.loads((out_dir / f"{scene_name}_acceptance.json").read_text(encoding="utf-8"))
+    assert rc == 0
+    assert artifact["status"] == "PASS"
+    assert artifact["missing_outputs"] == []
+    assert sorted(artifact["missing_optional_outputs"]) == ["config/scene3d_mesh_index.json", "urdf/scene.urdf.xacro"]
 
 
 def test_generated_canvas_acceptance_failure_reports_schema_blockers(monkeypatch, tmp_path: Path):
@@ -123,3 +171,45 @@ def test_stale_generation_json_not_reused(monkeypatch, tmp_path: Path, capsys):
     assert rc == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["blockers"] == ["generation_report_missing_or_stale"]
+
+
+def test_generated_canvas_acceptance_requires_core_package_contract_outputs(monkeypatch, tmp_path: Path):
+    scene_name = "scene3d_generated_canvas_acceptance"
+    out_dir = tmp_path / "out"
+    scene_dir = out_dir / "generated_scenes" / scene_name
+
+    def fake_run(cmd, cwd):
+        cmd_s = " ".join(cmd)
+        if "generate_scratch_cell_acceptance.py" in cmd_s:
+            (scene_dir / "launch").mkdir(parents=True, exist_ok=True)
+            (scene_dir / "scene_manifest.yaml").write_text("x", encoding="utf-8")
+            (scene_dir / "launch/demo.launch.py").write_text("x", encoding="utf-8")
+            (scene_dir / "package.xml").write_text("x", encoding="utf-8")
+            (scene_dir / "CMakeLists.txt").write_text("x", encoding="utf-8")
+            (scene_dir / "cell_definition.yaml").write_text("x", encoding="utf-8")
+            gen_json = Path(cmd[cmd.index("--json-out") + 1])
+            gen_json.parent.mkdir(parents=True, exist_ok=True)
+            gen_json.write_text(json.dumps({"scene_dir": str(scene_dir), "run_id": cmd[cmd.index("--run-id") + 1]}), encoding="utf-8")
+            return 0, "ok", ""
+        if "run_workcell_builder_scene3d_gui_smoke.py" in cmd_s:
+            smoke_json = Path(cmd[cmd.index("--output") + 1])
+            smoke_png = Path(cmd[cmd.index("--screenshot") + 1])
+            smoke_json.write_text(json.dumps({"counters": {"assembled_preview_item_count": 1, "filtered_visible_candidate_count": 1, "forwarded_to_viewport_count": 1, "viewport_received_count": 1, "rendered_count": 1, "selectable_count": 1, "hierarchy_rows": 1}}), encoding="utf-8")
+            smoke_png.write_bytes(b"png")
+            return 0, "ok", ""
+        if "validate_scene3d_runtime_acceptance.py" in cmd_s:
+            runtime_json = Path(cmd[cmd.index("--json") + 1])
+            runtime_md = Path(cmd[cmd.index("--markdown") + 1])
+            runtime_json.write_text("{}", encoding="utf-8")
+            runtime_md.write_text("# runtime", encoding="utf-8")
+            return 0, "ok", ""
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(target, "_run", fake_run)
+    monkeypatch.setattr(target, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(target.sys, "argv", ["prog", "--output-dir", str(out_dir), "--scene-name", scene_name])
+    rc = target.main()
+    artifact = json.loads((out_dir / f"{scene_name}_acceptance.json").read_text(encoding="utf-8"))
+    assert rc == 1
+    assert artifact["status"] == "FAIL"
+    assert artifact["missing_outputs"] == ["environment_layout.yaml"]


### PR DESCRIPTION
### Motivation
- Keep strict package contract guarantees for core files while allowing primitive/layout fallback when geometry assets are missing.
- Ensure runtime/render counters remain the functional gate for generated-canvas acceptance when optional geometry is absent.
- Add explicit tests that validate the acceptance contract (core vs optional outputs) and the scratch preflight expectations.

### Description
- Updated `scripts/run_scene3d_generated_canvas_acceptance.py` to require core package files (`scene_manifest.yaml`, `environment_layout.yaml`, `launch/demo.launch.py`, `package.xml`, `CMakeLists.txt`, `cell_definition.yaml`) and treat `config/scene3d_mesh_index.json` and `urdf/scene.urdf.xacro` as optional generated outputs.
- Added `optional_generated_outputs` and `missing_optional_outputs` to the produced acceptance artifact and preserved runtime/render counter checks as the functional pass/fail gating.
- Extended `tests/test_scene3d_generated_canvas_acceptance.py` with assertions for `missing_outputs`/`missing_optional_outputs` and added tests to verify that optional geometry may be absent when runtime counters pass and that missing a core contract file fails acceptance.
- Added `test_required_contract_files_remain_strict_for_scratch_generation` to `tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py` to assert `target.REQUIRED` contains the core package contract entries (including `cell_definition.yaml`).

### Testing
- Ran `pytest -q tests/test_scene3d_generated_canvas_acceptance.py tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py` and all tests passed.
- Test run result: `17 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13602bfd5c8331bcc4c0d65b3b4db5)