### PR TITLE
Add CreateEditableLayoutFromPreview workflow handler and tests

### DIFF
--- a/tests/test_workcell_studio_mainwindow_build_tokens.py
+++ b/tests/test_workcell_studio_mainwindow_build_tokens.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 
 
 def test_mainwindow_build_regression_tokens():
@@ -34,3 +35,38 @@ def test_mainwindow_build_regression_tokens():
     assert "entry.warning)" not in text
     assert "entry.warning;" not in text
     assert "entry.warnings" in text
+
+
+def test_create_editable_layout_recommended_action_handler_tokens():
+    header = Path("workcell_builder/workcell_builder/gui/mainwindow.h").read_text(encoding="utf-8")
+    source = Path("workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+
+    enum_match = re.search(
+        r"enum class RecommendedWorkflowActionHandler \{(?P<body>.*?)\n  \};",
+        header,
+        re.DOTALL,
+    )
+    assert enum_match is not None
+    assert "CreateEditableLayoutFromPreview" in enum_match.group("body")
+
+    trigger_match = re.search(
+        r"case RecommendedWorkflowActionHandler::CreateEditableLayoutFromPreview:\s*"
+        r"create_starter_layout_from_preview\(\);\s*"
+        r"return;",
+        source,
+        re.DOTALL,
+    )
+    assert trigger_match is not None
+
+    create_editable_action_blocks = re.findall(
+        r"add_action\(\s*"
+        r"\"create_editable_layout_from_preview\"\s*,\s*"
+        r"\"Create editable layout from preview\"(?P<body>.*?)\);",
+        source,
+        re.DOTALL,
+    )
+    assert create_editable_action_blocks
+    assert all(
+        "RecommendedWorkflowActionHandler::CreateEditableLayoutFromPreview" in block
+        for block in create_editable_action_blocks
+    )

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -7274,7 +7274,7 @@ std::vector<MainWindow::RecommendedWorkflowAction> MainWindow::resolve_recommend
   if (editable_layout_item_count_ == 0 && preview_fallback_item_count_ > 0) {
     add_action("create_editable_layout_from_preview", "Create editable layout from preview", true, QString(),
       "Create editable layout from preview",
-      RecommendedWorkflowActionHandler::SaveLayout);
+      RecommendedWorkflowActionHandler::CreateEditableLayoutFromPreview);
     add_action("generate_yaml", "Generate YAML", false, "Create an editable layout first.", "YAML generation requires editable layout content.", RecommendedWorkflowActionHandler::GenerateYaml);
     return actions;
   }
@@ -7297,7 +7297,7 @@ std::vector<MainWindow::RecommendedWorkflowAction> MainWindow::resolve_recommend
     if (legacy_preview_only_scene) {
       add_action("create_editable_layout_from_preview", "Create editable layout from preview", true, QString(),
         "Create editable layout from preview",
-        RecommendedWorkflowActionHandler::AddAsset);
+        RecommendedWorkflowActionHandler::CreateEditableLayoutFromPreview);
       add_action("add_asset", "Add asset", false, "Convert preview-only scene first.", "After conversion, add assets to finalize layout.", RecommendedWorkflowActionHandler::AddAsset);
       return actions;
     }
@@ -7365,6 +7365,9 @@ void MainWindow::trigger_recommended_workflow_action(RecommendedWorkflowActionHa
       return;
     case RecommendedWorkflowActionHandler::AddAsset:
       open_add_asset_dialog();
+      return;
+    case RecommendedWorkflowActionHandler::CreateEditableLayoutFromPreview:
+      create_starter_layout_from_preview();
       return;
     case RecommendedWorkflowActionHandler::SaveLayout:
       save_layout_changes();

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -177,6 +177,7 @@ private:
   enum class RecommendedWorkflowActionHandler {
     OpenOrCreateScene,
     AddAsset,
+    CreateEditableLayoutFromPreview,
     SaveLayout,
     GenerateYaml,
     ValidateScene,


### PR DESCRIPTION
### Motivation
- Provide a dedicated handler for the "Create editable layout from preview" recommendation so the recommendation maps directly to the correct operation instead of reusing `SaveLayout` or `AddAsset`.
- Make the recommended-workflow dispatch clearer and ensure recommended actions trigger the intended behavior.
- Add a static regression test to lock the mapping and dispatch behavior.

### Description
- Added `RecommendedWorkflowActionHandler::CreateEditableLayoutFromPreview` to the enum in `mainwindow.h`.
- Updated `MainWindow::resolve_recommended_workflow_actions` in `mainwindow.cpp` to use `CreateEditableLayoutFromPreview` for all "Create editable layout from preview" `add_action` calls (both preview-fallback and legacy preview-only branches).
- Implemented handling in `MainWindow::trigger_recommended_workflow_action` to call `create_starter_layout_from_preview()` when the new handler is triggered.
- Added/updated a static regression test `test_create_editable_layout_recommended_action_handler_tokens` in `tests/test_workcell_studio_mainwindow_build_tokens.py` that asserts the enum contains the new handler, the trigger case calls `create_starter_layout_from_preview()`, and the recommendation mappings use the new handler.

### Testing
- Ran `pytest -q tests/test_workcell_studio_mainwindow_build_tokens.py` and the test suite passed (`2 passed`).
- Ran `git diff --check` to verify no whitespace or diff issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186e7740f883318e2b192b0850fb72)