### PR TITLE
Fix index redeclaration in scene selection change handler

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -1345,9 +1345,9 @@ void SceneSelect::update_new_scene_lifecycle_and_canvas(const boost::filesystem:
   (void)scene_dir;
   refresh_scenes(static_cast<int>(workcell.scene_vector.size()) - 1, true);
   on_refresh_status_button_clicked();
-  const int index = ui_->scene_list->currentIndex();
-  if (index >= 0 && index < static_cast<int>(workcell.scene_vector.size())) {
-    const auto name = workcell.scene_vector[index].name;
+  const int current_index = ui_->scene_list->currentIndex();
+  if (current_index >= 0 && current_index < static_cast<int>(workcell.scene_vector.size())) {
+    const auto name = workcell.scene_vector[current_index].name;
     const auto it = all_scenes_readiness_.by_scene.find(name);
     if (it != all_scenes_readiness_.by_scene.end()) {
       const auto & r = it->second;
@@ -2191,9 +2191,9 @@ void SceneSelect::on_scene_list_currentIndexChanged(int index)
   }
   refresh_scene_status(index != scaffold_scene_index_, "Scene Selection Changed");
   on_refresh_status_button_clicked();
-  const int index = ui_->scene_list->currentIndex();
-  if (index >= 0 && index < static_cast<int>(workcell.scene_vector.size())) {
-    const auto name = workcell.scene_vector[index].name;
+  const int current_index = ui_->scene_list->currentIndex();
+  if (current_index >= 0 && current_index < static_cast<int>(workcell.scene_vector.size())) {
+    const auto name = workcell.scene_vector[current_index].name;
     const auto it = all_scenes_readiness_.by_scene.find(name);
     if (it != all_scenes_readiness_.by_scene.end()) {
       const auto & r = it->second;
@@ -3406,9 +3406,9 @@ void SceneSelect::on_validate_scene_button_clicked()
     }
   }
   on_refresh_status_button_clicked();
-  const int index = ui_->scene_list->currentIndex();
-  if (index >= 0 && index < static_cast<int>(workcell.scene_vector.size())) {
-    const auto name = workcell.scene_vector[index].name;
+  const int current_index = ui_->scene_list->currentIndex();
+  if (current_index >= 0 && current_index < static_cast<int>(workcell.scene_vector.size())) {
+    const auto name = workcell.scene_vector[current_index].name;
     const auto it = all_scenes_readiness_.by_scene.find(name);
     if (it != all_scenes_readiness_.by_scene.end()) {
       const auto & r = it->second;


### PR DESCRIPTION
### Motivation
- Resolve a local name collision in `SceneSelect::on_scene_list_currentIndexChanged(int index)` that caused a redeclaration of `index` and a compile error, while preserving existing behavior.

### Description
- Removed the conflicting local `index` redeclaration and introduced `current_index` for the readiness lookup block in `workcell_builder/workcell_builder/gui/scene_select.cpp` and updated references accordingly.

### Testing
- No automated tests or builds were run for this small, targeted rename-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1759448d5c8331be328a9bc52d4cac)