### PR TITLE
Fix canvas layout YAML bootstrap copy

### DIFF
--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -813,11 +813,12 @@ WorkcellStudioEnvironmentLayoutBootstrapResult bootstrap_environment_layout_from
   std::set<std::string> layout_ids;
   std::vector<std::string> layout_id_order;
   YAML::Node bootstrap_by_id(YAML::NodeType::Map);
-  for (const auto & layout_item : layout_items) {
+  for (YAML::const_iterator it = layout_items.begin(); it != layout_items.end(); ++it) {
+    const YAML::Node layout_item = *it;
     if (!layout_item_has_bootstrap_placeable_fields(layout_item)) continue;
     const std::string id = yaml_map_value_or_empty(layout_item, "id");
     if (layout_ids.insert(id).second) layout_id_order.push_back(id);
-    bootstrap_by_id[id] = layout_item;
+    bootstrap_by_id[id] = YAML::Clone(layout_item);
   }
   if (layout_ids.empty()) {
     result.error = "editable layout has no bootstrappable editable/placeable items";


### PR DESCRIPTION
### Motivation
- Prevent a yaml-cpp compile error when bootstrapping editable layout entries by avoiding storing `iterator_value` directly in a `YAML::Node` map.

### Description
- Replace range-based loop over `layout_items` with an explicit `YAML::const_iterator` loop and materialize each element into a `YAML::Node` before use in `bootstrap_environment_layout_from_editable_layout`.
- Clone each `layout_item` with `YAML::Clone` when inserting into `bootstrap_by_id` to avoid instantiating `YAML::convert<YAML::detail::iterator_value>` and preserve previous bootstrap semantics.
- Change affects `workcell_builder` and the file `workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp` only.

### Testing
- Ran `git diff --check` which passed.
- Attempted to run `colcon build --symlink-install --packages-select workcell_builder` but the container lacks `/opt/ros/humble/setup.bash`, so a full ROS build could not be executed here.
- No automated unit test run was possible in this environment; change is low-risk and localized to YAML node handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af0f71f3c8331bf1a9a5e55cb9cda)