### PR TITLE
Fix canvas model bootstrap function closure

### DIFF
--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -779,6 +779,8 @@ WorkcellStudioStarterLayoutSummary bootstrap_editable_layout_from_trusted_canoni
   root["items"] = items;
   summary.layout = root;
   return summary;
+}
+
 WorkcellStudioEnvironmentLayoutBootstrapResult bootstrap_environment_layout_from_editable_layout(
   const fs::path & scene_dir, const std::string & scene_name, const YAML::Node & editable_layout)
 {


### PR DESCRIPTION
### Motivation
- Resolve a C++ parse/compile error in Workcell Builder where subsequent functions were being parsed as nested definitions due to a missing function terminator in the canvas model source.

### Description
- Add the missing closing brace after `bootstrap_editable_layout_from_trusted_canonical_yaml` in `workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp` so `bootstrap_environment_layout_from_editable_layout` and following functions are at global scope.

### Testing
- Ran `git diff --check` which reported no whitespace/patch issues and verified the file change.
- Executed a brace-balance sanity check script over `src_workcell_studio_canvas_model.cpp` which reported balanced braces (`final level 0`).
- Attempted to run `colcon build --symlink-install --packages-select workcell_builder` but the container lacked `/opt/ros/humble/setup.bash` so a full build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af042ff408331818d39573a3d9dcd)