### PR TITLE
Track Scene3D visual-quality counters and derive preview status from render/source ratios

### DIFF
--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -641,9 +641,20 @@ private:
       candidate_json["visible"] = candidate.is_visible;
       candidate_json["parent_object_name"] = candidate.parent_object_name;
       candidate_json["viewport_received_count"] = candidate.counters.viewport_received_count;
+      candidate_json["total_payload_count"] = candidate.counters.total_payload_count;
       candidate_json["render_cache_count"] = candidate.counters.render_cache_count;
       candidate_json["rendered_count"] = candidate.counters.rendered_count;
       candidate_json["visible_count"] = candidate.counters.visible_count;
+      candidate_json["mesh_source_count"] = candidate.counters.mesh_source_count;
+      candidate_json["mesh_rendered_count"] = candidate.counters.mesh_rendered_count;
+      candidate_json["urdf_primitive_source_count"] = candidate.counters.urdf_primitive_source_count;
+      candidate_json["urdf_primitive_rendered_count"] = candidate.counters.urdf_primitive_rendered_count;
+      candidate_json["placeholder_count"] = candidate.counters.placeholder_count;
+      candidate_json["missing_geometry_count"] = candidate.counters.missing_geometry_count;
+      candidate_json["wireframe_fallback_count"] = candidate.counters.wireframe_fallback_count;
+      candidate_json["overlay_helper_count"] = candidate.counters.overlay_helper_count;
+      candidate_json["visual_quality_status"] = candidate.counters.visual_quality_status;
+      candidate_json["visual_quality_warnings"] = QJsonArray::fromStringList(candidate.counters.visual_quality_warnings);
       candidate_json["last_paint_completed"] = candidate.counters.last_paint_completed;
       viewport_candidates_json.append(candidate_json);
     }
@@ -715,6 +726,7 @@ private:
       }
       const auto rc = viewport ? viewport->render_debug_counters() : Scene3DViewportWidget::RenderDebugCounters{};
       counters["preview_items_count"] = rc.preview_items_count;
+      counters["total_payload_count"] = rc.total_payload_count;
       counters["viewport_received_count"] = rc.viewport_received_count;
       counters["render_cache_count"] = rc.render_cache_count;
       counters["visible_count"] = rc.visible_count;
@@ -722,8 +734,16 @@ private:
       counters["skipped_count"] = rc.skipped_count;
       counters["unique_visible_item_count"] = rc.unique_visible_item_count;
       counters["mesh_backed_count"] = rc.mesh_backed_count;
-      counters["placeholder_count"] = rc.placeholder_count;
+      counters["mesh_source_count"] = rc.mesh_source_count;
       counters["mesh_rendered_count"] = rc.mesh_rendered_count;
+      counters["urdf_primitive_source_count"] = rc.urdf_primitive_source_count;
+      counters["urdf_primitive_rendered_count"] = rc.urdf_primitive_rendered_count;
+      counters["placeholder_count"] = rc.placeholder_count;
+      counters["missing_geometry_count"] = rc.missing_geometry_count;
+      counters["wireframe_fallback_count"] = rc.wireframe_fallback_count;
+      counters["overlay_helper_count"] = rc.overlay_helper_count;
+      counters["visual_quality_status"] = rc.visual_quality_status;
+      counters["visual_quality_warnings"] = QJsonArray::fromStringList(rc.visual_quality_warnings);
       counters["generated_fallback_count"] = rc.generated_fallback_count;
       counters["editable_layout_count"] = rc.editable_layout_count;
       counters["primitive_fallback_count"] = rc.primitive_fallback_count;
@@ -746,14 +766,18 @@ private:
       qInfo() << "Scene3D smoke hierarchy ingest: scene=" << opts_.scene_name
               << "hierarchy_rows=" << rc.hierarchy_child_row_count;
     } else {
-      for (const QString & key : {QStringLiteral("preview_items_count"), QStringLiteral("viewport_received_count"), QStringLiteral("render_cache_count"),
+      for (const QString & key : {QStringLiteral("preview_items_count"), QStringLiteral("total_payload_count"), QStringLiteral("viewport_received_count"), QStringLiteral("render_cache_count"),
                                   QStringLiteral("visible_count"), QStringLiteral("rendered_count"), QStringLiteral("skipped_count"),
-                                  QStringLiteral("unique_visible_item_count"), QStringLiteral("mesh_backed_count"), QStringLiteral("placeholder_count"),
-                                  QStringLiteral("mesh_rendered_count"), QStringLiteral("generated_fallback_count"), QStringLiteral("editable_layout_count"),
+                                  QStringLiteral("unique_visible_item_count"), QStringLiteral("mesh_backed_count"), QStringLiteral("mesh_source_count"),
+                                  QStringLiteral("mesh_rendered_count"), QStringLiteral("urdf_primitive_source_count"), QStringLiteral("urdf_primitive_rendered_count"),
+                                  QStringLiteral("placeholder_count"), QStringLiteral("missing_geometry_count"), QStringLiteral("wireframe_fallback_count"),
+                                  QStringLiteral("overlay_helper_count"), QStringLiteral("generated_fallback_count"), QStringLiteral("editable_layout_count"),
                                   QStringLiteral("primitive_fallback_count"), QStringLiteral("locked_generated_urdf_visual_count"),
                                   QStringLiteral("overlay_count"), QStringLiteral("labels_drawn"), QStringLiteral("labels_suppressed_overlap")}) {
         counters[key] = 0;
       }
+      counters["visual_quality_status"] = QStringLiteral("UNAVAILABLE");
+      counters["visual_quality_warnings"] = QJsonArray{QStringLiteral("scene3d_viewport_widget_missing")};
       counters["last_paint_completed"] = false;
       counters["paint_cycle_completed"] = false;
       counters["active_viewport_received_count"] = 0;
@@ -790,36 +814,22 @@ private:
       warnings_.append("active_viewport_counter_handoff_failed");
       blockers_.append("active_viewport_counter_handoff_failed");
     }
-    const bool fallback_render_path_active =
-      counters.value("generated_fallback_count").toInt() > 0 ||
-      counters.value("primitive_fallback_count").toInt() > 0 ||
-      counters.value("editable_layout_count").toInt() > 0 ||
-      counters.value("smoke_fallback_render_used").toBool(false);
-    const bool paint_completed = counters.value("last_paint_completed").toBool(false);
-    const bool has_mesh_payload_pending_paint =
-      !paint_completed && counters.value("mesh_backed_count").toInt() > 0;
-    const bool has_mesh_or_meaningful_fallback =
-      counters.value("mesh_rendered_count").toInt() > 0 ||
-      has_mesh_payload_pending_paint ||
-      fallback_render_path_active;
-    const bool smoke_fallback_render_used =
-      counters.value("smoke_fallback_render_used").toBool(false);
-    const bool mesh_payload_failed_after_paint =
-      paint_completed &&
-      !smoke_fallback_render_used &&
-      counters.value("mesh_backed_count").toInt() > 0 &&
-      counters.value("mesh_rendered_count").toInt() <= 0;
-    const bool has_layout_mesh_warning_with_visible_fallback =
-      counters.value("visible_count").toInt() > 0 && fallback_render_path_active &&
-      (counters.value("placeholder_count").toInt() > 0 ||
-       counters.value("locked_generated_urdf_visual_count").toInt() > 0 ||
-       mesh_payload_failed_after_paint);
+    const QString visual_quality_status = counters.value("visual_quality_status").toString(QStringLiteral("UNAVAILABLE")).toUpper();
+    const int mesh_source_count = counters.value("mesh_source_count").toInt(counters.value("mesh_backed_count").toInt());
+    const int mesh_rendered_count = counters.value("mesh_rendered_count").toInt();
+    const int urdf_primitive_source_count = counters.value("urdf_primitive_source_count").toInt();
+    const int urdf_primitive_rendered_count = counters.value("urdf_primitive_rendered_count").toInt();
+    const bool source_render_ratio_failed =
+      (mesh_source_count > 0 && mesh_rendered_count <= 0) ||
+      (urdf_primitive_source_count > 0 && urdf_primitive_rendered_count <= 0);
 
     QString derived_preview_status = QStringLiteral("Unavailable");
-    if (has_layout_mesh_warning_with_visible_fallback) {
+    if (visual_quality_status == QStringLiteral("FAIL") || source_render_ratio_failed) {
+      derived_preview_status = QStringLiteral("Failed");
+    } else if (visual_quality_status == QStringLiteral("WARNING")) {
       derived_preview_status = QStringLiteral("Warning");
-    } else if (has_mesh_or_meaningful_fallback) {
-      derived_preview_status = fallback_render_path_active ? QStringLiteral("Fallback") : QStringLiteral("Available");
+    } else if (visual_quality_status == QStringLiteral("PASS")) {
+      derived_preview_status = QStringLiteral("Available");
     } else if (has_active_items) {
       derived_preview_status = QStringLiteral("Fallback");
     }
@@ -842,8 +852,8 @@ private:
     if (render_ready) {
       const int rendered_count = counters.value("rendered_count").toInt();
       const int unique_visible = counters.value("unique_visible_item_count").toInt();
-      const int classified = counters.value("mesh_rendered_count").toInt() + counters.value("generated_fallback_count").toInt() +
-        counters.value("editable_layout_count").toInt() + counters.value("overlay_count").toInt();
+      const int classified = counters.value("mesh_rendered_count").toInt() + counters.value("urdf_primitive_rendered_count").toInt() +
+        counters.value("wireframe_fallback_count").toInt() + counters.value("overlay_helper_count").toInt();
       if ((rendered_count > 0 && classified == 0) || unique_visible <= 1) blockers_.append("visual_quality_failed");
     }
     root["readiness_markers"] = readiness_markers;

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -4798,19 +4798,27 @@ void MainWindow::refresh_scene_builder_view_chips()
     launch_ready = s.has_launch_demo && s.has_package_xml;
     if (scene_preview_widget_) {
       const auto counters = scene_preview_widget_->render_debug_counters();
-      const int rendered = counters.rendered_count;
-      const int mesh_count = counters.mesh_rendered_count;
-      const int mesh_backed_count = counters.mesh_backed_count;
-      const int generated_fallback_count = counters.generated_fallback_count;
-      const int primitive_fallback_count = counters.primitive_fallback_count;
-      if (rendered <= 0 && mesh_backed_count <= 0) {
-        preview_chip_status = QStringLiteral("Unavailable");
-      } else if (mesh_count > 0 || (!counters.last_paint_completed && mesh_backed_count > 0)) {
+      const QString quality = counters.visual_quality_status.trimmed().toUpper();
+      const int mesh_source_count = counters.mesh_source_count > 0 ? counters.mesh_source_count : counters.mesh_backed_count;
+      const int mesh_rendered_count = counters.mesh_rendered_count;
+      const int urdf_primitive_source_count = counters.urdf_primitive_source_count;
+      const int urdf_primitive_rendered_count = counters.urdf_primitive_rendered_count;
+      const bool source_render_ratio_failed =
+        (mesh_source_count > 0 && mesh_rendered_count <= 0) ||
+        (urdf_primitive_source_count > 0 && urdf_primitive_rendered_count <= 0);
+      const bool high_mesh_source_low_render =
+        mesh_source_count >= 4 && mesh_rendered_count > 0 && mesh_rendered_count * 2 < mesh_source_count;
+
+      if (quality == QStringLiteral("FAIL") || source_render_ratio_failed) {
+        preview_chip_status = QStringLiteral("Failed");
+      } else if (quality == QStringLiteral("WARNING") || high_mesh_source_low_render) {
+        preview_chip_status = QStringLiteral("Warning");
+      } else if (quality == QStringLiteral("PASS")) {
         preview_chip_status = QStringLiteral("Available");
-      } else if (generated_fallback_count > 0 || primitive_fallback_count > 0 || counters.smoke_fallback_render_used) {
+      } else if (counters.rendered_count > 0 || counters.visible_count > 0 || counters.smoke_fallback_render_used) {
         preview_chip_status = QStringLiteral("Fallback");
       } else {
-        preview_chip_status = QStringLiteral("Warning");
+        preview_chip_status = QStringLiteral("Unavailable");
       }
     }
   }

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -82,6 +82,63 @@ bool item_has_credible_mesh_handoff(const ScenePreviewWidget::PreviewItem & item
          !item.source_path.trimmed().isEmpty();
 }
 
+bool item_has_explicit_primitive_dimensions(const ScenePreviewWidget::PreviewItem & item)
+{
+  return item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001;
+}
+
+void finalize_visual_quality(Scene3DViewportWidget::RenderDebugCounters & counters)
+{
+  counters.total_payload_count = counters.preview_items_count;
+  counters.mesh_backed_count = counters.mesh_source_count;
+  counters.overlay_count = counters.overlay_helper_count;
+  counters.primitive_fallback_count = counters.urdf_primitive_rendered_count;
+
+  QStringList warnings;
+  QString status = QStringLiteral("PASS");
+
+  if (counters.visible_count <= 0 && counters.total_payload_count <= 0) {
+    status = QStringLiteral("UNAVAILABLE");
+    warnings.append(QStringLiteral("no_preview_payload"));
+  }
+  if (counters.mesh_source_count > 0 && counters.mesh_rendered_count <= 0) {
+    status = QStringLiteral("FAIL");
+    warnings.append(QStringLiteral("mesh_sources_present_but_none_rendered"));
+  }
+  if (counters.urdf_primitive_source_count > 0 && counters.urdf_primitive_rendered_count <= 0) {
+    status = QStringLiteral("FAIL");
+    warnings.append(QStringLiteral("urdf_primitive_sources_present_but_none_rendered"));
+  }
+
+  const bool high_mesh_source_low_render =
+    counters.mesh_source_count >= 4 &&
+    counters.mesh_rendered_count > 0 &&
+    counters.mesh_rendered_count * 2 < counters.mesh_source_count;
+  if (high_mesh_source_low_render) {
+    if (status != QStringLiteral("FAIL")) status = QStringLiteral("WARNING");
+    warnings.append(QStringLiteral("mesh_source_count_high_but_mesh_rendered_count_low"));
+  }
+  if (counters.missing_geometry_count > 0) {
+    if (status == QStringLiteral("PASS")) status = QStringLiteral("WARNING");
+    warnings.append(QStringLiteral("missing_geometry_rendered_as_warning_markers"));
+  }
+  if (counters.placeholder_count > 0) {
+    if (status == QStringLiteral("PASS")) status = QStringLiteral("WARNING");
+    warnings.append(QStringLiteral("placeholder_geometry_rendered"));
+  }
+  if (counters.visible_count > 0 &&
+      counters.mesh_source_count <= 0 &&
+      counters.urdf_primitive_source_count <= 0 &&
+      counters.wireframe_fallback_count > 0 &&
+      status == QStringLiteral("PASS")) {
+    status = QStringLiteral("WARNING");
+    warnings.append(QStringLiteral("wireframe_fallback_only_preview"));
+  }
+
+  counters.visual_quality_status = status;
+  counters.visual_quality_warnings = warnings;
+}
+
 bool parse_ascii_stl(const QByteArray & bytes, Scene3DViewportWidget::InternalTriangleMesh & out_mesh,
                      QString & out_error, int triangle_limit)
 {
@@ -560,7 +617,8 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
   items = preview_items;
   int visible_item_count = 0;
   int skipped_item_count = 0;
-  int mesh_backed_count = 0;
+  int mesh_source_count = 0;
+  int urdf_primitive_source_count = 0;
   int locked_urdf_count = 0;
   int editable_layout_count = 0;
   QSet<QString> unique_visible_ids;
@@ -570,25 +628,34 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
     if (!show_safety && role == NormalizedRole::SafetyZone) { ++skipped_item_count; continue; }
     ++visible_item_count;
     unique_visible_ids.insert(it.id);
-    if (item_has_credible_mesh_handoff(it)) ++mesh_backed_count;
-    if (is_generated_urdf_visual_item(it) || is_locked_urdf_item(it)) ++locked_urdf_count;
+    const bool generated_urdf = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
+    const bool overlay_helper = is_overlay_only_item(it) || is_overlay_visual_role(role);
+    if (!overlay_helper && item_has_credible_mesh_handoff(it)) ++mesh_source_count;
+    if (!overlay_helper && generated_urdf && !item_has_credible_mesh_handoff(it) && item_has_explicit_primitive_dimensions(it)) ++urdf_primitive_source_count;
+    if (generated_urdf) ++locked_urdf_count;
     if (it.linked_to_editable_layout_state) ++editable_layout_count;
-    if (is_overlay_visual_role(role)) overlay_items.push_back(&it);
+    if (overlay_helper) overlay_items.push_back(&it);
   }
   last_render_counters.preview_items_count = items.size();
+  last_render_counters.total_payload_count = items.size();
   last_render_counters.viewport_received_count = items.size();
   last_render_counters.render_cache_count = mesh_cache_.size();
   last_render_counters.visible_count = visible_item_count;
   last_render_counters.skipped_count = skipped_item_count;
   last_render_counters.unique_visible_item_count = unique_visible_ids.size();
-  last_render_counters.mesh_backed_count = mesh_backed_count;
+  last_render_counters.mesh_source_count = mesh_source_count;
+  last_render_counters.mesh_backed_count = mesh_source_count;
   last_render_counters.mesh_rendered_count = 0;
+  last_render_counters.urdf_primitive_source_count = urdf_primitive_source_count;
+  last_render_counters.urdf_primitive_rendered_count = 0;
+  last_render_counters.overlay_helper_count = static_cast<int>(overlay_items.size());
   last_render_counters.overlay_count = static_cast<int>(overlay_items.size());
   last_render_counters.locked_generated_urdf_visual_count = locked_urdf_count;
   last_render_counters.editable_layout_count = editable_layout_count;
   last_render_counters.hierarchy_child_row_count = visible_item_count;
   last_render_counters.last_paint_completed = false;
   last_render_counters.smoke_fallback_render_used = false;
+  finalize_visual_quality(last_render_counters);
   const QString diagnostics_path = QString::fromUtf8(qgetenv("SCENE3D_MESH_DIAGNOSTICS_JSON"));
   if (!diagnostics_path.trimmed().isEmpty()) {
     QFile out_file(diagnostics_path);
@@ -709,9 +776,12 @@ void Scene3DViewportWidget::paintGL()
   int visible_item_count = 0;
   int skipped_item_count = 0;
   int rendered_item_count = 0;
-  int mesh_backed_count = 0;
+  int mesh_source_count = 0;
   int mesh_rendered_count = 0;
+  int urdf_primitive_source_count = 0;
+  int urdf_primitive_rendered_count = 0;
   int placeholder_count = 0;
+  int missing_geometry_count = 0;
   int wireframe_box_count = 0;
   int overlay_count = 0;
   int locked_urdf_count = 0;
@@ -725,23 +795,30 @@ void Scene3DViewportWidget::paintGL()
     if (!show_safety && role == NormalizedRole::SafetyZone) { ++skipped_item_count; continue; }
     ++visible_item_count;
     unique_visible_ids.insert(it->id);
-    if (is_generated_urdf_visual_item(*it) || is_locked_urdf_item(*it)) ++locked_urdf_count;
+    const bool generated_urdf = is_generated_urdf_visual_item(*it) || is_locked_urdf_item(*it);
+    const bool overlay_helper = is_overlay_only_item(*it) || is_overlay_visual_role(role);
+    if (generated_urdf) ++locked_urdf_count;
     if (it->linked_to_editable_layout_state) ++editable_layout_count;
-    if (is_overlay_visual_role(role)) overlay_items.push_back(it);
+    if (overlay_helper) overlay_items.push_back(it);
     else {
       physical_items.push_back(it);
       ++physical_item_count;
-      if (item_has_credible_mesh_handoff(*it)) ++mesh_backed_count;
+      if (item_has_credible_mesh_handoff(*it)) ++mesh_source_count;
+      if (generated_urdf && !item_has_credible_mesh_handoff(*it) && item_has_explicit_primitive_dimensions(*it)) {
+        ++urdf_primitive_source_count;
+      }
     }
   }
   overlay_count = static_cast<int>(overlay_items.size());
   last_render_counters = RenderDebugCounters{};
   last_render_counters.preview_items_count = items.size();
+  last_render_counters.total_payload_count = items.size();
   last_render_counters.viewport_received_count = received_item_count;
   last_render_counters.render_cache_count = mesh_cache_.size();
   last_render_counters.visible_count = visible_item_count;
   last_render_counters.skipped_count = skipped_item_count;
   last_render_counters.unique_visible_item_count = unique_visible_ids.size();
+  last_render_counters.overlay_helper_count = overlay_count;
   last_render_counters.overlay_count = overlay_count;
   last_render_counters.locked_generated_urdf_visual_count = locked_urdf_count;
   last_render_counters.editable_layout_count = editable_layout_count;
@@ -759,11 +836,16 @@ void Scene3DViewportWidget::paintGL()
       int item_placeholder_count = 0;
       int item_mesh_backed_count = 0;
       int item_wireframe_box_count = 0;
-      draw_truthful_item_geometry(*it, &item_placeholder_count, &item_mesh_backed_count, &item_wireframe_box_count);
+      int item_urdf_primitive_count = 0;
+      int item_missing_geometry_count = 0;
+      draw_truthful_item_geometry(*it, &item_placeholder_count, &item_mesh_backed_count, &item_wireframe_box_count,
+                                  &item_urdf_primitive_count, &item_missing_geometry_count);
       ++rendered_item_count;
       if (count_in_stats) {
         placeholder_count += item_placeholder_count;
         mesh_rendered_count += item_mesh_backed_count;
+        urdf_primitive_rendered_count += item_urdf_primitive_count;
+        missing_geometry_count += item_missing_geometry_count;
         wireframe_box_count += item_wireframe_box_count;
       }
       if (it->id == selected_id) {
@@ -777,11 +859,17 @@ void Scene3DViewportWidget::paintGL()
   draw_item_batch(overlay_items, false);  // draw translucent overlays before solids to keep physical meshes legible.
   draw_item_batch(physical_items, true);
   last_render_counters.rendered_count = rendered_item_count;
-  last_render_counters.mesh_backed_count = mesh_backed_count;
+  last_render_counters.mesh_source_count = mesh_source_count;
+  last_render_counters.mesh_backed_count = mesh_source_count;
   last_render_counters.mesh_rendered_count = mesh_rendered_count;
+  last_render_counters.urdf_primitive_source_count = urdf_primitive_source_count;
+  last_render_counters.urdf_primitive_rendered_count = urdf_primitive_rendered_count;
   last_render_counters.placeholder_count = placeholder_count;
-  last_render_counters.primitive_fallback_count = placeholder_count;
+  last_render_counters.missing_geometry_count = missing_geometry_count;
+  last_render_counters.wireframe_fallback_count = wireframe_box_count;
+  last_render_counters.primitive_fallback_count = urdf_primitive_rendered_count;
   last_render_counters.last_paint_completed = true;
+  finalize_visual_quality(last_render_counters);
   last_render_counters.smoke_fallback_render_used = false;
 
   glDisable(GL_BLEND);
@@ -790,7 +878,7 @@ void Scene3DViewportWidget::paintGL()
            << "visible=" << visible_item_count
            << "rendered=" << rendered_item_count
            << "skipped=" << skipped_item_count
-           << "mesh_backed=" << mesh_backed_count
+           << "mesh_sources=" << mesh_source_count
            << "placeholder=" << placeholder_count
            << "overlay=" << overlay_count
            << "mesh_rendered_count=" << last_render_counters.mesh_rendered_count
@@ -932,8 +1020,10 @@ void Scene3DViewportWidget::paintGL()
   painter.drawText(QRectF(20.0, 34.0, 344.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
                    QString("Scene: %1").arg(scene_name));
   painter.drawText(QRectF(20.0, 50.0, 460.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
-                   QString("Generated mesh %1 • URDF primitives %2 • Helpers %3 • Missing mesh %4")
-                     .arg(mesh_backed_count).arg(wireframe_box_count).arg(overlay_count).arg(placeholder_count));
+                   QString("Generated mesh %1/%2 • URDF primitives %3/%4 • Helpers %5 • Missing geometry %6")
+                     .arg(mesh_rendered_count).arg(mesh_source_count)
+                     .arg(urdf_primitive_rendered_count).arg(urdf_primitive_source_count)
+                     .arg(overlay_count).arg(missing_geometry_count));
   painter.drawText(QRectF(20.0, 66.0, 344.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
                    QString("Physical %1 • Locked URDF %2 • Fit: %3")
                      .arg(physical_item_count).arg(locked_urdf_count).arg(fit_include_overlays ? "all_items" : "generated_visuals"));
@@ -948,14 +1038,7 @@ void Scene3DViewportWidget::paintGL()
 Scene3DViewportWidget::RenderDebugCounters Scene3DViewportWidget::render_debug_counters() const
 {
   RenderDebugCounters counters = last_render_counters;
-  int credible_mesh_handoff_count = 0;
-  for (const auto & it : items) {
-    const NormalizedRole role = classify_item_role(it);
-    if (!show_safety && role == NormalizedRole::SafetyZone) continue;
-    if (item_has_credible_mesh_handoff(it)) ++credible_mesh_handoff_count;
-  }
-  counters.mesh_backed_count = credible_mesh_handoff_count;
-  if (!counters.last_paint_completed) counters.mesh_rendered_count = 0;
+  finalize_visual_quality(counters);
   return counters;
 }
 
@@ -972,8 +1055,12 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
   int visible_item_count = 0;
   int skipped_item_count = 0;
   int rendered_item_count = 0;
-  int mesh_backed_count = 0;
+  int mesh_source_count = 0;
+  int urdf_primitive_source_count = 0;
+  int urdf_primitive_rendered_count = 0;
   int placeholder_count = 0;
+  int missing_geometry_count = 0;
+  int wireframe_fallback_count = 0;
   int overlay_count = 0;
   int locked_urdf_count = 0;
   int editable_layout_count = 0;
@@ -1010,13 +1097,22 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
     }
     ++visible_item_count;
     unique_visible_ids.insert(it.id);
-    if (is_overlay_visual_role(role)) ++overlay_count;
-    if (is_locked_urdf_item(it) || is_generated_urdf_visual_item(it)) ++locked_urdf_count;
+    const bool overlay_helper = is_overlay_only_item(it) || is_overlay_visual_role(role);
+    const bool generated_urdf = is_locked_urdf_item(it) || is_generated_urdf_visual_item(it);
+    if (overlay_helper) ++overlay_count;
+    if (generated_urdf) ++locked_urdf_count;
     if (it.linked_to_editable_layout_state) ++editable_layout_count;
-    if (item_has_credible_mesh_handoff(it)) {
-      ++mesh_backed_count;
-    } else if (!item_has_explicit_dimensions(it)) {
+    if (!overlay_helper && item_has_credible_mesh_handoff(it)) {
+      ++mesh_source_count;
+    } else if (!overlay_helper && generated_urdf && item_has_explicit_dimensions(it)) {
+      ++urdf_primitive_source_count;
+      ++urdf_primitive_rendered_count;
+      ++wireframe_fallback_count;
+    } else if (!overlay_helper && !item_has_explicit_dimensions(it)) {
       ++placeholder_count;
+      ++missing_geometry_count;
+    } else if (!overlay_helper) {
+      ++wireframe_fallback_count;
     }
 
     const ItemBounds bounds = item_bounds_for_role(it);
@@ -1041,22 +1137,30 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
   painter.end();
 
   last_render_counters.preview_items_count = items.size();
+  last_render_counters.total_payload_count = items.size();
   last_render_counters.viewport_received_count = items.size();
   last_render_counters.render_cache_count = mesh_cache_.size();
   last_render_counters.visible_count = visible_item_count;
   last_render_counters.rendered_count = rendered_item_count;
   last_render_counters.skipped_count = skipped_item_count;
   last_render_counters.unique_visible_item_count = unique_visible_ids.size();
-  last_render_counters.mesh_backed_count = mesh_backed_count;
+  last_render_counters.mesh_source_count = mesh_source_count;
+  last_render_counters.mesh_backed_count = mesh_source_count;
   last_render_counters.mesh_rendered_count = 0;
+  last_render_counters.urdf_primitive_source_count = urdf_primitive_source_count;
+  last_render_counters.urdf_primitive_rendered_count = urdf_primitive_rendered_count;
   last_render_counters.placeholder_count = placeholder_count;
-  last_render_counters.primitive_fallback_count = placeholder_count;
+  last_render_counters.missing_geometry_count = missing_geometry_count;
+  last_render_counters.wireframe_fallback_count = wireframe_fallback_count;
+  last_render_counters.primitive_fallback_count = urdf_primitive_rendered_count;
+  last_render_counters.overlay_helper_count = overlay_count;
   last_render_counters.overlay_count = overlay_count;
   last_render_counters.locked_generated_urdf_visual_count = locked_urdf_count;
   last_render_counters.editable_layout_count = editable_layout_count;
   last_render_counters.hierarchy_child_row_count = visible_item_count;
   last_render_counters.last_paint_completed = rendered_item_count > 0;
   last_render_counters.smoke_fallback_render_used = rendered_item_count > 0;
+  finalize_visual_quality(last_render_counters);
   if (out_image) *out_image = img;
   return rendered_item_count > 0;
 }
@@ -1117,7 +1221,8 @@ QString Scene3DViewportWidget::placeholder_reason_for_item(const ScenePreviewWid
 }
 
 bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget::PreviewItem & it, int * out_placeholder_count,
-                                                        int * out_mesh_count, int * out_wireframe_count)
+                                                        int * out_mesh_count, int * out_wireframe_count,
+                                                        int * out_urdf_primitive_count, int * out_missing_geometry_count)
 {
   const QString source_layer = normalized_scene3d_layer_token(it.source_layer);
   const QString visual_source = normalized_scene3d_layer_token(it.active_visual_source);
@@ -1143,6 +1248,7 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
   if (!missing_reason.isEmpty()) {
     draw_missing_geometry_marker(it);
     if (out_placeholder_count) ++(*out_placeholder_count);
+    if (out_missing_geometry_count) ++(*out_missing_geometry_count);
     ++last_render_counters.generated_fallback_count;
     if (show_warning_labels) warn_mesh_fallback_once(it.id, QStringLiteral("missing geometry"), it.source_path);
     return false;
@@ -1158,10 +1264,14 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
     draw_box(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor(148, 163, 184, 56), true);
     draw_box_outline(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor("#94a3b8"), 1.2f);
     if (out_wireframe_count) ++(*out_wireframe_count);
+    if ((is_generated_urdf_visual_item(it) || is_locked_urdf_item(it)) && !item_has_credible_mesh_handoff(it)) {
+      if (out_urdf_primitive_count) ++(*out_urdf_primitive_count);
+    }
     return false;
   }
   draw_missing_geometry_marker(it);
   if (out_placeholder_count) ++(*out_placeholder_count);
+  if (out_missing_geometry_count) ++(*out_missing_geometry_count);
   ++last_render_counters.generated_fallback_count;
   return false;
 }

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -81,6 +81,7 @@ public:
   struct RenderDebugCounters
   {
     int preview_items_count{ 0 };
+    int total_payload_count{ 0 };
     int viewport_received_count{ 0 };
     int render_cache_count{ 0 };
     int visible_count{ 0 };
@@ -88,13 +89,21 @@ public:
     int skipped_count{ 0 };
     int unique_visible_item_count{ 0 };
     int mesh_backed_count{ 0 };
-    int placeholder_count{ 0 };
+    int mesh_source_count{ 0 };
     int mesh_rendered_count{ 0 };
+    int urdf_primitive_source_count{ 0 };
+    int urdf_primitive_rendered_count{ 0 };
+    int placeholder_count{ 0 };
+    int missing_geometry_count{ 0 };
+    int wireframe_fallback_count{ 0 };
+    int overlay_helper_count{ 0 };
     int generated_fallback_count{ 0 };
     int editable_layout_count{ 0 };
     int primitive_fallback_count{ 0 };
     int locked_generated_urdf_visual_count{ 0 };
     int overlay_count{ 0 };
+    QString visual_quality_status{ QStringLiteral("UNAVAILABLE") };
+    QStringList visual_quality_warnings;
     int labels_drawn{ 0 };
     int labels_suppressed_overlap{ 0 };
     int hierarchy_child_row_count{ 0 };
@@ -159,7 +168,8 @@ private:
   bool item_has_explicit_dimensions(const ScenePreviewWidget::PreviewItem & item) const;
   QString placeholder_reason_for_item(const ScenePreviewWidget::PreviewItem & item) const;
   bool draw_truthful_item_geometry(const ScenePreviewWidget::PreviewItem & it, int * out_placeholder_count = nullptr,
-                                   int * out_mesh_count = nullptr, int * out_wireframe_count = nullptr);
+                                   int * out_mesh_count = nullptr, int * out_wireframe_count = nullptr,
+                                   int * out_urdf_primitive_count = nullptr, int * out_missing_geometry_count = nullptr);
   QString gizmo_mode_label() const;
   void draw_robot_base_with_axis(const ScenePreviewWidget::PreviewItem & it);
   void draw_table_slab(const ScenePreviewWidget::PreviewItem & it);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -352,6 +352,7 @@ ScenePreviewWidget::RenderDebugCounters ScenePreviewWidget::render_debug_counter
   const auto counters = viewport ? viewport->render_debug_counters() : Scene3DViewportWidget::RenderDebugCounters{};
   RenderDebugCounters out;
   out.preview_items_count = preview_items_.size();
+  out.total_payload_count = preview_items_.size();
   out.viewport_received_count = counters.viewport_received_count;
   out.render_cache_count = counters.render_cache_count;
   out.visible_count = counters.visible_count;
@@ -359,13 +360,21 @@ ScenePreviewWidget::RenderDebugCounters ScenePreviewWidget::render_debug_counter
   out.skipped_count = counters.skipped_count;
   out.unique_visible_item_count = counters.unique_visible_item_count;
   out.mesh_backed_count = counters.mesh_backed_count;
-  out.placeholder_count = counters.placeholder_count;
-  out.overlay_count = counters.overlay_count;
+  out.mesh_source_count = counters.mesh_source_count;
   out.mesh_rendered_count = counters.mesh_rendered_count;
+  out.urdf_primitive_source_count = counters.urdf_primitive_source_count;
+  out.urdf_primitive_rendered_count = counters.urdf_primitive_rendered_count;
+  out.placeholder_count = counters.placeholder_count;
+  out.missing_geometry_count = counters.missing_geometry_count;
+  out.wireframe_fallback_count = counters.wireframe_fallback_count;
+  out.overlay_helper_count = counters.overlay_helper_count;
+  out.overlay_count = counters.overlay_count;
   out.generated_fallback_count = counters.generated_fallback_count;
   out.editable_layout_count = counters.editable_layout_count;
   out.primitive_fallback_count = counters.primitive_fallback_count;
   out.locked_generated_urdf_visual_count = counters.locked_generated_urdf_visual_count;
+  out.visual_quality_status = counters.visual_quality_status;
+  out.visual_quality_warnings = counters.visual_quality_warnings;
   out.labels_drawn = counters.labels_drawn;
   out.labels_suppressed_overlap = counters.labels_suppressed_overlap;
   out.hierarchy_child_row_count = counters.hierarchy_child_row_count;
@@ -416,12 +425,13 @@ void ScenePreviewWidget::refresh_info_chip()
   const auto counters = viewport ? viewport->render_debug_counters() : Scene3DViewportWidget::RenderDebugCounters{};
   const QString compact_stats = QString("Items %1 M%2 B%3 Miss%4 Ov%5 L-URDF%6")
                                   .arg(physical_count).arg(mesh_count).arg(box_count).arg(missing_count).arg(overlay_count).arg(locked_urdf_count);
-  const QString smoke_stats = QString("mesh_backed_count=%1 mesh_rendered_count=%2 paint_completed=%3 fallback_count=%4 overlay_count=%5 labels_drawn=%6 labels_suppressed_overlap=%7 hierarchy_child_row_count=%8 selected_scene_name=%9 selected_item_id=%10")
-                                  .arg(counters.mesh_backed_count).arg(counters.mesh_rendered_count)
+  const QString smoke_stats = QString("quality=%1 mesh=%2/%3 urdf_prim=%4/%5 missing=%6 placeholder=%7 wireframe=%8 helpers=%9 paint_completed=%10 selected_scene_name=%11 selected_item_id=%12")
+                                  .arg(counters.visual_quality_status)
+                                  .arg(counters.mesh_rendered_count).arg(counters.mesh_source_count)
+                                  .arg(counters.urdf_primitive_rendered_count).arg(counters.urdf_primitive_source_count)
+                                  .arg(counters.missing_geometry_count).arg(counters.placeholder_count)
+                                  .arg(counters.wireframe_fallback_count).arg(counters.overlay_helper_count)
                                   .arg(counters.last_paint_completed ? QStringLiteral("true") : QStringLiteral("false"))
-                                  .arg(counters.generated_fallback_count)
-                                  .arg(counters.overlay_count).arg(counters.labels_drawn).arg(counters.labels_suppressed_overlap)
-                                  .arg(counters.hierarchy_child_row_count)
                                   .arg(preview_scene_name_.isEmpty() ? QStringLiteral("(none)") : preview_scene_name_)
                                   .arg(selected_preview_item_id_.isEmpty() ? QStringLiteral("(none)") : selected_preview_item_id_);
   info_chip_label_->setText(QString("Scene: %1\nMode: %2\n%3\n%4  Warn: %5  Task: %6")

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -189,6 +189,7 @@ public:
   struct RenderDebugCounters
   {
     int preview_items_count{ 0 };
+    int total_payload_count{ 0 };
     int viewport_received_count{ 0 };
     int render_cache_count{ 0 };
     int visible_count{ 0 };
@@ -196,13 +197,21 @@ public:
     int skipped_count{ 0 };
     int unique_visible_item_count{ 0 };
     int mesh_backed_count{ 0 };
-    int placeholder_count{ 0 };
-    int overlay_count{ 0 };
+    int mesh_source_count{ 0 };
     int mesh_rendered_count{ 0 };
+    int urdf_primitive_source_count{ 0 };
+    int urdf_primitive_rendered_count{ 0 };
+    int placeholder_count{ 0 };
+    int missing_geometry_count{ 0 };
+    int wireframe_fallback_count{ 0 };
+    int overlay_helper_count{ 0 };
+    int overlay_count{ 0 };
     int generated_fallback_count{ 0 };
     int editable_layout_count{ 0 };
     int primitive_fallback_count{ 0 };
     int locked_generated_urdf_visual_count{ 0 };
+    QString visual_quality_status{ QStringLiteral("UNAVAILABLE") };
+    QStringList visual_quality_warnings;
     int labels_drawn{ 0 };
     int labels_suppressed_overlap{ 0 };
     int hierarchy_child_row_count{ 0 };


### PR DESCRIPTION
### Motivation
- Improve Scene3D preview health reporting by measuring actual visual quality from render paths rather than inferring from payload counts alone.
- Surface clear FAIL/WARNING conditions when mesh or URDF-primitive sources exist but do not render, and avoid counting valid URDF primitives as placeholders.
- Make smoke JSON output and UI preview chips reflect render/source ratios and explicit visual-quality status for more actionable diagnostics.

### Description
- Added new debug counters to `RenderDebugCounters` in `scene3d_viewport_widget.h` and `scene_preview_widget.h`: `total_payload_count`, `mesh_source_count`, `mesh_rendered_count`, `urdf_primitive_source_count`, `urdf_primitive_rendered_count`, `placeholder_count`, `missing_geometry_count`, `wireframe_fallback_count`, `overlay_helper_count`, `visual_quality_status`, and `visual_quality_warnings`.
- Populated those counters from real render/paint code paths (viewport paint path and smoke fallback) and from ingestion code so counts reflect actual source vs rendered outcomes and URDF primitives are tracked separately from placeholders (changes in `scene3d_viewport_widget.cpp`).
- Implemented `finalize_visual_quality()` to compute `visual_quality_status` and `visual_quality_warnings` using the acceptance rules (mesh/URDF source present but not rendered -> FAIL, high source/low render -> WARNING, treat missing geometry/placeholders as warnings) and integrated it into `render_debug_counters()` and smoke paths.
- Propagated counters into the smoke JSON writer and UI: updated `ScenePreviewWidget::render_debug_counters()` and smoke JSON emission in `main.cpp`, and changed `MainWindow::refresh_scene_builder_view_chips()` to derive preview status from `visual_quality_status` and source/render ratios instead of only `rendered_count > 0`.

### Testing
- Ran `git diff --check` to verify no whitespace/format issues and it passed.
- Executed scene validators `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` and `python3 scripts/validate_builder_generated_scene.py scenes/suction_test --json`, both completed successfully and returned expected scene diagnostics.
- Attempted local build/syntax checks but full `colcon` build and CMake configuration were not run in this container due to missing ROS/ament and Qt development environment, so platform build verification is pending in a ROS Humble environment.
- Confirmed no changes to launch files, runtime services, or hardware defaults so fake-hardware-first safety remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b3aacea388331a7c2843efa53f2ce)