### PR TITLE
Refresh scene browser after starter layout bootstrap

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -5225,6 +5225,7 @@ void MainWindow::create_starter_layout_from_preview()
   append_studio_log("Use Recommended Layout: added recommended editable layout items from current preview metadata.");
   rebuild_digital_twin_canvas();
   refresh_scene_builder_left_explorer();
+  refresh_scene_browser_ui();
   refresh_scene_builder_selected_scene_ui();
   refresh_canvas_generated_parity_ui();
   refresh_scene_workflow_rail();


### PR DESCRIPTION
### Motivation
- Ensure the scene browser reflects newly written starter-layout files by refreshing the missing UI surface after a successful `create_starter_layout_from_preview()` bootstrap.

### Description
- Added a call to `refresh_scene_browser_ui()` in `MainWindow::create_starter_layout_from_preview()` immediately after `rebuild_digital_twin_canvas()` and `refresh_scene_builder_left_explorer()` so the successful bootstrap path refreshes the scene browser alongside the other UI updates.

### Testing
- Ran `git diff --check`, which passed.
- Attempted to run `colcon build --symlink-install --packages-select workcell_builder` from the expected workspace with `source /opt/ros/humble/setup.bash`, but the build was blocked because `/home/user/workcell_ws` does not exist in this environment.
- Attempted to source `/opt/ros/humble/setup.bash` and build from the repository root, but that was blocked because `/opt/ros/humble/setup.bash` is not present in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1946b5763c83318565e1c917af4440)