### PR TITLE
Strengthen supported-scene readiness tests and add reusable scene fixtures

### DIFF
--- a/scripts/validate_supported_scenes_readiness.py
+++ b/scripts/validate_supported_scenes_readiness.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from supported_scene_catalog import DEFAULT_SUPPORTED_SCENES_CATALOG, load_supported_scene_catalog
@@ -45,6 +47,36 @@ def _run_validator(repo_root: Path, workspace_root: Path, scene: str, skip_build
     if not isinstance(payload, dict):
         payload = {"status": "BLOCKED", "blockers": ["validator_output_not_object"], "warnings": []}
     return cmd, proc.returncode, payload
+
+
+def _read_package_xml_name(scene_dir: Path) -> tuple[str | None, str | None]:
+    package_xml = scene_dir / "package.xml"
+    if not package_xml.exists():
+        return None, "package.xml missing"
+    try:
+        root = ET.fromstring(package_xml.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        return None, f"package.xml unreadable: {exc.__class__.__name__}: {exc}"
+    name = root.findtext("name")
+    if not name or not name.strip():
+        return None, "package.xml missing <name>"
+    return name.strip(), None
+
+
+def _read_cmake_project_name(scene_dir: Path) -> tuple[str | None, str | None]:
+    cmake = scene_dir / "CMakeLists.txt"
+    if not cmake.exists():
+        return None, "CMakeLists.txt missing"
+    text = cmake.read_text(encoding="utf-8", errors="replace")
+    match = re.search(r"(?im)^\s*project\s*\(\s*([^\s\)]+)", text)
+    if not match:
+        return None, "CMakeLists.txt missing project(...)"
+    return match.group(1).strip(), None
+
+
+def _catalog_declares_blocked(status: str, known_blocker: str) -> bool:
+    normalized = status.strip().lower().replace("-", "_")
+    return bool(known_blocker.strip()) or normalized in {"blocked", "known_blocked", "unsupported", "disabled"}
 
 
 def _build_markdown(report: dict) -> str:
@@ -169,10 +201,46 @@ def main() -> int:
             continue
 
         missing = [rel for rel in required if not (scene_dir / rel).exists()]
-        row["static_validation"] = {"status": "PASS" if not missing else "FAIL", "missing_files": missing}
-        if missing:
-            row["status"] = "FAIL"
+        static_errors: list[str] = []
+
+        package_xml_name, package_xml_error = _read_package_xml_name(scene_dir)
+        if package_xml_error:
+            static_errors.append(package_xml_error)
+        else:
+            if package_xml_name != catalog_entry.package_name:
+                static_errors.append(
+                    f"package_name mismatch: catalog package_name={catalog_entry.package_name!r} package.xml name={package_xml_name!r}"
+                )
+            if package_xml_name != catalog_entry.build_package_name:
+                static_errors.append(
+                    f"build_package_name mismatch: catalog build_package_name={catalog_entry.build_package_name!r} package.xml name={package_xml_name!r}"
+                )
+
+        cmake_project_name, cmake_project_error = _read_cmake_project_name(scene_dir)
+        if cmake_project_error:
+            static_errors.append(cmake_project_error)
+        elif package_xml_name and cmake_project_name != package_xml_name:
+            static_errors.append(
+                f"CMake project mismatch: CMakeLists.txt project={cmake_project_name!r} package.xml name={package_xml_name!r}"
+            )
+
+        is_catalog_blocked = _catalog_declares_blocked(catalog_entry.status, catalog_entry.known_blocker)
+        if is_catalog_blocked and catalog_entry.known_blocker:
+            row["blockers"].append(f"known_blocker: {catalog_entry.known_blocker}")
+
+        row["static_validation"] = {
+            "status": "PASS" if not missing and not static_errors else "FAIL",
+            "missing_files": missing,
+            "package_xml_name": package_xml_name,
+            "cmake_project_name": cmake_project_name,
+            "errors": static_errors,
+        }
+        if missing or static_errors or is_catalog_blocked:
             row["blockers"].extend([f"missing_required_file: {m}" for m in missing])
+            row["blockers"].extend(static_errors)
+            row["status"] = "BLOCKED" if is_catalog_blocked else "FAIL"
+            if missing and not catalog_entry.known_blocker and not is_catalog_blocked:
+                row["blockers"].append("catalog known_blocker is empty for a supported scene with missing required files")
             report["per_scene"].append(row)
             continue
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,3 +6,155 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
+
+
+import json
+from collections.abc import Callable, Iterable, Mapping
+from typing import Any
+
+import pytest
+import yaml
+
+SCENE_AUTHORING_FILES = ("environment.yaml", "layout/workcell_studio_layout.yaml")
+SCENE_GENERATED_FILES = (
+    "cell_definition.yaml",
+    "scene_manifest.yaml",
+    "urdf/scene.urdf.xacro",
+    "launch/demo.launch.py",
+    "generated/scene_visual_mesh_index.json",
+)
+SUPPORTED_SCENE_SCHEMA = "workcell_studio_supported_scenes/v1"
+
+
+def _remove_relpath(root: Path, relpath: str) -> None:
+    path = root / relpath
+    if path.exists():
+        path.unlink()
+
+
+def write_minimal_scene_dir(
+    scene_dir: Path,
+    *,
+    scene_name: str | None = None,
+    package_xml_name: str | None = None,
+    cmake_project_name: str | None = None,
+    missing_authoring_files: Iterable[str] = (),
+    missing_generated_files: Iterable[str] = (),
+    mesh_index_payload: Mapping[str, Any] | str | None = None,
+) -> Path:
+    """Write a minimal Workcell Studio scene fixture for validator tests.
+
+    Passing a string writes raw malformed JSON; mappings are JSON-serialized. Use
+    ``missing_generated_files`` to omit generated/scene_visual_mesh_index.json.
+    """
+    name = scene_name or scene_dir.name
+    package = package_xml_name or name
+    project = cmake_project_name or package
+    payload: Mapping[str, Any] | str | None = mesh_index_payload
+    if payload is None:
+        payload = {"items": [{"id": "fixture_mesh", "render_expected": True}]}
+
+    scene_dir.mkdir(parents=True, exist_ok=True)
+    (scene_dir / "package.xml").write_text(
+        f"<package format='3'><name>{package}</name><version>0.0.0</version><description>fixture</description><maintainer email='test@example.com'>Test</maintainer><license>Apache-2.0</license></package>\n",
+        encoding="utf-8",
+    )
+    (scene_dir / "CMakeLists.txt").write_text(
+        f"cmake_minimum_required(VERSION 3.8)\nproject({project})\nfind_package(ament_cmake REQUIRED)\nament_package()\n",
+        encoding="utf-8",
+    )
+    (scene_dir / "environment.yaml").write_text(
+        "schema_version: workcell_studio_environment/v1\nsupport_surfaces: []\ntask_zones: []\n",
+        encoding="utf-8",
+    )
+    (scene_dir / "cell_definition.yaml").write_text(
+        f"schema_version: workcell_cell_definition/v1\npackage_name: {package}\nrobot: ur5\nend_effector: suction\nenvironment: fixture\n",
+        encoding="utf-8",
+    )
+    (scene_dir / "scene_manifest.yaml").write_text(
+        f"schema_version: workcell_scene_manifest/v1\nscene_name: {name}\npackage_name: {package}\n",
+        encoding="utf-8",
+    )
+    (scene_dir / "layout").mkdir(exist_ok=True)
+    (scene_dir / "layout/workcell_studio_layout.yaml").write_text(
+        "schema_version: workcell_studio_layout/v1\nitems: [{id: fixture, type: marker}]\n",
+        encoding="utf-8",
+    )
+    (scene_dir / "launch").mkdir(exist_ok=True)
+    (scene_dir / "launch/demo.launch.py").write_text(
+        "# fixture launch supports use_fake_hardware launch_rviz robot_state_publisher xacro\n", encoding="utf-8"
+    )
+    (scene_dir / "urdf").mkdir(exist_ok=True)
+    (scene_dir / "urdf/scene.urdf.xacro").write_text("<robot name='fixture_scene'><link name='environment'/><link name='end_effector'/></robot>\n", encoding="utf-8")
+    (scene_dir / "generated").mkdir(exist_ok=True)
+    (scene_dir / "generated/scene_package_readiness.json").write_text(
+        json.dumps({"package_name": package}), encoding="utf-8"
+    )
+    if payload is not None:
+        index_path = scene_dir / "generated/scene_visual_mesh_index.json"
+        if isinstance(payload, str):
+            index_path.write_text(payload, encoding="utf-8")
+        else:
+            index_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    for relpath in [*missing_authoring_files, *missing_generated_files]:
+        _remove_relpath(scene_dir, relpath)
+    return scene_dir
+
+
+def minimal_supported_scene_entry(
+    scene_name: str,
+    *,
+    scene_path: str | None = None,
+    package_name: str | None = None,
+    build_package_name: str | None = None,
+    support_level: str = "supported",
+    status: str = "supported",
+    known_blocker: str = "",
+    authoring_files: Iterable[str] = SCENE_AUTHORING_FILES,
+    generated_files: Iterable[str] = SCENE_GENERATED_FILES,
+    fake_hardware_launch_command: str | None = None,
+    **overrides: Any,
+) -> dict[str, Any]:
+    package = package_name or scene_name
+    build_package = build_package_name or package
+    entry: dict[str, Any] = {
+        "scene_name": scene_name,
+        "package_name": package,
+        "scene_path": scene_path or f"scenes/{scene_name}",
+        "support_level": support_level,
+        "status": status,
+        "known_blocker": known_blocker,
+        "authoring_files": list(authoring_files),
+        "generated_files": list(generated_files),
+        "validation_command": f"python3 scripts/validate_builder_generated_scene.py scenes/{scene_name} --json",
+        "build_package_name": build_package,
+        "build_command": f"colcon build --symlink-install --packages-select {build_package}",
+        "fake_hardware_launch_command": fake_hardware_launch_command
+        or f"ros2 launch {build_package} demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+    }
+    entry.update(overrides)
+    return entry
+
+
+def write_supported_scene_catalog(path: Path, entries: Iterable[dict[str, Any]]) -> Path:
+    path.write_text(
+        yaml.safe_dump({"schema_version": SUPPORTED_SCENE_SCHEMA, "scenes": list(entries)}),
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.fixture
+def make_minimal_scene() -> Callable[..., Path]:
+    return write_minimal_scene_dir
+
+
+@pytest.fixture
+def make_supported_scene_entry() -> Callable[..., dict[str, Any]]:
+    return minimal_supported_scene_entry
+
+
+@pytest.fixture
+def write_scene_catalog() -> Callable[[Path, Iterable[dict[str, Any]]], Path]:
+    return write_supported_scene_catalog

--- a/tests/test_all_scene_reproducibility.py
+++ b/tests/test_all_scene_reproducibility.py
@@ -98,3 +98,36 @@ def test_moveit_launch_readiness_uses_synthetic_launch_report_statuses(tmp_path)
     assert audit_scene(repo_root=Path(__file__).resolve().parents[1], scene_dir=_mk_scene("s1", "PASS")).readiness["moveit_launch_readiness"].status == "PASS"
     assert audit_scene(repo_root=Path(__file__).resolve().parents[1], scene_dir=_mk_scene("s2", "WARN")).readiness["moveit_launch_readiness"].status == "WARN"
     assert audit_scene(repo_root=Path(__file__).resolve().parents[1], scene_dir=_mk_scene("s3", "FAIL")).readiness["moveit_launch_readiness"].status == "FAIL"
+
+
+def test_mesh_index_missing_malformed_and_non_renderable_are_clear(tmp_path, make_minimal_scene):
+    from scripts.validate_all_workcell_studio_scenes import audit_scene
+
+    repo_root = tmp_path / "repo_without_extract_script"
+    repo_root.mkdir()
+    missing = make_minimal_scene(
+        tmp_path / "missing_mesh_index",
+        missing_generated_files=["generated/scene_visual_mesh_index.json"],
+    )
+    malformed = make_minimal_scene(tmp_path / "malformed_mesh_index", mesh_index_payload="{not-json")
+    non_renderable = make_minimal_scene(
+        tmp_path / "non_renderable_mesh_index",
+        mesh_index_payload={"items": [{"id": "hidden", "render_expected": False}]},
+    )
+
+    missing_audit = audit_scene(repo_root=repo_root, scene_dir=missing)
+    malformed_audit = audit_scene(repo_root=repo_root, scene_dir=malformed)
+    non_renderable_audit = audit_scene(repo_root=repo_root, scene_dir=non_renderable)
+
+    assert missing_audit.status == "FAIL"
+    assert any("visual mesh index regeneration failed: extractor script missing" == blocker for blocker in missing_audit.blockers)
+    assert "generated mesh index unreadable: missing" in missing_audit.blockers
+    assert missing_audit.readiness["preview_readiness"].status == "FAIL"
+
+    assert malformed_audit.status == "FAIL"
+    assert any("generated mesh index unreadable: error: JSONDecodeError" in blocker for blocker in malformed_audit.blockers)
+    assert malformed_audit.readiness["preview_readiness"].status == "FAIL"
+
+    assert non_renderable_audit.status == "FAIL"
+    assert "generated mesh index has no renderable items" in non_renderable_audit.blockers
+    assert non_renderable_audit.readiness["preview_readiness"].status == "FAIL"

--- a/tests/test_all_workcell_studio_scene_reproducibility.py
+++ b/tests/test_all_workcell_studio_scene_reproducibility.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import yaml
+
 
 def test_all_scene_reproducibility_validator_runs_and_emits_json_report():
     repo_root = Path(__file__).resolve().parents[1]
@@ -22,20 +24,30 @@ def test_all_scene_reproducibility_validator_runs_and_emits_json_report():
     assert "Traceback" not in (proc.stdout + proc.stderr)
 
 
-def test_known_scene_set_matches_expected_contract():
+def test_report_scene_set_matches_supported_scene_catalog():
     repo_root = Path(__file__).resolve().parents[1]
-    script_text = (repo_root / "scripts" / "validate_all_workcell_studio_scenes.py").read_text(encoding="utf-8")
-    for name in [
-        "suction_test",
-        "ur10_2f_test",
-        "ur3_suction_test",
-        "ur5_2f_builder_pick_place_demo",
-        "ur5_2f_sorting_test",
-        "ur5_2f_test",
-        "ur5_3f_test",
-        "ur5_airpick4_test",
-    ]:
-        assert name in script_text
+    script = repo_root / "scripts" / "validate_all_workcell_studio_scenes.py"
+    catalog_path = repo_root / "scenes" / "supported_scenes.yaml"
+    report = repo_root / "build" / "workcell_studio" / "all_scene_reproducibility_report.json"
+
+    subprocess.run([sys.executable, str(script)], cwd=repo_root, check=True, capture_output=True, text=True)
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    catalog = yaml.safe_load(catalog_path.read_text(encoding="utf-8"))
+
+    expected = {
+        entry["scene_name"]: entry
+        for entry in catalog["scenes"]
+        if entry.get("enabled", True)
+    }
+    actual = {scene["scene_name"]: scene for scene in payload["scenes"]}
+
+    assert payload["supported_scene_catalog"].endswith("scenes/supported_scenes.yaml")
+    assert set(actual) == set(expected)
+    for scene_name, entry in expected.items():
+        scene = actual[scene_name]
+        assert scene["scene_name"] == entry["scene_name"]
+        if entry.get("known_blocker"):
+            assert any(entry["known_blocker"] in blocker for blocker in scene.get("blockers", []))
 
 
 def test_validator_has_no_suction_only_special_case():

--- a/tests/test_validate_supported_scenes_readiness.py
+++ b/tests/test_validate_supported_scenes_readiness.py
@@ -9,105 +9,147 @@ import yaml
 
 SCHEMA = "workcell_studio_supported_scenes/v1"
 AUTHORING = ["environment.yaml", "layout/workcell_studio_layout.yaml"]
-GENERATED = ["cell_definition.yaml", "launch/demo.launch.py", "urdf/scene.urdf.xacro", "generated/scene_visual_mesh_index.json"]
-
-
-def _entry(name: str, scene_path: str | None = None, **overrides):
-    package = overrides.pop("package_name", name)
-    entry = {
-        "scene_name": name,
-        "package_name": package,
-        "scene_path": scene_path or f"scenes/{name}",
-        "support_level": "supported",
-        "status": "supported",
-        "known_blocker": "",
-        "authoring_files": AUTHORING,
-        "generated_files": GENERATED,
-        "validation_command": f"python3 scripts/validate_builder_generated_scene.py scenes/{name} --json",
-        "build_package_name": package,
-        "build_command": f"colcon build --symlink-install --packages-select {package}",
-        "fake_hardware_launch_command": f"ros2 launch {package} demo.launch.py use_fake_hardware:=true launch_rviz:=true",
-    }
-    entry.update(overrides)
-    return entry
-
-
-def _catalog(entries):
-    return {"schema_version": SCHEMA, "scenes": entries}
+GENERATED = ["cell_definition.yaml", "scene_manifest.yaml", "urdf/scene.urdf.xacro", "launch/demo.launch.py", "generated/scene_visual_mesh_index.json"]
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "validate_supported_scenes_readiness.py"
 
 
-def _write_scene(scene_dir: Path, name: str) -> None:
-    scene_dir.mkdir(parents=True, exist_ok=True)
-    (scene_dir / "package.xml").write_text(f"<package><name>{name}</name></package>\n", encoding="utf-8")
-    (scene_dir / "CMakeLists.txt").write_text(f"project({name})\nament_package()\n", encoding="utf-8")
-    (scene_dir / "environment.yaml").write_text("name: env\n", encoding="utf-8")
-    (scene_dir / "cell_definition.yaml").write_text("robot: ur5\nend_effector: suction\nenvironment: demo\n", encoding="utf-8")
-    (scene_dir / "launch").mkdir(exist_ok=True)
-    (scene_dir / "launch/demo.launch.py").write_text("use_fake_hardware launch_rviz robot_state_publisher rviz xacro\n", encoding="utf-8")
-    (scene_dir / "urdf").mkdir(exist_ok=True)
-    (scene_dir / "urdf/scene.urdf.xacro").write_text("<robot name='x'></robot>\n", encoding="utf-8")
-    (scene_dir / "layout").mkdir(exist_ok=True)
-    (scene_dir / "layout/workcell_studio_layout.yaml").write_text("layout: ok\n", encoding="utf-8")
-    (scene_dir / "generated").mkdir(exist_ok=True)
-    (scene_dir / "generated/scene_package_readiness.json").write_text(json.dumps({"package_name": name}), encoding="utf-8")
-    (scene_dir / "generated/scene_visual_mesh_index.json").write_text(json.dumps({"items": [{"render_expected": True}]}), encoding="utf-8")
-
-
 def _run(tmp_path: Path, registry: Path, extra: list[str] | None = None) -> dict:
-    cmd = [sys.executable, str(SCRIPT), "--repo-root", str(tmp_path), "--workspace-root", str(tmp_path), "--registry", str(registry), "--json", "--skip-build", "--skip-launch-smoke"]
+    cmd = [
+        sys.executable,
+        str(SCRIPT),
+        "--repo-root",
+        str(tmp_path),
+        "--workspace-root",
+        str(tmp_path),
+        "--registry",
+        str(registry),
+        "--json",
+        "--skip-build",
+        "--skip-launch-smoke",
+    ]
     cmd.extend(extra or [])
     run = subprocess.run(cmd, capture_output=True, text=True, check=False)
     return json.loads(run.stdout)
 
 
-def test_disabled_and_experimental_skipped(tmp_path: Path):
-    _write_scene(tmp_path / "scenes/ok_scene", "ok_scene")
-    reg = tmp_path / "registry.yaml"
-    reg.write_text(yaml.safe_dump(_catalog([
-        _entry("disabled_scene", "scenes/disabled_scene", enabled=False),
-        _entry("exp_scene", "scenes/ok_scene", support_level="experimental"),
-    ])), encoding="utf-8")
+def test_disabled_and_experimental_skipped(tmp_path: Path, make_minimal_scene, make_supported_scene_entry, write_scene_catalog):
+    make_minimal_scene(tmp_path / "scenes/ok_scene", scene_name="ok_scene")
+    reg = write_scene_catalog(
+        tmp_path / "registry.yaml",
+        [
+            make_supported_scene_entry("disabled_scene", scene_path="scenes/disabled_scene", enabled=False),
+            make_supported_scene_entry("exp_scene", scene_path="scenes/ok_scene", support_level="experimental", package_name="ok_scene"),
+        ],
+    )
     payload = _run(tmp_path, reg)
     assert payload["summary"]["skipped"] == 2
 
 
-def test_missing_scene_is_blocked(tmp_path: Path):
-    reg = tmp_path / "registry.yaml"
-    reg.write_text(yaml.safe_dump(_catalog([_entry("missing", "scenes/missing")])), encoding="utf-8")
+def test_missing_scene_is_blocked(tmp_path: Path, make_supported_scene_entry, write_scene_catalog):
+    reg = write_scene_catalog(tmp_path / "registry.yaml", [make_supported_scene_entry("missing", scene_path="scenes/missing")])
     payload = _run(tmp_path, reg)
     assert payload["per_scene"][0]["status"] == "BLOCKED"
 
 
-def test_missing_required_file_is_fail(tmp_path: Path):
-    (tmp_path / "scenes/a").mkdir(parents=True)
-    reg = tmp_path / "registry.yaml"
-    reg.write_text(yaml.safe_dump(_catalog([_entry("a", "scenes/a")])), encoding="utf-8")
+def test_supported_scene_with_missing_required_file_and_empty_known_blocker_fails_clearly(
+    tmp_path: Path, make_minimal_scene, make_supported_scene_entry, write_scene_catalog
+):
+    make_minimal_scene(
+        tmp_path / "scenes/a",
+        scene_name="a",
+        missing_authoring_files=["environment.yaml"],
+    )
+    reg = write_scene_catalog(tmp_path / "registry.yaml", [make_supported_scene_entry("a", scene_path="scenes/a", known_blocker="")])
     payload = _run(tmp_path, reg)
-    assert payload["per_scene"][0]["status"] == "FAIL"
-    assert "missing_required_file: environment.yaml" in payload["per_scene"][0]["blockers"]
+    row = payload["per_scene"][0]
+    assert row["status"] == "FAIL"
+    assert "missing_required_file: environment.yaml" in row["blockers"]
+    assert "catalog known_blocker is empty for a supported scene with missing required files" in row["blockers"]
 
 
-def test_experimental_included_with_flag(tmp_path: Path):
-    _write_scene(tmp_path / "scenes/exp", "exp")
-    reg = tmp_path / "registry.yaml"
-    reg.write_text(yaml.safe_dump(_catalog([_entry("exp", "scenes/exp", support_level="experimental")])), encoding="utf-8")
+def test_blocked_scene_reports_known_blocker(tmp_path: Path, make_minimal_scene, make_supported_scene_entry, write_scene_catalog):
+    make_minimal_scene(tmp_path / "scenes/blocked", scene_name="blocked", missing_generated_files=["launch/demo.launch.py"])
+    reg = write_scene_catalog(
+        tmp_path / "registry.yaml",
+        [
+            make_supported_scene_entry(
+                "blocked",
+                scene_path="scenes/blocked",
+                status="blocked",
+                known_blocker="waiting on generated launch migration",
+            )
+        ],
+    )
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+    assert row["status"] == "BLOCKED"
+    assert row["known_blocker"] == "waiting on generated launch migration"
+    assert "known_blocker: waiting on generated launch migration" in row["blockers"]
+
+
+def test_fake_hardware_launch_command_requires_fake_hardware_true(tmp_path: Path, make_supported_scene_entry, write_scene_catalog):
+    reg = write_scene_catalog(
+        tmp_path / "registry.yaml",
+        [
+            make_supported_scene_entry(
+                "unsafe_scene",
+                fake_hardware_launch_command="ros2 launch unsafe_scene demo.launch.py launch_rviz:=true",
+            )
+        ],
+    )
+    payload = _run(tmp_path, reg)
+    assert payload["summary"]["blocked"] == 1
+    assert "unsafe_scene: fake_hardware_launch_command must explicitly set use_fake_hardware:=true" in payload["catalog_errors"]
+
+
+def test_package_and_build_names_must_match_package_xml(
+    tmp_path: Path, make_minimal_scene, make_supported_scene_entry, write_scene_catalog
+):
+    make_minimal_scene(tmp_path / "scenes/pkg_mismatch", scene_name="pkg_mismatch", package_xml_name="actual_pkg")
+    reg = write_scene_catalog(
+        tmp_path / "registry.yaml",
+        [make_supported_scene_entry("pkg_mismatch", scene_path="scenes/pkg_mismatch", package_name="catalog_pkg", build_package_name="catalog_pkg")],
+    )
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+    assert row["status"] == "FAIL"
+    assert "package_name mismatch: catalog package_name='catalog_pkg' package.xml name='actual_pkg'" in row["blockers"]
+    assert "build_package_name mismatch: catalog build_package_name='catalog_pkg' package.xml name='actual_pkg'" in row["blockers"]
+
+
+def test_cmake_project_name_must_match_package_xml(tmp_path: Path, make_minimal_scene, make_supported_scene_entry, write_scene_catalog):
+    make_minimal_scene(tmp_path / "scenes/cmake_mismatch", scene_name="cmake_mismatch", cmake_project_name="wrong_project")
+    reg = write_scene_catalog(tmp_path / "registry.yaml", [make_supported_scene_entry("cmake_mismatch", scene_path="scenes/cmake_mismatch")])
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+    assert row["status"] == "FAIL"
+    assert "CMake project mismatch: CMakeLists.txt project='wrong_project' package.xml name='cmake_mismatch'" in row["blockers"]
+
+
+def test_experimental_included_with_flag(tmp_path: Path, make_minimal_scene, make_supported_scene_entry, write_scene_catalog):
+    make_minimal_scene(tmp_path / "scenes/exp", scene_name="exp")
+    reg = write_scene_catalog(
+        tmp_path / "registry.yaml",
+        [make_supported_scene_entry("exp", scene_path="scenes/exp", support_level="experimental")],
+    )
     payload = _run(tmp_path, reg, ["--include-experimental"])
     assert payload["per_scene"][0]["status"] in {"PASS", "PASS_WITH_WARNINGS"}
 
 
-def test_summary_counts(tmp_path: Path):
-    _write_scene(tmp_path / "scenes/pass_scene", "pass_scene")
-    reg = tmp_path / "registry.yaml"
-    reg.write_text(yaml.safe_dump(_catalog([
-        _entry("pass_scene", "scenes/pass_scene"),
-        _entry("missing_scene", "scenes/missing_scene"),
-        _entry("disabled_scene", "scenes/disabled_scene", enabled=False),
-    ])), encoding="utf-8")
+def test_summary_counts(tmp_path: Path, make_minimal_scene, make_supported_scene_entry, write_scene_catalog):
+    make_minimal_scene(tmp_path / "scenes/pass_scene", scene_name="pass_scene")
+    reg = write_scene_catalog(
+        tmp_path / "registry.yaml",
+        [
+            make_supported_scene_entry("pass_scene", scene_path="scenes/pass_scene"),
+            make_supported_scene_entry("missing_scene", scene_path="scenes/missing_scene"),
+            make_supported_scene_entry("disabled_scene", scene_path="scenes/disabled_scene", enabled=False),
+        ],
+    )
     payload = _run(tmp_path, reg)
-    assert payload["summary"] == {"total": 3, "pass": 1, "fail": 0, "blocked": 1, "warnings": 1, "skipped": 1}
+    assert payload["summary"] == {"total": 3, "pass": 1, "fail": 0, "blocked": 1, "warnings": 0, "skipped": 1}
 
 
 def test_default_catalog_declares_required_contract_fields():


### PR DESCRIPTION
### Motivation
- Improve coverage and maintainability of all-scene readiness/reproducibility tests by replacing hardcoded scene-name assertions with a catalog-backed approach and reusable fixtures. 
- Surface deterministic, actionable failures when catalog entries diverge from on-disk artifacts such as `package.xml` and `CMakeLists.txt` and when mesh index artifacts are missing/malformed. 
- Ensure fake-hardware launch commands are explicitly safe by enforcing `use_fake_hardware:=true` in catalog validation.

### Description
- Add a reusable minimal scene fixture and catalog helpers to `tests/conftest.py` that can create scene directories with configurable `package.xml` name, CMake project name, missing authoring/generated files, mesh-index payloads, catalog status/support level, and `known_blocker` fields. (`tests/conftest.py`)
- Harden `scripts/validate_supported_scenes_readiness.py` to read and validate `package.xml` and `CMakeLists.txt`, detect `package_name` / `build_package_name` mismatches vs `package.xml`, report CMake project mismatches, and preserve/report catalog `known_blocker` context for blocked scenes. (`scripts/validate_supported_scenes_readiness.py`)
- Replace tests that relied on hardcoded scene names with catalog-driven assertions and add new tests that verify: missing required files with empty `known_blocker` fail clearly, blocked scenes include `known_blocker`, `fake_hardware_launch_command` must contain `use_fake_hardware:=true`, `package_name` / `build_package_name` mismatches are caught, and `CMakeLists.txt` project name mismatches are reported. (`tests/test_validate_supported_scenes_readiness.py`)
- Add all-scene reproducibility tests for mesh-index handling that assert missing, malformed, and non-renderable mesh indexes are reported clearly and degrade preview readiness. (`tests/test_all_scene_reproducibility.py`)
- Replace hardcoded source-text checks in the all-scenes reproducibility test with a check that loads `scenes/supported_scenes.yaml` and compares the generated report to the catalog entries. (`tests/test_all_workcell_studio_scene_reproducibility.py`)

### Testing
- Ran `python -m pytest tests/test_validate_supported_scenes_readiness.py tests/test_all_scene_reproducibility.py tests/test_all_workcell_studio_scene_reproducibility.py tests/test_all_scene_builder_reproducibility.py` and the selected test set passed (19 tests). 
- Compiled key scripts to validate syntax with `python -m py_compile scripts/validate_supported_scenes_readiness.py scripts/validate_all_workcell_studio_scenes.py tests/conftest.py tests/test_validate_supported_scenes_readiness.py tests/test_all_scene_reproducibility.py tests/test_all_workcell_studio_scene_reproducibility.py` which succeeded. 
- Running the full test suite with `python -m pytest` failed at collection due to missing external ROS/test-environment dependencies (for example `rospkg` and several ROS launch test modules) in this container; these are unrelated to the new tests and indicate environment limitations rather than regressions introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a194d0ae2848331bd32b9776076ed12)