### PR TITLE
Add supported scene registry and all-scenes readiness validator

### DIFF
--- a/scripts/validate_supported_scenes_readiness.py
+++ b/scripts/validate_supported_scenes_readiness.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except Exception:  # pragma: no cover
+    yaml = None
+
+DEFAULT_REGISTRY = Path("workcell_studio_supported_scenes.yaml")
+VALIDATOR = Path("scripts/validate_guided_generated_scene_build_readiness.py")
+
+
+def _load_yaml(path: Path) -> dict:
+    if yaml is None:
+        raise RuntimeError("PyYAML is not installed; cannot parse supported scene registry.")
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, dict) else {}
+
+
+def _run_validator(repo_root: Path, workspace_root: Path, scene_name: str, skip_build: bool, skip_launch_smoke: bool, timeout_sec: int):
+    validator_path = repo_root / VALIDATOR
+    if not validator_path.exists():
+        validator_path = Path(__file__).resolve().parent / 'validate_guided_generated_scene_build_readiness.py'
+    cmd = [
+        sys.executable,
+        str(validator_path),
+        "--scene",
+        scene_name,
+        "--repo-root",
+        str(repo_root),
+        "--workspace-root",
+        str(workspace_root),
+        "--json",
+        "--timeout-sec",
+        str(timeout_sec),
+    ]
+    if skip_build:
+        cmd.append("--skip-build")
+    if skip_launch_smoke:
+        cmd.append("--skip-launch-smoke")
+
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    payload = {}
+    if proc.stdout.strip():
+        try:
+            payload = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            payload = {"status": "BLOCKED", "blockers": ["validator_output_not_json"], "warnings": [proc.stdout.strip()[:500]]}
+    if not isinstance(payload, dict):
+        payload = {"status": "BLOCKED", "blockers": ["validator_output_not_object"], "warnings": []}
+    return cmd, proc.returncode, payload
+
+
+def _build_markdown(report: dict) -> str:
+    lines = [
+        "# Workcell Studio All Scenes Readiness Report",
+        "",
+        "Scene | Support Level | Static | Build | Fake Launch | Status | Blocker",
+        "--- | --- | --- | --- | --- | --- | ---",
+    ]
+    for row in report["per_scene"]:
+        blockers = "; ".join(row.get("blockers", [])) or "-"
+        lines.append(
+            f"{row['scene_name']} | {row['support_level']} | {row['static_validation']['status']} | {row['build']['status']} | {row['launch_smoke']['status']} | {row['status']} | {blockers}"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Validate supported Workcell Studio scenes from a registry.")
+    ap.add_argument("--repo-root", type=Path, required=True)
+    ap.add_argument("--workspace-root", type=Path, required=True)
+    ap.add_argument("--registry", type=Path, default=None)
+    ap.add_argument("--json", action="store_true", dest="json_out")
+    ap.add_argument("--skip-build", action="store_true")
+    ap.add_argument("--skip-launch-smoke", action="store_true")
+    ap.add_argument("--scene", action="append", default=[])
+    ap.add_argument("--include-experimental", action="store_true")
+    ap.add_argument("--timeout-sec", type=int, default=30)
+    ap.add_argument("--output", type=Path, default=None)
+    args = ap.parse_args()
+
+    repo_root = args.repo_root.resolve()
+    workspace_root = args.workspace_root.resolve()
+    registry_path = (args.registry or (repo_root / DEFAULT_REGISTRY)).resolve()
+
+    report = {
+        "registry_path": str(registry_path),
+        "workspace_root": str(workspace_root),
+        "repo_root": str(repo_root),
+        "scenes_checked": [],
+        "scenes_skipped": [],
+        "per_scene": [],
+        "summary": {"total": 0, "pass": 0, "fail": 0, "blocked": 0, "warnings": 0, "skipped": 0},
+    }
+
+    if not registry_path.exists():
+        report["summary"]["blocked"] = 1
+        report["error"] = f"Registry does not exist: {registry_path}"
+        if args.json_out:
+            print(json.dumps(report, indent=2))
+        return 2
+
+    registry = _load_yaml(registry_path)
+    entries = registry.get("scenes", []) if isinstance(registry, dict) else []
+    filter_set = set(args.scene or [])
+
+    for entry in entries:
+        scene_name = str(entry.get("scene_name", "")).strip()
+        if not scene_name:
+            continue
+        if filter_set and scene_name not in filter_set:
+            continue
+
+        support_level = str(entry.get("support_level", "supported"))
+        enabled = bool(entry.get("enabled", True))
+        scene_dir = (repo_root / str(entry.get("scene_path", f"scenes/{scene_name}"))).resolve()
+        required = list(entry.get("expected_files", []))
+        skip_build = args.skip_build or bool(entry.get("allow_skip_build", False))
+        skip_launch = args.skip_launch_smoke or bool(entry.get("allow_skip_launch_smoke", False))
+
+        row = {
+            "scene_name": scene_name,
+            "support_level": support_level,
+            "status": "SKIPPED",
+            "required_files": required,
+            "static_validation": {"status": "SKIPPED", "missing_files": []},
+            "guided_build_launch_readiness": {"status": "SKIPPED"},
+            "build": {"status": "SKIPPED"},
+            "launch_smoke": {"status": "SKIPPED"},
+            "blockers": list(entry.get("known_blockers", [])),
+            "warnings": [],
+            "commands_run": [],
+            "artifact_paths": {},
+        }
+
+        if not enabled:
+            report["scenes_skipped"].append(scene_name)
+            row["status"] = "SKIPPED"
+            row["blockers"].append("scene_disabled_in_registry")
+            report["per_scene"].append(row)
+            continue
+        if support_level == "experimental" and not args.include_experimental:
+            report["scenes_skipped"].append(scene_name)
+            row["status"] = "SKIPPED"
+            row["warnings"].append("experimental_scene_skipped_without_include_experimental")
+            report["per_scene"].append(row)
+            continue
+
+        report["scenes_checked"].append(scene_name)
+        if not scene_dir.exists():
+            row["status"] = "BLOCKED"
+            row["static_validation"] = {"status": "BLOCKED", "missing_files": required}
+            row["blockers"].append(f"scene_path_missing: {scene_dir}")
+            report["per_scene"].append(row)
+            continue
+
+        missing = [rel for rel in required if not (scene_dir / rel).exists()]
+        row["static_validation"] = {"status": "PASS" if not missing else "FAIL", "missing_files": missing}
+        if missing:
+            row["status"] = "FAIL"
+            row["blockers"].extend([f"missing_required_file: {m}" for m in missing])
+            report["per_scene"].append(row)
+            continue
+
+        cmd, _, payload = _run_validator(repo_root, workspace_root, scene_name, skip_build, skip_launch, args.timeout_sec)
+        row["commands_run"].append(" ".join(cmd))
+        guided_status = payload.get("status", "BLOCKED")
+        row["guided_build_launch_readiness"] = payload
+        row["build"] = payload.get("build", {"status": "SKIPPED"})
+        row["launch_smoke"] = payload.get("launch_smoke", {"status": "SKIPPED"})
+        row["artifact_paths"] = payload.get("artifact_paths", {})
+        row["warnings"].extend(payload.get("warnings", []))
+        row["blockers"].extend(payload.get("blockers", []))
+
+        if guided_status in {"PASS", "PASS_WITH_WARNINGS", "FAIL", "BLOCKED"}:
+            row["status"] = guided_status
+        else:
+            row["status"] = "BLOCKED"
+            row["blockers"].append(f"unknown_guided_status: {guided_status}")
+
+        report["per_scene"].append(row)
+
+    for row in report["per_scene"]:
+        report["summary"]["total"] += 1
+        status = row["status"]
+        if status == "PASS":
+            report["summary"]["pass"] += 1
+        elif status == "PASS_WITH_WARNINGS":
+            report["summary"]["pass"] += 1
+            report["summary"]["warnings"] += 1
+        elif status == "FAIL":
+            report["summary"]["fail"] += 1
+        elif status == "BLOCKED":
+            report["summary"]["blocked"] += 1
+        elif status == "SKIPPED":
+            report["summary"]["skipped"] += 1
+
+    md_path = args.output.resolve() if args.output else (repo_root / "build/workcell_studio/all_scenes_readiness_report.md")
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    md_path.write_text(_build_markdown(report), encoding="utf-8")
+    report["markdown_report_path"] = str(md_path)
+
+    if args.json_out:
+        print(json.dumps(report, indent=2))
+
+    json_path = None
+    if args.output and args.output.suffix.lower() == ".json":
+        json_path = args.output.resolve()
+    elif args.output:
+        json_path = args.output.resolve().with_suffix(".json")
+    if json_path is not None:
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    return 0 if report["summary"]["fail"] == 0 and report["summary"]["blocked"] == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_validate_supported_scenes_readiness.py
+++ b/tests/test_validate_supported_scenes_readiness.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "validate_supported_scenes_readiness.py"
+
+
+def _write_scene(scene_dir: Path, name: str) -> None:
+    scene_dir.mkdir(parents=True, exist_ok=True)
+    (scene_dir / "package.xml").write_text(f"<package><name>{name}</name></package>\n", encoding="utf-8")
+    (scene_dir / "CMakeLists.txt").write_text(f"project({name})\nament_package()\n", encoding="utf-8")
+    (scene_dir / "environment.yaml").write_text("name: env\n", encoding="utf-8")
+    (scene_dir / "cell_definition.yaml").write_text("robot: ur5\nend_effector: suction\nenvironment: demo\n", encoding="utf-8")
+    (scene_dir / "launch").mkdir(exist_ok=True)
+    (scene_dir / "launch/demo.launch.py").write_text("use_fake_hardware launch_rviz robot_state_publisher rviz xacro\n", encoding="utf-8")
+    (scene_dir / "urdf").mkdir(exist_ok=True)
+    (scene_dir / "urdf/scene.urdf.xacro").write_text("<robot name='x'></robot>\n", encoding="utf-8")
+    (scene_dir / "layout").mkdir(exist_ok=True)
+    (scene_dir / "layout/workcell_studio_layout.yaml").write_text("layout: ok\n", encoding="utf-8")
+    (scene_dir / "generated").mkdir(exist_ok=True)
+    (scene_dir / "generated/scene_package_readiness.json").write_text(json.dumps({"package_name": name}), encoding="utf-8")
+
+
+def _run(tmp_path: Path, registry: Path, extra: list[str] | None = None) -> dict:
+    cmd = [sys.executable, str(SCRIPT), "--repo-root", str(tmp_path), "--workspace-root", str(tmp_path), "--registry", str(registry), "--json", "--skip-build", "--skip-launch-smoke"]
+    cmd.extend(extra or [])
+    run = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    return json.loads(run.stdout)
+
+
+def test_disabled_and_experimental_skipped(tmp_path: Path):
+    _write_scene(tmp_path / "scenes/ok_scene", "ok_scene")
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump({"scenes": [
+        {"scene_name": "disabled_scene", "scene_path": "scenes/disabled_scene", "enabled": False, "support_level": "supported", "expected_files": ["package.xml"]},
+        {"scene_name": "exp_scene", "scene_path": "scenes/ok_scene", "enabled": True, "support_level": "experimental", "expected_files": ["package.xml"]},
+    ]}), encoding="utf-8")
+    payload = _run(tmp_path, reg)
+    assert payload["summary"]["skipped"] == 2
+
+
+def test_missing_scene_is_blocked(tmp_path: Path):
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump({"scenes": [{"scene_name": "missing", "scene_path": "scenes/missing", "enabled": True, "support_level": "supported", "expected_files": ["package.xml"]}]}), encoding="utf-8")
+    payload = _run(tmp_path, reg)
+    assert payload["per_scene"][0]["status"] == "BLOCKED"
+
+
+def test_missing_required_file_is_fail(tmp_path: Path):
+    (tmp_path / "scenes/a").mkdir(parents=True)
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump({"scenes": [{"scene_name": "a", "scene_path": "scenes/a", "enabled": True, "support_level": "supported", "expected_files": ["package.xml"]}]}), encoding="utf-8")
+    payload = _run(tmp_path, reg)
+    assert payload["per_scene"][0]["status"] == "FAIL"
+    assert "missing_required_file: package.xml" in payload["per_scene"][0]["blockers"]
+
+
+def test_experimental_included_with_flag(tmp_path: Path):
+    _write_scene(tmp_path / "scenes/exp", "exp")
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump({"scenes": [{"scene_name": "exp", "scene_path": "scenes/exp", "enabled": True, "support_level": "experimental", "expected_files": ["package.xml", "CMakeLists.txt", "environment.yaml", "cell_definition.yaml", "launch/demo.launch.py", "urdf/scene.urdf.xacro", "generated/scene_package_readiness.json"]}]}), encoding="utf-8")
+    payload = _run(tmp_path, reg, ["--include-experimental"])
+    assert payload["per_scene"][0]["status"] in {"PASS", "PASS_WITH_WARNINGS"}
+
+
+def test_summary_counts(tmp_path: Path):
+    _write_scene(tmp_path / "scenes/pass_scene", "pass_scene")
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump({"scenes": [
+        {"scene_name": "pass_scene", "scene_path": "scenes/pass_scene", "enabled": True, "support_level": "supported", "expected_files": ["package.xml", "CMakeLists.txt", "environment.yaml", "cell_definition.yaml", "launch/demo.launch.py", "urdf/scene.urdf.xacro", "generated/scene_package_readiness.json"]},
+        {"scene_name": "missing_scene", "scene_path": "scenes/missing_scene", "enabled": True, "support_level": "supported", "expected_files": ["package.xml"]},
+        {"scene_name": "disabled_scene", "scene_path": "scenes/disabled_scene", "enabled": False, "support_level": "supported", "expected_files": ["package.xml"]},
+    ]}), encoding="utf-8")
+    payload = _run(tmp_path, reg)
+    assert payload["summary"] == {"total": 3, "pass": 1, "fail": 0, "blocked": 1, "warnings": 1, "skipped": 1}

--- a/workcell_studio_supported_scenes.yaml
+++ b/workcell_studio_supported_scenes.yaml
@@ -1,0 +1,73 @@
+scenes:
+  - scene_name: ur5_2f_test
+    scene_path: scenes/ur5_2f_test
+    enabled: true
+    support_level: canonical
+    robot: ur5
+    end_effector: robotiq_2f
+    expected_package_name: ur5_2f_test
+    expected_files: &required_files
+      - package.xml
+      - CMakeLists.txt
+      - environment.yaml
+      - cell_definition.yaml
+      - launch/demo.launch.py
+      - urdf/scene.urdf.xacro
+    allow_skip_build: false
+    allow_skip_launch_smoke: false
+    known_blockers: []
+  - scene_name: ur5_3f_test
+    scene_path: scenes/ur5_3f_test
+    enabled: true
+    support_level: supported
+    robot: ur5
+    end_effector: robotiq_3f
+    expected_package_name: ur5_3f_test
+    expected_files: *required_files
+    allow_skip_build: false
+    allow_skip_launch_smoke: false
+    known_blockers: []
+  - scene_name: ur3_suction_test
+    scene_path: scenes/ur3_suction_test
+    enabled: true
+    support_level: supported
+    robot: ur3
+    end_effector: suction
+    expected_package_name: ur3_suction_test
+    expected_files: *required_files
+    allow_skip_build: false
+    allow_skip_launch_smoke: false
+    known_blockers: []
+  - scene_name: ur10_2f_test
+    scene_path: scenes/ur10_2f_test
+    enabled: true
+    support_level: supported
+    robot: ur10
+    end_effector: robotiq_2f
+    expected_package_name: ur10_2f_test
+    expected_files: *required_files
+    allow_skip_build: false
+    allow_skip_launch_smoke: false
+    known_blockers: []
+  - scene_name: ur5_airpick4_test
+    scene_path: scenes/ur5_airpick4_test
+    enabled: true
+    support_level: supported
+    robot: ur5
+    end_effector: airpick4
+    expected_package_name: ur5_airpick4_test
+    expected_files: *required_files
+    allow_skip_build: false
+    allow_skip_launch_smoke: false
+    known_blockers: []
+  - scene_name: suction_test
+    scene_path: scenes/suction_test
+    enabled: true
+    support_level: experimental
+    robot: ur5
+    end_effector: suction
+    expected_package_name: suction_test
+    expected_files: *required_files
+    allow_skip_build: true
+    allow_skip_launch_smoke: true
+    known_blockers: []


### PR DESCRIPTION
## Summary
- add `workcell_studio_supported_scenes.yaml` as a machine-readable registry for initial Workcell Studio scene support
- add `scripts/validate_supported_scenes_readiness.py` to iterate registry entries and produce combined JSON + markdown readiness output
- integrate per-scene checks with existing `validate_guided_generated_scene_build_readiness.py` to report PASS / FAIL / BLOCKED / PASS_WITH_WARNINGS / SKIPPED
- add `tests/test_validate_supported_scenes_readiness.py` covering skip, blocked, fail, experimental gating, minimal static pass path, and summary counting

## What the new validator reports
- top-level:
  - `registry_path`, `workspace_root`, `repo_root`
  - `scenes_checked`, `scenes_skipped`
  - `per_scene` with status, static validation, guided build/launch readiness payload, build/launch statuses, blockers/warnings, commands, artifacts
  - `summary` totals for pass/fail/blocked/warnings/skipped
- markdown table output at `build/workcell_studio/all_scenes_readiness_report.md` by default

## Safety / scope
- no real-hardware execution paths added
- build/launch are controllable via `--skip-build` and `--skip-launch-smoke`
- missing scene directories and files return clear blocker/fail states instead of crashing
- no broad refactors

## Manual validation commands
```bash
cd /home/user/workcell_ws/src/easy_manipulation_deployment

python3 scripts/validate_supported_scenes_readiness.py \
  --repo-root "$PWD" \
  --workspace-root /home/user/workcell_ws \
  --json \
  --skip-build \
  --skip-launch-smoke

python3 scripts/validate_supported_scenes_readiness.py \
  --repo-root "$PWD" \
  --workspace-root /home/user/workcell_ws \
  --json \
  --scene ur5_2f_test \
  --skip-launch-smoke

cd /home/user/workcell_ws
source /opt/ros/humble/setup.bash
colcon build --symlink-install --packages-select workcell_builder
```

## Test command run in this branch
```bash
python3 -m pytest -q tests/test_validate_supported_scenes_readiness.py
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a174faab5948331b115524e66966851)