### PR TITLE
Fix Save Layout paths for selected scene

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -4924,7 +4924,7 @@ void MainWindow::save_layout_changes()
   if (!digital_twin_scene_) return;
   const fs::path layout_path = selected_scene_environment_layout_path(scene_browser_result_, selected_scene_index_);
   if (layout_path.empty()) return;
-  const fs::path scene_dir = layout_path.parent_path().parent_path();
+  const fs::path scene_dir = layout_path.parent_path();
   const std::array<const char *, 4> required_dirs = {"layout", "task", "generated", "plan_preview"};
   for (const char * dir_name : required_dirs) {
     boost::system::error_code mk_ec;


### PR DESCRIPTION
## Summary
Fixes Save Layout writing `environment.yaml` and `layout/workcell_studio_layout.yaml` to the scenes root instead of the selected scene directory.

## Root cause
`save_layout_changes()` derived `scene_dir` from `environment_layout.yaml` using `parent_path().parent_path()`, which resolves to the scenes root. It now uses `parent_path()`, which resolves to the selected scene directory.

## Validation
Local validation performed:

- `colcon build --symlink-install --packages-select workcell_builder` passed
- Created fresh scene `test_save_path`
- Save Layout wrote `environment.yaml` under the selected scene
- Save Layout wrote `layout/workcell_studio_layout.yaml` under the selected scene
- Confirmed no parent-root `environment.yaml` was created
- Confirmed no parent-root `layout/workcell_studio_layout.yaml` was created

Validation notes:
`validate_builder_generated_scene.py` still reports `test_save_path` is not a complete ROS scene package because `package.xml`/`CMakeLists.txt` are missing and the task intent references zones not present in scene metadata. That is a separate new-scene generation/package-readiness issue, not this Save Layout path fix.

## Safety
- One-file hotfix
- No EPD changes
- No real hardware commands
- No generated artifacts committed