### PR TITLE
Fix Scene3D generated-smoke path fidelity and runtime secondary-check robustness

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -250,10 +250,26 @@ def main() -> int:
 
     if args.output.exists():
         app_status="UNKNOWN"
+        payload: dict[str, Any] = {}
         try:
-            app_status=json.loads(args.output.read_text(encoding="utf-8")).get("status","UNKNOWN")
+            payload=json.loads(args.output.read_text(encoding="utf-8"))
+            app_status=payload.get("status","UNKNOWN")
         except Exception:
-            pass
+            payload = {}
+        if args.scene_path:
+            expected_scene_path = str(args.scene_path.resolve())
+            counters = payload.get("counters") if isinstance(payload.get("counters"), dict) else {}
+            actual_scene_path = str(counters.get("inspector_scene_path") or counters.get("selected_scene_path") or "").strip()
+            if Path(actual_scene_path).as_posix() != Path(expected_scene_path).as_posix():
+                blockers = list(payload.get("blockers") or [])
+                blockers.append("explicit_scene_path_not_loaded")
+                payload["status"] = "FAIL"
+                payload["expected_scene_path"] = expected_scene_path
+                payload["actual_scene_path"] = actual_scene_path
+                payload["blockers"] = blockers
+                _write_json(args.output, payload)
+                print(f"status=FAIL smoke_status=EXPLICIT_SCENE_PATH_MISMATCH expected_scene_path={expected_scene_path} actual_scene_path={actual_scene_path}")
+                return 1
         print(f"status=PASS smoke_status=APP_JSON_PRESENT wrapper_status=PASS app_status={app_status} returncode={rc} timed_out={timed_out}")
         print("child_command=" + diag["child_command"])
         print("stdout_log_path=" + str(stdout_log))

--- a/scripts/validate_scene3d_runtime_acceptance.py
+++ b/scripts/validate_scene3d_runtime_acceptance.py
@@ -386,6 +386,7 @@ def main() -> int:
                     "default_filter_visibility_evidence": {},
                     "runtime_evidence": {"valid": False, "skipped": True},
                     "secondary_checks": {},
+                    "warnings": ["missing_secondary_checks"],
                     "pass": False,
                 }
             )
@@ -462,7 +463,10 @@ def main() -> int:
         for k, v in r.get("default_filter_visibility_evidence", {}).items():
             lines.append(f"- {k}: {v}")
         lines.append("### Secondary diagnostics")
-        for k, v in r["secondary_checks"].items():
+        sec = r.get("secondary_checks") if isinstance(r.get("secondary_checks"), dict) else {}
+        if not isinstance(r.get("secondary_checks"), dict):
+            lines.append("- warning: missing_secondary_checks")
+        for k, v in sec.items():
             if isinstance(v, bool):
                 lines.append(f"- {k}: {'PASS' if v else 'FAIL'}")
             else:

--- a/tests/test_scene3d_cli_contracts_pr2042.py
+++ b/tests/test_scene3d_cli_contracts_pr2042.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 from pathlib import Path
 
 import pytest
@@ -115,3 +116,27 @@ def test_gui_smoke_accepts_scene_path(monkeypatch, tmp_path: Path):
     child = " ".join(calls[0])
     assert "--scene-path" in child
 
+
+def test_gui_smoke_fails_if_explicit_scene_path_not_loaded(monkeypatch, tmp_path: Path):
+    out = tmp_path / 'smoke.json'
+    shot = tmp_path / 'smoke.png'
+    pkg = tmp_path / 'generated_scene'
+    pkg.mkdir(parents=True, exist_ok=True)
+    for rel in ['package.xml', 'scene_manifest.yaml', 'cell_definition.yaml', 'launch/demo.launch.py']:
+        p = pkg / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text('x', encoding='utf-8')
+
+    def fake_run(cmd, **kwargs):
+        out.write_text('{"status":"PASS","counters":{"inspector_scene_path":"/wrong/path"}}', encoding='utf-8')
+        return type('P', (), {'returncode': 0, 'stdout': '', 'stderr': ''})()
+
+    monkeypatch.setattr(smoke.subprocess, 'run', fake_run)
+    monkeypatch.setattr(smoke, 'resolve_repo_root', lambda explicit_repo_root=None: tmp_path)
+    monkeypatch.setattr(smoke, 'resolve_workspace_root', lambda repo_root, explicit_workspace_root=None: tmp_path)
+    monkeypatch.setattr(smoke, 'resolve_workcell_builder_executable', lambda workspace_root: Path('/bin/true'))
+    monkeypatch.setattr(smoke.sys, 'argv', ['prog', '--scene-path', str(pkg), '--output', str(out), '--screenshot', str(shot), '--timeout-sec', '1'])
+    assert smoke.main() == 1
+    payload = json.loads(out.read_text(encoding='utf-8'))
+    assert payload['status'] == 'FAIL'
+    assert 'explicit_scene_path_not_loaded' in payload['blockers']

--- a/tests/test_scene3d_runtime_acceptance.py
+++ b/tests/test_scene3d_runtime_acceptance.py
@@ -243,3 +243,17 @@ def test_runtime_acceptance_default_filter_zero_visible_is_blocker(tmp_path):
     assert result["default_filter_visibility_evidence"]["pass_mode"] == "failed"
     assert "scene3d_default_filter_hid_all_renderable_candidates" in result["blockers"]
     assert result["secondary_checks"]["layer_toggles_not_default_hide_all"] is False
+
+def test_runtime_acceptance_markdown_handles_missing_secondary_checks(tmp_path):
+    out_json = tmp_path / 'acceptance.json'
+    out_md = tmp_path / 'acceptance.md'
+    subprocess.run([
+        'python3',
+        str(ROOT / 'scripts' / 'validate_scene3d_runtime_acceptance.py'),
+        '--scene', 'definitely_missing_scene',
+        '--json', str(out_json),
+        '--markdown', str(out_md),
+    ], check=False)
+    assert out_md.exists()
+    text = out_md.read_text(encoding='utf-8')
+    assert 'missing_secondary_checks' in text

--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -314,6 +314,7 @@ struct Scene3DSmokeOptions
 {
   bool enabled{ false };
   QString scene_name;
+  QString scene_path;
   QString smoke_output;
   QString screenshot_path;
   bool exit_after_smoke{ false };
@@ -351,9 +352,9 @@ private:
       QTimer::singleShot(300, this, &Scene3DSmokeRunner::step_trigger_recommended_layout);
       return;
     }
-    if (!opts_.scene_name.trimmed().isEmpty()) {
+    if (!opts_.scene_path.trimmed().isEmpty() || !opts_.scene_name.trimmed().isEmpty()) {
       QStringList load_blockers;
-      if (!window_->load_scene_for_scene3d_smoke(opts_.scene_name, &load_blockers, &scene_load_diagnostics_)) {
+      if (!window_->load_scene_for_scene3d_smoke(opts_.scene_name, opts_.scene_path, &load_blockers, &scene_load_diagnostics_)) {
         for (const auto & b : load_blockers) blockers_.append(b);
       }
     } else {
@@ -546,6 +547,7 @@ private:
     root["schema"] = "workcell_studio_scene3d_gui_smoke/v1";
     root["timestamp"] = QDateTime::currentDateTimeUtc().toString(Qt::ISODate);
     root["scene"] = opts_.scene_name;
+    root["requested_scene_path"] = opts_.scene_path;
     root["new_cell_recommended_layout_smoke"] = opts_.new_cell_recommended_layout_smoke;
     root["scene_load_diagnostics"] = scene_load_diagnostics_;
     root["filter_diagnostics"] = window_->scene3d_filter_diagnostics();
@@ -975,6 +977,7 @@ int main(int argc, char * argv[])
   Scene3DSmokeOptions smoke_opts;
   smoke_opts.enabled = has_cli_flag(args, "--scene3d-smoke");
   smoke_opts.scene_name = cli_value(args, "--scene");
+  smoke_opts.scene_path = cli_value(args, "--scene-path");
   smoke_opts.smoke_output = cli_value(args, "--smoke-output");
   smoke_opts.screenshot_path = cli_value(args, "--smoke-screenshot");
   smoke_opts.exit_after_smoke = has_cli_flag(args, "--exit-after-smoke");

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -904,18 +904,36 @@ bool MainWindow::open_scene_builder_for_selected_scene(const QString & source_ac
   return true;
 }
 
-bool MainWindow::load_scene_for_scene3d_smoke(const QString & scene_name, QStringList * blockers, QJsonObject * diagnostics)
+bool MainWindow::load_scene_for_scene3d_smoke(const QString & scene_name, const QString & explicit_scene_path, QStringList * blockers, QJsonObject * diagnostics)
 {
   auto add_blocker = [&](const QString & b) {
     if (blockers) blockers->append(b);
   };
-  if (diagnostics) diagnostics->insert("requested_scene_name", scene_name);
+  if (diagnostics) { diagnostics->insert("requested_scene_name", scene_name); diagnostics->insert("explicit_scene_path_used", false); }
   sync_selected_scene_state();
   int scene_idx = -1;
-  for (int i = 0; i < static_cast<int>(scene_browser_result_.scenes.size()); ++i) {
-    if (QString::fromStdString(scene_browser_result_.scenes[static_cast<size_t>(i)].scene_name).trimmed() == scene_name.trimmed()) {
-      scene_idx = i;
-      break;
+  if (diagnostics) diagnostics->insert("requested_explicit_scene_path", explicit_scene_path);
+  if (!explicit_scene_path.trimmed().isEmpty()) {
+    const fs::path explicit_dir = fs::path(explicit_scene_path.toStdString());
+    const fs::path canonical_explicit = fs::weakly_canonical(explicit_dir);
+    int explicit_idx = -1;
+    for (int i = 0; i < static_cast<int>(scene_browser_result_.scenes.size()); ++i) {
+      const fs::path candidate = fs::weakly_canonical(scene_browser_result_.scenes[static_cast<size_t>(i)].scene_dir);
+      if (candidate == canonical_explicit) { explicit_idx = i; break; }
+    }
+    if (explicit_idx < 0) {
+      add_blocker(QString("explicit_scene_path_not_found:%1").arg(explicit_scene_path));
+      return false;
+    }
+    scene_idx = explicit_idx;
+    if (diagnostics) diagnostics->insert("explicit_scene_path_used", true);
+  }
+  if (scene_idx < 0) {
+    for (int i = 0; i < static_cast<int>(scene_browser_result_.scenes.size()); ++i) {
+      if (QString::fromStdString(scene_browser_result_.scenes[static_cast<size_t>(i)].scene_name).trimmed() == scene_name.trimmed()) {
+        scene_idx = i;
+        break;
+      }
     }
   }
   if (scene_idx < 0) {
@@ -1002,6 +1020,7 @@ bool MainWindow::load_scene_for_scene3d_smoke(const QString & scene_name, QStrin
   if (diagnostics) {
     const fs::path d = scene_browser_result_.scenes[static_cast<size_t>(scene_idx)].scene_dir;
     diagnostics->insert("resolved_scene_path", QString::fromStdString(d.string()));
+    diagnostics->insert("source_path_root", QString::fromStdString(d.string()));
     diagnostics->insert("source_layout_item_count", fs::exists(d / "layout" / "workcell_studio_layout.yaml") ? 1 : 0);
     diagnostics->insert("source_mesh_index_item_count", fs::exists(d / "generated" / "scene_visual_mesh_index.json") ? 1 : 0);
     diagnostics->insert("source_generated_layout_item_count", fs::exists(d / "layout" / "workcell_studio_layout.generated.yaml") ? 1 : 0);

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -85,7 +85,7 @@ public:
   explicit MainWindow(const QString & startup_workspace = QString(), const QString & startup_ros_distro = QString(), QWidget * parent = nullptr);
   ~MainWindow();
   ScenePreviewWidget * active_scene_preview_widget() const;
-  bool load_scene_for_scene3d_smoke(const QString & scene_name, QStringList * blockers = nullptr, QJsonObject * diagnostics = nullptr);
+  bool load_scene_for_scene3d_smoke(const QString & scene_name, const QString & explicit_scene_path = QString(), QStringList * blockers = nullptr, QJsonObject * diagnostics = nullptr);
   void refresh_scene_builder_state_from_active_scene();
   QJsonObject scene3d_filter_diagnostics() const;
   static bool parse_transform_clipboard_text(


### PR DESCRIPTION
## Summary
- Propagated `--scene-path` through Workcell Builder smoke CLI parsing into the Scene3D smoke runner.
- Updated MainWindow smoke loading to honor explicit scene directory selection deterministically (with diagnostics indicating explicit path usage and resolved path root).
- Added wrapper-level guard in `run_workcell_builder_scene3d_gui_smoke.py` to fail when an explicit `--scene-path` was requested but the app reports a different selected/inspector scene path.
- Hardened runtime acceptance markdown emission to handle missing `secondary_checks` without KeyError and emit `missing_secondary_checks` warning evidence.

## Key behavior changes
1. **Explicit scene path loading**
   - `workcell_builder --scene3d-smoke --scene-path <dir>` is now parsed and passed into `load_scene_for_scene3d_smoke(...)`.
   - Smoke diagnostics now include:
     - `requested_explicit_scene_path`
     - `explicit_scene_path_used`
     - `resolved_scene_path`
     - `source_path_root`

2. **False-positive prevention for generated smoke**
   - Wrapper now compares expected explicit scene path vs. app-reported selected path (`inspector_scene_path` / `selected_scene_path`).
   - On mismatch, smoke JSON is rewritten to `status: FAIL` with blocker:
     - `explicit_scene_path_not_loaded`
   - Includes `expected_scene_path` and `actual_scene_path` fields.

3. **Runtime acceptance robustness**
   - Missing `secondary_checks` no longer crashes markdown generation.
   - Emits warning marker `missing_secondary_checks` when structure is absent.

## Tests
- Added/updated tests covering:
  - wrapper fail-fast when explicit scene path is ignored.
  - runtime acceptance markdown handling when `secondary_checks` are missing.

## Notes
- No generated local validation artifacts were committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1366b4683c83318053925e9abad42a)