### PR TITLE
Report per-scene `blocker`, split missing authoring/generated files, and add `validation_result`

### DIFF
--- a/scripts/validate_supported_scenes_readiness.py
+++ b/scripts/validate_supported_scenes_readiness.py
@@ -47,6 +47,10 @@ def _run_validator(repo_root: Path, workspace_root: Path, scene: str, skip_build
     return cmd, proc.returncode, payload
 
 
+def _join_blockers(blockers: list[str]) -> str:
+    return "; ".join(str(blocker) for blocker in blockers if str(blocker).strip())
+
+
 def _build_markdown(report: dict) -> str:
     lines = [
         "# Workcell Studio All Scenes Readiness Report",
@@ -55,9 +59,9 @@ def _build_markdown(report: dict) -> str:
         "--- | --- | --- | --- | --- | --- | ---",
     ]
     for row in report["per_scene"]:
-        blockers = "; ".join(row.get("blockers", [])) or "-"
+        blocker = row.get("blocker") or _join_blockers(row.get("blockers", [])) or "-"
         lines.append(
-            f"{row['scene_name']} | {row['support_level']} | {row['static_validation']['status']} | {row['build']['status']} | {row['launch_smoke']['status']} | {row['status']} | {blockers}"
+            f"{row['scene_name']} | {row['support_level']} | {row['static_validation']['status']} | {row['build']['status']} | {row['launch_smoke']['status']} | {row['status']} | {blocker}"
         )
     lines.append("")
     return "\n".join(lines)
@@ -123,12 +127,20 @@ def main() -> int:
         skip_build = args.skip_build or bool(entry.get("allow_skip_build", False))
         skip_launch = args.skip_launch_smoke or bool(entry.get("allow_skip_launch_smoke", False))
 
+        missing_authoring_files = [rel for rel in catalog_entry.authoring_files if not (scene_dir / rel).exists()]
+        missing_generated_files = [rel for rel in catalog_entry.generated_files if not (scene_dir / rel).exists()]
+        missing_required_files = [*missing_authoring_files, *missing_generated_files]
+
         row = {
             "scene_name": scene_name,
             "support_level": support_level,
             "catalog_status": catalog_entry.status,
             "known_blocker": catalog_entry.known_blocker,
             "status": "SKIPPED",
+            "blocker": "",
+            "missing_authoring_files": missing_authoring_files,
+            "missing_generated_files": missing_generated_files,
+            "validation_result": "SKIPPED",
             "package_name": catalog_entry.package_name,
             "build_package_name": catalog_entry.build_package_name,
             "authoring_files": list(catalog_entry.authoring_files),
@@ -150,35 +162,50 @@ def main() -> int:
         if not enabled:
             report["scenes_skipped"].append(scene_name)
             row["status"] = "SKIPPED"
+            row["validation_result"] = "SKIPPED"
             row["blockers"].append("scene_disabled_in_catalog")
+            row["blocker"] = _join_blockers(row["blockers"])
             report["per_scene"].append(row)
             continue
         if support_level == "experimental" and not args.include_experimental:
             report["scenes_skipped"].append(scene_name)
             row["status"] = "SKIPPED"
+            row["validation_result"] = "SKIPPED"
             row["warnings"].append("experimental_scene_skipped_without_include_experimental")
+            report["per_scene"].append(row)
+            continue
+        if catalog_entry.status.lower() == "blocked":
+            report["scenes_checked"].append(scene_name)
+            row["status"] = "BLOCKED"
+            row["validation_result"] = "BLOCKED"
+            row["blocker"] = catalog_entry.known_blocker or "scene_blocked_in_catalog"
+            row["blockers"].append(row["blocker"])
             report["per_scene"].append(row)
             continue
 
         report["scenes_checked"].append(scene_name)
         if not scene_dir.exists():
             row["status"] = "BLOCKED"
+            row["validation_result"] = "BLOCKED"
             row["static_validation"] = {"status": "BLOCKED", "missing_files": required}
             row["blockers"].append(f"scene_path_missing: {scene_dir}")
+            row["blocker"] = _join_blockers(row["blockers"])
             report["per_scene"].append(row)
             continue
 
-        missing = [rel for rel in required if not (scene_dir / rel).exists()]
-        row["static_validation"] = {"status": "PASS" if not missing else "FAIL", "missing_files": missing}
-        if missing:
+        row["static_validation"] = {"status": "PASS" if not missing_required_files else "FAIL", "missing_files": missing_required_files}
+        if missing_required_files:
             row["status"] = "FAIL"
-            row["blockers"].extend([f"missing_required_file: {m}" for m in missing])
+            row["validation_result"] = "FAIL"
+            row["blockers"].extend([f"missing_required_file: {m}" for m in missing_required_files])
+            row["blocker"] = _join_blockers(row["blockers"])
             report["per_scene"].append(row)
             continue
 
         cmd, _, payload = _run_validator(repo_root, workspace_root, str(scene_dir), skip_build, skip_launch, args.timeout_sec)
         row["commands_run"].append(" ".join(cmd))
         guided_status = payload.get("status", "BLOCKED")
+        row["validation_result"] = guided_status
         row["guided_build_launch_readiness"] = payload
         row["build"] = payload.get("build", {"status": "SKIPPED"})
         row["launch_smoke"] = payload.get("launch_smoke", {"status": "SKIPPED"})
@@ -192,6 +219,7 @@ def main() -> int:
             row["status"] = "BLOCKED"
             row["blockers"].append(f"unknown_guided_status: {guided_status}")
 
+        row["blocker"] = _join_blockers(row["blockers"])
         report["per_scene"].append(row)
 
     for row in report["per_scene"]:

--- a/tests/test_validate_supported_scenes_readiness.py
+++ b/tests/test_validate_supported_scenes_readiness.py
@@ -63,6 +63,18 @@ def _run(tmp_path: Path, registry: Path, extra: list[str] | None = None) -> dict
     return json.loads(run.stdout)
 
 
+def _row_by_scene(payload: dict, scene_name: str) -> dict:
+    rows = {row["scene_name"]: row for row in payload["per_scene"]}
+    return rows[scene_name]
+
+
+def _assert_readiness_fields(row: dict) -> None:
+    assert "blocker" in row
+    assert "missing_authoring_files" in row
+    assert "missing_generated_files" in row
+    assert "validation_result" in row
+
+
 def test_disabled_and_experimental_skipped(tmp_path: Path):
     _write_scene(tmp_path / "scenes/ok_scene", "ok_scene")
     reg = tmp_path / "registry.yaml"
@@ -73,21 +85,52 @@ def test_disabled_and_experimental_skipped(tmp_path: Path):
     payload = _run(tmp_path, reg)
     assert payload["summary"]["skipped"] == 2
 
+    disabled = _row_by_scene(payload, "disabled_scene")
+    _assert_readiness_fields(disabled)
+    assert disabled["status"] == "SKIPPED"
+    assert disabled["validation_result"] == "SKIPPED"
+    assert disabled["blocker"] == "scene_disabled_in_catalog"
+    assert disabled["missing_authoring_files"] == AUTHORING
+    assert disabled["missing_generated_files"] == GENERATED
+
+    experimental = _row_by_scene(payload, "exp_scene")
+    _assert_readiness_fields(experimental)
+    assert experimental["status"] == "SKIPPED"
+    assert experimental["validation_result"] == "SKIPPED"
+    assert experimental["blocker"] == ""
+    assert experimental["missing_authoring_files"] == []
+    assert experimental["missing_generated_files"] == []
+
 
 def test_missing_scene_is_blocked(tmp_path: Path):
     reg = tmp_path / "registry.yaml"
     reg.write_text(yaml.safe_dump(_catalog([_entry("missing", "scenes/missing")])), encoding="utf-8")
     payload = _run(tmp_path, reg)
-    assert payload["per_scene"][0]["status"] == "BLOCKED"
+    row = payload["per_scene"][0]
+    _assert_readiness_fields(row)
+    assert row["status"] == "BLOCKED"
+    assert row["validation_result"] == "BLOCKED"
+    assert row["blocker"].startswith("scene_path_missing:")
+    assert row["missing_authoring_files"] == AUTHORING
+    assert row["missing_generated_files"] == GENERATED
 
 
 def test_missing_required_file_is_fail(tmp_path: Path):
-    (tmp_path / "scenes/a").mkdir(parents=True)
+    scene_dir = tmp_path / "scenes/a"
+    _write_scene(scene_dir, "a")
+    (scene_dir / "environment.yaml").unlink()
+    (scene_dir / "generated/scene_visual_mesh_index.json").unlink()
     reg = tmp_path / "registry.yaml"
     reg.write_text(yaml.safe_dump(_catalog([_entry("a", "scenes/a")])), encoding="utf-8")
     payload = _run(tmp_path, reg)
-    assert payload["per_scene"][0]["status"] == "FAIL"
-    assert "missing_required_file: environment.yaml" in payload["per_scene"][0]["blockers"]
+    row = payload["per_scene"][0]
+    _assert_readiness_fields(row)
+    assert row["status"] == "FAIL"
+    assert row["validation_result"] == "FAIL"
+    assert row["missing_authoring_files"] == ["environment.yaml"]
+    assert row["missing_generated_files"] == ["generated/scene_visual_mesh_index.json"]
+    assert row["blocker"] == "missing_required_file: environment.yaml; missing_required_file: generated/scene_visual_mesh_index.json"
+    assert "missing_required_file: environment.yaml" in row["blockers"]
 
 
 def test_experimental_included_with_flag(tmp_path: Path):
@@ -95,7 +138,28 @@ def test_experimental_included_with_flag(tmp_path: Path):
     reg = tmp_path / "registry.yaml"
     reg.write_text(yaml.safe_dump(_catalog([_entry("exp", "scenes/exp", support_level="experimental")])), encoding="utf-8")
     payload = _run(tmp_path, reg, ["--include-experimental"])
-    assert payload["per_scene"][0]["status"] in {"PASS", "PASS_WITH_WARNINGS"}
+    row = payload["per_scene"][0]
+    _assert_readiness_fields(row)
+    assert row["status"] in {"PASS", "PASS_WITH_WARNINGS"}
+    assert row["validation_result"] == row["guided_build_launch_readiness"]["status"]
+    assert row["missing_authoring_files"] == []
+    assert row["missing_generated_files"] == []
+
+
+def test_catalog_blocked_scene_uses_known_blocker(tmp_path: Path):
+    _write_scene(tmp_path / "scenes/blocked", "blocked")
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry("blocked", "scenes/blocked", status="blocked", known_blocker="awaiting generated launch repair"),
+    ])), encoding="utf-8")
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+    _assert_readiness_fields(row)
+    assert row["status"] == "BLOCKED"
+    assert row["validation_result"] == "BLOCKED"
+    assert row["blocker"] == "awaiting generated launch repair"
+    assert row["missing_authoring_files"] == []
+    assert row["missing_generated_files"] == []
 
 
 def test_summary_counts(tmp_path: Path):


### PR DESCRIPTION
### Motivation
- Make the all-scenes readiness JSON more actionable by preserving the source-of-truth file categories and surfacing a single human-friendly `blocker` for UI/reporting.
- Ensure catalog-level blocked/disabled/experimental scenes and static missing-file failures are reported with clear, distinct statuses so downstream consumers can act without running the guided validator.

### Description
- Updated `scripts/validate_supported_scenes_readiness.py` to add per-scene fields: `blocker`, `missing_authoring_files`, `missing_generated_files`, and `validation_result`, and to compute `missing_*` from `catalog_entry.authoring_files` and `catalog_entry.generated_files` instead of the combined `static_validation.missing_files`.
- Catalog-blocked scenes now populate `validation_result` as `BLOCKED` and set `blocker` to `catalog_entry.known_blocker` (or a fallback), while disabled/experimental scenes set `validation_result` to `SKIPPED`.
- When static checks stop early due to missing files or missing scene path the script sets `validation_result` to `FAIL`/`BLOCKED` and aggregates runtime blockers into the `blocker` string (joined with `; `) for markdown/report rows.
- Extended `tests/test_validate_supported_scenes_readiness.py` to assert the new fields and behaviors for passing, missing-file, blocked, disabled, and experimental catalog entries.

### Testing
- Compiled the script with `python3 -m py_compile scripts/validate_supported_scenes_readiness.py` and it succeeded.
- Ran unit tests with `pytest -q tests/test_validate_supported_scenes_readiness.py` and all tests passed (`7 passed`).
- Verified `git diff --check` produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a194c967ca883318897bbe697aac2b9)