### PR TITLE
Add bootstrap layout helper and tests; wire GUI action to shared helper

### DIFF
--- a/tests/test_workcell_studio_bootstrap_gui_wiring.py
+++ b/tests/test_workcell_studio_bootstrap_gui_wiring.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import re
+
+
+SOURCE = Path("workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+HEADER = Path("workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp").read_text(encoding="utf-8")
+
+
+def test_create_editable_layout_button_uses_shared_model_layer_bootstrap_helper():
+    assert "bootstrap_editable_layout_from_trusted_canonical_yaml" in HEADER
+    create_match = re.search(
+        r"void MainWindow::create_starter_layout_from_preview\(\)\n\{(?P<body>.*?)\n\}\n\nvoid MainWindow::revert_layout_changes",
+        SOURCE,
+        re.DOTALL,
+    )
+    assert create_match is not None
+    body = create_match.group("body")
+    assert "workcell_builder::bootstrap_editable_layout_from_trusted_canonical_yaml(s.scene_dir, s.scene_name)" in body
+    assert "workcell_builder::build_starter_layout_entries_from_preview(model)" not in body
+    assert "Create editable layout from preview" in SOURCE
+    assert "connect(create_starter_layout_button_, &QPushButton::clicked, this, &MainWindow::create_starter_layout_from_preview)" in SOURCE
+
+
+def test_invalid_layout_yaml_token_path_stays_warning_not_crash():
+    derive_match = re.search(
+        r"static LayoutStateModel derive_layout_state_model\([^)]*\)\s*\{(?P<body>.*?)\n\}\n\n\nstatic QMap",
+        SOURCE,
+        re.DOTALL,
+    )
+    assert derive_match is not None
+    body = derive_match.group("body")
+    assert "YAML::LoadFile(layout.string())" in body
+    assert "catch (const YAML::Exception &)" in body
+    assert "catch (const std::exception &)" in body
+    assert "return LayoutStateModel::INVALID_LAYOUT_YAML;" in body
+    assert "case LayoutStateModel::INVALID_LAYOUT_YAML:" in SOURCE
+    assert "layout_status = SceneWorkflowStepStatus::Warning" in SOURCE

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -519,10 +519,17 @@ static LayoutStateModel derive_layout_state_model(const fs::path & scene_dir, co
   if (!fs::exists(layout)) {
     return model.items.empty() ? LayoutStateModel::PREVIEW_UNAVAILABLE : LayoutStateModel::NO_LAYOUT_FILE;
   }
-  const auto inspection = workcell_builder::inspect_editable_layout_entries(scene_dir);
-  if (!inspection.valid) return LayoutStateModel::INVALID_LAYOUT_YAML;
-  if (!inspection.has_items_sequence || inspection.total_item_entries == 0 || inspection.editable_item_count == 0) {
-    return model.items.empty() ? LayoutStateModel::EMPTY_LAYOUT : LayoutStateModel::PREVIEW_ONLY_AVAILABLE;
+  try {
+    (void)YAML::LoadFile(layout.string());
+    const auto inspection = workcell_builder::inspect_editable_layout_entries(scene_dir);
+    if (!inspection.valid) return LayoutStateModel::INVALID_LAYOUT_YAML;
+    if (!inspection.has_items_sequence || inspection.total_item_entries == 0 || inspection.editable_item_count == 0) {
+      return model.items.empty() ? LayoutStateModel::EMPTY_LAYOUT : LayoutStateModel::PREVIEW_ONLY_AVAILABLE;
+    }
+  } catch (const YAML::Exception &) {
+    return LayoutStateModel::INVALID_LAYOUT_YAML;
+  } catch (const std::exception &) {
+    return LayoutStateModel::INVALID_LAYOUT_YAML;
   }
   return LayoutStateModel::EDITABLE_LAYOUT_PRESENT;
 }
@@ -5139,8 +5146,7 @@ void MainWindow::create_starter_layout_from_preview()
 {
   if (!has_selected_scene()) return;
   const auto & s = scene_browser_result_.scenes[static_cast<size_t>(selected_scene_index_)];
-  const auto model = workcell_builder::build_workcell_studio_canvas_model(s.scene_dir, s.scene_name);
-  const auto starter_layout_summary = workcell_builder::build_starter_layout_entries_from_preview(model);
+  const auto starter_layout_summary = workcell_builder::bootstrap_editable_layout_from_trusted_canonical_yaml(s.scene_dir, s.scene_name);
   const auto starter_layout_counts_message = [&starter_layout_summary]() {
     const auto count_text = [](std::size_t count) { return QString::fromStdString(std::to_string(count)); };
     return QString("Cannot create editable layout from preview: no preview geometry or safe metadata found. "

--- a/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
@@ -76,5 +76,6 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const boost::filesy
 WorkcellStudioEditableLayoutInspection inspect_editable_layout_entries(const boost::filesystem::path & scene_dir);
 std::size_t count_editable_layout_entries(const boost::filesystem::path & scene_dir);
 bool is_save_layout_workflow_ready(const boost::filesystem::path & scene_dir);
+WorkcellStudioStarterLayoutSummary bootstrap_editable_layout_from_trusted_canonical_yaml(const boost::filesystem::path & scene_dir, const std::string & scene_name);
 WorkcellStudioStarterLayoutSummary build_starter_layout_entries_from_preview(const WorkcellStudioCanvasModel & model);
 }

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -44,10 +44,14 @@ static YamlLoadStatus read_yaml(const fs::path & p, YAML::Node * out)
 
 static void add_mesh_candidate(const YAML::Node & node, std::vector<std::string> * out)
 {
-  if (!node.IsScalar()) return;
-  const std::string text = node.as<std::string>("");
-  if (text.empty()) return;
-  if (text.rfind("package://", 0) == 0 || text.find(".stl") != std::string::npos || text.find("meshes/") != std::string::npos) out->push_back(text);
+  try {
+    if (!node.IsDefined() || !node.IsScalar()) return;
+    const std::string text = node.as<std::string>("");
+    if (text.empty()) return;
+    if (text.rfind("package://", 0) == 0 || text.find(".stl") != std::string::npos || text.find("meshes/") != std::string::npos) out->push_back(text);
+  } catch (...) {
+    return;
+  }
 }
 
 static bool mesh_node_disabled(const YAML::Node & node)
@@ -66,25 +70,41 @@ static std::string provenance_summary_text(const WorkcellStudioProvenanceStatus 
     " items loaded from scene metadata.";
 }
 
+static bool yaml_node_is_map(const YAML::Node & node)
+{
+  try { return node.IsDefined() && node.IsMap(); } catch (...) { return false; }
+}
+
+static bool yaml_node_is_sequence(const YAML::Node & node)
+{
+  try { return node.IsDefined() && node.IsSequence(); } catch (...) { return false; }
+}
+
+static bool yaml_node_is_defined(const YAML::Node & node)
+{
+  try { return node.IsDefined(); } catch (...) { return false; }
+}
+
 static std::vector<std::string> gather_mesh_candidates(const YAML::Node & env, const YAML::Node & manifest, const YAML::Node & layout_items, const std::string & item_id)
 {
   std::vector<std::string> out;
   const auto scan_fields = [&out](const YAML::Node & n) {
     const YAML::Node mesh = yaml_map_key(n, "mesh");
-    if (mesh && mesh.IsMap()) add_mesh_candidate(optional_scalar(mesh, "path"), &out);
+    if (yaml_node_is_map(mesh)) add_mesh_candidate(optional_scalar(mesh, "path"), &out);
     else add_mesh_candidate(mesh, &out);
     add_mesh_candidate(optional_scalar(n, "mesh_path"), &out);
     add_mesh_candidate(yaml_map_key(n, "visual_mesh"), &out);
     add_mesh_candidate(yaml_map_key(n, "collision_mesh"), &out);
-    YAML::Node v = yaml_map_key(yaml_map_key(n, "visual"), "geometry");
+    const YAML::Node visual = yaml_map_key(n, "visual");
+    const YAML::Node v = yaml_node_is_map(visual) ? yaml_map_key(visual, "geometry") : YAML::Node();
     add_mesh_candidate(yaml_map_key(v, "filepath"), &out);
     add_mesh_candidate(yaml_map_key(v, "mesh"), &out);
   };
   scan_fields(env);
   scan_fields(manifest);
-  if (layout_items.IsSequence()) {
+  if (yaml_node_is_sequence(layout_items)) {
     for (const auto & node : layout_items) {
-      if (!node.IsMap()) continue;
+      if (!yaml_node_is_map(node)) continue;
       if (yaml_map_value_or_empty(node, "id") != item_id) continue;
       scan_fields(node);
       YAML::Node metadata = yaml_map_key(node, "metadata");
@@ -293,7 +313,7 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
         std::string source_file = read_string_or_warn(yaml_map_key(node, "source_path"), "items[].source_path", "");
         if (source_file.empty()) source_file = read_string_or_warn(yaml_map_key(node, "source_layer"), "items[].source_layer", "layout/workcell_studio_layout.yaml");
         extra.source_file = source_file.empty() ? "layout/workcell_studio_layout.yaml" : source_file;
-        extra.provenance = WorkcellStudioItemProvenance::GeneratedOrLegacyPreview;
+        extra.provenance = WorkcellStudioItemProvenance::EditableLayout;
         YAML::Node pose = yaml_map_key(node, "pose");
         if (pose.IsDefined() && pose.IsMap()) {
           YAML::Node xyz = yaml_map_key(pose, "xyz");
@@ -310,12 +330,12 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
           } else if (rpy.IsDefined()) add_warning("items[].pose.rpy", "expected sequence; using defaults");
         } else if (pose.IsDefined()) add_warning("items[].pose", "expected map; using defaults");
         YAML::Node size = yaml_map_key(node, "size");
-        if (size.IsDefined()) {
-          if (size.IsMap()) {
+        if (yaml_node_is_defined(size)) {
+          if (yaml_node_is_map(size)) {
             extra.width = read_double_or_warn(yaml_map_key(size, "width"), "items[].size.width", extra.width);
             extra.depth = read_double_or_warn(yaml_map_key(size, "depth"), "items[].size.depth", extra.depth);
             extra.height = read_double_or_warn(yaml_map_key(size, "height"), "items[].size.height", extra.height);
-          } else if (size.IsSequence()) {
+          } else if (yaml_node_is_sequence(size)) {
             extra.width = read_double_or_warn(yaml_seq_index(size, 0), "items[].size[0]", extra.width);
             extra.depth = read_double_or_warn(yaml_seq_index(size, 1), "items[].size[1]", extra.depth);
             extra.height = read_double_or_warn(yaml_seq_index(size, 2), "items[].size[2]", extra.height);
@@ -402,11 +422,11 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
       for (const auto & node : layout_items) {
         if (!node.IsMap() || yaml_map_value_or_empty(node, "id") != item.id) continue;
         const YAML::Node mesh = yaml_map_key(node, "mesh");
-        if (!mesh || mesh.IsNull() || mesh_node_disabled(mesh)) {
+        if (!yaml_node_is_defined(mesh) || mesh_node_disabled(mesh)) {
           item.mesh_available = false;
           item.mesh_path.clear();
           item.mesh_load_warning = "mesh metadata missing or legacy; using primitive preview";
-        } else if (mesh.IsMap()) {
+        } else if (yaml_node_is_map(mesh)) {
           item.has_mesh_metadata = true;
           const std::string path = get_optional_string(mesh, "path", "");
           if (path.empty()) {
@@ -418,19 +438,19 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
             item.mesh_path = resolved_path.generic_string();
           }
           const YAML::Node scale = yaml_map_key(mesh, "scale");
-          if (scale.IsSequence()) {
+          if (yaml_node_is_sequence(scale)) {
             item.mesh_scale_x = read_double_or_warn(yaml_seq_index(scale, 0), "items[].mesh.scale[0]", item.mesh_scale_x);
             item.mesh_scale_y = read_double_or_warn(yaml_seq_index(scale, 1), "items[].mesh.scale[1]", item.mesh_scale_y);
             item.mesh_scale_z = read_double_or_warn(yaml_seq_index(scale, 2), "items[].mesh.scale[2]", item.mesh_scale_z);
           }
           const YAML::Node rpy = yaml_map_key(mesh, "rpy");
-          if (rpy.IsSequence()) {
+          if (yaml_node_is_sequence(rpy)) {
             item.mesh_r = read_double_or_warn(yaml_seq_index(rpy, 0), "items[].mesh.rpy[0]", item.mesh_r);
             item.mesh_p = read_double_or_warn(yaml_seq_index(rpy, 1), "items[].mesh.rpy[1]", item.mesh_p);
             item.mesh_y = read_double_or_warn(yaml_seq_index(rpy, 2), "items[].mesh.rpy[2]", item.mesh_y);
           }
           const YAML::Node origin = yaml_map_key(mesh, "origin_offset");
-          if (origin.IsSequence()) {
+          if (yaml_node_is_sequence(origin)) {
             item.has_origin_offset = true;
             item.origin_offset_x = read_double_or_warn(yaml_seq_index(origin, 0), "items[].mesh.origin_offset[0]", item.origin_offset_x);
             item.origin_offset_y = read_double_or_warn(yaml_seq_index(origin, 1), "items[].mesh.origin_offset[1]", item.origin_offset_y);
@@ -479,7 +499,7 @@ static bool layout_item_is_fallback_preview_entry(const YAML::Node & node)
 {
   const std::array<std::string, 5> marker_keys = {"source_layer", "source_file", "source_path", "provenance", "preview_source"};
   for (const auto & key : marker_keys) {
-    const std::string value = lower_scalar_or_empty(yaml_map_key(node, key));
+    const std::string value = lower_scalar_or_empty(yaml_map_key(node, key.c_str()));
     if (value.find("fallback") != std::string::npos || value.find("static_preview") != std::string::npos) return true;
   }
   return false;
@@ -537,6 +557,169 @@ bool is_save_layout_workflow_ready(const fs::path & scene_dir)
   return layout.exists && layout.valid && layout.editable_item_count > 0 &&
     fs::exists(scene_dir / "environment_layout.yaml") &&
     fs::exists(scene_dir / "environment.yaml");
+}
+
+
+static double yaml_double_or_default(const YAML::Node & node, double fallback)
+{
+  double out = fallback;
+  return yaml_read_double(node, &out) ? out : fallback;
+}
+
+static std::string canonical_item_id_from_node(const YAML::Node & node)
+{
+  std::string id = yaml_map_value_or_empty(node, "id");
+  if (id.empty()) id = yaml_map_value_or_empty(node, "name");
+  if (id.empty()) id = yaml_map_value_or_empty(node, "asset_id");
+  return id;
+}
+
+static std::string canonical_item_type_from_node(const YAML::Node & node)
+{
+  std::string type = yaml_map_value_or_empty(node, "type");
+  if (type.empty()) type = yaml_map_value_or_empty(node, "role");
+  if (type.empty()) type = yaml_map_value_or_empty(node, "source");
+  return type.empty() ? "object" : type;
+}
+
+static void copy_pose_from_canonical_node(const YAML::Node & source, YAML::Node * target)
+{
+  YAML::Node pose = yaml_map_key(source, "pose");
+  YAML::Node xyz;
+  YAML::Node rpy;
+  if (yaml_node_is_map(pose)) {
+    xyz = yaml_map_key(pose, "xyz");
+    rpy = yaml_map_key(pose, "rpy");
+  } else if (yaml_node_is_sequence(pose)) {
+    xyz = pose;
+  }
+
+  YAML::Node out_pose(YAML::NodeType::Map);
+  out_pose["xyz"].push_back(yaml_double_or_default(yaml_seq_index(xyz, 0), 0.0));
+  out_pose["xyz"].push_back(yaml_double_or_default(yaml_seq_index(xyz, 1), 0.0));
+  out_pose["xyz"].push_back(yaml_double_or_default(yaml_seq_index(xyz, 2), 0.0));
+  out_pose["rpy"].push_back(yaml_double_or_default(yaml_seq_index(rpy, 0), 0.0));
+  out_pose["rpy"].push_back(yaml_double_or_default(yaml_seq_index(rpy, 1), 0.0));
+  out_pose["rpy"].push_back(yaml_double_or_default(yaml_seq_index(rpy, 2), 0.0));
+  (*target)["pose"] = out_pose;
+}
+
+static void copy_dimensions_from_canonical_node(const YAML::Node & source, YAML::Node * target)
+{
+  try {
+    YAML::Node size = yaml_map_key(source, "size");
+    if (!yaml_node_is_defined(size)) size = yaml_map_key(source, "dimensions");
+    if (yaml_node_is_map(size)) {
+      (*target)["dimensions"].push_back(yaml_double_or_default(yaml_map_key(size, "width"), 0.25));
+      (*target)["dimensions"].push_back(yaml_double_or_default(yaml_map_key(size, "depth"), 0.25));
+      (*target)["dimensions"].push_back(yaml_double_or_default(yaml_map_key(size, "height"), 0.25));
+    } else if (yaml_node_is_sequence(size)) {
+      (*target)["dimensions"].push_back(yaml_double_or_default(yaml_seq_index(size, 0), 0.25));
+      (*target)["dimensions"].push_back(yaml_double_or_default(yaml_seq_index(size, 1), 0.25));
+      (*target)["dimensions"].push_back(yaml_double_or_default(yaml_seq_index(size, 2), 0.25));
+    }
+  } catch (const YAML::Exception &) {
+  } catch (const std::exception &) {
+  }
+}
+
+static bool append_canonical_layout_item(const YAML::Node & source, const std::string & source_name, YAML::Node * items)
+{
+  if (!yaml_node_is_map(source)) return false;
+  const std::string id = canonical_item_id_from_node(source);
+  if (id.empty()) return false;
+
+  YAML::Node item(YAML::NodeType::Map);
+  item["id"] = id;
+  const std::string type = canonical_item_type_from_node(source);
+  item["type"] = type;
+  item["category"] = type;
+  copy_pose_from_canonical_node(source, &item);
+  copy_dimensions_from_canonical_node(source, &item);
+
+  const YAML::Node mesh = yaml_map_key(source, "mesh");
+  const std::string mesh_path = yaml_node_is_map(mesh) ? yaml_map_value_or_empty(mesh, "path") : yaml_scalar_or_empty(mesh);
+  if (!mesh_path.empty()) {
+    YAML::Node mesh_out(YAML::NodeType::Map);
+    mesh_out["path"] = mesh_path;
+    mesh_out["source"] = source_name;
+    item["mesh"] = mesh_out;
+  }
+  const std::string collision_mesh = yaml_map_value_or_empty(source, "collision_mesh");
+  if (!collision_mesh.empty() && !item["mesh"].IsDefined()) {
+    YAML::Node mesh_out(YAML::NodeType::Map);
+    mesh_out["path"] = collision_mesh;
+    mesh_out["source"] = source_name;
+    item["mesh"] = mesh_out;
+  }
+  item["source"] = source_name;
+  item["editable"] = true;
+  item["locked"] = false;
+  items->push_back(item);
+  return true;
+}
+
+WorkcellStudioStarterLayoutSummary bootstrap_editable_layout_from_trusted_canonical_yaml(const fs::path & scene_dir, const std::string & scene_name)
+{
+  WorkcellStudioStarterLayoutSummary summary;
+  YAML::Node root(YAML::NodeType::Map);
+  root["schema_version"] = "workcell_studio_layout/v1";
+  root["scene_name"] = scene_name;
+  YAML::Node items(YAML::NodeType::Sequence);
+
+  YAML::Node env;
+  const YamlLoadStatus env_status = read_yaml(scene_dir / "environment.yaml", &env);
+  if (env_status.loaded) {
+    const YAML::Node placed_objects = yaml_map_key(env, "placed_objects");
+    if (yaml_node_is_sequence(placed_objects)) {
+      for (const auto & node : placed_objects) {
+        ++summary.total_preview_items;
+        if (append_canonical_layout_item(node, "environment.yaml", &items)) ++summary.editable_items_created;
+        else ++summary.skipped_unsafe_or_missing_metadata_items;
+      }
+    }
+    const YAML::Node workspace = yaml_map_key(env, "workspace");
+    const YAML::Node workspace_zones = yaml_node_is_map(workspace) ? yaml_map_key(workspace, "zones") : YAML::Node();
+    if (yaml_node_is_sequence(workspace_zones)) {
+      for (const auto & node : workspace_zones) {
+        ++summary.total_preview_items;
+        if (append_canonical_layout_item(node, "environment.yaml", &items)) ++summary.editable_items_created;
+        else ++summary.skipped_unsafe_or_missing_metadata_items;
+      }
+    }
+    const YAML::Node camera = yaml_map_key(env, "camera");
+    bool camera_enabled = false;
+    if (yaml_node_is_map(camera) && yaml_read_bool(yaml_map_key(camera, "enabled"), &camera_enabled) && camera_enabled) {
+      ++summary.total_preview_items;
+      YAML::Node camera_item = YAML::Clone(camera);
+      if (!camera_item["id"]) camera_item["id"] = "camera";
+      if (!camera_item["type"]) camera_item["type"] = "camera";
+      if (append_canonical_layout_item(camera_item, "environment.yaml", &items)) ++summary.editable_items_created;
+      else ++summary.skipped_unsafe_or_missing_metadata_items;
+    }
+  } else {
+    ++summary.skipped_unsafe_or_missing_metadata_items;
+  }
+
+  if (summary.editable_items_created == 0) {
+    const auto model = build_workcell_studio_canvas_model(scene_dir, scene_name);
+    const auto preview_summary = build_starter_layout_entries_from_preview(model);
+    summary.total_preview_items += preview_summary.total_preview_items;
+    summary.skipped_locked_items += preview_summary.skipped_locked_items;
+    summary.skipped_static_fallback_items += preview_summary.skipped_static_fallback_items;
+    summary.skipped_unsafe_or_missing_metadata_items += preview_summary.skipped_unsafe_or_missing_metadata_items;
+    if (preview_summary.editable_items_created > 0) {
+      root = preview_summary.layout;
+      summary.editable_items_created = preview_summary.editable_items_created;
+      summary.layout = root;
+      return summary;
+    }
+  }
+
+  root["empty_layout_marker"] = summary.editable_items_created == 0;
+  root["items"] = items;
+  summary.layout = root;
+  return summary;
 }
 
 static bool has_safe_starter_layout_metadata(const WorkcellStudioCanvasItem & preview_item)

--- a/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
@@ -180,6 +180,130 @@ TEST(WorkcellStudioCanvasMesh, CountEditableLayoutEntriesWithOneEditable)
   EXPECT_EQ(workcell_builder::count_editable_layout_entries(root), 1u);
 }
 
+
+TEST(WorkcellStudioCanvasMesh, BootstrapFromEnvironmentCreatesEditableLayoutWithoutExistingLayout)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_bootstrap_no_layout";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "environment.yaml",
+    "schema_version: workcell_scene/v1\n"
+    "scene:\n  id: demo\n"
+    "placed_objects:\n"
+    "  - id: table_main\n"
+    "    type: table\n"
+    "    mesh: meshes/visual/table_main.stl\n"
+    "    pose:\n"
+    "      xyz: [0.25, -0.5, 0.75]\n"
+    "      rpy: [0.1, 0.2, 0.3]\n"
+    "    size: {width: 1.0, depth: 0.6, height: 0.2}\n");
+  ASSERT_FALSE(fs::exists(root / "layout" / "workcell_studio_layout.yaml"));
+
+  const auto summary = workcell_builder::bootstrap_editable_layout_from_trusted_canonical_yaml(root, "demo");
+  EXPECT_EQ(summary.total_preview_items, 1u);
+  EXPECT_EQ(summary.editable_items_created, 1u);
+  ASSERT_TRUE(summary.layout["items"] && summary.layout["items"].IsSequence());
+  ASSERT_EQ(summary.layout["items"].size(), 1u);
+  EXPECT_EQ(summary.layout["items"][0]["id"].as<std::string>(), "table_main");
+  EXPECT_TRUE(summary.layout["items"][0]["editable"].as<bool>());
+  EXPECT_FALSE(summary.layout["items"][0]["locked"].as<bool>());
+}
+
+TEST(WorkcellStudioCanvasMesh, LockedOnlyLayoutBecomesReadyAfterCanonicalBootstrapWrite)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_bootstrap_locked_only";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "layout" / "workcell_studio_layout.yaml",
+    "schema_version: workcell_studio_layout/v1\n"
+    "items:\n"
+    "  - id: locked_table\n"
+    "    editable: true\n"
+    "    locked: true\n");
+  write_file(root / "environment_layout.yaml", "schema_version: environment_layout/v1\nitems: []\n");
+  write_file(root / "environment.yaml",
+    "schema_version: workcell_scene/v1\n"
+    "placed_objects:\n"
+    "  - id: canonical_table\n"
+    "    type: table\n"
+    "    pose:\n"
+    "      xyz: [1.0, 2.0, 3.0]\n"
+    "      rpy: [0.0, 0.1, 0.2]\n");
+
+  EXPECT_FALSE(workcell_builder::is_save_layout_workflow_ready(root));
+  const auto summary = workcell_builder::bootstrap_editable_layout_from_trusted_canonical_yaml(root, "demo");
+  ASSERT_EQ(summary.editable_items_created, 1u);
+  write_yaml_file(root / "layout" / "workcell_studio_layout.yaml", summary.layout);
+
+  const auto inspection = workcell_builder::inspect_editable_layout_entries(root);
+  EXPECT_EQ(inspection.editable_item_count, 1u);
+  EXPECT_TRUE(workcell_builder::is_save_layout_workflow_ready(root));
+}
+
+TEST(WorkcellStudioCanvasMesh, BootstrapSaveReloadPreservesIdsAndPose)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_bootstrap_save_reload_pose";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "environment.yaml",
+    "schema_version: workcell_scene/v1\n"
+    "placed_objects:\n"
+    "  - id: precise_fixture\n"
+    "    type: fixture\n"
+    "    mesh: meshes/visual/precise_fixture.stl\n"
+    "    pose:\n"
+    "      xyz: [0.125, -0.25, 0.375]\n"
+    "      rpy: [1.0, -0.5, 0.25]\n");
+
+  const auto summary = workcell_builder::bootstrap_editable_layout_from_trusted_canonical_yaml(root, "demo");
+  ASSERT_EQ(summary.editable_items_created, 1u);
+  write_yaml_file(root / "layout" / "workcell_studio_layout.yaml", summary.layout);
+
+  const auto reloaded = workcell_builder::build_workcell_studio_canvas_model(root, "demo");
+  bool found = false;
+  for (const auto & item : reloaded.items) {
+    if (item.id != "precise_fixture") continue;
+    found = true;
+    EXPECT_EQ(item.provenance, workcell_builder::WorkcellStudioItemProvenance::EditableLayout);
+    EXPECT_DOUBLE_EQ(item.x, 0.125);
+    EXPECT_DOUBLE_EQ(item.y, -0.25);
+    EXPECT_DOUBLE_EQ(item.z, 0.375);
+    EXPECT_DOUBLE_EQ(item.roll, 1.0);
+    EXPECT_DOUBLE_EQ(item.pitch, -0.5);
+    EXPECT_DOUBLE_EQ(item.yaw, 0.25);
+  }
+  EXPECT_TRUE(found);
+
+  const YAML::Node saved = load_yaml_file(root / "layout" / "workcell_studio_layout.yaml");
+  ASSERT_TRUE(saved["items"] && saved["items"].IsSequence());
+  ASSERT_EQ(saved["items"].size(), 1u);
+  EXPECT_EQ(saved["items"][0]["id"].as<std::string>(), "precise_fixture");
+  EXPECT_DOUBLE_EQ(saved["items"][0]["pose"]["xyz"][0].as<double>(), 0.125);
+  EXPECT_DOUBLE_EQ(saved["items"][0]["pose"]["xyz"][1].as<double>(), -0.25);
+  EXPECT_DOUBLE_EQ(saved["items"][0]["pose"]["xyz"][2].as<double>(), 0.375);
+  EXPECT_DOUBLE_EQ(saved["items"][0]["pose"]["rpy"][0].as<double>(), 1.0);
+  EXPECT_DOUBLE_EQ(saved["items"][0]["pose"]["rpy"][1].as<double>(), -0.5);
+  EXPECT_DOUBLE_EQ(saved["items"][0]["pose"]["rpy"][2].as<double>(), 0.25);
+}
+
+TEST(WorkcellStudioCanvasMesh, InvalidLayoutYamlInspectionIsInvalidAndDoesNotThrow)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_invalid_layout_no_throw";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "layout" / "workcell_studio_layout.yaml", "schema_version: [oops\nitems: [\n");
+  EXPECT_NO_THROW({
+    const auto inspection = workcell_builder::inspect_editable_layout_entries(root);
+    EXPECT_TRUE(inspection.exists);
+    EXPECT_FALSE(inspection.valid);
+    EXPECT_EQ(inspection.editable_item_count, 0u);
+  });
+}
+
 TEST(WorkcellStudioCanvasMesh, BuildStarterLayoutSummarizesSkipsAndEditableItems)
 {
   workcell_builder::WorkcellStudioCanvasModel model;


### PR DESCRIPTION
### Motivation
- Provide a shared model-layer helper to bootstrap an editable `layout/workcell_studio_layout.yaml` from trusted canonical scene metadata and ensure the GUI uses it instead of duplicating logic.
- Cover edge cases around missing/malformed layout YAML, locked-only layouts, fallback-only previews, and save/reload pose preservation via automated tests.

### Description
- Add `bootstrap_editable_layout_from_trusted_canonical_yaml` to the model API and implement canonical-item extraction (id/type/pose/dimensions/mesh) and safe serialization into the starter layout YAML. (`include/workcell_studio_canvas_model.hpp`, `src_workcell_studio_canvas_model.cpp`).
- Harden YAML parsing helpers and defensive node checks so malformed nodes do not throw and invalid layout YAML maps to `INVALID_LAYOUT_YAML` rather than crashing. (`src_workcell_studio_canvas_model.cpp`, `gui/mainwindow.cpp`).
- Wire the GUI `Create editable layout from preview` flow to call the shared bootstrap helper instead of duplicating preview-only logic. (`gui/mainwindow.cpp`).
- Add/extend tests: C++ unit tests exercising bootstrap/no-layout, locked-only -> bootstrap, fallback-only skipping, invalid-layout detection, and save/reload preserving ids/pose; and a Python pytest that asserts the GUI wiring and invalid-YAML state tokens. (`test/workcell_studio_canvas_model_mesh_test.cpp`, `tests/test_workcell_studio_bootstrap_gui_wiring.py`).

### Testing
- Ran `pytest -q tests/test_workcell_studio_bootstrap_gui_wiring.py tests/test_workcell_builder_layout_yaml_error_handling.py tests/test_workcell_studio_mainwindow_build_tokens.py`, and all Python tests passed (`7 passed`).
- Compiled and ran the C++ unit test binary for the canvas model tests and executed the relevant GTest suite; model tests passed locally (`15 passed, 1 skipped` where the skipped test requires external scene fixtures). 
- Attempted `colcon test` for ROS packaging but `colcon` was not available in the environment, so that CI-style invocation was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1943ba68548331bf7ff1c16b1e877b)