### PR TITLE
Add starter-layout acceptance coverage

### DIFF
--- a/scripts/run_starter_layout_acceptance.py
+++ b/scripts/run_starter_layout_acceptance.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Run the offline Workcell Studio starter-layout acceptance test.
+
+The acceptance coverage lives in the workcell_builder C++ gtest so it can call
+build_workcell_studio_canvas_model() and build_starter_layout_entries_from_preview()
+directly. This wrapper only locates and invokes that already-built test binary.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+TEST_NAME = "*StarterLayoutAcceptanceCopiesSceneAndFiltersUnsafePreviewItems"
+BINARY_NAME = "workcell_studio_canvas_model_mesh_test"
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def candidate_binaries(root: Path) -> list[Path]:
+    patterns = [
+        f"build/**/{BINARY_NAME}",
+        f"install/**/{BINARY_NAME}",
+        f"**/{BINARY_NAME}",
+    ]
+    candidates: list[Path] = []
+    for pattern in patterns:
+        candidates.extend(path for path in root.glob(pattern) if path.is_file() and path.stat().st_mode & 0o111)
+    return sorted(set(candidates), key=lambda p: (len(p.parts), str(p)))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run starter-layout generation acceptance coverage without hardware.")
+    parser.add_argument("--test-binary", type=Path, help="Path to an already-built workcell_studio_canvas_model_mesh_test binary.")
+    args = parser.parse_args()
+
+    root = repo_root()
+    test_binary = args.test_binary
+    if test_binary is None:
+        candidates = candidate_binaries(root)
+        if not candidates:
+            print(
+                "Could not find an executable workcell_studio_canvas_model_mesh_test binary. "
+                "Build the workcell_builder tests first, or pass --test-binary.",
+                file=sys.stderr,
+            )
+            return 2
+        test_binary = candidates[0]
+
+    command = [str(test_binary), f"--gtest_filter={TEST_NAME}"]
+    print("Running:", " ".join(command))
+    return subprocess.call(command, cwd=root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -401,6 +401,8 @@ if(BUILD_TESTING)
   if(TARGET workcell_studio_canvas_model_mesh_test)
     target_link_libraries(workcell_studio_canvas_model_mesh_test yaml-cpp ${Boost_LIBRARIES})
     target_include_directories(workcell_studio_canvas_model_mesh_test PRIVATE ${Boost_INCLUDE_DIRS} include)
+    target_compile_definitions(workcell_studio_canvas_model_mesh_test PRIVATE
+      WORKCELL_BUILDER_REPO_ROOT="${CMAKE_CURRENT_SOURCE_DIR}/../..")
   endif()
 
   if(TARGET workcell_new_cell_wizard_test)

--- a/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <boost/filesystem.hpp>
 #include <fstream>
+#include <set>
 
 #include "workcell_studio_canvas_model.hpp"
 
@@ -11,6 +12,47 @@ static void write_file(const fs::path & path, const std::string & text)
   fs::create_directories(path.parent_path());
   std::ofstream out(path.string());
   out << text;
+}
+
+static void copy_directory_tree(const fs::path & source, const fs::path & destination)
+{
+  fs::create_directories(destination);
+  for (fs::recursive_directory_iterator it(source), end; it != end; ++it) {
+    const fs::path relative = fs::relative(it->path(), source);
+    const fs::path target = destination / relative;
+    if (fs::is_directory(it->path())) {
+      fs::create_directories(target);
+    } else if (fs::is_regular_file(it->path())) {
+      fs::create_directories(target.parent_path());
+      fs::copy_file(it->path(), target, fs::copy_option::overwrite_if_exists);
+    }
+  }
+}
+
+static YAML::Node load_yaml_file(const fs::path & path)
+{
+  return YAML::LoadFile(path.string());
+}
+
+static void write_yaml_file(const fs::path & path, const YAML::Node & node)
+{
+  fs::create_directories(path.parent_path());
+  std::ofstream out(path.string());
+  out << node;
+  out << "\n";
+}
+
+static std::set<std::string> editable_item_ids(const YAML::Node & layout)
+{
+  std::set<std::string> ids;
+  const YAML::Node items = layout["items"];
+  if (!items || !items.IsSequence()) return ids;
+  for (const auto & item : items) {
+    if (!item || !item.IsMap() || !item["id"]) continue;
+    const bool editable = item["editable"] ? item["editable"].as<bool>(false) : false;
+    if (editable) ids.insert(item["id"].as<std::string>());
+  }
+  return ids;
 }
 
 TEST(WorkcellStudioCanvasMesh, ResolvesAbsoluteAndPackagePaths)
@@ -164,4 +206,100 @@ TEST(WorkcellStudioCanvasMesh, BuildStarterLayoutFiltersLockedAndFallbackPreview
   ASSERT_TRUE(items && items.IsSequence());
   ASSERT_EQ(items.size(), 1u);
   EXPECT_EQ(items[0]["id"].as<std::string>(), "safe_item");
+}
+
+
+TEST(WorkcellStudioCanvasMesh, StarterLayoutAcceptanceCopiesSceneAndFiltersUnsafePreviewItems)
+{
+#ifndef WORKCELL_BUILDER_REPO_ROOT
+  GTEST_SKIP() << "WORKCELL_BUILDER_REPO_ROOT is not configured for scene acceptance coverage";
+#else
+  const fs::path repo_root = fs::path(WORKCELL_BUILDER_REPO_ROOT);
+  fs::path source_scene = repo_root / "scenes" / "ur5_2f_test";
+  std::string scene_name = "ur5_2f_test";
+  if (!fs::exists(source_scene)) {
+    source_scene = repo_root / "scenes" / "suction_test";
+    scene_name = "suction_test";
+  }
+  ASSERT_TRUE(fs::exists(source_scene)) << "expected ur5_2f_test or suction_test scene fixture";
+
+  const fs::path temp_root = fs::temp_directory_path() / fs::unique_path("wc_starter_layout_acceptance_%%%%-%%%%-%%%%");
+  const fs::path copied_scene = temp_root / scene_name;
+  copy_directory_tree(source_scene, copied_scene);
+
+  const fs::path editable_layout_path = copied_scene / "layout" / "workcell_studio_layout.yaml";
+  ASSERT_TRUE(fs::exists(editable_layout_path));
+  const YAML::Node before_layout = load_yaml_file(editable_layout_path);
+  ASSERT_TRUE(before_layout && before_layout.IsMap());
+  ASSERT_EQ(before_layout["schema_version"].as<std::string>(), "workcell_studio_layout/v1");
+  ASSERT_TRUE(before_layout["items"] && before_layout["items"].IsSequence());
+
+  const auto valid_model = workcell_builder::build_workcell_studio_canvas_model(copied_scene, scene_name);
+  std::set<std::string> safe_unlocked_preview_ids;
+  std::set<std::string> locked_preview_ids;
+  for (const auto & item : valid_model.items) {
+    if (item.locked) {
+      locked_preview_ids.insert(item.id);
+      continue;
+    }
+    if (item.provenance != workcell_builder::WorkcellStudioItemProvenance::StaticFallbackPreview) {
+      safe_unlocked_preview_ids.insert(item.id);
+    }
+  }
+  ASSERT_FALSE(safe_unlocked_preview_ids.empty()) << "scene should expose at least one safe/unlocked preview item";
+  ASSERT_FALSE(locked_preview_ids.empty()) << "scene should expose locked generated preview items";
+
+  const YAML::Node starter_layout = workcell_builder::build_starter_layout_entries_from_preview(valid_model);
+  write_yaml_file(editable_layout_path, starter_layout);
+
+  const YAML::Node after_layout = load_yaml_file(editable_layout_path);
+  ASSERT_TRUE(after_layout && after_layout.IsMap());
+  ASSERT_EQ(after_layout["schema_version"].as<std::string>(), "workcell_studio_layout/v1");
+  ASSERT_EQ(after_layout["scene_name"].as<std::string>(), scene_name);
+  ASSERT_TRUE(after_layout["items"] && after_layout["items"].IsSequence());
+
+  const std::set<std::string> after_editable_ids = editable_item_ids(after_layout);
+  if (safe_unlocked_preview_ids.count("table") > 0) {
+    EXPECT_EQ(after_editable_ids.count("table"), 1u)
+      << "starter layout should include the expected safe/unlocked table preview item as editable";
+  } else {
+    bool wrote_expected_safe_editable = false;
+    for (const auto & id : safe_unlocked_preview_ids) {
+      if (after_editable_ids.count(id) > 0) {
+        wrote_expected_safe_editable = true;
+        break;
+      }
+    }
+    EXPECT_TRUE(wrote_expected_safe_editable) << "starter layout should include an editable safe/unlocked preview item";
+  }
+  for (const auto & id : locked_preview_ids) {
+    EXPECT_EQ(after_editable_ids.count(id), 0u) << "locked generated preview item was written editable: " << id;
+  }
+
+  const fs::path fallback_scene = temp_root / (scene_name + "_fallback_only");
+  copy_directory_tree(source_scene, fallback_scene);
+  const fs::path fallback_layout_path = fallback_scene / "layout" / "workcell_studio_layout.yaml";
+  ASSERT_TRUE(fs::exists(fallback_layout_path));
+  const YAML::Node fallback_before_layout = load_yaml_file(fallback_layout_path);
+  ASSERT_TRUE(fallback_before_layout && fallback_before_layout.IsMap());
+  fs::remove(fallback_layout_path);
+
+  const auto fallback_model = workcell_builder::build_workcell_studio_canvas_model(fallback_scene, scene_name);
+  std::set<std::string> static_fallback_ids;
+  for (const auto & item : fallback_model.items) {
+    if (item.provenance == workcell_builder::WorkcellStudioItemProvenance::StaticFallbackPreview) {
+      static_fallback_ids.insert(item.id);
+    }
+  }
+  ASSERT_FALSE(static_fallback_ids.empty()) << "missing layout should force static fallback-only preview metadata";
+  const YAML::Node fallback_starter_layout = workcell_builder::build_starter_layout_entries_from_preview(fallback_model);
+  write_yaml_file(fallback_layout_path, fallback_starter_layout);
+  const YAML::Node fallback_after_layout = load_yaml_file(fallback_layout_path);
+  const std::set<std::string> fallback_after_editable_ids = editable_item_ids(fallback_after_layout);
+  for (const auto & id : static_fallback_ids) {
+    EXPECT_EQ(fallback_after_editable_ids.count(id), 0u) << "static fallback-only preview item was written editable: " << id;
+  }
+
+  fs::remove_all(temp_root);
+#endif
 }


### PR DESCRIPTION
### Motivation
- Provide an offline acceptance test that verifies starter-layout generation behavior without mutating scene fixtures or touching hardware.
- Ensure starter-layout generation uses safe/unlocked preview metadata and does not expose locked or static-fallback preview items as editable.

### Description
- Added a new wrapper script `scripts/run_starter_layout_acceptance.py` that finds and invokes the focused C++ gtest binary `workcell_studio_canvas_model_mesh_test` with the starter-layout acceptance filter, keeping the flow offline and avoiding hardware paths.
- Extended `workcell_builder/.../test/workcell_studio_canvas_model_mesh_test.cpp` with helpers to copy a scene into a temp directory, load/write YAML, collect editable IDs, and a new acceptance test that prefers `scenes/ur5_2f_test` (falls back to `scenes/suction_test`), inspects `layout/workcell_studio_layout.yaml` before and after running `build_workcell_studio_canvas_model` + `build_starter_layout_entries_from_preview`, and asserts the generated YAML contains `schema_version: workcell_studio_layout/v1`, `scene_name`, `items`, includes at least one expected `editable: true` entry for safe/unlocked preview metadata, and that locked/generated and static fallback preview items are not written editable.
- Added `WORKCELL_BUILDER_REPO_ROOT` compile-time definition to the test target in `workcell_builder/workcell_builder/CMakeLists.txt` so the gtest can locate scene fixtures at test runtime.

### Testing
- `python3 -m py_compile scripts/run_starter_layout_acceptance.py` succeeded and validated the wrapper script syntax.
- Executing `scripts/run_starter_layout_acceptance.py` in this environment printed a clear message that no built `workcell_studio_canvas_model_mesh_test` binary was found (expected in CI/local dev where tests are built), so the wrapper exercised its missing-binary path (non-fatal).
- `git diff --check` and repository checks (`rg` searches used during the rollout) passed with no YAML/hardcoding violations detected.
- No hardware paths were invoked and the acceptance coverage is offline-only as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186e8453c08331bf3de1c2f7997b36)