### PR TITLE
Bootstrap environment_layout.yaml from starter editable layout

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -5201,6 +5201,21 @@ void MainWindow::create_starter_layout_from_preview()
   }
   const int generated_count = static_cast<int>(starter_layout_summary.editable_items_created);
   append_studio_log(QString("Use Recommended Layout: wrote %1 item(s) to %2").arg(generated_count).arg(QString::fromStdString(layout_file.string())));
+  const auto environment_bootstrap = workcell_builder::bootstrap_environment_layout_from_editable_layout(
+    s.scene_dir, s.scene_name, layout);
+  if (!environment_bootstrap.ok) {
+    append_studio_log(QString("Use Recommended Layout: environment_layout.yaml bootstrap failed (%1).")
+      .arg(QString::fromStdString(environment_bootstrap.error)));
+    QMessageBox::warning(this, "Create Starter Layout",
+      QString("Editable layout was written, but environment_layout.yaml could not be bootstrapped:\n%1")
+        .arg(QString::fromStdString(environment_bootstrap.error)));
+  } else if (environment_bootstrap.wrote) {
+    append_studio_log(QString("Use Recommended Layout: wrote %1 editable/placeable item(s) to %2")
+      .arg(static_cast<int>(environment_bootstrap.placed_assets_written))
+      .arg(QString::fromStdString((s.scene_dir / "environment_layout.yaml").string())));
+  } else {
+    append_studio_log("Use Recommended Layout: environment_layout.yaml already contained the bootstrapped editable/placeable item set.");
+  }
   append_studio_log("Use Recommended Layout: added recommended editable layout items from current preview metadata.");
   rebuild_digital_twin_canvas();
   refresh_scene_builder_left_explorer();

--- a/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
@@ -72,9 +72,20 @@ struct WorkcellStudioEditableLayoutInspection
   std::size_t editable_item_count{0};
 };
 
+struct WorkcellStudioEnvironmentLayoutBootstrapResult
+{
+  bool ok{false};
+  bool wrote{false};
+  bool created{false};
+  std::size_t placed_assets_written{0};
+  std::string error;
+};
+
 WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const boost::filesystem::path & scene_dir, const std::string & scene_name);
 WorkcellStudioEditableLayoutInspection inspect_editable_layout_entries(const boost::filesystem::path & scene_dir);
 std::size_t count_editable_layout_entries(const boost::filesystem::path & scene_dir);
 bool is_save_layout_workflow_ready(const boost::filesystem::path & scene_dir);
 WorkcellStudioStarterLayoutSummary build_starter_layout_entries_from_preview(const WorkcellStudioCanvasModel & model);
+WorkcellStudioEnvironmentLayoutBootstrapResult bootstrap_environment_layout_from_editable_layout(
+  const boost::filesystem::path & scene_dir, const std::string & scene_name, const YAML::Node & editable_layout);
 }

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -4,7 +4,9 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <fstream>
 #include <set>
+#include <vector>
 #include <yaml-cpp/yaml.h>
 
 namespace fs = boost::filesystem;
@@ -503,6 +505,63 @@ static bool layout_item_is_effectively_editable(const YAML::Node & node)
   return true;
 }
 
+
+static YAML::Node ensure_map_child(YAML::Node parent, const char * key)
+{
+  if (!parent[key] || !parent[key].IsMap()) parent[key] = YAML::Node(YAML::NodeType::Map);
+  return parent[key];
+}
+
+static YAML::Node ensure_sequence_child(YAML::Node parent, const char * key)
+{
+  if (!parent[key] || !parent[key].IsSequence()) parent[key] = YAML::Node(YAML::NodeType::Sequence);
+  return parent[key];
+}
+
+static bool yaml_nodes_equal(const YAML::Node & lhs, const YAML::Node & rhs)
+{
+  return YAML::Dump(lhs) == YAML::Dump(rhs);
+}
+
+static bool layout_item_has_bootstrap_placeable_fields(const YAML::Node & item)
+{
+  if (!item || !item.IsMap()) return false;
+  if (yaml_map_value_or_empty(item, "id").empty()) return false;
+  const YAML::Node pose = yaml_map_key(item, "pose");
+  const YAML::Node xyz = yaml_map_key(pose, "xyz");
+  const YAML::Node rpy = yaml_map_key(pose, "rpy");
+  const YAML::Node dimensions = yaml_map_key(item, "dimensions");
+  if (!pose || !pose.IsMap() || !xyz || !xyz.IsSequence() || xyz.size() < 3) return false;
+  if (!rpy || !rpy.IsSequence() || rpy.size() < 3) return false;
+  if (!dimensions || !dimensions.IsSequence() || dimensions.size() < 3) return false;
+  if (yaml_map_value_or_empty(item, "source").empty()) return false;
+  bool editable = false;
+  bool locked = true;
+  if (!yaml_read_bool(yaml_map_key(item, "editable"), &editable) || !editable) return false;
+  if (!yaml_read_bool(yaml_map_key(item, "locked"), &locked) || locked) return false;
+  return layout_item_is_effectively_editable(item);
+}
+
+static YAML::Node bootstrap_environment_asset_from_layout_item(const YAML::Node & existing, const YAML::Node & layout_item)
+{
+  YAML::Node out = (existing && existing.IsMap()) ? YAML::Clone(existing) : YAML::Node(YAML::NodeType::Map);
+  out["id"] = yaml_map_key(layout_item, "id");
+  const YAML::Node type = yaml_map_key(layout_item, "type");
+  if (type.IsDefined()) out["type"] = type;
+  const YAML::Node category = yaml_map_key(layout_item, "category");
+  if (category.IsDefined()) out["category"] = category;
+  YAML::Node pose = ensure_map_child(out, "pose");
+  pose["xyz"] = YAML::Clone(yaml_map_key(yaml_map_key(layout_item, "pose"), "xyz"));
+  pose["rpy"] = YAML::Clone(yaml_map_key(yaml_map_key(layout_item, "pose"), "rpy"));
+  out["dimensions"] = YAML::Clone(yaml_map_key(layout_item, "dimensions"));
+  out["source"] = yaml_map_key(layout_item, "source");
+  out["editable"] = yaml_map_key(layout_item, "editable");
+  out["locked"] = yaml_map_key(layout_item, "locked");
+  const YAML::Node mesh = yaml_map_key(layout_item, "mesh");
+  if (mesh.IsDefined()) out["mesh"] = YAML::Clone(mesh);
+  return out;
+}
+
 WorkcellStudioEditableLayoutInspection inspect_editable_layout_entries(const fs::path & scene_dir)
 {
   WorkcellStudioEditableLayoutInspection out;
@@ -537,6 +596,101 @@ bool is_save_layout_workflow_ready(const fs::path & scene_dir)
   return layout.exists && layout.valid && layout.editable_item_count > 0 &&
     fs::exists(scene_dir / "environment_layout.yaml") &&
     fs::exists(scene_dir / "environment.yaml");
+}
+
+
+WorkcellStudioEnvironmentLayoutBootstrapResult bootstrap_environment_layout_from_editable_layout(
+  const fs::path & scene_dir, const std::string & scene_name, const YAML::Node & editable_layout)
+{
+  WorkcellStudioEnvironmentLayoutBootstrapResult result;
+  const YAML::Node layout_items = yaml_map_key(editable_layout, "items");
+  if (!layout_items || !layout_items.IsSequence()) {
+    result.error = "editable layout has no items sequence";
+    return result;
+  }
+
+  YAML::Node env_root(YAML::NodeType::Map);
+  const fs::path env_layout_path = scene_dir / "environment_layout.yaml";
+  result.created = !fs::exists(env_layout_path);
+  if (!result.created) {
+    try {
+      env_root = YAML::LoadFile(env_layout_path.string());
+    } catch (const std::exception & e) {
+      result.error = std::string("failed to parse environment_layout.yaml: ") + e.what();
+      return result;
+    }
+    if (!env_root || !env_root.IsMap()) env_root = YAML::Node(YAML::NodeType::Map);
+  }
+
+  YAML::Node before = YAML::Clone(env_root);
+  env_root["schema_version"] = "environment_layout/v1";
+  if (!env_root["scene_name"] || !env_root["scene_name"].IsScalar()) env_root["scene_name"] = scene_name;
+
+  YAML::Node placed_assets = ensure_sequence_child(env_root, "placed_assets");
+
+  std::set<std::string> layout_ids;
+  std::vector<std::string> layout_id_order;
+  YAML::Node bootstrap_by_id(YAML::NodeType::Map);
+  for (const auto & layout_item : layout_items) {
+    if (!layout_item_has_bootstrap_placeable_fields(layout_item)) continue;
+    const std::string id = yaml_map_value_or_empty(layout_item, "id");
+    if (layout_ids.insert(id).second) layout_id_order.push_back(id);
+    bootstrap_by_id[id] = layout_item;
+  }
+  if (layout_ids.empty()) {
+    result.error = "editable layout has no bootstrappable editable/placeable items";
+    return result;
+  }
+
+  YAML::Node updated_placed_assets(YAML::NodeType::Sequence);
+  std::set<std::string> emitted_ids;
+  for (std::size_t i = 0; i < placed_assets.size(); ++i) {
+    const YAML::Node existing = placed_assets[i];
+    if (!existing || !existing.IsMap()) {
+      updated_placed_assets.push_back(existing);
+      continue;
+    }
+    const std::string id = yaml_map_value_or_empty(existing, "id");
+    if (!id.empty() && layout_ids.count(id) != 0) {
+      updated_placed_assets.push_back(bootstrap_environment_asset_from_layout_item(existing, bootstrap_by_id[id]));
+      emitted_ids.insert(id);
+    } else {
+      updated_placed_assets.push_back(existing);
+    }
+  }
+  for (const auto & id : layout_id_order) {
+    if (emitted_ids.count(id) != 0) continue;
+    updated_placed_assets.push_back(bootstrap_environment_asset_from_layout_item(YAML::Node(), bootstrap_by_id[id]));
+  }
+  env_root["placed_assets"] = updated_placed_assets;
+  result.placed_assets_written = layout_ids.size();
+
+  if (!result.created && yaml_nodes_equal(before, env_root)) {
+    result.ok = true;
+    result.wrote = false;
+    return result;
+  }
+
+  boost::system::error_code ec;
+  fs::create_directories(scene_dir, ec);
+  if (ec) {
+    result.error = std::string("failed to create scene directory: ") + ec.message();
+    return result;
+  }
+  std::ofstream out(env_layout_path.string());
+  if (!out.good()) {
+    result.error = "failed to open environment_layout.yaml for write";
+    return result;
+  }
+  out << env_root << "\n";
+  out.close();
+  if (!out.good()) {
+    result.error = "failed to write environment_layout.yaml";
+    return result;
+  }
+  result.ok = true;
+  result.wrote = true;
+  return result;
 }
 
 static bool has_safe_starter_layout_metadata(const WorkcellStudioCanvasItem & preview_item)

--- a/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
@@ -315,6 +315,125 @@ TEST(WorkcellStudioCanvasMesh, StarterLayoutAcceptanceCopiesSceneAndFiltersUnsaf
 #endif
 }
 
+
+TEST(WorkcellStudioCanvasMesh, BootstrapEnvironmentLayoutFromEditableLayoutCreatesAndMirrorsPlaceableFields)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_bootstrap_env_layout_missing";
+  fs::remove_all(root);
+  fs::create_directories(root / "layout");
+
+  YAML::Node editable(YAML::NodeType::Map);
+  editable["schema_version"] = "workcell_studio_layout/v1";
+  editable["scene_name"] = "bootstrap_scene";
+  YAML::Node item(YAML::NodeType::Map);
+  item["id"] = "editable_table";
+  item["type"] = "table";
+  item["category"] = "support_surface";
+  item["pose"]["xyz"].push_back(1.0);
+  item["pose"]["xyz"].push_back(2.0);
+  item["pose"]["xyz"].push_back(3.0);
+  item["pose"]["rpy"].push_back(0.1);
+  item["pose"]["rpy"].push_back(0.2);
+  item["pose"]["rpy"].push_back(0.3);
+  item["dimensions"].push_back(0.4);
+  item["dimensions"].push_back(0.5);
+  item["dimensions"].push_back(0.6);
+  item["source"] = "generated/environment_assets.yaml";
+  item["editable"] = true;
+  item["locked"] = false;
+  item["mesh"]["path"] = "meshes/visual/table.stl";
+  editable["items"].push_back(item);
+  write_yaml_file(root / "layout" / "workcell_studio_layout.yaml", editable);
+  write_file(root / "environment.yaml", "environment: {}\n");
+
+  EXPECT_FALSE(workcell_builder::is_save_layout_workflow_ready(root));
+  const auto result = workcell_builder::bootstrap_environment_layout_from_editable_layout(root, "bootstrap_scene", editable);
+  EXPECT_TRUE(result.ok) << result.error;
+  EXPECT_TRUE(result.created);
+  EXPECT_TRUE(result.wrote);
+  EXPECT_EQ(result.placed_assets_written, 1u);
+
+  const YAML::Node env = load_yaml_file(root / "environment_layout.yaml");
+  ASSERT_EQ(env["schema_version"].as<std::string>(), "environment_layout/v1");
+  ASSERT_EQ(env["scene_name"].as<std::string>(), "bootstrap_scene");
+  ASSERT_TRUE(env["placed_assets"] && env["placed_assets"].IsSequence());
+  ASSERT_EQ(env["placed_assets"].size(), 1u);
+  const YAML::Node placed = env["placed_assets"][0];
+  EXPECT_EQ(placed["id"].as<std::string>(), item["id"].as<std::string>());
+  EXPECT_EQ(YAML::Dump(placed["pose"]["xyz"]), YAML::Dump(item["pose"]["xyz"]));
+  EXPECT_EQ(YAML::Dump(placed["pose"]["rpy"]), YAML::Dump(item["pose"]["rpy"]));
+  EXPECT_EQ(YAML::Dump(placed["dimensions"]), YAML::Dump(item["dimensions"]));
+  EXPECT_EQ(placed["source"].as<std::string>(), item["source"].as<std::string>());
+  EXPECT_TRUE(placed["editable"].as<bool>());
+  EXPECT_FALSE(placed["locked"].as<bool>());
+  EXPECT_TRUE(workcell_builder::is_save_layout_workflow_ready(root));
+
+  fs::remove_all(root);
+}
+
+TEST(WorkcellStudioCanvasMesh, BootstrapEnvironmentLayoutPreservesUnrelatedExistingFields)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_bootstrap_env_layout_preserve";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  YAML::Node editable(YAML::NodeType::Map);
+  editable["schema_version"] = "workcell_studio_layout/v1";
+  YAML::Node item(YAML::NodeType::Map);
+  item["id"] = "shared_asset";
+  item["type"] = "fixture";
+  item["category"] = "fixture";
+  item["pose"]["xyz"].push_back(7.0);
+  item["pose"]["xyz"].push_back(8.0);
+  item["pose"]["xyz"].push_back(9.0);
+  item["pose"]["rpy"].push_back(0.7);
+  item["pose"]["rpy"].push_back(0.8);
+  item["pose"]["rpy"].push_back(0.9);
+  item["dimensions"].push_back(1.1);
+  item["dimensions"].push_back(1.2);
+  item["dimensions"].push_back(1.3);
+  item["source"] = "layout/workcell_studio_layout.yaml";
+  item["editable"] = true;
+  item["locked"] = false;
+  editable["items"].push_back(item);
+
+  write_file(root / "environment_layout.yaml",
+    "schema_version: environment_layout/v1\n"
+    "scene_name: existing_scene\n"
+    "custom_top_level: keep_me\n"
+    "placed_assets:\n"
+    "  - id: unrelated_asset\n"
+    "    custom: untouched\n"
+    "  - id: shared_asset\n"
+    "    custom_existing: preserved\n"
+    "    pose:\n"
+    "      xyz: [0, 0, 0]\n"
+    "      frame: keep_frame\n");
+
+  const auto result = workcell_builder::bootstrap_environment_layout_from_editable_layout(root, "new_scene", editable);
+  EXPECT_TRUE(result.ok) << result.error;
+  EXPECT_FALSE(result.created);
+  EXPECT_TRUE(result.wrote);
+
+  const YAML::Node env = load_yaml_file(root / "environment_layout.yaml");
+  EXPECT_EQ(env["scene_name"].as<std::string>(), "existing_scene");
+  EXPECT_EQ(env["custom_top_level"].as<std::string>(), "keep_me");
+  ASSERT_EQ(env["placed_assets"].size(), 2u);
+  EXPECT_EQ(env["placed_assets"][0]["id"].as<std::string>(), "unrelated_asset");
+  EXPECT_EQ(env["placed_assets"][0]["custom"].as<std::string>(), "untouched");
+  const YAML::Node shared = env["placed_assets"][1];
+  EXPECT_EQ(shared["custom_existing"].as<std::string>(), "preserved");
+  EXPECT_EQ(shared["pose"]["frame"].as<std::string>(), "keep_frame");
+  EXPECT_EQ(YAML::Dump(shared["pose"]["xyz"]), YAML::Dump(item["pose"]["xyz"]));
+  EXPECT_EQ(YAML::Dump(shared["pose"]["rpy"]), YAML::Dump(item["pose"]["rpy"]));
+  EXPECT_EQ(YAML::Dump(shared["dimensions"]), YAML::Dump(item["dimensions"]));
+  EXPECT_EQ(shared["source"].as<std::string>(), item["source"].as<std::string>());
+  EXPECT_TRUE(shared["editable"].as<bool>());
+  EXPECT_FALSE(shared["locked"].as<bool>());
+
+  fs::remove_all(root);
+}
+
 TEST(WorkcellStudioCanvasMesh, SaveLayoutReadinessRejectsEmptyEditableLayout)
 {
   const fs::path root = fs::temp_directory_path() / "wc_save_layout_empty_ready";


### PR DESCRIPTION
### Motivation
- When creating a starter editable layout from the preview, the scene should also bootstrap or update `environment_layout.yaml` so downstream tooling has the editable/placeable item set present.
- Preserve unrelated existing fields in an operator-authored `environment_layout.yaml` when augmenting it from the starter editable layout to avoid overwriting operator metadata.
- Ensure the save-layout readiness transition (`is_save_layout_workflow_ready`) becomes true only when a valid editable layout with editable items exists and required scene files are present.

### Description
- Wire `MainWindow::create_starter_layout_from_preview()` to call a new helper `bootstrap_environment_layout_from_editable_layout()` after writing `layout/workcell_studio_layout.yaml` and log/report bootstrap results to the user.
- Add `WorkcellStudioEnvironmentLayoutBootstrapResult` and the function `bootstrap_environment_layout_from_editable_layout()` in the canvas model library which creates or updates `environment_layout.yaml` by merging/preserving top-level fields and per-item fields where possible.
- The bootstrap merges or emits `placed_assets` entries using the same item IDs and mirrors `pose.xyz`, `pose.rpy`, `dimensions`, `source`, `editable`, `locked`, and optional `mesh`/type/category fields, while preserving unrelated existing fields and per-item custom keys.
- Add C++ unit tests that cover creating a missing `environment_layout.yaml`, mirroring placeable fields, preserving unrelated existing fields, and the save-readiness transition when required files exist (`test/workcell_studio_canvas_model_mesh_test.cpp`).

### Testing
- Ran `pytest -q tests/test_workcell_studio_mainwindow_build_tokens.py` and the suite passed (`3 passed`).
- Ran `python3 scripts/validate_scene_builder_ux_integration.py` and it passed (integration checks all `PASS`).
- Added C++ unit tests and attempted to compile/run them in-container, but building/running the C++ tests could not be executed here due to missing system development headers/libs (`Boost`, `yaml-cpp`, `gtest`) in this environment; the tests are included and will run in CI where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1943b85ca8833187704663f8a7d24d)