### PR TITLE
Keep Scene3D smoke generated URDF layer additive

### DIFF
--- a/tests/test_scene3d_full_payload_handoff.py
+++ b/tests/test_scene3d_full_payload_handoff.py
@@ -4,6 +4,7 @@ ROOT = Path(__file__).resolve().parents[1]
 CANDIDATE_CPP = (ROOT / 'workcell_builder/workcell_builder/gui/scene3d_candidate_assembly.cpp').read_text(encoding='utf-8')
 MAIN_CPP = (ROOT / 'workcell_builder/workcell_builder/gui/mainwindow.cpp').read_text(encoding='utf-8')
 VIEWPORT_CPP = (ROOT / 'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp').read_text(encoding='utf-8')
+GUI_MAIN_CPP = (ROOT / 'workcell_builder/workcell_builder/gui/main.cpp').read_text(encoding='utf-8')
 
 
 def test_default_layer_visibility_keeps_generated_mesh_preview_in_full_payload():
@@ -33,3 +34,33 @@ def test_scene3d_payload_filter_connections_are_null_guarded():
     assert 'if (fine_move_action && fine_move_mode_box_) {' in MAIN_CPP
     assert 'if (unlock_action && unlock_robot_base_box_) {' in MAIN_CPP
     assert 'if (minimap_action && show_minimap_box_) {' in MAIN_CPP
+
+
+def test_scene3d_smoke_load_keeps_generated_urdf_layer_additive_for_mesh_index_payloads():
+    smoke_start = MAIN_CPP.index('bool MainWindow::load_scene_for_scene3d_smoke')
+    smoke_end = MAIN_CPP.index('void MainWindow::open_new_scene_creation_flow', smoke_start)
+    smoke_block = MAIN_CPP[smoke_start:smoke_end]
+
+    assert 'compute_scene3d_default_layer_visibility(all_scene_preview_items_)' in smoke_block
+    assert 'preview_layer_generated_urdf_visual_box_->setChecked(defaults.locked_generated_urdf_visual);' in smoke_block
+    assert 'preview_layer_generated_urdf_visual_box_->setChecked(!has_renderable_editable_mesh_or_primitive);' not in smoke_block
+    assert 'has_renderable_editable_mesh_or_primitive' not in smoke_block
+
+    # Regression coverage for the editable-layout + generated mesh-index smoke path:
+    # the smoke counters must expose both the assembled static payload and the
+    # post-filter counts forwarded through ScenePreviewWidget into the viewport.
+    for token in [
+        'source_mesh_index_item_count',
+        'assembled_preview_item_count',
+        'forwarded_to_preview_widget_count',
+        'forwarded_to_viewport_count',
+        'filtered_visible_candidate_count',
+    ]:
+        assert token in GUI_MAIN_CPP or token in MAIN_CPP
+
+    # The additive default means generated/locked URDF visuals are eligible in
+    # the same layer set as editable rows, mesh previews, and primitive fallbacks.
+    assert '"locked_generated_urdf_visual"' in smoke_block
+    assert '"editable_layout"' in smoke_block
+    assert '"mesh_preview"' in smoke_block
+    assert '"primitive_fallback"' in smoke_block

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -996,23 +996,14 @@ bool MainWindow::load_scene_for_scene3d_smoke(const QString & scene_name, const 
   }
   QApplication::processEvents(QEventLoop::AllEvents, 250);
   populate_scene_hierarchy();
-  const bool has_renderable_editable_mesh_or_primitive = [&]() {
-      for (const auto & item : all_scene_preview_items_) {
-        const QString source_layer = item.source_layer.trimmed().toLower();
-        const QString active_visual_source = item.active_visual_source.trimmed().toLower();
-        if (source_layer == QStringLiteral("editable_layout")) return true;
-        if (active_visual_source == QStringLiteral("mesh_preview")) return true;
-        if (source_layer == QStringLiteral("primitive_fallback") || active_visual_source == QStringLiteral("primitive_fallback")) return true;
-      }
-      return false;
-    }();
-  if (preview_layer_editable_layout_box_) preview_layer_editable_layout_box_->setChecked(true);
-  if (preview_layer_mesh_preview_box_) preview_layer_mesh_preview_box_->setChecked(true);
-  if (preview_layer_primitive_fallback_box_) preview_layer_primitive_fallback_box_->setChecked(true);
+  const auto defaults = workcell_builder::compute_scene3d_default_layer_visibility(all_scene_preview_items_);
+  if (preview_layer_editable_layout_box_) preview_layer_editable_layout_box_->setChecked(defaults.editable_layout);
+  if (preview_layer_mesh_preview_box_) preview_layer_mesh_preview_box_->setChecked(defaults.mesh_preview);
+  if (preview_layer_primitive_fallback_box_) preview_layer_primitive_fallback_box_->setChecked(defaults.primitive_fallback);
   if (preview_layer_overlays_helpers_box_) preview_layer_overlays_helpers_box_->setChecked(
       blockers == nullptr || blockers->isEmpty());
   if (preview_layer_generated_urdf_visual_box_) {
-    preview_layer_generated_urdf_visual_box_->setChecked(!has_renderable_editable_mesh_or_primitive);
+    preview_layer_generated_urdf_visual_box_->setChecked(defaults.locked_generated_urdf_visual);
   }
 
   const auto count_visible_for_layers = [&](const QSet<QString> & enabled_layers) {


### PR DESCRIPTION
### Motivation
- Ensure Scene3D smoke/load commits generated URDF visuals together with editable layout, mesh preview, and primitive fallback items instead of disabling generated visuals when mesh-index items exist.
- Reuse the shared Scene3D default visibility helper so smoke loads follow the same additive layer defaults used elsewhere.

### Description
- Replaced the local `has_renderable_editable_mesh_or_primitive` heuristic in `MainWindow::load_scene_for_scene3d_smoke` with `workcell_builder::compute_scene3d_default_layer_visibility(all_scene_preview_items_)` and applied its `defaults` to the preview layer checkboxes.
- Set `preview_layer_generated_urdf_visual_box_->setChecked(defaults.locked_generated_urdf_visual)` so generated/locked URDF visuals remain enabled by the shared default instead of being turned off when editable/mesh/primitive items exist.
- Preserved additive layer semantics in the visible-item calculation and fallback logic so editable layout, mesh preview, primitive fallback, and locked/generated URDF visuals can be forwarded together.
- Added a focused regression test `test_scene3d_smoke_load_keeps_generated_urdf_layer_additive_for_mesh_index_payloads` in `tests/test_scene3d_full_payload_handoff.py` that asserts the new default helper is used and that smoke/runtime counter tokens for assembled/forwarded preview payloads are present.

### Testing
- Ran `pytest -q tests/test_scene3d_full_payload_handoff.py` and all tests passed (`4 passed`).
- Ran `pytest -q tests/test_scene3d_runtime_acceptance.py` and all tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b008173388331800ca5817515c84f)