### PR TITLE
Add missing Scene3D robot classification fields

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -68,6 +68,8 @@ public:
     double visual_origin_roll{ 0.0 }, visual_origin_pitch{ 0.0 }, visual_origin_yaw{ 0.0 };
     bool transform_chain_applied{ false };
     bool visual_origin_applied{ false };
+    bool robot_candidate{ false };
+    QString robot_classification_source;
     QString robot_base_frame;
     QString robot_world_pose;
   };


### PR DESCRIPTION
Fixes workcell_builder build failure by adding the PreviewItem robot classification fields used by scene3d_candidate_assembly.cpp and scene3d_render_role_classifier_test.cpp.

Validation:
- colcon build --symlink-install --packages-select workcell_builder

No EPD changes.
No real hardware commands.