### PR TITLE
Validate supported scene catalog statuses and handle catalog-blocked scenes in readiness report

### DIFF
--- a/scripts/supported_scene_catalog.py
+++ b/scripts/supported_scene_catalog.py
@@ -8,6 +8,9 @@ import yaml  # type: ignore
 
 DEFAULT_SUPPORTED_SCENES_CATALOG = Path("scenes/supported_scenes.yaml")
 CATALOG_SCHEMA_VERSION = "workcell_studio_supported_scenes/v1"
+ACCEPTED_CATALOG_STATUSES = frozenset({"supported", "blocked", "disabled"})
+ACCEPTED_SUPPORT_LEVELS = frozenset({"supported", "experimental"})
+
 REQUIRED_SCENE_FIELDS = (
     "scene_name",
     "package_name",
@@ -102,6 +105,16 @@ def load_supported_scene_catalog(path: Path) -> tuple[dict[str, Any], list[Suppo
         fake_hardware_launch_command = str(raw.get("fake_hardware_launch_command", "")).strip()
         enabled = bool(raw.get("enabled", True))
 
+        if status not in ACCEPTED_CATALOG_STATUSES:
+            accepted = ", ".join(sorted(ACCEPTED_CATALOG_STATUSES))
+            errors.append(f"{scene_name}: status must be one of [{accepted}]; got {status!r}")
+        if support_level not in ACCEPTED_SUPPORT_LEVELS:
+            accepted = ", ".join(sorted(ACCEPTED_SUPPORT_LEVELS))
+            errors.append(f"{scene_name}: support_level must be one of [{accepted}]; got {support_level!r}")
+        if status == "blocked" and not known_blocker:
+            errors.append(f"{scene_name}: known_blocker must be non-empty when status is 'blocked'")
+        if status == "supported" and known_blocker:
+            errors.append(f"{scene_name}: known_blocker must be empty when status is 'supported'")
         if package_name != build_package_name:
             errors.append(f"{scene_name}: package_name and build_package_name should match unless intentionally documented")
         if not authoring_files:

--- a/scripts/validate_supported_scenes_readiness.py
+++ b/scripts/validate_supported_scenes_readiness.py
@@ -252,7 +252,27 @@ def main() -> int:
             "artifact_paths": {},
         }
 
-        if not enabled:
+        if catalog_entry.status == "blocked":
+            report["scenes_checked"].append(scene_name)
+            catalog_blocker = catalog_entry.known_blocker
+            row["status"] = "BLOCKED"
+            row["validation_result"] = "BLOCKED"
+            row["known_blocker"] = catalog_blocker
+            row["blocker"] = catalog_blocker
+            row["blockers"] = [catalog_blocker]
+            row["static_validation"] = {
+                "status": "PASS" if not missing_required_files else "FAIL",
+                "missing_files": missing_required_files,
+            }
+            if scene_dir.exists():
+                mesh_index = _check_mesh_index_contract(scene_dir)
+                row["mesh_index_validation"] = mesh_index
+                row["mesh_index"] = mesh_index
+                row["blockers"].extend(mesh_index.get("blockers", []))
+            report["per_scene"].append(row)
+            continue
+
+        if not enabled or catalog_entry.status == "disabled":
             report["scenes_skipped"].append(scene_name)
             row["status"] = "SKIPPED"
             row["validation_result"] = "SKIPPED"
@@ -284,15 +304,6 @@ def main() -> int:
         row["mesh_index"] = mesh_index
         if mesh_index["status"] != "PASS":
             row["blockers"].extend(mesh_index.get("blockers", []))
-
-        if str(catalog_entry.status).lower() == "blocked":
-            row["status"] = "BLOCKED"
-            row["validation_result"] = "BLOCKED"
-            catalog_blocker = catalog_entry.known_blocker or "scene_blocked_in_catalog"
-            row["blockers"].insert(0, catalog_blocker)
-            row["blocker"] = _join_blockers(row["blockers"])
-            report["per_scene"].append(row)
-            continue
 
         if missing_required_files:
             row["status"] = "FAIL"

--- a/tests/test_validate_supported_scenes_readiness.py
+++ b/tests/test_validate_supported_scenes_readiness.py
@@ -163,6 +163,82 @@ def test_catalog_blocked_scene_uses_known_blocker(tmp_path: Path):
     assert row["missing_generated_files"] == []
 
 
+def test_catalog_blocked_scene_reports_catalog_blocker_and_skips_guided_validator(tmp_path: Path):
+    scene_dir = tmp_path / "scenes/blocked_static"
+    _write_scene(scene_dir, "blocked_static")
+    (scene_dir / "environment.yaml").unlink()
+    known_blocker = "awaiting scene regeneration after robot-tool metadata repair"
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry("blocked_static", "scenes/blocked_static", status="blocked", known_blocker=known_blocker),
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+
+    assert row["status"] == "BLOCKED"
+    assert row["validation_result"] == "BLOCKED"
+    assert row["known_blocker"] == known_blocker
+    assert row["blocker"] == known_blocker
+    assert row["blockers"] == [known_blocker]
+    assert row["static_validation"] == {"status": "FAIL", "missing_files": ["environment.yaml"]}
+    assert row["missing_authoring_files"] == ["environment.yaml"]
+    assert row["commands_run"] == []
+    assert row["guided_build_launch_readiness"] == {"status": "SKIPPED"}
+    assert row["mesh_index_validation"]["status"] == "PASS"
+
+
+def test_catalog_rejects_supported_scene_with_stale_known_blocker(tmp_path: Path):
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry("stale", "scenes/stale", status="supported", known_blocker="old blocker should be cleared"),
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+
+    assert payload["summary"]["blocked"] == 1
+    assert payload["per_scene"] == []
+    assert "catalog_errors" in payload
+    assert any(
+        "stale: known_blocker must be empty when status is 'supported'" in error
+        for error in payload["catalog_errors"]
+    )
+
+
+def test_catalog_rejects_blocked_scene_without_known_blocker(tmp_path: Path):
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry("blocked_without_reason", "scenes/blocked_without_reason", status="blocked", known_blocker=""),
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+
+    assert payload["summary"]["blocked"] == 1
+    assert any(
+        "blocked_without_reason: known_blocker must be non-empty when status is 'blocked'" in error
+        for error in payload["catalog_errors"]
+    )
+
+
+def test_catalog_rejects_unknown_status_and_support_level(tmp_path: Path):
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry("unknown_contract", "scenes/unknown_contract", status="needs_triage", support_level="beta"),
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+
+    assert payload["summary"]["blocked"] == 1
+    assert any(
+        "unknown_contract: status must be one of [blocked, disabled, supported]; got 'needs_triage'" in error
+        for error in payload["catalog_errors"]
+    )
+    assert any(
+        "unknown_contract: support_level must be one of [experimental, supported]; got 'beta'" in error
+        for error in payload["catalog_errors"]
+    )
+
+
 def test_summary_counts(tmp_path: Path):
     _write_scene(tmp_path / "scenes/pass_scene", "pass_scene")
     reg = tmp_path / "registry.yaml"


### PR DESCRIPTION
### Motivation
- Make the supported-scenes catalog contract explicit by accepting only known `status` and `support_level` values and by enforcing `known_blocker` consistency. 
- Ensure the all-scenes readiness report treats catalog-declared blocked scenes clearly and deterministically without invoking the guided validator for those scenes.

### Description
- Added accepted catalog enums `ACCEPTED_CATALOG_STATUSES = frozenset({"supported", "blocked", "disabled"})` and `ACCEPTED_SUPPORT_LEVELS = frozenset({"supported", "experimental"})` in `scripts/supported_scene_catalog.py` and validate entries against them. 
- Enforced catalog rules in `load_supported_scene_catalog` so unknown `status`/`support_level` values produce clear catalog errors, `status: blocked` requires non-empty `known_blocker`, and `status: supported` must have an empty `known_blocker`.
- Updated `scripts/validate_supported_scenes_readiness.py` to emit a per-scene `BLOCKED` row for catalog-blocked scenes with `status: "BLOCKED"`, set `blocker`/`known_blocker` from the catalog entry, preserve cheap static checks and mesh-index details when available, and skip the guided validator for those scenes.
- Treat `status: disabled` the same as `enabled: false` (skip the scene) in readiness reporting.
- Added regression tests to `tests/test_validate_supported_scenes_readiness.py` covering catalog-blocked scenes (including static missing-file cases), stale/non-empty blockers on supported scenes, missing blocker on blocked scenes, and unknown `status`/`support_level` values.
- No changes to launch files, controllers, runtime services, or real-hardware defaults were made.

### Testing
- Ran `python3 -m pytest tests/test_validate_supported_scenes_readiness.py -q` and all tests passed (`16 passed`).
- Verified `load_supported_scene_catalog(Path('scenes/supported_scenes.yaml'))` returns entries and no errors for the repo catalog (`entries=8, errors=0`).
- Verified syntax by running `python3 -m py_compile scripts/supported_scene_catalog.py scripts/validate_supported_scenes_readiness.py` which succeeded.
- Ran the repository-wide readiness script `python3 scripts/validate_supported_scenes_readiness.py --repo-root /workspace/Easy_Manipulator_Improved --workspace-root /workspace/Easy_Manipulator_Improved --json --skip-build --skip-launch-smoke` which returned non-zero due to current catalog state (summary: `total=8, pass=0, fail=1, blocked=7`) and produced no catalog-errors for the shipped catalog; this is expected while multiple scenes remain catalog-blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ad4a366548331a6d6075fdfb7dc7c)