### PR TITLE
Report starter layout preview skip counts and avoid writing empty layouts

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -5140,9 +5140,21 @@ void MainWindow::create_starter_layout_from_preview()
   if (!has_selected_scene()) return;
   const auto & s = scene_browser_result_.scenes[static_cast<size_t>(selected_scene_index_)];
   const auto model = workcell_builder::build_workcell_studio_canvas_model(s.scene_dir, s.scene_name);
-  if (model.items.empty()) {
-    append_studio_log("Create Starter Layout failed: preview items count is 0.");
-    QMessageBox::warning(this, "Create Starter Layout", "Cannot create editable layout from preview: no preview geometry or safe metadata found. Generate Scene Package first or add layout items manually.");
+  const auto starter_layout_result = workcell_builder::build_starter_layout_result_from_preview(model);
+  const auto starter_layout_counts_message = [&starter_layout_result]() {
+    return QString("Cannot create editable layout from preview: no preview geometry or safe metadata found. "
+                   "total preview items=%1; skipped locked items=%2; skipped static fallback items=%3; "
+                   "skipped unsafe/missing metadata items=%4; editable items created=%5.")
+      .arg(static_cast<qulonglong>(starter_layout_result.total_preview_items))
+      .arg(static_cast<qulonglong>(starter_layout_result.skipped_locked_items))
+      .arg(static_cast<qulonglong>(starter_layout_result.skipped_static_fallback_items))
+      .arg(static_cast<qulonglong>(starter_layout_result.skipped_unsafe_or_missing_metadata_items))
+      .arg(static_cast<qulonglong>(starter_layout_result.editable_items_created));
+  };
+  if (starter_layout_result.editable_items_created == 0) {
+    const QString message = starter_layout_counts_message();
+    append_studio_log(QString("Create Starter Layout failed: %1").arg(message));
+    QMessageBox::warning(this, "Create Starter Layout", message);
     return;
   }
   const fs::path layout_dir = s.scene_dir / "layout";
@@ -5170,7 +5182,7 @@ void MainWindow::create_starter_layout_from_preview()
     }
     append_studio_log(QString("Create Starter Layout: backup created at %1").arg(QString::fromStdString(backup.string())));
   }
-  const YAML::Node layout = workcell_builder::build_starter_layout_entries_from_preview(model);
+  const YAML::Node layout = starter_layout_result.layout;
   std::ofstream out(layout_file.string());
   if (!out.good()) {
     append_studio_log("Create Starter Layout failed: unable to open output file for write.");
@@ -5182,13 +5194,7 @@ void MainWindow::create_starter_layout_from_preview()
     append_studio_log("Create Starter Layout failed: write error while saving starter layout.");
     return;
   }
-  const YAML::Node generated_items = workcell_builder::yaml_map_key(layout, "items");
-  const int generated_count = (generated_items && generated_items.IsSequence()) ? static_cast<int>(generated_items.size()) : 0;
-  if (generated_count == 0) {
-    append_studio_log("Cannot create editable layout from preview: no preview geometry or safe metadata found. Generate Scene Package first or add layout items manually.");
-    QMessageBox::warning(this, "Create Starter Layout", "Cannot create editable layout from preview: no preview geometry or safe metadata found. Generate Scene Package first or add layout items manually.");
-    return;
-  }
+  const auto generated_count = static_cast<int>(starter_layout_result.editable_items_created);
   append_studio_log(QString("Use Recommended Layout: wrote %1 item(s) to %2").arg(generated_count).arg(QString::fromStdString(layout_file.string())));
   append_studio_log("Use Recommended Layout: added recommended editable layout items from current preview metadata.");
   rebuild_digital_twin_canvas();

--- a/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <boost/filesystem.hpp>
+#include <cstddef>
 #include <string>
 #include <vector>
 #include <yaml-cpp/yaml.h>
@@ -50,7 +51,18 @@ struct WorkcellStudioCanvasModel {
   WorkcellStudioProvenanceStatus provenance_status;
   std::vector<std::string> warnings; std::vector<WorkcellStudioCanvasItem> items;
 };
+
+struct WorkcellStudioStarterLayoutResult {
+  std::size_t total_preview_items{0};
+  std::size_t skipped_locked_items{0};
+  std::size_t skipped_static_fallback_items{0};
+  std::size_t skipped_unsafe_or_missing_metadata_items{0};
+  std::size_t editable_items_created{0};
+  YAML::Node layout;
+};
+
 WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const boost::filesystem::path & scene_dir, const std::string & scene_name);
 std::size_t count_editable_layout_entries(const boost::filesystem::path & scene_dir);
+WorkcellStudioStarterLayoutResult build_starter_layout_result_from_preview(const WorkcellStudioCanvasModel & model);
 YAML::Node build_starter_layout_entries_from_preview(const WorkcellStudioCanvasModel & model);
 }

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -16,6 +16,12 @@ struct YamlLoadStatus
   std::string reason;
 };
 
+
+static bool yaml_node_defined(const YAML::Node & node)
+{
+  try { return node.IsDefined(); } catch (...) { return false; }
+}
+
 static YamlLoadStatus read_yaml(const fs::path & p, YAML::Node * out)
 {
   YamlLoadStatus status;
@@ -42,7 +48,7 @@ static YamlLoadStatus read_yaml(const fs::path & p, YAML::Node * out)
 
 static void add_mesh_candidate(const YAML::Node & node, std::vector<std::string> * out)
 {
-  if (!node.IsScalar()) return;
+  if (!yaml_node_defined(node) || !node.IsScalar()) return;
   const std::string text = node.as<std::string>("");
   if (text.empty()) return;
   if (text.rfind("package://", 0) == 0 || text.find(".stl") != std::string::npos || text.find("meshes/") != std::string::npos) out->push_back(text);
@@ -50,7 +56,7 @@ static void add_mesh_candidate(const YAML::Node & node, std::vector<std::string>
 
 static bool mesh_node_disabled(const YAML::Node & node)
 {
-  if (!node || !node.IsScalar()) return false;
+  if (!yaml_node_defined(node) || !node.IsScalar()) return false;
   std::string value;
   if (!yaml_read_string(node, &value)) return false;
   std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c){ return static_cast<char>(std::tolower(c)); });
@@ -69,7 +75,7 @@ static std::vector<std::string> gather_mesh_candidates(const YAML::Node & env, c
   std::vector<std::string> out;
   const auto scan_fields = [&out](const YAML::Node & n) {
     const YAML::Node mesh = yaml_map_key(n, "mesh");
-    if (mesh && mesh.IsMap()) add_mesh_candidate(optional_scalar(mesh, "path"), &out);
+    if (yaml_node_defined(mesh) && mesh.IsMap()) add_mesh_candidate(optional_scalar(mesh, "path"), &out);
     else add_mesh_candidate(mesh, &out);
     add_mesh_candidate(optional_scalar(n, "mesh_path"), &out);
     add_mesh_candidate(yaml_map_key(n, "visual_mesh"), &out);
@@ -80,7 +86,7 @@ static std::vector<std::string> gather_mesh_candidates(const YAML::Node & env, c
   };
   scan_fields(env);
   scan_fields(manifest);
-  if (layout_items.IsSequence()) {
+  if (yaml_node_defined(layout_items) && layout_items.IsSequence()) {
     for (const auto & node : layout_items) {
       if (!node.IsMap()) continue;
       if (yaml_map_value_or_empty(node, "id") != item_id) continue;
@@ -396,11 +402,11 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
       m.warnings.push_back(item.mesh_load_warning);
     }
 
-    if (layout_items.IsSequence()) {
+    if (yaml_node_defined(layout_items) && layout_items.IsSequence()) {
       for (const auto & node : layout_items) {
         if (!node.IsMap() || yaml_map_value_or_empty(node, "id") != item.id) continue;
         const YAML::Node mesh = yaml_map_key(node, "mesh");
-        if (!mesh || mesh.IsNull() || mesh_node_disabled(mesh)) {
+        if (!yaml_node_defined(mesh) || mesh.IsNull() || mesh_node_disabled(mesh)) {
           item.mesh_available = false;
           item.mesh_path.clear();
           item.mesh_load_warning = "mesh metadata missing or legacy; using primitive preview";
@@ -416,19 +422,19 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
             item.mesh_path = resolved_path.generic_string();
           }
           const YAML::Node scale = yaml_map_key(mesh, "scale");
-          if (scale.IsSequence()) {
+          if (yaml_node_defined(scale) && scale.IsSequence()) {
             item.mesh_scale_x = read_double_or_warn(yaml_seq_index(scale, 0), "items[].mesh.scale[0]", item.mesh_scale_x);
             item.mesh_scale_y = read_double_or_warn(yaml_seq_index(scale, 1), "items[].mesh.scale[1]", item.mesh_scale_y);
             item.mesh_scale_z = read_double_or_warn(yaml_seq_index(scale, 2), "items[].mesh.scale[2]", item.mesh_scale_z);
           }
           const YAML::Node rpy = yaml_map_key(mesh, "rpy");
-          if (rpy.IsSequence()) {
+          if (yaml_node_defined(rpy) && rpy.IsSequence()) {
             item.mesh_r = read_double_or_warn(yaml_seq_index(rpy, 0), "items[].mesh.rpy[0]", item.mesh_r);
             item.mesh_p = read_double_or_warn(yaml_seq_index(rpy, 1), "items[].mesh.rpy[1]", item.mesh_p);
             item.mesh_y = read_double_or_warn(yaml_seq_index(rpy, 2), "items[].mesh.rpy[2]", item.mesh_y);
           }
           const YAML::Node origin = yaml_map_key(mesh, "origin_offset");
-          if (origin.IsSequence()) {
+          if (yaml_node_defined(origin) && origin.IsSequence()) {
             item.has_origin_offset = true;
             item.origin_offset_x = read_double_or_warn(yaml_seq_index(origin, 0), "items[].mesh.origin_offset[0]", item.origin_offset_x);
             item.origin_offset_y = read_double_or_warn(yaml_seq_index(origin, 1), "items[].mesh.origin_offset[1]", item.origin_offset_y);
@@ -472,10 +478,10 @@ std::size_t count_editable_layout_entries(const fs::path & scene_dir)
   const std::string schema_version = yaml_map_value_or_empty(layout, "schema_version");
   if (schema_version != "workcell_studio_layout/v1") return 0;
   const YAML::Node items = yaml_map_key(layout, "items");
-  if (!items || !items.IsSequence()) return 0;
+  if (!yaml_node_defined(items) || !items.IsSequence()) return 0;
   std::size_t count = 0;
   for (const auto & node : items) {
-    if (!node || !node.IsMap()) continue;
+    if (!yaml_node_defined(node) || !node.IsMap()) continue;
     bool editable = true;
     if (yaml_read_bool(yaml_map_key(node, "editable"), &editable)) {
       if (editable) ++count;
@@ -491,17 +497,36 @@ std::size_t count_editable_layout_entries(const fs::path & scene_dir)
   return count;
 }
 
-YAML::Node build_starter_layout_entries_from_preview(const WorkcellStudioCanvasModel & model)
+static bool starter_preview_item_has_safe_metadata(const WorkcellStudioCanvasItem & preview_item)
 {
+  if (preview_item.id.empty() || preview_item.type.empty() || preview_item.source_file.empty()) return false;
+  if (!preview_item.has_mesh_metadata || preview_item.mesh_path.empty()) return false;
+  if (!preview_item.mesh_load_warning.empty() || !preview_item.alignment_warning.empty()) return false;
+  return preview_item.warnings.empty();
+}
+
+WorkcellStudioStarterLayoutResult build_starter_layout_result_from_preview(const WorkcellStudioCanvasModel & model)
+{
+  WorkcellStudioStarterLayoutResult result;
   YAML::Node root(YAML::NodeType::Map);
   root["schema_version"] = "workcell_studio_layout/v1";
   root["scene_name"] = model.scene_name;
   root["empty_layout_marker"] = false;
   YAML::Node items(YAML::NodeType::Sequence);
   for (const auto & preview_item : model.items) {
-    if (preview_item.locked) continue;
-    const bool safe_provenance = preview_item.provenance != WorkcellStudioItemProvenance::StaticFallbackPreview;
-    if (!safe_provenance) continue;
+    ++result.total_preview_items;
+    if (preview_item.locked) {
+      ++result.skipped_locked_items;
+      continue;
+    }
+    if (preview_item.provenance == WorkcellStudioItemProvenance::StaticFallbackPreview) {
+      ++result.skipped_static_fallback_items;
+      continue;
+    }
+    if (!starter_preview_item_has_safe_metadata(preview_item)) {
+      ++result.skipped_unsafe_or_missing_metadata_items;
+      continue;
+    }
     YAML::Node item(YAML::NodeType::Map);
     item["id"] = preview_item.id;
     item["type"] = preview_item.type;
@@ -518,16 +543,23 @@ YAML::Node build_starter_layout_entries_from_preview(const WorkcellStudioCanvasM
     item["dimensions"].push_back(preview_item.depth);
     item["dimensions"].push_back(preview_item.height);
     YAML::Node mesh(YAML::NodeType::Map);
-    mesh["path"] = preview_item.mesh_path.empty() ? preview_item.source_file : preview_item.mesh_path;
+    mesh["path"] = preview_item.mesh_path;
     mesh["source"] = preview_item.source_file;
     item["mesh"] = mesh;
     item["source"] = preview_item.source_file;
     item["editable"] = true;
     item["locked"] = false;
     items.push_back(item);
+    ++result.editable_items_created;
   }
   root["items"] = items;
-  return root;
+  result.layout = root;
+  return result;
+}
+
+YAML::Node build_starter_layout_entries_from_preview(const WorkcellStudioCanvasModel & model)
+{
+  return build_starter_layout_result_from_preview(model).layout;
 }
 
 }  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
@@ -138,13 +138,16 @@ TEST(WorkcellStudioCanvasMesh, CountEditableLayoutEntriesWithOneEditable)
   EXPECT_EQ(workcell_builder::count_editable_layout_entries(root), 1u);
 }
 
-TEST(WorkcellStudioCanvasMesh, BuildStarterLayoutFiltersLockedAndFallbackPreviewItems)
+TEST(WorkcellStudioCanvasMesh, BuildStarterLayoutReportsEachSkipCategoryAndEditableItems)
 {
   workcell_builder::WorkcellStudioCanvasModel model;
   model.scene_name = "demo";
   workcell_builder::WorkcellStudioCanvasItem safe;
   safe.id = "safe_item";
   safe.type = "object";
+  safe.source_file = "environment.yaml";
+  safe.has_mesh_metadata = true;
+  safe.mesh_path = "assets/environment_objects/safe_item/meshes/visual/safe_item.stl";
   safe.provenance = workcell_builder::WorkcellStudioItemProvenance::GeneratedOrLegacyPreview;
   safe.locked = false;
   model.items.push_back(safe);
@@ -159,9 +162,63 @@ TEST(WorkcellStudioCanvasMesh, BuildStarterLayoutFiltersLockedAndFallbackPreview
   fallback.provenance = workcell_builder::WorkcellStudioItemProvenance::StaticFallbackPreview;
   model.items.push_back(fallback);
 
+  workcell_builder::WorkcellStudioCanvasItem unsafe = safe;
+  unsafe.id = "unsafe_item";
+  unsafe.has_mesh_metadata = false;
+  unsafe.mesh_path.clear();
+  unsafe.mesh_load_warning = "mesh metadata missing or legacy; using primitive preview";
+  model.items.push_back(unsafe);
+
+  const auto result = workcell_builder::build_starter_layout_result_from_preview(model);
+  EXPECT_EQ(result.total_preview_items, 4u);
+  EXPECT_EQ(result.skipped_locked_items, 1u);
+  EXPECT_EQ(result.skipped_static_fallback_items, 1u);
+  EXPECT_EQ(result.skipped_unsafe_or_missing_metadata_items, 1u);
+  EXPECT_EQ(result.editable_items_created, 1u);
+  const YAML::Node items = result.layout["items"];
+  ASSERT_TRUE(items && items.IsSequence());
+  ASSERT_EQ(items.size(), 1u);
+  EXPECT_EQ(items[0]["id"].as<std::string>(), "safe_item");
+  EXPECT_EQ(items[0]["mesh"]["path"].as<std::string>(), safe.mesh_path);
+}
+
+TEST(WorkcellStudioCanvasMesh, BuildStarterLayoutEntriesWrapperReturnsEditableLayout)
+{
+  workcell_builder::WorkcellStudioCanvasModel model;
+  model.scene_name = "demo";
+  workcell_builder::WorkcellStudioCanvasItem safe;
+  safe.id = "safe_item";
+  safe.type = "object";
+  safe.source_file = "environment.yaml";
+  safe.has_mesh_metadata = true;
+  safe.mesh_path = "assets/environment_objects/safe_item/meshes/visual/safe_item.stl";
+  model.items.push_back(safe);
+
   const YAML::Node layout = workcell_builder::build_starter_layout_entries_from_preview(model);
   const YAML::Node items = layout["items"];
   ASSERT_TRUE(items && items.IsSequence());
   ASSERT_EQ(items.size(), 1u);
   EXPECT_EQ(items[0]["id"].as<std::string>(), "safe_item");
+}
+
+TEST(WorkcellStudioCanvasMesh, BuildStarterLayoutSkipsPreviewItemsWithWarningMetadata)
+{
+  workcell_builder::WorkcellStudioCanvasModel model;
+  model.scene_name = "demo";
+  workcell_builder::WorkcellStudioCanvasItem warned;
+  warned.id = "warned_item";
+  warned.type = "object";
+  warned.source_file = "environment.yaml";
+  warned.has_mesh_metadata = true;
+  warned.mesh_path = "assets/environment_objects/warned_item/meshes/visual/warned_item.stl";
+  warned.warnings.push_back("metadata warning");
+  model.items.push_back(warned);
+
+  const auto result = workcell_builder::build_starter_layout_result_from_preview(model);
+  EXPECT_EQ(result.total_preview_items, 1u);
+  EXPECT_EQ(result.skipped_unsafe_or_missing_metadata_items, 1u);
+  EXPECT_EQ(result.editable_items_created, 0u);
+  const YAML::Node items = result.layout["items"];
+  ASSERT_TRUE(items && items.IsSequence());
+  EXPECT_EQ(items.size(), 0u);
 }


### PR DESCRIPTION
### Motivation
- Make starter-layout generation more transparent by counting preview items and distinct skip categories so the UI can report why no editable layout was produced.
- Prevent unsafe or incomplete preview metadata from being serialized as editable items and avoid leaving an empty `layout/workcell_studio_layout.yaml` behind.
- Add regression coverage to ensure each skip category and the successful editable-item path are exercised.

### Description
- Added `WorkcellStudioStarterLayoutResult` with fields `total_preview_items`, `skipped_locked_items`, `skipped_static_fallback_items`, `skipped_unsafe_or_missing_metadata_items`, `editable_items_created`, and `YAML::Node layout` in `workcell_studio_canvas_model.hpp`.
- Implemented `build_starter_layout_result_from_preview(const WorkcellStudioCanvasModel &)` in `src_workcell_studio_canvas_model.cpp` which computes the counts, builds the YAML only for safe items, and left a wrapper `build_starter_layout_entries_from_preview` that returns the generated `YAML::Node`.
- Introduced `starter_preview_item_has_safe_metadata` to treat preview items with missing/unsafe metadata (using existing `WorkcellStudioCanvasItem` fields such as `locked`, `provenance`, `has_mesh_metadata`, `mesh_path`, `source_file`, `mesh_load_warning`, `alignment_warning`, and `warnings`) as skipped rather than serialized.
- Hardened YAML handling with a `yaml_node_defined` helper to avoid exceptions when probing mesh metadata.
- Updated `MainWindow::create_starter_layout_from_preview` to compute the starter-layout result first, show/log the exact counts when `editable_items_created == 0`, and write the layout file only when editable items exist.
- Added/updated unit tests in `test/workcell_studio_canvas_model_mesh_test.cpp` to cover locked, static-fallback, unsafe/missing-metadata, warning-metadata skip categories and the successful editable-item serialization path.

### Testing
- Compiled and ran the modified mesh/canvas tests directly with g++ and dependencies and executed the test binary: `workcell_studio_canvas_model_mesh_test`; all tests passed (9/9).
- Ran `git diff --check` to ensure no whitespace errors; no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186e7a13148331a72c64b8c62b90a6)