### PR TITLE
test: use synthetic Scene3D fixtures for runtime acceptance

### DIFF
--- a/tests/test_scene3d_runtime_acceptance.py
+++ b/tests/test_scene3d_runtime_acceptance.py
@@ -5,14 +5,134 @@ from pathlib import Path
 import scripts.validate_scene3d_runtime_acceptance as runtime
 
 ROOT = Path(__file__).resolve().parents[1]
+SYNTHETIC_SCENE = "synthetic_scene3d_acceptance"
+
+
+def _write_scene_fixture(
+    tmp_path: Path,
+    smoke_payload: dict,
+    *,
+    scene: str = SYNTHETIC_SCENE,
+    editable_items: int = 2,
+    mesh_items: int = 1,
+    locked_items: int = 1,
+    overlay_items: int = 1,
+    primitive_fallback_count: int = 0,
+) -> tuple[Path, Path, Path, Path, Path, str]:
+    repo = tmp_path / "repo"
+    scene_root = repo / "scenes"
+    sdir = scene_root / scene
+    (sdir / "layout").mkdir(parents=True, exist_ok=True)
+    (sdir / "generated").mkdir(parents=True, exist_ok=True)
+    (sdir / "config").mkdir(parents=True, exist_ok=True)
+    (repo / "workcell_builder/workcell_builder/gui").mkdir(parents=True, exist_ok=True)
+
+    # Strong synthetic scene identity for CLI discovery without relying on any real scene names.
+    (sdir / "package.xml").write_text(
+        "<package format=\"3\"><name>synthetic_scene3d_acceptance</name><version>0.0.0</version>"
+        "<description>synthetic Scene3D acceptance fixture</description>"
+        "<maintainer email=\"test@example.com\">test</maintainer><license>Apache-2.0</license></package>\n",
+        encoding="utf-8",
+    )
+    (sdir / "scene_manifest.yaml").write_text(
+        "schema: workcell_studio_scene_manifest/v1\nscene: synthetic_scene3d_acceptance\n",
+        encoding="utf-8",
+    )
+
+    layout_entries = "".join(
+        f"  - id: editable_{i}\n    type: box\n    source: editable_layout\n    selectable: true\n    editable: true\n"
+        for i in range(editable_items)
+    )
+    (sdir / "layout/workcell_studio_layout.yaml").write_text(
+        ("items:\n" + layout_entries) if layout_entries else "items: []\n",
+        encoding="utf-8",
+    )
+
+    visual_items = [{"id": f"mesh_preview_{i}", "mesh": f"package://fixture/mesh_{i}.stl"} for i in range(mesh_items)]
+    mesh_index_items = [
+        {"id": item["id"], "source_layer": "mesh_preview", "renderable": True, "selectable": True}
+        for item in visual_items
+    ]
+    mesh_index_items.extend(
+        {"id": f"locked_preview_{i}", "source_layer": "locked_generated_urdf_visual", "renderable": True, "editable": False}
+        for i in range(locked_items)
+    )
+    mesh_index_items.extend(
+        {"id": f"overlay_helper_{i}", "source_layer": "overlay", "renderable": False, "helper": True}
+        for i in range(overlay_items)
+    )
+    (sdir / "generated/scene_visual_mesh_index.json").write_text(
+        json.dumps(
+            {
+                "safe_for_preview": True,
+                "visual_items": visual_items,
+                "unresolved_placeholder_count": primitive_fallback_count,
+                "items": mesh_index_items,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    generated_entries = "".join(
+        f"  - id: locked_preview_{i}\n    source: locked_generated_urdf_visual\n    locked: true\n    editable: false\n"
+        for i in range(locked_items)
+    )
+    (sdir / "layout/workcell_studio_layout.generated.yaml").write_text(
+        ("items:\n" + generated_entries) if generated_entries else "items: []\n",
+        encoding="utf-8",
+    )
+    overlays = [{"id": f"overlay_helper_{i}", "kind": "helper", "source": "diagnostic_overlay"} for i in range(overlay_items)]
+    (sdir / "generated/scene_preview_metadata.json").write_text(json.dumps({"overlays": overlays}), encoding="utf-8")
+
+    gui_dir = repo / "workcell_builder/workcell_builder/gui"
+    main_path = gui_dir / "mainwindow.cpp"
+    main_path.write_text("select_cb\napply_scene_selection(\nupdate_scene_builder_inspector_for_selected_item\n", encoding="utf-8")
+    preview_path = gui_dir / "scene_preview_widget.cpp"
+    preview_path.write_text("select_cb\n", encoding="utf-8")
+    viewport_path = gui_dir / "scene3d_viewport_widget.cpp"
+    viewport_path.write_text(
+        "draw_ground_grid_pass\ndraw_world_axes_pass\nmouseMoveEvent\nwheelEvent\npan_mode\n"
+        "transform_changed_cb\nScene3D runtime render: received=\n",
+        encoding="utf-8",
+    )
+
+    smoke = sdir / "generated/scene3d_gui_smoke.json"
+    smoke.write_text(json.dumps(smoke_payload), encoding="utf-8")
+    return repo, scene_root, main_path, preview_path, viewport_path, scene
+
+
+def _passing_smoke(**counter_overrides: int) -> dict:
+    counters = {
+        "viewport_received_count": 3,
+        "render_cache_count": 3,
+        "rendered_count": 3,
+        "selectable_count": 3,
+        "editable_physical_item_count": 2,
+        "selectable_physical_item_count": 3,
+        "hierarchy_rows_count": 4,
+        "mesh_rendered_count": 1,
+        "assembled_preview_item_count": 4,
+        "filtered_visible_candidate_count": 3,
+    }
+    counters.update(counter_overrides)
+    return {
+        "schema": "workcell_studio_scene3d_gui_smoke/v1",
+        "status": "PASS",
+        "counters": counters,
+    }
 
 
 def test_runtime_acceptance_script_emits_structured_runtime_payload(tmp_path):
+    repo, _, _, _, _, scene = _write_scene_fixture(tmp_path, _passing_smoke())
     out_json = tmp_path / 'scene3d_runtime_acceptance.json'
     out_md = tmp_path / 'scene3d_runtime_acceptance.md'
     subprocess.run([
         'python3',
         str(ROOT / 'scripts' / 'validate_scene3d_runtime_acceptance.py'),
+        '--repo-root',
+        str(repo),
+        '--scene',
+        scene,
         '--json',
         str(out_json),
         '--markdown',
@@ -25,11 +145,11 @@ def test_runtime_acceptance_script_emits_structured_runtime_payload(tmp_path):
     assert 'blockers' in payload
     assert isinstance(payload['scenes'], list) and payload['scenes']
 
-    scene = payload['scenes'][0]
-    assert 'counts' in scene
-    assert 'visibility_contract' in scene
-    assert 'layers' in scene
-    assert 'sources' in scene
+    scene_result = payload['scenes'][0]
+    assert 'counts' in scene_result
+    assert 'visibility_contract' in scene_result
+    assert 'layers' in scene_result
+    assert 'sources' in scene_result
 
     for field in (
         'editable_layout_count',
@@ -38,10 +158,10 @@ def test_runtime_acceptance_script_emits_structured_runtime_payload(tmp_path):
         'locked_generated_urdf_visual_count',
         'overlay_count',
     ):
-        assert field in scene['counts']
-        assert isinstance(scene['counts'][field], int)
+        assert field in scene_result['counts']
+        assert isinstance(scene_result['counts'][field], int)
 
-    visibility = scene['visibility_contract']
+    visibility = scene_result['visibility_contract']
     assert set(visibility) == {
         'input_items_count',
         'visible_after_default_filters',
@@ -53,8 +173,8 @@ def test_runtime_acceptance_script_emits_structured_runtime_payload(tmp_path):
         visibility['input_items_count'] - visibility['visible_after_default_filters']
     )
 
-    expected_scene_pass = visibility['visible_after_default_filters'] > 0 and not scene['blockers']
-    assert scene['pass'] == expected_scene_pass
+    expected_scene_pass = visibility['visible_after_default_filters'] > 0 and not scene_result['blockers']
+    assert scene_result['pass'] == expected_scene_pass
 
 
 def test_runtime_acceptance_script_fails_for_missing_scene(tmp_path):
@@ -77,25 +197,28 @@ def test_runtime_acceptance_script_fails_for_missing_scene(tmp_path):
     assert payload['blockers']
 
 
-def test_runtime_acceptance_preview_warn_done_semantics_for_fixture_scenes(tmp_path):
-    for scene_name in ('ur5_2f_test', 'ur5_2f_sorting_test'):
-        out_json = tmp_path / f'{scene_name}_runtime_acceptance.json'
-        subprocess.run([
-            'python3',
-            str(ROOT / 'scripts' / 'validate_scene3d_runtime_acceptance.py'),
-            '--scene',
-            scene_name,
-            '--json',
-            str(out_json),
-        ], check=False)
-        payload = json.loads(out_json.read_text(encoding='utf-8'))
-        scene = payload['scenes'][0]
-        assert scene['counts']['editable_layout_count'] > 0
-        # Preview can still be considered done for visuals even with warning/blocker metadata.
-        assert scene['visibility_contract']['visible_after_default_filters'] > 0
+def test_runtime_acceptance_preview_warn_done_semantics_for_synthetic_scene(tmp_path):
+    repo, scene_root, main_path, preview_path, viewport_path, scene = _write_scene_fixture(
+        tmp_path,
+        _passing_smoke(),
+        editable_items=2,
+        mesh_items=1,
+        locked_items=2,
+        overlay_items=2,
+    )
+    result = runtime.evaluate_scene(repo, scene_root, main_path, preview_path, viewport_path, scene, None)
+
+    assert result['counts']['editable_layout_count'] == 2
+    assert result['counts']['mesh_preview_count'] == 1
+    assert result['counts']['locked_generated_urdf_visual_count'] == 2
+    assert result['counts']['overlay_count'] == 2
+    # Preview can still be considered done for editable/mesh visuals even with diagnostic-only layers present.
+    assert result['visibility_contract']['visible_after_default_filters'] == 3
+    assert result['visibility_contract']['hidden_by_filters_count'] == 4
 
 
 def test_runtime_acceptance_accepts_pass_status_and_hierarchy_counter_aliases(tmp_path):
+    repo, scene_root, main_path, preview_path, viewport_path, scene = _write_scene_fixture(tmp_path, _passing_smoke())
     smoke = tmp_path / "smoke.json"
     smoke.write_text(json.dumps({
         "schema": "workcell_studio_scene3d_gui_smoke/v1",
@@ -109,21 +232,13 @@ def test_runtime_acceptance_accepts_pass_status_and_hierarchy_counter_aliases(tm
             "mesh_rendered_count": 8
         }
     }), encoding="utf-8")
-    out_json = tmp_path / "acceptance.json"
-    subprocess.run([
-        "python3",
-        str(ROOT / "scripts" / "validate_scene3d_runtime_acceptance.py"),
-        "--scene", "ur5_2f_test",
-        "--smoke-json", str(smoke),
-        "--json", str(out_json),
-    ], check=False)
-    payload = json.loads(out_json.read_text(encoding="utf-8"))
-    scene = payload["scenes"][0]
-    assert "runtime smoke evidence status is not passing" not in "\n".join(scene["blockers"])
-    assert scene["counts"]["hierarchy_rows_count"] == 10
+    result = runtime.evaluate_scene(repo, scene_root, main_path, preview_path, viewport_path, scene, str(smoke))
+    assert "runtime smoke evidence status is not passing" not in "\n".join(result["blockers"])
+    assert result["counts"]["hierarchy_rows_count"] == 10
 
 
 def test_runtime_acceptance_reads_hierarchy_child_row_count_alias(tmp_path):
+    repo, scene_root, main_path, preview_path, viewport_path, scene = _write_scene_fixture(tmp_path, _passing_smoke())
     smoke = tmp_path / "smoke_alias.json"
     smoke.write_text(json.dumps({
         "schema": "workcell_studio_scene3d_gui_smoke/v1",
@@ -136,60 +251,86 @@ def test_runtime_acceptance_reads_hierarchy_child_row_count_alias(tmp_path):
             "hierarchy_child_row_count": 7
         }
     }), encoding="utf-8")
-    out_json = tmp_path / "acceptance_alias.json"
-    subprocess.run([
-        "python3",
-        str(ROOT / "scripts" / "validate_scene3d_runtime_acceptance.py"),
-        "--scene", "ur5_2f_test",
-        "--smoke-json", str(smoke),
-        "--json", str(out_json),
-    ], check=False)
-    payload = json.loads(out_json.read_text(encoding="utf-8"))
-    assert payload["scenes"][0]["counts"]["hierarchy_rows_count"] == 7
+    result = runtime.evaluate_scene(repo, scene_root, main_path, preview_path, viewport_path, scene, str(smoke))
+    assert result["counts"]["hierarchy_rows_count"] == 7
 
 
-def _write_scene_fixture(tmp_path: Path, smoke_payload: dict) -> tuple[Path, Path, Path, Path, Path, Path]:
-    repo = tmp_path / "repo"
-    scene_root = repo / "scenes"
-    scene = "demo_scene"
-    sdir = scene_root / scene
-    (sdir / "layout").mkdir(parents=True, exist_ok=True)
-    (sdir / "generated").mkdir(parents=True, exist_ok=True)
-    (repo / "cpp").mkdir(parents=True, exist_ok=True)
+def test_runtime_acceptance_counts_editable_locked_and_overlay_layers_independently(tmp_path):
+    repo, scene_root, main_path, preview_path, viewport_path, scene = _write_scene_fixture(
+        tmp_path,
+        _passing_smoke(
+            viewport_received_count=5,
+            render_cache_count=5,
+            rendered_count=3,
+            selectable_count=3,
+            hierarchy_rows_count=5,
+            mesh_rendered_count=1,
+            assembled_preview_item_count=5,
+            filtered_visible_candidate_count=3,
+        ),
+        editable_items=2,
+        mesh_items=1,
+        locked_items=2,
+        overlay_items=2,
+    )
 
-    (sdir / "layout/workcell_studio_layout.yaml").write_text("items:\n  - id: a\n", encoding="utf-8")
-    (sdir / "generated/scene_visual_mesh_index.json").write_text(json.dumps({"safe_for_preview": True, "visual_items": [{"id": "m1"}], "items": []}), encoding="utf-8")
-    (sdir / "layout/workcell_studio_layout.generated.yaml").write_text("items: []\n", encoding="utf-8")
+    result = runtime.evaluate_scene(repo, scene_root, main_path, preview_path, viewport_path, scene, None)
 
-    main_path = repo / "cpp/mainwindow.cpp"
-    main_path.write_text("select_cb\napply_scene_selection(\nupdate_scene_builder_inspector_for_selected_item\n", encoding="utf-8")
-    preview_path = repo / "cpp/scene_preview_widget.cpp"
-    preview_path.write_text("select_cb\n", encoding="utf-8")
-    viewport_path = repo / "cpp/scene3d_viewport_widget.cpp"
-    viewport_path.write_text("draw_ground_grid_pass\ndraw_world_axes_pass\nmouseMoveEvent\nwheelEvent\npan_mode\ntransform_changed_cb\nScene3D runtime render: received=\n", encoding="utf-8")
+    assert result["counts"]["editable_layout_count"] == 2
+    assert result["counts"]["selectable_count"] == 3
+    assert result["visibility_contract"]["visible_after_default_filters"] == 3
+    assert result["layers"]["editable_layout_visible"] == 2
 
-    smoke = sdir / "generated/scene3d_gui_smoke.json"
-    smoke.write_text(json.dumps(smoke_payload), encoding="utf-8")
-    return repo, scene_root, main_path, preview_path, viewport_path, scene
+    assert result["counts"]["locked_generated_urdf_visual_count"] == 2
+    assert result["layers"]["locked_generated_urdf_visual_hidden_default"] == 2
+    assert result["visibility_contract"]["hidden_by_filters_count"] == 4
+
+    assert result["counts"]["overlay_count"] == 2
+    assert result["source_layer_counts"]["overlay"] == 2
+    assert result["default_filter_visibility_evidence"]["pass_mode"] == "default_pass"
+    assert "scene3d_default_filter_hid_all_renderable_candidates" not in result["blockers"]
+
+
+def test_runtime_acceptance_overlay_helpers_do_not_satisfy_render_success(tmp_path):
+    repo, scene_root, main_path, preview_path, viewport_path, scene = _write_scene_fixture(
+        tmp_path,
+        _passing_smoke(
+            viewport_received_count=1,
+            render_cache_count=1,
+            rendered_count=1,
+            selectable_count=0,
+            hierarchy_rows_count=1,
+            mesh_rendered_count=0,
+            assembled_preview_item_count=1,
+            filtered_visible_candidate_count=0,
+        ),
+        editable_items=0,
+        mesh_items=0,
+        locked_items=0,
+        overlay_items=2,
+    )
+
+    result = runtime.evaluate_scene(repo, scene_root, main_path, preview_path, viewport_path, scene, None)
+
+    assert result["counts"]["overlay_count"] == 2
+    assert result["visibility_contract"]["visible_after_default_filters"] == 0
+    assert "no visible scene items after default filters" in result["blockers"]
+    assert result["pass"] is False
 
 
 def test_runtime_acceptance_default_filter_default_pass_from_runtime_smoke(tmp_path):
     repo, scene_root, main_path, preview_path, viewport_path, scene = _write_scene_fixture(
         tmp_path,
-        {
-            "schema": "workcell_studio_scene3d_gui_smoke/v1",
-            "status": "PASS",
-            "counters": {
-                "viewport_received_count": 3,
-                "render_cache_count": 3,
-                "rendered_count": 3,
-                "selectable_count": 3,
-                "hierarchy_rows_count": 3,
-                "mesh_rendered_count": 3,
-                "assembled_preview_item_count": 2,
-                "filtered_visible_candidate_count": 2,
-            },
-        },
+        _passing_smoke(
+            viewport_received_count=3,
+            render_cache_count=3,
+            rendered_count=3,
+            selectable_count=3,
+            hierarchy_rows_count=3,
+            mesh_rendered_count=3,
+            assembled_preview_item_count=2,
+            filtered_visible_candidate_count=2,
+        ),
     )
     result = runtime.evaluate_scene(repo, scene_root, main_path, preview_path, viewport_path, scene, None)
     assert result["default_filter_visibility_evidence"]["pass_mode"] == "default_pass"
@@ -198,24 +339,18 @@ def test_runtime_acceptance_default_filter_default_pass_from_runtime_smoke(tmp_p
 
 
 def test_runtime_acceptance_default_filter_fallback_pass_requires_warning(tmp_path):
-    repo, scene_root, main_path, preview_path, viewport_path, scene = _write_scene_fixture(
-        tmp_path,
-        {
-            "schema": "workcell_studio_scene3d_gui_smoke/v1",
-            "status": "PASS",
-            "counters": {
-                "viewport_received_count": 3,
-                "render_cache_count": 3,
-                "rendered_count": 3,
-                "selectable_count": 3,
-                "hierarchy_rows_count": 3,
-                "mesh_rendered_count": 3,
-                "assembled_preview_item_count": 2,
-                "filtered_visible_candidate_count": 1,
-            },
-            "warnings": ["default_filter_fallback_kept_renderable_items_visible"],
-        },
+    payload = _passing_smoke(
+        viewport_received_count=3,
+        render_cache_count=3,
+        rendered_count=3,
+        selectable_count=3,
+        hierarchy_rows_count=3,
+        mesh_rendered_count=3,
+        assembled_preview_item_count=2,
+        filtered_visible_candidate_count=1,
     )
+    payload["warnings"] = ["default_filter_fallback_kept_renderable_items_visible"]
+    repo, scene_root, main_path, preview_path, viewport_path, scene = _write_scene_fixture(tmp_path, payload)
     result = runtime.evaluate_scene(repo, scene_root, main_path, preview_path, viewport_path, scene, None)
     assert result["default_filter_visibility_evidence"]["pass_mode"] == "fallback_pass"
     assert result["secondary_checks"]["layer_toggles_not_default_hide_all"] is True
@@ -224,25 +359,22 @@ def test_runtime_acceptance_default_filter_fallback_pass_requires_warning(tmp_pa
 def test_runtime_acceptance_default_filter_zero_visible_is_blocker(tmp_path):
     repo, scene_root, main_path, preview_path, viewport_path, scene = _write_scene_fixture(
         tmp_path,
-        {
-            "schema": "workcell_studio_scene3d_gui_smoke/v1",
-            "status": "PASS",
-            "counters": {
-                "viewport_received_count": 3,
-                "render_cache_count": 3,
-                "rendered_count": 3,
-                "selectable_count": 3,
-                "hierarchy_rows_count": 3,
-                "mesh_rendered_count": 3,
-                "assembled_preview_item_count": 2,
-                "filtered_visible_candidate_count": 0,
-            },
-        },
+        _passing_smoke(
+            viewport_received_count=3,
+            render_cache_count=3,
+            rendered_count=3,
+            selectable_count=3,
+            hierarchy_rows_count=3,
+            mesh_rendered_count=3,
+            assembled_preview_item_count=2,
+            filtered_visible_candidate_count=0,
+        ),
     )
     result = runtime.evaluate_scene(repo, scene_root, main_path, preview_path, viewport_path, scene, None)
     assert result["default_filter_visibility_evidence"]["pass_mode"] == "failed"
     assert "scene3d_default_filter_hid_all_renderable_candidates" in result["blockers"]
     assert result["secondary_checks"]["layer_toggles_not_default_hide_all"] is False
+
 
 def test_runtime_acceptance_markdown_handles_missing_secondary_checks(tmp_path):
     out_json = tmp_path / 'acceptance.json'


### PR DESCRIPTION
### Motivation
- Make Scene3D runtime acceptance tests self-contained and not rely on hardcoded real scene names so discovery and CI are deterministic. 
- Provide richer synthetic fixtures that exercise editable layout, preview, generated preview, overlay/helper metadata, and GUI smoke counters used by the acceptance logic.

### Description
- Replaced tests that looped over `ur5_2f_test`/`ur5_2f_sorting_test` with a synthetic scene implementation created under `tmp_path` and a CLI-compatible repo layout. 
- Extended `_write_scene_fixture` to emit a synthetic `package.xml` and `scene_manifest.yaml`, `layout/workcell_studio_layout.yaml`, `layout/workcell_studio_layout.generated.yaml`, `generated/scene_visual_mesh_index.json`, `generated/scene_preview_metadata.json`, and `generated/scene3d_gui_smoke.json` to model editable items, mesh preview items, locked generated preview items, overlays/helpers, and placeholder counts. 
- Updated tests to either call `runtime.evaluate_scene` directly with the synthetic repo/scene paths or invoke the script with `--repo-root` and the synthetic scene name, and removed any special-casing of real scene names. 
- Added assertions verifying that editable layout items are counted/selectable, locked/generated preview items are visible/diagnosable but not editable, overlay/helper items do not satisfy render success, and default filters do not hide all physical renderable candidates.

### Testing
- Ran `python3 -m pytest tests/test_scene3d_runtime_acceptance.py -q` and observed all tests in that file passed (`11 passed`).
- Ran `python3 -m pytest tests/test_scene3d_discovery_and_runtime_contract.py tests/test_scene3d_runtime_acceptance.py -q` and observed both files passed together (`14 passed`).
- This is a test-only change and did not touch launches, controllers, runtime services, or hardware configuration; fake-hardware-first behavior is unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f171494ec8331a585b851e06fdb85)