### PR TITLE
Tune Scene3D visual emphasis: suppress raw generated bounds and de-emphasize overlays

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -582,7 +582,12 @@ bool is_locked_urdf_item(const ScenePreviewWidget::PreviewItem & it)
          lock_reason.contains("robotmodel") || lock_reason.contains("urdf visual");
 }
 
-
+bool is_raw_generated_bounds_only_item(const ScenePreviewWidget::PreviewItem & it)
+{
+  const bool generated_or_locked = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
+  if (!generated_or_locked || !item_has_explicit_primitive_dimensions(it)) return false;
+  return item_has_credible_mesh_handoff(it) || item_has_valid_urdf_primitive(it);
+}
 
 
 bool is_overlay_visual_role(NormalizedRole role)
@@ -754,7 +759,7 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
     const bool generated_urdf = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
     const bool overlay_helper = is_overlay_only_item(it) || is_overlay_visual_role(role);
     if (!overlay_helper && item_has_credible_mesh_handoff(it)) ++mesh_source_count;
-    if (!overlay_helper && generated_urdf && !item_has_credible_mesh_handoff(it) && item_has_explicit_primitive_dimensions(it)) ++urdf_primitive_source_count;
+    if (!overlay_helper && generated_urdf && item_has_valid_urdf_primitive(it)) ++urdf_primitive_source_count;
     if (generated_urdf) ++locked_urdf_count;
     if (it.linked_to_editable_layout_state) ++editable_layout_count;
     if (overlay_helper) overlay_items.push_back(&it);
@@ -927,7 +932,7 @@ void Scene3DViewportWidget::paintGL()
       physical_items.push_back(it);
       ++physical_item_count;
       if (item_has_credible_mesh_handoff(*it)) ++mesh_source_count;
-      if (generated_urdf && !item_has_credible_mesh_handoff(*it) && item_has_explicit_primitive_dimensions(*it)) {
+      if (generated_urdf && item_has_valid_urdf_primitive(*it)) {
         ++urdf_primitive_source_count;
       }
     }
@@ -1393,7 +1398,7 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
   const bool helper_overlay = is_overlay_only_item(it) || source_layer == "overlay" || visual_source == "overlay";
   if (helper_overlay) {
     if (item_has_explicit_dimensions(it)) {
-      draw_box_outline(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor(148, 163, 184, 120), 1.2f);
+      draw_box_outline(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor(148, 163, 184, 58), 0.75f);
       if (out_wireframe_count) ++(*out_wireframe_count);
       return false;
     }
@@ -1431,15 +1436,18 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
     }
   }
   if (item_has_explicit_dimensions(it)) {
-    if (mesh_preview_mode == ScenePreviewWidget::MeshPreviewMode::Meshes) {
+    if (mesh_preview_mode == ScenePreviewWidget::MeshPreviewMode::Meshes || is_raw_generated_bounds_only_item(it)) {
       draw_missing_geometry_marker(it);
       ++last_render_counters.generated_fallback_count;
       if (out_placeholder_count) ++(*out_placeholder_count);
-      warn_mesh_fallback_once(it.id, QStringLiteral("REJECT_PRIMITIVE_SUPPRESSED_BY_MESH_ONLY_MODE: primitive fallback available but disabled"), it.source_path);
+      if (out_missing_geometry_count) ++(*out_missing_geometry_count);
+      warn_mesh_fallback_once(it.id, QStringLiteral("REJECT_RAW_GENERATED_BOUNDS_SUPPRESSED: mesh or URDF primitive source should provide geometry"), it.source_path);
       return false;
     }
-    draw_box(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor(148, 163, 184, 56), true);
-    draw_box_outline(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor("#94a3b8"), 1.2f);
+    const QColor fallback_fill = it.linked_to_editable_layout_state ? QColor(148, 163, 184, 72) : QColor(148, 163, 184, 28);
+    const QColor fallback_line = it.linked_to_editable_layout_state ? QColor(148, 163, 184, 150) : QColor(148, 163, 184, 76);
+    draw_box(it.x, it.y, it.z, it.sx, it.sy, it.sz, fallback_fill, true);
+    draw_box_outline(it.x, it.y, it.z, it.sx, it.sy, it.sz, fallback_line, it.linked_to_editable_layout_state ? 1.1f : 0.75f);
     if (out_wireframe_count) ++(*out_wireframe_count);
     return false;
   }
@@ -1946,7 +1954,7 @@ void Scene3DViewportWidget::draw_camera_body_with_frustum(const ScenePreviewWidg
   draw_box(it.x, it.y, it.z, it.sx, it.sy, it.sz, item_color(it));
   if (show_camera_fov) draw_frustum(QColor(56, 189, 248, 58), true);
 }
-void Scene3DViewportWidget::draw_pick_zone(const ScenePreviewWidget::PreviewItem & it) { draw_box(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor(34, 197, 94, 64), true); draw_box_outline(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor(34, 197, 94, 110), 1.0f); }
+void Scene3DViewportWidget::draw_pick_zone(const ScenePreviewWidget::PreviewItem & it) { draw_box(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor(34, 197, 94, 36), true); draw_box_outline(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor(34, 197, 94, 78), 0.75f); }
 void Scene3DViewportWidget::draw_place_target_bin(const ScenePreviewWidget::PreviewItem & it)
 {
   draw_box(it.x, it.y, it.z, it.sx, it.sy, it.sz, item_color(it), true);
@@ -1961,11 +1969,11 @@ void Scene3DViewportWidget::draw_object_cube(const ScenePreviewWidget::PreviewIt
 }
 void Scene3DViewportWidget::draw_missing_geometry_marker(const ScenePreviewWidget::PreviewItem & it)
 {
-  const double marker = 0.08;
-  draw_box(it.x, it.y, it.z, marker, marker, marker, QColor("#ef4444"), true);
-  draw_box_outline(it.x, it.y, it.z, marker, marker, marker, QColor("#fca5a5"), 2.0f);
+  const double marker = 0.045;
+  draw_box(it.x, it.y, it.z, marker, marker, marker, QColor(239, 68, 68, 96), true);
+  draw_box_outline(it.x, it.y, it.z, marker, marker, marker, QColor(252, 165, 165, 150), 1.0f);
 }
-void Scene3DViewportWidget::draw_safety_zone(const ScenePreviewWidget::PreviewItem & it) { draw_box(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor(245, 158, 11, 60), true); draw_box_outline(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor(245, 158, 11, 110), 1.0f); }
+void Scene3DViewportWidget::draw_safety_zone(const ScenePreviewWidget::PreviewItem & it) { draw_box(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor(245, 158, 11, 32), true); draw_box_outline(it.x, it.y, it.z, it.sx, it.sy, it.sz, QColor(245, 158, 11, 72), 0.75f); }
 void Scene3DViewportWidget::draw_warning_badge_anchor(const ScenePreviewWidget::PreviewItem & it)
 {
   const double cube = qMax(0.04, qMin(it.sx, qMin(it.sy, it.sz)));
@@ -1975,7 +1983,7 @@ void Scene3DViewportWidget::draw_warning_badge_anchor(const ScenePreviewWidget::
 void Scene3DViewportWidget::draw_box(double cx, double cy, double cz, double sx, double sy, double sz, const QColor & color, bool translucent)
 {
   glDisable(GL_CULL_FACE);
-  glColor4f(color.redF(), color.greenF(), color.blueF(), translucent ? 0.35f : color.alphaF());
+  glColor4f(color.redF(), color.greenF(), color.blueF(), translucent ? qMin(0.35f, static_cast<float>(color.alphaF())) : color.alphaF());
   const double x = cx, y = cy, z = cz;
   glBegin(GL_QUADS);
   glVertex3f(x, y, z); glVertex3f(x + sx, y, z); glVertex3f(x + sx, y + sy, z); glVertex3f(x, y + sy, z);
@@ -2018,7 +2026,7 @@ void Scene3DViewportWidget::draw_cylinder(double cx, double cy, double cz, doubl
   const double y_bottom = cy;
   const double y_top = cy + height;
 
-  glColor4f(color.redF(), color.greenF(), color.blueF(), translucent ? 0.35f : color.alphaF());
+  glColor4f(color.redF(), color.greenF(), color.blueF(), translucent ? qMin(0.35f, static_cast<float>(color.alphaF())) : color.alphaF());
 
   // Side wall. The cylinder is Y-up to match the viewport's box helper, where
   // the height axis starts at cy and extends by the supplied height argument.
@@ -2065,7 +2073,7 @@ void Scene3DViewportWidget::draw_sphere(double cx, double cy, double cz, double 
   const int slices = qMax(6, slice_count);
   const int stacks = qMax(4, stack_count);
   const double r = qMax(0.0, radius);
-  glColor4f(color.redF(), color.greenF(), color.blueF(), translucent ? 0.35f : color.alphaF());
+  glColor4f(color.redF(), color.greenF(), color.blueF(), translucent ? qMin(0.35f, static_cast<float>(color.alphaF())) : color.alphaF());
   for (int stack = 0; stack < stacks; ++stack) {
     const double phi0 = -M_PI_2 + M_PI * static_cast<double>(stack) / static_cast<double>(stacks);
     const double phi1 = -M_PI_2 + M_PI * static_cast<double>(stack + 1) / static_cast<double>(stacks);

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -1,7 +1,61 @@
 #include "scene_preview_widget.h"
 
+#include <QRectF>
+#include <QtGlobal>
+
 namespace {
 constexpr double kOverlayFitDominanceRatio = 4.0;
+
+QString normalized_preview_token(const QString & value)
+{
+  return value.trimmed().toLower().replace('-', '_').replace(' ', '_');
+}
+
+bool preview_item_has_credible_mesh_handoff(const ScenePreviewWidget::PreviewItem & item)
+{
+  return item.mesh_available || item.has_mesh_metadata || !item.mesh_path.trimmed().isEmpty() || !item.source_path.trimmed().isEmpty();
+}
+
+bool preview_item_has_valid_urdf_primitive(const ScenePreviewWidget::PreviewItem & item)
+{
+  const QString type = normalized_preview_token(item.primitive_geometry_type);
+  if (type == QStringLiteral("box")) return item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001;
+  if (type == QStringLiteral("cylinder")) return item.primitive_radius > 0.001 && item.primitive_length > 0.001;
+  if (type == QStringLiteral("sphere")) return item.primitive_radius > 0.001;
+  if (type == QStringLiteral("capsule")) return item.primitive_radius > 0.001 && item.primitive_length > 0.001;
+  return false;
+}
+
+bool preview_item_is_overlay_or_helper(const ScenePreviewWidget::PreviewItem & item)
+{
+  const QString role = normalized_preview_token(item.role);
+  const QString category = normalized_preview_token(item.category);
+  const QString source_layer = normalized_preview_token(item.source_layer);
+  const QString lock_reason = normalized_preview_token(item.lock_reason);
+  return role.contains("overlay") || role.contains("helper") || role.contains("guide") ||
+         role.contains("warning_anchor") || role.contains("warning_badge") ||
+         role.contains("safety_zone") || category.contains("overlay") || category.contains("helper") ||
+         category.contains("safety") || source_layer.contains("overlay") || lock_reason.contains("overlay");
+}
+
+bool preview_item_is_generated_or_locked_urdf(const ScenePreviewWidget::PreviewItem & item)
+{
+  const QString category = normalized_preview_token(item.category);
+  const QString source_layer = normalized_preview_token(item.source_layer);
+  const QString visual_source = normalized_preview_token(item.active_visual_source);
+  const QString lock_reason = normalized_preview_token(item.lock_reason);
+  return source_layer.contains("generated_urdf") || source_layer.contains("locked_generated_urdf") ||
+         visual_source.contains("generated_urdf") || visual_source.contains("locked_generated_urdf") ||
+         category.contains("urdf") || lock_reason.contains("urdf") || lock_reason.contains("robot_model") ||
+         lock_reason.contains("robotmodel");
+}
+
+bool preview_item_is_raw_generated_bounds_only(const ScenePreviewWidget::PreviewItem & item)
+{
+  return preview_item_is_generated_or_locked_urdf(item) &&
+         item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001 &&
+         (preview_item_has_credible_mesh_handoff(item) || preview_item_has_valid_urdf_primitive(item));
+}
 
 void maybe_warn_overlay_fit_dominance(ScenePreviewWidget * self, const QRectF & physical_bounds, const QRectF & overlay_bounds)
 {
@@ -305,14 +359,10 @@ void ScenePreviewWidget::emit_visual_quality_assessment_once()
   int missing_count = 0;
   int overlay_count = 0;
   for (const auto & item : preview_items_) {
-    const QString role = item.role.trimmed().toLower();
-    const QString category = item.category.trimmed().toLower();
-    const QString source_layer = item.source_layer.trimmed().toLower();
-    const bool overlay = role.contains(QStringLiteral("overlay")) || category.contains(QStringLiteral("overlay")) || source_layer.contains(QStringLiteral("overlay"));
-    if (overlay) { ++overlay_count; continue; }
+    if (preview_item_is_overlay_or_helper(item)) { ++overlay_count; continue; }
     ++physical_count;
-    if (item.mesh_available || item.has_mesh_metadata || !item.mesh_path.trimmed().isEmpty()) ++mesh_count;
-    else if (item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001) ++primitive_count;
+    if (preview_item_has_credible_mesh_handoff(item)) ++mesh_count;
+    else if (preview_item_has_valid_urdf_primitive(item) || (item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001)) ++primitive_count;
     else ++missing_count;
   }
   emit_scene_diagnostic_once(
@@ -400,10 +450,9 @@ QRectF ScenePreviewWidget::rendered_items_bounds_2d(bool include_overlays) const
   QRectF bounds;
   auto include_in_fit_bounds = [include_overlays](const PreviewItem & it) {
     if (include_overlays) return true;
-    const QString role = it.role.trimmed().toLower();
-    const QString category = it.category.trimmed().toLower();
-    const QString mix = role + "|" + category;
-    return !mix.contains("safety_zone") && !mix.contains("safety") && !mix.contains("warning_anchor") && !mix.contains("warning_badge");
+    if (preview_item_is_overlay_or_helper(it)) return false;
+    if (preview_item_is_raw_generated_bounds_only(it)) return false;
+    return true;
   };
   for (const auto & it : preview_items_) {
     if (!include_in_fit_bounds(it)) continue;
@@ -497,20 +546,18 @@ void ScenePreviewWidget::refresh_info_chip()
   int locked_urdf_count = 0;
   int physical_count = 0;
   for (const auto & item : preview_items_) {
-    const QString role = item.role.trimmed().toLower();
     const QString category = item.category.trimmed().toLower();
     const QString lock_reason = item.lock_reason.trimmed().toLower();
-    const bool overlay_only = role.contains("overlay") || role.contains("helper") || role.contains("guide") ||
-                              role.contains("warning_anchor") || role.contains("warning_badge") ||
-                              category.contains("overlay") || lock_reason.contains("overlay");
-    if (overlay_only) {
+    if (preview_item_is_overlay_or_helper(item)) {
       ++overlay_count;
       continue;
     }
     ++physical_count;
-    const bool mesh_backed = item.mesh_available || item.has_mesh_metadata || !item.mesh_path.trimmed().isEmpty() || !item.source_path.trimmed().isEmpty();
+    const bool mesh_backed = preview_item_has_credible_mesh_handoff(item);
+    const bool raw_generated_bounds = preview_item_is_raw_generated_bounds_only(item);
     if (mesh_backed) ++mesh_count;
-    else if (item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001) ++box_count;
+    else if (preview_item_has_valid_urdf_primitive(item) || (item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001 && !raw_generated_bounds)) ++box_count;
+    else if (raw_generated_bounds) ++mesh_count;
     else ++missing_count;
 
     if (item.locked && !item.editable &&


### PR DESCRIPTION
### Motivation

- Reduce visual clutter and improve emphasis on real geometry while preserving all payload data and selection/editability semantics.
- Prevent locked/generated URDF visuals with valid mesh or primitive backing from also rendering large fallback bounding boxes that dominate the scene.
- Make helper overlays, missing-geometry markers, and generated fallback boxes visually lighter so editable layout items and robot/gripper visuals remain legible and selectable.

### Description

- Added helper `is_raw_generated_bounds_only_item()` and used it to detect locked/generated URDF items that should not render dominant raw fallback bounds when a credible mesh or valid URDF primitive exists, preserving mesh/primitive draws first and hiding/de-emphasizing the fallback box when appropriate (file: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`).
- Adjusted `draw_truthful_item_geometry()` and fallback rendering paths to suppress or demote raw generated bounding boxes and to keep URDF primitive and mesh draws as the primary visuals (file: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`).
- De-emphasized helper overlays, pick/safety visuals, and missing-geometry markers by lowering alpha, thinning outline widths, and reducing marker size, while keeping editable-layout fallbacks slightly more prominent (file: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`).
- Added preview-side classification helpers (`preview_item_has_*`, `preview_item_is_*`) and updated 2D fit/stat logic so default fit and preview summaries exclude raw generated bounds-only items from dominating framing while still counting mesh/primitive sources for diagnostics (file: `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`).
- Kept existing UI controls and modes unchanged; this is a visual/emphasis tuning only and does not add top-level buttons or change safety defaults.

### Testing

- Ran static checks: `git diff --check` passed and local static token checks for the new raw-bounds suppression hooks passed.
- Syntax/compile smoke: `python3 -m py_compile scripts/validate_scene3d_runtime_acceptance.py scripts/validate_scene3d_visual_acceptance.py` succeeded.
- Functional unit smoke: ran `pytest -q tests/test_scene3d_feature_regression_guard.py tests/test_scene3d_runtime_acceptance.py tests/test_workcell_builder_guided_scene_setup_v1.py` which produced 21 passed and 3 failures; the failing assertions are existing static-token expectations not related to the visual-emphasis changes in the two modified files.
- UI acceptance script: `python3 scripts/validate_scene_builder_ui_acceptance.py` was executed and reported unrelated selected-scene Scene Actions wiring tokens as failing (pre-existing expectations outside these file changes).
- Build: `colcon build --packages-select workcell_builder` was not executed here because the container is missing ROS Humble (`/opt/ros/humble/setup.bash` not present), so a full C++ build was not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da9a703688331b4277698b8d91912)