### PR TITLE
Unblock Generate Scene Package when layout merge script is unavailable

### DIFF
--- a/tests/test_workcell_studio_layout_merge_fallback_contract.py
+++ b/tests/test_workcell_studio_layout_merge_fallback_contract.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+CPP = Path("workcell_builder/workcell_builder/src_workcell_studio_layout_merge.cpp").read_text(encoding="utf-8")
+
+
+def test_missing_merge_script_uses_fallback_warning_and_report():
+    assert "layout_merge_fallback_used" in CPP
+    assert "write_layout_merge_fallback_report" in CPP
+    assert "out.status = out.blockers.empty();" in CPP
+
+
+def test_fallback_blocks_only_on_missing_required_authoring_files_with_exact_names():
+    for token in [
+        'scene_dir / "environment.yaml"',
+        'scene_dir / "environment_layout.yaml"',
+        'scene_dir / "layout" / "workcell_studio_layout.yaml"',
+        'scene_dir / "cell_definition.yaml"',
+        'Missing required authoring file: ',
+    ]:
+        assert token in CPP

--- a/workcell_builder/workcell_builder/src_workcell_studio_layout_merge.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_layout_merge.cpp
@@ -6,9 +6,54 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <fstream>
 
 namespace fs = boost::filesystem;
 namespace workcell_builder {
+
+namespace {
+
+void write_layout_merge_fallback_report(
+  const fs::path& scene_dir,
+  const std::vector<std::string>& warnings,
+  const std::vector<std::string>& blockers,
+  bool layout_applied)
+{
+  boost::system::error_code ec;
+  fs::create_directories(scene_dir / "generated", ec);
+  const fs::path report = scene_dir / "generated" / "workcell_studio_layout_merge_report.json";
+  const fs::path summary = scene_dir / "generated" / "workcell_studio_layout_merge_summary.txt";
+
+  QJsonObject root;
+  root.insert("layout_applied", layout_applied);
+  root.insert("generated_from_saved_layout", layout_applied);
+  QJsonArray warning_json;
+  for (const auto& w : warnings) warning_json.push_back(QString::fromStdString(w));
+  root.insert("warnings", warning_json);
+  QJsonArray blocker_json;
+  for (const auto& b : blockers) blocker_json.push_back(QString::fromStdString(b));
+  root.insert("blockers", blocker_json);
+  root.insert("merge_mode", "fallback");
+  root.insert("layout_merge_fallback_used", true);
+
+  QFile report_file(QString::fromStdString(report.string()));
+  if (report_file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+    report_file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+    report_file.write("\n");
+  }
+
+  std::ofstream summary_out(summary.string());
+  if (summary_out.is_open()) {
+    summary_out << "layout_applied=" << (layout_applied ? "true" : "false") << "\n";
+    summary_out << "generated_from_saved_layout=" << (layout_applied ? "true" : "false") << "\n";
+    summary_out << "layout_merge_fallback_used=true\n";
+    for (const auto& w : warnings) summary_out << "warning=" << w << "\n";
+    for (const auto& b : blockers) summary_out << "blocker=" << b << "\n";
+  }
+}
+
+}  // namespace
+
 LayoutMergeResult merge_workcell_studio_layout(const fs::path& scene_dir)
 {
   LayoutMergeResult out;
@@ -22,7 +67,22 @@ LayoutMergeResult merge_workcell_studio_layout(const fs::path& scene_dir)
   const fs::path repo_root = scene_dir.parent_path().parent_path();
   const fs::path script_path = repo_root / "scripts" / "workcell_studio_layout_merge.py";
   if (!fs::exists(script_path)) {
-    out.blockers.push_back("Layout merge script missing: scripts/workcell_studio_layout_merge.py");
+    const std::vector<fs::path> required_authoring_files{
+      scene_dir / "environment.yaml",
+      scene_dir / "environment_layout.yaml",
+      scene_dir / "layout" / "workcell_studio_layout.yaml",
+      scene_dir / "cell_definition.yaml"
+    };
+    for (const auto& required_file : required_authoring_files) {
+      if (!fs::exists(required_file)) {
+        out.blockers.push_back("Missing required authoring file: " + required_file.filename().string());
+      }
+    }
+    out.warnings.push_back("layout_merge_fallback_used");
+    write_layout_merge_fallback_report(scene_dir, out.warnings, out.blockers, out.layout_applied);
+    out.report_path = (scene_dir / "generated" / "workcell_studio_layout_merge_report.json").string();
+    out.summary_path = (scene_dir / "generated" / "workcell_studio_layout_merge_summary.txt").string();
+    out.status = out.blockers.empty();
     return out;
   }
 


### PR DESCRIPTION
## Summary
Implement a safe fallback in `merge_workcell_studio_layout()` so Generate Scene Package is not hard-blocked when `scripts/workcell_studio_layout_merge.py` is missing.

## Root cause
`workcell_builder/workcell_builder/src_workcell_studio_layout_merge.cpp` returned a hard blocker immediately if the helper script was not found at `scripts/workcell_studio_layout_merge.py`, which prevented package generation from continuing for new scenes.

## What changed
- Added an internal fallback path when the helper script is missing.
- Fallback behavior:
  - validates required authoring files:
    - `environment.yaml`
    - `environment_layout.yaml`
    - `layout/workcell_studio_layout.yaml`
    - `cell_definition.yaml`
  - if required files exist, merge step returns success and emits warning `layout_merge_fallback_used`.
  - if required files are missing, merge step blocks with exact missing file names.
  - always writes deterministic fallback diagnostics to:
    - `generated/workcell_studio_layout_merge_report.json`
    - `generated/workcell_studio_layout_merge_summary.txt`
- Added contract tests in `tests/test_workcell_studio_layout_merge_fallback_contract.py`.

## Files changed
- `workcell_builder/workcell_builder/src_workcell_studio_layout_merge.cpp`
- `tests/test_workcell_studio_layout_merge_fallback_contract.py`

## Validation
Ran:
- `pytest -q tests/test_workcell_builder_guided_scene_setup_v1.py tests/test_guided_scene_package_rviz_generation.py tests/test_workcell_studio_layout_merge_fallback_contract.py`

Result: `12 passed`.

## Constraints honored
- No EPD changes.
- No hardware execution.
- No `use_fake_hardware:=false` usage.
- No generated scenes/test artifacts committed.
- PR scoped to layout merge/generation blocker.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a145af442dc8331893592d8f644d20f)