### PR TITLE
Fix workcell_builder compile error in scene xacro generator

### DIFF
--- a/workcell_builder/workcell_builder/src_workcell_studio_template_instantiator.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_template_instantiator.cpp
@@ -46,7 +46,7 @@ std::string generated_scene_xacro(const std::string & scene_name, const std::str
     "    <origin xyz=\"0 0 0\" rpy=\"0 0 0\"/>\n"
     "  </joint>\n"
     "\n"
-    "  <!-- selected_robot_metadata: ") + robot_id + " -->\n"
+    "  <!-- selected_robot_metadata: " + robot_id + " -->\n"
     "  <!-- selected_end_effector_metadata: " + end_effector_id + " -->\n"
     "  <!-- missing end-effector xacro -> placeholder visual only -->\n"
     "\n"


### PR DESCRIPTION
## Summary
- fixed a malformed string concatenation in `generated_scene_xacro` in `workcell_builder/src_workcell_studio_template_instantiator.cpp`
- corrected the robot metadata comment line to concatenate `robot_id` within the same expression

## Why
`colcon build --packages-select workcell_builder` failed with:
- `expected ';' before ')' token`
- `expected primary-expression before ')' token`

The issue was caused by an extra closing parenthesis in the string-building expression.

## Impact
- restores successful compilation for this translation unit
- allows the selected `robot_id` and `end_effector_id` metadata comments to be emitted as intended in generated scene xacro output

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14598821ac8331b62c7aea2419c586)