### PR TITLE
docs: clarify validation workspace paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,6 +328,8 @@ The core 3-month path should remain RViz/MoveIt-first.
 
 ## Testing and validation commands
 
+The example commands below use `/home/user/workcell_ws` as the expected ROS workspace layout. Before running them, Codex should confirm the actual checkout and workspace path for the current container or machine, then map the example path accordingly. In this container, the repository checkout is `/workspace/Easy_Manipulator_Improved`; use that path directly for static repo inspection, and use a sourced ROS workspace only for commands that build, source `install/setup.bash`, run `ros2`, or launch RViz/MoveIt.
+
 For builder changes, run at minimum:
 
 ```bash


### PR DESCRIPTION
### Motivation

- Make the `Testing and validation commands` section explicit that the example path `/home/user/workcell_ws` is an illustrative ROS workspace layout and that Codex should confirm and map the example path to the actual checkout (with an in-repo example for this container).

### Description

- Added a short note to `AGENTS.md` near `Testing and validation commands` that explains the example workspace path, documents this container's checkout as `/workspace/Easy_Manipulator_Improved`, and clarifies that a sourced ROS workspace is required for commands that call `colcon`, source `install/setup.bash`, run `ros2`, or launch RViz/MoveIt.`

### Testing

- Ran `git diff --check` which passed and committed the documentation change; ROS build/launch validation was not run because this is a docs-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19490dfedc833196d11c10cb47d3f9)