### PR TITLE
Fix layout readiness for locked-only layouts

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -151,6 +151,7 @@ add_executable(workcell_builder
     src_workcell_studio_template_instantiator.cpp
     src_workcell_studio_canvas_model.cpp
     src_workcell_studio_layout_editor.cpp
+    src_workcell_layout_readiness.cpp
     src_workcell_studio_layout_merge.cpp
     src_workcell_studio_id_utils.cpp
     src_workcell_warning_once.cpp
@@ -341,6 +342,10 @@ if(BUILD_TESTING)
     test/workcell_studio_canvas_model_mesh_test.cpp
     src_workcell_studio_canvas_model.cpp
     src_workcell_warning_once.cpp
+    src_workcell_yaml_utils.cpp)
+  ament_add_gtest(workcell_layout_readiness_test
+    test/workcell_layout_readiness_test.cpp
+    src_workcell_layout_readiness.cpp
     src_workcell_yaml_utils.cpp)
   ament_add_gtest(workcell_asset_catalog_discovery_test
     test/asset_catalog_discovery_test.cpp
@@ -553,6 +558,11 @@ if(BUILD_TESTING)
     target_include_directories(workcell_studio_layout_editor_test PRIVATE ${Boost_INCLUDE_DIRS} include)
   endif()
 
+  if(TARGET workcell_layout_readiness_test)
+    target_link_libraries(workcell_layout_readiness_test yaml-cpp ${Boost_LIBRARIES})
+    target_include_directories(workcell_layout_readiness_test PRIVATE ${Boost_INCLUDE_DIRS} include)
+  endif()
+
   if(TARGET workcell_mainwindow_rviz_preview_compile_test)
     target_link_libraries(workcell_mainwindow_rviz_preview_compile_test Qt5::Widgets)
     target_include_directories(workcell_mainwindow_rviz_preview_compile_test
@@ -586,6 +596,7 @@ if(BUILD_TESTING)
     command_builders_test.cpp
     scene_preview_widget_ui_test.cpp
     workcell_studio_canvas_model_mesh_test.cpp
+    workcell_layout_readiness_test.cpp
     asset_catalog_discovery_test.cpp
     transform_clipboard_utils_test.cpp
     layout_serialization_contract_test.cpp

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -112,6 +112,7 @@
 #include "include/workcell_directory_inspection.h"
 #include "workcell_studio_scene_browser.hpp"
 #include "workcell_studio_canvas_model.hpp"
+#include "workcell_layout_readiness.hpp"
 #include "scene_preview_widget.h"
 #include "scene3d_viewport_widget.h"
 #include "scene3d_candidate_assembly.h"
@@ -500,34 +501,11 @@ static QString canonical_scene_path_string(const fs::path & scene_dir)
   const fs::path canonical = fs::weakly_canonical(scene_dir, ec);
   return QString::fromStdString((ec ? scene_dir.lexically_normal() : canonical).string());
 }
-enum class LayoutStateModel {
-  NO_LAYOUT_FILE,
-  EMPTY_LAYOUT,
-  EDITABLE_LAYOUT_PRESENT,
-  PREVIEW_ONLY_AVAILABLE,
-  PREVIEW_UNAVAILABLE,
-  PATH_MISMATCH,
-  INVALID_LAYOUT_YAML
-};
-
-static LayoutStateModel derive_layout_state_model(const fs::path & scene_dir, const workcell_builder::WorkcellStudioCanvasModel & model, bool path_match)
+static workcell_builder::LayoutReadinessState derive_layout_state_model(const fs::path & scene_dir, const workcell_builder::WorkcellStudioCanvasModel & model, bool path_match)
 {
-  if (!path_match) return LayoutStateModel::PATH_MISMATCH;
-  const fs::path layout = scene_dir / "layout" / "workcell_studio_layout.yaml";
-  if (!fs::exists(layout)) {
-    return model.items.empty() ? LayoutStateModel::PREVIEW_UNAVAILABLE : LayoutStateModel::NO_LAYOUT_FILE;
-  }
-  try {
-    const YAML::Node node = YAML::LoadFile(layout.string());
-    const YAML::Node items = workcell_builder::yaml_map_key(node, "items");
-    if (!items || !items.IsSequence() || items.size() == 0) {
-      return model.items.empty() ? LayoutStateModel::EMPTY_LAYOUT : LayoutStateModel::PREVIEW_ONLY_AVAILABLE;
-    }
-    return LayoutStateModel::EDITABLE_LAYOUT_PRESENT;
-  } catch (const YAML::Exception &) {
-    return LayoutStateModel::INVALID_LAYOUT_YAML;
-  }
+  return workcell_builder::derive_layout_state_model(scene_dir, model.items.size(), path_match);
 }
+
 
 
 static QMap<QString, QString> discover_visual_mesh_package_map(const fs::path & scene_dir, const QString & workspace_root)
@@ -7016,9 +6994,6 @@ std::vector<MainWindow::SceneWorkflowStep> MainWindow::scene_workflow_steps() co
   const bool launch_ready = has("launch/demo.launch.py");
   const bool package_xml_ready = has("package.xml");
   const bool cmake_ready = has("CMakeLists.txt");
-  const bool environment_yaml_ready = has("environment.yaml");
-  const bool environment_layout_ready = has("environment_layout.yaml");
-  const bool studio_layout_ready = has("layout/workcell_studio_layout.yaml");
   const bool scene_xacro_ready = has("urdf/scene.urdf.xacro") || s.has_scene_urdf_xacro;
   const bool placeholder_launch_only = launch_ready && !scene_xacro_ready;
   const bool validation_report_ready = has("validation/readiness_report.json") || has("diagnostics/readiness_report.json") || has("run_acceptance.txt");
@@ -7099,19 +7074,19 @@ std::vector<MainWindow::SceneWorkflowStep> MainWindow::scene_workflow_steps() co
     "Scene",
     scene_selected, "A scene is selected.", "Select or create a scene first.", {}, gates));
   const bool canonical_path_match = (canonical_scene_path_string(dir) == canonical_scene_path_string(fs::path(selected_scene_path().toStdString())));
-  const LayoutStateModel layout_state = derive_layout_state_model(dir, canvas_model, canonical_path_match);
+  const workcell_builder::LayoutReadinessState layout_state = derive_layout_state_model(dir, canvas_model, canonical_path_match);
   QString layout_ready_detail = "Saved: environment_layout.yaml, layout/workcell_studio_layout.yaml, environment.yaml are present.";
   QString layout_missing_detail = "Create/edit and save layout to persist edits before YAML generation.";
   SceneWorkflowStepStatus layout_status = SceneWorkflowStepStatus::NeedsAction;
   bool layout_ready = false;
-  switch (layout_state) {
-    case LayoutStateModel::NO_LAYOUT_FILE: layout_missing_detail = "Save Layout Needed: no layout file"; break;
-    case LayoutStateModel::EMPTY_LAYOUT: layout_missing_detail = "Save Layout Needed: no editable items"; break;
-    case LayoutStateModel::PREVIEW_ONLY_AVAILABLE: layout_missing_detail = "Save Layout Needed: no editable items"; break;
-    case LayoutStateModel::PREVIEW_UNAVAILABLE: layout_missing_detail = "Save Layout Needed: no editable items"; break;
-    case LayoutStateModel::PATH_MISMATCH: layout_missing_detail = "Save Layout Blocked: scene path mismatch"; layout_status = SceneWorkflowStepStatus::Blocked; break;
-    case LayoutStateModel::INVALID_LAYOUT_YAML: layout_missing_detail = "Save Layout Needed: invalid layout YAML"; layout_status = SceneWorkflowStepStatus::Warning; break;
-    case LayoutStateModel::EDITABLE_LAYOUT_PRESENT: layout_ready = layout_saved_ && environment_yaml_ready && environment_layout_ready && studio_layout_ready; layout_status = layout_ready ? SceneWorkflowStepStatus::Done : SceneWorkflowStepStatus::NeedsAction; break;
+  switch (layout_state.state) {
+    case workcell_builder::LayoutStateModel::NO_LAYOUT_FILE: layout_missing_detail = "Save Layout Needed: no layout file"; break;
+    case workcell_builder::LayoutStateModel::EMPTY_LAYOUT: layout_missing_detail = "Save Layout Needed: no editable items"; break;
+    case workcell_builder::LayoutStateModel::PREVIEW_ONLY_AVAILABLE: layout_missing_detail = "Save Layout Needed: no editable items"; break;
+    case workcell_builder::LayoutStateModel::PREVIEW_UNAVAILABLE: layout_missing_detail = "Save Layout Needed: no editable items"; break;
+    case workcell_builder::LayoutStateModel::PATH_MISMATCH: layout_missing_detail = "Save Layout Blocked: scene path mismatch"; layout_status = SceneWorkflowStepStatus::Blocked; break;
+    case workcell_builder::LayoutStateModel::INVALID_LAYOUT_YAML: layout_missing_detail = "Save Layout Needed: invalid layout YAML"; layout_status = SceneWorkflowStepStatus::Warning; break;
+    case workcell_builder::LayoutStateModel::EDITABLE_LAYOUT_PRESENT: layout_ready = workcell_builder::save_layout_workflow_ready(dir, layout_state); layout_status = layout_ready ? SceneWorkflowStepStatus::Done : SceneWorkflowStepStatus::NeedsAction; break;
   }
   steps.push_back(compute_scene_workflow_step(
     "Save Layout",

--- a/workcell_builder/workcell_builder/include/workcell_layout_readiness.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_layout_readiness.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <boost/filesystem.hpp>
+#include <cstddef>
+
+namespace workcell_builder {
+
+enum class LayoutStateModel {
+  NO_LAYOUT_FILE,
+  EMPTY_LAYOUT,
+  EDITABLE_LAYOUT_PRESENT,
+  PREVIEW_ONLY_AVAILABLE,
+  PREVIEW_UNAVAILABLE,
+  PATH_MISMATCH,
+  INVALID_LAYOUT_YAML
+};
+
+struct LayoutReadinessState {
+  LayoutStateModel state{LayoutStateModel::NO_LAYOUT_FILE};
+  std::size_t editable_item_count{0};
+};
+
+LayoutReadinessState derive_layout_state_model(
+  const boost::filesystem::path & scene_dir,
+  std::size_t preview_item_count,
+  bool path_match);
+
+bool save_layout_workflow_ready(
+  const boost::filesystem::path & scene_dir,
+  const LayoutReadinessState & layout_state);
+
+}  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/src_workcell_layout_readiness.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_layout_readiness.cpp
@@ -1,0 +1,129 @@
+#include "workcell_layout_readiness.hpp"
+#include "workcell_yaml_utils.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <exception>
+#include <string>
+#include <yaml-cpp/yaml.h>
+
+namespace fs = boost::filesystem;
+
+namespace workcell_builder {
+namespace {
+
+bool file_exists(const fs::path & path)
+{
+  boost::system::error_code ec;
+  return fs::exists(path, ec) && !ec;
+}
+
+struct BoolField
+{
+  bool defined{false};
+  bool valid{false};
+  bool value{false};
+};
+
+BoolField read_bool_field(const YAML::Node & node)
+{
+  BoolField field;
+  field.defined = node.IsDefined();
+  field.valid = yaml_read_bool(node, &field.value);
+  return field;
+}
+
+bool layout_item_is_fallback_only(const YAML::Node & item)
+{
+  const YAML::Node source_layer = yaml_map_key(item, "source_layer");
+  const YAML::Node visual_source = yaml_map_key(item, "visual_source");
+  const YAML::Node active_visual_source = yaml_map_key(item, "active_visual_source");
+  const YAML::Node provenance = yaml_map_key(item, "provenance");
+  const YAML::Node status = yaml_map_key(item, "status");
+
+  std::string value;
+  const YAML::Node candidates[] = {source_layer, visual_source, active_visual_source, provenance, status};
+  for (const YAML::Node & candidate : candidates) {
+    if (!yaml_read_string(candidate, &value)) continue;
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+    });
+    if (value == "primitive_fallback" || value == "static_fallback" ||
+        value == "legacy_static_fallback" || value == "fallback" ||
+        value == "preview_only" || value == "generated_urdf_visual") {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool layout_item_is_effectively_editable(const YAML::Node & item)
+{
+  if (!item || !item.IsMap()) return false;
+  if (layout_item_is_fallback_only(item)) return false;
+
+  const BoolField locked = read_bool_field(yaml_map_key(item, "locked"));
+  if (locked.defined && (!locked.valid || locked.value)) return false;
+
+  const BoolField editable = read_bool_field(yaml_map_key(item, "editable"));
+  if (editable.defined) return editable.valid && editable.value;
+
+  return !locked.defined || (locked.valid && !locked.value);
+}
+
+}  // namespace
+
+LayoutReadinessState derive_layout_state_model(
+  const fs::path & scene_dir,
+  std::size_t preview_item_count,
+  bool path_match)
+{
+  LayoutReadinessState result;
+  if (!path_match) {
+    result.state = LayoutStateModel::PATH_MISMATCH;
+    return result;
+  }
+
+  const fs::path layout = scene_dir / "layout" / "workcell_studio_layout.yaml";
+  if (!file_exists(layout)) {
+    result.state = preview_item_count == 0 ? LayoutStateModel::PREVIEW_UNAVAILABLE : LayoutStateModel::NO_LAYOUT_FILE;
+    return result;
+  }
+
+  try {
+    const YAML::Node node = YAML::LoadFile(layout.string());
+    const YAML::Node items = yaml_map_key(node, "items");
+    if (!items || !items.IsSequence() || items.size() == 0) {
+      result.state = preview_item_count == 0 ? LayoutStateModel::EMPTY_LAYOUT : LayoutStateModel::PREVIEW_ONLY_AVAILABLE;
+      return result;
+    }
+
+    for (const auto & item : items) {
+      if (layout_item_is_effectively_editable(item)) ++result.editable_item_count;
+    }
+    result.state = result.editable_item_count > 0 ?
+      LayoutStateModel::EDITABLE_LAYOUT_PRESENT :
+      (preview_item_count == 0 ? LayoutStateModel::EMPTY_LAYOUT : LayoutStateModel::PREVIEW_ONLY_AVAILABLE);
+    return result;
+  } catch (const YAML::Exception &) {
+    result.state = LayoutStateModel::INVALID_LAYOUT_YAML;
+  } catch (const std::exception &) {
+    result.state = LayoutStateModel::INVALID_LAYOUT_YAML;
+  } catch (...) {
+    result.state = LayoutStateModel::INVALID_LAYOUT_YAML;
+  }
+  return result;
+}
+
+bool save_layout_workflow_ready(
+  const fs::path & scene_dir,
+  const LayoutReadinessState & layout_state)
+{
+  return layout_state.state == LayoutStateModel::EDITABLE_LAYOUT_PRESENT &&
+    layout_state.editable_item_count > 0 &&
+    file_exists(scene_dir / "environment_layout.yaml") &&
+    file_exists(scene_dir / "layout" / "workcell_studio_layout.yaml") &&
+    file_exists(scene_dir / "environment.yaml");
+}
+
+}  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -476,17 +476,19 @@ std::size_t count_editable_layout_entries(const fs::path & scene_dir)
   std::size_t count = 0;
   for (const auto & node : items) {
     if (!node || !node.IsMap()) continue;
-    bool editable = true;
+    bool locked = false;
+    if (yaml_read_bool(yaml_map_key(node, "locked"), &locked) && locked) continue;
+
+    bool editable = false;
     if (yaml_read_bool(yaml_map_key(node, "editable"), &editable)) {
       if (editable) ++count;
       continue;
     }
-    bool locked = false;
-    if (yaml_read_bool(yaml_map_key(node, "locked"), &locked)) {
-      if (!locked) ++count;
-      continue;
+
+    if (!yaml_map_key(node, "editable").IsDefined()) {
+      if (!yaml_map_key(node, "locked").IsDefined()) ++count;
+      else if (yaml_read_bool(yaml_map_key(node, "locked"), &locked) && !locked) ++count;
     }
-    ++count;
   }
   return count;
 }

--- a/workcell_builder/workcell_builder/test/workcell_layout_readiness_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_layout_readiness_test.cpp
@@ -1,0 +1,113 @@
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+#include <fstream>
+#include <string>
+
+#include "workcell_layout_readiness.hpp"
+
+namespace fs = boost::filesystem;
+
+namespace {
+
+void write_file(const fs::path & path, const std::string & text)
+{
+  fs::create_directories(path.parent_path());
+  std::ofstream out(path.string());
+  out << text;
+}
+
+fs::path fresh_scene(const std::string & name)
+{
+  const fs::path root = fs::temp_directory_path() / name;
+  fs::remove_all(root);
+  fs::create_directories(root);
+  return root;
+}
+
+}  // namespace
+
+TEST(WorkcellLayoutReadiness, EmptyLayoutStaysNonReady)
+{
+  const fs::path root = fresh_scene("wc_layout_readiness_empty");
+  write_file(root / "layout" / "workcell_studio_layout.yaml",
+    "schema_version: workcell_studio_layout/v1\nitems: []\n");
+  write_file(root / "environment_layout.yaml", "items: []\n");
+  write_file(root / "environment.yaml", "robot: ur5\n");
+
+  const auto state = workcell_builder::derive_layout_state_model(root, 0, true);
+  EXPECT_EQ(state.state, workcell_builder::LayoutStateModel::EMPTY_LAYOUT);
+  EXPECT_EQ(state.editable_item_count, 0u);
+  EXPECT_FALSE(workcell_builder::save_layout_workflow_ready(root, state));
+}
+
+TEST(WorkcellLayoutReadiness, LockedOnlyLayoutStaysNonReady)
+{
+  const fs::path root = fresh_scene("wc_layout_readiness_locked_only");
+  write_file(root / "layout" / "workcell_studio_layout.yaml",
+    "schema_version: workcell_studio_layout/v1\n"
+    "items:\n"
+    "- id: locked_table\n"
+    "  editable: true\n"
+    "  locked: true\n"
+    "- id: disabled_bin\n"
+    "  editable: false\n"
+    "  locked: false\n"
+    "- id: fallback_preview\n"
+    "  source_layer: primitive_fallback\n");
+  write_file(root / "environment_layout.yaml", "items: []\n");
+  write_file(root / "environment.yaml", "robot: ur5\n");
+
+  const auto state = workcell_builder::derive_layout_state_model(root, 3, true);
+  EXPECT_EQ(state.state, workcell_builder::LayoutStateModel::PREVIEW_ONLY_AVAILABLE);
+  EXPECT_EQ(state.editable_item_count, 0u);
+  EXPECT_FALSE(workcell_builder::save_layout_workflow_ready(root, state));
+}
+
+TEST(WorkcellLayoutReadiness, EditableLayoutWithMissingEnvironmentFilesStaysNonReady)
+{
+  const fs::path root = fresh_scene("wc_layout_readiness_missing_environment_files");
+  write_file(root / "layout" / "workcell_studio_layout.yaml",
+    "schema_version: workcell_studio_layout/v1\n"
+    "items:\n"
+    "- id: editable_table\n"
+    "  editable: true\n"
+    "  locked: false\n");
+
+  const auto state = workcell_builder::derive_layout_state_model(root, 1, true);
+  EXPECT_EQ(state.state, workcell_builder::LayoutStateModel::EDITABLE_LAYOUT_PRESENT);
+  EXPECT_EQ(state.editable_item_count, 1u);
+  EXPECT_FALSE(workcell_builder::save_layout_workflow_ready(root, state));
+}
+
+TEST(WorkcellLayoutReadiness, EditableLayoutPlusRequiredEnvironmentFilesBecomesReady)
+{
+  const fs::path root = fresh_scene("wc_layout_readiness_ready");
+  write_file(root / "layout" / "workcell_studio_layout.yaml",
+    "schema_version: workcell_studio_layout/v1\n"
+    "items:\n"
+    "- id: legacy_effectively_editable\n"
+    "  locked: false\n"
+    "- id: explicit_editable\n"
+    "  editable: true\n");
+  write_file(root / "environment_layout.yaml", "items: []\n");
+  write_file(root / "environment.yaml", "robot: ur5\n");
+
+  const auto state = workcell_builder::derive_layout_state_model(root, 2, true);
+  EXPECT_EQ(state.state, workcell_builder::LayoutStateModel::EDITABLE_LAYOUT_PRESENT);
+  EXPECT_EQ(state.editable_item_count, 2u);
+  EXPECT_TRUE(workcell_builder::save_layout_workflow_ready(root, state));
+}
+
+TEST(WorkcellLayoutReadiness, InvalidLayoutYamlIsNonReady)
+{
+  const fs::path root = fresh_scene("wc_layout_readiness_invalid_yaml");
+  write_file(root / "layout" / "workcell_studio_layout.yaml", "items: [unterminated\n");
+  write_file(root / "environment_layout.yaml", "items: []\n");
+  write_file(root / "environment.yaml", "robot: ur5\n");
+
+  const auto state = workcell_builder::derive_layout_state_model(root, 1, true);
+  EXPECT_EQ(state.state, workcell_builder::LayoutStateModel::INVALID_LAYOUT_YAML);
+  EXPECT_EQ(state.editable_item_count, 0u);
+  EXPECT_FALSE(workcell_builder::save_layout_workflow_ready(root, state));
+}


### PR DESCRIPTION
### Motivation
- Ensure the Save Layout workflow only reports Ready when there are truly editable layout items and required environment files, and avoid treating preview/fallback-only or locked items as editable.
- Safely parse `layout/workcell_studio_layout.yaml` and correctly classify items as editable, non-editable, fallback-only, or invalid YAML so the UI workflow reflects real authoring state.

### Description
- Added a shared readiness model in `workcell_builder/workcell_builder/include/workcell_layout_readiness.hpp` and `workcell_builder/workcell_builder/src_workcell_layout_readiness.cpp` that safely loads `layout/workcell_studio_layout.yaml`, counts effectively editable items, detects fallback-only items, and returns a `LayoutReadinessState` (state + editable count).
- Updated `mainwindow.cpp` to delegate `derive_layout_state_model` to the shared readiness model and to use `save_layout_workflow_ready` to decide the "Save Layout" workflow step readiness.
- Adjusted counting semantics in `src_workcell_studio_canvas_model.cpp` so `count_editable_layout_entries` treats `editable: true`, explicit non-editable, and legacy behavior (no `editable` and no `locked`) per the specified rules, and treats `locked: true` and `editable: false` as non-editable.
- Added regression tests `workcell_builder/workcell_builder/test/workcell_layout_readiness_test.cpp` covering empty layout, locked-only layout, editable layout with missing environment files, editable layout with required files (becomes ready), and invalid YAML; and updated `CMakeLists.txt` to register the new source and tests.

### Testing
- Ran `git diff --check` locally to ensure no whitespace/format errors and it passed.
- Attempted `cmake -S workcell_builder/workcell_builder -B /tmp/workcell_builder_cmake_check` but configuration was blocked in this environment due to missing ROS/`ament_cmake` support (CI should run full CMake/ament checks).
- Attempted to compile and run the new gtest binary with `g++` locally, but the run was blocked by missing development headers/libs (`gtest`, Boost, `yaml-cpp`) in the sandbox; the new unit tests are included and expected to run in CI where those dependencies are provided.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186e7ffc648331bdfec2a1d2d3e151)