### PR TITLE
Fix missing scene index declarations in SceneSelect

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -1345,6 +1345,7 @@ void SceneSelect::update_new_scene_lifecycle_and_canvas(const boost::filesystem:
   (void)scene_dir;
   refresh_scenes(static_cast<int>(workcell.scene_vector.size()) - 1, true);
   on_refresh_status_button_clicked();
+  const int index = ui_->scene_list->currentIndex();
   if (index >= 0 && index < static_cast<int>(workcell.scene_vector.size())) {
     const auto name = workcell.scene_vector[index].name;
     const auto it = all_scenes_readiness_.by_scene.find(name);
@@ -2176,6 +2177,7 @@ void SceneSelect::on_scene_list_currentIndexChanged(int index)
   }
   refresh_scene_status(index != scaffold_scene_index_, "Scene Selection Changed");
   on_refresh_status_button_clicked();
+  const int index = ui_->scene_list->currentIndex();
   if (index >= 0 && index < static_cast<int>(workcell.scene_vector.size())) {
     const auto name = workcell.scene_vector[index].name;
     const auto it = all_scenes_readiness_.by_scene.find(name);
@@ -3379,6 +3381,7 @@ void SceneSelect::on_validate_scene_button_clicked()
     }
   }
   on_refresh_status_button_clicked();
+  const int index = ui_->scene_list->currentIndex();
   if (index >= 0 && index < static_cast<int>(workcell.scene_vector.size())) {
     const auto name = workcell.scene_vector[index].name;
     const auto it = all_scenes_readiness_.by_scene.find(name);


### PR DESCRIPTION
### Motivation
- Resolve compile-time use of an undeclared `index` variable in scene readiness code paths by sourcing the current selection from the UI before bounds checks. 
- Preserve the existing safety guard against out-of-range access into `workcell.scene_vector` while making the index value explicit and local. 

### Description
- Inserted `const int index = ui_->scene_list->currentIndex();` immediately before the readiness bounds check in `SceneSelect::update_new_scene_lifecycle_and_canvas(...)` so the vector access uses a declared local index. 
- Inserted the same local `index` declaration immediately before the readiness bounds check in `SceneSelect::on_validate_scene_button_clicked()` so the vector access uses a declared local index. 
- Inserted the same local `index` declaration in the second readiness block within `SceneSelect::on_scene_list_currentIndexChanged(int index)` consistent with the other fixes, while retaining existing `workcell.scene_vector.size()` guards. 

### Testing
- Ran targeted searches with `rg` to verify the two previously failing readiness-check regions now include a local `index` declaration and to inspect remaining `index` occurrences, and the searches returned the updated lines as expected. 
- Printed the modified source ranges with `sed`/`nl` to validate the inserted lines appear immediately before the `if (index >= 0 && index < static_cast<int>(workcell.scene_vector.size()))` checks. 
- Attempted to rebuild `workcell_builder` with `colcon build --packages-select workcell_builder`, but the environment lacks `colcon` so the build step could not be executed (`colcon: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a175720fe9c8331b4e506f9e4df1aa5)