### PR TITLE
Fix Scene3D full preview handoff

### DIFF
--- a/tests/test_scene3d_full_payload_handoff.py
+++ b/tests/test_scene3d_full_payload_handoff.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CANDIDATE_CPP = (ROOT / 'workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp').read_text(encoding='utf-8')
+MAIN_CPP = (ROOT / 'workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
+VIEWPORT_CPP = (ROOT / 'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp').read_text(encoding='utf-8')
+
+
+def test_default_layer_visibility_keeps_generated_mesh_preview_in_full_payload():
+    assert 'out.locked_generated_urdf_visual = true;' in CANDIDATE_CPP
+    assert 'Generated/locked URDF visuals are part of the full Scene3D payload' in CANDIDATE_CPP
+    assert 'Scene3D full payload committed: scene=%1 editable=%2 preview=%3 total=%4 visible=%5 mesh=%6 locked=%7' in MAIN_CPP
+
+
+def test_viewport_ingest_counters_reflect_combined_editable_and_preview_payload_before_paint():
+    ingest_start = VIEWPORT_CPP.index('void Scene3DViewportWidget::ingest_preview_items')
+    ingest_end = VIEWPORT_CPP.index('void Scene3DViewportWidget::fit_scene', ingest_start)
+    ingest_block = VIEWPORT_CPP[ingest_start:ingest_end]
+    for token in [
+        'last_render_counters.viewport_received_count = items.size();',
+        'last_render_counters.mesh_backed_count = mesh_backed_count;',
+        'last_render_counters.mesh_rendered_count = mesh_backed_count;',
+        'last_render_counters.locked_generated_urdf_visual_count = locked_urdf_count;',
+        'last_render_counters.editable_layout_count = editable_layout_count;',
+    ]:
+        assert token in ingest_block
+
+
+def test_scene3d_payload_filter_connections_are_null_guarded():
+    assert 'if (box) {' in MAIN_CPP
+    assert 'connect(box, &QCheckBox::toggled, this, [this](bool) { apply_scene3d_preview_layer_filters(true); });' in MAIN_CPP
+    assert 'if (snap_action && snap_to_grid_box_) {' in MAIN_CPP
+    assert 'if (fine_move_action && fine_move_mode_box_) {' in MAIN_CPP
+    assert 'if (unlock_action && unlock_robot_base_box_) {' in MAIN_CPP
+    assert 'if (minimap_action && show_minimap_box_) {' in MAIN_CPP

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -2164,7 +2164,9 @@ connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo
       preview_layer_mesh_preview_box_, preview_layer_primitive_fallback_box_,
       preview_layer_overlays_helpers_box_, preview_layer_warnings_missing_assets_box_})
   {
-    connect(box, &QCheckBox::toggled, this, [this](bool) { apply_scene3d_preview_layer_filters(true); });
+    if (box) {
+      connect(box, &QCheckBox::toggled, this, [this](bool) { apply_scene3d_preview_layer_filters(true); });
+    }
   }
   connect(duplicate_layout_button_, &QPushButton::clicked, this, &MainWindow::duplicate_selected_item);
   connect(delete_layout_button_, &QPushButton::clicked, this, &MainWindow::delete_selected_item);
@@ -2186,22 +2188,38 @@ connect(run_demo, &QPushButton::clicked, this, [this](){ append_studio_log("Demo
   connect(place_mode_button, &QPushButton::clicked, this, [this](){ set_canvas_interaction_mode(CanvasInteractionMode::Place); });
   connect(move_mode_button, &QPushButton::clicked, this, [this](){ set_canvas_interaction_mode(CanvasInteractionMode::Move); });
   connect(inspect_mode_button, &QPushButton::clicked, this, [this](){ set_canvas_interaction_mode(CanvasInteractionMode::Inspect); });
-  connect(snap_to_grid_box_, &QCheckBox::toggled, this, [this](bool){ rebuild_digital_twin_canvas(); });
-  connect(snap_action, &QAction::toggled, snap_to_grid_box_, &QCheckBox::setChecked);
-  connect(snap_to_grid_box_, &QCheckBox::toggled, snap_action, &QAction::setChecked);
-  connect(fine_move_action, &QAction::toggled, fine_move_mode_box_, &QCheckBox::setChecked);
-  connect(fine_move_mode_box_, &QCheckBox::toggled, fine_move_action, &QAction::setChecked);
-  connect(unlock_action, &QAction::toggled, unlock_robot_base_box_, &QCheckBox::setChecked);
-  connect(unlock_robot_base_box_, &QCheckBox::toggled, unlock_action, &QAction::setChecked);
-  connect(minimap_action, &QAction::toggled, show_minimap_box_, &QCheckBox::setChecked);
-  connect(show_minimap_box_, &QCheckBox::toggled, minimap_action, &QAction::setChecked);
-  connect(show_minimap_box_, &QCheckBox::toggled, this, [this](bool on){
-    minimap_requested_visible_ = on;
-    refresh_minimap_card();
-  });
+  if (snap_to_grid_box_) {
+    connect(snap_to_grid_box_, &QCheckBox::toggled, this, [this](bool){ rebuild_digital_twin_canvas(); });
+  }
+  if (snap_action && snap_to_grid_box_) {
+    connect(snap_action, &QAction::toggled, snap_to_grid_box_, &QCheckBox::setChecked);
+    connect(snap_to_grid_box_, &QCheckBox::toggled, snap_action, &QAction::setChecked);
+  }
+  if (fine_move_action && fine_move_mode_box_) {
+    connect(fine_move_action, &QAction::toggled, fine_move_mode_box_, &QCheckBox::setChecked);
+    connect(fine_move_mode_box_, &QCheckBox::toggled, fine_move_action, &QAction::setChecked);
+  }
+  if (unlock_action && unlock_robot_base_box_) {
+    connect(unlock_action, &QAction::toggled, unlock_robot_base_box_, &QCheckBox::setChecked);
+    connect(unlock_robot_base_box_, &QCheckBox::toggled, unlock_action, &QAction::setChecked);
+  }
+  if (minimap_action && show_minimap_box_) {
+    connect(minimap_action, &QAction::toggled, show_minimap_box_, &QCheckBox::setChecked);
+    connect(show_minimap_box_, &QCheckBox::toggled, minimap_action, &QAction::setChecked);
+  }
+  if (show_minimap_box_) {
+    connect(show_minimap_box_, &QCheckBox::toggled, this, [this](bool on){
+      minimap_requested_visible_ = on;
+      refresh_minimap_card();
+    });
+  }
   connect(digital_twin_canvas_->horizontalScrollBar(), &QScrollBar::valueChanged, this, [this](int){ refresh_minimap_card(); });
   connect(digital_twin_canvas_->verticalScrollBar(), &QScrollBar::valueChanged, this, [this](int){ refresh_minimap_card(); });
-  for (auto * box : {show_reach_overlay_box_, show_camera_fov_overlay_box_, show_pick_place_overlay_box_, show_trajectory_overlay_box_}) connect(box, &QCheckBox::toggled, this, [this](bool){ rebuild_digital_twin_canvas(); });
+  for (auto * box : {show_reach_overlay_box_, show_camera_fov_overlay_box_, show_pick_place_overlay_box_, show_trajectory_overlay_box_}) {
+    if (box) {
+      connect(box, &QCheckBox::toggled, this, [this](bool){ rebuild_digital_twin_canvas(); });
+    }
+  }
   auto * del_sc = new QShortcut(QKeySequence(Qt::Key_Delete), scene_builder); connect(del_sc,&QShortcut::activated,this,&MainWindow::delete_selected_item);
   auto * save_sc = new QShortcut(QKeySequence::Save, scene_builder); connect(save_sc,&QShortcut::activated,this,&MainWindow::save_layout_changes);
   auto * undo_sc = new QShortcut(QKeySequence::Undo, scene_builder); connect(undo_sc, &QShortcut::activated, this, &MainWindow::undo_layout_edit);
@@ -6777,6 +6795,17 @@ void MainWindow::populate_scene_hierarchy()
     scene_preview_widget_->set_preview_scene_name(selected_scene_state_.name);
     scene_preview_widget_->set_preview_status_summary(preview_provenance_summary_);
     apply_scene3d_preview_layer_filters(false);
+
+    const auto scene3d_full_payload_counters = scene_preview_widget_->render_debug_counters();
+    append_studio_log(QString(
+      "Scene3D full payload committed: scene=%1 editable=%2 preview=%3 total=%4 visible=%5 mesh=%6 locked=%7")
+      .arg(selected_scene_state_.name)
+      .arg(scene3d_full_payload_counters.editable_layout_count)
+      .arg(qMax(0, scene3d_full_payload_counters.viewport_received_count - scene3d_full_payload_counters.editable_layout_count))
+      .arg(scene3d_full_payload_counters.viewport_received_count)
+      .arg(scene3d_full_payload_counters.visible_count)
+      .arg(scene3d_full_payload_counters.mesh_backed_count)
+      .arg(scene3d_full_payload_counters.locked_generated_urdf_visual_count));
   }
   preview_warning_details_ = preview_warning_details;
 

--- a/workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp
@@ -30,16 +30,14 @@ bool include_preview_item_for_scene3d(
 Scene3DLayerVisibilityDefaults compute_scene3d_default_layer_visibility(
   const QVector<ScenePreviewWidget::PreviewItem> & all_items)
 {
-  bool has_editable = false, has_mesh = false, has_primitive = false;
-  for (const auto & item : all_items) {
-    const QString source_layer = token(item.source_layer);
-    const QString visual_source = token(item.active_visual_source);
-    if (source_layer == "editable_layout") has_editable = true;
-    if (visual_source == "mesh_preview") has_mesh = true;
-    if (source_layer == "primitive_fallback" || visual_source == "primitive_fallback") has_primitive = true;
-  }
+  Q_UNUSED(all_items);
   Scene3DLayerVisibilityDefaults out;
-  out.locked_generated_urdf_visual = !(has_editable || has_mesh || has_primitive);
+  // Generated/locked URDF visuals are part of the full Scene3D payload, not a
+  // mutually exclusive fallback. Keep them visible by default so opening a
+  // scene with editable layout rows plus mesh-index rows commits the combined
+  // payload to the viewport instead of leaving the render loop on the initial
+  // editable-only subset.
+  out.locked_generated_urdf_visual = true;
   return out;
 }
 

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -552,6 +552,9 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
   items = preview_items;
   int visible_item_count = 0;
   int skipped_item_count = 0;
+  int mesh_backed_count = 0;
+  int locked_urdf_count = 0;
+  int editable_layout_count = 0;
   QSet<QString> unique_visible_ids;
   std::vector<const ScenePreviewWidget::PreviewItem *> overlay_items;
   for (const auto & it : items) {
@@ -559,6 +562,9 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
     if (!show_safety && role == NormalizedRole::SafetyZone) { ++skipped_item_count; continue; }
     ++visible_item_count;
     unique_visible_ids.insert(it.id);
+    if (it.mesh_available || !it.mesh_path.trimmed().isEmpty()) ++mesh_backed_count;
+    if (is_generated_urdf_visual_item(it) || is_locked_urdf_item(it)) ++locked_urdf_count;
+    if (it.linked_to_editable_layout_state) ++editable_layout_count;
     if (is_overlay_visual_role(role)) overlay_items.push_back(&it);
   }
   last_render_counters.preview_items_count = items.size();
@@ -567,7 +573,11 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
   last_render_counters.visible_count = visible_item_count;
   last_render_counters.skipped_count = skipped_item_count;
   last_render_counters.unique_visible_item_count = unique_visible_ids.size();
+  last_render_counters.mesh_backed_count = mesh_backed_count;
+  last_render_counters.mesh_rendered_count = mesh_backed_count;
   last_render_counters.overlay_count = static_cast<int>(overlay_items.size());
+  last_render_counters.locked_generated_urdf_visual_count = locked_urdf_count;
+  last_render_counters.editable_layout_count = editable_layout_count;
   last_render_counters.hierarchy_child_row_count = visible_item_count;
   last_render_counters.last_paint_completed = false;
   last_render_counters.smoke_fallback_render_used = false;
@@ -758,6 +768,7 @@ void Scene3DViewportWidget::paintGL()
   draw_item_batch(physical_items, true);
   last_render_counters.rendered_count = rendered_item_count;
   last_render_counters.mesh_backed_count = mesh_backed_count;
+  last_render_counters.mesh_rendered_count = mesh_backed_count;
   last_render_counters.placeholder_count = placeholder_count;
   last_render_counters.primitive_fallback_count = placeholder_count;
   last_render_counters.last_paint_completed = true;
@@ -1018,6 +1029,7 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
   last_render_counters.skipped_count = skipped_item_count;
   last_render_counters.unique_visible_item_count = unique_visible_ids.size();
   last_render_counters.mesh_backed_count = mesh_backed_count;
+  last_render_counters.mesh_rendered_count = mesh_backed_count;
   last_render_counters.placeholder_count = placeholder_count;
   last_render_counters.primitive_fallback_count = placeholder_count;
   last_render_counters.overlay_count = overlay_count;


### PR DESCRIPTION
Summary:
- Keeps generated/locked URDF visual layers enabled by default so Scene3D commits the combined editable + mesh-preview payload after scene open.
- Adds a consolidated `Scene3D full payload committed` diagnostic using viewport counters for editable, preview, total, visible, mesh, and locked counts.
- Updates viewport ingest counters so pre-paint diagnostics reflect mesh-backed, editable, and locked preview items instead of reporting an editable-only payload.
- Guards several checkbox/action connections to avoid nullptr QObject connect warnings during startup.
- Adds focused regression coverage for the full payload handoff and guarded connections.

Validation:
- `git diff --check` — passed.
- `python3 -m pytest tests/test_scene3d_full_payload_handoff.py tests/test_scene3d_viewport_data_handoff.py tests/test_scene3d_viewport_render_cache_handoff.py tests/test_scene3d_hierarchy_layer_manager.py` — passed, 14 tests.
- Manual GUI/ROS validation not run in this container because `/opt/ros/humble/setup.bash` is missing.
- Requested manual validation commands to run in a ROS Humble workspace:
```bash
cd /home/user/workcell_ws
source /opt/ros/humble/setup.bash
colcon build --symlink-install --packages-select workcell_builder
source install/setup.bash
workcell_builder
```

Safety:
- Scene3D preview filtering/render handoff only; no launch files, controllers, runtime services, hardware parameters, or real robot motion paths changed.
- Fake-hardware defaults and real-hardware guards are unchanged.

Risks / rollback:
- Generated/locked URDF visuals are now visible by default in Scene3D. Users can still explicitly disable that layer with the existing preview layer control.
- If the expanded default payload is too visually dense for a scene, rollback is limited to the default layer visibility change in `scene3d_candidate_assembly.cpp` plus the associated diagnostics/tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af6b012ac83319f20fe89533deace)