### PR TITLE
Validate Scene3D overlay render evidence

### DIFF
--- a/scripts/run_scene3d_visual_quality_screenshots.py
+++ b/scripts/run_scene3d_visual_quality_screenshots.py
@@ -48,6 +48,19 @@ _COUNTER_KEYS = (
     "missing_geometry_count",
     "wireframe_fallback_count",
     "overlay_helper_count",
+    "overlay_count",
+    "label_count",
+    "warning_anchor_count",
+    "fov_helper_count",
+    "reach_helper_count",
+    "safety_zone_count",
+    "helper_overlay_count",
+    "physical_rendered_count",
+    "physical_fit_bounds_count",
+    "helper_fit_bounds_count",
+    "overlay_fit_bounds_count",
+    "physical_items_in_fit_bounds_count",
+    "overlay_items_in_fit_bounds_count",
     "locked_generated_urdf_visual_count",
     "editable_layout_count",
     "visual_quality_status",
@@ -428,16 +441,17 @@ def main(argv: list[str] | None = None) -> int:
         f"- FAIL: {totals['FAIL']}",
         f"- BLOCKED: {totals['BLOCKED']}",
         "",
-        "| Scene | Status | Smoke JSON | Screenshot | Blocker reasons | Mesh failure reasons |",
-        "|---|---|---|---|---|---|",
+        "| Scene | Status | Smoke JSON | Screenshot | Blocker reasons | Actionable blockers | Mesh failure reasons |",
+        "|---|---|---|---|---|---|---|",
     ]
     for result in results:
         reasons = result["mesh_failure_summary_by_reason_code"].get("by_reason_code", {})
         reason_text = ", ".join(f"{k}={v}" for k, v in reasons.items()) or "none"
         blocker_reason_text = ", ".join(str(reason) for reason in result.get("blocker_reasons", [])) or "none"
+        blocker_text = "; ".join(str(blocker).replace("|", "/") for blocker in result.get("blockers", [])) or "none"
         md.append(
             f"| {result['scene']} | {result['status']} | `{result['smoke_json']}` | "
-            f"`{result['screenshot_path']}` | {blocker_reason_text} | {reason_text} |"
+            f"`{result['screenshot_path']}` | {blocker_reason_text} | {blocker_text} | {reason_text} |"
         )
     (output_dir / "scene3d_visual_quality_screenshots_summary.md").write_text("\n".join(md) + "\n", encoding="utf-8")
     print(json.dumps(payload, indent=2))

--- a/scripts/validate_scene3d_visual_quality_matrix.py
+++ b/scripts/validate_scene3d_visual_quality_matrix.py
@@ -12,6 +12,38 @@ import yaml
 SCHEMA = "workcell_studio_scene3d_visual_quality_matrix/v1"
 SMOKE_SCHEMA = "workcell_studio_scene3d_gui_smoke/v1"
 PHYSICAL_ITEM_DOMINANCE_RATIO = 0.5
+PHYSICAL_FALLBACK_DOMINANCE_RATIO = 0.5
+
+HELPER_OVERLAY_COUNTER_KEYS = (
+    "overlay_helper_count",
+    "overlay_count",
+    "label_count",
+    "warning_anchor_count",
+    "fov_helper_count",
+    "reach_helper_count",
+    "safety_zone_count",
+)
+PHYSICAL_FALLBACK_COUNTER_KEYS = (
+    "physical_fallback_count",
+    "valid_physical_fallback_count",
+    "primitive_fallback_count",
+    "generated_fallback_count",
+)
+PHYSICAL_FIT_BOUNDS_COUNTER_KEYS = (
+    "physical_fit_bounds_count",
+    "physical_fit_bound_count",
+    "physical_fit_bounds_item_count",
+    "physical_items_in_fit_bounds_count",
+    "physical_fit_included_count",
+)
+HELPER_FIT_BOUNDS_COUNTER_KEYS = (
+    "helper_fit_bounds_count",
+    "overlay_fit_bounds_count",
+    "overlay_helper_fit_bounds_count",
+    "helper_items_in_fit_bounds_count",
+    "overlay_items_in_fit_bounds_count",
+    "overlay_fit_included_count",
+)
 
 MESH_KEYS = {"mesh", "mesh_path", "mesh_uri", "mesh_filename", "filename", "resource", "uri"}
 PRIMITIVE_TYPES = {"box", "cube", "cylinder", "sphere", "capsule", "cone", "primitive"}
@@ -40,6 +72,15 @@ def _as_int(value: Any, default: int = 0) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _counter_present(payload: dict[str, Any], *keys: str) -> bool:
+    sources = [payload]
+    for nested in ("counters", "render_debug_counters"):
+        nested_payload = payload.get(nested)
+        if isinstance(nested_payload, dict):
+            sources.append(nested_payload)
+    return any(key in source for source in sources for key in keys)
 
 
 def _counter(payload: dict[str, Any], *keys: str) -> int:
@@ -257,6 +298,24 @@ def evaluate_scene(
     wireframe_fallback_count = _counter(smoke_payload, "wireframe_fallback_count", "wireframe_box_count")
     rendered_count = _counter(smoke_payload, "rendered_count")
 
+    helper_overlay_counts = {key: _counter(smoke_payload, key) for key in HELPER_OVERLAY_COUNTER_KEYS}
+    helper_overlay_count = max(helper_overlay_counts["overlay_helper_count"], helper_overlay_counts["overlay_count"]) + sum(
+        helper_overlay_counts[key] for key in ("label_count", "warning_anchor_count", "fov_helper_count", "reach_helper_count", "safety_zone_count")
+    )
+    physical_fallback_raw_count = max(_counter(smoke_payload, key) for key in PHYSICAL_FALLBACK_COUNTER_KEYS)
+    physical_rendered_base_count = mesh_rendered_count + primitive_rendered_count
+    physical_fallback_count = 0
+    if physical_fallback_raw_count > 0:
+        fallback_limit = max(1, int(physical_rendered_base_count * PHYSICAL_FALLBACK_DOMINANCE_RATIO))
+        if physical_rendered_base_count > 0 and physical_fallback_raw_count <= fallback_limit:
+            physical_fallback_count = physical_fallback_raw_count
+    physical_rendered_count = physical_rendered_base_count + physical_fallback_count
+
+    physical_fit_bounds_present = _counter_present(smoke_payload, *PHYSICAL_FIT_BOUNDS_COUNTER_KEYS)
+    helper_fit_bounds_present = _counter_present(smoke_payload, *HELPER_FIT_BOUNDS_COUNTER_KEYS)
+    physical_fit_bounds_count = max(_counter(smoke_payload, key) for key in PHYSICAL_FIT_BOUNDS_COUNTER_KEYS)
+    helper_fit_bounds_count = max(_counter(smoke_payload, key) for key in HELPER_FIT_BOUNDS_COUNTER_KEYS)
+
     if mesh_source_count > 0 and mesh_rendered_count <= 0:
         blockers.append("mesh_source_count > 0 requires mesh_rendered_count > 0")
     if primitive_source_count > 0 and primitive_rendered_count <= 0:
@@ -268,10 +327,27 @@ def evaluate_scene(
     if rendered_count == total_payload_count and total_payload_count > 0:
         warnings.append("rendered_count equals total_payload_count; pass still requires mesh/primitive-specific rendered counts")
 
-    visible_physical_count = mesh_rendered_count + primitive_rendered_count + placeholder_count + wireframe_fallback_count
+    visible_physical_count = physical_rendered_count + placeholder_count + wireframe_fallback_count
     if wireframe_fallback_count > 0 and visible_physical_count > 0:
         if wireframe_fallback_count > int(visible_physical_count * PHYSICAL_ITEM_DOMINANCE_RATIO):
             blockers.append("wireframe_fallback_count dominates visible physical items")
+    if helper_overlay_count > 0 and helper_overlay_count >= physical_rendered_count:
+        add_blocker(
+            "helper/overlay render counters dominate physical rendered evidence "
+            f"(helper_overlay_count={helper_overlay_count}, physical_rendered_count={physical_rendered_count})",
+            "overlay_helper_domination",
+        )
+    if helper_overlay_count > 0 and physical_rendered_count <= 0 and rendered_count > 0:
+        add_blocker(
+            "helper/overlay counters are the only render evidence; rendered_count alone cannot prove physical Scene3D quality",
+            "overlay_only_render_evidence",
+        )
+    if physical_fit_bounds_present and helper_fit_bounds_present and helper_fit_bounds_count > 0 and helper_fit_bounds_count >= physical_fit_bounds_count:
+        add_blocker(
+            "helper/overlay fit-bounds counters dominate physical fit-bounds counters "
+            f"(helper_fit_bounds_count={helper_fit_bounds_count}, physical_fit_bounds_count={physical_fit_bounds_count})",
+            "overlay_fit_bounds_domination",
+        )
     if missing_geometry_count > 0:
         warnings.append(f"{missing_geometry_count} source payload item(s) lack mesh or primitive geometry")
 
@@ -302,6 +378,13 @@ def evaluate_scene(
         "missing_geometry_count": missing_geometry_count,
         "wireframe_fallback_count": wireframe_fallback_count,
         "rendered_count": rendered_count,
+        "physical_rendered_count": physical_rendered_count,
+        "physical_fallback_count": physical_fallback_count,
+        "physical_fallback_raw_count": physical_fallback_raw_count,
+        "helper_overlay_count": helper_overlay_count,
+        **helper_overlay_counts,
+        "physical_fit_bounds_count": physical_fit_bounds_count,
+        "helper_fit_bounds_count": helper_fit_bounds_count,
         "visual_quality_status": visual_quality_status,
         "warnings": warnings,
         "blockers": blockers,

--- a/tests/test_scene3d_visual_quality_matrix.py
+++ b/tests/test_scene3d_visual_quality_matrix.py
@@ -94,6 +94,15 @@ def test_visual_quality_matrix_emits_required_fields_and_synthetic_fixture_passe
             "placeholder_count",
             "missing_geometry_count",
             "wireframe_fallback_count",
+            "physical_rendered_count",
+            "helper_overlay_count",
+            "overlay_helper_count",
+            "overlay_count",
+            "label_count",
+            "warning_anchor_count",
+            "fov_helper_count",
+            "reach_helper_count",
+            "safety_zone_count",
             "visual_quality_status",
             "warnings",
             "blocker_reasons",
@@ -104,6 +113,8 @@ def test_visual_quality_matrix_emits_required_fields_and_synthetic_fixture_passe
         assert scene["primitive_source_count"] == 1
         assert scene["primitive_rendered_count"] == 1
         assert scene["placeholder_count"] == 0
+        assert scene["physical_rendered_count"] == 2
+        assert scene["helper_overlay_count"] == 0
         assert scene["visual_quality_status"] == "PASS"
         assert scene["blocker_reasons"] == []
 
@@ -278,6 +289,85 @@ def test_screenshot_runner_marks_visual_quality_blocker_reasons_blocked(tmp_path
     assert result["status"] == "BLOCKED"
     assert "screenshot_missing" in result["blocker_reasons"]
     assert result["visual_quality_evaluation"]["blocker_reasons"] == ["screenshot_missing"]
+
+def _overlay_only_smoke() -> dict:
+    return {
+        "schema": "workcell_studio_scene3d_gui_smoke/v1",
+        "status": "PASS",
+        "counters": {
+            "rendered_count": 5,
+            "mesh_rendered_count": 0,
+            "primitive_rendered_count": 0,
+            "overlay_helper_count": 2,
+            "overlay_count": 2,
+            "label_count": 1,
+            "warning_anchor_count": 1,
+            "fov_helper_count": 1,
+            "reach_helper_count": 1,
+            "safety_zone_count": 1,
+            "physical_fit_bounds_count": 0,
+            "overlay_fit_bounds_count": 3,
+        },
+    }
+
+
+def test_visual_quality_matrix_rejects_overlay_only_render_evidence_even_with_rendered_count(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scene_dir = _write_scene(repo, "overlay_only_scene", _mesh_and_primitive_index(), _overlay_only_smoke())
+    result = matrix.evaluate_scene(
+        scene_name="overlay_only_scene",
+        scene_dir=scene_dir,
+        mesh_index_path=scene_dir / "generated" / "scene_visual_mesh_index.json",
+        smoke_json_path=scene_dir / "generated" / "scene3d_gui_smoke.json",
+    )
+
+    assert result["rendered_count"] == 5
+    assert result["physical_rendered_count"] == 0
+    assert result["helper_overlay_count"] == 7
+    assert result["overlay_helper_count"] == 2
+    assert result["overlay_count"] == 2
+    assert result["label_count"] == 1
+    assert result["warning_anchor_count"] == 1
+    assert result["fov_helper_count"] == 1
+    assert result["reach_helper_count"] == 1
+    assert result["safety_zone_count"] == 1
+    assert result["visual_quality_status"] == "FAIL"
+    assert "overlay_helper_domination" in result["blocker_reasons"]
+    assert "overlay_only_render_evidence" in result["blocker_reasons"]
+    assert "overlay_fit_bounds_domination" in result["blocker_reasons"]
+
+
+def test_visual_quality_matrix_ignores_dominating_physical_fallback_for_physical_rendered_count(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scene_dir = _write_scene(
+        repo,
+        "fallback_dominated_scene",
+        _mesh_and_primitive_index(),
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "counters": {
+                "rendered_count": 10,
+                "mesh_rendered_count": 1,
+                "primitive_rendered_count": 1,
+                "physical_fallback_count": 8,
+                "overlay_helper_count": 3,
+            },
+        },
+    )
+
+    result = matrix.evaluate_scene(
+        scene_name="fallback_dominated_scene",
+        scene_dir=scene_dir,
+        mesh_index_path=scene_dir / "generated" / "scene_visual_mesh_index.json",
+        smoke_json_path=scene_dir / "generated" / "scene3d_gui_smoke.json",
+    )
+
+    assert result["physical_fallback_raw_count"] == 8
+    assert result["physical_fallback_count"] == 0
+    assert result["physical_rendered_count"] == 2
+    assert "overlay_helper_domination" in result["blocker_reasons"]
+
 
 def test_visual_quality_matrix_cli_writes_json(tmp_path: Path) -> None:
     repo = tmp_path / "repo"

--- a/tests/test_scene3d_visual_quality_screenshots_runner.py
+++ b/tests/test_scene3d_visual_quality_screenshots_runner.py
@@ -124,3 +124,71 @@ def test_visual_quality_screenshot_runner_captures_required_summaries(tmp_path: 
     assert result["mesh_failure_summary_by_reason_code"]["by_reason_code"] == {"mesh_missing_on_disk": 1}
     assert Path(result["smoke_json"]).exists()
     assert Path(result["screenshot_path"]).exists()
+
+
+def _write_overlay_only_executable(path: Path) -> None:
+    path.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, pathlib, sys\n"
+        "args=sys.argv[1:]\n"
+        "out=pathlib.Path(args[args.index('--smoke-output')+1])\n"
+        "png=pathlib.Path(args[args.index('--smoke-screenshot')+1]) if '--smoke-screenshot' in args else None\n"
+        "scene=args[args.index('--scene')+1] if '--scene' in args else pathlib.Path(args[args.index('--scene-path')+1]).name\n"
+        "payload={'schema':'workcell_studio_scene3d_gui_smoke/v1','status':'PASS','scene':scene,'counters':{"
+        "'rendered_count':5,'mesh_rendered_count':0,'urdf_primitive_rendered_count':0,"
+        "'overlay_helper_count':2,'overlay_count':2,'label_count':1,'warning_anchor_count':1,"
+        "'fov_helper_count':1,'reach_helper_count':1,'safety_zone_count':1,"
+        "'physical_fit_bounds_count':0,'overlay_fit_bounds_count':3}}\n"
+        "out.parent.mkdir(parents=True, exist_ok=True); out.write_text(json.dumps(payload))\n"
+        "png.parent.mkdir(parents=True, exist_ok=True); png.write_bytes(b'png') if png else None\n"
+        "sys.exit(0)\n",
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | 0o111)
+
+
+def test_visual_quality_screenshot_runner_reports_overlay_domination_blockers_in_json_and_markdown(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    os.symlink(ROOT / "scripts", repo / "scripts", target_is_directory=True)
+    (repo / "workcell_builder").mkdir()
+    _write_scene(repo, "overlay_scene")
+    fake_exe = tmp_path / "workcell_builder_overlay"
+    _write_overlay_only_executable(fake_exe)
+    out = tmp_path / "out"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo-root",
+            str(repo),
+            "--workspace-root",
+            str(repo),
+            "--executable",
+            str(fake_exe),
+            "--scene",
+            "overlay_scene",
+            "--output-dir",
+            str(out),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    summary = json.loads((out / "scene3d_visual_quality_screenshots_summary.json").read_text(encoding="utf-8"))
+    result = summary["results"][0]
+    assert result["status"] == "BLOCKED"
+    assert result["visual_quality_counter_summary"]["overlay_helper_count"] == 2
+    assert result["visual_quality_counter_summary"]["label_count"] == 1
+    assert "overlay_helper_domination" in result["blocker_reasons"]
+    assert "overlay_only_render_evidence" in result["blocker_reasons"]
+    assert "overlay_fit_bounds_domination" in result["blocker_reasons"]
+    assert any("helper/overlay render counters dominate physical rendered evidence" in blocker for blocker in result["blockers"])
+    markdown = (out / "scene3d_visual_quality_screenshots_summary.md").read_text(encoding="utf-8")
+    assert "Actionable blockers" in markdown
+    assert "overlay_helper_domination" in markdown
+    assert "helper/overlay render counters dominate physical rendered evidence" in markdown


### PR DESCRIPTION
### Motivation

- Prevent helper/overlay visual elements (labels, anchors, FOV/reach helpers, safety zones, etc.) from masking missing physical scene rendering when evaluating Scene3D smoke outputs.
- Ensure `physical_rendered_count` is computed from credible physical evidence and not inflated by dominating fallback counters.
- Surface actionable overlay/helper domination issues in screenshot runner summaries so they are visible to downstream consumers.

### Description

- Extract additional helper/overlay counters from smoke payloads including `overlay_helper_count`, `overlay_count`, `label_count`, `warning_anchor_count`, `fov_helper_count`, `reach_helper_count`, and `safety_zone_count` and expose them on per-scene matrix output (`scripts/validate_scene3d_visual_quality_matrix.py`).
- Compute `physical_rendered_count` from core physical evidence (`mesh_rendered_count` + `primitive_rendered_count`) and only include non-dominating physical fallback counters under a dominance threshold to avoid misleading physical counts.
- Add blockers when helper/overlay counters dominate physical rendered evidence, when helper/overlay counters are the only render evidence despite `rendered_count > 0`, and when helper/overlay fit-bounds counters dominate physical fit-bounds counters.
- Extend the screenshot-runner counter summary keys and JSON/Markdown outputs to include overlay/helper counters and a new "Actionable blockers" column so blocking messages about overlay domination appear in both JSON and Markdown reports (`scripts/run_scene3d_visual_quality_screenshots.py`).
- Add synthetic unit tests and runner tests that assert overlay-only smoke payloads fail visual-quality checks and that overlay domination blockers surface in JSON and Markdown summaries (`tests/test_scene3d_visual_quality_matrix.py`, `tests/test_scene3d_visual_quality_screenshots_runner.py`).

### Testing

- Ran Python compilation checks: `python3 -m py_compile scripts/validate_scene3d_visual_quality_matrix.py scripts/run_scene3d_visual_quality_screenshots.py` and it succeeded.
- Ran the test suite for the affected tests: `pytest -q tests/test_scene3d_visual_quality_matrix.py tests/test_scene3d_visual_quality_screenshots_runner.py` and all tests passed (13 tests total for the invoked suites).
- Added synthetic scenarios in tests that specifically validate overlay-only smoke payloads fail and that screenshot-runner JSON/Markdown include actionable overlay domination blockers, and these tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f1921aa808331a0e498b15606ba2d)