### PR TITLE
Scene3D: detect and block overlay/helper-dominated visual evidence

### DIFF
--- a/scripts/run_scene3d_visual_quality_screenshots.py
+++ b/scripts/run_scene3d_visual_quality_screenshots.py
@@ -48,6 +48,26 @@ _COUNTER_KEYS = (
     "missing_geometry_count",
     "wireframe_fallback_count",
     "overlay_helper_count",
+    "overlay_count",
+    "label_count",
+    "labels_drawn",
+    "warning_anchor_count",
+    "fov_helper_count",
+    "reach_helper_count",
+    "safety_zone_count",
+    "physical_fit_bounds_count",
+    "physical_fit_bound_count",
+    "physical_bounds_count",
+    "fit_bounds_physical_count",
+    "overlay_fit_bounds_count",
+    "overlay_fit_bound_count",
+    "helper_fit_bounds_count",
+    "helper_overlay_fit_bounds_count",
+    "fit_bounds_overlay_count",
+    "valid_physical_fallback_count",
+    "physical_fallback_count",
+    "physical_fallback_rendered_count",
+    "collision_primitive_rendered_count",
     "locked_generated_urdf_visual_count",
     "editable_layout_count",
     "visual_quality_status",
@@ -274,6 +294,32 @@ def _as_int(value: Any, default: int = 0) -> int:
         return default
 
 
+def _counter_max(counter_summary: dict[str, Any], visual_quality: dict[str, Any], *keys: str) -> int:
+    counter_values = [_as_int(counter_summary.get(key)) for key in keys]
+    visual_quality_values = [_as_int(visual_quality.get(key)) for key in keys]
+    return max([*counter_values, *visual_quality_values], default=0)
+
+
+def _helper_overlay_count(counter_summary: dict[str, Any], visual_quality: dict[str, Any]) -> int:
+    overlay_family_count = max(
+        _counter_max(counter_summary, visual_quality, "overlay_helper_count"),
+        _counter_max(counter_summary, visual_quality, "overlay_count"),
+    )
+    helper_counter_keys = (
+        "label_count",
+        "labels_drawn",
+        "warning_anchor_count",
+        "fov_helper_count",
+        "reach_helper_count",
+        "safety_zone_count",
+    )
+    return overlay_family_count + sum(_counter_max(counter_summary, visual_quality, key) for key in helper_counter_keys)
+
+
+def _fit_bounds_count(counter_summary: dict[str, Any], visual_quality: dict[str, Any], *keys: str) -> int:
+    return _counter_max(counter_summary, visual_quality, *keys)
+
+
 def _add_reason(reasons: list[str], reason: str) -> None:
     if reason and reason not in reasons:
         reasons.append(reason)
@@ -303,9 +349,13 @@ def _normalize_blocker_text(text: str) -> str | None:
         or "wireframe_fallback_count dominates" in lowered
     ):
         return "placeholder_missing_geometry_dominates"
-    if "overlay_helper_dominates" in lowered or ("overlay helper" in lowered and "dominat" in lowered):
+    if (
+        "overlay_helper_dominates" in lowered
+        or ("overlay helper" in lowered and "dominat" in lowered)
+        or ("helper/overlay" in lowered and ("dominat" in lowered or "greater than or equal" in lowered))
+    ):
         return "overlay_helper_dominates"
-    if "no_physical_scene_items_rendered" in lowered:
+    if "no_physical_scene_items_rendered" in lowered or "only render evidence" in lowered:
         return "no_physical_scene_items_rendered"
     return lowered.split(":", 1)[0].strip().replace(" ", "_")
 
@@ -353,9 +403,29 @@ def _normalized_blocker_reasons(
     placeholder_count = max(_as_int(counter_summary.get("placeholder_count")), _as_int(visual_quality.get("placeholder_count")))
     missing_geometry_count = max(_as_int(counter_summary.get("missing_geometry_count")), _as_int(visual_quality.get("missing_geometry_count")))
     wireframe_fallback_count = max(_as_int(counter_summary.get("wireframe_fallback_count")), _as_int(visual_quality.get("wireframe_fallback_count")))
-    overlay_helper_count = _as_int(counter_summary.get("overlay_helper_count"))
+    overlay_helper_count = _helper_overlay_count(counter_summary, visual_quality)
     rendered_count = max(_as_int(counter_summary.get("rendered_count")), _as_int(visual_quality.get("rendered_count")))
-    physical_rendered_count = mesh_rendered_count + primitive_rendered_count + placeholder_count + wireframe_fallback_count
+    physical_rendered_count = max(
+        _as_int(visual_quality.get("physical_rendered_count")),
+        mesh_rendered_count + primitive_rendered_count,
+    )
+    physical_fit_bounds_count = _fit_bounds_count(
+        counter_summary,
+        visual_quality,
+        "physical_fit_bounds_count",
+        "physical_fit_bound_count",
+        "physical_bounds_count",
+        "fit_bounds_physical_count",
+    )
+    helper_overlay_fit_bounds_count = _fit_bounds_count(
+        counter_summary,
+        visual_quality,
+        "helper_overlay_fit_bounds_count",
+        "overlay_fit_bounds_count",
+        "overlay_fit_bound_count",
+        "helper_fit_bounds_count",
+        "fit_bounds_overlay_count",
+    )
     source_count = mesh_source_count + primitive_source_count
 
     if mesh_source_count > 0 and mesh_rendered_count <= 0:
@@ -366,7 +436,13 @@ def _normalized_blocker_reasons(
     credible_rendered_count = mesh_rendered_count + primitive_rendered_count
     if placeholder_or_missing_count > max(credible_rendered_count, 0) and placeholder_or_missing_count > 0:
         _add_reason(reasons, "placeholder_missing_geometry_dominates")
-    if overlay_helper_count > max(physical_rendered_count, 0) and overlay_helper_count > 0:
+    if overlay_helper_count >= max(physical_rendered_count, 0) and overlay_helper_count > 0:
+        _add_reason(reasons, "overlay_helper_dominates")
+    if (
+        physical_fit_bounds_count > 0
+        and helper_overlay_fit_bounds_count >= physical_fit_bounds_count
+        and helper_overlay_fit_bounds_count > 0
+    ):
         _add_reason(reasons, "overlay_helper_dominates")
     if source_count > 0 and physical_rendered_count <= 0:
         _add_reason(reasons, "no_physical_scene_items_rendered")

--- a/scripts/validate_scene3d_visual_quality_matrix.py
+++ b/scripts/validate_scene3d_visual_quality_matrix.py
@@ -13,6 +13,37 @@ SCHEMA = "workcell_studio_scene3d_visual_quality_matrix/v1"
 SMOKE_SCHEMA = "workcell_studio_scene3d_gui_smoke/v1"
 PHYSICAL_ITEM_DOMINANCE_RATIO = 0.5
 DIAGNOSTIC_FALLBACK_DOMINANCE_RATIO = 0.5
+VALID_PHYSICAL_FALLBACK_DOMINANCE_RATIO = 0.5
+
+HELPER_OVERLAY_COUNTERS = (
+    "overlay_helper_count",
+    "overlay_count",
+    "label_count",
+    "labels_drawn",
+    "warning_anchor_count",
+    "fov_helper_count",
+    "reach_helper_count",
+    "safety_zone_count",
+)
+PHYSICAL_FIT_BOUNDS_COUNTERS = (
+    "physical_fit_bounds_count",
+    "physical_fit_bound_count",
+    "physical_bounds_count",
+    "fit_bounds_physical_count",
+)
+HELPER_OVERLAY_FIT_BOUNDS_COUNTERS = (
+    "overlay_fit_bounds_count",
+    "overlay_fit_bound_count",
+    "helper_fit_bounds_count",
+    "helper_overlay_fit_bounds_count",
+    "fit_bounds_overlay_count",
+)
+VALID_PHYSICAL_FALLBACK_COUNTERS = (
+    "valid_physical_fallback_count",
+    "physical_fallback_count",
+    "physical_fallback_rendered_count",
+    "collision_primitive_rendered_count",
+)
 
 MESH_KEYS = {"mesh", "mesh_path", "mesh_uri", "mesh_filename", "filename", "resource", "uri"}
 PRIMITIVE_TYPES = {"box", "cube", "cylinder", "sphere", "capsule", "cone", "primitive"}
@@ -54,6 +85,29 @@ def _counter(payload: dict[str, Any], *keys: str) -> int:
             if key in source:
                 return _as_int(source.get(key))
     return 0
+
+
+def _counter_values(payload: dict[str, Any], keys: tuple[str, ...]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for key in keys:
+        value = _counter(payload, key)
+        if value > 0:
+            counts[key] = value
+    return counts
+
+
+def _helper_overlay_counts(payload: dict[str, Any]) -> tuple[dict[str, int], int]:
+    counts = _counter_values(payload, HELPER_OVERLAY_COUNTERS)
+    overlay_family_count = max(counts.get("overlay_helper_count", 0), counts.get("overlay_count", 0))
+    helper_overlay_count = overlay_family_count
+    for key, value in counts.items():
+        if key not in {"overlay_helper_count", "overlay_count"}:
+            helper_overlay_count += value
+    return counts, helper_overlay_count
+
+
+def _max_counter(payload: dict[str, Any], keys: tuple[str, ...]) -> int:
+    return max((_counter(payload, key) for key in keys), default=0)
 
 
 def _list_field(payload: dict[str, Any], *keys: str) -> list[Any]:
@@ -273,9 +327,21 @@ def evaluate_scene(
         "missing_geometry_fallback_count",
     )
     rendered_count = _counter(smoke_payload, "rendered_count")
+    helper_overlay_counts, helper_overlay_count = _helper_overlay_counts(smoke_payload)
+    physical_fit_bounds_count = _max_counter(smoke_payload, PHYSICAL_FIT_BOUNDS_COUNTERS)
+    helper_overlay_fit_bounds_count = _max_counter(smoke_payload, HELPER_OVERLAY_FIT_BOUNDS_COUNTERS)
+    valid_physical_fallback_count = _max_counter(smoke_payload, VALID_PHYSICAL_FALLBACK_COUNTERS)
 
     credible_source_count = mesh_source_count + primitive_source_count
-    physical_rendered_count = mesh_rendered_count + primitive_rendered_count
+    credible_physical_rendered_count = mesh_rendered_count + primitive_rendered_count
+    physical_rendered_count = credible_physical_rendered_count
+    valid_physical_fallback_dominates = False
+    if valid_physical_fallback_count > 0:
+        valid_fallback_limit = credible_physical_rendered_count * VALID_PHYSICAL_FALLBACK_DOMINANCE_RATIO
+        if credible_physical_rendered_count > 0 and valid_physical_fallback_count <= valid_fallback_limit:
+            physical_rendered_count += valid_physical_fallback_count
+        else:
+            valid_physical_fallback_dominates = True
     diagnostic_fallback_count = (
         raw_generated_bounds_count
         + placeholder_count
@@ -298,8 +364,35 @@ def evaluate_scene(
         warnings.append(
             "diagnostic fallback evidence present; physical_rendered_count excludes raw bounds, placeholders, and wireframes"
         )
+    if helper_overlay_count > 0:
+        warnings.append("helper/overlay render evidence present; physical_rendered_count excludes helper overlays")
+    if valid_physical_fallback_dominates:
+        add_blocker(
+            "valid physical fallback counters dominate credible mesh/primitive render evidence; physical_rendered_count excludes them",
+            "physical_fallback_dominates",
+        )
     if missing_geometry_count > 0:
         warnings.append(f"{missing_geometry_count} source payload item(s) lack mesh or primitive geometry")
+
+    if helper_overlay_count > 0 and physical_rendered_count <= 0 and rendered_count > 0:
+        add_blocker(
+            "no_physical_scene_items_rendered: helper/overlay count is the only render evidence; rendered_count cannot prove Scene3D visual quality",
+            "no_physical_scene_items_rendered",
+        )
+    if helper_overlay_count > 0 and helper_overlay_count >= physical_rendered_count:
+        add_blocker(
+            "overlay_helper_dominates: helper/overlay count is greater than or equal to physical_rendered_count; render physical scene items instead of relying on overlays",
+            "overlay_helper_dominates",
+        )
+    if (
+        physical_fit_bounds_count > 0
+        and helper_overlay_fit_bounds_count >= physical_fit_bounds_count
+        and helper_overlay_fit_bounds_count > 0
+    ):
+        add_blocker(
+            "overlay_helper_dominates: helper/overlay fit-bounds counters dominate physical fit-bounds counters; fit the camera to physical scene bounds",
+            "overlay_helper_dominates",
+        )
 
     if credible_source_count > 0 and physical_rendered_count <= 0 and raw_generated_bounds_count > 0:
         blockers.append("raw/generated fallback bounds are the only visible evidence despite mesh or URDF primitive sources")
@@ -341,6 +434,12 @@ def evaluate_scene(
         "primitive_source_count": primitive_source_count,
         "primitive_rendered_count": primitive_rendered_count,
         "physical_rendered_count": physical_rendered_count,
+        "credible_physical_rendered_count": credible_physical_rendered_count,
+        "valid_physical_fallback_count": valid_physical_fallback_count,
+        "helper_overlay_count": helper_overlay_count,
+        "helper_overlay_counts": helper_overlay_counts,
+        "physical_fit_bounds_count": physical_fit_bounds_count,
+        "helper_overlay_fit_bounds_count": helper_overlay_fit_bounds_count,
         "placeholder_count": placeholder_count,
         "raw_generated_bounds_count": raw_generated_bounds_count,
         "missing_geometry_box_count": missing_geometry_box_count,

--- a/tests/test_scene3d_visual_quality_matrix.py
+++ b/tests/test_scene3d_visual_quality_matrix.py
@@ -92,6 +92,12 @@ def test_visual_quality_matrix_emits_required_fields_and_synthetic_fixture_passe
             "primitive_source_count",
             "primitive_rendered_count",
             "physical_rendered_count",
+            "credible_physical_rendered_count",
+            "helper_overlay_count",
+            "helper_overlay_counts",
+            "physical_fit_bounds_count",
+            "helper_overlay_fit_bounds_count",
+            "valid_physical_fallback_count",
             "placeholder_count",
             "raw_generated_bounds_count",
             "missing_geometry_box_count",
@@ -113,6 +119,97 @@ def test_visual_quality_matrix_emits_required_fields_and_synthetic_fixture_passe
         assert scene["visual_quality_status"] == "PASS"
         assert scene["blocker_reasons"] == []
 
+
+
+def test_visual_quality_matrix_rejects_overlay_only_render_evidence_even_when_rendered_count_positive(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scene_dir = _write_scene(
+        repo,
+        "overlay_only_scene",
+        _mesh_and_primitive_index(),
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "counters": {
+                "rendered_count": 7,
+                "mesh_rendered_count": 0,
+                "primitive_rendered_count": 0,
+                "overlay_helper_count": 2,
+                "overlay_count": 2,
+                "label_count": 1,
+                "warning_anchor_count": 1,
+                "fov_helper_count": 1,
+                "reach_helper_count": 1,
+                "safety_zone_count": 1,
+                "physical_fit_bounds_count": 0,
+                "overlay_fit_bounds_count": 7,
+            },
+        },
+    )
+    mesh_index = scene_dir / "generated" / "scene_visual_mesh_index.json"
+    smoke_json = scene_dir / "generated" / "scene3d_gui_smoke.json"
+
+    result = matrix.evaluate_scene(
+        scene_name="overlay_only_scene",
+        scene_dir=scene_dir,
+        mesh_index_path=mesh_index,
+        smoke_json_path=smoke_json,
+    )
+
+    assert result["visual_quality_status"] == "FAIL"
+    assert result["rendered_count"] == 7
+    assert result["physical_rendered_count"] == 0
+    assert result["helper_overlay_count"] == 7
+    assert result["helper_overlay_counts"] == {
+        "overlay_helper_count": 2,
+        "overlay_count": 2,
+        "label_count": 1,
+        "warning_anchor_count": 1,
+        "fov_helper_count": 1,
+        "reach_helper_count": 1,
+        "safety_zone_count": 1,
+    }
+    assert "no_physical_scene_items_rendered" in result["blocker_reasons"]
+    assert "overlay_helper_dominates" in result["blocker_reasons"]
+    assert any("helper/overlay count is the only render evidence" in blocker for blocker in result["blockers"])
+    assert any("helper/overlay count is greater than or equal" in blocker for blocker in result["blockers"])
+
+
+def test_visual_quality_matrix_rejects_helper_overlay_fit_bounds_dominance(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scene_dir = _write_scene(
+        repo,
+        "overlay_fit_bounds_scene",
+        _mesh_and_primitive_index(),
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "render_debug_counters": {
+                "rendered_count": 4,
+                "mesh_rendered_count": 2,
+                "primitive_rendered_count": 2,
+                "overlay_helper_count": 1,
+                "physical_fit_bounds_count": 2,
+                "helper_overlay_fit_bounds_count": 2,
+            },
+        },
+    )
+    mesh_index = scene_dir / "generated" / "scene_visual_mesh_index.json"
+    smoke_json = scene_dir / "generated" / "scene3d_gui_smoke.json"
+
+    result = matrix.evaluate_scene(
+        scene_name="overlay_fit_bounds_scene",
+        scene_dir=scene_dir,
+        mesh_index_path=mesh_index,
+        smoke_json_path=smoke_json,
+    )
+
+    assert result["visual_quality_status"] == "FAIL"
+    assert result["physical_rendered_count"] == 4
+    assert result["physical_fit_bounds_count"] == 2
+    assert result["helper_overlay_fit_bounds_count"] == 2
+    assert "overlay_helper_dominates" in result["blocker_reasons"]
+    assert any("helper/overlay fit-bounds counters dominate" in blocker for blocker in result["blockers"])
 
 def test_visual_quality_matrix_rejects_rendered_count_only_and_missing_primitive_render_counter(tmp_path: Path) -> None:
     repo = tmp_path / "repo"

--- a/tests/test_scene3d_visual_quality_screenshots_runner.py
+++ b/tests/test_scene3d_visual_quality_screenshots_runner.py
@@ -67,7 +67,9 @@ def _write_failing_fake_executable(path: Path) -> None:
         "payload={'schema':'workcell_studio_scene3d_gui_smoke/v1','status':'PASS','scene':scene,'counters':{"
         "'rendered_count':4,'mesh_source_count':1,'mesh_rendered_count':0,'urdf_primitive_source_count':1,"
         "'urdf_primitive_rendered_count':0,'primitive_rendered_count':0,'primitive_fallback_count':0,'placeholder_count':0,"
-        "'missing_geometry_count':2,'wireframe_fallback_count':0,'overlay_helper_count':4,'visual_quality_status':'FAIL'}}\n"
+        "'missing_geometry_count':2,'wireframe_fallback_count':0,'overlay_helper_count':4,'overlay_count':4,"
+        "'label_count':1,'warning_anchor_count':1,'fov_helper_count':1,'reach_helper_count':1,'safety_zone_count':1,"
+        "'physical_fit_bounds_count':1,'helper_overlay_fit_bounds_count':4,'visual_quality_status':'FAIL'}}\n"
         "out.parent.mkdir(parents=True, exist_ok=True); out.write_text(json.dumps(payload))\n"
         "sys.exit(0)\n",
         encoding="utf-8",
@@ -198,7 +200,12 @@ def test_visual_quality_screenshot_runner_reports_blockers_in_json_and_markdown_
         assert "mesh_source_not_rendered" in result["blocker_reasons"]
         assert "urdf_primitive_source_not_rendered" in result["blocker_reasons"]
         assert "overlay_helper_dominates" in result["blocker_reasons"]
+        assert "no_physical_scene_items_rendered" in result["blocker_reasons"]
+        assert result["visual_quality_counter_summary"]["overlay_count"] == 4
+        assert result["visual_quality_counter_summary"]["label_count"] == 1
+        assert result["visual_quality_counter_summary"]["helper_overlay_fit_bounds_count"] == 4
         assert "capture or attach the Scene3D smoke screenshot" in result["blocker_text"]
+        assert "overlay helpers cannot prove visual quality" in result["blocker_text"]
 
     markdown = (out / "scene3d_visual_quality_screenshots_summary.md").read_text(encoding="utf-8")
     assert "| Scene | Status | Smoke JSON | Screenshot | Blockers | Mesh failure reasons |" in markdown
@@ -208,3 +215,4 @@ def test_visual_quality_screenshot_runner_reports_blockers_in_json_and_markdown_
     assert "synthetic_failing_b" in markdown
     assert "capture or attach the Scene3D smoke screenshot" in markdown
     assert "overlay helpers cannot prove visual quality" in markdown
+    assert "render at least one physical mesh, primitive, or fallback scene item" in markdown


### PR DESCRIPTION
### Motivation
- Prevent overlay/helper visuals (labels, FOV helpers, safety zones, etc.) from being misinterpreted as physical scene render evidence in the Scene3D visual-quality matrix.
- Ensure `physical_rendered_count` is computed conservatively from credible physical evidence (mesh/primitive renders and only non-dominating valid physical fallbacks).
- Surface helper/overlay and fit-bounds counters so the runner and matrix can produce actionable blocker categories and clearer diagnostics.

### Description
- Added extraction of helper/overlay counters and related families in `scripts/validate_scene3d_visual_quality_matrix.py`, including `overlay_helper_count`, `overlay_count`, `label_count`, `warning_anchor_count`, `fov_helper_count`, `reach_helper_count`, and `safety_zone_count`, plus fit-bounds and valid-physical-fallback counter groups.
- Tightened `physical_rendered_count` computation to use credible mesh/primitive evidence and to include non-dominating valid physical fallback counters only when safe, exposing `credible_physical_rendered_count` and `valid_physical_fallback_count` in the matrix output.
- Added blockers when helper/overlay evidence dominates: overlay-only render evidence, helper/overlay count >= physical rendered count, overlay/helper fit-bounds dominating physical fit-bounds, and when helper/overlay is the only render evidence despite `rendered_count > 0`.
- Updated the screenshots runner `scripts/run_scene3d_visual_quality_screenshots.py` to aggregate helper/overlay counters, compute normalized blocker reasons, and include overlay domination as actionable blocker categories and richer JSON/Markdown summaries.
- Added synthetic unit tests in `tests/test_scene3d_visual_quality_matrix.py` for overlay-only smoke payloads and helper/overlay fit-bounds domination, and updated runner tests in `tests/test_scene3d_visual_quality_screenshots_runner.py` to assert the new counters and blocker text are present.

### Testing
- Ran the test suite with `pytest -q tests/test_scene3d_visual_quality_matrix.py tests/test_scene3d_visual_quality_screenshots_runner.py`, and all tests passed (`16 passed`).
- Verified the modified scripts compile with `python -m py_compile` during development and that the screenshot-runner JSON/Markdown outputs include the new helper/overlay counters and blocker summaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f1ab435d883319342a71eb18d3d89)