### PR TITLE
Validate generated scene_visual_mesh_index.json and report mesh-index status in readiness report

### DIFF
--- a/scripts/validate_supported_scenes_readiness.py
+++ b/scripts/validate_supported_scenes_readiness.py
@@ -47,17 +47,122 @@ def _run_validator(repo_root: Path, workspace_root: Path, scene: str, skip_build
     return cmd, proc.returncode, payload
 
 
+def _mesh_index_failure(issue_code: str, message: str, index_path: Path, **extra: object) -> dict:
+    result = {
+        "status": "FAIL",
+        "issue_code": issue_code,
+        "message": message,
+        "index_path": str(index_path),
+        "item_key": None,
+        "item_count": 0,
+        "renderable_item_count": 0,
+        "malformed_item_count": 0,
+    }
+    result.update(extra)
+    return result
+
+
+def _validate_mesh_index(scene_path: Path) -> dict:
+    index_path = scene_path / "generated" / "scene_visual_mesh_index.json"
+    if not index_path.exists():
+        return _mesh_index_failure(
+            "missing_file",
+            "Missing generated/scene_visual_mesh_index.json; regenerate the scene visual mesh index before treating the scene as supported.",
+            index_path,
+        )
+
+    try:
+        payload = json.loads(index_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return _mesh_index_failure(
+            "invalid_json",
+            f"generated/scene_visual_mesh_index.json is not valid JSON: {exc.msg} at line {exc.lineno}, column {exc.colno}.",
+            index_path,
+        )
+
+    if not isinstance(payload, dict):
+        return _mesh_index_failure(
+            "json_root_not_object",
+            "generated/scene_visual_mesh_index.json must contain a JSON object at the root.",
+            index_path,
+        )
+
+    if "visual_items" in payload:
+        item_key = "visual_items"
+    elif "items" in payload:
+        item_key = "items"
+    else:
+        return _mesh_index_failure(
+            "missing_items_and_visual_items",
+            "generated/scene_visual_mesh_index.json must contain either an 'items' or 'visual_items' list.",
+            index_path,
+        )
+
+    items = payload.get(item_key)
+    if not isinstance(items, list):
+        return _mesh_index_failure(
+            "malformed_item_entries",
+            f"generated/scene_visual_mesh_index.json field '{item_key}' must be a list of item objects.",
+            index_path,
+            item_key=item_key,
+        )
+
+    malformed: list[str] = []
+    renderable_count = 0
+    for idx, item in enumerate(items):
+        if not isinstance(item, dict):
+            malformed.append(f"{item_key}[{idx}] is not an object")
+            continue
+        if "render_expected" in item and not isinstance(item.get("render_expected"), bool):
+            malformed.append(f"{item_key}[{idx}].render_expected is not a boolean")
+            continue
+        if item.get("render_expected") is True:
+            renderable_count += 1
+
+    if malformed:
+        return _mesh_index_failure(
+            "malformed_item_entries",
+            "Malformed mesh-index item entries: " + "; ".join(malformed[:5]),
+            index_path,
+            item_key=item_key,
+            item_count=len(items),
+            renderable_item_count=renderable_count,
+            malformed_item_count=len(malformed),
+            malformed_items=malformed,
+        )
+
+    if renderable_count == 0:
+        return _mesh_index_failure(
+            "no_renderable_items",
+            f"generated/scene_visual_mesh_index.json contains {len(items)} {item_key} entries but none are marked render_expected=true.",
+            index_path,
+            item_key=item_key,
+            item_count=len(items),
+        )
+
+    return {
+        "status": "PASS",
+        "issue_code": None,
+        "message": f"Mesh index has {renderable_count} renderable item(s).",
+        "index_path": str(index_path),
+        "item_key": item_key,
+        "item_count": len(items),
+        "renderable_item_count": renderable_count,
+        "malformed_item_count": 0,
+    }
+
+
 def _build_markdown(report: dict) -> str:
     lines = [
         "# Workcell Studio All Scenes Readiness Report",
         "",
-        "Scene | Support Level | Static | Build | Fake Launch | Status | Blocker",
-        "--- | --- | --- | --- | --- | --- | ---",
+        "Scene | Support Level | Static | Mesh Index | Build | Fake Launch | Status | Blocker",
+        "--- | --- | --- | --- | --- | --- | --- | ---",
     ]
     for row in report["per_scene"]:
         blockers = "; ".join(row.get("blockers", [])) or "-"
         lines.append(
-            f"{row['scene_name']} | {row['support_level']} | {row['static_validation']['status']} | {row['build']['status']} | {row['launch_smoke']['status']} | {row['status']} | {blockers}"
+            f"{row['scene_name']} | {row['support_level']} | {row['static_validation']['status']} | {row.get('mesh_index_validation', {}).get('status', 'SKIPPED')} | {row['build']['status']} | {row['launch_smoke']['status']} | {row['status']} | {blockers}"
         )
     lines.append("")
     return "\n".join(lines)
@@ -141,6 +246,7 @@ def main() -> int:
             "guided_build_launch_readiness": {"status": "SKIPPED"},
             "build": {"status": "SKIPPED"},
             "launch_smoke": {"status": "SKIPPED"},
+            "mesh_index_validation": {"status": "SKIPPED"},
             "blockers": [],
             "warnings": [],
             "commands_run": [],
@@ -170,9 +276,22 @@ def main() -> int:
 
         missing = [rel for rel in required if not (scene_dir / rel).exists()]
         row["static_validation"] = {"status": "PASS" if not missing else "FAIL", "missing_files": missing}
+        mesh_index_validation = _validate_mesh_index(scene_dir)
+        row["mesh_index_validation"] = mesh_index_validation
+        mesh_issue_code = mesh_index_validation.get("issue_code")
+        if mesh_issue_code:
+            issue = f"mesh_index_validation: {mesh_issue_code}"
+            if catalog_entry.status == "supported":
+                row["blockers"].append(issue)
+            else:
+                row["warnings"].append(issue)
         if missing:
             row["status"] = "FAIL"
             row["blockers"].extend([f"missing_required_file: {m}" for m in missing])
+            report["per_scene"].append(row)
+            continue
+        if catalog_entry.status == "supported" and mesh_index_validation["status"] != "PASS":
+            row["status"] = "FAIL"
             report["per_scene"].append(row)
             continue
 

--- a/tests/test_validate_supported_scenes_readiness.py
+++ b/tests/test_validate_supported_scenes_readiness.py
@@ -132,3 +132,85 @@ def test_default_catalog_declares_required_contract_fields():
         assert entry["scene_name"] in entry["validation_command"]
         assert entry["build_package_name"] in entry["build_command"]
         assert "use_fake_hardware:=true" in entry["fake_hardware_launch_command"]
+
+
+def test_missing_mesh_index_reports_mesh_validation_issue(tmp_path: Path):
+    scene = tmp_path / "scenes/missing_mesh"
+    _write_scene(scene, "missing_mesh")
+    (scene / "generated/scene_visual_mesh_index.json").unlink()
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([_entry("missing_mesh", "scenes/missing_mesh")])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+
+    assert row["status"] == "FAIL"
+    assert row["mesh_index_validation"]["status"] == "FAIL"
+    assert row["mesh_index_validation"]["issue_code"] == "missing_file"
+    assert "mesh_index_validation: missing_file" in row["blockers"]
+
+
+def test_malformed_mesh_index_item_entries_block_supported_scene(tmp_path: Path):
+    scene = tmp_path / "scenes/malformed_mesh"
+    _write_scene(scene, "malformed_mesh")
+    (scene / "generated/scene_visual_mesh_index.json").write_text(
+        json.dumps({"visual_items": [{"render_expected": True}, "not-an-object"]}),
+        encoding="utf-8",
+    )
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([_entry("malformed_mesh", "scenes/malformed_mesh")])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+
+    assert row["status"] == "FAIL"
+    assert row["mesh_index_validation"]["status"] == "FAIL"
+    assert row["mesh_index_validation"]["issue_code"] == "malformed_item_entries"
+    assert row["mesh_index_validation"]["malformed_item_count"] == 1
+    assert "mesh_index_validation: malformed_item_entries" in row["blockers"]
+
+
+def test_zero_renderable_mesh_index_blocks_supported_scene(tmp_path: Path):
+    scene = tmp_path / "scenes/zero_mesh"
+    _write_scene(scene, "zero_mesh")
+    (scene / "generated/scene_visual_mesh_index.json").write_text(
+        json.dumps({"visual_items": [{"render_expected": False}]}),
+        encoding="utf-8",
+    )
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([_entry("zero_mesh", "scenes/zero_mesh")])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+
+    assert row["status"] == "FAIL"
+    assert row["mesh_index_validation"]["status"] == "FAIL"
+    assert row["mesh_index_validation"]["issue_code"] == "no_renderable_items"
+    assert row["mesh_index_validation"]["renderable_item_count"] == 0
+    assert "mesh_index_validation: no_renderable_items" in row["blockers"]
+
+
+def test_blocked_catalog_scene_keeps_known_blocker_and_reports_mesh_issue(tmp_path: Path):
+    scene = tmp_path / "scenes/blocked_mesh"
+    _write_scene(scene, "blocked_mesh")
+    (scene / "generated/scene_visual_mesh_index.json").write_text(
+        json.dumps({"visual_items": []}),
+        encoding="utf-8",
+    )
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry(
+            "blocked_mesh",
+            "scenes/blocked_mesh",
+            status="blocked",
+            known_blocker="waiting on upstream asset export",
+        )
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+
+    assert row["known_blocker"] == "waiting on upstream asset export"
+    assert row["mesh_index_validation"]["issue_code"] == "no_renderable_items"
+    assert "mesh_index_validation: no_renderable_items" in row["warnings"]
+    assert "mesh_index_validation: no_renderable_items" not in row["blockers"]


### PR DESCRIPTION
### Motivation

- Ensure generated `generated/scene_visual_mesh_index.json` is present and well-formed because Workcell Studio depends on it for 3D preview/rendering readiness.
- Surface clear, machine-readable mesh-index issues (missing file, invalid JSON, wrong root, missing item list, malformed entries, zero renderable items) so readiness failures are actionable.
- Treat malformed or non-renderable mesh indexes as blockers for catalog `status: supported` scenes while preserving `known_blocker` for `status: blocked` scenes.

### Description

- Added `_validate_mesh_index()` and helper `_mesh_index_failure()` to validate `<scene>/generated/scene_visual_mesh_index.json` and produce structured issue codes/messages for the conditions requested.
- Added `mesh_index_validation` to each per-scene row and included the mesh-index status in the generated markdown table as a `Mesh Index` column.
- For catalog entries with `status: supported`, non-`PASS` mesh-index results are treated as blockers affecting the scene `status`; for non-supported/`blocked` entries the mesh-index issue is recorded as a warning while keeping `known_blocker` visible.
- Added regression tests to `tests/test_validate_supported_scenes_readiness.py` covering missing index, malformed item entries, zero renderable items, and the blocked-catalog behavior that preserves `known_blocker` while reporting the mesh issue.

### Testing

- Ran `python3 -m py_compile scripts/validate_supported_scenes_readiness.py` which succeeded.
- Ran `pytest -q tests/test_validate_supported_scenes_readiness.py` which passed (10 tests).
- The new tests validate the reported `mesh_index_validation` structure and that mesh-index issues become blockers for `supported` scenes and warnings for `blocked` scenes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a194d06e0dc8331ab09f8de01ce9588)