### PR TITLE
Fix save layout readiness for non-editable layouts

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -519,20 +519,12 @@ static LayoutStateModel derive_layout_state_model(const fs::path & scene_dir, co
   if (!fs::exists(layout)) {
     return model.items.empty() ? LayoutStateModel::PREVIEW_UNAVAILABLE : LayoutStateModel::NO_LAYOUT_FILE;
   }
-  try {
-    const YAML::Node node = YAML::LoadFile(layout.string());
-    const YAML::Node items = workcell_builder::yaml_map_key(node, "items");
-    if (!items || !items.IsSequence() || items.size() == 0) {
-      return model.items.empty() ? LayoutStateModel::EMPTY_LAYOUT : LayoutStateModel::PREVIEW_ONLY_AVAILABLE;
-    }
-    return LayoutStateModel::EDITABLE_LAYOUT_PRESENT;
-  } catch (const YAML::Exception &) {
-    return LayoutStateModel::INVALID_LAYOUT_YAML;
-  } catch (const std::exception &) {
-    return LayoutStateModel::INVALID_LAYOUT_YAML;
-  } catch (...) {
-    return LayoutStateModel::INVALID_LAYOUT_YAML;
+  const auto inspection = workcell_builder::inspect_editable_layout_entries(scene_dir);
+  if (!inspection.valid) return LayoutStateModel::INVALID_LAYOUT_YAML;
+  if (!inspection.has_items_sequence || inspection.total_item_entries == 0 || inspection.editable_item_count == 0) {
+    return model.items.empty() ? LayoutStateModel::EMPTY_LAYOUT : LayoutStateModel::PREVIEW_ONLY_AVAILABLE;
   }
+  return LayoutStateModel::EDITABLE_LAYOUT_PRESENT;
 }
 
 
@@ -7038,12 +7030,13 @@ std::vector<MainWindow::SceneWorkflowStep> MainWindow::scene_workflow_steps() co
   const bool environment_yaml_ready = has("environment.yaml");
   const bool environment_layout_ready = has("environment_layout.yaml");
   const bool studio_layout_ready = has("layout/workcell_studio_layout.yaml");
+  const auto editable_layout_inspection = workcell_builder::inspect_editable_layout_entries(dir);
   const bool scene_xacro_ready = has("urdf/scene.urdf.xacro") || s.has_scene_urdf_xacro;
   const bool placeholder_launch_only = launch_ready && !scene_xacro_ready;
   const bool validation_report_ready = has("validation/readiness_report.json") || has("diagnostics/readiness_report.json") || has("run_acceptance.txt");
   const bool scene_selected = has_selected_scene();
   const auto canvas_model = workcell_builder::build_workcell_studio_canvas_model(s.scene_dir, s.scene_name);
-  const bool editable_layout_ready = !canvas_model.items.empty();
+  const bool editable_layout_ready = editable_layout_inspection.valid && editable_layout_inspection.editable_item_count > 0;
   const bool has_warnings = !readiness_warning_details_.isEmpty();
   const bool validation_gate_ready = validation_report_ready && !validation_stale_;
   const bool export_ready = yaml_ready && launch_ready;
@@ -7130,7 +7123,7 @@ std::vector<MainWindow::SceneWorkflowStep> MainWindow::scene_workflow_steps() co
     case LayoutStateModel::PREVIEW_UNAVAILABLE: layout_missing_detail = "Save Layout Needed: no editable items"; break;
     case LayoutStateModel::PATH_MISMATCH: layout_missing_detail = "Save Layout Blocked: scene path mismatch"; layout_status = SceneWorkflowStepStatus::Blocked; break;
     case LayoutStateModel::INVALID_LAYOUT_YAML: layout_missing_detail = "Save Layout Needed: invalid layout YAML"; layout_status = SceneWorkflowStepStatus::Warning; break;
-    case LayoutStateModel::EDITABLE_LAYOUT_PRESENT: layout_ready = layout_saved_ && environment_yaml_ready && environment_layout_ready && studio_layout_ready; layout_status = layout_ready ? SceneWorkflowStepStatus::Done : SceneWorkflowStepStatus::NeedsAction; break;
+    case LayoutStateModel::EDITABLE_LAYOUT_PRESENT: layout_ready = workcell_builder::is_save_layout_workflow_ready(dir); layout_status = layout_ready ? SceneWorkflowStepStatus::Done : SceneWorkflowStepStatus::NeedsAction; break;
   }
   steps.push_back(compute_scene_workflow_step(
     "Save Layout",

--- a/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
@@ -62,7 +62,19 @@ struct WorkcellStudioStarterLayoutSummary
   YAML::Node layout;
 };
 
+
+struct WorkcellStudioEditableLayoutInspection
+{
+  bool exists{false};
+  bool valid{false};
+  bool has_items_sequence{false};
+  std::size_t total_item_entries{0};
+  std::size_t editable_item_count{0};
+};
+
 WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const boost::filesystem::path & scene_dir, const std::string & scene_name);
+WorkcellStudioEditableLayoutInspection inspect_editable_layout_entries(const boost::filesystem::path & scene_dir);
 std::size_t count_editable_layout_entries(const boost::filesystem::path & scene_dir);
+bool is_save_layout_workflow_ready(const boost::filesystem::path & scene_dir);
 WorkcellStudioStarterLayoutSummary build_starter_layout_entries_from_preview(const WorkcellStudioCanvasModel & model);
 }

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -2,6 +2,8 @@
 #include "workcell_yaml_utils.hpp"
 #include "workcell_warning_once.hpp"
 #include <algorithm>
+#include <array>
+#include <cctype>
 #include <set>
 #include <yaml-cpp/yaml.h>
 
@@ -465,30 +467,76 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   return fallback;
 }
 
-std::size_t count_editable_layout_entries(const fs::path & scene_dir)
+static std::string lower_scalar_or_empty(const YAML::Node & node)
 {
+  std::string value;
+  if (!yaml_read_string(node, &value)) return "";
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c){ return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+static bool layout_item_is_fallback_preview_entry(const YAML::Node & node)
+{
+  const std::array<std::string, 5> marker_keys = {"source_layer", "source_file", "source_path", "provenance", "preview_source"};
+  for (const auto & key : marker_keys) {
+    const std::string value = lower_scalar_or_empty(yaml_map_key(node, key));
+    if (value.find("fallback") != std::string::npos || value.find("static_preview") != std::string::npos) return true;
+  }
+  return false;
+}
+
+static bool layout_item_is_effectively_editable(const YAML::Node & node)
+{
+  if (!node || !node.IsMap()) return false;
+
+  bool locked = false;
+  const YAML::Node locked_node = yaml_map_key(node, "locked");
+  if (yaml_read_bool(locked_node, &locked) && locked) return false;
+  if (locked_node.IsDefined() && !yaml_read_bool(locked_node, &locked)) return false;
+
+  bool editable = false;
+  const YAML::Node editable_node = yaml_map_key(node, "editable");
+  if (yaml_read_bool(editable_node, &editable)) return editable;
+  if (editable_node.IsDefined()) return false;
+
+  if (layout_item_is_fallback_preview_entry(node)) return false;
+  return true;
+}
+
+WorkcellStudioEditableLayoutInspection inspect_editable_layout_entries(const fs::path & scene_dir)
+{
+  WorkcellStudioEditableLayoutInspection out;
+  const fs::path layout_path = scene_dir / "layout" / "workcell_studio_layout.yaml";
+  out.exists = fs::exists(layout_path);
   YAML::Node layout;
-  if (!read_yaml(scene_dir / "layout" / "workcell_studio_layout.yaml", &layout).loaded) return 0;
+  if (!read_yaml(layout_path, &layout).loaded) return out;
   const std::string schema_version = yaml_map_value_or_empty(layout, "schema_version");
-  if (schema_version != "workcell_studio_layout/v1") return 0;
   const YAML::Node items = yaml_map_key(layout, "items");
-  if (!items || !items.IsSequence()) return 0;
-  std::size_t count = 0;
+  const bool schema_current = (schema_version == "workcell_studio_layout/v1");
+  const bool schema_legacy = schema_version.empty() && items.IsSequence();
+  if (!schema_current && !schema_legacy) return out;
+  out.valid = true;
+  if (!items || !items.IsSequence()) return out;
+  out.has_items_sequence = true;
   for (const auto & node : items) {
     if (!node || !node.IsMap()) continue;
-    bool editable = true;
-    if (yaml_read_bool(yaml_map_key(node, "editable"), &editable)) {
-      if (editable) ++count;
-      continue;
-    }
-    bool locked = false;
-    if (yaml_read_bool(yaml_map_key(node, "locked"), &locked)) {
-      if (!locked) ++count;
-      continue;
-    }
-    ++count;
+    ++out.total_item_entries;
+    if (layout_item_is_effectively_editable(node)) ++out.editable_item_count;
   }
-  return count;
+  return out;
+}
+
+std::size_t count_editable_layout_entries(const fs::path & scene_dir)
+{
+  return inspect_editable_layout_entries(scene_dir).editable_item_count;
+}
+
+bool is_save_layout_workflow_ready(const fs::path & scene_dir)
+{
+  const WorkcellStudioEditableLayoutInspection layout = inspect_editable_layout_entries(scene_dir);
+  return layout.exists && layout.valid && layout.editable_item_count > 0 &&
+    fs::exists(scene_dir / "environment_layout.yaml") &&
+    fs::exists(scene_dir / "environment.yaml");
 }
 
 static bool has_safe_starter_layout_metadata(const WorkcellStudioCanvasItem & preview_item)

--- a/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
@@ -314,3 +314,89 @@ TEST(WorkcellStudioCanvasMesh, StarterLayoutAcceptanceCopiesSceneAndFiltersUnsaf
   fs::remove_all(temp_root);
 #endif
 }
+
+TEST(WorkcellStudioCanvasMesh, SaveLayoutReadinessRejectsEmptyEditableLayout)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_save_layout_empty_ready";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "layout" / "workcell_studio_layout.yaml",
+    "schema_version: workcell_studio_layout/v1\nitems: []\n");
+  write_file(root / "environment_layout.yaml", "schema_version: environment_layout/v1\nitems: []\n");
+  write_file(root / "environment.yaml", "environment: {}\n");
+
+  const auto inspection = workcell_builder::inspect_editable_layout_entries(root);
+  EXPECT_TRUE(inspection.exists);
+  EXPECT_TRUE(inspection.valid);
+  EXPECT_TRUE(inspection.has_items_sequence);
+  EXPECT_EQ(inspection.total_item_entries, 0u);
+  EXPECT_EQ(inspection.editable_item_count, 0u);
+  EXPECT_FALSE(workcell_builder::is_save_layout_workflow_ready(root));
+}
+
+TEST(WorkcellStudioCanvasMesh, SaveLayoutReadinessRejectsLockedOnlyAndFallbackOnlyLayout)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_save_layout_locked_ready";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "layout" / "workcell_studio_layout.yaml",
+    "schema_version: workcell_studio_layout/v1\n"
+    "items:\n"
+    "  - id: locked_table\n"
+    "    editable: true\n"
+    "    locked: true\n"
+    "  - id: explicitly_not_editable\n"
+    "    editable: false\n"
+    "  - id: fallback_table\n"
+    "    source_layer: primitive_fallback\n");
+  write_file(root / "environment_layout.yaml", "schema_version: environment_layout/v1\nitems: []\n");
+  write_file(root / "environment.yaml", "environment: {}\n");
+
+  const auto inspection = workcell_builder::inspect_editable_layout_entries(root);
+  EXPECT_EQ(inspection.total_item_entries, 3u);
+  EXPECT_EQ(inspection.editable_item_count, 0u);
+  EXPECT_FALSE(workcell_builder::is_save_layout_workflow_ready(root));
+}
+
+TEST(WorkcellStudioCanvasMesh, SaveLayoutReadinessRejectsEditableLayoutWithMissingEnvironmentFiles)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_save_layout_missing_env_ready";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "layout" / "workcell_studio_layout.yaml",
+    "schema_version: workcell_studio_layout/v1\n"
+    "items:\n"
+    "  - id: editable_table\n"
+    "    editable: true\n");
+
+  const auto inspection = workcell_builder::inspect_editable_layout_entries(root);
+  EXPECT_EQ(inspection.editable_item_count, 1u);
+  EXPECT_FALSE(workcell_builder::is_save_layout_workflow_ready(root));
+}
+
+TEST(WorkcellStudioCanvasMesh, SaveLayoutReadinessAcceptsEditableLayoutWithRequiredEnvironmentFiles)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_save_layout_complete_ready";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "layout" / "workcell_studio_layout.yaml",
+    "schema_version: workcell_studio_layout/v1\n"
+    "items:\n"
+    "  - id: legacy_absent_flags_table\n"
+    "  - id: legacy_unlocked_table\n"
+    "    locked: false\n"
+    "  - id: explicit_editable_zone\n"
+    "    editable: true\n");
+  write_file(root / "environment_layout.yaml", "schema_version: environment_layout/v1\nitems: []\n");
+  write_file(root / "environment.yaml", "environment: {}\n");
+
+  const auto inspection = workcell_builder::inspect_editable_layout_entries(root);
+  EXPECT_TRUE(inspection.valid);
+  EXPECT_EQ(inspection.total_item_entries, 3u);
+  EXPECT_EQ(inspection.editable_item_count, 3u);
+  EXPECT_TRUE(workcell_builder::is_save_layout_workflow_ready(root));
+}


### PR DESCRIPTION
### Motivation
- Prevent the UI from reporting the Save Layout step as ready when the `layout/workcell_studio_layout.yaml` file contains only locked, explicitly non-editable, or fallback-preview entries.
- Parse `layout/workcell_studio_layout.yaml` safely (no UI-side YAML exceptions) and preserve legacy behavior that treats items with no `editable` field and no `locked: true` as editable.

### Description
- Replace direct YAML loading in `derive_layout_state_model` with a safe inspection helper `inspect_editable_layout_entries` and return `INVALID_LAYOUT_YAML` when parsing fails, and `EMPTY_LAYOUT`/`PREVIEW_ONLY_AVAILABLE` when only non-editable entries are present (file: `workcell_builder/workcell_builder/gui/mainwindow.cpp`).
- Add `WorkcellStudioEditableLayoutInspection` and expose `inspect_editable_layout_entries`, `count_editable_layout_entries`, and `is_save_layout_workflow_ready` to encapsulate: existence, validity, items sequence presence, total item entries, and truly editable item count (file: `workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp`).
- Implement logic to count an item as editable only when it is explicitly `editable: true` or when `editable` is absent and `locked` is absent/false, while treating `editable: false`, `locked: true`, malformed fields, and fallback/preview-marked entries as non-editable (file: `workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp`).
- Gate the Save Layout workflow readiness on: editable item count > 0, presence of `environment_layout.yaml`, presence of `layout/workcell_studio_layout.yaml`, and presence of `environment.yaml` by using `is_save_layout_workflow_ready` (files: `workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp`, `workcell_builder/workcell_builder/gui/mainwindow.cpp`).
- Update `scene_workflow_steps` to use the new inspection/readiness APIs so the UI reflects the correct Save Layout readiness state (file: `workcell_builder/workcell_builder/gui/mainwindow.cpp`).
- Add regression tests that cover empty layout, locked/fallback-only layout, editable layout with missing environment files, and editable layout with required environment files (file: `workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp`).

### Testing
- Added unit tests in `workcell_studio_canvas_model_mesh_test.cpp` for four scenarios: empty editable list, locked/fallback-only, editable but missing environment files, and editable with required environment files. (Tests added; not executed in this environment.)
- Ran `git diff --check` which reported no issues.
- Attempted to run `colcon test` for the package but it could not be executed in this environment because `colcon` is not installed, so the new tests were not run here.
- Attempted a local compile check with `g++ -std=c++17 -Iworkcell_builder/workcell_builder/include -c workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp` but compilation failed due to missing system dependencies (Boost headers) in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a187299dc848331a652358c34501b9c)