### PR TITLE
Fix workcell canvas model namespace closure

### DIFF
--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -529,3 +529,5 @@ YAML::Node build_starter_layout_entries_from_preview(const WorkcellStudioCanvasM
   root["items"] = items;
   return root;
 }
+
+}  // namespace workcell_builder


### PR DESCRIPTION
### Motivation
- The `src_workcell_studio_canvas_model.cpp` translation unit was missing the closing brace for the `workcell_builder` namespace, causing a compile error `expected ‘}’ at end of input` and breaking builds/tests that compile this file.

### Description
- Add the missing closing brace and namespace comment to `workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp` so the file is syntactically balanced (`}  // namespace workcell_builder`).

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_canvas_model.py`, which succeeded (`3 passed`).
- Ran a broader pytest invocation across several canvas/scene tests (`tests/test_workcell_studio_canvas_model.py`, `tests/test_3d_canvas_selection_transform_roundtrip.py`, `tests/test_scene3d_mesh_metadata_flow_static.py`, `tests/test_workcell_studio_asset_to_canvas.py`, `tests/test_workcell_studio_canvas_drag_drop.py`) that collected 16 tests with 15 passing and 1 failing (the failing test is unrelated to this namespace fix and checks tokens in `mainwindow.cpp`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18689ee93483318725678ef8447a68)