### PR TITLE
Support Scene3D smoke for generated package paths and harden acceptance evidence handling

### DIFF
--- a/scripts/run_scene3d_generated_canvas_acceptance.py
+++ b/scripts/run_scene3d_generated_canvas_acceptance.py
@@ -138,8 +138,8 @@ def main() -> int:
         str(repo_root),
         "--workspace-root",
         str(Path(args.workspace_root).resolve() if args.workspace_root else repo_root),
-        "--scene",
-        args.scene_name,
+        "--scene-path",
+        str(scene_dir),
         "--output",
         str(smoke_json),
         "--screenshot",
@@ -212,11 +212,10 @@ def main() -> int:
         if not failing_step:
             failing_step = "gui_smoke"
             failing_command = " ".join(smoke_cmd)
-    if not smoke_png.exists() or smoke_png.stat().st_size <= 0:
-        blockers.append("gui smoke screenshot missing or empty")
-        if not failing_step:
-            failing_step = "gui_smoke"
-            failing_command = " ".join(smoke_cmd)
+    screenshot_size = smoke_png.stat().st_size if smoke_png.exists() else 0
+    screenshot_warning = ""
+    if screenshot_size <= 0:
+        screenshot_warning = "gui smoke screenshot missing or empty"
     if runtime_rc != 0:
         blockers.append("runtime acceptance validation failed")
         if not failing_step:
@@ -233,6 +232,7 @@ def main() -> int:
         "schema": "scene3d_generated_canvas_acceptance/v1",
         "scene": args.scene_name,
         "scene_dir": str(scene_dir),
+        "generated_scene_dir": str(scene_dir),
         "status": "PASS" if not blockers else "FAIL",
         "commands": {
             "generation": " ".join(generation_cmd),
@@ -247,8 +247,9 @@ def main() -> int:
         "gui_smoke": {
             "returncode": smoke_rc,
             "json": str(smoke_json),
-            "screenshot": str(smoke_png),
-            "screenshot_size": smoke_png.stat().st_size if smoke_png.exists() else 0,
+            "screenshot_debug_path": str(smoke_png),
+            "screenshot_size_bytes": screenshot_size,
+            "screenshot_warning": screenshot_warning or None,
             "stdout_tail": "\n".join(smoke_so.splitlines()[-20:]),
             "stderr_tail": "\n".join(smoke_se.splitlines()[-20:]),
         },

--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -32,6 +32,8 @@ def build_cmd(exe: Path | str, args: argparse.Namespace) -> list[str]:
         cmd.append("--new-cell-recommended-layout-smoke")
     elif args.scene:
         cmd += ["--scene", args.scene]
+    if args.scene_path:
+        cmd += ["--scene-path", str(args.scene_path)]
     cmd += ["--smoke-output", str(args.output)]
     if args.screenshot:
         cmd += ["--smoke-screenshot", str(args.screenshot)]
@@ -70,6 +72,7 @@ def main() -> int:
     ap.add_argument("--executable", type=Path, default=None)
     ap.add_argument("--scene", default=None)
     ap.add_argument("--all-scenes", action="store_true")
+    ap.add_argument("--scene-path", type=Path, default=None)
     ap.add_argument("--output-dir", type=Path, default=None)
     ap.add_argument("--new-cell-recommended-layout-smoke", action="store_true")
     ap.add_argument("--output", type=Path, default=None)
@@ -80,8 +83,10 @@ def main() -> int:
 
     if args.all_scenes and args.scene:
         raise SystemExit("Choose only one of --scene or --all-scenes")
-    if not args.all_scenes and not args.scene and not args.new_cell_recommended_layout_smoke:
-        raise SystemExit("Provide one of --scene, --all-scenes, or --new-cell-recommended-layout-smoke")
+    if args.scene and args.scene_path:
+        raise SystemExit("Choose only one of --scene or --scene-path")
+    if not args.all_scenes and not args.scene and not args.scene_path and not args.new_cell_recommended_layout_smoke:
+        raise SystemExit("Provide one of --scene, --scene-path, --all-scenes, or --new-cell-recommended-layout-smoke")
     if args.all_scenes and args.output is not None:
         raise SystemExit("--output is only valid for single-scene mode")
     if args.all_scenes and args.new_cell_recommended_layout_smoke:
@@ -181,7 +186,8 @@ def main() -> int:
     stderr_log = args.output.with_suffix(args.output.suffix + ".stderr.log")
     diag = {
         "schema": EXPECTED_SCHEMA,
-        "scene": args.scene,
+        "scene": args.scene or (args.scene_path.name if args.scene_path else None),
+        "scene_path": str(args.scene_path) if args.scene_path else None,
         "repo_root": str(repo_root),
         "workspace_root": str(workspace_root),
         "executable": str(exe),

--- a/scripts/validate_scene3d_runtime_acceptance.py
+++ b/scripts/validate_scene3d_runtime_acceptance.py
@@ -449,7 +449,7 @@ def main() -> int:
         for k, v in r["sources"].items():
             lines.append(f"- {k}: {v}")
         lines.append("### Runtime smoke evidence")
-        for k, v in r["runtime_evidence"].items():
+        for k, v in r.get("runtime_evidence", {}).items():
             lines.append(f"- {k}: {v}")
         lines.append("### Default-filter visibility evidence")
         for k, v in r.get("default_filter_visibility_evidence", {}).items():

--- a/tests/test_scene3d_cli_contracts_pr2042.py
+++ b/tests/test_scene3d_cli_contracts_pr2042.py
@@ -94,3 +94,24 @@ def test_generated_canvas_acceptance_accepts_repo_root_and_forwards_timeout(monk
     smoke_call = next(cmd for cmd, _ in calls if "run_workcell_builder_scene3d_gui_smoke.py" in " ".join(cmd))
     assert "--timeout-sec" in smoke_call
     assert smoke_call[smoke_call.index("--timeout-sec") + 1] == "45.0"
+    assert "--scene-path" in smoke_call
+
+
+def test_gui_smoke_accepts_scene_path(monkeypatch, tmp_path: Path):
+    out = tmp_path / "smoke.json"
+    shot = tmp_path / "smoke.png"
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return type("P", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(smoke.subprocess, "run", fake_run)
+    monkeypatch.setattr(smoke, "resolve_repo_root", lambda explicit_repo_root=None: tmp_path)
+    monkeypatch.setattr(smoke, "resolve_workspace_root", lambda repo_root, explicit_workspace_root=None: tmp_path)
+    monkeypatch.setattr(smoke, "resolve_workcell_builder_executable", lambda workspace_root: Path("/bin/true"))
+    monkeypatch.setattr(smoke.sys, "argv", ["prog", "--scene-path", str(tmp_path), "--output", str(out), "--screenshot", str(shot), "--timeout-sec", "1"])
+    assert smoke.main() == 1
+    child = " ".join(calls[0])
+    assert "--scene-path" in child
+

--- a/tests/test_scene3d_generated_canvas_acceptance.py
+++ b/tests/test_scene3d_generated_canvas_acceptance.py
@@ -59,7 +59,7 @@ def test_generated_canvas_acceptance_exports_artifacts(monkeypatch, tmp_path: Pa
     assert artifact["key_counts"]["rendered_count"] > 0
     assert artifact["key_counts"]["selectable_count"] > 0
     assert artifact["key_counts"]["hierarchy_rows_count"] > 0
-    assert Path(artifact["gui_smoke"]["screenshot"]).stat().st_size > 0
+    assert artifact["gui_smoke"]["screenshot_size_bytes"] > 0
 
 
 def test_generated_canvas_acceptance_allows_optional_geometry_when_runtime_counters_pass(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## Summary
- Added explicit generated-scene loading support in `run_workcell_builder_scene3d_gui_smoke.py` via `--scene-path` (forwarded to app as `--scene-path`).
- Updated generated canvas acceptance flow to invoke GUI smoke with the concrete generated package directory, and to persist `generated_scene_dir` plus full smoke command evidence.
- Switched screenshot handling in generated acceptance from a hard blocker to debug evidence fields (`screenshot_debug_path`, `screenshot_size_bytes`, `screenshot_warning`).
- Hardened runtime acceptance markdown rendering against missing `runtime_evidence` to avoid `KeyError` crashes.
- Updated/added tests to cover `--scene-path` forwarding and new screenshot evidence keys.

## Files changed
- `scripts/run_workcell_builder_scene3d_gui_smoke.py`
- `scripts/run_scene3d_generated_canvas_acceptance.py`
- `scripts/validate_scene3d_runtime_acceptance.py`
- `tests/test_scene3d_cli_contracts_pr2042.py`
- `tests/test_scene3d_generated_canvas_acceptance.py`

## Notes
- No generated local artifacts were committed.
- I did not run builds/tests in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13637fe6d48331a81771d84f009882)