### PR TITLE
Preserve Scene3D preview-only selections

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -2803,6 +2803,55 @@ MainWindow::SelectedSceneItemState MainWindow::current_selected_scene_item() con
     state.valid = !state.id.isEmpty();
     return state.valid;
   };
+  const auto fill_from_preview = [&](const ScenePreviewWidget::PreviewItem * item) {
+    if (!item) return false;
+    state.id = item->id.trimmed();
+    state.display_name = item->display_name.trimmed();
+    state.role_or_category = item->role.trimmed();
+    if (state.role_or_category.isEmpty()) state.role_or_category = item->category.trimmed();
+    state.source_path = item->source_path.trimmed();
+    state.source_layer = item->source_layer.trimmed();
+    state.active_visual_source = item->active_visual_source.trimmed();
+    state.editable = item->editable && !item->locked;
+    state.locked = item->locked || !item->editable;
+    state.lock_reason = item->lock_reason.trimmed();
+    state.linked_to_editable_layout_state = item->linked_to_editable_layout_state;
+    state.visual_backing_status = item->mesh_available ? QStringLiteral("mesh") : QStringLiteral("primitive_fallback");
+    if (!item->mesh_load_warning.trimmed().isEmpty()) state.visual_backing_status = item->mesh_load_warning.trimmed();
+    state.generated_visual = item->locked || item->active_visual_source.trimmed() == QStringLiteral("locked_generated_urdf_visual");
+    state.item_type_classification = item->category.trimmed();
+    state.camera_id = item->camera_id.trimmed();
+    state.frame_id = item->frame_id.trimmed();
+    state.detection_label = item->detection_label.trimmed();
+    state.confidence = item->confidence;
+    state.tracking_id = item->tracking_id.trimmed();
+    state.snapshot_source_file = item->snapshot_source_file.trimmed();
+    state.alignment_warning = item->alignment_warning.trimmed();
+    state.pose_available = true;
+    state.pose_x = item->x;
+    state.pose_y = item->y;
+    state.pose_z = item->z;
+    state.roll = item->roll;
+    state.pitch = item->pitch;
+    state.yaw = item->yaw;
+    state.pose_text = QStringLiteral("xyz=(%1, %2, %3) rpy=(%4, %5, %6)")
+      .arg(item->x, 0, 'f', 3)
+      .arg(item->y, 0, 'f', 3)
+      .arg(item->z, 0, 'f', 3)
+      .arg(item->roll, 0, 'f', 3)
+      .arg(item->pitch, 0, 'f', 3)
+      .arg(item->yaw, 0, 'f', 3);
+    state.valid = !state.id.isEmpty();
+    return state.valid;
+  };
+  const auto find_preview_item_by_id = [&](const QString & id) -> const ScenePreviewWidget::PreviewItem * {
+    const QString stable_id = id.trimmed();
+    if (stable_id.isEmpty()) return nullptr;
+    for (const auto & item : all_scene_preview_items_) {
+      if (item.id.trimmed() == stable_id) return &item;
+    }
+    return scene_preview_widget_ ? scene_preview_widget_->preview_item_by_id(stable_id) : nullptr;
+  };
   const auto find_tree_item_by_id = [&](const QString & id) -> QTreeWidgetItem * {
     if (!scene_hierarchy_tree_ || id.trimmed().isEmpty()) return nullptr;
     for (int row = 0; row < scene_hierarchy_tree_->topLevelItemCount(); ++row) {
@@ -2831,11 +2880,16 @@ MainWindow::SelectedSceneItemState MainWindow::current_selected_scene_item() con
     if (fill_from_tree(tree_item)) return state;
     auto * canvas_item = find_canvas_item_by_id(selected_id);
     if (fill_from_canvas(canvas_item, selected_id)) return state;
+    if (fill_from_preview(find_preview_item_by_id(selected_id))) return state;
     return {};
   }
   if (scene_hierarchy_tree_ && fill_from_tree(scene_hierarchy_tree_->currentItem())) return state;
   if (digital_twin_scene_ && !digital_twin_scene_->selectedItems().isEmpty() &&
     fill_from_canvas(digital_twin_scene_->selectedItems().front())) return state;
+  if (scene_preview_widget_) {
+    const QString preview_selected_id = scene_preview_widget_->selected_preview_item_id().trimmed();
+    if (fill_from_preview(find_preview_item_by_id(preview_selected_id))) return state;
+  }
   return {};
 }
 
@@ -4858,7 +4912,7 @@ void MainWindow::apply_scene_selection(const QString & id, const QString & role,
   QGraphicsItem * matched_canvas_item = nullptr;
   if (digital_twin_scene_) {
     for (auto * gi : digital_twin_scene_->items()) {
-      if (gi->data(RoleId).toString().trimmed() == selected_id) {
+      if (gi && gi->data(RoleId).toString().trimmed() == selected_id) {
         matched_canvas_item = gi;
         break;
       }
@@ -4870,15 +4924,26 @@ void MainWindow::apply_scene_selection(const QString & id, const QString & role,
       if (auto * rect = qgraphicsitem_cast<QGraphicsRectItem *>(matched_canvas_item)) {
         rect->setPen(QPen(QColor("#f8fafc"), 3));
       }
+    } else {
+      digital_twin_scene_->clearSelection();
     }
   }
 
+  const auto find_preview_item_by_id = [&](const QString & stable_id) -> const ScenePreviewWidget::PreviewItem * {
+    const QString trimmed_id = stable_id.trimmed();
+    if (trimmed_id.isEmpty()) return nullptr;
+    for (const auto & item : all_scene_preview_items_) {
+      if (item.id.trimmed() == trimmed_id) return &item;
+    }
+    return scene_preview_widget_ ? scene_preview_widget_->preview_item_by_id(trimmed_id) : nullptr;
+  };
+  const ScenePreviewWidget::PreviewItem * matched_preview_item = find_preview_item_by_id(selected_id);
   if (scene_preview_widget_) scene_preview_widget_->select_preview_item(selected_id);
   selection_update_guard_ = false;
 
-  const bool selection_resolved = matched_tree_item || matched_canvas_item;
+  const bool selection_resolved = matched_tree_item || matched_canvas_item || matched_preview_item;
   if (!selection_resolved) {
-    append_studio_log(QString("Selection id missing after refresh, clearing atomically: %1").arg(selected_id));
+    append_studio_log(QString("Selection id absent from active scene payload after refresh, clearing atomically: %1").arg(selected_id));
     apply_scene_selection(QString(), selected_role, true, false);
     return;
   }
@@ -4888,6 +4953,25 @@ void MainWindow::apply_scene_selection(const QString & id, const QString & role,
   } else {
     sync_selected_item_state();
     refresh_selected_scene_item_labels(selected_item_state_);
+    if (selected_item_state_.valid) {
+      inspector_update_guard_ = true;
+      if (inspector_x_) inspector_x_->setValue(selected_item_state_.pose_x);
+      if (inspector_y_) inspector_y_->setValue(selected_item_state_.pose_y);
+      if (inspector_z_) inspector_z_->setValue(selected_item_state_.pose_z);
+      if (inspector_roll_) inspector_roll_->setValue(selected_item_state_.roll);
+      if (inspector_pitch_) inspector_pitch_->setValue(selected_item_state_.pitch);
+      if (inspector_yaw_) inspector_yaw_->setValue(selected_item_state_.yaw);
+      for (auto * sb : {inspector_x_, inspector_y_, inspector_z_, inspector_roll_, inspector_pitch_, inspector_yaw_}) {
+        if (sb) sb->setReadOnly(true);
+      }
+      for (auto * sb : {inspector_dim_x_, inspector_dim_y_, inspector_dim_z_}) {
+        if (sb) sb->setReadOnly(true);
+      }
+      if (inspector_apply_button_) inspector_apply_button_->setEnabled(false);
+      if (inspector_revert_button_) inspector_revert_button_->setEnabled(false);
+      if (inspector_live_update_box_) inspector_live_update_box_->setEnabled(false);
+      inspector_update_guard_ = false;
+    }
   }
   const auto selected_state = current_selected_scene_item();
   append_studio_log(QString("Selected item: %1 (%2) type=%3 source=%4 editable=%5 locked=%6")

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -230,7 +230,7 @@ void ScenePreviewWidget::set_3d_available(bool available, const QString & reason
   refresh_mode_and_state();
 }
 void ScenePreviewWidget::on_mode_changed(int){ refresh_mode_and_state(); }
-void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items){ preview_items_ = items; auto * viewport = static_cast<Scene3DViewportWidget *>(simple_3d_view_); viewport->ingest_preview_items(preview_items_); emit studio_log_requested(QString("Scene3D diagnostics {preview_items_count=%1, viewport_received_count=%2}").arg(preview_items_.size()).arg(viewport->render_debug_counters().viewport_received_count)); const bool has_selected = std::any_of(preview_items_.cbegin(), preview_items_.cend(), [this](const PreviewItem & it){ return it.id == selected_preview_item_id_; }); if (!has_selected && !selected_preview_item_id_.isEmpty()) { emit studio_log_requested(QString("Preview selection cleared after refresh (id missing): %1").arg(selected_preview_item_id_)); selected_preview_item_id_.clear(); static_cast<Scene3DViewportWidget *>(simple_3d_view_)->selected_id.clear(); emit preview_item_selected(QString(), QStringLiteral("unknown")); } else { static_cast<Scene3DViewportWidget *>(simple_3d_view_)->selected_id = selected_preview_item_id_; if (!selected_preview_item_id_.isEmpty()) emit studio_log_requested(QString("Preview selection restored after refresh: %1").arg(selected_preview_item_id_)); } viewport->fit_include_overlays = false; viewport->fit_scene(); emit studio_log_requested(preview_status_summary_.isEmpty() ? QString("Preview items loaded: %1.").arg(preview_items_.size()) : preview_status_summary_); fit_fallback_scene_to_items(false); refresh_info_chip(); update(); }
+void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items){ preview_items_ = items; auto * viewport = static_cast<Scene3DViewportWidget *>(simple_3d_view_); viewport->ingest_preview_items(preview_items_); emit studio_log_requested(QString("Scene3D diagnostics {preview_items_count=%1, viewport_received_count=%2}").arg(preview_items_.size()).arg(viewport->render_debug_counters().viewport_received_count)); const bool has_selected = std::any_of(preview_items_.cbegin(), preview_items_.cend(), [this](const PreviewItem & it){ return it.id == selected_preview_item_id_; }); static_cast<Scene3DViewportWidget *>(simple_3d_view_)->selected_id = selected_preview_item_id_; if (!selected_preview_item_id_.isEmpty()) { emit studio_log_requested(has_selected ? QString("Preview selection restored after refresh: %1").arg(selected_preview_item_id_) : QString("Preview selection retained after refresh; id is hidden by filters or absent from the visible preview payload: %1").arg(selected_preview_item_id_)); } viewport->fit_include_overlays = false; viewport->fit_scene(); emit studio_log_requested(preview_status_summary_.isEmpty() ? QString("Preview items loaded: %1.").arg(preview_items_.size()) : preview_status_summary_); fit_fallback_scene_to_items(false); refresh_info_chip(); update(); }
 void ScenePreviewWidget::set_preview_scene_name(const QString & scene_name){ preview_scene_name_ = scene_name.trimmed().isEmpty() ? "No scene" : scene_name.trimmed(); auto * v = static_cast<Scene3DViewportWidget *>(simple_3d_view_); v->scene_name = preview_scene_name_; refresh_info_chip(); v->update(); }
 void ScenePreviewWidget::set_preview_status_summary(const QString & summary){ preview_status_summary_ = summary.trimmed(); refresh_info_chip(); }
 void ScenePreviewWidget::set_task_overlay_model(const TaskOverlayModel & model){ overlay_model_ = model; static_cast<Scene3DViewportWidget *>(simple_3d_view_)->task_overlay = model; refresh_info_chip(); simple_3d_view_->update(); }
@@ -246,6 +246,15 @@ void ScenePreviewWidget::set_task_overlay_visibility(bool task_route, bool pick_
 }
 void ScenePreviewWidget::select_preview_item(const QString & id){ selected_preview_item_id_ = id; static_cast<Scene3DViewportWidget *>(simple_3d_view_)->selected_id = id; simple_3d_view_->update(); }
 QString ScenePreviewWidget::selected_preview_item_id() const { return selected_preview_item_id_; }
+const ScenePreviewWidget::PreviewItem * ScenePreviewWidget::preview_item_by_id(const QString & id) const
+{
+  const QString stable_id = id.trimmed();
+  if (stable_id.isEmpty()) return nullptr;
+  for (const auto & item : preview_items_) {
+    if (item.id.trimmed() == stable_id) return &item;
+  }
+  return nullptr;
+}
 
 ScenePreviewWidget::MeshPreviewMode ScenePreviewWidget::mesh_preview_mode() const { return mesh_preview_mode_; }
 

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -183,6 +183,7 @@ public:
   void set_label_mode(LabelMode mode);
   void select_preview_item(const QString & id);
   QString selected_preview_item_id() const;
+  const PreviewItem * preview_item_by_id(const QString & id) const;
   MeshPreviewMode mesh_preview_mode() const;
   void reload_meshes();
   struct RenderDebugCounters


### PR DESCRIPTION
### Motivation

- The selection logic cleared user selections when a selected item existed only in the canonical Scene3D preview payload and not in the 2D hierarchy or canvas, causing preview-only/generated/locked items to appear unselectable or to lose inspector visibility after a refresh.
- Generated/locked preview items must remain selectable and highlightable in the 3D preview while remaining read-only in the inspector and 2D canvas.

### Description

- Resolve selections against the canonical Scene3D preview payload in addition to the hierarchy tree and 2D canvas by adding a stable-id lookup path into `MainWindow::current_selected_scene_item()` and `MainWindow::apply_scene_selection()` so a matching preview item counts as a valid selection.
- Added `ScenePreviewWidget::preview_item_by_id()` and updated `ScenePreviewWidget::set_preview_items()` to preserve the selected id across filtered/visible refreshes instead of clearing it when the item is not present in the current visible list.
- When a selection is preview-only (no matching `QGraphicsItem`), keep the preview highlighted via `ScenePreviewWidget::select_preview_item()` and surface the item in the inspector while making transform controls read-only and disabling edit actions to enforce generated/locked semantics.
- Adjusted canvas selection handling to clear 2D selection when only a preview match exists and only clear the global selection if the id is absent from all three sources (hierarchy, canvas, preview).
- Files changed: `workcell_builder/workcell_builder/gui/mainwindow.cpp`, `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`, and `workcell_builder/workcell_builder/gui/scene_preview_widget.h`.

### Testing

- Ran `git diff --check` with no whitespace or trivial issues reported and the code changes staged cleanly.
- Attempted to run `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder`, but the build was blocked because `/opt/ros/humble/setup.bash` is not available in this container so a full build could not be executed.
- No automated unit tests were present for selection plumbing; manual runtime validation is recommended in an environment with ROS 2 Humble available (follow repository validation guidance: build `workcell_builder` and open the Scene Builder to confirm preview-only selections remain selectable, inspector is read-only for generated items, and selection is only cleared when the id no longer exists in the active scene payload).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b2b9472ac83319f9966758ee3e41d)