### PR TITLE
Add synthetic Scene3D selection roundtrip fixture and pytest for inspector/save/reload rules

### DIFF
--- a/tests/fixtures/scene3d_selection_roundtrip/cell_definition.yaml
+++ b/tests/fixtures/scene3d_selection_roundtrip/cell_definition.yaml
@@ -1,0 +1,9 @@
+schema_version: workcell_cell_definition/v1
+scene_name: synthetic_scene3d_selection_fixture
+assets:
+  - id: editable_fixture_plate
+    type: fixture
+    source: layout/workcell_studio_layout.yaml
+robot:
+  id: synthetic_fixture_robot
+  use_fake_hardware: true

--- a/tests/fixtures/scene3d_selection_roundtrip/environment.yaml
+++ b/tests/fixtures/scene3d_selection_roundtrip/environment.yaml
@@ -1,0 +1,13 @@
+schema_version: workcell_scene/v1
+scene:
+  id: synthetic_scene3d_selection_fixture
+robot:
+  name: synthetic_fixture_robot
+tool:
+  name: synthetic_fixture_tool
+placed_objects:
+  - id: editable_fixture_plate
+    type: fixture
+    pose:
+      xyz: [0.25, -0.10, 0.05]
+      rpy: [0.0, 0.0, 0.1]

--- a/tests/fixtures/scene3d_selection_roundtrip/generated/scene_visual_mesh_index.json
+++ b/tests/fixtures/scene3d_selection_roundtrip/generated/scene_visual_mesh_index.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "workcell_studio_visual_mesh_index/v1",
+  "scene_name": "synthetic_scene3d_selection_fixture",
+  "safe_for_preview": true,
+  "extraction_mode": "synthetic_fixture",
+  "visual_items": [
+    {
+      "id": "generated_locked_robot_visual",
+      "link": "synthetic_robot_base_link",
+      "category": "URDF Visual",
+      "geometry_type": "mesh",
+      "render_expected": true,
+      "resolved": true,
+      "source_path": "meshes/generated_locked_robot_visual.stl",
+      "resolved_path": "meshes/generated_locked_robot_visual.stl",
+      "resolved_source_path": "meshes/generated_locked_robot_visual.stl",
+      "package_uri": "package://synthetic_scene3d_selection_fixture/meshes/generated_locked_robot_visual.stl",
+      "pose": {"xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
+      "world_pose": {"xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
+      "visual_origin": {"xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
+      "mesh_scale": [1.0, 1.0, 1.0],
+      "chain_status": "ok",
+      "triangle_count": 12
+    }
+  ],
+  "items": [
+    {
+      "id": "generated_locked_robot_visual",
+      "source_layer": "locked_generated_urdf_visual",
+      "editable": false,
+      "locked": true
+    }
+  ]
+}

--- a/tests/fixtures/scene3d_selection_roundtrip/layout/workcell_studio_layout.yaml
+++ b/tests/fixtures/scene3d_selection_roundtrip/layout/workcell_studio_layout.yaml
@@ -1,0 +1,20 @@
+schema_version: workcell_studio_layout/v1
+scene_name: synthetic_scene3d_selection_fixture
+items:
+  - id: editable_fixture_plate
+    display_name: Editable Fixture Plate
+    type: fixture
+    category: fixture
+    role: object
+    source_path: meshes/editable_fixture_plate.stl
+    editable: true
+    locked: false
+    pose:
+      xyz: [0.25, -0.10, 0.05]
+      rpy: [0.0, 0.0, 0.1]
+    dimensions: [0.40, 0.20, 0.04]
+    mesh:
+      path: meshes/editable_fixture_plate.stl
+      scale: [1.0, 1.0, 1.0]
+      rpy: [0.0, 0.0, 0.0]
+      origin_offset: [0.0, 0.0, 0.0]

--- a/tests/fixtures/scene3d_selection_roundtrip/meshes/editable_fixture_plate.stl
+++ b/tests/fixtures/scene3d_selection_roundtrip/meshes/editable_fixture_plate.stl
@@ -1,0 +1,2 @@
+solid editable_fixture_plate
+endsolid editable_fixture_plate

--- a/tests/fixtures/scene3d_selection_roundtrip/meshes/generated_locked_robot_visual.stl
+++ b/tests/fixtures/scene3d_selection_roundtrip/meshes/generated_locked_robot_visual.stl
@@ -1,0 +1,2 @@
+solid generated_locked_robot_visual
+endsolid generated_locked_robot_visual

--- a/tests/fixtures/scene3d_selection_roundtrip/scene_manifest.yaml
+++ b/tests/fixtures/scene3d_selection_roundtrip/scene_manifest.yaml
@@ -1,0 +1,11 @@
+schema_version: workcell_scene_manifest/v1
+scene_name: synthetic_scene3d_selection_fixture
+template_name: synthetic_scene3d_selection_roundtrip
+files:
+  environment: environment.yaml
+  layout: layout/workcell_studio_layout.yaml
+  cell_definition: cell_definition.yaml
+  visual_mesh_index: generated/scene_visual_mesh_index.json
+safety:
+  fake_hardware_first: true
+  runtime_execution_enabled: false

--- a/tests/test_scene3d_synthetic_selection_roundtrip.py
+++ b/tests/test_scene3d_synthetic_selection_roundtrip.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tests" / "fixtures" / "scene3d_selection_roundtrip"
+
+
+@dataclass(frozen=True)
+class PreviewItem:
+    id: str
+    source_layer: str
+    active_visual_source: str
+    editable: bool
+    locked: bool
+    linked_to_editable_layout_state: bool
+    pose: dict[str, list[float]]
+    source_path: str
+
+
+def _load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _write_yaml(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _copy_fixture(tmp_path: Path, scene_name: str = "renamed_scene_without_branch") -> Path:
+    scene = tmp_path / scene_name
+    shutil.copytree(FIXTURE, scene)
+
+    for rel in [
+        "environment.yaml",
+        "layout/workcell_studio_layout.yaml",
+        "cell_definition.yaml",
+        "scene_manifest.yaml",
+    ]:
+        path = scene / rel
+        payload = _load_yaml(path)
+        if "scene_name" in payload:
+            payload["scene_name"] = scene_name
+        if payload.get("scene", {}).get("id"):
+            payload["scene"]["id"] = scene_name
+        _write_yaml(path, payload)
+
+    index_path = scene / "generated" / "scene_visual_mesh_index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["scene_name"] = scene_name
+    index_path.write_text(json.dumps(index, indent=2) + "\n", encoding="utf-8")
+    return scene
+
+
+def _build_preview_payload(scene: Path) -> list[PreviewItem]:
+    layout = _load_yaml(scene / "layout" / "workcell_studio_layout.yaml")
+    items: list[PreviewItem] = []
+    for item in layout.get("items", []):
+        if not isinstance(item, dict):
+            continue
+        locked = bool(item.get("locked", False))
+        editable = bool(item.get("editable", False)) and not locked
+        items.append(
+            PreviewItem(
+                id=item["id"],
+                source_layer="editable_layout",
+                active_visual_source="editable_layout",
+                editable=editable,
+                locked=locked,
+                linked_to_editable_layout_state=editable,
+                pose=item.get("pose", {"xyz": [0, 0, 0], "rpy": [0, 0, 0]}),
+                source_path=item.get("source_path") or item.get("mesh", {}).get("path", ""),
+            )
+        )
+
+    mesh_index = json.loads((scene / "generated" / "scene_visual_mesh_index.json").read_text(encoding="utf-8"))
+    for visual in mesh_index.get("visual_items", []):
+        if not isinstance(visual, dict):
+            continue
+        items.append(
+            PreviewItem(
+                id=visual["id"],
+                source_layer="locked_generated_urdf_visual",
+                active_visual_source="mesh_preview" if visual.get("geometry_type") == "mesh" else "primitive_fallback",
+                editable=False,
+                locked=True,
+                linked_to_editable_layout_state=False,
+                pose=visual.get("pose", {"xyz": [0, 0, 0], "rpy": [0, 0, 0]}),
+                source_path=visual.get("source_path", ""),
+            )
+        )
+    return items
+
+
+def _select(items: list[PreviewItem], item_id: str) -> PreviewItem:
+    return next(item for item in items if item.id == item_id)
+
+
+def _inspector_editable(item: PreviewItem) -> bool:
+    if item.locked:
+        return False
+    if item.source_layer == "editable_layout":
+        return item.editable
+    if item.source_layer in {"mesh_preview", "primitive_fallback"} or item.active_visual_source in {"mesh_preview", "primitive_fallback"}:
+        return item.editable and item.linked_to_editable_layout_state
+    return False
+
+
+def _save_editable_pose(scene: Path, selected: PreviewItem, xyz: list[float], rpy: list[float]) -> None:
+    if not _inspector_editable(selected):
+        raise PermissionError(f"locked/generated item edit rejected: {selected.id}")
+    layout_path = scene / "layout" / "workcell_studio_layout.yaml"
+    layout = _load_yaml(layout_path)
+    for item in layout.get("items", []):
+        if item.get("id") == selected.id:
+            item["pose"] = {"xyz": xyz, "rpy": rpy}
+            break
+    else:
+        raise KeyError(selected.id)
+    _write_yaml(layout_path, layout)
+
+
+def test_synthetic_fixture_has_required_authoring_and_preview_files() -> None:
+    required = [
+        "environment.yaml",
+        "layout/workcell_studio_layout.yaml",
+        "cell_definition.yaml",
+        "scene_manifest.yaml",
+        "generated/scene_visual_mesh_index.json",
+    ]
+    for rel in required:
+        assert (FIXTURE / rel).is_file(), rel
+
+    items = (_load_yaml(FIXTURE / "layout" / "workcell_studio_layout.yaml").get("items") or [])
+    editable_items = [item for item in items if item.get("editable") is True and item.get("locked") is False]
+    mesh_index = json.loads((FIXTURE / "generated" / "scene_visual_mesh_index.json").read_text(encoding="utf-8"))
+    locked_visuals = [item for item in mesh_index.get("visual_items", []) if item.get("id")]
+
+    assert [item["id"] for item in editable_items] == ["editable_fixture_plate"]
+    assert [item["id"] for item in locked_visuals] == ["generated_locked_robot_visual"]
+    assert mesh_index["safe_for_preview"] is True
+
+
+def test_selection_and_inspector_rules_are_layer_based_without_scene_name_branches(tmp_path: Path) -> None:
+    scene = _copy_fixture(tmp_path, "arbitrary_customer_fixture_name")
+    preview = _build_preview_payload(scene)
+
+    editable = _select(preview, "editable_fixture_plate")
+    locked = _select(preview, "generated_locked_robot_visual")
+
+    assert editable.source_layer == "editable_layout"
+    assert editable.linked_to_editable_layout_state is True
+    assert _inspector_editable(editable) is True
+
+    assert locked.source_layer == "locked_generated_urdf_visual"
+    assert locked.active_visual_source == "mesh_preview"
+    assert locked.linked_to_editable_layout_state is False
+    assert _inspector_editable(locked) is False
+
+
+def test_save_and_reload_updates_only_editable_layout_and_preserves_locked_preview(tmp_path: Path) -> None:
+    scene = _copy_fixture(tmp_path, "another_non_catalog_scene_name")
+    before = _build_preview_payload(scene)
+    editable = _select(before, "editable_fixture_plate")
+    locked = _select(before, "generated_locked_robot_visual")
+
+    _save_editable_pose(scene, editable, xyz=[0.70, -0.20, 0.11], rpy=[0.1, 0.2, 0.3])
+    try:
+        _save_editable_pose(scene, locked, xyz=[9, 9, 9], rpy=[9, 9, 9])
+    except PermissionError as exc:
+        assert "locked/generated item edit rejected" in str(exc)
+    else:  # pragma: no cover - this is the regression failure path.
+        raise AssertionError("locked generated mesh preview item was editable")
+
+    after = _build_preview_payload(scene)
+    reloaded_editable = _select(after, "editable_fixture_plate")
+    reloaded_locked = _select(after, "generated_locked_robot_visual")
+
+    assert reloaded_editable.pose == {"xyz": [0.70, -0.20, 0.11], "rpy": [0.1, 0.2, 0.3]}
+    assert reloaded_locked.pose == locked.pose
+    assert reloaded_locked.locked is True
+    assert reloaded_locked.linked_to_editable_layout_state is False


### PR DESCRIPTION
### Motivation
- Provide a small, self-contained Scene3D fixture and automated test to validate selection, inspector editable/read-only semantics, save, and reload behavior without relying on existing scene-name branches.

### Description
- Added a synthetic scene fixture under `tests/fixtures/scene3d_selection_roundtrip` containing `environment.yaml`, `layout/workcell_studio_layout.yaml`, `cell_definition.yaml`, `scene_manifest.yaml`, `generated/scene_visual_mesh_index.json`, and two meshes (one editable and one generated/locked).
- Added `tests/test_scene3d_synthetic_selection_roundtrip.py` which copies the fixture into a `tmp_path` with arbitrary scene names and exercises selection, inspector editability rules, saving editable layout items, and reloading while preserving locked generated previews.
- Test helpers implement a minimal preview payload builder, layer-based selection rules, and a save routine that only writes editable layout items to layout YAML, preserving fake-hardware-first / preview-only safety defaults.

### Testing
- Ran `pytest -q tests/test_scene3d_synthetic_selection_roundtrip.py` and it passed (3 tests passed).
- Verified fixture YAML/JSON parse with a small script that loads the authored YAMLs and `generated/scene_visual_mesh_index.json` and it succeeded.
- Ran a broader pytest set `pytest -q tests/test_scene3d_transform_editing_guard.py tests/test_scene3d_full_payload_handoff.py tests/test_scene3d_filter_behavior.py tests/test_scene3d_synthetic_selection_roundtrip.py` which produced 16 passing tests and 1 pre-existing failure in `test_viewport_ingest_counters_reflect_combined_editable_and_preview_payload_before_paint` due to `scene3d_viewport_widget.cpp` currently assigning `last_render_counters.mesh_rendered_count = 0` during ingest instead of the expected `mesh_backed_count` token.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b2b9959f48331a0d3a38c9ef9e765)