### PR TITLE
Fix scratch acceptance generation path collision and add audit regression guard

### DIFF
--- a/scripts/generate_scratch_cell_acceptance.py
+++ b/scripts/generate_scratch_cell_acceptance.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import argparse, json, subprocess, sys, re, hashlib
+import argparse, json, subprocess, sys, re, hashlib, shutil
 from datetime import datetime, timezone
 from pathlib import Path
 import yaml
@@ -100,7 +100,8 @@ def main():
  except Exception as exc: r['blockers'].append(get_message('MISSING_WORKSPACE',detail=f'invalid output root: {a.output_root} ({exc})')); print(json.dumps(r,indent=2)); return 1
  sd=_safe_scene_dir(a.output_root,a.scene_name); sd.mkdir(parents=True,exist_ok=True); r['scene_dir']=str(sd)
  if sd.name!=a.scene_name: r['warnings'].append(get_message('SCENE_ALREADY_EXISTS',detail=f'Scene already existed; using {sd.name}'))
- cell=sd/'cell_definition.yaml'; cell.write_text(CELL_TMPL.format(scene=sd.name),encoding='utf-8')
+ cell_tmp=a.output_root/f".{sd.name}.cell_definition.yaml"; cell_tmp.write_text(CELL_TMPL.format(scene=sd.name),encoding='utf-8')
+ cell=cell_tmp
  cell_text=cell.read_text(encoding='utf-8')
  cell_sha256=hashlib.sha256(cell_text.encode('utf-8')).hexdigest()
  cell_doc=yaml.safe_load(cell_text) if cell_text.strip() else {}
@@ -145,6 +146,8 @@ def main():
  generator_stdout_tail='\n'.join(generator_stdout.splitlines()[-120:])
  generator_stderr_tail='\n'.join(generator_stderr.splitlines()[-120:])
  r['generator']={'command':' '.join(generator_cmd),'returncode':rc,'stdout_tail':generator_stdout_tail,'stderr_tail':generator_stderr_tail}
+ if rc==0 and not (sd/'cell_definition.yaml').exists() and cell.exists():
+  shutil.copy2(cell, sd/'cell_definition.yaml')
  if rc!=0:
   summary=(generator_stderr or generator_stdout).splitlines()[-1] if (generator_stderr or generator_stdout) else 'Generator failed.'
   r['failure_step']='generation'

--- a/tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py
+++ b/tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py
@@ -280,3 +280,37 @@ def test_required_contract_files_remain_strict_for_scratch_generation():
     assert "environment_layout.yaml" in required
     assert "launch/demo.launch.py" in required
     assert "cell_definition.yaml" in required
+
+
+def test_regression_generated_package_has_required_files_before_file_output_audit(tmp_path, monkeypatch):
+    report = tmp_path / "acceptance.json"
+    output_root = tmp_path / "out"
+    scene_name = "scratchauditguard"
+    monkeypatch.setattr(
+        target.sys,
+        "argv",
+        ["prog", "--scene-name", scene_name, "--output-root", str(output_root), "--json-out", str(report)],
+    )
+
+    def fake_run(cmd):
+        cmd_s = " ".join(cmd)
+        if "validate_cell_definition.py" in cmd_s:
+            return 0, json.dumps({"errors": [], "warnings": []}), ""
+        if "generate_workcell_from_cell_definition.py" in cmd_s:
+            package_name = cmd[cmd.index("--package-name") + 1]
+            scene_dir = output_root / package_name
+            for rel in target.REQUIRED:
+                p = scene_dir / rel
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text("x", encoding="utf-8")
+            return 0, "ok", ""
+        if "audit_new_cell_file_outputs.py" in cmd_s:
+            scene_dir = Path(cmd[cmd.index("--scene-dir") + 1])
+            assert (scene_dir / "cell_definition.yaml").exists()
+            assert (scene_dir / "launch" / "demo.launch.py").exists()
+            return 0, "ok", ""
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(target, "_run", fake_run)
+    rc = target.main()
+    assert rc == 0


### PR DESCRIPTION
### Motivation
- The scratch acceptance flow could lose the produced `cell_definition.yaml` when the generator runs `--force` into the same package directory, causing `file_output_audit` to block due to missing files.
- The goal is to ensure the seed cell definition used to drive generation survives the generation step and that the generated package contains required artifacts before the audit runs.

### Description
- Change `scripts/generate_scratch_cell_acceptance.py` to write the seed `cell_definition.yaml` to a temporary file under the `--output-root` (named `.<scene>.cell_definition.yaml`) instead of writing it directly into the package root.
- Add a fallback copy that, when generation succeeds, ensures `<scene_dir>/cell_definition.yaml` exists by copying the temporary seed file into the package root if necessary; also added `shutil` import.
- Add a regression test `test_regression_generated_package_has_required_files_before_file_output_audit` in `tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py` that asserts `cell_definition.yaml` and `launch/demo.launch.py` exist in the generated package directory before `audit_new_cell_file_outputs.py` runs.

### Testing
- Ran `pytest -q tests/test_generate_scratch_cell_acceptance_preflight_and_artifacts.py`, which passed (12 passed).
- Ran the end-to-end generator invocation via `scripts/run_scene3d_generated_canvas_acceptance.py`, which now reports the generation and `file_output_audit` stages passing for the generated scene directory, while downstream GUI/runtime checks still fail in this environment (unrelated to the generation/file-output fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13616a3d188331a51ba2ea1d05e571)