### PR TITLE
Split Scene3D visual fallback counters and tighten visual-quality blockers

### DIFF
--- a/scripts/validate_scene3d_visual_quality_matrix.py
+++ b/scripts/validate_scene3d_visual_quality_matrix.py
@@ -11,7 +11,7 @@ import yaml
 
 SCHEMA = "workcell_studio_scene3d_visual_quality_matrix/v1"
 SMOKE_SCHEMA = "workcell_studio_scene3d_gui_smoke/v1"
-PHYSICAL_ITEM_DOMINANCE_RATIO = 0.5
+DIAGNOSTIC_FALLBACK_DOMINANCE_RATIO = 0.5
 
 MESH_KEYS = {"mesh", "mesh_path", "mesh_uri", "mesh_filename", "filename", "resource", "uri"}
 PRIMITIVE_TYPES = {"box", "cube", "cylinder", "sphere", "capsule", "cone", "primitive"}
@@ -244,9 +244,29 @@ def evaluate_scene(
 
     mesh_rendered_count = _counter(smoke_payload, "mesh_rendered_count", "mesh_backed_count")
     primitive_rendered_count = _counter(smoke_payload, "primitive_rendered_count", "urdf_primitive_rendered_count")
-    placeholder_count = _counter(smoke_payload, "placeholder_count", "placeholder_box_count", "primitive_fallback_count")
+    raw_generated_bounds_count = _counter(
+        smoke_payload,
+        "raw_generated_bounds_count",
+        "generated_bounds_count",
+        "generated_fallback_count",
+        "fallback_bounds_count",
+    )
+    placeholder_count = _counter(smoke_payload, "placeholder_count", "placeholder_box_count")
     wireframe_fallback_count = _counter(smoke_payload, "wireframe_fallback_count", "wireframe_box_count")
+    missing_geometry_box_count = _counter(
+        smoke_payload, "missing_geometry_box_count", "missing_geometry_boxes_count", "missing_geometry_count"
+    )
     rendered_count = _counter(smoke_payload, "rendered_count")
+
+    physical_rendered_count = mesh_rendered_count + primitive_rendered_count
+    diagnostic_fallback_count = (
+        raw_generated_bounds_count
+        + placeholder_count
+        + wireframe_fallback_count
+        + missing_geometry_box_count
+    )
+    visible_evidence_count = physical_rendered_count + diagnostic_fallback_count
+    credible_source_count = mesh_source_count + primitive_source_count
 
     if mesh_source_count > 0 and mesh_rendered_count <= 0:
         blockers.append("mesh_source_count > 0 requires mesh_rendered_count > 0")
@@ -254,15 +274,26 @@ def evaluate_scene(
         blockers.append("primitive_source_count > 0 requires primitive_rendered_count > 0")
     if primitive_source_count > 0 and placeholder_count > missing_geometry_count:
         blockers.append("valid URDF primitives must not increment placeholder_count")
-    if total_payload_count > 0 and mesh_source_count + primitive_source_count <= 0:
+    if total_payload_count > 0 and credible_source_count <= 0:
         blockers.append("source geometry classification missing; rendered_count alone cannot prove visual quality")
     if rendered_count == total_payload_count and total_payload_count > 0:
         warnings.append("rendered_count equals total_payload_count; pass still requires mesh/primitive-specific rendered counts")
 
-    visible_physical_count = mesh_rendered_count + primitive_rendered_count + placeholder_count + wireframe_fallback_count
-    if wireframe_fallback_count > 0 and visible_physical_count > 0:
-        if wireframe_fallback_count > int(visible_physical_count * PHYSICAL_ITEM_DOMINANCE_RATIO):
+    if credible_source_count > 0 and raw_generated_bounds_count > 0:
+        if physical_rendered_count <= 0 and raw_generated_bounds_count == visible_evidence_count:
+            blockers.append("raw/generated fallback bounds are the only visible evidence despite mesh or primitive sources")
+        elif raw_generated_bounds_count > int(visible_evidence_count * DIAGNOSTIC_FALLBACK_DOMINANCE_RATIO):
+            blockers.append("raw/generated fallback bounds dominate visible evidence despite mesh or primitive sources")
+        else:
+            warnings.append("raw/generated fallback bounds were rendered alongside credible mesh or primitive evidence")
+
+    if diagnostic_fallback_count > 0 and visible_evidence_count > 0:
+        if diagnostic_fallback_count > int(visible_evidence_count * DIAGNOSTIC_FALLBACK_DOMINANCE_RATIO):
+            blockers.append("diagnostic fallback evidence dominates credible physical render evidence")
+        if wireframe_fallback_count > int(visible_evidence_count * DIAGNOSTIC_FALLBACK_DOMINANCE_RATIO):
             blockers.append("wireframe_fallback_count dominates visible physical items")
+    elif wireframe_fallback_count > 0:
+        warnings.append("wireframe_fallback_count is diagnostic evidence and does not count as physical rendering")
     if missing_geometry_count > 0:
         warnings.append(f"{missing_geometry_count} source payload item(s) lack mesh or primitive geometry")
 
@@ -289,9 +320,13 @@ def evaluate_scene(
         "mesh_rendered_count": mesh_rendered_count,
         "primitive_source_count": primitive_source_count,
         "primitive_rendered_count": primitive_rendered_count,
+        "physical_rendered_count": physical_rendered_count,
+        "raw_generated_bounds_count": raw_generated_bounds_count,
         "placeholder_count": placeholder_count,
         "missing_geometry_count": missing_geometry_count,
+        "missing_geometry_box_count": missing_geometry_box_count,
         "wireframe_fallback_count": wireframe_fallback_count,
+        "diagnostic_fallback_count": diagnostic_fallback_count,
         "rendered_count": rendered_count,
         "visual_quality_status": visual_quality_status,
         "warnings": warnings,

--- a/tests/test_scene3d_visual_quality_matrix.py
+++ b/tests/test_scene3d_visual_quality_matrix.py
@@ -52,7 +52,9 @@ def _passing_smoke() -> dict:
             "rendered_count": 2,
             "mesh_rendered_count": 1,
             "primitive_rendered_count": 1,
+            "raw_generated_bounds_count": 0,
             "placeholder_count": 0,
+            "missing_geometry_box_count": 0,
             "wireframe_fallback_count": 0,
         },
     }
@@ -90,9 +92,13 @@ def test_visual_quality_matrix_emits_required_fields_and_synthetic_fixture_passe
             "mesh_rendered_count",
             "primitive_source_count",
             "primitive_rendered_count",
+            "physical_rendered_count",
+            "raw_generated_bounds_count",
             "placeholder_count",
             "missing_geometry_count",
+            "missing_geometry_box_count",
             "wireframe_fallback_count",
+            "diagnostic_fallback_count",
             "visual_quality_status",
             "warnings",
         ):
@@ -101,6 +107,9 @@ def test_visual_quality_matrix_emits_required_fields_and_synthetic_fixture_passe
         assert scene["mesh_rendered_count"] == 1
         assert scene["primitive_source_count"] == 1
         assert scene["primitive_rendered_count"] == 1
+        assert scene["physical_rendered_count"] == 2
+        assert scene["raw_generated_bounds_count"] == 0
+        assert scene["diagnostic_fallback_count"] == 0
         assert scene["placeholder_count"] == 0
         assert scene["visual_quality_status"] == "PASS"
 
@@ -181,6 +190,190 @@ def test_visual_quality_matrix_rejects_primitive_placeholders_and_wireframe_domi
     assert scene["visual_quality_status"] == "FAIL"
     assert "valid URDF primitives must not increment placeholder_count" in scene["blockers"]
     assert "wireframe_fallback_count dominates visible physical items" in scene["blockers"]
+
+
+def test_visual_quality_matrix_rejects_raw_generated_bounds_only_with_credible_sources(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_scene(
+        repo,
+        "raw_bounds_only_scene",
+        _mesh_and_primitive_index(),
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "render_debug_counters": {
+                "rendered_count": 1,
+                "mesh_rendered_count": 0,
+                "primitive_rendered_count": 0,
+                "generated_fallback_count": 1,
+                "placeholder_count": 0,
+                "wireframe_fallback_count": 0,
+            },
+        },
+    )
+    catalog = _write_catalog(
+        repo,
+        {
+            "scene_name": "raw_bounds_only_scene",
+            "package_name": "raw_bounds_only_scene",
+            "scene_path": "scenes/raw_bounds_only_scene",
+            "support_level": "supported",
+            "status": "supported",
+            "enabled": True,
+        },
+    )
+    fixture = _write_scene(repo, "synthetic_visual_quality_fixture", _mesh_and_primitive_index(), _passing_smoke())
+
+    payload = matrix.build_matrix(repo_root=repo, supported_scenes=catalog, synthetic_fixture=fixture)
+    scene = next(scene for scene in payload["scenes"] if scene["scene_name"] == "raw_bounds_only_scene")
+
+    assert payload["pass"] is False
+    assert scene["physical_rendered_count"] == 0
+    assert scene["raw_generated_bounds_count"] == 1
+    assert scene["diagnostic_fallback_count"] == 1
+    assert "raw/generated fallback bounds are the only visible evidence despite mesh or primitive sources" in scene["blockers"]
+
+
+def test_visual_quality_matrix_rejects_excessive_raw_generated_bounds_with_mesh_evidence(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_scene(
+        repo,
+        "raw_bounds_dominant_scene",
+        {
+            "visual_items": [
+                {"id": "mesh_item", "geometry": {"mesh": {"filename": "package://demo/meshes/tool.stl"}}},
+            ],
+        },
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "render_debug_counters": {
+                "rendered_count": 3,
+                "mesh_rendered_count": 1,
+                "primitive_rendered_count": 0,
+                "generated_fallback_count": 2,
+                "placeholder_count": 0,
+                "wireframe_fallback_count": 0,
+            },
+        },
+    )
+    catalog = _write_catalog(
+        repo,
+        {
+            "scene_name": "raw_bounds_dominant_scene",
+            "package_name": "raw_bounds_dominant_scene",
+            "scene_path": "scenes/raw_bounds_dominant_scene",
+            "support_level": "supported",
+            "status": "supported",
+            "enabled": True,
+        },
+    )
+    fixture = _write_scene(repo, "synthetic_visual_quality_fixture", _mesh_and_primitive_index(), _passing_smoke())
+
+    payload = matrix.build_matrix(repo_root=repo, supported_scenes=catalog, synthetic_fixture=fixture)
+    scene = next(scene for scene in payload["scenes"] if scene["scene_name"] == "raw_bounds_dominant_scene")
+
+    assert payload["pass"] is False
+    assert scene["physical_rendered_count"] == 1
+    assert scene["raw_generated_bounds_count"] == 2
+    assert "raw/generated fallback bounds dominate visible evidence despite mesh or primitive sources" in scene["blockers"]
+    assert "diagnostic fallback evidence dominates credible physical render evidence" in scene["blockers"]
+
+
+def test_visual_quality_matrix_warns_for_non_dominant_raw_generated_bounds_with_mesh_evidence(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_scene(
+        repo,
+        "raw_bounds_warning_scene",
+        {
+            "visual_items": [
+                {"id": "mesh_item_a", "geometry": {"mesh": {"filename": "package://demo/meshes/a.stl"}}},
+                {"id": "mesh_item_b", "geometry": {"mesh": {"filename": "package://demo/meshes/b.stl"}}},
+            ],
+        },
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "render_debug_counters": {
+                "rendered_count": 3,
+                "mesh_rendered_count": 2,
+                "primitive_rendered_count": 0,
+                "generated_fallback_count": 1,
+                "placeholder_count": 0,
+                "wireframe_fallback_count": 0,
+            },
+        },
+    )
+    catalog = _write_catalog(
+        repo,
+        {
+            "scene_name": "raw_bounds_warning_scene",
+            "package_name": "raw_bounds_warning_scene",
+            "scene_path": "scenes/raw_bounds_warning_scene",
+            "support_level": "supported",
+            "status": "supported",
+            "enabled": True,
+        },
+    )
+    fixture = _write_scene(repo, "synthetic_visual_quality_fixture", _mesh_and_primitive_index(), _passing_smoke())
+
+    payload = matrix.build_matrix(repo_root=repo, supported_scenes=catalog, synthetic_fixture=fixture)
+    scene = next(scene for scene in payload["scenes"] if scene["scene_name"] == "raw_bounds_warning_scene")
+
+    assert payload["pass"] is True
+    assert scene["visual_quality_status"] == "PASS"
+    assert scene["physical_rendered_count"] == 2
+    assert scene["raw_generated_bounds_count"] == 1
+    assert any("raw/generated fallback bounds were rendered alongside credible mesh or primitive evidence" in warning for warning in scene["warnings"])
+
+
+def test_visual_quality_matrix_accepts_valid_urdf_primitive_render_without_placeholder_inflation(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_scene(
+        repo,
+        "primitive_only_scene",
+        {
+            "visual_items": [
+                {"id": "primitive_item", "geometry": {"box": {"size": [1.0, 1.0, 0.1]}}},
+            ],
+        },
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "render_debug_counters": {
+                "rendered_count": 1,
+                "mesh_rendered_count": 0,
+                "urdf_primitive_rendered_count": 1,
+                "generated_fallback_count": 0,
+                "placeholder_count": 0,
+                "primitive_fallback_count": 1,
+                "wireframe_fallback_count": 0,
+            },
+        },
+    )
+    catalog = _write_catalog(
+        repo,
+        {
+            "scene_name": "primitive_only_scene",
+            "package_name": "primitive_only_scene",
+            "scene_path": "scenes/primitive_only_scene",
+            "support_level": "supported",
+            "status": "supported",
+            "enabled": True,
+        },
+    )
+    fixture = _write_scene(repo, "synthetic_visual_quality_fixture", _mesh_and_primitive_index(), _passing_smoke())
+
+    payload = matrix.build_matrix(repo_root=repo, supported_scenes=catalog, synthetic_fixture=fixture)
+    scene = next(scene for scene in payload["scenes"] if scene["scene_name"] == "primitive_only_scene")
+
+    assert payload["pass"] is True
+    assert scene["visual_quality_status"] == "PASS"
+    assert scene["primitive_source_count"] == 1
+    assert scene["primitive_rendered_count"] == 1
+    assert scene["physical_rendered_count"] == 1
+    assert scene["placeholder_count"] == 0
+    assert scene["diagnostic_fallback_count"] == 0
 
 
 def test_visual_quality_matrix_cli_writes_json(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Improve Scene3D visual-quality diagnostics by separating credible physical render evidence from diagnostic fallback evidence so pass/fail decisions reflect true mesh/primitive rendering rather than synthetic bounds or wireframes.
- Surface clearer blockers when only raw/generated fallback bounds are visible or when diagnostic fallbacks dominate despite credible mesh/primitive sources.
- Ensure valid URDF primitive renders are not mis-counted as placeholder inflation.

### Description

- Split fallback counters by introducing `raw_generated_bounds_count`, `missing_geometry_box_count`, `physical_rendered_count` (mesh + primitive), and `diagnostic_fallback_count` (raw-generated bounds + placeholders + wireframes + missing-geometry boxes) and compute `visible_evidence_count` and `credible_source_count` for decision logic.
- Add blockers and warnings: block when raw/generated bounds are the only visible evidence for scenes with mesh/primitive sources, block when raw/generated bounds or diagnostic fallbacks dominate above a configurable dominance ratio, and warn when non-dominant diagnostic fallbacks appear alongside credible evidence.
- Stop counting primitive-fallback aliases as placeholder inflation so valid URDF primitive renders pass without placeholder-driven failures.
- Export the new behavior/counter fields in the matrix output and add synthetic fixture tests that exercise: raw generated bounds-only failure, raw-generated-bounds dominance failure/warning thresholds, and valid URDF primitive rendering without placeholder inflation.

### Testing

- Compiled the script with `python3 -m py_compile scripts/validate_scene3d_visual_quality_matrix.py` and it passed successfully.
- Ran `pytest -q tests/test_scene3d_visual_quality_matrix.py tests/test_scene3d_visual_quality_screenshots_runner.py` and all tests passed (10 passed).
- No runtime launch files, controllers, hardware parameters, or real-hardware behavior were changed and fake-hardware defaults remain unaffected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f16fb9d2c833187470aa7343bdac4)