### PR TITLE
Map non-YAML exceptions to INVALID_LAYOUT_YAML in derive_layout_state_model

### DIFF
--- a/tests/test_workcell_builder_layout_yaml_error_handling.py
+++ b/tests/test_workcell_builder_layout_yaml_error_handling.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import re
+
+MAINWINDOW_CPP = Path('workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text()
+
+
+def _derive_layout_state_model_body() -> str:
+    match = re.search(
+        r'static LayoutStateModel derive_layout_state_model\([^)]*\)\s*\{(?P<body>.*?)\n\}\n\n\nstatic QMap',
+        MAINWINDOW_CPP,
+        re.S,
+    )
+    assert match, 'derive_layout_state_model body should be statically discoverable'
+    return match.group('body')
+
+
+def test_derive_layout_state_model_maps_non_yaml_exceptions_to_invalid_layout_yaml():
+    body = _derive_layout_state_model_body()
+
+    assert 'catch (const YAML::Exception &)' in body
+    assert 'catch (const std::exception &)' in body
+    assert body.count('return LayoutStateModel::INVALID_LAYOUT_YAML;') >= 2
+
+
+def test_invalid_layout_yaml_is_reported_as_non_crashing_warning_state():
+    body = _derive_layout_state_model_body()
+
+    assert 'YAML::LoadFile(layout.string())' in body
+    assert 'return LayoutStateModel::INVALID_LAYOUT_YAML;' in body
+    assert 'case LayoutStateModel::INVALID_LAYOUT_YAML:' in MAINWINDOW_CPP
+    assert 'Save Layout Needed: invalid layout YAML' in MAINWINDOW_CPP
+    assert 'layout_status = SceneWorkflowStepStatus::Warning' in MAINWINDOW_CPP

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -96,6 +96,7 @@
 #include <array>
 #include <cstdlib>
 #include <cmath>
+#include <exception>
 #include <ctime>
 #include <fstream>
 #include <functional>
@@ -525,6 +526,10 @@ static LayoutStateModel derive_layout_state_model(const fs::path & scene_dir, co
     }
     return LayoutStateModel::EDITABLE_LAYOUT_PRESENT;
   } catch (const YAML::Exception &) {
+    return LayoutStateModel::INVALID_LAYOUT_YAML;
+  } catch (const std::exception &) {
+    return LayoutStateModel::INVALID_LAYOUT_YAML;
+  } catch (...) {
     return LayoutStateModel::INVALID_LAYOUT_YAML;
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure layout parsing failures that throw non-YAML exceptions do not crash the UI and instead map to the existing non-crashing warning state for invalid layout YAML.

### Description
- In `workcell_builder/workcell_builder/gui/mainwindow.cpp` kept the existing `catch (const YAML::Exception &)`, added `catch (const std::exception &)` and a final `catch (...)` that both return `LayoutStateModel::INVALID_LAYOUT_YAML`, and added `#include <exception>` to satisfy the header usage.
- Added a small static/regression test `tests/test_workcell_builder_layout_yaml_error_handling.py` that validates the `derive_layout_state_model` code path contains the `YAML::Exception` handler, the `std::exception` handler, and that `INVALID_LAYOUT_YAML` is used to drive the non-crashing warning UI state.

### Testing
- Ran the focused regression tests with `python3 -m pytest tests/test_workcell_builder_layout_yaml_error_handling.py -q` and the test suite passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186e82a354833193c2758c620c5894)