### PR TITLE
test: Harden supported scene readiness coverage and add minimal scene fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,109 @@
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
+
+MINIMAL_AUTHORING_FILES = ["environment.yaml", "layout/workcell_studio_layout.yaml"]
+MINIMAL_GENERATED_FILES = [
+    "cell_definition.yaml",
+    "launch/demo.launch.py",
+    "urdf/scene.urdf.xacro",
+    "generated/scene_visual_mesh_index.json",
+]
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+@pytest.fixture
+def minimal_scene_factory(tmp_path: Path):
+    """Write configurable minimal scene directories and matching catalog entries."""
+
+    def _make_scene(
+        name: str,
+        *,
+        scene_path: str | None = None,
+        package_xml_name: str | None = None,
+        cmake_project_name: str | None = None,
+        package_name: str | None = None,
+        build_package_name: str | None = None,
+        missing_authoring_files: list[str] | tuple[str, ...] = (),
+        missing_generated_files: list[str] | tuple[str, ...] = (),
+        mesh_index_payload: Any = None,
+        catalog_status: str = "supported",
+        support_level: str = "supported",
+        known_blocker: str = "",
+        fake_hardware_launch_command: str | None = None,
+        build_command: str | None = None,
+        validation_command: str | None = None,
+        enabled: bool = True,
+        repo_root: Path | None = None,
+    ) -> tuple[Path, dict[str, Any]]:
+        root = repo_root or tmp_path
+        rel_scene_path = scene_path or f"scenes/{name}"
+        scene_dir = root / rel_scene_path
+        package_xml_name = package_xml_name or package_name or name
+        cmake_project_name = cmake_project_name or package_xml_name
+        package_name = package_name or package_xml_name
+        build_package_name = build_package_name or package_name
+        fake_hardware_launch_command = fake_hardware_launch_command or (
+            f"ros2 launch {package_name} demo.launch.py use_fake_hardware:=true launch_rviz:=true"
+        )
+        build_command = build_command or f"colcon build --symlink-install --packages-select {build_package_name}"
+        validation_command = validation_command or f"python3 scripts/validate_builder_generated_scene.py {rel_scene_path} --json"
+
+        _write_text(scene_dir / "package.xml", f"<package><name>{package_xml_name}</name></package>\n")
+        _write_text(scene_dir / "CMakeLists.txt", f"project({cmake_project_name})\nament_package()\n")
+
+        file_payloads = {
+            "environment.yaml": "name: env\n",
+            "layout/workcell_studio_layout.yaml": "schema_version: workcell_studio_layout/v1\nitems: [{id: item_1, type: marker}]\n",
+            "cell_definition.yaml": "robot: ur5\nend_effector: suction\nenvironment: demo\n",
+            "launch/demo.launch.py": "use_fake_hardware launch_rviz robot_state_publisher rviz xacro\n",
+            "urdf/scene.urdf.xacro": "<robot name='x'></robot>\n",
+            "scene_manifest.yaml": "schema_version: workcell_studio_scene_manifest/v1\n",
+            "generated/scene_package_readiness.json": json.dumps({"package_name": package_xml_name}),
+        }
+        for rel, text in file_payloads.items():
+            _write_text(scene_dir / rel, text)
+
+        if mesh_index_payload is None:
+            mesh_index_payload = {"items": [{"render_expected": True}]}
+        if isinstance(mesh_index_payload, str):
+            _write_text(scene_dir / "generated/scene_visual_mesh_index.json", mesh_index_payload)
+        else:
+            _write_text(scene_dir / "generated/scene_visual_mesh_index.json", json.dumps(mesh_index_payload))
+
+        for rel in [*missing_authoring_files, *missing_generated_files]:
+            target = scene_dir / rel
+            if target.exists():
+                target.unlink()
+
+        entry = {
+            "scene_name": name,
+            "package_name": package_name,
+            "scene_path": rel_scene_path,
+            "support_level": support_level,
+            "status": catalog_status,
+            "known_blocker": known_blocker,
+            "authoring_files": list(MINIMAL_AUTHORING_FILES),
+            "generated_files": list(MINIMAL_GENERATED_FILES),
+            "validation_command": validation_command,
+            "build_package_name": build_package_name,
+            "build_command": build_command,
+            "fake_hardware_launch_command": fake_hardware_launch_command,
+            "enabled": enabled,
+        }
+        return scene_dir, entry
+
+    return _make_scene

--- a/tests/test_all_scene_reproducibility.py
+++ b/tests/test_all_scene_reproducibility.py
@@ -23,9 +23,9 @@ def test_validator_emits_per_scene_report_and_contract_keys():
     import yaml
 
     catalog = yaml.safe_load((repo_root / "scenes" / "supported_scenes.yaml").read_text(encoding="utf-8"))
-    expected_names = {entry["scene_name"] for entry in catalog["scenes"] if entry.get("enabled", True)}
+    expected_entries = {entry["scene_name"]: entry for entry in catalog["scenes"] if entry.get("enabled", True)}
     names = {s.get("scene_name") for s in scenes}
-    assert expected_names == names
+    assert set(expected_entries) == names
     assert payload.get("supported_scene_catalog", "").endswith("scenes/supported_scenes.yaml")
 
     expected_keys = {
@@ -52,6 +52,12 @@ def test_validator_emits_per_scene_report_and_contract_keys():
         assert scene["status"] in {"PASS", "WARN", "FAIL", "SKIP", "BLOCKED"}
         assert isinstance(scene["support_level"], str) and scene["support_level"]
         assert isinstance(scene["catalog_status"], str) and scene["catalog_status"]
+        catalog_entry = expected_entries[scene["scene_name"]]
+        assert scene["support_level"] == catalog_entry["support_level"]
+        assert scene["catalog_status"] == catalog_entry["status"]
+        assert scene["known_blocker"] == catalog_entry["known_blocker"]
+        assert "use_fake_hardware:=true" in scene["fake_hardware_smoke_command"]
+        assert scene["fake_hardware_smoke_command"] == catalog_entry["fake_hardware_launch_command"]
         assert isinstance(scene["known_blocker"], str)
         assert isinstance(scene["blockers"], list)
         assert isinstance(scene["warnings"], list)
@@ -222,3 +228,31 @@ def test_missing_mesh_index_regeneration_is_opt_in(tmp_path, monkeypatch):
 
     assert audit.mesh_index_regeneration_status == "skipped_missing_regeneration_disabled"
     assert any("--regenerate-missing-mesh-indexes" in blocker for blocker in audit.blockers)
+
+
+def test_audit_scene_reports_malformed_mesh_index_clearly(tmp_path, minimal_scene_factory):
+    from scripts.validate_all_workcell_studio_scenes import audit_scene
+
+    scene_dir, _ = minimal_scene_factory("fixture_all_scene_bad_mesh", mesh_index_payload="{not-json")
+
+    audit = audit_scene(repo_root=tmp_path, scene_dir=scene_dir)
+
+    assert audit.status == "FAIL"
+    assert audit.mesh_index_regeneration_status == "not_needed"
+    assert audit.mesh_index_renderable_items == 0
+    assert any("generated mesh index unreadable: error: JSONDecodeError" in blocker for blocker in audit.blockers)
+
+
+def test_audit_scene_reports_non_renderable_mesh_index_clearly(tmp_path, minimal_scene_factory):
+    from scripts.validate_all_workcell_studio_scenes import audit_scene
+
+    scene_dir, _ = minimal_scene_factory(
+        "fixture_all_scene_empty_mesh",
+        mesh_index_payload={"items": [{"render_expected": False}]},
+    )
+
+    audit = audit_scene(repo_root=tmp_path, scene_dir=scene_dir)
+
+    assert audit.status == "FAIL"
+    assert audit.mesh_index_renderable_items == 0
+    assert "generated mesh index has no renderable items" in audit.blockers

--- a/tests/test_all_workcell_studio_scene_reproducibility.py
+++ b/tests/test_all_workcell_studio_scene_reproducibility.py
@@ -5,6 +5,14 @@ import subprocess
 import sys
 from pathlib import Path
 
+import yaml
+
+
+def _enabled_catalog_entries(repo_root: Path) -> list[dict]:
+    catalog = yaml.safe_load((repo_root / "scenes" / "supported_scenes.yaml").read_text(encoding="utf-8"))
+    entries = catalog.get("scenes", [])
+    return [entry for entry in entries if entry.get("enabled", True)]
+
 
 def test_all_scene_reproducibility_validator_runs_and_emits_json_report():
     repo_root = Path(__file__).resolve().parents[1]
@@ -22,24 +30,33 @@ def test_all_scene_reproducibility_validator_runs_and_emits_json_report():
     assert "Traceback" not in (proc.stdout + proc.stderr)
 
 
-def test_known_scene_set_matches_expected_contract():
+def test_report_scene_set_matches_supported_scene_catalog():
     repo_root = Path(__file__).resolve().parents[1]
-    script_text = (repo_root / "scripts" / "validate_all_workcell_studio_scenes.py").read_text(encoding="utf-8")
-    for name in [
-        "suction_test",
-        "ur10_2f_test",
-        "ur3_suction_test",
-        "ur5_2f_builder_pick_place_demo",
-        "ur5_2f_sorting_test",
-        "ur5_2f_test",
-        "ur5_3f_test",
-        "ur5_airpick4_test",
-    ]:
-        assert name in script_text
+    script = repo_root / "scripts" / "validate_all_workcell_studio_scenes.py"
+    report = repo_root / "build" / "workcell_studio" / "all_scene_reproducibility_report.json"
+
+    subprocess.run([sys.executable, str(script)], cwd=repo_root, check=True, capture_output=True, text=True)
+    payload = json.loads(report.read_text(encoding="utf-8"))
+
+    expected_entries = _enabled_catalog_entries(repo_root)
+    expected_names = {entry["scene_name"] for entry in expected_entries}
+    actual_by_name = {entry.get("scene_name"): entry for entry in payload.get("scenes", [])}
+
+    assert set(actual_by_name) == expected_names
+    for catalog_entry in expected_entries:
+        report_entry = actual_by_name[catalog_entry["scene_name"]]
+        assert report_entry["support_level"] == catalog_entry["support_level"]
+        assert report_entry["catalog_status"] == catalog_entry["status"]
+        assert report_entry["known_blocker"] == catalog_entry["known_blocker"]
 
 
-def test_validator_has_no_suction_only_special_case():
+def test_validator_has_no_catalog_scene_name_special_cases():
     repo_root = Path(__file__).resolve().parents[1]
     script_text = (repo_root / "scripts" / "validate_all_workcell_studio_scenes.py").read_text(encoding="utf-8")
-    assert "== \"suction_test\"" not in script_text
-    assert "!= \"suction_test\"" not in script_text
+
+    for entry in _enabled_catalog_entries(repo_root):
+        name = entry["scene_name"]
+        assert f'== "{name}"' not in script_text
+        assert f"== '{name}'" not in script_text
+        assert f'!= "{name}"' not in script_text
+        assert f"!= '{name}'" not in script_text

--- a/tests/test_validate_supported_scenes_readiness.py
+++ b/tests/test_validate_supported_scenes_readiness.py
@@ -117,18 +117,21 @@ def test_missing_scene_is_blocked(tmp_path: Path):
     assert row["missing_generated_files"] == GENERATED
 
 
-def test_missing_required_file_is_fail(tmp_path: Path):
-    scene_dir = tmp_path / "scenes/a"
-    _write_scene(scene_dir, "a")
-    (scene_dir / "environment.yaml").unlink()
-    (scene_dir / "generated/scene_visual_mesh_index.json").unlink()
+def test_supported_scene_with_missing_required_files_and_empty_blocker_fails_clearly(tmp_path: Path, minimal_scene_factory):
+    _, entry = minimal_scene_factory(
+        "fixture_missing_required",
+        missing_authoring_files=["environment.yaml"],
+        missing_generated_files=["generated/scene_visual_mesh_index.json"],
+        known_blocker="",
+    )
     reg = tmp_path / "registry.yaml"
-    reg.write_text(yaml.safe_dump(_catalog([_entry("a", "scenes/a")])), encoding="utf-8")
+    reg.write_text(yaml.safe_dump(_catalog([entry])), encoding="utf-8")
     payload = _run(tmp_path, reg)
     row = payload["per_scene"][0]
     _assert_readiness_fields(row)
     assert row["status"] == "FAIL"
     assert row["validation_result"] == "FAIL"
+    assert row["known_blocker"] == ""
     assert row["missing_authoring_files"] == ["environment.yaml"]
     assert row["missing_generated_files"] == ["generated/scene_visual_mesh_index.json"]
     assert row["blocker"].startswith("missing_required_file: environment.yaml; missing_required_file: generated/scene_visual_mesh_index.json")
@@ -148,12 +151,14 @@ def test_experimental_included_with_flag(tmp_path: Path):
     assert row["missing_generated_files"] == []
 
 
-def test_catalog_blocked_scene_uses_known_blocker(tmp_path: Path):
-    _write_scene(tmp_path / "scenes/blocked", "blocked")
+def test_blocked_scene_reports_known_blocker(tmp_path: Path, minimal_scene_factory):
+    _, entry = minimal_scene_factory(
+        "fixture_blocked",
+        catalog_status="blocked",
+        known_blocker="awaiting generated launch repair",
+    )
     reg = tmp_path / "registry.yaml"
-    reg.write_text(yaml.safe_dump(_catalog([
-        _entry("blocked", "scenes/blocked", status="blocked", known_blocker="awaiting generated launch repair"),
-    ])), encoding="utf-8")
+    reg.write_text(yaml.safe_dump(_catalog([entry])), encoding="utf-8")
     payload = _run(tmp_path, reg)
     row = payload["per_scene"][0]
     _assert_readiness_fields(row)
@@ -221,6 +226,23 @@ def test_catalog_rejects_blocked_scene_without_known_blocker(tmp_path: Path):
     )
 
 
+def test_catalog_rejects_fake_hardware_launch_command_without_fake_hardware_true(tmp_path: Path, minimal_scene_factory):
+    _, entry = minimal_scene_factory(
+        "fixture_unsafe_launch",
+        fake_hardware_launch_command="ros2 launch fixture_unsafe_launch demo.launch.py launch_rviz:=true",
+    )
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump(_catalog([entry])), encoding="utf-8")
+
+    payload = _run(tmp_path, reg)
+
+    assert payload["summary"]["blocked"] == 1
+    assert payload["per_scene"] == []
+    assert any(
+        "fixture_unsafe_launch: fake_hardware_launch_command must explicitly set use_fake_hardware:=true" in error
+        for error in payload["catalog_errors"]
+    )
+
 def test_catalog_rejects_unknown_status_and_support_level(tmp_path: Path):
     reg = tmp_path / "registry.yaml"
     reg.write_text(yaml.safe_dump(_catalog([
@@ -276,11 +298,10 @@ def test_default_catalog_declares_required_contract_fields():
         assert "use_fake_hardware:=true" in entry["fake_hardware_launch_command"]
 
 
-def test_malformed_mesh_index_reports_clear_contract_failure(tmp_path: Path):
-    _write_scene(tmp_path / "scenes/bad_mesh", "bad_mesh")
-    (tmp_path / "scenes/bad_mesh/generated/scene_visual_mesh_index.json").write_text("{not-json", encoding="utf-8")
+def test_malformed_mesh_index_reports_clear_contract_failure(tmp_path: Path, minimal_scene_factory):
+    _, entry = minimal_scene_factory("fixture_bad_mesh", mesh_index_payload="{not-json")
     reg = tmp_path / "registry.yaml"
-    reg.write_text(yaml.safe_dump(_catalog([_entry("bad_mesh", "scenes/bad_mesh")])), encoding="utf-8")
+    reg.write_text(yaml.safe_dump(_catalog([entry])), encoding="utf-8")
 
     payload = _run(tmp_path, reg)
     row = payload["per_scene"][0]
@@ -290,13 +311,10 @@ def test_malformed_mesh_index_reports_clear_contract_failure(tmp_path: Path):
     assert any("mesh_index_validation_invalid_json: generated/scene_visual_mesh_index.json" in b for b in row["blockers"])
 
 
-def test_zero_renderable_mesh_index_reports_clear_contract_failure(tmp_path: Path):
-    _write_scene(tmp_path / "scenes/empty_mesh", "empty_mesh")
-    (tmp_path / "scenes/empty_mesh/generated/scene_visual_mesh_index.json").write_text(
-        json.dumps({"visual_items": []}), encoding="utf-8"
-    )
+def test_zero_renderable_mesh_index_reports_clear_contract_failure(tmp_path: Path, minimal_scene_factory):
+    _, entry = minimal_scene_factory("fixture_empty_mesh", mesh_index_payload={"visual_items": []})
     reg = tmp_path / "registry.yaml"
-    reg.write_text(yaml.safe_dump(_catalog([_entry("empty_mesh", "scenes/empty_mesh")])), encoding="utf-8")
+    reg.write_text(yaml.safe_dump(_catalog([entry])), encoding="utf-8")
 
     payload = _run(tmp_path, reg)
     row = payload["per_scene"][0]
@@ -307,11 +325,13 @@ def test_zero_renderable_mesh_index_reports_clear_contract_failure(tmp_path: Pat
     assert "mesh_index_validation_no_renderable_items: generated/scene_visual_mesh_index.json contains 0 renderable items" in row["blockers"]
 
 
-def test_missing_mesh_index_reports_clear_validation_failure(tmp_path: Path):
-    _write_scene(tmp_path / "scenes/missing_mesh", "missing_mesh")
-    (tmp_path / "scenes/missing_mesh/generated/scene_visual_mesh_index.json").unlink()
+def test_missing_mesh_index_reports_clear_validation_failure(tmp_path: Path, minimal_scene_factory):
+    _, entry = minimal_scene_factory(
+        "fixture_missing_mesh",
+        missing_generated_files=["generated/scene_visual_mesh_index.json"],
+    )
     reg = tmp_path / "registry.yaml"
-    reg.write_text(yaml.safe_dump(_catalog([_entry("missing_mesh", "scenes/missing_mesh")])), encoding="utf-8")
+    reg.write_text(yaml.safe_dump(_catalog([entry])), encoding="utf-8")
 
     payload = _run(tmp_path, reg)
     row = payload["per_scene"][0]
@@ -321,13 +341,13 @@ def test_missing_mesh_index_reports_clear_validation_failure(tmp_path: Path):
     assert "mesh_index_validation_missing_file: generated/scene_visual_mesh_index.json" in row["blockers"]
 
 
-def test_malformed_mesh_index_item_entries_are_blockers(tmp_path: Path):
-    _write_scene(tmp_path / "scenes/malformed_items", "malformed_items")
-    (tmp_path / "scenes/malformed_items/generated/scene_visual_mesh_index.json").write_text(
-        json.dumps({"items": [{"render_expected": True}, "not-an-object"]}), encoding="utf-8"
+def test_malformed_mesh_index_item_entries_are_blockers(tmp_path: Path, minimal_scene_factory):
+    _, entry = minimal_scene_factory(
+        "fixture_malformed_items",
+        mesh_index_payload={"items": [{"render_expected": True}, "not-an-object"]},
     )
     reg = tmp_path / "registry.yaml"
-    reg.write_text(yaml.safe_dump(_catalog([_entry("malformed_items", "scenes/malformed_items")])), encoding="utf-8")
+    reg.write_text(yaml.safe_dump(_catalog([entry])), encoding="utf-8")
 
     payload = _run(tmp_path, reg)
     row = payload["per_scene"][0]
@@ -357,19 +377,17 @@ def test_blocked_scene_preserves_known_blocker_and_reports_mesh_issue(tmp_path: 
     assert "mesh_index_validation_no_renderable_items: generated/scene_visual_mesh_index.json contains 0 renderable items" in row["blockers"]
 
 
-def test_package_xml_name_mismatch_blocks_supported_scene(tmp_path: Path):
-    _write_scene(tmp_path / "scenes/pkg_mismatch", "actual_package")
+def test_package_xml_name_mismatch_blocks_supported_scene(tmp_path: Path, minimal_scene_factory):
+    _, entry = minimal_scene_factory(
+        "fixture_pkg_mismatch",
+        package_xml_name="actual_package",
+        package_name="catalog_package",
+        build_package_name="actual_package",
+        build_command="colcon build --symlink-install --packages-select actual_package",
+        fake_hardware_launch_command="ros2 launch catalog_package demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+    )
     reg = tmp_path / "registry.yaml"
-    reg.write_text(yaml.safe_dump(_catalog([
-        _entry(
-            "pkg_mismatch",
-            "scenes/pkg_mismatch",
-            package_name="catalog_package",
-            build_package_name="actual_package",
-            build_command="colcon build --symlink-install --packages-select actual_package",
-            fake_hardware_launch_command="ros2 launch catalog_package demo.launch.py use_fake_hardware:=true launch_rviz:=true",
-        ),
-    ])), encoding="utf-8")
+    reg.write_text(yaml.safe_dump(_catalog([entry])), encoding="utf-8")
 
     payload = _run(tmp_path, reg)
     row = payload["per_scene"][0]
@@ -381,19 +399,17 @@ def test_package_xml_name_mismatch_blocks_supported_scene(tmp_path: Path):
     assert any("catalog_package_name_mismatch" in blocker for blocker in row["blockers"])
 
 
-def test_build_package_name_mismatch_blocks_supported_scene(tmp_path: Path):
-    _write_scene(tmp_path / "scenes/build_pkg_mismatch", "actual_package")
+def test_build_package_name_mismatch_blocks_supported_scene(tmp_path: Path, minimal_scene_factory):
+    _, entry = minimal_scene_factory(
+        "fixture_build_pkg_mismatch",
+        package_xml_name="actual_package",
+        package_name="actual_package",
+        build_package_name="stale_build_package",
+        build_command="colcon build --symlink-install --packages-select stale_build_package",
+        fake_hardware_launch_command="ros2 launch actual_package demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+    )
     reg = tmp_path / "registry.yaml"
-    reg.write_text(yaml.safe_dump(_catalog([
-        _entry(
-            "build_pkg_mismatch",
-            "scenes/build_pkg_mismatch",
-            package_name="actual_package",
-            build_package_name="stale_build_package",
-            build_command="colcon build --symlink-install --packages-select stale_build_package",
-            fake_hardware_launch_command="ros2 launch actual_package demo.launch.py use_fake_hardware:=true launch_rviz:=true",
-        ),
-    ])), encoding="utf-8")
+    reg.write_text(yaml.safe_dump(_catalog([entry])), encoding="utf-8")
 
     payload = _run(tmp_path, reg)
     row = payload["per_scene"][0]


### PR DESCRIPTION
### Motivation

- Reduce brittle tests that assert hardcoded scene names and centralize scene fixture creation for reproducible catalog-driven tests.
- Ensure the supported-scene readiness validators surface clear failures for missing/generated files, malformed mesh indexes, package/launch mismatches, and catalog blocking metadata.
- Make tests assert that fake-hardware launch commands explicitly include `use_fake_hardware:=true` to preserve fake-hardware-first safety expectations.

### Description

- Added a reusable pytest fixture `minimal_scene_factory` in `tests/conftest.py` that writes minimal scene package directories and returns a matching supported-scene catalog entry with configurable `package.xml` name, CMake project name, `package_name`/`build_package_name`, missing authoring/generated files, mesh-index payload, `support_level`/`status`/`known_blocker`, and launch/build commands.
- Updated readiness and reproducibility tests to use the new fixture and removed hardcoded scene-name assertions by loading `scenes/supported_scenes.yaml` and comparing validator output to catalog entries instead of scanning source text.
- Added/updated tests to assert: supported scenes with missing required files and empty `known_blocker` fail clearly; blocked scenes preserve and report `known_blocker`; `fake_hardware_launch_command` values must include `use_fake_hardware:=true`; mismatches between `package.xml` `name` and catalog `package_name` / `build_package_name` / `--packages-select` are detected; malformed, missing, or non-renderable mesh indexes are reported clearly.
- Modified test files: `tests/conftest.py`, `tests/test_validate_supported_scenes_readiness.py`, `tests/test_all_scene_reproducibility.py`, and `tests/test_all_workcell_studio_scene_reproducibility.py` to use the fixture and new assertions.

### Testing

- Ran `pytest -q tests/test_validate_supported_scenes_readiness.py tests/test_all_scene_reproducibility.py tests/test_all_workcell_studio_scene_reproducibility.py`, and the suite completed successfully with `33 passed`.
- Compiled test modules with `python3 -m py_compile tests/conftest.py tests/test_validate_supported_scenes_readiness.py tests/test_all_scene_reproducibility.py tests/test_all_workcell_studio_scene_reproducibility.py` and observed no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ae64f39c08331903d8ff861c7c1f8)