### PR TITLE
Add explicit generated scene-path handling in Scene3D acceptance flow

### DIFF
--- a/scripts/run_scene3d_generated_canvas_acceptance.py
+++ b/scripts/run_scene3d_generated_canvas_acceptance.py
@@ -176,6 +176,7 @@ def main() -> int:
 
     smoke_payload = _json(smoke_json) if smoke_json.exists() else {}
     runtime_payload = _json(runtime_json) if runtime_json.exists() else {}
+    smoke_status = str(smoke_payload.get("status", "UNKNOWN")).upper() if isinstance(smoke_payload, dict) else "UNKNOWN"
     smoke_counters = smoke_payload.get("counters", {}) if isinstance(smoke_payload, dict) else {}
     runtime_counters = runtime_payload.get("counters", {}) if isinstance(runtime_payload, dict) else {}
 
@@ -207,8 +208,8 @@ def main() -> int:
     failing_command = ""
     if missing_outputs:
         blockers.append(f"missing generated outputs: {', '.join(missing_outputs)}")
-    if smoke_rc != 0:
-        blockers.append("gui smoke command failed")
+    if smoke_rc != 0 or smoke_status not in {"PASS", "OK"}:
+        blockers.append("gui smoke failed")
         if not failing_step:
             failing_step = "gui_smoke"
             failing_command = " ".join(smoke_cmd)

--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -52,6 +52,13 @@ def _write_json(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
+
+
+def _scene_package_markers_ok(scene_dir: Path) -> tuple[bool, list[str]]:
+    required = ["package.xml", "scene_manifest.yaml", "cell_definition.yaml", "launch/demo.launch.py"]
+    missing = [name for name in required if not (scene_dir / name).is_file()]
+    return (not missing), missing
+
 def _discover_scene_targets(repo_root: Path) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     scenes_root = resolve_scene_root(repo_root)
@@ -83,8 +90,6 @@ def main() -> int:
 
     if args.all_scenes and args.scene:
         raise SystemExit("Choose only one of --scene or --all-scenes")
-    if args.scene and args.scene_path:
-        raise SystemExit("Choose only one of --scene or --scene-path")
     if not args.all_scenes and not args.scene and not args.scene_path and not args.new_cell_recommended_layout_smoke:
         raise SystemExit("Provide one of --scene, --scene-path, --all-scenes, or --new-cell-recommended-layout-smoke")
     if args.all_scenes and args.output is not None:
@@ -178,6 +183,23 @@ def main() -> int:
             md += [f"- {r['scene']}: {r.get('ignore_reason', 'ignored')}" for r in ignored_non_scenes]
         (out_dir / "scene3d_gui_smoke_summary.md").write_text("\n".join(md) + "\n", encoding="utf-8")
         return 1 if totals["FAIL"] or totals["BLOCKED"] else 0
+
+    if args.scene_path:
+        sp = args.scene_path.resolve()
+        ok, missing = _scene_package_markers_ok(sp)
+        if not ok:
+            fail_payload = {
+                "schema": EXPECTED_SCHEMA,
+                "status": "FAIL",
+                "scene": args.scene or sp.name,
+                "scene_path": str(sp),
+                "blockers": [f"scene_path_missing_required_files:{','.join(missing)}"],
+                "warnings": [],
+            }
+            _write_json(args.output, fail_payload)
+            print("status=FAIL smoke_status=SCENE_PATH_INVALID")
+            return 1
+        args.scene_path = sp
 
     cmd = build_cmd(exe, args)
     cmd, xwarn = with_xvfb(cmd, args.xvfb)

--- a/scripts/validate_scene3d_runtime_acceptance.py
+++ b/scripts/validate_scene3d_runtime_acceptance.py
@@ -45,7 +45,10 @@ def load_yaml(path: Path) -> dict:
 
 
 def load_json(path: Path) -> dict:
-    data = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
     return data if isinstance(data, dict) else {}
 
 
@@ -306,6 +309,7 @@ def evaluate_scene(repo_root: Path, scenes_root: Path, main_path: Path, preview_
             "preview_metadata": str(preview_metadata_path) if preview_metadata_path.exists() else None,
             "generated_layout": str(urdf_generated_layout_path) if urdf_generated_layout_path.exists() else None,
             "overlay_files": [str(p) for p in overlay_sources if p.exists()],
+            "smoke_json": str(smoke_path),
         },
         "source_layer_counts": source_layer_counts,
         "runtime_evidence": runtime_evidence,
@@ -449,7 +453,10 @@ def main() -> int:
         for k, v in r["sources"].items():
             lines.append(f"- {k}: {v}")
         lines.append("### Runtime smoke evidence")
-        for k, v in r.get("runtime_evidence", {}).items():
+        runtime_evidence = r.get("runtime_evidence", {}) if isinstance(r.get("runtime_evidence", {}), dict) else {}
+        if not runtime_evidence:
+            runtime_evidence = {"valid": False, "error": "runtime_evidence_missing", "smoke_json": r.get("sources", {}).get("smoke_json")}
+        for k, v in runtime_evidence.items():
             lines.append(f"- {k}: {v}")
         lines.append("### Default-filter visibility evidence")
         for k, v in r.get("default_filter_visibility_evidence", {}).items():


### PR DESCRIPTION
## Summary
- Added `--scene-path` package marker validation in `run_workcell_builder_scene3d_gui_smoke.py` so generated scene directories can be smoke-tested directly without requiring discovery under repo `scenes/`.
- Updated generated canvas acceptance to treat GUI smoke pass/fail based on both process return code and smoke JSON status, while still passing generated package path explicitly.
- Hardened runtime acceptance report generation to avoid crashes when smoke/runtime evidence is missing or malformed by using safe JSON parsing and defensive runtime-evidence markdown rendering.

## Why
Generated packages under `build/workcell_studio/local_validation/generated_scenes/<scene>` were not reliably accepted by downstream smoke/runtime validation when evidence was missing or not discoverable through normal scene roots.

## Notes
- Existing `--scene` behavior for standard scenes remains intact.
- Screenshot remains debug evidence and not a primary gate.
- No generated local artifacts were committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13649c9bf48331ba8f3861fde1c855)