### PR TITLE
Refresh scene workflow after saving layout

### DIFF
--- a/tests/test_workcell_studio_mainwindow_build_tokens.py
+++ b/tests/test_workcell_studio_mainwindow_build_tokens.py
@@ -34,3 +34,18 @@ def test_mainwindow_build_regression_tokens():
     assert "entry.warning)" not in text
     assert "entry.warning;" not in text
     assert "entry.warnings" in text
+
+
+def test_save_layout_success_refreshes_scene_builder_workflow_after_writes():
+    text = Path("workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+    start = text.index("void MainWindow::save_layout_changes()")
+    end = text.index("void MainWindow::create_starter_layout_from_preview()", start)
+    body = text[start:end]
+
+    workcell_write = body.index('"Save Layout: wrote editable layout items to %1"')
+    environment_write = body.index('"Save Layout: wrote environment metadata to %1"')
+    browser_refresh = body.index("refresh_scene_browser_ui();")
+    workflow_refresh = body.index("refresh_scene_workflow_rail();", browser_refresh)
+    chip_refresh = body.index("refresh_scene_builder_view_chips();", workflow_refresh)
+
+    assert workcell_write < environment_write < browser_refresh < workflow_refresh < chip_refresh

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -5133,6 +5133,8 @@ void MainWindow::save_layout_changes()
     append_studio_log("Save Layout: no selected stable item id to reselect.");
   }
   refresh_scene_browser_ui();
+  refresh_scene_workflow_rail();
+  refresh_scene_builder_view_chips();
 }
 
 void MainWindow::create_starter_layout_from_preview()


### PR DESCRIPTION
### Motivation
- Ensure the Scene Builder workflow rail and its status chips are updated immediately after a successful Save Layout so the UI reflects newly written `layout/workcell_studio_layout.yaml` and `environment.yaml` artifacts.

### Description
- In `MainWindow::save_layout_changes()` (file `workcell_builder/workcell_builder/gui/mainwindow.cpp`) call `refresh_scene_workflow_rail()` and the existing status-chip refresh helper `refresh_scene_builder_view_chips()` immediately after `refresh_scene_browser_ui()` in the successful write path.
- Add a token-level regression test in `tests/test_workcell_studio_mainwindow_build_tokens.py` that asserts the Save Layout success path writes the workcell and environment files before invoking `refresh_scene_browser_ui()`, `refresh_scene_workflow_rail()`, and `refresh_scene_builder_view_chips()` in that order.

### Testing
- Ran `pytest -q tests/test_workcell_studio_mainwindow_build_tokens.py` and the test suite passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186e7c1d2c833197aefa1b7a45ad03)