### PR TITLE
Classify Scene3D mesh load failures and thread PreviewItem metadata into mesh cache

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -82,6 +82,30 @@ bool item_has_credible_mesh_handoff(const ScenePreviewWidget::PreviewItem & item
          !item.source_path.trimmed().isEmpty();
 }
 
+bool is_package_uri_string(const QString & path)
+{
+  return path.trimmed().startsWith(QStringLiteral("package://"));
+}
+
+QString mesh_load_failure_reason_for_item(const QString & path, const ScenePreviewWidget::PreviewItem * item)
+{
+  const QString trimmed_path = path.trimmed();
+  if (is_package_uri_string(trimmed_path)) return QStringLiteral("package_uri_unresolved");
+  if (item) {
+    const QString package_uri = item->package_uri.trimmed();
+    const QString outcome = item->source_path_resolution_outcome.trimmed().toLower();
+    const bool package_uri_resolution_failed =
+      is_package_uri_string(package_uri) &&
+      (!item->resolved_source_path_stale ||
+       outcome.contains(QStringLiteral("unresolved_after_package_uri_attempt")) ||
+       outcome.contains(QStringLiteral("package_uri_unresolved")) ||
+       outcome.contains(QStringLiteral("unresolved_package_uri")));
+    if (package_uri_resolution_failed) return QStringLiteral("package_uri_unresolved");
+    if (item->resolved_source_path_stale) return QStringLiteral("stale_path");
+  }
+  return QStringLiteral("file_not_found");
+}
+
 bool parse_ascii_stl(const QByteArray & bytes, Scene3DViewportWidget::InternalTriangleMesh & out_mesh,
                      QString & out_error, int triangle_limit)
 {
@@ -1260,12 +1284,19 @@ bool Scene3DViewportWidget::should_draw_as_wireframe_for_test(const ScenePreview
          role == "real_urdf_primitive";
 }
 
-bool Scene3DViewportWidget::try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical) const
+bool Scene3DViewportWidget::try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical,
+                                                               const ScenePreviewWidget::PreviewItem * item,
+                                                               QString * out_failure_reason) const
 {
+  if (out_failure_reason) out_failure_reason->clear();
   QFileInfo info(path);
-  if (!info.exists() || !info.isFile()) return false;
+  if (!info.exists() || !info.isFile()) {
+    if (out_failure_reason) *out_failure_reason = mesh_load_failure_reason_for_item(path, item);
+    return false;
+  }
   out_canonical = info.canonicalFilePath();
   if (out_canonical.isEmpty()) out_canonical = info.absoluteFilePath();
+  if (out_canonical.isEmpty() && out_failure_reason) *out_failure_reason = mesh_load_failure_reason_for_item(path, item);
   return !out_canonical.isEmpty();
 }
 
@@ -1278,18 +1309,29 @@ bool Scene3DViewportWidget::warn_mesh_fallback_once(const QString & item_id, con
   return true;
 }
 
-const Scene3DViewportWidget::MeshCacheEntry & Scene3DViewportWidget::ensure_mesh_cached(const QString & path)
+const Scene3DViewportWidget::MeshCacheEntry & Scene3DViewportWidget::ensure_mesh_cached(const ScenePreviewWidget::PreviewItem & item,
+                                                                                           const QString & path)
 {
   const QFileInfo input_info(path);
   QString canonical;
-  if (!try_resolve_canonical_mesh_path(path, canonical)) canonical = input_info.absoluteFilePath();
+  QString load_failure_reason;
+  if (!try_resolve_canonical_mesh_path(path, canonical, &item, &load_failure_reason)) canonical = input_info.absoluteFilePath();
   auto it = mesh_cache_.find(canonical);
   if (it != mesh_cache_.end()) return it.value();
   MeshCacheEntry entry;
   entry.loaded = true;
+  entry.requested_path = path;
+  entry.package_uri = item.package_uri;
+  entry.resolved_source_path_original = item.resolved_source_path_original;
+  entry.source_path_resolution_outcome = item.source_path_resolution_outcome;
+  entry.resolved_source_path_stale = item.resolved_source_path_stale;
+  entry.load_failure_reason = load_failure_reason;
   if (!input_info.exists() || !input_info.isFile()) {
     entry.valid = false;
-    entry.warning = QStringLiteral("mesh missing on disk");
+    if (entry.load_failure_reason.trimmed().isEmpty()) {
+      entry.load_failure_reason = mesh_load_failure_reason_for_item(path, &item);
+    }
+    entry.warning = QStringLiteral("mesh missing on disk (reason: %1)").arg(entry.load_failure_reason);
     return mesh_cache_.insert(canonical, entry).value();
   }
   QFile file(canonical);
@@ -1375,6 +1417,12 @@ QJsonArray Scene3DViewportWidget::mesh_diagnostics_export() const
     row["loaded"] = e.loaded;
     row["valid"] = e.valid;
     row["warning"] = e.warning;
+    row["load_failure_reason"] = e.load_failure_reason;
+    row["requested_path"] = e.requested_path;
+    row["package_uri"] = e.package_uri;
+    row["resolved_source_path_stale"] = e.resolved_source_path_stale;
+    row["resolved_source_path_original"] = e.resolved_source_path_original;
+    row["source_path_resolution_outcome"] = e.source_path_resolution_outcome;
     row["oversized"] = e.oversized;
     const QString parser = (e.parser_type == "stl" || e.parser_type == "dae") ? e.parser_type : QStringLiteral("unsupported");
     row["parser_type"] = parser;
@@ -1398,7 +1446,7 @@ QJsonArray Scene3DViewportWidget::mesh_diagnostics_export() const
     for (const auto & item : items) {
       const QString mesh_source = !item.mesh_path.trimmed().isEmpty() ? item.mesh_path : item.source_path;
       QString canonical_source;
-      if (!try_resolve_canonical_mesh_path(mesh_source, canonical_source)) canonical_source = QFileInfo(mesh_source).absoluteFilePath();
+      if (!try_resolve_canonical_mesh_path(mesh_source, canonical_source, &item)) canonical_source = QFileInfo(mesh_source).absoluteFilePath();
       if (canonical_source != canonical_path) continue;
       QVector3D raw_span, final_span;
       QString reason;
@@ -1443,7 +1491,7 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
     warn_for_mode(QStringLiteral("mesh source missing"), mesh_source);
     return false;
   }
-  const MeshCacheEntry & entry = ensure_mesh_cached(mesh_source);
+  const MeshCacheEntry & entry = ensure_mesh_cached(it, mesh_source);
   auto reject = [&](const QString & code, const QString & detail = QString()) {
     const QString reason = detail.isEmpty() ? code : QStringLiteral("%1: %2").arg(code, detail);
     warn_for_mode(reason, mesh_source);
@@ -1738,7 +1786,7 @@ bool Scene3DViewportWidget::mesh_world_bounds_for_item(const ScenePreviewWidget:
 {
   const QString mesh_source = !item.mesh_path.trimmed().isEmpty() ? item.mesh_path : item.source_path;
   if (mesh_source.trimmed().isEmpty()) return false;
-  const MeshCacheEntry & cache = const_cast<Scene3DViewportWidget *>(this)->ensure_mesh_cached(mesh_source);
+  const MeshCacheEntry & cache = const_cast<Scene3DViewportWidget *>(this)->ensure_mesh_cached(item, mesh_source);
   if (!cache.loaded || !cache.valid || !cache.has_bounds) return false;
 
   QMatrix4x4 transform;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -199,6 +199,12 @@ private:
     QString parser_type;
     QString parse_status;
     QString parse_error;
+    QString load_failure_reason;
+    QString requested_path;
+    QString package_uri;
+    QString resolved_source_path_original;
+    QString source_path_resolution_outcome;
+    bool resolved_source_path_stale{ false };
     InternalTriangleMesh mesh;
     bool has_bounds{ false };
     QVector3D local_min;
@@ -212,9 +218,11 @@ private:
   };
   QHash<QString, MeshCacheEntry> mesh_cache_;
   QSet<QString> warned_mesh_fallbacks_;
-  bool try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical) const;
+  bool try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical,
+                                       const ScenePreviewWidget::PreviewItem * item = nullptr,
+                                       QString * out_failure_reason = nullptr) const;
   bool warn_mesh_fallback_once(const QString & item_id, const QString & reason, const QString & path);
-  const MeshCacheEntry & ensure_mesh_cached(const QString & path);
+  const MeshCacheEntry & ensure_mesh_cached(const ScenePreviewWidget::PreviewItem & item, const QString & path);
   bool validate_mesh_final_span(const ScenePreviewWidget::PreviewItem & it,
                                 const MeshCacheEntry & entry,
                                 const QString & mesh_source,

--- a/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
@@ -61,3 +61,16 @@ TEST(Scene3DMeshPreviewRegression, KeepsScene3DDiagnosticsSummaryLine)
   EXPECT_NE(src.find("Scene3D: editable=%1, mesh=%2, generated=%3, fallback=%4, missing=%5, locked=%6"), std::string::npos);
   EXPECT_NE(src.find("Scene3D warnings: missing_mesh=%1, unresolved_package_uri=%2, unsupported_extension=%3, stale_or_absolute_only_mesh_index=%4"), std::string::npos);
 }
+
+TEST(Scene3DMeshPreviewRegression, KeepsMeshLoadFailureReasonDiagnostics)
+{
+  const std::string src = load_file(std::string(WORKCELL_BUILDER_SOURCE_DIR) + "/gui/scene3d_viewport_widget.cpp");
+  ASSERT_FALSE(src.empty());
+  EXPECT_NE(src.find("package_uri_unresolved"), std::string::npos);
+  EXPECT_NE(src.find("stale_path"), std::string::npos);
+  EXPECT_NE(src.find("file_not_found"), std::string::npos);
+  EXPECT_NE(src.find("row[\"load_failure_reason\"]"), std::string::npos);
+  EXPECT_NE(src.find("mesh missing on disk (reason: %1)"), std::string::npos);
+  EXPECT_NE(src.find("ensure_mesh_cached(it, mesh_source)"), std::string::npos);
+  EXPECT_NE(src.find("ensure_mesh_cached(item, mesh_source)"), std::string::npos);
+}


### PR DESCRIPTION
### Motivation
- Improve diagnostics and user-facing warnings when a visual mesh cannot be loaded by using existing `PreviewItem` metadata to distinguish package URI resolution vs stale vs plain filesystem misses.
- Surface the specific failure reason in mesh diagnostics and visual-quality warnings so loaders and downstream tooling can act on deterministic, diagnosable outcomes.

### Description
- Update `try_resolve_canonical_mesh_path` to accept an optional `ScenePreviewWidget::PreviewItem` context and an `out_failure_reason` so resolution failures can be classified (`package_uri_unresolved`, `stale_path`, `file_not_found`).
- Add helper functions `is_package_uri_string` and `mesh_load_failure_reason_for_item` to encapsulate classification logic and reference `PreviewItem` fields: `package_uri`, `resolved_source_path_stale`, `resolved_source_path_original`, and `source_path_resolution_outcome`.
- Thread `PreviewItem` through mesh cache call sites by changing `ensure_mesh_cached` to accept the `PreviewItem` and record cache metadata fields (`load_failure_reason`, `requested_path`, `package_uri`, `resolved_source_path_original`, `source_path_resolution_outcome`, `resolved_source_path_stale`) in `MeshCacheEntry` and in `mesh_diagnostics_export()` output.
- Use the computed failure reason in missing-mesh warnings and the rejection/visual-quality paths so `mesh_diagnostics_export()` and visual warning badges include the reason.
- Add a small static regression check in `test/scene3d_mesh_preview_regression_test.cpp` that asserts presence of the new failure-reason markers and the item-aware cache call sites in the source file.

Files changed (key):
- `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`
- `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h`
- `workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp`

### Testing
- Ran a static marker check (inline Python snippet) to ensure the new failure reason strings and item-aware cache call sites are present in `scene3d_viewport_widget.cpp`, and it passed.
- Ran `git diff --check` to validate there are no whitespace/git-diff issues, and it passed.
- Attempted to run the component build with `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder`, but it was not executed successfully in this environment because `/opt/ros/humble/setup.bash` is not available; full build/test was therefore not run here.
- Note: the update includes only UI/diagnostic and data-flow changes; no runtime launch files, controller settings, or real-hardware paths were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b3ae0cd3083319824575a7e4539c8)