### PR TITLE
Block missing Scene3D visual evidence and expose machine-readable blocker_reasons

### DIFF
--- a/scripts/run_scene3d_visual_quality_screenshots.py
+++ b/scripts/run_scene3d_visual_quality_screenshots.py
@@ -338,11 +338,17 @@ def build_result_for_target(
     )
     counter_summary = _counter_summary(smoke_payload)
     all_blockers = list(wrapper_blockers)
+    all_blocker_reasons = list(wrapper_blockers)
     if isinstance(smoke_payload.get("blockers"), list):
         all_blockers.extend(str(x) for x in smoke_payload["blockers"])
+    if isinstance(smoke_payload.get("blocker_reasons"), list):
+        all_blocker_reasons.extend(str(x) for x in smoke_payload["blocker_reasons"])
     all_blockers.extend(str(x) for x in visual_quality.get("blockers", []))
+    if isinstance(visual_quality.get("blocker_reasons"), list):
+        all_blocker_reasons.extend(str(x) for x in visual_quality["blocker_reasons"])
+    all_blocker_reasons = list(dict.fromkeys(reason for reason in all_blocker_reasons if reason))
     status = "PASS" if rc == 0 and not all_blockers and str(smoke_payload.get("status", "")).upper() in {"PASS", "OK"} else "FAIL"
-    if str(smoke_payload.get("status", "")).upper() == "BLOCKED" or wrapper_blockers:
+    if str(smoke_payload.get("status", "")).upper() == "BLOCKED" or wrapper_blockers or all_blocker_reasons:
         status = "BLOCKED"
     return {
         "scene": target["scene_name"],
@@ -359,6 +365,7 @@ def build_result_for_target(
         "mesh_failure_summary_by_reason_code": mesh_failure_summary(mesh_index),
         "visual_quality_evaluation": visual_quality,
         "blockers": all_blockers,
+        "blocker_reasons": all_blocker_reasons,
     }
 
 
@@ -421,15 +428,16 @@ def main(argv: list[str] | None = None) -> int:
         f"- FAIL: {totals['FAIL']}",
         f"- BLOCKED: {totals['BLOCKED']}",
         "",
-        "| Scene | Status | Smoke JSON | Screenshot | Mesh failure reasons |",
-        "|---|---|---|---|---|",
+        "| Scene | Status | Smoke JSON | Screenshot | Blocker reasons | Mesh failure reasons |",
+        "|---|---|---|---|---|---|",
     ]
     for result in results:
         reasons = result["mesh_failure_summary_by_reason_code"].get("by_reason_code", {})
         reason_text = ", ".join(f"{k}={v}" for k, v in reasons.items()) or "none"
+        blocker_reason_text = ", ".join(str(reason) for reason in result.get("blocker_reasons", [])) or "none"
         md.append(
             f"| {result['scene']} | {result['status']} | `{result['smoke_json']}` | "
-            f"`{result['screenshot_path']}` | {reason_text} |"
+            f"`{result['screenshot_path']}` | {blocker_reason_text} | {reason_text} |"
         )
     (output_dir / "scene3d_visual_quality_screenshots_summary.md").write_text("\n".join(md) + "\n", encoding="utf-8")
     print(json.dumps(payload, indent=2))

--- a/scripts/validate_scene3d_visual_quality_matrix.py
+++ b/scripts/validate_scene3d_visual_quality_matrix.py
@@ -218,6 +218,12 @@ def evaluate_scene(
 ) -> dict[str, Any]:
     warnings: list[str] = []
     blockers: list[str] = []
+    blocker_reasons: list[str] = []
+
+    def add_blocker(message: str, reason: str | None = None) -> None:
+        blockers.append(message)
+        if reason and reason not in blocker_reasons:
+            blocker_reasons.append(reason)
 
     mesh_index: dict[str, Any] = {}
     if not mesh_index_path.exists():
@@ -234,11 +240,14 @@ def evaluate_scene(
     if smoke_exists and smoke_json_path is not None:
         smoke_payload = _load_json(smoke_json_path)
         if smoke_payload.get("_load_error"):
-            blockers.append(f"could not read smoke JSON: {smoke_json_path}: {smoke_payload['_load_error']}")
+            add_blocker(
+                f"smoke_json_unreadable: could not read smoke JSON: {smoke_json_path}: {smoke_payload['_load_error']}",
+                "smoke_json_unreadable",
+            )
         elif smoke_payload.get("schema") not in {SMOKE_SCHEMA, None}:
             warnings.append(f"unexpected smoke schema: {smoke_payload.get('schema')!r}")
     elif smoke_json_path is not None:
-        warnings.append(f"smoke JSON not found: {smoke_json_path}")
+        add_blocker(f"smoke_json_missing: smoke JSON not found: {smoke_json_path}", "smoke_json_missing")
     else:
         warnings.append("smoke JSON not provided")
 
@@ -267,7 +276,7 @@ def evaluate_scene(
         warnings.append(f"{missing_geometry_count} source payload item(s) lack mesh or primitive geometry")
 
     if screenshot_path is not None and not screenshot_path.exists():
-        warnings.append(f"screenshot not found: {screenshot_path}")
+        add_blocker(f"screenshot_missing: screenshot not found: {screenshot_path}", "screenshot_missing")
 
     if synthetic_fixture:
         if mesh_source_count < 1 or primitive_source_count < 1:
@@ -296,6 +305,7 @@ def evaluate_scene(
         "visual_quality_status": visual_quality_status,
         "warnings": warnings,
         "blockers": blockers,
+        "blocker_reasons": blocker_reasons,
     }
 
 

--- a/tests/test_scene3d_visual_quality_matrix.py
+++ b/tests/test_scene3d_visual_quality_matrix.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import yaml
 
+import scripts.run_scene3d_visual_quality_screenshots as screenshots
 import scripts.validate_scene3d_visual_quality_matrix as matrix
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -95,6 +96,7 @@ def test_visual_quality_matrix_emits_required_fields_and_synthetic_fixture_passe
             "wireframe_fallback_count",
             "visual_quality_status",
             "warnings",
+            "blocker_reasons",
         ):
             assert field in scene
         assert scene["mesh_source_count"] == 1
@@ -103,6 +105,7 @@ def test_visual_quality_matrix_emits_required_fields_and_synthetic_fixture_passe
         assert scene["primitive_rendered_count"] == 1
         assert scene["placeholder_count"] == 0
         assert scene["visual_quality_status"] == "PASS"
+        assert scene["blocker_reasons"] == []
 
 
 def test_visual_quality_matrix_rejects_rendered_count_only_and_missing_primitive_render_counter(tmp_path: Path) -> None:
@@ -182,6 +185,99 @@ def test_visual_quality_matrix_rejects_primitive_placeholders_and_wireframe_domi
     assert "valid URDF primitives must not increment placeholder_count" in scene["blockers"]
     assert "wireframe_fallback_count dominates visible physical items" in scene["blockers"]
 
+
+def test_evaluate_scene_blocks_missing_smoke_json_with_reason_code(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scene_dir = repo / "scenes" / "missing_smoke_scene"
+    mesh_index = scene_dir / "generated" / "scene_visual_mesh_index.json"
+    _write_json(mesh_index, _mesh_and_primitive_index())
+    missing_smoke = scene_dir / "generated" / "scene3d_gui_smoke.json"
+
+    result = matrix.evaluate_scene(
+        scene_name="missing_smoke_scene",
+        scene_dir=scene_dir,
+        mesh_index_path=mesh_index,
+        smoke_json_path=missing_smoke,
+    )
+
+    assert result["visual_quality_status"] == "FAIL"
+    assert "smoke_json_missing" in result["blocker_reasons"]
+    assert any(blocker.startswith("smoke_json_missing:") for blocker in result["blockers"])
+    assert not any("smoke JSON not found" in warning for warning in result["warnings"])
+
+
+def test_evaluate_scene_blocks_unreadable_smoke_json_with_reason_code(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scene_dir = repo / "scenes" / "unreadable_smoke_scene"
+    mesh_index = scene_dir / "generated" / "scene_visual_mesh_index.json"
+    smoke_json = scene_dir / "generated" / "scene3d_gui_smoke.json"
+    _write_json(mesh_index, _mesh_and_primitive_index())
+    smoke_json.parent.mkdir(parents=True, exist_ok=True)
+    smoke_json.write_text("{not valid json", encoding="utf-8")
+
+    result = matrix.evaluate_scene(
+        scene_name="unreadable_smoke_scene",
+        scene_dir=scene_dir,
+        mesh_index_path=mesh_index,
+        smoke_json_path=smoke_json,
+    )
+
+    assert result["visual_quality_status"] == "FAIL"
+    assert "smoke_json_unreadable" in result["blocker_reasons"]
+    assert any(blocker.startswith("smoke_json_unreadable:") for blocker in result["blockers"])
+
+
+def test_evaluate_scene_blocks_missing_screenshot_with_reason_code(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scene_dir = _write_scene(repo, "missing_screenshot_scene", _mesh_and_primitive_index(), _passing_smoke())
+    mesh_index = scene_dir / "generated" / "scene_visual_mesh_index.json"
+    smoke_json = scene_dir / "generated" / "scene3d_gui_smoke.json"
+    screenshot = scene_dir / "generated" / "scene3d_gui_smoke.png"
+
+    result = matrix.evaluate_scene(
+        scene_name="missing_screenshot_scene",
+        scene_dir=scene_dir,
+        mesh_index_path=mesh_index,
+        smoke_json_path=smoke_json,
+        screenshot_path=screenshot,
+    )
+
+    assert result["visual_quality_status"] == "FAIL"
+    assert "screenshot_missing" in result["blocker_reasons"]
+    assert any(blocker.startswith("screenshot_missing:") for blocker in result["blockers"])
+    assert not any("screenshot not found" in warning for warning in result["warnings"])
+
+
+
+def test_screenshot_runner_marks_visual_quality_blocker_reasons_blocked(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    output_dir = tmp_path / "out"
+    scene_dir = _write_scene(repo, "runner_scene", _mesh_and_primitive_index(), _passing_smoke())
+    smoke_json = scene_dir / "generated" / "scene3d_gui_smoke.json"
+    missing_screenshot = output_dir / "scene3d_gui_smoke_runner_scene.png"
+
+    def fake_run_smoke_for_target(**kwargs):
+        return 0, smoke_json, missing_screenshot, _passing_smoke(), [], "fake smoke command"
+
+    monkeypatch.setattr(screenshots, "_run_smoke_for_target", fake_run_smoke_for_target)
+
+    result = screenshots.build_result_for_target(
+        repo_root=repo,
+        workspace_root=repo,
+        executable=None,
+        target={
+            "target_kind": "explicit_scene",
+            "scene_name": "runner_scene",
+            "scene_path": str(scene_dir),
+        },
+        output_dir=output_dir,
+        timeout_sec=1.0,
+        xvfb=False,
+    )
+
+    assert result["status"] == "BLOCKED"
+    assert "screenshot_missing" in result["blocker_reasons"]
+    assert result["visual_quality_evaluation"]["blocker_reasons"] == ["screenshot_missing"]
 
 def test_visual_quality_matrix_cli_writes_json(tmp_path: Path) -> None:
     repo = tmp_path / "repo"


### PR DESCRIPTION
### Motivation
- Ensure visual-evidence gaps (missing/unreadable smoke JSON and missing screenshots) are treated as blockers, not silent warnings, so CI and dashboards can reliably detect incomplete Scene3D GUI smoke runs. 
- Provide stable, machine-readable reason codes alongside human-readable blockers to allow automated consumers to react programmatically.

### Description
- Change `evaluate_scene` in `scripts/validate_scene3d_visual_quality_matrix.py` to treat missing smoke JSON, unreadable smoke JSON, and missing screenshots as blockers and to emit stable reason codes `smoke_json_missing`, `smoke_json_unreadable`, and `screenshot_missing` via a new `blocker_reasons` list in the returned payload. 
- Add an `add_blocker` helper to collect both human `blockers` and machine `blocker_reasons`. 
- Update `scripts/run_scene3d_visual_quality_screenshots.py` to aggregate `blocker_reasons` from wrapper, smoke payload, and visual-quality evaluation, to mark results `BLOCKED` when blocker reasons exist, and to include `blocker_reasons` in each result and in the Markdown summary table. 
- Add synthetic unit tests to `tests/test_scene3d_visual_quality_matrix.py` covering missing smoke JSON, unreadable smoke JSON, missing screenshot, and the screenshot-runner propagation of `blocker_reasons`; also assert `blocker_reasons` present/empty where appropriate.

### Testing
- Ran the test suite for the modified module with `python3 -m pytest tests/test_scene3d_visual_quality_matrix.py -q`, which completed successfully with all tests passing (8 passed).
- Existing visual-quality tests were retained and the new synthetic cases execute as part of the same test run and passed.
- No runtime or launch behavior was modified; change is limited to validation/reporting scripts and tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f16ede734833188a3877b77097efe)