### PR TITLE
Fix SceneSelect ui pointer typo

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_select.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_select.cpp
@@ -1345,7 +1345,7 @@ void SceneSelect::update_new_scene_lifecycle_and_canvas(const boost::filesystem:
   (void)scene_dir;
   refresh_scenes(static_cast<int>(workcell.scene_vector.size()) - 1, true);
   on_refresh_status_button_clicked();
-  const int current_index = ui_->scene_list->currentIndex();
+  const int current_index = ui->scene_list->currentIndex();
   if (current_index >= 0 && current_index < static_cast<int>(workcell.scene_vector.size())) {
     const auto name = workcell.scene_vector[current_index].name;
     const auto it = all_scenes_readiness_.by_scene.find(name);
@@ -2191,7 +2191,7 @@ void SceneSelect::on_scene_list_currentIndexChanged(int index)
   }
   refresh_scene_status(index != scaffold_scene_index_, "Scene Selection Changed");
   on_refresh_status_button_clicked();
-  const int current_index = ui_->scene_list->currentIndex();
+  const int current_index = ui->scene_list->currentIndex();
   if (current_index >= 0 && current_index < static_cast<int>(workcell.scene_vector.size())) {
     const auto name = workcell.scene_vector[current_index].name;
     const auto it = all_scenes_readiness_.by_scene.find(name);
@@ -3406,7 +3406,7 @@ void SceneSelect::on_validate_scene_button_clicked()
     }
   }
   on_refresh_status_button_clicked();
-  const int current_index = ui_->scene_list->currentIndex();
+  const int current_index = ui->scene_list->currentIndex();
   if (current_index >= 0 && current_index < static_cast<int>(workcell.scene_vector.size())) {
     const auto name = workcell.scene_vector[current_index].name;
     const auto it = all_scenes_readiness_.by_scene.find(name);


### PR DESCRIPTION
### Motivation
- Resolve compile failures caused by incorrect `ui_` identifier usage when accessing the scene list, which produced "`ui_` was not declared" errors during build.

### Description
- Replaced three mistaken `ui_` references with `ui` in `workcell_builder/workcell_builder/gui/scene_select.cpp` inside the `update_new_scene_lifecycle_and_canvas`, `on_scene_list_currentIndexChanged`, and `on_validate_scene_button_clicked` code paths so widget access uses the correct UI pointer.

### Testing
- Confirmed the replacements with `rg` to ensure `ui_` usages were removed and corrected to `ui->scene_list->currentIndex()`.
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but `colcon` is not installed in this environment, so a full build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a175ab99af883318f9f437ee0441fc9)