### PR TITLE
Split Scene3D visual fallback evidence counters and tighten visual-quality validation

### DIFF
--- a/scripts/validate_scene3d_visual_quality_matrix.py
+++ b/scripts/validate_scene3d_visual_quality_matrix.py
@@ -12,6 +12,7 @@ import yaml
 SCHEMA = "workcell_studio_scene3d_visual_quality_matrix/v1"
 SMOKE_SCHEMA = "workcell_studio_scene3d_gui_smoke/v1"
 PHYSICAL_ITEM_DOMINANCE_RATIO = 0.5
+DIAGNOSTIC_FALLBACK_DOMINANCE_RATIO = 0.5
 
 MESH_KEYS = {"mesh", "mesh_path", "mesh_uri", "mesh_filename", "filename", "resource", "uri"}
 PRIMITIVE_TYPES = {"box", "cube", "cylinder", "sphere", "capsule", "cone", "primitive"}
@@ -253,9 +254,34 @@ def evaluate_scene(
 
     mesh_rendered_count = _counter(smoke_payload, "mesh_rendered_count", "mesh_backed_count")
     primitive_rendered_count = _counter(smoke_payload, "primitive_rendered_count", "urdf_primitive_rendered_count")
-    placeholder_count = _counter(smoke_payload, "placeholder_count", "placeholder_box_count", "primitive_fallback_count")
+    # Diagnostic fallback evidence is useful for debugging viewport plumbing, but it is not
+    # proof that a scene rendered its physical mesh/URDF-primitive geometry truthfully.
+    placeholder_count = _counter(smoke_payload, "placeholder_count", "placeholder_box_count")
     wireframe_fallback_count = _counter(smoke_payload, "wireframe_fallback_count", "wireframe_box_count")
+    raw_generated_bounds_count = _counter(
+        smoke_payload,
+        "raw_generated_bounds_count",
+        "generated_bounds_count",
+        "generated_fallback_count",
+        "raw_generated_fallback_count",
+        "bounds_fallback_count",
+    )
+    missing_geometry_box_count = _counter(
+        smoke_payload,
+        "missing_geometry_box_count",
+        "missing_geometry_rendered_count",
+        "missing_geometry_fallback_count",
+    )
     rendered_count = _counter(smoke_payload, "rendered_count")
+
+    credible_source_count = mesh_source_count + primitive_source_count
+    physical_rendered_count = mesh_rendered_count + primitive_rendered_count
+    diagnostic_fallback_count = (
+        raw_generated_bounds_count
+        + placeholder_count
+        + wireframe_fallback_count
+        + max(0, missing_geometry_box_count - placeholder_count)
+    )
 
     if mesh_source_count > 0 and mesh_rendered_count <= 0:
         blockers.append("mesh_source_count > 0 requires mesh_rendered_count > 0")
@@ -263,17 +289,31 @@ def evaluate_scene(
         blockers.append("primitive_source_count > 0 requires primitive_rendered_count > 0")
     if primitive_source_count > 0 and placeholder_count > missing_geometry_count:
         blockers.append("valid URDF primitives must not increment placeholder_count")
-    if total_payload_count > 0 and mesh_source_count + primitive_source_count <= 0:
+    if total_payload_count > 0 and credible_source_count <= 0:
         blockers.append("source geometry classification missing; rendered_count alone cannot prove visual quality")
     if rendered_count == total_payload_count and total_payload_count > 0:
         warnings.append("rendered_count equals total_payload_count; pass still requires mesh/primitive-specific rendered counts")
 
-    visible_physical_count = mesh_rendered_count + primitive_rendered_count + placeholder_count + wireframe_fallback_count
+    if diagnostic_fallback_count > 0:
+        warnings.append(
+            "diagnostic fallback evidence present; physical_rendered_count excludes raw bounds, placeholders, and wireframes"
+        )
+    if missing_geometry_count > 0:
+        warnings.append(f"{missing_geometry_count} source payload item(s) lack mesh or primitive geometry")
+
+    if credible_source_count > 0 and physical_rendered_count <= 0 and raw_generated_bounds_count > 0:
+        blockers.append("raw/generated fallback bounds are the only visible evidence despite mesh or URDF primitive sources")
+    if credible_source_count > 0 and physical_rendered_count > 0 and raw_generated_bounds_count > 0:
+        if raw_generated_bounds_count > int(physical_rendered_count * DIAGNOSTIC_FALLBACK_DOMINANCE_RATIO):
+            blockers.append("raw/generated fallback bounds dominate physical render evidence despite mesh or URDF primitive sources")
+    if credible_source_count > 0 and physical_rendered_count > 0 and diagnostic_fallback_count > 0:
+        if diagnostic_fallback_count > int(physical_rendered_count * DIAGNOSTIC_FALLBACK_DOMINANCE_RATIO):
+            blockers.append("diagnostic fallback evidence dominates physical render evidence despite mesh or URDF primitive sources")
+
+    visible_physical_count = physical_rendered_count
     if wireframe_fallback_count > 0 and visible_physical_count > 0:
         if wireframe_fallback_count > int(visible_physical_count * PHYSICAL_ITEM_DOMINANCE_RATIO):
             blockers.append("wireframe_fallback_count dominates visible physical items")
-    if missing_geometry_count > 0:
-        warnings.append(f"{missing_geometry_count} source payload item(s) lack mesh or primitive geometry")
 
     if screenshot_path is not None and not screenshot_path.exists():
         add_blocker(f"screenshot_missing: screenshot not found: {screenshot_path}", "screenshot_missing")
@@ -285,6 +325,8 @@ def evaluate_scene(
             blockers.append("synthetic fixture must render both one mesh and one primitive")
         if placeholder_count != 0:
             blockers.append("synthetic fixture must render mesh and primitive without placeholder boxes")
+        if diagnostic_fallback_count != 0:
+            blockers.append("synthetic fixture must render mesh and primitive without diagnostic fallback bounds or boxes")
 
     visual_quality_status = "PASS" if not blockers else "FAIL"
     return {
@@ -298,7 +340,11 @@ def evaluate_scene(
         "mesh_rendered_count": mesh_rendered_count,
         "primitive_source_count": primitive_source_count,
         "primitive_rendered_count": primitive_rendered_count,
+        "physical_rendered_count": physical_rendered_count,
         "placeholder_count": placeholder_count,
+        "raw_generated_bounds_count": raw_generated_bounds_count,
+        "missing_geometry_box_count": missing_geometry_box_count,
+        "diagnostic_fallback_count": diagnostic_fallback_count,
         "missing_geometry_count": missing_geometry_count,
         "wireframe_fallback_count": wireframe_fallback_count,
         "rendered_count": rendered_count,

--- a/tests/test_scene3d_visual_quality_matrix.py
+++ b/tests/test_scene3d_visual_quality_matrix.py
@@ -91,7 +91,11 @@ def test_visual_quality_matrix_emits_required_fields_and_synthetic_fixture_passe
             "mesh_rendered_count",
             "primitive_source_count",
             "primitive_rendered_count",
+            "physical_rendered_count",
             "placeholder_count",
+            "raw_generated_bounds_count",
+            "missing_geometry_box_count",
+            "diagnostic_fallback_count",
             "missing_geometry_count",
             "wireframe_fallback_count",
             "visual_quality_status",
@@ -103,7 +107,9 @@ def test_visual_quality_matrix_emits_required_fields_and_synthetic_fixture_passe
         assert scene["mesh_rendered_count"] == 1
         assert scene["primitive_source_count"] == 1
         assert scene["primitive_rendered_count"] == 1
+        assert scene["physical_rendered_count"] == 2
         assert scene["placeholder_count"] == 0
+        assert scene["diagnostic_fallback_count"] == 0
         assert scene["visual_quality_status"] == "PASS"
         assert scene["blocker_reasons"] == []
 
@@ -185,6 +191,125 @@ def test_visual_quality_matrix_rejects_primitive_placeholders_and_wireframe_domi
     assert "valid URDF primitives must not increment placeholder_count" in scene["blockers"]
     assert "wireframe_fallback_count dominates visible physical items" in scene["blockers"]
 
+
+
+def test_visual_quality_matrix_rejects_raw_generated_bounds_only_visible_evidence(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scene_dir = _write_scene(
+        repo,
+        "raw_bounds_only_scene",
+        _mesh_and_primitive_index(),
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "render_debug_counters": {
+                "rendered_count": 2,
+                "mesh_rendered_count": 0,
+                "primitive_rendered_count": 0,
+                "generated_fallback_count": 2,
+                "placeholder_count": 0,
+                "wireframe_fallback_count": 0,
+            },
+        },
+    )
+    mesh_index = scene_dir / "generated" / "scene_visual_mesh_index.json"
+    smoke_json = scene_dir / "generated" / "scene3d_gui_smoke.json"
+
+    result = matrix.evaluate_scene(
+        scene_name="raw_bounds_only_scene",
+        scene_dir=scene_dir,
+        mesh_index_path=mesh_index,
+        smoke_json_path=smoke_json,
+    )
+
+    assert result["visual_quality_status"] == "FAIL"
+    assert result["physical_rendered_count"] == 0
+    assert result["raw_generated_bounds_count"] == 2
+    assert result["diagnostic_fallback_count"] == 2
+    assert "raw/generated fallback bounds are the only visible evidence despite mesh or URDF primitive sources" in result["blockers"]
+
+
+def test_visual_quality_matrix_rejects_mesh_scene_with_excessive_raw_generated_fallback_bounds(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scene_dir = _write_scene(
+        repo,
+        "mesh_with_excessive_raw_bounds_scene",
+        _mesh_and_primitive_index(),
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "render_debug_counters": {
+                "rendered_count": 4,
+                "mesh_rendered_count": 1,
+                "primitive_rendered_count": 1,
+                "raw_generated_bounds_count": 2,
+                "placeholder_count": 0,
+                "wireframe_fallback_count": 0,
+            },
+        },
+    )
+    mesh_index = scene_dir / "generated" / "scene_visual_mesh_index.json"
+    smoke_json = scene_dir / "generated" / "scene3d_gui_smoke.json"
+
+    result = matrix.evaluate_scene(
+        scene_name="mesh_with_excessive_raw_bounds_scene",
+        scene_dir=scene_dir,
+        mesh_index_path=mesh_index,
+        smoke_json_path=smoke_json,
+    )
+
+    assert result["visual_quality_status"] == "FAIL"
+    assert result["physical_rendered_count"] == 2
+    assert result["raw_generated_bounds_count"] == 2
+    assert result["diagnostic_fallback_count"] == 2
+    assert "raw/generated fallback bounds dominate physical render evidence despite mesh or URDF primitive sources" in result["blockers"]
+    assert "diagnostic fallback evidence dominates physical render evidence despite mesh or URDF primitive sources" in result["blockers"]
+
+
+def test_visual_quality_matrix_allows_valid_urdf_primitive_render_without_placeholder_inflation(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    primitive_index = {
+        "safe_for_preview": True,
+        "visual_items": [
+            {"id": "primitive_item", "geometry": {"cylinder": {"radius": 0.2, "length": 0.8}}},
+        ],
+    }
+    scene_dir = _write_scene(
+        repo,
+        "primitive_scene",
+        primitive_index,
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "render_debug_counters": {
+                "rendered_count": 1,
+                "mesh_rendered_count": 0,
+                "urdf_primitive_rendered_count": 1,
+                "primitive_fallback_count": 1,
+                "placeholder_count": 0,
+                "wireframe_fallback_count": 0,
+                "generated_fallback_count": 0,
+            },
+        },
+    )
+    mesh_index = scene_dir / "generated" / "scene_visual_mesh_index.json"
+    smoke_json = scene_dir / "generated" / "scene3d_gui_smoke.json"
+
+    result = matrix.evaluate_scene(
+        scene_name="primitive_scene",
+        scene_dir=scene_dir,
+        mesh_index_path=mesh_index,
+        smoke_json_path=smoke_json,
+    )
+
+    assert result["visual_quality_status"] == "PASS"
+    assert result["mesh_source_count"] == 0
+    assert result["primitive_source_count"] == 1
+    assert result["primitive_rendered_count"] == 1
+    assert result["physical_rendered_count"] == 1
+    assert result["placeholder_count"] == 0
+    assert result["diagnostic_fallback_count"] == 0
+    assert result["blockers"] == []
 
 def test_evaluate_scene_blocks_missing_smoke_json_with_reason_code(tmp_path: Path) -> None:
     repo = tmp_path / "repo"


### PR DESCRIPTION
### Motivation
- Ensure the Scene3D visual-quality matrix treats credible physical evidence (actual mesh or URDF-primitive renders) separately from diagnostic fallback artifacts so previews aren't considered "good" solely because of generated bounds/placeholders/wireframes.
- Prevent false positives where raw/generated fallback bounds or diagnostic boxes dominate the viewport counters despite source mesh or primitive geometry existing.
- Provide stronger, deterministic synthetic fixtures and unit coverage to catch regressions in render-evidence handling using only counter fields rather than scene-name heuristics.

### Description
- Introduced a new dominance threshold `DIAGNOSTIC_FALLBACK_DOMINANCE_RATIO` and computed `physical_rendered_count` (mesh + primitive) while adding diagnostic counters `raw_generated_bounds_count`, `missing_geometry_box_count`, and `diagnostic_fallback_count` in `scripts/validate_scene3d_visual_quality_matrix.py`.
- Excluded raw/generated bounds, placeholder boxes, and wireframes from `physical_rendered_count` and added blockers when raw/generated fallback bounds are the only visible evidence or when diagnostic fallback evidence dominates credible physical render evidence.
- Tightened synthetic fixture rules so fixtures must render mesh and primitive sources without placeholder or diagnostic fallback evidence.
- Expanded and added synthetic unit tests in `tests/test_scene3d_visual_quality_matrix.py` to assert the new counters and to cover: raw generated bounds-only failure, mesh+excessive raw fallback bounds failure, and valid URDF primitive rendering without placeholder inflation.
- Continued to use only behavior/counter fields for decisions and avoided any branching on specific scene names.

### Testing
- Ran `pytest -q tests/test_scene3d_visual_quality_matrix.py` and the updated matrix tests passed (11 passed).
- Ran the broader smoke test set `pytest -q tests/test_scene3d_visual_quality_matrix.py tests/test_scene3d_visual_quality_screenshots_runner.py tests/test_scene3d_smoke_render_counters.py` and all tests passed (15 passed).
- Performed `python3 -m py_compile scripts/validate_scene3d_visual_quality_matrix.py` which succeeded and ran `git diff --check` before committing with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f18fde70883318c2266068a433bb0)