### PR TITLE
docs: clarify Scene3D visual quality acceptance

### DIFF
--- a/docs/manuals/WORKCELL_STUDIO_DIGITAL_TWIN_CANVAS.md
+++ b/docs/manuals/WORKCELL_STUDIO_DIGITAL_TWIN_CANVAS.md
@@ -52,14 +52,33 @@ python3 scripts/run_scene3d_visual_quality_screenshots.py \
   --xvfb
 ```
 
-To run the same capture for every enabled entry in the supported scene catalog, use:
+To run the same capture for every enabled entry in the supported scene catalog, use this strict all-scene acceptance command:
 
 ```bash
-python3 scripts/run_scene3d_visual_quality_screenshots.py \
-  --supported-scenes scenes/supported_scenes.yaml \
-  --synthetic-fixture tests/fixtures/scene3d_visual_quality_minimal_fixture \
-  --output-dir build/scene3d_visual_quality_screenshots \
-  --xvfb
+python3 scripts/run_scene3d_visual_quality_screenshots.py --supported-scenes scenes/supported_scenes.yaml --synthetic-fixture tests/fixtures/scene3d_visual_quality_minimal_fixture --output-dir build/scene3d_visual_quality_screenshots --xvfb
 ```
+
+The strict all-scene run writes both machine-readable and review-friendly summary artifacts:
+
+- `build/scene3d_visual_quality_screenshots/scene3d_visual_quality_screenshots_summary.json`
+- `build/scene3d_visual_quality_screenshots/scene3d_visual_quality_screenshots_summary.md`
+
+Result meanings:
+
+- `PASS`: credible physical mesh/primitive evidence rendered, no blockers.
+- `FAIL`: runner completed but behavior-based visual quality blockers exist.
+- `BLOCKED`: screenshot/smoke capture could not provide required evidence, or prerequisite files are missing/unreadable.
+
+Common blocker reasons and how to read them:
+
+- Missing screenshot: capture did not produce the expected image artifact, so visual evidence cannot be reviewed.
+- Smoke JSON missing/unreadable: the per-scene smoke runner did not write parseable JSON, so counters and evidence paths cannot be trusted.
+- Mesh source exists but mesh render count is zero: scene metadata or generated URDF points at mesh-backed geometry, but the renderer did not render any mesh instances.
+- URDF primitive source exists but primitive render count is zero: generated primitive geometry exists, but the renderer did not render primitive-backed scene items.
+- Placeholder/missing geometry dominates: missing-mesh placeholders or fallback markers outweigh credible physical geometry evidence.
+- Overlay/helper visuals dominate: helper graphics such as axes, bounds, labels, grids, guides, or selection affordances dominate the capture instead of physical scene items.
+- No physical scene items rendered: the screenshot/smoke evidence contains no credible robot, tool, fixture, table, conveyor, object, bin, zone, or other physical workcell item.
+
+Helper overlays and raw generated fallback bounds do not count as physical render success. A scene only earns physical render credit from credible mesh-backed visuals or legitimate URDF primitive visuals representing actual workcell geometry.
 
 Scene names are only CLI inputs and report labels. Rendering remains data-driven from each scene package or generated fixture; do not add scene-specific render branches to make one target pass.


### PR DESCRIPTION
### Motivation
- Make the Scene3D visual-quality smoke/run instructions strict and unambiguous so all supported scenes can be validated consistently with a single acceptance command.
- Ensure reviewers and CI can find the machine-readable and human-friendly summary artifacts and understand pass/fail semantics and common blocker causes.

### Description
- Add a single strict all-scene acceptance command as the recommended invocation: `python3 scripts/run_scene3d_visual_quality_screenshots.py --supported-scenes scenes/supported_scenes.yaml --synthetic-fixture tests/fixtures/scene3d_visual_quality_minimal_fixture --output-dir build/scene3d_visual_quality_screenshots --xvfb`.
- Document the two summary artifacts written by that run: `build/scene3d_visual_quality_screenshots/scene3d_visual_quality_screenshots_summary.json` and `build/scene3d_visual_quality_screenshots/scene3d_visual_quality_screenshots_summary.md`.
- Define result meanings: `PASS`, `FAIL`, and `BLOCKED`, with concise definitions for each.
- List common blocker reasons that appear in the summary and explain how to read them, and explicitly state that helper overlays and generated fallback bounds do not count as physical render success.

### Testing
- Ran a Python presence-check that validated the required command string, output paths, result-meaning lines, and the helper-overlay clarification are present in `docs/manuals/WORKCELL_STUDIO_DIGITAL_TWIN_CANVAS.md`, and it succeeded.
- This is a documentation-only change and no runtime/launch tests were required or performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f17276ce4833196b5e1e533fb88b7)