### PR TITLE
Render full 3D cylinders in Workcell Builder viewport

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1659,8 +1659,54 @@ void Scene3DViewportWidget::draw_box_outline(double cx, double cy, double cz, do
   glEnd();
   glEnable(GL_CULL_FACE);
 }
-void Scene3DViewportWidget::draw_cylinder(double cx, double cy, double cz, double radius, double height, const QColor & color, bool translucent)
-{ glColor4f(color.redF(), color.greenF(), color.blueF(), translucent ? 0.25f : 1.0f); glBegin(GL_TRIANGLE_FAN); glVertex3f(cx, cy, cz); for (int i = 0; i <= 32; ++i) { const double a = 2.0 * M_PI * i / 32.0; glVertex3f(cx + radius * qCos(a), cy, cz + radius * qSin(a)); } glEnd(); Q_UNUSED(height); }
+void Scene3DViewportWidget::draw_cylinder(double cx, double cy, double cz, double radius, double height, const QColor & color, bool translucent, int segment_count)
+{
+  const int segments = qMax(3, segment_count);
+  const double safe_radius = qMax(0.0, radius);
+  const double y_bottom = cy;
+  const double y_top = cy + height;
+
+  glColor4f(color.redF(), color.greenF(), color.blueF(), translucent ? 0.35f : 1.0f);
+
+  // Side wall. The cylinder is Y-up to match the viewport's box helper, where
+  // the height axis starts at cy and extends by the supplied height argument.
+  glBegin(GL_QUADS);
+  for (int i = 0; i < segments; ++i) {
+    const double a0 = 2.0 * M_PI * static_cast<double>(i) / static_cast<double>(segments);
+    const double a1 = 2.0 * M_PI * static_cast<double>(i + 1) / static_cast<double>(segments);
+    const double x0 = cx + safe_radius * qCos(a0);
+    const double z0 = cz + safe_radius * qSin(a0);
+    const double x1 = cx + safe_radius * qCos(a1);
+    const double z1 = cz + safe_radius * qSin(a1);
+    glVertex3f(static_cast<GLfloat>(x0), static_cast<GLfloat>(y_bottom), static_cast<GLfloat>(z0));
+    glVertex3f(static_cast<GLfloat>(x0), static_cast<GLfloat>(y_top), static_cast<GLfloat>(z0));
+    glVertex3f(static_cast<GLfloat>(x1), static_cast<GLfloat>(y_top), static_cast<GLfloat>(z1));
+    glVertex3f(static_cast<GLfloat>(x1), static_cast<GLfloat>(y_bottom), static_cast<GLfloat>(z1));
+  }
+  glEnd();
+
+  // Bottom cap.
+  glBegin(GL_TRIANGLE_FAN);
+  glVertex3f(static_cast<GLfloat>(cx), static_cast<GLfloat>(y_bottom), static_cast<GLfloat>(cz));
+  for (int i = 0; i <= segments; ++i) {
+    const double a = 2.0 * M_PI * static_cast<double>(i) / static_cast<double>(segments);
+    glVertex3f(static_cast<GLfloat>(cx + safe_radius * qCos(a)),
+               static_cast<GLfloat>(y_bottom),
+               static_cast<GLfloat>(cz + safe_radius * qSin(a)));
+  }
+  glEnd();
+
+  // Top cap.
+  glBegin(GL_TRIANGLE_FAN);
+  glVertex3f(static_cast<GLfloat>(cx), static_cast<GLfloat>(y_top), static_cast<GLfloat>(cz));
+  for (int i = segments; i >= 0; --i) {
+    const double a = 2.0 * M_PI * static_cast<double>(i) / static_cast<double>(segments);
+    glVertex3f(static_cast<GLfloat>(cx + safe_radius * qCos(a)),
+               static_cast<GLfloat>(y_top),
+               static_cast<GLfloat>(cz + safe_radius * qSin(a)));
+  }
+  glEnd();
+}
 void Scene3DViewportWidget::draw_frustum(const QColor & color, bool translucent)
 {
   const double h = qDegreesToRadians(camera_overlay.horizontal_fov_deg * 0.5);

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -150,7 +150,8 @@ private:
   void camera_matrices(QMatrix4x4 & out_proj, QMatrix4x4 & out_view) const;
   void draw_box(double cx, double cy, double cz, double sx, double sy, double sz, const QColor & color, bool translucent = false);
   void draw_box_outline(double cx, double cy, double cz, double sx, double sy, double sz, const QColor & color, float line_width = 2.5f);
-  void draw_cylinder(double cx, double cy, double cz, double radius, double height, const QColor & color, bool translucent = false);
+  void draw_cylinder(double cx, double cy, double cz, double radius, double height, const QColor & color,
+                     bool translucent = false, int segment_count = 32);
   void draw_frustum(const QColor & color, bool translucent = true);
   void draw_ground_grid_pass();
   void draw_world_axes_pass();


### PR DESCRIPTION
### Motivation
- Improve the cylinder primitive visual fidelity in the 3D viewport so cylinders have correct height, caps, and side walls and match box translucency behavior.
- Allow adjustable tessellation for smoother cylinders via a segment count while preserving existing callers.

### Description
- Changed `Scene3DViewportWidget::draw_cylinder()` signature to accept an optional `segment_count` (default `32`) in `scene3d_viewport_widget.h` and updated all code in `scene3d_viewport_widget.cpp` accordingly.
- Replaced the single-disk fallback with a full Y-up cylinder implementation that uses `height` to set the top (`cy + height`) and bottom (`cy`) Y coordinates, renders side walls as quads, and renders top and bottom caps with triangle fans.
- Matched translucent alpha to `draw_box()` by using `0.35f` for translucent mode and `1.0f` for opaque mode.
- Files changed: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp` and `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h`.

### Testing
- Ran `git diff --check` and repository diff checks, which succeeded without whitespace or conflict issues.
- Attempted to build with `colcon build --symlink-install --packages-select workcell_builder`, but the build was not executed because `/opt/ros/humble/setup.bash` is not present in this container (ROS 2 Humble missing), so compilation could not be verified here.
- Verified the change preserves caller compatibility by providing a default value for `segment_count` so existing calls such as `draw_robot_base_with_axis` remain source-compatible; no runtime regressions were validated due to the missing ROS build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b3adeb0e083319999df2838c74c87)