### PR TITLE
Fix Workcell Builder preview render debug counter build error

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -7095,9 +7095,6 @@ std::vector<MainWindow::SceneWorkflowStep> MainWindow::scene_workflow_steps() co
   const bool launch_ready = has("launch/demo.launch.py");
   const bool package_xml_ready = has("package.xml");
   const bool cmake_ready = has("CMakeLists.txt");
-  const bool environment_yaml_ready = has("environment.yaml");
-  const bool environment_layout_ready = has("environment_layout.yaml");
-  const bool studio_layout_ready = has("layout/workcell_studio_layout.yaml");
   const auto editable_layout_inspection = workcell_builder::inspect_editable_layout_entries(dir);
   const bool scene_xacro_ready = has("urdf/scene.urdf.xacro") || s.has_scene_urdf_xacro;
   const bool placeholder_launch_only = launch_ready && !scene_xacro_ready;
@@ -7109,7 +7106,6 @@ std::vector<MainWindow::SceneWorkflowStep> MainWindow::scene_workflow_steps() co
   const bool validation_gate_ready = validation_report_ready && !validation_stale_;
   const bool export_ready = yaml_ready && launch_ready;
   const bool fake_hardware_ready = launch_artifacts_ready_ && validation_gate_ready;
-  const bool preview_only_scene = !editable_layout_ready && (launch_ready || yaml_ready);
 
   int classified_editable_count = 0;
   int classified_generated_count = 0;

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -361,6 +361,7 @@ ScenePreviewWidget::RenderDebugCounters ScenePreviewWidget::render_debug_counter
   out.labels_suppressed_overlap = counters.labels_suppressed_overlap;
   out.hierarchy_child_row_count = counters.hierarchy_child_row_count;
   out.last_paint_completed = counters.last_paint_completed;
+  out.smoke_fallback_render_used = counters.smoke_fallback_render_used;
   return out;
 }
 

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -206,6 +206,7 @@ public:
     int labels_suppressed_overlap{ 0 };
     int hierarchy_child_row_count{ 0 };
     bool last_paint_completed{ false };
+    bool smoke_fallback_render_used{ false };
   };
   RenderDebugCounters render_debug_counters() const;
 


### PR DESCRIPTION
### Motivation
- Fix a compile error in `MainWindow::refresh_scene_builder_view_chips()` where `counters.smoke_fallback_render_used` was consumed but not forwarded from the preview widget, causing the `workcell_builder` package build to fail.

### Description
- Added `smoke_fallback_render_used` to `ScenePreviewWidget::RenderDebugCounters` in `workcell_builder/workcell_builder/gui/scene_preview_widget.h` so the preview counter matches the viewport counter.
- Forwarded `smoke_fallback_render_used` from `Scene3DViewportWidget::RenderDebugCounters` through `ScenePreviewWidget::render_debug_counters()` in `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp` so `MainWindow` can read the value.
- Removed unused local workflow variables in `workcell_builder/workcell_builder/gui/mainwindow.cpp` that produced warnings during the failed build.
- Affected files: `mainwindow.cpp`, `scene_preview_widget.h`, and `scene_preview_widget.cpp` under `workcell_builder/workcell_builder/gui`.

### Testing
- Ran `git diff --check` with no issues detected.
- Searched for occurrences with `rg "smoke_fallback_render_used"` to confirm the counter is declared, forwarded, and consumed; results matched the intended changes.
- Attempted `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder` but the command could not complete because `/opt/ros/humble/setup.bash` is not present in this container.
- Attempted `colcon build --symlink-install --packages-select workcell_builder` without ROS sourcing but the command could not run because `colcon` is not installed in this container, so a full build verification was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b0641af10833195153f1b6e01994e)