### PR TITLE
Add robot-specific Scene3D camera fit and Fit Robot UI action

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "gui/mainwindow.h"
+#include "gui/scene3d_viewport_widget.h"
 #include <QFileDialog>
 #include <QAction>
 #include <QCoreApplication>
@@ -1510,6 +1511,7 @@ void MainWindow::setup_studio_shell()
   auto * right_action = camera_view_menu->addAction("Right");
   auto * front_action = camera_view_menu->addAction("Front");
   auto * fit_button = camera_view_menu->addAction("Fit Cell");
+  auto * fit_robot_button = camera_view_menu->addAction("Fit Robot");
   auto * reset_button = camera_view_menu->addAction("Reset View");
   auto * zoom_in = camera_view_menu->addAction("Zoom In");
   auto * zoom_out = camera_view_menu->addAction("Zoom Out");
@@ -2064,6 +2066,12 @@ connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo
   connect(copy_source_cmd, &QPushButton::clicked, this, [this](){ QApplication::clipboard()->setText("source install/setup.bash"); });
   connect(open_logs_cmd, &QPushButton::clicked, this, [this](){ open_diagnostics_folder(); });
   connect(fit_button, &QAction::triggered, this, [this](){ if (digital_twin_canvas_ && digital_twin_canvas_->scene()) digital_twin_canvas_->fitInView(digital_twin_canvas_->scene()->itemsBoundingRect().adjusted(-24,-24,24,24), Qt::KeepAspectRatio); });
+  connect(fit_robot_button, &QAction::triggered, this, [this](){
+    if (!scene_preview_widget_) return;
+    auto * viewport = scene_preview_widget_->findChild<Scene3DViewportWidget *>();
+    if (!viewport) return;
+    viewport->fit_robot();
+  });
   connect(reset_button, &QAction::triggered, this, [this](){ if (digital_twin_canvas_) digital_twin_canvas_->resetTransform(); rebuild_digital_twin_canvas(); });
   connect(zoom_in, &QAction::triggered, this, [this](){ if (digital_twin_canvas_) digital_twin_canvas_->scale(1.15,1.15); });
   connect(zoom_out, &QAction::triggered, this, [this](){ if (digital_twin_canvas_) digital_twin_canvas_->scale(0.85,0.85); });

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -576,6 +576,11 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
     QFile out_file(diagnostics_path);
     if (out_file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
       QJsonObject root;
+      root["camera_fit_target"] = last_camera_fit_target_;
+      if (has_robot_aabb_diag_) {
+        root["robot_aabb_min"] = QJsonArray{last_robot_aabb_min_.x(), last_robot_aabb_min_.y(), last_robot_aabb_min_.z()};
+        root["robot_aabb_max"] = QJsonArray{last_robot_aabb_max_.x(), last_robot_aabb_max_.y(), last_robot_aabb_max_.z()};
+      }
       root["mesh_diagnostics"] = mesh_diagnostics_export();
       out_file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
       out_file.close();
@@ -618,6 +623,29 @@ void Scene3DViewportWidget::fit_scene() {
   distance_ = qBound(min_distance_, fit_distance, max_distance_);
   pitch_ = qBound(0.28, pitch_, 0.9);
   orbit_offset_.setY(orbit_offset_.y() + static_cast<float>(qMax(0.10, radius * 0.05)));
+  last_camera_fit_target_ = QStringLiteral("scene");
+  has_robot_aabb_diag_ = false;
+  update();
+}
+void Scene3DViewportWidget::fit_robot()
+{
+  QVector3D bmin, bmax;
+  if (!robot_bounds_from_rendered_visuals(bmin, bmax)) {
+    fit_scene();
+    return;
+  }
+  orbit_offset_ = (bmin + bmax) * 0.5f;
+  const QVector3D ext = bmax - bmin;
+  const double radius = qMax(0.2, 0.5 * qSqrt(ext.x() * ext.x() + ext.y() * ext.y() + ext.z() * ext.z()));
+  scene_radius_ = radius;
+  const double fov = qDegreesToRadians(50.0);
+  const double fit_distance = (radius / qTan(fov * 0.5)) * 1.05;
+  distance_ = qBound(min_distance_, fit_distance, max_distance_);
+  pitch_ = qBound(0.28, pitch_, 0.9);
+  last_camera_fit_target_ = QStringLiteral("robot");
+  has_robot_aabb_diag_ = true;
+  last_robot_aabb_min_ = bmin;
+  last_robot_aabb_max_ = bmax;
   update();
 }
 void Scene3DViewportWidget::focus_selected() {
@@ -1020,6 +1048,29 @@ bool Scene3DViewportWidget::scene_bounds_from_visible_items(QVector3D & out_min,
     out_max.setZ(std::max(out_max.z(), static_cast<float>(bounds.z + bounds.sz)));
   }
   return has_fittable_item;
+}
+
+bool Scene3DViewportWidget::robot_bounds_from_rendered_visuals(QVector3D & out_min, QVector3D & out_max) const
+{
+  out_min = QVector3D(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
+  out_max = QVector3D(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
+  bool has_robot_visual = false;
+  for (const auto & it : items) {
+    const bool urdf_visual = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
+    const bool robot_base_marker = classify_item_role(it) == NormalizedRole::RobotBase && it.linked_to_editable_layout_state;
+    if (!urdf_visual && !robot_base_marker) continue;
+    if (is_overlay_only_item(it)) continue;
+    ItemBounds bounds{};
+    if (!mesh_world_bounds_for_item(it, bounds)) bounds = { it.x, it.y, it.z, it.sx, it.sy, it.sz };
+    out_min.setX(std::min(out_min.x(), static_cast<float>(bounds.x)));
+    out_min.setY(std::min(out_min.y(), static_cast<float>(bounds.y)));
+    out_min.setZ(std::min(out_min.z(), static_cast<float>(bounds.z)));
+    out_max.setX(std::max(out_max.x(), static_cast<float>(bounds.x + bounds.sx)));
+    out_max.setY(std::max(out_max.y(), static_cast<float>(bounds.y + bounds.sy)));
+    out_max.setZ(std::max(out_max.z(), static_cast<float>(bounds.z + bounds.sz)));
+    has_robot_visual = true;
+  }
+  return has_robot_visual;
 }
 
 bool Scene3DViewportWidget::item_has_explicit_dimensions(const ScenePreviewWidget::PreviewItem & item) const
@@ -1602,9 +1653,11 @@ void Scene3DViewportWidget::camera_matrices(QMatrix4x4 & out_proj, QMatrix4x4 & 
     static_cast<float>(qSin(pitch_)),
     cp * static_cast<float>(qCos(yaw_)));
   const QVector3D eye = orbit_offset_ - (forward * clamped_distance);
-  const float far_plane = qMax(100.0f, clamped_distance + static_cast<float>(scene_radius_ * 6.0));
+  const float radius = static_cast<float>(qMax(0.2, scene_radius_));
+  const float near_plane = qMax(0.01f, qMin(0.2f, radius * 0.05f));
+  const float far_plane = qMax(clamped_distance + (radius * 8.0f), radius * 20.0f);
   out_proj.setToIdentity();
-  out_proj.perspective(50.0f, aspect, 0.05f, far_plane);
+  out_proj.perspective(50.0f, aspect, near_plane, far_plane);
   out_view.setToIdentity();
   out_view.lookAt(eye, orbit_offset_, QVector3D(0.0f, 1.0f, 0.0f));
 }

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -69,6 +69,7 @@ public:
 
   void reset_view();
   void fit_scene();
+  void fit_robot();
   void focus_selected();
   void set_top_view();
   void set_front_view();
@@ -154,6 +155,7 @@ private:
   void draw_ground_grid_pass();
   void draw_world_axes_pass();
   bool scene_bounds_from_visible_items(QVector3D & out_min, QVector3D & out_max, bool include_overlays) const;
+  bool robot_bounds_from_rendered_visuals(QVector3D & out_min, QVector3D & out_max) const;
   bool item_has_explicit_dimensions(const ScenePreviewWidget::PreviewItem & item) const;
   QString placeholder_reason_for_item(const ScenePreviewWidget::PreviewItem & item) const;
   bool draw_truthful_item_geometry(const ScenePreviewWidget::PreviewItem & it, int * out_placeholder_count = nullptr,
@@ -231,4 +233,8 @@ private:
   QString drag_asset_drop_status_;
   QPoint drag_asset_screen_pos_;
   QJsonObject drag_asset_payload_;
+  QString last_camera_fit_target_{ "scene" };
+  bool has_robot_aabb_diag_{ false };
+  QVector3D last_robot_aabb_min_;
+  QVector3D last_robot_aabb_max_;
 };

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -104,7 +104,7 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   mouse_help_label->setToolTip(scene_preview_mouse_help_tooltip(QString()));
   mouse_help_label->setStatusTip(QString::fromUtf8(kScenePreviewMouseHelpText));
   controls->addWidget(mouse_help_label);
-  overlays_selector_ = new QComboBox(this); overlays_selector_->addItems({"Overlays", "Reachability Heatmap", "Collision Warnings", "Safety Zones", "Work Envelope", "Warning Labels", "Labels", "Pick/Place Zones", "Task Route", "Approach/Retreat", "Camera FOV", "Pick Coverage", "EPD Detections", "Detection Labels", "Warnings", "Focus Selected", "Fit Scene", "Fit overlays", "Clear Selection"}); controls->addWidget(overlays_selector_);
+  overlays_selector_ = new QComboBox(this); overlays_selector_->addItems({"Overlays", "Reachability Heatmap", "Collision Warnings", "Safety Zones", "Work Envelope", "Warning Labels", "Labels", "Pick/Place Zones", "Task Route", "Approach/Retreat", "Camera FOV", "Pick Coverage", "EPD Detections", "Detection Labels", "Warnings", "Focus Selected", "Fit Scene", "Fit Robot", "Fit overlays", "Clear Selection"}); controls->addWidget(overlays_selector_);
   controls->addStretch(1);
   root->addLayout(controls);
   stack_ = new QStackedWidget(this);
@@ -201,6 +201,7 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
     else if (choice == "Warning Labels") v->show_warning_labels = !v->show_warning_labels;
     else if (choice == "Focus Selected") on_focus_selected_clicked();
     else if (choice == "Fit Scene") on_fit_scene_clicked();
+    else if (choice == "Fit Robot") on_fit_robot_clicked();
     else if (choice == "Fit overlays") on_fit_overlays_clicked();
     else if (choice == "Clear Selection") on_clear_selection_clicked();
     v->update();
@@ -258,6 +259,7 @@ void ScenePreviewWidget::reload_meshes()
 }
 void ScenePreviewWidget::on_reset_view_clicked(){ static_cast<Scene3DViewportWidget *>(simple_3d_view_)->reset_view(); reset_fallback_scene_view(); }
 void ScenePreviewWidget::on_fit_scene_clicked(){ auto *v = static_cast<Scene3DViewportWidget *>(simple_3d_view_); v->fit_include_overlays = false; v->fit_scene(); fit_fallback_scene_to_items(false); } // Fit Scene intentionally excludes overlay-only bounds by default.
+void ScenePreviewWidget::on_fit_robot_clicked(){ auto *v = static_cast<Scene3DViewportWidget *>(simple_3d_view_); v->fit_robot(); fit_fallback_scene_to_items(false); }
 void ScenePreviewWidget::on_fit_overlays_clicked(){ auto *v = static_cast<Scene3DViewportWidget *>(simple_3d_view_); const QRectF physical_bounds = rendered_items_bounds_2d(false); const QRectF overlay_bounds = rendered_items_bounds_2d(true); maybe_warn_overlay_fit_dominance(this, physical_bounds, overlay_bounds); v->fit_include_overlays = true; v->fit_scene(); fit_fallback_scene_to_items(true); v->fit_include_overlays = false; } // Fit overlays includes overlay bounds for explicit overlay-focused framing.
 void ScenePreviewWidget::on_focus_selected_clicked(){ static_cast<Scene3DViewportWidget *>(simple_3d_view_)->focus_selected(); }
 void ScenePreviewWidget::on_clear_selection_clicked(){ selected_preview_item_id_.clear(); static_cast<Scene3DViewportWidget *>(simple_3d_view_)->selected_id.clear(); simple_3d_view_->update(); emit studio_log_requested("Cleared preview selection."); emit preview_item_selected(QString(), QStringLiteral("unknown")); }

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -205,6 +205,7 @@ private slots:
   void on_mode_changed(int index);
   void on_reset_view_clicked();
   void on_fit_scene_clicked();
+  void on_fit_robot_clicked();
   void on_focus_selected_clicked();
   void on_fit_overlays_clicked();
   void on_clear_selection_clicked();


### PR DESCRIPTION
### Motivation
- Provide a camera-fit path that focuses the 3D viewport on robot visuals (URDF-generated visuals and robot-linked editable base marker) while excluding overlay-only helpers to improve robot inspection and framing.
- Prefer accurate mesh-derived world bounds when available and avoid view clipping/tiny-view artifacts by scaling camera near/far planes relative to the active fit radius.

### Description
- Added `bool robot_bounds_from_rendered_visuals(QVector3D & out_min, QVector3D & out_max) const` to `Scene3DViewportWidget` which collects robot visuals (URDF visuals + robot-linked editable base marker), excludes overlay-only items, and prefers `mesh_world_bounds_for_item` when present.
- Added public `void fit_robot()` to `Scene3DViewportWidget` which centers `orbit_offset_` on the robot AABB center, sets `distance_` from the robot bounding-sphere radius, updates `scene_radius_`, records diagnostics (`camera_fit_target=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a142fecd8c48331aff4520793acad30)