### PR TITLE
Validate supported scene package contracts

### DIFF
--- a/scripts/supported_scene_catalog.py
+++ b/scripts/supported_scene_catalog.py
@@ -102,8 +102,6 @@ def load_supported_scene_catalog(path: Path) -> tuple[dict[str, Any], list[Suppo
         fake_hardware_launch_command = str(raw.get("fake_hardware_launch_command", "")).strip()
         enabled = bool(raw.get("enabled", True))
 
-        if package_name != build_package_name:
-            errors.append(f"{scene_name}: package_name and build_package_name should match unless intentionally documented")
         if not authoring_files:
             errors.append(f"{scene_name}: authoring_files must list at least one file")
         if not generated_files:

--- a/scripts/validate_supported_scenes_readiness.py
+++ b/scripts/validate_supported_scenes_readiness.py
@@ -3,14 +3,99 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import subprocess
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from supported_scene_catalog import DEFAULT_SUPPORTED_SCENES_CATALOG, load_supported_scene_catalog
 
 DEFAULT_REGISTRY = DEFAULT_SUPPORTED_SCENES_CATALOG
 VALIDATOR = Path("scripts/validate_guided_generated_scene_build_readiness.py")
+
+
+def _parse_package_xml_name(scene_path: Path) -> tuple[str | None, list[str]]:
+    """Return the ROS package name declared by scene_path/package.xml."""
+    package_xml = scene_path / "package.xml"
+    if not package_xml.exists():
+        return None, [f"package_xml_missing: {package_xml}"]
+    if not package_xml.is_file():
+        return None, [f"package_xml_not_file: {package_xml}"]
+    try:
+        root = ET.parse(package_xml).getroot()
+    except ET.ParseError as exc:
+        return None, [f"package_xml_malformed: {exc}"]
+    name_node = root.find("name")
+    package_name = (name_node.text or "").strip() if name_node is not None else ""
+    if not package_name:
+        return None, ["package_xml_missing_name"]
+    return package_name, []
+
+
+def _build_command_package_selection(build_command: str) -> list[str]:
+    try:
+        tokens = shlex.split(build_command)
+    except ValueError:
+        return []
+
+    selected: list[str] = []
+    for idx, token in enumerate(tokens):
+        if token == "--packages-select":
+            for value in tokens[idx + 1 :]:
+                if value.startswith("-"):
+                    break
+                selected.append(value)
+            break
+        if token.startswith("--packages-select="):
+            selected.append(token.split("=", 1)[1])
+            break
+    return selected
+
+
+def _fake_hardware_launch_package(fake_hardware_launch_command: str) -> str | None:
+    try:
+        tokens = shlex.split(fake_hardware_launch_command)
+    except ValueError:
+        return None
+
+    for idx in range(len(tokens) - 2):
+        if tokens[idx] == "ros2" and tokens[idx + 1] == "launch":
+            return tokens[idx + 2]
+    return None
+
+
+def _catalog_contract_mismatches(catalog_entry, scene_dir: Path) -> tuple[str | None, list[str]]:
+    package_xml_name, package_xml_errors = _parse_package_xml_name(scene_dir)
+    mismatches = list(package_xml_errors)
+
+    if package_xml_name:
+        if catalog_entry.package_name != package_xml_name:
+            mismatches.append(
+                "catalog_package_name_mismatch: "
+                f"catalog package_name '{catalog_entry.package_name}' != package.xml <name> '{package_xml_name}'"
+            )
+        if catalog_entry.build_package_name != package_xml_name:
+            mismatches.append(
+                "build_package_name_mismatch: "
+                f"catalog build_package_name '{catalog_entry.build_package_name}' != package.xml <name> '{package_xml_name}'"
+            )
+
+    build_selection = _build_command_package_selection(catalog_entry.build_command)
+    if build_selection != [catalog_entry.build_package_name]:
+        mismatches.append(
+            "build_command_package_selection_mismatch: "
+            f"build_command --packages-select {build_selection or '<missing>'} != build_package_name '{catalog_entry.build_package_name}'"
+        )
+
+    launch_package = _fake_hardware_launch_package(catalog_entry.fake_hardware_launch_command)
+    if launch_package != catalog_entry.package_name:
+        mismatches.append(
+            "fake_hardware_launch_package_mismatch: "
+            f"fake_hardware_launch_command package '{launch_package or '<missing>'}' != package_name '{catalog_entry.package_name}'"
+        )
+
+    return package_xml_name, mismatches
 
 
 def _run_validator(repo_root: Path, workspace_root: Path, scene: str, skip_build: bool, skip_launch_smoke: bool, timeout_sec: int):
@@ -131,6 +216,7 @@ def main() -> int:
             "status": "SKIPPED",
             "package_name": catalog_entry.package_name,
             "build_package_name": catalog_entry.build_package_name,
+            "package_xml_name": None,
             "authoring_files": list(catalog_entry.authoring_files),
             "generated_files": list(catalog_entry.generated_files),
             "required_files": required,
@@ -145,6 +231,7 @@ def main() -> int:
             "warnings": [],
             "commands_run": [],
             "artifact_paths": {},
+            "catalog_contract": {"status": "SKIPPED", "mismatches": []},
         }
 
         if not enabled:
@@ -164,15 +251,43 @@ def main() -> int:
         if not scene_dir.exists():
             row["status"] = "BLOCKED"
             row["static_validation"] = {"status": "BLOCKED", "missing_files": required}
-            row["blockers"].append(f"scene_path_missing: {scene_dir}")
+            if catalog_entry.status == "blocked":
+                row["blockers"].append(catalog_entry.known_blocker or "scene_marked_blocked_in_catalog")
+            else:
+                row["blockers"].append(f"scene_path_missing: {scene_dir}")
             report["per_scene"].append(row)
             continue
+
+        package_xml_name, catalog_mismatches = _catalog_contract_mismatches(catalog_entry, scene_dir)
+        row["package_xml_name"] = package_xml_name
+        row["catalog_contract"] = {
+            "status": "FAIL" if catalog_mismatches else "PASS",
+            "mismatches": catalog_mismatches,
+        }
 
         missing = [rel for rel in required if not (scene_dir / rel).exists()]
         row["static_validation"] = {"status": "PASS" if not missing else "FAIL", "missing_files": missing}
         if missing:
-            row["status"] = "FAIL"
-            row["blockers"].extend([f"missing_required_file: {m}" for m in missing])
+            if catalog_entry.status == "blocked":
+                row["status"] = "BLOCKED"
+                row["blockers"].append(catalog_entry.known_blocker or "scene_marked_blocked_in_catalog")
+            else:
+                row["status"] = "FAIL"
+                row["blockers"].extend([f"missing_required_file: {m}" for m in missing])
+                if catalog_entry.status == "supported":
+                    row["blockers"].extend(catalog_mismatches)
+            report["per_scene"].append(row)
+            continue
+
+        if catalog_entry.status == "blocked":
+            row["status"] = "BLOCKED"
+            row["blockers"].append(catalog_entry.known_blocker or "scene_marked_blocked_in_catalog")
+            report["per_scene"].append(row)
+            continue
+
+        if catalog_entry.status == "supported" and catalog_mismatches:
+            row["status"] = "BLOCKED"
+            row["blockers"].extend(catalog_mismatches)
             report["per_scene"].append(row)
             continue
 

--- a/tests/test_validate_supported_scenes_readiness.py
+++ b/tests/test_validate_supported_scenes_readiness.py
@@ -132,3 +132,78 @@ def test_default_catalog_declares_required_contract_fields():
         assert entry["scene_name"] in entry["validation_command"]
         assert entry["build_package_name"] in entry["build_command"]
         assert "use_fake_hardware:=true" in entry["fake_hardware_launch_command"]
+
+
+def test_package_xml_name_mismatch_is_supported_scene_blocker(tmp_path: Path):
+    _write_scene(tmp_path / "scenes/pkg_mismatch", "actual_pkg")
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([_entry("pkg_mismatch", "scenes/pkg_mismatch")])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+
+    assert row["status"] == "BLOCKED"
+    assert row["package_xml_name"] == "actual_pkg"
+    assert row["catalog_contract"]["status"] == "FAIL"
+    assert any("catalog_package_name_mismatch" in blocker for blocker in row["blockers"])
+
+
+def test_build_package_name_mismatch_is_supported_scene_blocker(tmp_path: Path):
+    _write_scene(tmp_path / "scenes/build_pkg_mismatch", "build_pkg_mismatch")
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry(
+            "build_pkg_mismatch",
+            "scenes/build_pkg_mismatch",
+            build_package_name="wrong_build_pkg",
+            build_command="colcon build --symlink-install --packages-select wrong_build_pkg",
+        )
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+
+    assert row["status"] == "BLOCKED"
+    assert row["package_xml_name"] == "build_pkg_mismatch"
+    assert any("build_package_name_mismatch" in blocker for blocker in row["blockers"])
+    assert row["catalog_contract"]["mismatches"] == row["blockers"]
+
+
+def test_fake_hardware_launch_package_mismatch_is_supported_scene_blocker(tmp_path: Path):
+    _write_scene(tmp_path / "scenes/launch_pkg_mismatch", "launch_pkg_mismatch")
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry(
+            "launch_pkg_mismatch",
+            "scenes/launch_pkg_mismatch",
+            fake_hardware_launch_command="ros2 launch wrong_launch_pkg demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+        )
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+
+    assert row["status"] == "BLOCKED"
+    assert row["catalog_contract"]["status"] == "FAIL"
+    assert any("fake_hardware_launch_package_mismatch" in blocker for blocker in row["blockers"])
+
+
+def test_catalog_blocked_scene_reports_contract_mismatch_without_replacing_known_blocker(tmp_path: Path):
+    _write_scene(tmp_path / "scenes/blocked_pkg_mismatch", "actual_blocked_pkg")
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry(
+            "blocked_pkg_mismatch",
+            "scenes/blocked_pkg_mismatch",
+            status="blocked",
+            known_blocker="waiting for upstream mesh assets",
+        )
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+
+    assert row["status"] == "BLOCKED"
+    assert row["blockers"] == ["waiting for upstream mesh assets"]
+    assert row["catalog_contract"]["status"] == "FAIL"
+    assert any("catalog_package_name_mismatch" in mismatch for mismatch in row["catalog_contract"]["mismatches"])


### PR DESCRIPTION
### Motivation
- Ensure the supported-scenes readiness validator enforces contract consistency between the catalog and generated scene packages so drift is detected early.
- Promote package-related mismatches (catalog package name, build package, build command selection, fake-hardware launch package) into explicit blockers for scenes marked `status: supported`.
- Preserve existing catalog `blocked` semantics so known blockers remain authoritative while still exposing contract mismatches for diagnostics.

### Description
- Added `package.xml` parsing using `xml.etree.ElementTree` and a helper `_parse_package_xml_name` to extract the scene package `<name>` from `package.xml` in `scripts/validate_supported_scenes_readiness.py`.
- Added helpers to parse `--packages-select` from `build_command` and to extract the package name from `fake_hardware_launch_command` (`_build_command_package_selection` and `_fake_hardware_launch_package`) and a top-level `_catalog_contract_mismatches` to collect mismatches.
- Integrated per-row fields `package_xml_name` and `catalog_contract` into the readiness report and made contract mismatches become blockers for `status: supported` scenes while preserving `known_blocker` for `status: blocked` scenes.
- Relaxed one catalog-level assertion so `build_package_name` mismatches surface as row-level contract failures instead of aborting catalog load, and added unit tests in `tests/test_validate_supported_scenes_readiness.py` covering package.xml name mismatch, `build_package_name` mismatch, fake-hardware launch package mismatch, and catalog-blocked reporting.

### Testing
- Ran the focused unit tests with `pytest -q tests/test_validate_supported_scenes_readiness.py`, which passed (`10 passed`).
- Verified syntax with `python3 -m py_compile scripts/validate_supported_scenes_readiness.py scripts/supported_scene_catalog.py tests/test_validate_supported_scenes_readiness.py`, which succeeded.
- Ran the repository-level validator `python3 scripts/validate_supported_scenes_readiness.py --repo-root /workspace/Easy_Manipulator_Improved --workspace-root /workspace/Easy_Manipulator_Improved --json --skip-build --skip-launch-smoke`, which completed but reported existing launch contract failures for the default catalog scenes (missing `launch_rviz`), unrelated to the new contract checks.
- Ran full `pytest -q` which was blocked during collection by missing ROS/test dependencies (e.g. `rospkg` and launch-test modules), so broader test collection was not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a194ca2f97c8331968a6b822ff3d6c2)