### PR TITLE
Enforce catalog statuses/support-levels and emit BLOCKED rows for catalog-blocked scenes

### DIFF
--- a/scripts/supported_scene_catalog.py
+++ b/scripts/supported_scene_catalog.py
@@ -8,6 +8,9 @@ import yaml  # type: ignore
 
 DEFAULT_SUPPORTED_SCENES_CATALOG = Path("scenes/supported_scenes.yaml")
 CATALOG_SCHEMA_VERSION = "workcell_studio_supported_scenes/v1"
+ACCEPTED_CATALOG_STATUSES = frozenset({"supported", "blocked", "disabled"})
+ACCEPTED_SUPPORT_LEVELS = frozenset({"supported", "experimental"})
+
 REQUIRED_SCENE_FIELDS = (
     "scene_name",
     "package_name",
@@ -101,6 +104,17 @@ def load_supported_scene_catalog(path: Path) -> tuple[dict[str, Any], list[Suppo
         build_command = str(raw.get("build_command", f"colcon build --symlink-install --packages-select {build_package_name}")).strip()
         fake_hardware_launch_command = str(raw.get("fake_hardware_launch_command", "")).strip()
         enabled = bool(raw.get("enabled", True))
+
+        if status not in ACCEPTED_CATALOG_STATUSES:
+            accepted = ", ".join(sorted(ACCEPTED_CATALOG_STATUSES))
+            errors.append(f"{scene_name}: unknown status {status!r}; accepted values: {accepted}")
+        if support_level not in ACCEPTED_SUPPORT_LEVELS:
+            accepted = ", ".join(sorted(ACCEPTED_SUPPORT_LEVELS))
+            errors.append(f"{scene_name}: unknown support_level {support_level!r}; accepted values: {accepted}")
+        if status == "blocked" and not known_blocker:
+            errors.append(f"{scene_name}: known_blocker must be non-empty when status is blocked")
+        if status == "supported" and known_blocker:
+            errors.append(f"{scene_name}: known_blocker must be empty when status is supported")
 
         if package_name != build_package_name:
             errors.append(f"{scene_name}: package_name and build_package_name should match unless intentionally documented")

--- a/scripts/validate_supported_scenes_readiness.py
+++ b/scripts/validate_supported_scenes_readiness.py
@@ -128,6 +128,8 @@ def main() -> int:
             "support_level": support_level,
             "catalog_status": catalog_entry.status,
             "known_blocker": catalog_entry.known_blocker,
+            "blocker": "",
+            "validation_result": "SKIPPED",
             "status": "SKIPPED",
             "package_name": catalog_entry.package_name,
             "build_package_name": catalog_entry.build_package_name,
@@ -147,15 +149,40 @@ def main() -> int:
             "artifact_paths": {},
         }
 
-        if not enabled:
+        if not enabled or catalog_entry.status == "disabled":
             report["scenes_skipped"].append(scene_name)
             row["status"] = "SKIPPED"
+            row["validation_result"] = "SKIPPED"
+            row["blocker"] = "scene_disabled_in_catalog"
             row["blockers"].append("scene_disabled_in_catalog")
             report["per_scene"].append(row)
             continue
+
+        if catalog_entry.status == "blocked":
+            report["scenes_checked"].append(scene_name)
+            missing = required
+            if scene_dir.exists():
+                missing = [rel for rel in required if not (scene_dir / rel).exists()]
+                row["static_validation"] = {"status": "PASS" if not missing else "FAIL", "missing_files": missing}
+            else:
+                row["static_validation"] = {"status": "BLOCKED", "missing_files": missing}
+
+            row["status"] = "BLOCKED"
+            row["validation_result"] = "BLOCKED"
+            row["blocker"] = catalog_entry.known_blocker
+            row["known_blocker"] = catalog_entry.known_blocker
+            row["guided_build_launch_readiness"] = {"status": "BLOCKED", "blockers": [catalog_entry.known_blocker]}
+            row["blockers"].append(catalog_entry.known_blocker)
+            if not scene_dir.exists():
+                row["blockers"].append(f"scene_path_missing: {scene_dir}")
+            row["blockers"].extend([f"missing_required_file: {m}" for m in missing])
+            report["per_scene"].append(row)
+            continue
+
         if support_level == "experimental" and not args.include_experimental:
             report["scenes_skipped"].append(scene_name)
             row["status"] = "SKIPPED"
+            row["validation_result"] = "SKIPPED"
             row["warnings"].append("experimental_scene_skipped_without_include_experimental")
             report["per_scene"].append(row)
             continue
@@ -163,6 +190,7 @@ def main() -> int:
         report["scenes_checked"].append(scene_name)
         if not scene_dir.exists():
             row["status"] = "BLOCKED"
+            row["validation_result"] = "BLOCKED"
             row["static_validation"] = {"status": "BLOCKED", "missing_files": required}
             row["blockers"].append(f"scene_path_missing: {scene_dir}")
             report["per_scene"].append(row)
@@ -172,6 +200,7 @@ def main() -> int:
         row["static_validation"] = {"status": "PASS" if not missing else "FAIL", "missing_files": missing}
         if missing:
             row["status"] = "FAIL"
+            row["validation_result"] = "FAIL"
             row["blockers"].extend([f"missing_required_file: {m}" for m in missing])
             report["per_scene"].append(row)
             continue
@@ -188,8 +217,10 @@ def main() -> int:
 
         if guided_status in {"PASS", "PASS_WITH_WARNINGS", "FAIL", "BLOCKED"}:
             row["status"] = guided_status
+            row["validation_result"] = guided_status
         else:
             row["status"] = "BLOCKED"
+            row["validation_result"] = "BLOCKED"
             row["blockers"].append(f"unknown_guided_status: {guided_status}")
 
         report["per_scene"].append(row)

--- a/tests/test_validate_supported_scenes_readiness.py
+++ b/tests/test_validate_supported_scenes_readiness.py
@@ -132,3 +132,77 @@ def test_default_catalog_declares_required_contract_fields():
         assert entry["scene_name"] in entry["validation_command"]
         assert entry["build_package_name"] in entry["build_command"]
         assert "use_fake_hardware:=true" in entry["fake_hardware_launch_command"]
+
+
+def test_catalog_blocked_scene_reports_known_blocker_without_guided_validator(tmp_path: Path):
+    _write_scene(tmp_path / "scenes/blocked_scene", "blocked_scene")
+    reg = tmp_path / "registry.yaml"
+    blocker = "tracked upstream MoveIt config issue"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry("blocked_scene", "scenes/blocked_scene", status="blocked", known_blocker=blocker),
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+    assert row["status"] == "BLOCKED"
+    assert row["validation_result"] == "BLOCKED"
+    assert row["blocker"] == blocker
+    assert row["known_blocker"] == blocker
+    assert row["blockers"][0] == blocker
+    assert row["static_validation"] == {"status": "PASS", "missing_files": []}
+    assert row["guided_build_launch_readiness"] == {"status": "BLOCKED", "blockers": [blocker]}
+    assert row["commands_run"] == []
+
+
+def test_catalog_blocked_scene_keeps_static_missing_file_details(tmp_path: Path):
+    (tmp_path / "scenes/blocked_missing_files").mkdir(parents=True)
+    reg = tmp_path / "registry.yaml"
+    blocker = "intentionally parked until generated assets are restored"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry("blocked_missing_files", "scenes/blocked_missing_files", status="blocked", known_blocker=blocker),
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+    assert row["status"] == "BLOCKED"
+    assert row["validation_result"] == "BLOCKED"
+    assert row["blocker"] == blocker
+    assert row["known_blocker"] == blocker
+    assert row["static_validation"]["status"] == "FAIL"
+    assert "environment.yaml" in row["static_validation"]["missing_files"]
+    assert "missing_required_file: environment.yaml" in row["blockers"]
+    assert row["commands_run"] == []
+
+
+def test_supported_scene_with_stale_known_blocker_is_catalog_error(tmp_path: Path):
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry("stale_blocker", "scenes/stale_blocker", status="supported", known_blocker="old fixed issue"),
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    assert payload["summary"]["blocked"] == 1
+    assert "stale_blocker: known_blocker must be empty when status is supported" in payload["catalog_errors"]
+
+
+def test_blocked_scene_without_known_blocker_is_catalog_error(tmp_path: Path):
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry("blocked_without_reason", "scenes/blocked_without_reason", status="blocked", known_blocker=""),
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    assert payload["summary"]["blocked"] == 1
+    assert "blocked_without_reason: known_blocker must be non-empty when status is blocked" in payload["catalog_errors"]
+
+
+def test_unknown_catalog_status_and_support_level_are_catalog_errors(tmp_path: Path):
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry("bad_catalog_values", "scenes/bad_catalog_values", status="parked", support_level="beta"),
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    assert payload["summary"]["blocked"] == 1
+    assert "bad_catalog_values: unknown status 'parked'; accepted values: blocked, disabled, supported" in payload["catalog_errors"]
+    assert "bad_catalog_values: unknown support_level 'beta'; accepted values: experimental, supported" in payload["catalog_errors"]


### PR DESCRIPTION
### Motivation
- Make the supported-scenes catalog schema explicit by defining accepted `status` and `support_level` values and fail-fast on unknown values. 
- Ensure scenes intentionally marked `blocked` carry an explict `known_blocker` and avoid running the guided validator for these catalog-blocked scenes. 
- Preserve cheap static checks for blocked scenes so the readiness report still shows missing-file diagnostics without performing expensive guided validation.

### Description
- Add `ACCEPTED_CATALOG_STATUSES` (`supported`, `blocked`, `disabled`) and `ACCEPTED_SUPPORT_LEVELS` (`supported`, `experimental`) and validate entries in `load_supported_scene_catalog` to reject unknown values. 
- Enforce that `status: blocked` requires a non-empty `known_blocker` and `status: supported` requires an empty `known_blocker` in `load_supported_scene_catalog`. 
- Extend per-scene readiness rows with `blocker` and `validation_result`, treat `disabled` catalog entries as skipped, and for `catalog_entry.status == "blocked"` emit a per-scene row with `status: "BLOCKED"`, `validation_result: "BLOCKED"`, `blocker`/`known_blocker` populated from the catalog, and cheap static missing-file details; do not invoke the guided validator for these scenes. 
- Preserve existing behavior for experimental/disabled/normal supported scenes and ensure fake-hardware defaults and real-hardware guarded paths are unchanged.

### Testing
- Ran unit tests with `python3 -m pytest tests/test_validate_supported_scenes_readiness.py`, all tests passed (11 passed). 
- Verified syntax with `python3 -m py_compile scripts/supported_scene_catalog.py scripts/validate_supported_scenes_readiness.py`, which completed without errors. 
- Exercised the all-scenes readiness runner `python3 scripts/validate_supported_scenes_readiness.py --repo-root /workspace/Easy_Manipulator_Improved --workspace-root /workspace/Easy_Manipulator_Improved --json --skip-build --skip-launch-smoke` and observed the repository’s existing scene-state failures (readiness summary reported existing `fail` results); no new catalog schema errors were produced for the repository catalog.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a194c9fa7bc8331a89e80ffbc7742b5)