### PR TITLE
Render URDF primitives in Scene3D preview

### DIFF
--- a/scripts/extract_scene_urdf_visual_mesh_index.py
+++ b/scripts/extract_scene_urdf_visual_mesh_index.py
@@ -8,7 +8,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 SCENES_ROOT = ROOT / "scenes"
-EXTRACTOR_VERSION = "2.3"
+EXTRACTOR_VERSION = "2.4"
 PLACEHOLDER_RE = re.compile(r"(\$\{[^}]+\}|\$\(arg\s+[^)]+\)|\$\(find\s+[^)]+\))")
 
 def read_yaml(path):
@@ -124,6 +124,12 @@ def resolve_mesh_uri(uri, package_map):
 
 def extract_from_urdf(xml_text, package_map):
     root=ET.fromstring(xml_text); items=[]; idx=0
+    global_materials={}
+    for mat in [m for m in list(root) if tag_name(m)=='material']:
+        name=mat.attrib.get('name','')
+        color=next((c for c in list(mat) if tag_name(c)=='color'),None)
+        if name and color is not None:
+            global_materials[name]=parse_vec(color.attrib.get('rgba',''),4,1.0)
     links={l.attrib.get('name',''):l for l in root.iter() if tag_name(l)=='link'}
     joints=[]
     for j in root.iter():
@@ -161,12 +167,22 @@ def extract_from_urdf(xml_text, package_map):
             vxyz=parse_vec((origin.attrib.get('xyz') if origin is not None else ''),3,0.0); vrpy=parse_vec((origin.attrib.get('rpy') if origin is not None else ''),3,0.0)
             link_tf, link_status, chain, root_link, unresolved = link_world_tf(lname)
             if link_tf is None: link_tf=identity_tf()
-            final_tf=matmul4(link_tf, tf_from_xyz_rpy(vxyz,vrpy)); pose=xyz_rpy_from_tf(final_tf)
-            common={'id':item_id,'link':lname,'visual':vname,'parent_link':root_link or '','pose':pose,'link_transform_status':link_status,'transform_status':link_status,'transform_chain':chain,'render_expected':True}
+            pose=xyz_rpy_from_tf(link_tf)
+            material_node=next((c for c in list(visual) if tag_name(c)=='material'),None)
+            material={'name':'','color':None}
+            if material_node is not None:
+                material['name']=material_node.attrib.get('name','')
+                color_node=next((c for c in list(material_node) if tag_name(c)=='color'),None)
+                if color_node is not None:
+                    material['color']=parse_vec(color_node.attrib.get('rgba',''),4,1.0)
+                elif material['name'] in global_materials:
+                    material['color']=global_materials[material['name']]
+            common={'id':item_id,'link':lname,'visual':vname,'parent_link':root_link or '','pose':pose,'visual_origin':{'xyz':vxyz,'rpy':vrpy},'material':material,'link_transform_status':link_status,'transform_status':link_status,'transform_chain':chain,'render_expected':True}
             mesh=next((c for c in list(geom) if tag_name(c)=='mesh'),None)
             box=next((c for c in list(geom) if tag_name(c)=='box'),None)
             cyl=next((c for c in list(geom) if tag_name(c)=='cylinder'),None)
             sph=next((c for c in list(geom) if tag_name(c)=='sphere'),None)
+            cap=next((c for c in list(geom) if tag_name(c)=='capsule'),None)
             warning=unresolved
             if mesh is not None:
                 mesh_uri=mesh.attrib.get('filename',''); resolved_path, skip_reason=resolve_mesh_uri(mesh_uri, package_map)
@@ -178,6 +194,8 @@ def extract_from_urdf(xml_text, package_map):
                 items.append({**common,'geometry_type':'cylinder','radius':float(cyl.attrib.get('radius','0.05') or 0.05),'length':float(cyl.attrib.get('length','0.1') or 0.1),'resolved':True,'warning':warning or ''})
             elif sph is not None:
                 items.append({**common,'geometry_type':'sphere','radius':float(sph.attrib.get('radius','0.05') or 0.05),'resolved':True,'warning':warning or ''})
+            elif cap is not None:
+                items.append({**common,'geometry_type':'capsule','radius':float(cap.attrib.get('radius','0.05') or 0.05),'length':float(cap.attrib.get('length',cap.attrib.get('height','0.1')) or 0.1),'resolved':True,'warning':warning or ''})
             idx+=1
     return items
 
@@ -242,7 +260,7 @@ def main():
         report['candidate_mesh_count']=report.get('candidate_mesh_count',0)+len(items)
         report['emitted_visual_count']=report.get('emitted_visual_count',0)+len(items)
         report['unresolved_placeholder_count']=report.get('unresolved_placeholder_count',0)+len(unresolved)
-        report['scenes'].append({'scene':scene_dir.name,'extraction_mode':mode,'xacro_available':payload['xacro_available'],'expanded_urdf_written':bool(expanded_path),'safe_for_preview':safe,'unresolved_placeholder_count':len(unresolved),'mesh_backed_count':sum(1 for i in items if i.get('geometry_type')=='mesh'),'skipped_count':sum(1 for i in items if i.get('render_skip_reason')),'fallback_reason':fallback_reason,'primitive_fallback_count':sum(1 for i in items if i.get('geometry_type') in ('box','cylinder','sphere')),'stale_index':False,'status':'PASS' if safe else 'WARN'})
+        report['scenes'].append({'scene':scene_dir.name,'extraction_mode':mode,'xacro_available':payload['xacro_available'],'expanded_urdf_written':bool(expanded_path),'safe_for_preview':safe,'unresolved_placeholder_count':len(unresolved),'mesh_backed_count':sum(1 for i in items if i.get('geometry_type')=='mesh'),'skipped_count':sum(1 for i in items if i.get('render_skip_reason')),'fallback_reason':fallback_reason,'urdf_primitive_count':sum(1 for i in items if i.get('geometry_type') in ('box','cylinder','sphere','capsule')),'primitive_fallback_count':0,'stale_index':False,'status':'PASS' if safe else 'WARN'})
         if a.require_xacro and mode != 'xacro_expanded': return 2
     (ROOT/'build').mkdir(exist_ok=True)
     (ROOT/'build/workcell_studio_urdf_visual_mesh_index_report.json').write_text(json.dumps(report,indent=2)+'\n')

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -6876,6 +6876,15 @@ void MainWindow::populate_scene_hierarchy()
     p.sz = item.height;
     p.mesh_path = QString::fromStdString(item.mesh_path);
     p.mesh_type = QString::fromStdString(item.mesh_type);
+    p.primitive_geometry_type = QString::fromStdString(item.primitive_geometry_type);
+    p.primitive_radius = item.primitive_radius;
+    p.primitive_length = item.primitive_length;
+    p.has_material_color = item.has_material_color;
+    p.material_r = item.material_r;
+    p.material_g = item.material_g;
+    p.material_b = item.material_b;
+    p.material_a = item.material_a;
+    p.material_name = QString::fromStdString(item.material_name);
     p.mesh_scale_x = item.mesh_scale_x;
     p.mesh_scale_y = item.mesh_scale_y;
     p.mesh_scale_z = item.mesh_scale_z;
@@ -7044,7 +7053,7 @@ void MainWindow::populate_scene_hierarchy()
           }
           const QString geometry_type = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "geometry_type"));
           if (geometry_type == "mesh") ++mesh_item_count;
-          else if (geometry_type == "box" || geometry_type == "cylinder" || geometry_type == "sphere") ++primitive_item_count;
+          else if (geometry_type == "box" || geometry_type == "cylinder" || geometry_type == "sphere" || geometry_type == "capsule") ++primitive_item_count;
           else ++unknown_item_count;
           const bool render_expected = workcell_builder::yaml_map_key(v, "render_expected").as<bool>(false);
           const YAML::Node pose = workcell_builder::yaml_map_key(v, "pose");
@@ -7133,7 +7142,7 @@ void MainWindow::populate_scene_hierarchy()
           p.robot_base_frame = chain_base_frame.trimmed().isEmpty() ? QStringLiteral("unknown") : chain_base_frame;
           p.source_layer = QStringLiteral("generated_urdf_visual");
           p.active_visual_source = (geometry_type == "mesh") ? QStringLiteral("mesh_preview")
-                                                              : QStringLiteral("primitive_fallback");
+                                                              : QStringLiteral("urdf_primitive");
           p.linked_to_editable_layout_state = false;
           p.editable = false;
           p.selectable = true;
@@ -7185,6 +7194,17 @@ void MainWindow::populate_scene_hierarchy()
           p.mesh_scale_x = workcell_builder::yaml_seq_index(scale,0).as<double>(1.0);
           p.mesh_scale_y = workcell_builder::yaml_seq_index(scale,1).as<double>(1.0);
           p.mesh_scale_z = workcell_builder::yaml_seq_index(scale,2).as<double>(1.0);
+          p.primitive_geometry_type = geometry_type;
+          const YAML::Node material = workcell_builder::yaml_map_key(v, "material");
+          p.material_name = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(material, "name"));
+          const YAML::Node material_color = workcell_builder::yaml_map_key(material, "color");
+          if (material_color && material_color.IsSequence() && material_color.size() >= 3) {
+            p.has_material_color = true;
+            p.material_r = workcell_builder::yaml_seq_index(material_color,0).as<double>(0.0);
+            p.material_g = workcell_builder::yaml_seq_index(material_color,1).as<double>(0.0);
+            p.material_b = workcell_builder::yaml_seq_index(material_color,2).as<double>(0.0);
+            p.material_a = workcell_builder::yaml_seq_index(material_color,3).as<double>(1.0);
+          }
           p.sx = 0.25;
           p.sy = 0.25;
           p.sz = 0.25;
@@ -7196,17 +7216,28 @@ void MainWindow::populate_scene_hierarchy()
           } else if (geometry_type == "cylinder") {
             const double radius = workcell_builder::yaml_map_key(v, "radius").as<double>(0.1);
             const double length = workcell_builder::yaml_map_key(v, "length").as<double>(0.2);
+            p.primitive_radius = radius;
+            p.primitive_length = length;
             p.sx = radius * 2.0;
             p.sy = radius * 2.0;
             p.sz = length;
           } else if (geometry_type == "sphere") {
             const double radius = workcell_builder::yaml_map_key(v, "radius").as<double>(0.1);
+            p.primitive_radius = radius;
             p.sx = radius * 2.0;
             p.sy = radius * 2.0;
             p.sz = radius * 2.0;
+          } else if (geometry_type == "capsule") {
+            const double radius = workcell_builder::yaml_map_key(v, "radius").as<double>(0.1);
+            const double length = workcell_builder::yaml_map_key(v, "length").as<double>(0.2);
+            p.primitive_radius = radius;
+            p.primitive_length = length;
+            p.sx = radius * 2.0;
+            p.sy = radius * 2.0;
+            p.sz = length + radius * 2.0;
           }
           const QString lower_name = (p.display_name + " " + p.id + " " + p.role).toLower();
-          if (p.sx <= 0.001 || p.sy <= 0.001 || p.sz <= 0.001 || (p.sx == 0.25 && p.sy == 0.25 && p.sz == 0.25)) {
+          if (geometry_type.trimmed().isEmpty() && (p.sx <= 0.001 || p.sy <= 0.001 || p.sz <= 0.001 || (p.sx == 0.25 && p.sy == 0.25 && p.sz == 0.25))) {
             if (lower_name.contains("base")) { p.sx = 0.45; p.sy = 0.45; p.sz = 0.22; }
             else if (lower_name.contains("shoulder") || lower_name.contains("upper_arm") || lower_name.contains("forearm")) { p.sx = 0.14; p.sy = 0.14; p.sz = 0.52; }
             else if (lower_name.contains("wrist")) { p.sx = 0.10; p.sy = 0.10; p.sz = 0.18; }
@@ -7217,7 +7248,7 @@ void MainWindow::populate_scene_hierarchy()
             else { p.sx = 0.08; p.sy = 0.08; p.sz = 0.08; }
           }
           const bool resolved = workcell_builder::yaml_map_key(v, "resolved").as<bool>(false);
-          const bool is_primitive = (geometry_type == "box" || geometry_type == "cylinder" || geometry_type == "sphere");
+          const bool is_primitive = (geometry_type == "box" || geometry_type == "cylinder" || geometry_type == "sphere" || geometry_type == "capsule");
           bool mesh_fallback = false;
           if (geometry_type == "mesh") {
             if (p.mesh_path.trimmed().isEmpty()) {
@@ -7280,8 +7311,14 @@ void MainWindow::populate_scene_hierarchy()
             const QString warning = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "warning"));
             if (!warning.isEmpty()) p.warnings << warning;
           } else {
-            p.mesh_available = true;
-            p.has_mesh_metadata = true;
+            if (is_primitive) {
+              p.mesh_available = false;
+              p.has_mesh_metadata = false;
+              p.active_visual_source = QStringLiteral("urdf_primitive");
+            } else {
+              p.mesh_available = true;
+              p.has_mesh_metadata = true;
+            }
           }
           if (unresolved_package_uri) ++unresolved_package_uri_count;
           if (unresolved_package_uri && !is_primitive) add_skip_reason(QStringLiteral("missing_source_path"));

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -82,9 +82,19 @@ bool item_has_credible_mesh_handoff(const ScenePreviewWidget::PreviewItem & item
          !item.source_path.trimmed().isEmpty();
 }
 
+bool item_has_valid_urdf_primitive(const ScenePreviewWidget::PreviewItem & item)
+{
+  const QString type = item.primitive_geometry_type.trimmed().toLower().replace(QLatin1Char('-'), QLatin1Char('_')).replace(QLatin1Char(' '), QLatin1Char('_'));
+  if (type == QStringLiteral("box")) return item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001;
+  if (type == QStringLiteral("cylinder")) return item.primitive_radius > 0.001 && item.primitive_length > 0.001;
+  if (type == QStringLiteral("sphere")) return item.primitive_radius > 0.001;
+  if (type == QStringLiteral("capsule")) return item.primitive_radius > 0.001 && item.primitive_length > 0.001;
+  return false;
+}
+
 bool item_has_explicit_primitive_dimensions(const ScenePreviewWidget::PreviewItem & item)
 {
-  return item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001;
+  return item_has_valid_urdf_primitive(item) || (item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001);
 }
 
 void finalize_visual_quality(Scene3DViewportWidget::RenderDebugCounters & counters)
@@ -496,6 +506,12 @@ bool is_critical_label_role(NormalizedRole role)
 }
 QColor item_color(const ScenePreviewWidget::PreviewItem & it)
 {
+  if (it.has_material_color) {
+    QColor c;
+    c.setRgbF(qBound(0.0, it.material_r, 1.0), qBound(0.0, it.material_g, 1.0),
+              qBound(0.0, it.material_b, 1.0), qBound(0.0, it.material_a, 1.0));
+    return c;
+  }
   switch (classify_item_role(it)) {
     case NormalizedRole::RobotBase: return QColor("#a78bfa");
     case NormalizedRole::Table: return QColor("#64748b");
@@ -1216,8 +1232,49 @@ bool Scene3DViewportWidget::item_has_explicit_dimensions(const ScenePreviewWidge
 QString Scene3DViewportWidget::placeholder_reason_for_item(const ScenePreviewWidget::PreviewItem & item) const
 {
   if (item_has_credible_mesh_handoff(item)) return QString();
-  if (item_has_explicit_dimensions(item)) return QString();
+  if (item_has_valid_urdf_primitive(item) || item_has_explicit_dimensions(item)) return QString();
   return QStringLiteral("missing geometry");
+}
+
+
+bool Scene3DViewportWidget::draw_urdf_primitive_geometry(const ScenePreviewWidget::PreviewItem & it, const QColor & color)
+{
+  const QString type = normalized_token(it.primitive_geometry_type);
+  if (!item_has_valid_urdf_primitive(it)) return false;
+
+  glPushMatrix();
+  glTranslated(it.x, it.y, it.z);
+  glRotated(qRadiansToDegrees(it.roll), 1.0, 0.0, 0.0);
+  glRotated(qRadiansToDegrees(it.pitch), 0.0, 1.0, 0.0);
+  glRotated(qRadiansToDegrees(it.yaw), 0.0, 0.0, 1.0);
+  if (it.visual_origin_applied) {
+    glTranslated(it.visual_origin_x, it.visual_origin_y, it.visual_origin_z);
+    glRotated(qRadiansToDegrees(it.visual_origin_roll), 1.0, 0.0, 0.0);
+    glRotated(qRadiansToDegrees(it.visual_origin_pitch), 0.0, 1.0, 0.0);
+    glRotated(qRadiansToDegrees(it.visual_origin_yaw), 0.0, 0.0, 1.0);
+  }
+  glScaled(it.mesh_scale_x, it.mesh_scale_y, it.mesh_scale_z);
+
+  if (type == QStringLiteral("box")) {
+    draw_box(-it.sx * 0.5, -it.sy * 0.5, -it.sz * 0.5, it.sx, it.sy, it.sz, color, color.alphaF() < 0.99);
+  } else if (type == QStringLiteral("cylinder")) {
+    const double r = it.primitive_radius;
+    const double h = it.primitive_length;
+    draw_cylinder(0.0, -h * 0.5, 0.0, r, h, color, color.alphaF() < 0.99, 32);
+  } else if (type == QStringLiteral("sphere")) {
+    draw_sphere(0.0, 0.0, 0.0, it.primitive_radius, color, color.alphaF() < 0.99, 24, 12);
+  } else if (type == QStringLiteral("capsule")) {
+    const double r = it.primitive_radius;
+    const double h = it.primitive_length;
+    draw_cylinder(0.0, -h * 0.5, 0.0, r, h, color, color.alphaF() < 0.99, 32);
+    draw_sphere(0.0, -h * 0.5, 0.0, r, color, color.alphaF() < 0.99, 24, 8);
+    draw_sphere(0.0, h * 0.5, 0.0, r, color, color.alphaF() < 0.99, 24, 8);
+  } else {
+    glPopMatrix();
+    return false;
+  }
+  glPopMatrix();
+  return true;
 }
 
 bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget::PreviewItem & it, int * out_placeholder_count,
@@ -1237,7 +1294,7 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
   }
   // Always try mesh-backed draw first for physical items.
   QColor visual_color = item_color(it);
-  if (is_generated_urdf_visual_item(it) || is_locked_urdf_item(it)) {
+  if ((is_generated_urdf_visual_item(it) || is_locked_urdf_item(it)) && !it.has_material_color) {
     visual_color = QColor("#cfd4da");
   }
   if (draw_mesh_preview_if_available(it, visual_color, true)) {
@@ -1253,6 +1310,19 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
     if (show_warning_labels) warn_mesh_fallback_once(it.id, QStringLiteral("REJECT_MISSING_GEOMETRY: no mesh metadata or explicit primitive dimensions"), it.source_path);
     return false;
   }
+  if (item_has_valid_urdf_primitive(it)) {
+    if (mesh_preview_mode == ScenePreviewWidget::MeshPreviewMode::Meshes) {
+      draw_missing_geometry_marker(it);
+      ++last_render_counters.generated_fallback_count;
+      if (out_placeholder_count) ++(*out_placeholder_count);
+      warn_mesh_fallback_once(it.id, QStringLiteral("REJECT_PRIMITIVE_SUPPRESSED_BY_MESH_ONLY_MODE: URDF primitive available but disabled"), it.source_path);
+      return false;
+    }
+    if (draw_urdf_primitive_geometry(it, visual_color)) {
+      if (out_urdf_primitive_count) ++(*out_urdf_primitive_count);
+      return true;
+    }
+  }
   if (item_has_explicit_dimensions(it)) {
     if (mesh_preview_mode == ScenePreviewWidget::MeshPreviewMode::Meshes) {
       draw_missing_geometry_marker(it);
@@ -1264,9 +1334,6 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
     draw_box(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor(148, 163, 184, 56), true);
     draw_box_outline(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor("#94a3b8"), 1.2f);
     if (out_wireframe_count) ++(*out_wireframe_count);
-    if ((is_generated_urdf_visual_item(it) || is_locked_urdf_item(it)) && !item_has_credible_mesh_handoff(it)) {
-      if (out_urdf_primitive_count) ++(*out_urdf_primitive_count);
-    }
     return false;
   }
   draw_missing_geometry_marker(it);
@@ -1366,8 +1433,8 @@ bool Scene3DViewportWidget::should_draw_as_wireframe_for_test(const ScenePreview
 {
   Q_UNUSED(mode);
   const QString role = render_role_for_test(item);
-  return role == "helper_overlay" || role == "missing_mesh_fallback" || role == "generated_urdf_primitive" ||
-         role == "real_urdf_primitive";
+  if (item_has_valid_urdf_primitive(item)) return false;
+  return role == "helper_overlay" || role == "missing_mesh_fallback";
 }
 
 bool Scene3DViewportWidget::try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical,
@@ -1607,6 +1674,12 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
   glRotated(qRadiansToDegrees(it.roll), 1.0, 0.0, 0.0);
   glRotated(qRadiansToDegrees(it.pitch), 0.0, 1.0, 0.0);
   glRotated(qRadiansToDegrees(it.yaw), 0.0, 0.0, 1.0);
+  if (it.visual_origin_applied) {
+    glTranslated(it.visual_origin_x, it.visual_origin_y, it.visual_origin_z);
+    glRotated(qRadiansToDegrees(it.visual_origin_roll), 1.0, 0.0, 0.0);
+    glRotated(qRadiansToDegrees(it.visual_origin_pitch), 0.0, 1.0, 0.0);
+    glRotated(qRadiansToDegrees(it.visual_origin_yaw), 0.0, 0.0, 1.0);
+  }
   glRotated(qRadiansToDegrees(it.mesh_r), 1.0, 0.0, 0.0);
   glRotated(qRadiansToDegrees(it.mesh_p), 0.0, 1.0, 0.0);
   glRotated(qRadiansToDegrees(it.mesh_y), 0.0, 0.0, 1.0);
@@ -1768,14 +1841,18 @@ void Scene3DViewportWidget::draw_warning_badge_anchor(const ScenePreviewWidget::
 
 void Scene3DViewportWidget::draw_box(double cx, double cy, double cz, double sx, double sy, double sz, const QColor & color, bool translucent)
 {
-  glColor4f(color.redF(), color.greenF(), color.blueF(), translucent ? 0.35f : 1.0f);
+  glDisable(GL_CULL_FACE);
+  glColor4f(color.redF(), color.greenF(), color.blueF(), translucent ? 0.35f : color.alphaF());
   const double x = cx, y = cy, z = cz;
   glBegin(GL_QUADS);
   glVertex3f(x, y, z); glVertex3f(x + sx, y, z); glVertex3f(x + sx, y + sy, z); glVertex3f(x, y + sy, z);
-  glVertex3f(x, y, z + sz); glVertex3f(x + sx, y, z + sz); glVertex3f(x + sx, y + sy, z + sz); glVertex3f(x, y + sy, z + sz);
+  glVertex3f(x, y, z + sz); glVertex3f(x, y + sy, z + sz); glVertex3f(x + sx, y + sy, z + sz); glVertex3f(x + sx, y, z + sz);
+  glVertex3f(x, y, z); glVertex3f(x, y, z + sz); glVertex3f(x + sx, y, z + sz); glVertex3f(x + sx, y, z);
+  glVertex3f(x, y + sy, z); glVertex3f(x + sx, y + sy, z); glVertex3f(x + sx, y + sy, z + sz); glVertex3f(x, y + sy, z + sz);
   glVertex3f(x, y, z); glVertex3f(x, y + sy, z); glVertex3f(x, y + sy, z + sz); glVertex3f(x, y, z + sz);
-  glVertex3f(x + sx, y, z); glVertex3f(x + sx, y + sy, z); glVertex3f(x + sx, y + sy, z + sz); glVertex3f(x + sx, y, z + sz);
+  glVertex3f(x + sx, y, z); glVertex3f(x + sx, y, z + sz); glVertex3f(x + sx, y + sy, z + sz); glVertex3f(x + sx, y + sy, z);
   glEnd();
+  glEnable(GL_CULL_FACE);
 }
 void Scene3DViewportWidget::draw_box_outline(double cx, double cy, double cz, double sx, double sy, double sz, const QColor & color, float line_width)
 {
@@ -1808,7 +1885,7 @@ void Scene3DViewportWidget::draw_cylinder(double cx, double cy, double cz, doubl
   const double y_bottom = cy;
   const double y_top = cy + height;
 
-  glColor4f(color.redF(), color.greenF(), color.blueF(), translucent ? 0.35f : 1.0f);
+  glColor4f(color.redF(), color.greenF(), color.blueF(), translucent ? 0.35f : color.alphaF());
 
   // Side wall. The cylinder is Y-up to match the viewport's box helper, where
   // the height axis starts at cy and extends by the supplied height argument.
@@ -1849,6 +1926,32 @@ void Scene3DViewportWidget::draw_cylinder(double cx, double cy, double cz, doubl
   }
   glEnd();
 }
+
+void Scene3DViewportWidget::draw_sphere(double cx, double cy, double cz, double radius, const QColor & color, bool translucent, int slice_count, int stack_count)
+{
+  const int slices = qMax(6, slice_count);
+  const int stacks = qMax(4, stack_count);
+  const double r = qMax(0.0, radius);
+  glColor4f(color.redF(), color.greenF(), color.blueF(), translucent ? 0.35f : color.alphaF());
+  for (int stack = 0; stack < stacks; ++stack) {
+    const double phi0 = -M_PI_2 + M_PI * static_cast<double>(stack) / static_cast<double>(stacks);
+    const double phi1 = -M_PI_2 + M_PI * static_cast<double>(stack + 1) / static_cast<double>(stacks);
+    glBegin(GL_QUAD_STRIP);
+    for (int slice = 0; slice <= slices; ++slice) {
+      const double theta = 2.0 * M_PI * static_cast<double>(slice) / static_cast<double>(slices);
+      const double c = qCos(theta);
+      const double s = qSin(theta);
+      glVertex3f(static_cast<GLfloat>(cx + r * qCos(phi0) * c),
+                 static_cast<GLfloat>(cy + r * qSin(phi0)),
+                 static_cast<GLfloat>(cz + r * qCos(phi0) * s));
+      glVertex3f(static_cast<GLfloat>(cx + r * qCos(phi1) * c),
+                 static_cast<GLfloat>(cy + r * qSin(phi1)),
+                 static_cast<GLfloat>(cz + r * qCos(phi1) * s));
+    }
+    glEnd();
+  }
+}
+
 void Scene3DViewportWidget::draw_frustum(const QColor & color, bool translucent)
 {
   const double h = qDegreesToRadians(camera_overlay.horizontal_fov_deg * 0.5);
@@ -1934,6 +2037,12 @@ bool Scene3DViewportWidget::mesh_world_bounds_for_item(const ScenePreviewWidget:
   transform.rotate(qRadiansToDegrees(item.roll), 1.0f, 0.0f, 0.0f);
   transform.rotate(qRadiansToDegrees(item.pitch), 0.0f, 1.0f, 0.0f);
   transform.rotate(qRadiansToDegrees(item.yaw), 0.0f, 0.0f, 1.0f);
+  if (item.visual_origin_applied) {
+    transform.translate(item.visual_origin_x, item.visual_origin_y, item.visual_origin_z);
+    transform.rotate(qRadiansToDegrees(item.visual_origin_roll), 1.0f, 0.0f, 0.0f);
+    transform.rotate(qRadiansToDegrees(item.visual_origin_pitch), 0.0f, 1.0f, 0.0f);
+    transform.rotate(qRadiansToDegrees(item.visual_origin_yaw), 0.0f, 0.0f, 1.0f);
+  }
   transform.rotate(qRadiansToDegrees(item.mesh_r), 1.0f, 0.0f, 0.0f);
   transform.rotate(qRadiansToDegrees(item.mesh_p), 0.0f, 1.0f, 0.0f);
   transform.rotate(qRadiansToDegrees(item.mesh_y), 0.0f, 0.0f, 1.0f);

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -161,6 +161,8 @@ private:
   void draw_box_outline(double cx, double cy, double cz, double sx, double sy, double sz, const QColor & color, float line_width = 2.5f);
   void draw_cylinder(double cx, double cy, double cz, double radius, double height, const QColor & color,
                      bool translucent = false, int segment_count = 32);
+  void draw_sphere(double cx, double cy, double cz, double radius, const QColor & color,
+                   bool translucent = false, int slice_count = 24, int stack_count = 12);
   void draw_frustum(const QColor & color, bool translucent = true);
   void draw_ground_grid_pass();
   void draw_world_axes_pass();
@@ -168,6 +170,7 @@ private:
   bool robot_bounds_from_rendered_visuals(QVector3D & out_min, QVector3D & out_max) const;
   bool item_has_explicit_dimensions(const ScenePreviewWidget::PreviewItem & item) const;
   QString placeholder_reason_for_item(const ScenePreviewWidget::PreviewItem & item) const;
+  bool draw_urdf_primitive_geometry(const ScenePreviewWidget::PreviewItem & it, const QColor & color);
   bool draw_truthful_item_geometry(const ScenePreviewWidget::PreviewItem & it, int * out_placeholder_count = nullptr,
                                    int * out_mesh_count = nullptr, int * out_wireframe_count = nullptr,
                                    int * out_urdf_primitive_count = nullptr, int * out_missing_geometry_count = nullptr);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -32,6 +32,12 @@ public:
     QString role;
     QString mesh_path;
     QString mesh_type;
+    QString primitive_geometry_type;
+    double primitive_radius{ 0.0 };
+    double primitive_length{ 0.0 };
+    bool has_material_color{ false };
+    double material_r{ 0.0 }, material_g{ 0.0 }, material_b{ 0.0 }, material_a{ 1.0 };
+    QString material_name;
     double mesh_scale_x{ 1.0 }, mesh_scale_y{ 1.0 }, mesh_scale_z{ 1.0 };
     double mesh_roll{ 0.0 }, mesh_pitch{ 0.0 }, mesh_yaw{ 0.0 };
     bool mesh_available{ false };

--- a/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
@@ -26,6 +26,12 @@ struct WorkcellStudioCanvasItem {
   double x{0.0}, y{0.0}, z{0.0}, roll{0.0}, pitch{0.0}, yaw{0.0}, width{0.25}, depth{0.25}, height{0.25}, radius{0.0};
   std::string mesh_path;
   std::string mesh_type;
+  std::string primitive_geometry_type;
+  double primitive_radius{0.0};
+  double primitive_length{0.0};
+  bool has_material_color{false};
+  double material_r{0.0}, material_g{0.0}, material_b{0.0}, material_a{1.0};
+  std::string material_name;
   double mesh_scale_x{1.0}, mesh_scale_y{1.0}, mesh_scale_z{1.0};
   double mesh_r{0.0}, mesh_p{0.0}, mesh_y{0.0};
   bool has_mesh_metadata{false};

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -258,6 +258,27 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   push_default_item("object_a", "object", "object", "Object", "environment.yaml", 0.6, 0.1, 0, 0, 0, 0, 0.08, 0.08, 0.08, 0, false);
   push_default_item("home_pose", "safety", "safety/home", "config/workcell_builder_task_intent.yaml", "config/workcell_builder_task_intent.yaml", -0.4, 0.5, 0, 0, 0, 0, 0.14, 0.14, 0.14, 0, true);
 
+
+  const auto copy_primitive_metadata = [&](WorkcellStudioCanvasItem & item, const YAML::Node & node) {
+    const std::string primitive_type = read_string_or_warn(yaml_map_key(node, "primitive_geometry_type"), "items[].primitive_geometry_type",
+      read_string_or_warn(yaml_map_key(node, "geometry_type"), "items[].geometry_type", ""));
+    if (!primitive_type.empty() && primitive_type != "mesh") item.primitive_geometry_type = primitive_type;
+    item.primitive_radius = read_double_or_warn(yaml_map_key(node, "primitive_radius"), "items[].primitive_radius",
+      read_double_or_warn(yaml_map_key(node, "radius"), "items[].radius", item.primitive_radius));
+    item.primitive_length = read_double_or_warn(yaml_map_key(node, "primitive_length"), "items[].primitive_length",
+      read_double_or_warn(yaml_map_key(node, "length"), "items[].length", item.primitive_length));
+    item.material_name = read_string_or_warn(yaml_map_key(node, "material_name"), "items[].material_name", item.material_name);
+    const YAML::Node material = yaml_map_key(node, "material");
+    const YAML::Node color = yaml_node_is_map(material) ? yaml_map_key(material, "color") : yaml_map_key(node, "material_color");
+    if (yaml_node_is_sequence(color) && color.size() >= 3) {
+      item.has_material_color = true;
+      item.material_r = read_double_or_warn(yaml_seq_index(color, 0), "items[].material.color[0]", item.material_r);
+      item.material_g = read_double_or_warn(yaml_seq_index(color, 1), "items[].material.color[1]", item.material_g);
+      item.material_b = read_double_or_warn(yaml_seq_index(color, 2), "items[].material.color[2]", item.material_b);
+      item.material_a = read_double_or_warn(yaml_seq_index(color, 3), "items[].material.color[3]", item.material_a);
+    }
+  };
+
   const std::string schema_version = read_string_or_warn(yaml_map_key(layout, "schema_version"), "schema_version", "");
   YAML::Node layout_items = yaml_map_key(layout, "items");
   const bool schema_current = (schema_version == "workcell_studio_layout/v1");
@@ -276,6 +297,7 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
         if (item.id == id) {
           matched_existing = true;
           item.provenance = WorkcellStudioItemProvenance::EditableLayout;
+          copy_primitive_metadata(item, node);
           YAML::Node pose = yaml_map_key(node, "pose");
           if (pose.IsDefined() && pose.IsMap()) {
             YAML::Node xyz = yaml_map_key(pose, "xyz");
@@ -316,6 +338,7 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
         if (source_file.empty()) source_file = read_string_or_warn(yaml_map_key(node, "source_layer"), "items[].source_layer", "layout/workcell_studio_layout.yaml");
         extra.source_file = source_file.empty() ? "layout/workcell_studio_layout.yaml" : source_file;
         extra.provenance = WorkcellStudioItemProvenance::EditableLayout;
+        copy_primitive_metadata(extra, node);
         YAML::Node pose = yaml_map_key(node, "pose");
         if (pose.IsDefined() && pose.IsMap()) {
           YAML::Node xyz = yaml_map_key(pose, "xyz");

--- a/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
@@ -73,6 +73,26 @@ TEST(Scene3DRenderRoleClassifier, MeshesModeDoesNotDrawFallbackSolid)
   EXPECT_TRUE(Scene3DViewportWidget::should_draw_as_wireframe_for_test(missing, ScenePreviewWidget::MeshPreviewMode::Meshes));
 }
 
+TEST(Scene3DRenderRoleClassifier, ValidUrdfPrimitivesAreSolidNotWireframeFallback)
+{
+  auto primitive = make_item("urdf_cylinder");
+  primitive.locked = true;
+  primitive.editable = false;
+  primitive.lock_reason = "Generated URDF visual";
+  primitive.source_layer = "generated_urdf_visual";
+  primitive.active_visual_source = "urdf_primitive";
+  primitive.mesh_available = false;
+  primitive.has_mesh_metadata = false;
+  primitive.mesh_path.clear();
+  primitive.primitive_geometry_type = "cylinder";
+  primitive.primitive_radius = 0.05;
+  primitive.primitive_length = 0.20;
+
+  EXPECT_EQ(Scene3DViewportWidget::render_role_for_test(primitive), "generated_urdf_primitive");
+  EXPECT_TRUE(Scene3DViewportWidget::should_draw_as_solid_for_test(primitive, ScenePreviewWidget::MeshPreviewMode::Auto));
+  EXPECT_FALSE(Scene3DViewportWidget::should_draw_as_wireframe_for_test(primitive, ScenePreviewWidget::MeshPreviewMode::Auto));
+}
+
 TEST(Scene3DRenderRoleClassifier, AcceptsCanonicalAndLegacyGeneratedUrdfTokens)
 {
   auto canonical = make_item("canonical");


### PR DESCRIPTION
### Motivation
- Preserve URDF primitive visuals (box/cylinder/sphere/capsule) and material/color metadata so generated previews are truthful instead of falling back to wireframe/placeholders.
- Make preview rendering use the original visual origin, primitive dimensions, and material color when available for more accurate builder UX and diagnostics.

### Description
- Added primitive metadata fields to the preview and model carriers: `primitive_geometry_type`, `primitive_radius`, `primitive_length`, optional material/color (`has_material_color`, `material_r`, `material_g`, `material_b`, `material_a`, `material_name`) in `ScenePreviewWidget::PreviewItem` and `WorkcellStudioCanvasItem`.
- Propagated primitive/material data when assembling preview items inside `MainWindow::populate_scene_hierarchy` so generated URDF visuals preserve source primitive and material info rather than being marked as generic fallbacks.
- Extended `scripts/extract_scene_urdf_visual_mesh_index.py` to preserve `box`, `cylinder`, `sphere`, and `capsule` entries (including visual origin and material color) and emit them in the visual index as primitive sources instead of placeholder-only counts.
- Implemented solid primitive rendering in `Scene3DViewportWidget`: added `draw_urdf_primitive_geometry()` plus `draw_sphere()`, applied item pose, visual origin, scale, primitive dimensions, and material color, and incremented the URDF primitive counters when rendered.
- Updated classification/visibility logic so valid URDF primitives are not treated as wireframe fallbacks (`should_draw_as_wireframe_for_test` and related role logic) and added a unit test to cover the behavior.

### Testing
- `python3 -m py_compile scripts/extract_scene_urdf_visual_mesh_index.py` succeeded and a small inline extractor smoke test verified preserved visual origin and material color for a `box` and `capsule` sample.
- Ran `python3 scripts/extract_scene_urdf_visual_mesh_index.py --scene ur5_2f_test --no-write` successfully to exercise the extractor on a real scene.
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` and validated the scene report returned `ok: true` with no regressions in visual readiness counters.
- Attempted to build/run C++ tests locally but `colcon` / `ament_cmake` are not available in this container so full compilation of GUI tests was not executed; code-level unit additions were run as source-level checks and a role-classifier unit test was added for CI to run where the build environment exists.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da51e07b8833194a225e22e7962ac)