### PR TITLE
Validate supported scene package contracts

### DIFF
--- a/scripts/supported_scene_catalog.py
+++ b/scripts/supported_scene_catalog.py
@@ -115,16 +115,12 @@ def load_supported_scene_catalog(path: Path) -> tuple[dict[str, Any], list[Suppo
             errors.append(f"{scene_name}: known_blocker must be non-empty when status is 'blocked'")
         if status == "supported" and known_blocker:
             errors.append(f"{scene_name}: known_blocker must be empty when status is 'supported'")
-        if package_name != build_package_name:
-            errors.append(f"{scene_name}: package_name and build_package_name should match unless intentionally documented")
         if not authoring_files:
             errors.append(f"{scene_name}: authoring_files must list at least one file")
         if not generated_files:
             errors.append(f"{scene_name}: generated_files must list at least one file")
         if scene_name not in validation_command:
             errors.append(f"{scene_name}: validation_command must name the scene explicitly")
-        if build_package_name not in build_command:
-            errors.append(f"{scene_name}: build_command must use build_package_name")
         if "use_fake_hardware:=true" not in fake_hardware_launch_command:
             errors.append(f"{scene_name}: fake_hardware_launch_command must explicitly set use_fake_hardware:=true")
         if "ros2 launch" not in fake_hardware_launch_command:

--- a/scripts/validate_supported_scenes_readiness.py
+++ b/scripts/validate_supported_scenes_readiness.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import subprocess
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from supported_scene_catalog import DEFAULT_SUPPORTED_SCENES_CATALOG, load_supported_scene_catalog
@@ -47,6 +49,98 @@ def _run_validator(repo_root: Path, workspace_root: Path, scene: str, skip_build
     return cmd, proc.returncode, payload
 
 MESH_INDEX_REL_PATH = "generated/scene_visual_mesh_index.json"
+
+
+def _parse_package_xml_name(scene_dir: Path) -> tuple[str | None, str | None]:
+    """Return the ROS package name declared by <scene_dir>/package.xml."""
+    package_xml = scene_dir / "package.xml"
+    if not package_xml.exists():
+        return None, "package_xml_missing: package.xml"
+    try:
+        root = ET.parse(package_xml).getroot()
+    except ET.ParseError as exc:
+        return None, f"package_xml_invalid_xml: package.xml ({exc})"
+    name_element = root.find("name")
+    if name_element is None or not (name_element.text or "").strip():
+        return None, "package_xml_missing_name: package.xml <name> must be non-empty"
+    return name_element.text.strip(), None
+
+
+def _extract_colcon_packages_select(command: str) -> list[str]:
+    """Extract package names passed to colcon build --packages-select."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return []
+    try:
+        option_index = tokens.index("--packages-select")
+    except ValueError:
+        return []
+    selected: list[str] = []
+    for token in tokens[option_index + 1:]:
+        if token.startswith("-"):
+            break
+        selected.extend(part for part in token.split(",") if part)
+    return selected
+
+
+def _extract_ros2_launch_package(command: str) -> str | None:
+    """Extract the package argument from a ros2 launch command."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return None
+    for index in range(len(tokens) - 2):
+        if tokens[index] == "ros2" and tokens[index + 1] == "launch":
+            return tokens[index + 2]
+    try:
+        launch_index = tokens.index("launch")
+    except ValueError:
+        return None
+    if launch_index + 1 < len(tokens):
+        return tokens[launch_index + 1]
+    return None
+
+
+def _check_package_contract(catalog_entry, scene_dir: Path) -> dict:
+    """Validate catalog package names and commands against package.xml."""
+    package_xml_name, package_xml_error = _parse_package_xml_name(scene_dir)
+    build_command_packages = _extract_colcon_packages_select(catalog_entry.build_command)
+    fake_launch_package = _extract_ros2_launch_package(catalog_entry.fake_hardware_launch_command)
+
+    result = {
+        "status": "PASS",
+        "package_xml_name": package_xml_name,
+        "build_command_packages_select": build_command_packages,
+        "fake_hardware_launch_package": fake_launch_package,
+        "blockers": [],
+    }
+
+    if package_xml_error:
+        result["blockers"].append(package_xml_error)
+    else:
+        if catalog_entry.package_name != package_xml_name:
+            result["blockers"].append(
+                f"catalog_package_name_mismatch: package_name={catalog_entry.package_name!r} package.xml name={package_xml_name!r}"
+            )
+        if catalog_entry.build_package_name != package_xml_name:
+            result["blockers"].append(
+                f"catalog_build_package_name_mismatch: build_package_name={catalog_entry.build_package_name!r} package.xml name={package_xml_name!r}"
+            )
+
+    if build_command_packages != [catalog_entry.build_package_name]:
+        result["blockers"].append(
+            "build_command_package_selection_mismatch: "
+            f"--packages-select={build_command_packages!r} build_package_name={catalog_entry.build_package_name!r}"
+        )
+    if fake_launch_package != catalog_entry.package_name:
+        result["blockers"].append(
+            f"fake_hardware_launch_package_mismatch: launch_package={fake_launch_package!r} package_name={catalog_entry.package_name!r}"
+        )
+
+    if result["blockers"]:
+        result["status"] = "BLOCKED"
+    return result
 
 
 def _mesh_index_result(status: str, blocker: str | None = None) -> dict:
@@ -244,6 +338,7 @@ def main() -> int:
             "guided_build_launch_readiness": {"status": "SKIPPED"},
             "build": {"status": "SKIPPED"},
             "launch_smoke": {"status": "SKIPPED"},
+            "package_contract": {"status": "SKIPPED"},
             "mesh_index_validation": {"status": "SKIPPED"},
             "mesh_index": {"status": "SKIPPED"},
             "blockers": [],
@@ -265,6 +360,9 @@ def main() -> int:
                 "missing_files": missing_required_files,
             }
             if scene_dir.exists():
+                package_contract = _check_package_contract(catalog_entry, scene_dir)
+                row["package_contract"] = package_contract
+                row["blockers"].extend(package_contract.get("blockers", []))
                 mesh_index = _check_mesh_index_contract(scene_dir)
                 row["mesh_index_validation"] = mesh_index
                 row["mesh_index"] = mesh_index
@@ -299,11 +397,25 @@ def main() -> int:
 
         row["static_validation"] = {"status": "PASS" if not missing_required_files else "FAIL", "missing_files": missing_required_files}
 
+        package_contract = _check_package_contract(catalog_entry, scene_dir)
+        row["package_contract"] = package_contract
+        if package_contract["status"] != "PASS":
+            row["blockers"].extend(package_contract.get("blockers", []))
+
         mesh_index = _check_mesh_index_contract(scene_dir)
         row["mesh_index_validation"] = mesh_index
         row["mesh_index"] = mesh_index
         if mesh_index["status"] != "PASS":
             row["blockers"].extend(mesh_index.get("blockers", []))
+
+        if package_contract["status"] != "PASS":
+            row["status"] = "BLOCKED"
+            row["validation_result"] = "BLOCKED"
+            if missing_required_files:
+                row["blockers"] = [f"missing_required_file: {m}" for m in missing_required_files] + row["blockers"]
+            row["blocker"] = _join_blockers(row["blockers"])
+            report["per_scene"].append(row)
+            continue
 
         if missing_required_files:
             row["status"] = "FAIL"

--- a/tests/test_validate_supported_scenes_readiness.py
+++ b/tests/test_validate_supported_scenes_readiness.py
@@ -73,6 +73,7 @@ def _assert_readiness_fields(row: dict) -> None:
     assert "missing_authoring_files" in row
     assert "missing_generated_files" in row
     assert "validation_result" in row
+    assert "package_contract" in row
     assert "mesh_index_validation" in row
 
 
@@ -354,3 +355,124 @@ def test_blocked_scene_preserves_known_blocker_and_reports_mesh_issue(tmp_path: 
     assert row["blockers"][0] == "awaiting launch repair"
     assert row["mesh_index_validation"]["status"] == "NO_RENDERABLE_ITEMS"
     assert "mesh_index_validation_no_renderable_items: generated/scene_visual_mesh_index.json contains 0 renderable items" in row["blockers"]
+
+
+def test_package_xml_name_mismatch_blocks_supported_scene(tmp_path: Path):
+    _write_scene(tmp_path / "scenes/pkg_mismatch", "actual_package")
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry(
+            "pkg_mismatch",
+            "scenes/pkg_mismatch",
+            package_name="catalog_package",
+            build_package_name="actual_package",
+            build_command="colcon build --symlink-install --packages-select actual_package",
+            fake_hardware_launch_command="ros2 launch catalog_package demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+        ),
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+
+    assert row["status"] == "BLOCKED"
+    assert row["validation_result"] == "BLOCKED"
+    assert row["package_contract"]["package_xml_name"] == "actual_package"
+    assert row["package_contract"]["status"] == "BLOCKED"
+    assert any("catalog_package_name_mismatch" in blocker for blocker in row["blockers"])
+
+
+def test_build_package_name_mismatch_blocks_supported_scene(tmp_path: Path):
+    _write_scene(tmp_path / "scenes/build_pkg_mismatch", "actual_package")
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry(
+            "build_pkg_mismatch",
+            "scenes/build_pkg_mismatch",
+            package_name="actual_package",
+            build_package_name="stale_build_package",
+            build_command="colcon build --symlink-install --packages-select stale_build_package",
+            fake_hardware_launch_command="ros2 launch actual_package demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+        ),
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+
+    assert row["status"] == "BLOCKED"
+    assert row["validation_result"] == "BLOCKED"
+    assert row["package_contract"]["package_xml_name"] == "actual_package"
+    assert row["package_contract"]["build_command_packages_select"] == ["stale_build_package"]
+    assert any("catalog_build_package_name_mismatch" in blocker for blocker in row["blockers"])
+
+
+def test_build_command_package_selection_mismatch_blocks_supported_scene(tmp_path: Path):
+    _write_scene(tmp_path / "scenes/build_command_mismatch", "actual_package")
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry(
+            "build_command_mismatch",
+            "scenes/build_command_mismatch",
+            package_name="actual_package",
+            build_package_name="actual_package",
+            build_command="colcon build --symlink-install --packages-select stale_build_package",
+            fake_hardware_launch_command="ros2 launch actual_package demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+        ),
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+
+    assert row["status"] == "BLOCKED"
+    assert row["validation_result"] == "BLOCKED"
+    assert row["package_contract"]["build_command_packages_select"] == ["stale_build_package"]
+    assert any("build_command_package_selection_mismatch" in blocker for blocker in row["blockers"])
+
+
+def test_fake_hardware_launch_package_mismatch_blocks_supported_scene(tmp_path: Path):
+    _write_scene(tmp_path / "scenes/launch_pkg_mismatch", "actual_package")
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry(
+            "launch_pkg_mismatch",
+            "scenes/launch_pkg_mismatch",
+            package_name="actual_package",
+            build_package_name="actual_package",
+            build_command="colcon build --symlink-install --packages-select actual_package",
+            fake_hardware_launch_command="ros2 launch stale_launch_package demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+        ),
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+
+    assert row["status"] == "BLOCKED"
+    assert row["validation_result"] == "BLOCKED"
+    assert row["package_contract"]["fake_hardware_launch_package"] == "stale_launch_package"
+    assert any("fake_hardware_launch_package_mismatch" in blocker for blocker in row["blockers"])
+
+
+def test_blocked_scene_preserves_known_blocker_and_reports_package_mismatch(tmp_path: Path):
+    _write_scene(tmp_path / "scenes/blocked_pkg_mismatch", "actual_package")
+    known_blocker = "awaiting package regeneration"
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([
+        _entry(
+            "blocked_pkg_mismatch",
+            "scenes/blocked_pkg_mismatch",
+            status="blocked",
+            known_blocker=known_blocker,
+            package_name="catalog_package",
+            build_package_name="actual_package",
+            build_command="colcon build --symlink-install --packages-select actual_package",
+            fake_hardware_launch_command="ros2 launch catalog_package demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+        ),
+    ])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+    row = payload["per_scene"][0]
+
+    assert row["status"] == "BLOCKED"
+    assert row["blocker"] == known_blocker
+    assert row["blockers"][0] == known_blocker
+    assert row["package_contract"]["status"] == "BLOCKED"
+    assert any("catalog_package_name_mismatch" in blocker for blocker in row["blockers"])


### PR DESCRIPTION
### Motivation
- Ensure the readiness validator verifies that catalog package names and build/launch commands actually match the scene's `package.xml` to catch stale or mismatched catalog entries early in per-scene readiness reporting. 
- Surface actionable blockers for package/command mismatches while preserving existing catalog blockers for scenes intentionally marked `blocked`.

### Description
- Added `scripts/validate_supported_scenes_readiness.py` helpers: `_parse_package_xml_name` (parses `<name>` from `package.xml` via `xml.etree.ElementTree`), `_extract_colcon_packages_select`, `_extract_ros2_launch_package`, and `_check_package_contract` to validate package/command contracts and produce `package_contract` results per scene. 
- For each scene, the readiness row now includes `package_contract` and the script compares `catalog_entry.package_name` and `catalog_entry.build_package_name` against the `package.xml` name, compares `--packages-select` in `build_command` to `build_package_name`, and compares the ros2 launch package argument in `fake_hardware_launch_command` to `package_name`; mismatches become blockers for `status: supported` scenes. 
- For `status: blocked` catalog entries the script preserves the known catalog blocker and appends any package-contract mismatch blockers to the row so the catalog reason remains authoritative while still surfacing mismatch details. 
- Relaxed early catalog-level rejection of package/build-command checks in `scripts/supported_scene_catalog.py` so the readiness script can report these mismatches per scene instead of failing catalog load. 
- Added tests in `tests/test_validate_supported_scenes_readiness.py` covering package.xml name mismatch, `build_package_name` mismatch, `--packages-select` selection mismatch, fake-hardware launch package mismatch, and blocked-scene mismatch reporting.

### Testing
- Compiled updated scripts with `python -m py_compile scripts/validate_supported_scenes_readiness.py scripts/supported_scene_catalog.py` and the files compiled successfully. 
- Ran the test suite with `pytest -q tests/test_validate_supported_scenes_readiness.py` and all tests passed (`21 passed`). 
- Executed the readiness runner `scripts/validate_supported_scenes_readiness.py --repo-root /workspace/Easy_Manipulator_Improved --workspace-root /workspace/Easy_Manipulator_Improved --json --skip-build --skip-launch-smoke` to produce the readiness report and markdown, which completed and produced a summary reflecting current catalog state (`total=8, fail=1, blocked=7`) so mismatches and existing scene blockers are visible in the report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1adf63f5f08331b40b7ac689aebe25)