### PR TITLE
Clarify PR branch guidance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,6 +388,8 @@ If a script does not exist or a scene is missing, do not invent success. Report 
 
 Use small incremental PRs.
 
+For normal development PR tasks, create or use a branch named like `codex/<short-task-name>` unless the user explicitly requests no branch or no PR for that task.
+
 Each PR should:
 
 - target one repo only unless explicitly required


### PR DESCRIPTION
### Motivation
- Make PR rules explicit that branch creation using `codex/<short-task-name>` is the default for normal development PR tasks while allowing task-specific user requests for no branch or no PR to take precedence.

### Description
- Updated `AGENTS.md` under "PR rules" to add a single-sentence clarification that normal development PRs should use a `codex/<short-task-name>` branch unless the user explicitly requests no branch or no PR, while preserving the existing small incremental PR guidance.

### Testing
- Ran `git diff --check` which passed, and skipped ROS/build validation because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a194910f3c48331a3ebb76b87cc4ab2)