### PR TITLE
Add Scene3D visual quality fixture coverage

### DIFF
--- a/scripts/run_scene3d_visual_quality_screenshots.py
+++ b/scripts/run_scene3d_visual_quality_screenshots.py
@@ -109,6 +109,7 @@ _BLOCKER_CATEGORY_KEYS = (
     "placeholder_missing_geometry_dominates",
     "overlay_helper_dominates",
     "no_physical_scene_items_rendered",
+    "mesh_missing_on_disk",
 )
 
 _BLOCKER_ACTION_TEXT = {
@@ -120,6 +121,7 @@ _BLOCKER_ACTION_TEXT = {
     "placeholder_missing_geometry_dominates": "replace dominant placeholder/missing-geometry visuals with mesh or primitive geometry",
     "overlay_helper_dominates": "render physical scene items; overlay helpers cannot prove visual quality",
     "no_physical_scene_items_rendered": "render at least one physical mesh, primitive, or fallback scene item",
+    "mesh_missing_on_disk": "restore the missing mesh asset on disk or update the scene mesh path",
 }
 
 

--- a/scripts/validate_scene3d_runtime_acceptance.py
+++ b/scripts/validate_scene3d_runtime_acceptance.py
@@ -138,6 +138,8 @@ def evaluate_scene(repo_root: Path, scenes_root: Path, main_path: Path, preview_
 
     layout_items = layout.get("items") or []
     editable_layout_count = len(layout_items)
+    editable_layout_selectable_count = sum(1 for item in layout_items if bool(item.get("selectable", True)))
+    editable_layout_editable_count = sum(1 for item in layout_items if bool(item.get("editable", True)))
 
     visual_items = mesh_index.get("visual_items") or []
     safe_for_preview = bool(mesh_index.get("safe_for_preview"))
@@ -145,9 +147,11 @@ def evaluate_scene(repo_root: Path, scenes_root: Path, main_path: Path, preview_
     primitive_fallback_count = int(mesh_index.get("unresolved_placeholder_count") or 0)
 
     generated_items = generated_layout.get("items") or []
-    locked_generated_urdf_visual_count = sum(
-        1 for item in generated_items if normalize_layer_token(item.get("source")) == "locked_generated_urdf_visual"
-    )
+    locked_generated_urdf_visual_items = [
+        item for item in generated_items if normalize_layer_token(item.get("source")) == "locked_generated_urdf_visual"
+    ]
+    locked_generated_urdf_visual_count = len(locked_generated_urdf_visual_items)
+    locked_generated_urdf_editable_count = sum(1 for item in locked_generated_urdf_visual_items if bool(item.get("editable")))
 
     overlay_count = 0
     if preview_metadata:
@@ -170,6 +174,12 @@ def evaluate_scene(repo_root: Path, scenes_root: Path, main_path: Path, preview_
 
     if not blockers and visible_after_default_filters == 0:
         blockers.append("no visible scene items after default filters")
+    if editable_layout_count > 0 and editable_layout_selectable_count <= 0:
+        blockers.append("editable layout items must remain selectable")
+    if editable_layout_count > 0 and editable_layout_editable_count <= 0:
+        blockers.append("editable layout items must remain editable")
+    if locked_generated_urdf_editable_count > 0:
+        blockers.append("locked/generated URDF preview items must not be editable")
 
     smoke_path = Path(smoke_json_path) if smoke_json_path else runtime_smoke_json_default(repo_root, scenes_root, scene)
     runtime_evidence: dict = {"path": str(smoke_path), "valid": False}
@@ -277,9 +287,12 @@ def evaluate_scene(repo_root: Path, scenes_root: Path, main_path: Path, preview_
         "blockers": blockers,
         "counts": {
             "editable_layout_count": editable_layout_count,
+            "editable_layout_selectable_count": editable_layout_selectable_count,
+            "editable_layout_editable_count": editable_layout_editable_count,
             "primitive_fallback_count": primitive_fallback_count,
             "mesh_preview_count": mesh_preview_count,
             "locked_generated_urdf_visual_count": locked_generated_urdf_visual_count,
+            "locked_generated_urdf_editable_count": locked_generated_urdf_editable_count,
             "overlay_count": overlay_count,
             "missing_count": missing_count,
             "viewport_received_count": _runtime_counter(runtime_counts, "viewport_received_count"),
@@ -312,6 +325,13 @@ def evaluate_scene(repo_root: Path, scenes_root: Path, main_path: Path, preview_
             "smoke_json": str(smoke_path),
         },
         "source_layer_counts": source_layer_counts,
+        "interaction_contract": {
+            "editable_layout_selectable_count": editable_layout_selectable_count,
+            "editable_layout_editable_count": editable_layout_editable_count,
+            "locked_generated_urdf_visual_count": locked_generated_urdf_visual_count,
+            "locked_generated_urdf_editable_count": locked_generated_urdf_editable_count,
+            "locked_generated_urdf_diagnosable_count": locked_generated_urdf_visual_count,
+        },
         "runtime_evidence": runtime_evidence,
         "default_filter_visibility_evidence": {
             "assembled_preview_item_count": assembled_preview_item_count,

--- a/scripts/validate_scene3d_visual_quality_matrix.py
+++ b/scripts/validate_scene3d_visual_quality_matrix.py
@@ -46,6 +46,16 @@ VALID_PHYSICAL_FALLBACK_COUNTERS = (
 )
 
 MESH_KEYS = {"mesh", "mesh_path", "mesh_uri", "mesh_filename", "filename", "resource", "uri"}
+MESH_FAILURE_REASON_KEYS = (
+    "reason_code",
+    "failure_reason_code",
+    "mesh_failure_reason_code",
+    "mesh_failure_reason",
+    "failure_reason",
+    "unresolved_reason",
+    "reason",
+    "warning",
+)
 PRIMITIVE_TYPES = {"box", "cube", "cylinder", "sphere", "capsule", "cone", "primitive"}
 
 
@@ -212,6 +222,35 @@ def classify_source_geometry(mesh_index: dict[str, Any]) -> tuple[int, int, int,
     return total_payload_count, mesh_source_count, primitive_source_count, missing_geometry_count
 
 
+def _mesh_failure_reason_for_item(item: dict[str, Any]) -> str | None:
+    for key in MESH_FAILURE_REASON_KEYS:
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower().replace(" ", "_")
+    if item.get("resolved") is False and _looks_like_mesh(item):
+        return "unresolved_mesh_without_reason_code"
+    return None
+
+
+def mesh_failure_summary(mesh_index: dict[str, Any]) -> dict[str, int]:
+    reasons: dict[str, int] = {}
+    for item in _visual_items(mesh_index):
+        if item.get("resolved") is False and _looks_like_mesh(item):
+            reason = _mesh_failure_reason_for_item(item) or "unresolved_mesh_without_reason_code"
+            reasons[reason] = reasons.get(reason, 0) + 1
+    unresolved = mesh_index.get("unresolved")
+    if isinstance(unresolved, list):
+        for raw in unresolved:
+            if isinstance(raw, dict):
+                reason = _mesh_failure_reason_for_item(raw) or "unresolved_mesh_without_reason_code"
+            elif isinstance(raw, str) and raw.strip():
+                reason = raw.strip().lower().replace(" ", "_")
+            else:
+                continue
+            reasons[reason] = reasons.get(reason, 0) + 1
+    return dict(sorted(reasons.items()))
+
+
 def _scene_entries(catalog_path: Path) -> list[dict[str, Any]]:
     catalog = _load_yaml(catalog_path)
     scenes = catalog.get("scenes")
@@ -289,6 +328,7 @@ def evaluate_scene(
             blockers.append(f"could not read mesh/source payload: {mesh_index_path}: {mesh_index['_load_error']}")
 
     total_payload_count, mesh_source_count, primitive_source_count, missing_geometry_count = classify_source_geometry(mesh_index)
+    mesh_failure_reasons = mesh_failure_summary(mesh_index)
 
     smoke_payload: dict[str, Any] = {}
     smoke_exists = bool(smoke_json_path and smoke_json_path.exists())
@@ -373,6 +413,8 @@ def evaluate_scene(
         )
     if missing_geometry_count > 0:
         warnings.append(f"{missing_geometry_count} source payload item(s) lack mesh or primitive geometry")
+    for reason, count in mesh_failure_reasons.items():
+        add_blocker(f"{reason}: {count} mesh-backed source item(s) could not be resolved", reason)
 
     if helper_overlay_count > 0 and physical_rendered_count <= 0 and rendered_count > 0:
         add_blocker(
@@ -431,6 +473,7 @@ def evaluate_scene(
         "total_payload_count": total_payload_count,
         "mesh_source_count": mesh_source_count,
         "mesh_rendered_count": mesh_rendered_count,
+        "mesh_failure_summary_by_reason_code": mesh_failure_reasons,
         "primitive_source_count": primitive_source_count,
         "primitive_rendered_count": primitive_rendered_count,
         "physical_rendered_count": physical_rendered_count,

--- a/tests/test_scene3d_runtime_acceptance.py
+++ b/tests/test_scene3d_runtime_acceptance.py
@@ -389,3 +389,63 @@ def test_runtime_acceptance_markdown_handles_missing_secondary_checks(tmp_path):
     assert out_md.exists()
     text = out_md.read_text(encoding='utf-8')
     assert 'missing_secondary_checks' in text
+
+
+def test_runtime_acceptance_editable_layout_fixture_is_selectable_and_editable(tmp_path):
+    repo, scene_root, main_path, preview_path, viewport_path, scene = _write_scene_fixture(
+        tmp_path,
+        _passing_smoke(
+            viewport_received_count=2,
+            render_cache_count=2,
+            rendered_count=2,
+            selectable_count=2,
+            hierarchy_rows_count=2,
+            mesh_rendered_count=1,
+            assembled_preview_item_count=2,
+            filtered_visible_candidate_count=2,
+        ),
+        editable_items=1,
+        mesh_items=1,
+        locked_items=0,
+        overlay_items=0,
+    )
+
+    result = runtime.evaluate_scene(repo, scene_root, main_path, preview_path, viewport_path, scene, None)
+
+    assert result["counts"]["editable_layout_count"] == 1
+    assert result["interaction_contract"]["editable_layout_selectable_count"] == 1
+    assert result["interaction_contract"]["editable_layout_editable_count"] == 1
+    assert result["counts"]["selectable_count"] > 0
+    assert result["secondary_checks"]["selection_callback_wired"] is True
+    assert result["secondary_checks"]["inspector_callback_wired"] is True
+    assert result["pass"] is True
+
+
+def test_runtime_acceptance_locked_generated_preview_is_visible_diagnosable_and_not_editable(tmp_path):
+    repo, scene_root, main_path, preview_path, viewport_path, scene = _write_scene_fixture(
+        tmp_path,
+        _passing_smoke(
+            viewport_received_count=2,
+            render_cache_count=2,
+            rendered_count=2,
+            selectable_count=1,
+            hierarchy_rows_count=2,
+            mesh_rendered_count=1,
+            assembled_preview_item_count=2,
+            filtered_visible_candidate_count=1,
+        ),
+        editable_items=1,
+        mesh_items=1,
+        locked_items=1,
+        overlay_items=0,
+    )
+
+    result = runtime.evaluate_scene(repo, scene_root, main_path, preview_path, viewport_path, scene, None)
+
+    assert result["counts"]["locked_generated_urdf_visual_count"] == 1
+    assert result["layers"]["locked_generated_urdf_visual_hidden_default"] == 1
+    assert result["visibility_contract"]["hidden_by_filters_count"] >= 1
+    assert result["interaction_contract"]["locked_generated_urdf_diagnosable_count"] == 1
+    assert result["interaction_contract"]["locked_generated_urdf_editable_count"] == 0
+    assert result["counts"]["locked_generated_urdf_editable_count"] == 0
+    assert result["pass"] is True

--- a/tests/test_scene3d_visual_quality_matrix.py
+++ b/tests/test_scene3d_visual_quality_matrix.py
@@ -540,3 +540,199 @@ def test_visual_quality_matrix_cli_writes_json(tmp_path: Path) -> None:
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["schema"] == "workcell_studio_scene3d_visual_quality_matrix/v1"
     assert payload["pass"] is True
+
+
+def _mesh_only_index(*, resolved: bool = True, reason_code: str | None = None) -> dict:
+    mesh_item = {
+        "id": "healthy_mesh_item" if resolved else "missing_mesh_item",
+        "geometry": {"mesh": {"filename": "package://demo/meshes/part.stl"}},
+        "resolved": resolved,
+    }
+    if reason_code:
+        mesh_item["reason_code"] = reason_code
+    return {"safe_for_preview": True, "visual_items": [mesh_item]}
+
+
+def _primitive_only_index() -> dict:
+    return {
+        "safe_for_preview": True,
+        "visual_items": [
+            {"id": "healthy_primitive_item", "geometry": {"cylinder": {"radius": 0.15, "length": 0.4}}},
+        ],
+    }
+
+
+def test_visual_quality_matrix_has_healthy_mesh_backed_fixture_requiring_mesh_source_and_render(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scene_dir = _write_scene(
+        repo,
+        "healthy_mesh_backed_scene",
+        _mesh_only_index(),
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "render_debug_counters": {
+                "rendered_count": 1,
+                "mesh_rendered_count": 1,
+                "primitive_rendered_count": 0,
+                "placeholder_count": 0,
+                "wireframe_fallback_count": 0,
+            },
+        },
+    )
+
+    result = matrix.evaluate_scene(
+        scene_name="healthy_mesh_backed_scene",
+        scene_dir=scene_dir,
+        mesh_index_path=scene_dir / "generated" / "scene_visual_mesh_index.json",
+        smoke_json_path=scene_dir / "generated" / "scene3d_gui_smoke.json",
+    )
+
+    assert result["visual_quality_status"] == "PASS"
+    assert result["mesh_source_count"] > 0
+    assert result["mesh_rendered_count"] > 0
+    assert result["primitive_source_count"] == 0
+    assert result["primitive_rendered_count"] == 0
+    assert result["physical_rendered_count"] == result["mesh_rendered_count"]
+    assert result["blockers"] == []
+
+
+def test_visual_quality_matrix_has_healthy_urdf_primitive_fixture_requiring_primitive_source_and_render(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scene_dir = _write_scene(
+        repo,
+        "healthy_urdf_primitive_scene",
+        _primitive_only_index(),
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "render_debug_counters": {
+                "rendered_count": 1,
+                "mesh_rendered_count": 0,
+                "primitive_rendered_count": 1,
+                "placeholder_count": 0,
+                "wireframe_fallback_count": 0,
+                "generated_fallback_count": 0,
+            },
+        },
+    )
+
+    result = matrix.evaluate_scene(
+        scene_name="healthy_urdf_primitive_scene",
+        scene_dir=scene_dir,
+        mesh_index_path=scene_dir / "generated" / "scene_visual_mesh_index.json",
+        smoke_json_path=scene_dir / "generated" / "scene3d_gui_smoke.json",
+    )
+
+    assert result["visual_quality_status"] == "PASS"
+    assert result["mesh_source_count"] == 0
+    assert result["mesh_rendered_count"] == 0
+    assert result["primitive_source_count"] > 0
+    assert result["primitive_rendered_count"] > 0
+    assert result["physical_rendered_count"] == result["primitive_rendered_count"]
+    assert result["blockers"] == []
+
+
+def test_visual_quality_matrix_reports_missing_mesh_reason_code_in_matrix_summary(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_scene(
+        repo,
+        "missing_mesh_scene",
+        _mesh_only_index(resolved=False, reason_code="mesh_missing_on_disk"),
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "render_debug_counters": {
+                "rendered_count": 0,
+                "mesh_rendered_count": 0,
+                "primitive_rendered_count": 0,
+            },
+        },
+    )
+    catalog = _write_catalog(
+        repo,
+        {
+            "scene_name": "missing_mesh_scene",
+            "package_name": "missing_mesh_scene",
+            "scene_path": "scenes/missing_mesh_scene",
+            "support_level": "supported",
+            "status": "supported",
+            "enabled": True,
+        },
+    )
+    fixture = _write_scene(repo, "synthetic_visual_quality_fixture", _mesh_and_primitive_index(), _passing_smoke())
+
+    payload = matrix.build_matrix(repo_root=repo, supported_scenes=catalog, synthetic_fixture=fixture)
+    scene = next(scene for scene in payload["scenes"] if scene["scene_name"] == "missing_mesh_scene")
+
+    assert payload["pass"] is False
+    assert scene["visual_quality_status"] == "FAIL"
+    assert scene["mesh_source_count"] > 0
+    assert scene["mesh_rendered_count"] == 0
+    assert scene["mesh_failure_summary_by_reason_code"] == {"mesh_missing_on_disk": 1}
+    assert "mesh_missing_on_disk" in scene["blocker_reasons"]
+
+
+def test_visual_quality_matrix_overlay_only_fixture_with_positive_helper_counters_still_fails(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scene_dir = _write_scene(
+        repo,
+        "overlay_only_positive_helpers_scene",
+        _mesh_only_index(),
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "render_debug_counters": {
+                "rendered_count": 3,
+                "mesh_rendered_count": 0,
+                "primitive_rendered_count": 0,
+                "overlay_helper_count": 2,
+                "label_count": 1,
+            },
+        },
+    )
+
+    result = matrix.evaluate_scene(
+        scene_name="overlay_only_positive_helpers_scene",
+        scene_dir=scene_dir,
+        mesh_index_path=scene_dir / "generated" / "scene_visual_mesh_index.json",
+        smoke_json_path=scene_dir / "generated" / "scene3d_gui_smoke.json",
+    )
+
+    assert result["rendered_count"] > 0
+    assert result["helper_overlay_count"] > 0
+    assert result["physical_rendered_count"] == 0
+    assert result["visual_quality_status"] == "FAIL"
+    assert "no_physical_scene_items_rendered" in result["blocker_reasons"]
+
+
+def test_visual_quality_matrix_raw_generated_bounds_fixture_does_not_count_as_physical_render_success(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scene_dir = _write_scene(
+        repo,
+        "raw_generated_bounds_fixture_scene",
+        _mesh_only_index(),
+        {
+            "schema": "workcell_studio_scene3d_gui_smoke/v1",
+            "status": "PASS",
+            "render_debug_counters": {
+                "rendered_count": 1,
+                "mesh_rendered_count": 0,
+                "primitive_rendered_count": 0,
+                "raw_generated_bounds_count": 1,
+            },
+        },
+    )
+
+    result = matrix.evaluate_scene(
+        scene_name="raw_generated_bounds_fixture_scene",
+        scene_dir=scene_dir,
+        mesh_index_path=scene_dir / "generated" / "scene_visual_mesh_index.json",
+        smoke_json_path=scene_dir / "generated" / "scene3d_gui_smoke.json",
+    )
+
+    assert result["raw_generated_bounds_count"] == 1
+    assert result["diagnostic_fallback_count"] == 1
+    assert result["physical_rendered_count"] == 0
+    assert result["visual_quality_status"] == "FAIL"
+    assert "raw/generated fallback bounds are the only visible evidence despite mesh or URDF primitive sources" in result["blockers"]

--- a/tests/test_scene3d_visual_quality_screenshots_runner.py
+++ b/tests/test_scene3d_visual_quality_screenshots_runner.py
@@ -110,7 +110,7 @@ def test_visual_quality_screenshot_runner_captures_required_summaries(tmp_path: 
     repo.mkdir()
     os.symlink(ROOT / "scripts", repo / "scripts", target_is_directory=True)
     (repo / "workcell_builder").mkdir()
-    _write_scene(repo, "demo_scene", failure_reason="mesh_missing_on_disk")
+    _write_scene(repo, "demo_scene")
     fake_exe = tmp_path / "workcell_builder"
     _write_fake_executable(fake_exe)
     out = tmp_path / "out"
@@ -143,7 +143,7 @@ def test_visual_quality_screenshot_runner_captures_required_summaries(tmp_path: 
     assert result["screenshot_path"].endswith("scene3d_gui_smoke_demo_scene.png")
     assert result["visual_quality_counter_summary"]["mesh_rendered_count"] == 1
     assert result["primitive_render_summary"]["primitive_rendered_count"] == 1
-    assert result["mesh_failure_summary_by_reason_code"]["by_reason_code"] == {"mesh_missing_on_disk": 1}
+    assert result["mesh_failure_summary_by_reason_code"]["by_reason_code"] == {}
     assert Path(result["smoke_json"]).exists()
     assert Path(result["screenshot_path"]).exists()
 
@@ -216,3 +216,126 @@ def test_visual_quality_screenshot_runner_reports_blockers_in_json_and_markdown_
     assert "capture or attach the Scene3D smoke screenshot" in markdown
     assert "overlay helpers cannot prove visual quality" in markdown
     assert "render at least one physical mesh, primitive, or fallback scene item" in markdown
+
+
+def _write_fake_executable_for_scene_counters(path: Path, counters_by_scene: dict[str, dict]) -> None:
+    path.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, pathlib, sys\n"
+        f"counters_by_scene={counters_by_scene!r}\n"
+        "args=sys.argv[1:]\n"
+        "out=pathlib.Path(args[args.index('--smoke-output')+1])\n"
+        "png=pathlib.Path(args[args.index('--smoke-screenshot')+1]) if '--smoke-screenshot' in args else None\n"
+        "scene=args[args.index('--scene')+1] if '--scene' in args else pathlib.Path(args[args.index('--scene-path')+1]).name\n"
+        "payload={'schema':'workcell_studio_scene3d_gui_smoke/v1','status':'PASS','scene':scene,'counters':counters_by_scene[scene]}\n"
+        "out.parent.mkdir(parents=True, exist_ok=True); out.write_text(json.dumps(payload))\n"
+        "png.parent.mkdir(parents=True, exist_ok=True); png.write_bytes(b'png') if png else None\n"
+        "sys.exit(0)\n",
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | 0o111)
+
+
+def test_visual_quality_screenshot_runner_summarizes_healthy_and_blocked_visual_fixtures(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    os.symlink(ROOT / "scripts", repo / "scripts", target_is_directory=True)
+    (repo / "workcell_builder").mkdir()
+    healthy_mesh_scene = _write_scene(repo, "healthy_mesh_scene")
+    healthy_primitive_scene = _write_scene(repo, "healthy_primitive_scene")
+    missing_mesh_scene = _write_scene(repo, "missing_mesh_scene", failure_reason="mesh_missing_on_disk")
+    overlay_only_scene = _write_scene(repo, "overlay_only_scene")
+    raw_bounds_only_scene = _write_scene(repo, "raw_bounds_only_scene")
+    _write_json(
+        healthy_mesh_scene / "generated" / "scene_visual_mesh_index.json",
+        {"safe_for_preview": True, "visual_items": [{"id": "mesh", "geometry": {"mesh": {"filename": "package://demo/meshes/tool.stl"}}, "resolved": True}]},
+    )
+    _write_json(
+        healthy_primitive_scene / "generated" / "scene_visual_mesh_index.json",
+        {"safe_for_preview": True, "visual_items": [{"id": "primitive", "geometry": {"box": {"size": [1, 1, 1]}}, "resolved": True}]},
+    )
+    _write_json(
+        overlay_only_scene / "generated" / "scene_visual_mesh_index.json",
+        {"safe_for_preview": True, "visual_items": [{"id": "mesh", "geometry": {"mesh": {"filename": "package://demo/meshes/tool.stl"}}, "resolved": True}]},
+    )
+    _write_json(
+        raw_bounds_only_scene / "generated" / "scene_visual_mesh_index.json",
+        {"safe_for_preview": True, "visual_items": [{"id": "mesh", "geometry": {"mesh": {"filename": "package://demo/meshes/tool.stl"}}, "resolved": True}]},
+    )
+    fake_exe = tmp_path / "visual_fixture_workcell_builder"
+    _write_fake_executable_for_scene_counters(
+        fake_exe,
+        {
+            "healthy_mesh_scene": {"rendered_count": 1, "mesh_rendered_count": 1, "primitive_rendered_count": 0},
+            "healthy_primitive_scene": {"rendered_count": 1, "mesh_rendered_count": 0, "primitive_rendered_count": 1},
+            "missing_mesh_scene": {"rendered_count": 0, "mesh_rendered_count": 0, "primitive_rendered_count": 0},
+            "overlay_only_scene": {
+                "rendered_count": 3,
+                "mesh_rendered_count": 0,
+                "primitive_rendered_count": 0,
+                "overlay_helper_count": 2,
+                "label_count": 1,
+            },
+            "raw_bounds_only_scene": {
+                "rendered_count": 1,
+                "mesh_rendered_count": 0,
+                "primitive_rendered_count": 0,
+                "raw_generated_bounds_count": 1,
+            },
+        },
+    )
+    out = tmp_path / "out"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo-root",
+            str(repo),
+            "--workspace-root",
+            str(repo),
+            "--executable",
+            str(fake_exe),
+            "--scene",
+            "healthy_mesh_scene",
+            "--scene",
+            "healthy_primitive_scene",
+            "--scene",
+            "missing_mesh_scene",
+            "--scene",
+            "overlay_only_scene",
+            "--scene",
+            "raw_bounds_only_scene",
+            "--output-dir",
+            str(out),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    summary = json.loads((out / "scene3d_visual_quality_screenshots_summary.json").read_text(encoding="utf-8"))
+    by_scene = {result["scene"]: result for result in summary["results"]}
+
+    assert by_scene["healthy_mesh_scene"]["status"] == "PASS"
+    assert by_scene["healthy_mesh_scene"]["visual_quality_evaluation"]["mesh_source_count"] > 0
+    assert by_scene["healthy_mesh_scene"]["visual_quality_evaluation"]["mesh_rendered_count"] > 0
+    assert by_scene["healthy_primitive_scene"]["status"] == "PASS"
+    assert by_scene["healthy_primitive_scene"]["visual_quality_evaluation"]["primitive_source_count"] > 0
+    assert by_scene["healthy_primitive_scene"]["visual_quality_evaluation"]["primitive_rendered_count"] > 0
+
+    assert by_scene["missing_mesh_scene"]["mesh_failure_summary_by_reason_code"]["by_reason_code"] == {"mesh_missing_on_disk": 1}
+    assert "mesh_missing_on_disk" in by_scene["missing_mesh_scene"]["blocker_reasons"]
+    assert summary["blocker_reason_summary"]["mesh_missing_on_disk"] == 1
+
+    assert by_scene["overlay_only_scene"]["visual_quality_evaluation"]["physical_rendered_count"] == 0
+    assert "no_physical_scene_items_rendered" in by_scene["overlay_only_scene"]["blocker_reasons"]
+    assert by_scene["raw_bounds_only_scene"]["visual_quality_evaluation"]["physical_rendered_count"] == 0
+    assert by_scene["raw_bounds_only_scene"]["visual_quality_evaluation"]["raw_generated_bounds_count"] == 1
+    assert by_scene["raw_bounds_only_scene"]["status"] == "BLOCKED"
+
+    markdown = (out / "scene3d_visual_quality_screenshots_summary.md").read_text(encoding="utf-8")
+    assert "- mesh_missing_on_disk: 1" in markdown
+    assert "mesh_missing_on_disk=1" in markdown


### PR DESCRIPTION
### Motivation
- Improve Scene3D visual-quality coverage by exercising mesh-backed and URDF-primitive source paths, and ensure the matrix/screenshot runner reports stable missing-mesh reason codes and overlay/raw-fallback failures.
- Make runtime acceptance tests explicitly validate editable layout interaction and that locked/generated URDF previews remain diagnosable but not editable.

### Description
- Add mesh failure extraction and summary to `scripts/validate_scene3d_visual_quality_matrix.py` and surface `mesh_failure_summary_by_reason_code` in visual-quality payloads. 
- Add `mesh_missing_on_disk` blocker category and remediation text to `scripts/run_scene3d_visual_quality_screenshots.py` and include mesh-failure aggregation in screenshot summaries. 
- Extend `scripts/validate_scene3d_runtime_acceptance.py` to report editable/selectable counts, locked-generated preview diagnostics, and to enforce editable/locked interaction checks. 
- Add new tests to `tests/test_scene3d_visual_quality_matrix.py`, `tests/test_scene3d_visual_quality_screenshots_runner.py`, and `tests/test_scene3d_runtime_acceptance.py` that cover: healthy mesh-backed fixture, healthy URDF primitive fixture, missing-mesh reason-code propagation, overlay-only helper evidence failure, raw-generated-bounds-only failure, editable-layout selectability/editability, and locked/generated preview diagnosability/non-editability.

### Testing
- Ran the visual-quality and runtime acceptance test suites with `pytest -q tests/test_scene3d_visual_quality_matrix.py tests/test_scene3d_visual_quality_screenshots_runner.py tests/test_scene3d_runtime_acceptance.py` and the tests passed (`35 passed`).
- Verified screenshot-runner JSON/Markdown aggregation and that the matrix emits the new `mesh_failure_summary_by_reason_code` field by executing the updated scripts via the test harness. 
- Ran `git diff --check` to confirm no trailing whitespace or obvious diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f1c36fab88331ba86c22702b26a53)