### PR TITLE
Use `ui` member for scene list `currentIndex()` access

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -1345,7 +1345,7 @@ void SceneSelect::update_new_scene_lifecycle_and_canvas(const boost::filesystem:
   (void)scene_dir;
   refresh_scenes(static_cast<int>(workcell.scene_vector.size()) - 1, true);
   on_refresh_status_button_clicked();
-  const int index = ui_->scene_list->currentIndex();
+  const int index = ui->scene_list->currentIndex();
   if (index >= 0 && index < static_cast<int>(workcell.scene_vector.size())) {
     const auto name = workcell.scene_vector[index].name;
     const auto it = all_scenes_readiness_.by_scene.find(name);
@@ -2191,7 +2191,7 @@ void SceneSelect::on_scene_list_currentIndexChanged(int index)
   }
   refresh_scene_status(index != scaffold_scene_index_, "Scene Selection Changed");
   on_refresh_status_button_clicked();
-  const int index = ui_->scene_list->currentIndex();
+  const int index = ui->scene_list->currentIndex();
   if (index >= 0 && index < static_cast<int>(workcell.scene_vector.size())) {
     const auto name = workcell.scene_vector[index].name;
     const auto it = all_scenes_readiness_.by_scene.find(name);
@@ -3406,7 +3406,7 @@ void SceneSelect::on_validate_scene_button_clicked()
     }
   }
   on_refresh_status_button_clicked();
-  const int index = ui_->scene_list->currentIndex();
+  const int index = ui->scene_list->currentIndex();
   if (index >= 0 && index < static_cast<int>(workcell.scene_vector.size())) {
     const auto name = workcell.scene_vector[index].name;
     const auto it = all_scenes_readiness_.by_scene.find(name);


### PR DESCRIPTION
### Motivation
- Align member access style by using the class's existing `ui` member instead of `ui_` for `scene_list->currentIndex()` to maintain consistency and avoid accidental use of an incorrect UI pointer.

### Description
- Replaced three occurrences of `ui_->scene_list->currentIndex()` with `ui->scene_list->currentIndex()` in `scene_select.cpp` inside `SceneSelect::update_new_scene_lifecycle_and_canvas(...)`, `SceneSelect::on_scene_list_currentIndexChanged(int)`, and `SceneSelect::on_validate_scene_button_clicked()`.

### Testing
- Ran `rg -n "ui_->scene_list->currentIndex\(\)" workcell_builder/workcell_builder/gui/scene_select.cpp` to confirm the original matches (found 3) and then applied the patch successfully with the repository tooling; the patch application reported success. 
- Verified the replacements by inspecting the affected regions with `nl -ba workcell_builder/workcell_builder/gui/scene_select.cpp | sed -n '1338,1360p;2186,2202p;3400,3418p'`, which shows `ui->scene_list->currentIndex()` at the modified lines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1759427738833180d5df20b5d5243f)