### PR TITLE
Fix Generate Scene Package reliability when layout-merge script is missing

### DIFF
--- a/tests/test_workcell_studio_generate_scene_package_action_flow.py
+++ b/tests/test_workcell_studio_generate_scene_package_action_flow.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+MAIN = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+
+
+def test_generate_scene_package_action_runs_merge_then_generation():
+    assert 'Generate Scene Package: requested for scene' in MAIN
+    assert 'run_layout_merge_for_selected_scene(true);' in MAIN
+    assert 'generate_scene_package_for_selected_scene();' in MAIN

--- a/tests/test_workcell_studio_layout_merge_fallback_contract.py
+++ b/tests/test_workcell_studio_layout_merge_fallback_contract.py
@@ -6,6 +6,8 @@ CPP = Path("workcell_builder/workcell_builder/src_workcell_studio_layout_merge.c
 
 def test_missing_merge_script_uses_fallback_warning_and_report():
     assert "layout_merge_fallback_used" in CPP
+    assert 'root.insert("layout_merge_status", blockers.empty() ? "WARN" : "BLOCKED");' in CPP
+    assert 'root.insert("layout_merge_warning", "missing script fallback used");' in CPP
     assert "write_layout_merge_fallback_report" in CPP
     assert "out.status = out.blockers.empty();" in CPP
 
@@ -16,6 +18,7 @@ def test_fallback_blocks_only_on_missing_required_authoring_files_with_exact_nam
         'scene_dir / "environment_layout.yaml"',
         'scene_dir / "layout" / "workcell_studio_layout.yaml"',
         'scene_dir / "cell_definition.yaml"',
-        'Missing required authoring file: ',
+        "Next action: click Save Layout.",
+        "Next action: click Generate YAML.",
     ]:
         assert token in CPP

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -2251,7 +2251,11 @@ void MainWindow::build_studio_header_actions()
   action_workspace_open_scene_builder_ = new QAction("Open Scene Builder", this);
   connect(action_workspace_open_scene_builder_, &QAction::triggered, this, [this]() { open_scene_builder_for_selected_scene("Header Scenes/Open"); });
   action_generate_package_ = new QAction("Generate Scene Package", this);
-  connect(action_generate_package_, &QAction::triggered, this, [this]() { append_studio_log(QString("Generate Scene Package: requested for scene '%1'.").arg(selected_scene_name())); run_layout_merge_for_selected_scene(true); });
+  connect(action_generate_package_, &QAction::triggered, this, [this]() {
+    append_studio_log(QString("Generate Scene Package: requested for scene '%1'.").arg(selected_scene_name()));
+    run_layout_merge_for_selected_scene(true);
+    generate_scene_package_for_selected_scene();
+  });
   action_generate_yaml_ = new QAction("Generate YAML", this);
   connect(action_generate_yaml_, &QAction::triggered, this, &MainWindow::generate_yaml_draft_for_selected_scene);
   action_generate_task_intent_ = new QAction("Generate/Update Task Intent", this);

--- a/workcell_builder/workcell_builder/src_workcell_studio_layout_merge.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_layout_merge.cpp
@@ -35,6 +35,8 @@ void write_layout_merge_fallback_report(
   root.insert("blockers", blocker_json);
   root.insert("merge_mode", "fallback");
   root.insert("layout_merge_fallback_used", true);
+  root.insert("layout_merge_status", blockers.empty() ? "WARN" : "BLOCKED");
+  root.insert("layout_merge_warning", "missing script fallback used");
 
   QFile report_file(QString::fromStdString(report.string()));
   if (report_file.open(QIODevice::WriteOnly | QIODevice::Text)) {
@@ -67,18 +69,18 @@ LayoutMergeResult merge_workcell_studio_layout(const fs::path& scene_dir)
   const fs::path repo_root = scene_dir.parent_path().parent_path();
   const fs::path script_path = repo_root / "scripts" / "workcell_studio_layout_merge.py";
   if (!fs::exists(script_path)) {
-    const std::vector<fs::path> required_authoring_files{
-      scene_dir / "environment.yaml",
-      scene_dir / "environment_layout.yaml",
-      scene_dir / "layout" / "workcell_studio_layout.yaml",
-      scene_dir / "cell_definition.yaml"
+    const std::vector<std::pair<fs::path, std::string>> required_authoring_files{
+      {scene_dir / "environment.yaml", "Missing required authoring file: environment.yaml. Next action: click Save Layout."},
+      {scene_dir / "environment_layout.yaml", "Missing required authoring file: environment_layout.yaml. Next action: click Save Layout."},
+      {scene_dir / "layout" / "workcell_studio_layout.yaml", "Missing required authoring file: layout/workcell_studio_layout.yaml. Next action: click Save Layout."},
+      {scene_dir / "cell_definition.yaml", "Missing required authoring file: cell_definition.yaml. Next action: click Generate YAML."}
     };
     for (const auto& required_file : required_authoring_files) {
-      if (!fs::exists(required_file)) {
-        out.blockers.push_back("Missing required authoring file: " + required_file.filename().string());
+      if (!fs::exists(required_file.first)) {
+        out.blockers.push_back(required_file.second);
       }
     }
-    out.warnings.push_back("layout_merge_fallback_used");
+    out.warnings.push_back("missing script fallback used");
     write_layout_merge_fallback_report(scene_dir, out.warnings, out.blockers, out.layout_applied);
     out.report_path = (scene_dir / "generated" / "workcell_studio_layout_merge_report.json").string();
     out.summary_path = (scene_dir / "generated" / "workcell_studio_layout_merge_summary.txt").string();


### PR DESCRIPTION
## Summary
This PR fixes Workcell Studio's `Generate Scene Package` flow so it no longer hard-stops when `scripts/workcell_studio_layout_merge.py` is missing, as long as required authoring files are present.

## Root cause
The `Generate Scene Package` action in `mainwindow.cpp` only ran layout merge and did not continue to package generation. In addition, fallback layout-merge diagnostics were too generic and missing script fallback behavior was not explicit enough for guided UX.

## What changed
- **Generate Scene Package action flow**
  - Updated action handler to run:
    1. `run_layout_merge_for_selected_scene(true)`
    2. `generate_scene_package_for_selected_scene()`
  - This allows package generation to continue after a successful merge/fallback.

- **Layout merge fallback diagnostics and blocking rules**
  - In `src_workcell_studio_layout_merge.cpp`, when merge script is missing:
    - Continue with fallback if required authoring files exist.
    - Block only when required authoring files are missing.
    - Emit explicit diagnostics in merge report:
      - `layout_merge_fallback_used: true`
      - `layout_merge_status: WARN` (or `BLOCKED` if required files missing)
      - `layout_merge_warning: missing script fallback used`
    - Emit exact missing-file + next-action blocker messages:
      - `environment.yaml` → click Save Layout
      - `environment_layout.yaml` → click Save Layout
      - `layout/workcell_studio_layout.yaml` → click Save Layout
      - `cell_definition.yaml` → click Generate YAML

## Files changed
- `workcell_builder/workcell_builder/gui/mainwindow.cpp`
- `workcell_builder/workcell_builder/src_workcell_studio_layout_merge.cpp`
- `tests/test_workcell_studio_layout_merge_fallback_contract.py`
- `tests/test_workcell_studio_generate_scene_package_action_flow.py` (new)

## Tests run
- `python3 -m pytest -q tests/test_workcell_studio_layout_merge_fallback_contract.py tests/test_workcell_studio_generate_scene_package_action_flow.py tests/test_guided_scene_package_rviz_generation.py tests/test_workcell_builder_guided_scene_setup_v1.py`
- Result: **13 passed**

## Scope / safety
- No EPD changes.
- No real hardware commands.
- No `use_fake_hardware:=false` introduced.
- Focused only on generation-flow reliability and diagnostics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a145ca187d48331aa9e9bcc58977a6e)