### PR TITLE
Add scene readiness matrix and synthetic pytest coverage

### DIFF
--- a/scripts/run_workcell_studio_scene_readiness_matrix.py
+++ b/scripts/run_workcell_studio_scene_readiness_matrix.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Build a Workcell Studio supported-scene readiness matrix.
+
+The matrix intentionally reports evidence and blockers without launching real robot
+motion.  Launch smoke checks are represented as command records and are safely
+skipped when ROS 2 Humble is not available in the current environment.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from supported_scene_catalog import default_catalog_path, load_supported_scene_catalog
+
+SCHEMA_VERSION = "workcell_studio_scene_readiness_matrix/v1"
+PASS = "PASS"
+WARN = "WARN"
+FAIL = "FAIL"
+BLOCKED = "BLOCKED"
+SKIP = "SKIP"
+
+CORE_REQUIRED_FILES = (
+    "package.xml",
+    "CMakeLists.txt",
+    "environment.yaml",
+    "scene_manifest.yaml",
+    "cell_definition.yaml",
+    "launch/demo.launch.py",
+)
+VISUAL_MESH_INDEX = "generated/scene_visual_mesh_index.json"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_yaml(path: Path) -> tuple[Any | None, str | None]:
+    if not path.exists():
+        return None, f"missing_file: {path.name}"
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8")), None
+    except Exception as exc:  # noqa: BLE001 - reports are diagnostic by design.
+        return None, f"yaml_parse_error: {path.name}: {exc.__class__.__name__}: {exc}"
+
+
+def _load_json(path: Path) -> tuple[Any | None, str | None]:
+    if not path.exists():
+        return None, f"missing_file: {path.name}"
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), None
+    except Exception as exc:  # noqa: BLE001 - reports are diagnostic by design.
+        return None, f"json_parse_error: {path.name}: {exc.__class__.__name__}: {exc}"
+
+
+def _status_from_blockers(blockers: list[str]) -> str:
+    return PASS if not blockers else BLOCKED
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+def _required_files_for_entry(entry: Any) -> list[str]:
+    required = [*CORE_REQUIRED_FILES, *getattr(entry, "required_files", [])]
+    return _dedupe([rel for rel in required if rel])
+
+
+def _relative_reference_values(value: Any, parent_key: str = "") -> list[tuple[str, str]]:
+    """Return likely local file references from a manifest-like structure."""
+    refs: list[tuple[str, str]] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_key = f"{parent_key}.{key}" if parent_key else str(key)
+            refs.extend(_relative_reference_values(child, child_key))
+        return refs
+    if isinstance(value, list):
+        for idx, child in enumerate(value):
+            refs.extend(_relative_reference_values(child, f"{parent_key}[{idx}]"))
+        return refs
+    if not isinstance(value, str):
+        return refs
+
+    normalized = value.strip()
+    if not normalized or "://" in normalized or normalized.startswith(("package://", "$(", "${", "/")):
+        return refs
+    key = parent_key.lower()
+    suffixes = ("path", "file", "files", "reference", "references", "urdf", "xacro", "launch", "layout", "environment")
+    looks_like_file = "/" in normalized or "." in Path(normalized).name
+    if looks_like_file and (key.endswith(suffixes) or any(part in key for part in ("files", "assets", "generated_assets"))):
+        refs.append((parent_key, normalized))
+    return refs
+
+
+def _manifest_reference_blockers(scene_dir: Path) -> list[str]:
+    manifest, error = _load_yaml(scene_dir / "scene_manifest.yaml")
+    if error:
+        return [f"manifest_reference_failure: {error}"]
+    refs = _relative_reference_values(manifest)
+    blockers: list[str] = []
+    for key, rel in refs:
+        if rel.startswith("../") or "/../" in rel:
+            blockers.append(f"manifest_reference_failure: {key} -> {rel} escapes scene directory")
+            continue
+        if not (scene_dir / rel).exists():
+            blockers.append(f"manifest_reference_failure: {key} -> {rel} missing")
+    return blockers
+
+
+def _cell_definition_blockers(scene_dir: Path) -> list[str]:
+    cell_path = scene_dir / "cell_definition.yaml"
+    data, error = _load_yaml(cell_path)
+    if error:
+        return [f"schema_validation_blocker: cell_definition.yaml: {error}"]
+    if not isinstance(data, dict):
+        return ["schema_validation_blocker: cell_definition.yaml root must be a YAML map"]
+    # Synthetic fixtures and legacy generated scenes use a few different shapes;
+    # require enough identity to prove this is not an empty placeholder.
+    identity_keys = {"robot", "robot_model", "workcell", "cell", "metadata", "scene"}
+    if not any(key in data for key in identity_keys):
+        return ["schema_validation_blocker: cell_definition.yaml missing robot/workcell identity"]
+    return []
+
+
+def _visual_status(scene_dir: Path) -> tuple[str, list[str], dict[str, Any]]:
+    index_path = scene_dir / VISUAL_MESH_INDEX
+    payload, error = _load_json(index_path)
+    if error:
+        return BLOCKED, [f"visual_evidence_blocked: missing_file: {VISUAL_MESH_INDEX}"], {"path": str(index_path)}
+    if not isinstance(payload, dict):
+        return BLOCKED, [f"visual_evidence_blocked: invalid_json_shape: {VISUAL_MESH_INDEX} root must be an object"], {"path": str(index_path)}
+
+    visual_quality_status = str(
+        payload.get("visual_quality_status")
+        or payload.get("visual_status")
+        or payload.get("status")
+        or PASS
+    ).upper()
+    if visual_quality_status in {BLOCKED, FAIL}:
+        reasons = payload.get("blocker_reasons") or payload.get("blockers") or ["visual quality report blocked scene"]
+        if not isinstance(reasons, list):
+            reasons = [str(reasons)]
+        return BLOCKED, [f"visual_quality_blocked: {reason}" for reason in reasons], {"path": str(index_path), "payload_status": visual_quality_status}
+
+    items = payload.get("visual_items") if isinstance(payload.get("visual_items"), list) else payload.get("items")
+    if not isinstance(items, list) or not items:
+        return BLOCKED, [f"visual_evidence_blocked: {VISUAL_MESH_INDEX} has no visual_items/items evidence"], {"path": str(index_path)}
+    return PASS, [], {"path": str(index_path), "visual_item_count": len(items), "payload_status": visual_quality_status}
+
+
+def ros_humble_available() -> bool:
+    return Path("/opt/ros/humble/setup.bash").exists() and shutil.which("ros2") is not None
+
+
+def derive_fake_hardware_launch_command(entry: Any) -> str:
+    command = str(getattr(entry, "fake_hardware_launch_command", "") or "").strip()
+    package_name = str(getattr(entry, "package_name", "") or getattr(entry, "scene_name", "")).strip()
+    if not command:
+        command = f"ros2 launch {package_name} demo.launch.py use_fake_hardware:=true launch_rviz:=true"
+    if "use_fake_hardware:=" not in command:
+        command = f"{command} use_fake_hardware:=true"
+    elif "use_fake_hardware:=true" not in command:
+        command = command.replace("use_fake_hardware:=false", "use_fake_hardware:=true")
+    return command
+
+
+def _launch_command_record(entry: Any, *, ros_available: bool | None = None) -> tuple[str, dict[str, Any], list[str]]:
+    command = derive_fake_hardware_launch_command(entry)
+    safety_blockers: list[str] = []
+    if "use_fake_hardware:=true" not in command:
+        safety_blockers.append("unsafe_launch_command: missing use_fake_hardware:=true")
+    if "use_fake_hardware:=false" in command or "real_hardware:=true" in command:
+        safety_blockers.append("unsafe_launch_command: command appears to enable real hardware")
+
+    available = ros_humble_available() if ros_available is None else ros_available
+    if not available:
+        return SKIP, {
+            "name": "fake_hardware_launch_smoke",
+            "command": command,
+            "status": SKIP,
+            "executed": False,
+            "safely_skipped": True,
+            "reason": "ROS Humble unavailable in this environment; launch smoke was not executed and is not treated as a scene failure.",
+        }, safety_blockers
+
+    return PASS if not safety_blockers else BLOCKED, {
+        "name": "fake_hardware_launch_smoke",
+        "command": command,
+        "status": "READY_TO_RUN" if not safety_blockers else BLOCKED,
+        "executed": False,
+        "safely_skipped": True,
+        "reason": "Launch command derived only; no robot motion commanded by readiness matrix.",
+    }, safety_blockers
+
+
+def recommended_next_action(category_statuses: dict[str, str], blockers: list[str]) -> str:
+    if any("missing_file:" in blocker for blocker in blockers):
+        return "Regenerate the scene package or restore the missing required file, then rerun the readiness matrix."
+    if category_statuses.get("manifest_references") == BLOCKED:
+        return "Fix scene_manifest.yaml local file references so every referenced scene-local artifact exists."
+    if category_statuses.get("visual_evidence") == BLOCKED or category_statuses.get("visual_quality") == BLOCKED:
+        return "Regenerate generated/scene_visual_mesh_index.json and rerun visual-quality validation."
+    if category_statuses.get("launch_smoke") == SKIP:
+        return "Install/source ROS 2 Humble in a ROS workspace to run the fake-hardware launch smoke check."
+    return "Validate / Plan & Simulate using fake hardware."
+
+
+def evaluate_scene(repo_root: Path, entry: Any, *, ros_available: bool | None = None) -> dict[str, Any]:
+    scene_dir = repo_root / getattr(entry, "scene_path", f"scenes/{getattr(entry, 'scene_name', '')}")
+    file_blockers = [f"missing_file: {rel}" for rel in _required_files_for_entry(entry) if not (scene_dir / rel).exists()]
+    schema_blockers = _cell_definition_blockers(scene_dir)
+    manifest_blockers = _manifest_reference_blockers(scene_dir)
+    visual_overall_status, visual_blockers, visual_evidence = _visual_status(scene_dir)
+    launch_status, launch_record, safety_blockers = _launch_command_record(entry, ros_available=ros_available)
+
+    category_statuses = {
+        "file_presence": _status_from_blockers(file_blockers),
+        "schema_validation": _status_from_blockers(schema_blockers),
+        "manifest_references": _status_from_blockers(manifest_blockers),
+        "visual_evidence": PASS if visual_overall_status == PASS else BLOCKED,
+        "visual_quality": visual_overall_status,
+        "launch_smoke": launch_status,
+        "safety": _status_from_blockers(safety_blockers),
+    }
+    blocker_reasons = [*file_blockers, *schema_blockers, *manifest_blockers, *visual_blockers, *safety_blockers]
+    overall_status = PASS if not blocker_reasons else BLOCKED
+    if overall_status == PASS and launch_status == SKIP:
+        # Environment-only launch skips should not turn an otherwise healthy scene into a failure.
+        overall_status = PASS
+
+    return {
+        "scene_name": getattr(entry, "scene_name", scene_dir.name),
+        "package_name": getattr(entry, "package_name", scene_dir.name),
+        "scene_path": str(scene_dir),
+        "support_level": getattr(entry, "support_level", "supported"),
+        "catalog_status": getattr(entry, "status", "supported"),
+        "known_blocker": getattr(entry, "known_blocker", ""),
+        "overall_status": overall_status,
+        "category_statuses": category_statuses,
+        "blocker_reasons": blocker_reasons,
+        "recommended_next_action": recommended_next_action(category_statuses, blocker_reasons),
+        "command_records": [launch_record],
+        "visual_evidence": visual_evidence,
+    }
+
+
+def build_readiness_matrix(repo_root: Path, *, catalog_path: Path | None = None, ros_available: bool | None = None) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    catalog_path = catalog_path or default_catalog_path(repo_root)
+    _catalog, entries, catalog_errors = load_supported_scene_catalog(catalog_path)
+    enabled_entries = [entry for entry in entries if entry.enabled]
+    scenes = [evaluate_scene(repo_root, entry, ros_available=ros_available) for entry in enabled_entries]
+    totals = {PASS: 0, WARN: 0, FAIL: 0, BLOCKED: 0, SKIP: 0}
+    for scene in scenes:
+        totals[scene["overall_status"]] = totals.get(scene["overall_status"], 0) + 1
+    command_records = [record for scene in scenes for record in scene.get("command_records", [])]
+    overall_status = PASS if totals.get(BLOCKED, 0) == 0 and not catalog_errors else BLOCKED
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": _utc_now(),
+        "repo_root": str(repo_root),
+        "catalog_path": str(catalog_path),
+        "overall_status": overall_status,
+        "scene_count": len(scenes),
+        "totals": totals,
+        "catalog_errors": catalog_errors,
+        "scenes": scenes,
+        "command_records": command_records,
+    }
+
+
+def write_readiness_matrix(report: dict[str, Any], output: Path) -> Path:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    return output
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build Workcell Studio supported-scene readiness matrix JSON.")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--catalog", type=Path, default=None)
+    parser.add_argument("--output", type=Path, default=Path("build/workcell_studio/scene_readiness_matrix.json"))
+    parser.add_argument("--json", action="store_true", help="Print the JSON report to stdout")
+    args = parser.parse_args(argv)
+
+    output = args.output
+    if not output.is_absolute():
+        output = args.repo_root / output
+    report = build_readiness_matrix(args.repo_root, catalog_path=args.catalog)
+    write_readiness_matrix(report, output)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    return 0 if report["overall_status"] == PASS else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_workcell_studio_scene_readiness_matrix.py
+++ b/tests/test_workcell_studio_scene_readiness_matrix.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts import run_workcell_studio_scene_readiness_matrix as matrix
+
+
+def _write_catalog(repo_root: Path, entries: list[dict[str, Any]]) -> Path:
+    path = repo_root / "scenes" / "supported_scenes.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "workcell_studio_supported_scenes/v1",
+                "scenes": entries,
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _single_scene_report(tmp_path: Path, minimal_scene_factory: Any, name: str, **kwargs: Any) -> dict[str, Any]:
+    ros_available = kwargs.pop("ros_available", True)
+    _scene_dir, entry = minimal_scene_factory(name, repo_root=tmp_path, **kwargs)
+    catalog = _write_catalog(tmp_path, [entry])
+    return matrix.build_readiness_matrix(tmp_path, catalog_path=catalog, ros_available=ros_available)
+
+
+def _only_scene(report: dict[str, Any]) -> dict[str, Any]:
+    assert report["schema_version"] == matrix.SCHEMA_VERSION
+    assert report["scene_count"] == 1
+    assert isinstance(report["totals"], dict)
+    assert len(report["scenes"]) == 1
+    scene = report["scenes"][0]
+    assert "category_statuses" in scene
+    assert "blocker_reasons" in scene
+    assert "recommended_next_action" in scene
+    assert "command_records" in scene
+    assert report["command_records"] == scene["command_records"]
+    return scene
+
+
+def test_fully_healthy_synthetic_scene_produces_overall_pass(tmp_path: Path, minimal_scene_factory: Any) -> None:
+    report = _single_scene_report(tmp_path, minimal_scene_factory, "healthy_scene")
+
+    scene = _only_scene(report)
+    assert report["overall_status"] == "PASS"
+    assert report["totals"]["PASS"] == 1
+    assert scene["overall_status"] == "PASS"
+    assert all(status == "PASS" for status in scene["category_statuses"].values())
+    assert scene["blocker_reasons"] == []
+
+
+def test_missing_package_xml_records_missing_file_blocker(tmp_path: Path, minimal_scene_factory: Any) -> None:
+    scene_dir, entry = minimal_scene_factory("missing_package_xml", repo_root=tmp_path)
+    (scene_dir / "package.xml").unlink()
+    catalog = _write_catalog(tmp_path, [entry])
+
+    report = matrix.build_readiness_matrix(tmp_path, catalog_path=catalog, ros_available=True)
+
+    scene = _only_scene(report)
+    assert scene["overall_status"] == "BLOCKED"
+    assert scene["category_statuses"]["file_presence"] == "BLOCKED"
+    assert "missing_file: package.xml" in scene["blocker_reasons"]
+
+
+def test_missing_cell_definition_records_schema_or_file_blocker(tmp_path: Path, minimal_scene_factory: Any) -> None:
+    report = _single_scene_report(
+        tmp_path,
+        minimal_scene_factory,
+        "missing_cell_definition",
+        missing_generated_files=["cell_definition.yaml"],
+    )
+
+    scene = _only_scene(report)
+    assert scene["overall_status"] == "BLOCKED"
+    assert scene["category_statuses"]["schema_validation"] == "BLOCKED"
+    assert any("cell_definition.yaml" in reason for reason in scene["blocker_reasons"])
+    assert any(
+        reason.startswith("schema_validation_blocker:") or reason.startswith("missing_file:")
+        for reason in scene["blocker_reasons"]
+    )
+
+
+def test_bad_scene_manifest_local_reference_records_manifest_reference_failure(
+    tmp_path: Path,
+    minimal_scene_factory: Any,
+) -> None:
+    scene_dir, entry = minimal_scene_factory("bad_manifest_reference", repo_root=tmp_path)
+    (scene_dir / "scene_manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "scene": {"name": "bad_manifest_reference"},
+                "files": {"environment": "environment.yaml", "missing_urdf": "urdf/does_not_exist.xacro"},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    catalog = _write_catalog(tmp_path, [entry])
+
+    report = matrix.build_readiness_matrix(tmp_path, catalog_path=catalog, ros_available=True)
+
+    scene = _only_scene(report)
+    assert scene["overall_status"] == "BLOCKED"
+    assert scene["category_statuses"]["manifest_references"] == "BLOCKED"
+    assert any(reason.startswith("manifest_reference_failure:") for reason in scene["blocker_reasons"])
+    assert any("urdf/does_not_exist.xacro" in reason for reason in scene["blocker_reasons"])
+
+
+def test_missing_visual_mesh_index_blocks_visual_evidence(tmp_path: Path, minimal_scene_factory: Any) -> None:
+    report = _single_scene_report(
+        tmp_path,
+        minimal_scene_factory,
+        "missing_visual_mesh_index",
+        missing_generated_files=["generated/scene_visual_mesh_index.json"],
+    )
+
+    scene = _only_scene(report)
+    assert scene["overall_status"] == "BLOCKED"
+    assert scene["category_statuses"]["visual_evidence"] == "BLOCKED"
+    assert any("visual_evidence_blocked" in reason for reason in scene["blocker_reasons"])
+    assert any("generated/scene_visual_mesh_index.json" in reason for reason in scene["blocker_reasons"])
+
+
+def test_visual_quality_blocked_scene_propagates_blocked_visual_status(
+    tmp_path: Path,
+    minimal_scene_factory: Any,
+) -> None:
+    report = _single_scene_report(
+        tmp_path,
+        minimal_scene_factory,
+        "blocked_visual_quality",
+        mesh_index_payload={
+            "visual_quality_status": "BLOCKED",
+            "visual_items": [{"render_expected": True}],
+            "blocker_reasons": ["rendered physical scene evidence is unavailable"],
+        },
+    )
+
+    scene = _only_scene(report)
+    assert scene["overall_status"] == "BLOCKED"
+    assert scene["category_statuses"]["visual_quality"] == "BLOCKED"
+    assert any("visual_quality_blocked" in reason for reason in scene["blocker_reasons"])
+
+
+def test_ros_humble_unavailable_records_launch_smoke_as_safely_skipped(
+    tmp_path: Path,
+    minimal_scene_factory: Any,
+) -> None:
+    report = _single_scene_report(tmp_path, minimal_scene_factory, "ros_unavailable_scene", ros_available=False)
+
+    scene = _only_scene(report)
+    launch_record = scene["command_records"][0]
+    assert scene["overall_status"] == "PASS"
+    assert scene["category_statuses"]["launch_smoke"] == "SKIP"
+    assert launch_record["status"] == "SKIP"
+    assert launch_record["executed"] is False
+    assert launch_record["safely_skipped"] is True
+    assert "ROS Humble unavailable" in launch_record["reason"]
+
+
+def test_fake_hardware_launch_command_is_derived_with_fake_hardware_true(
+    tmp_path: Path,
+    minimal_scene_factory: Any,
+) -> None:
+    scene_dir, entry = minimal_scene_factory(
+        "derived_fake_hardware_command",
+        repo_root=tmp_path,
+        fake_hardware_launch_command="",
+    )
+    # The catalog requires a safe command, but the callable helper should still
+    # be able to derive the launch command from a package entry if the raw entry
+    # passed to the evaluator has no command.
+    entry["fake_hardware_launch_command"] = "ros2 launch derived_fake_hardware_command demo.launch.py"
+    catalog = _write_catalog(tmp_path, [entry])
+
+    report = matrix.build_readiness_matrix(tmp_path, catalog_path=catalog, ros_available=True)
+
+    scene = _only_scene(report)
+    command = scene["command_records"][0]["command"]
+    assert scene_dir.name == "derived_fake_hardware_command"
+    assert "ros2 launch derived_fake_hardware_command demo.launch.py" in command
+    assert "use_fake_hardware:=true" in command
+    assert "use_fake_hardware:=false" not in command


### PR DESCRIPTION
### Motivation
- Provide a callable Workcell Studio scene readiness matrix to report per-scene readiness evidence and blockers without executing real robot launches. 
- Make scene-readiness checks testable in CI using temporary synthetic scene fixtures so validators do not depend on the real supported scene catalog or a ROS runtime. 
- Preserve safety: ensure fake-hardware-first semantics and treat ROS Humble absence as a safe skip rather than a failure.

### Description
- Added `scripts/run_workcell_studio_scene_readiness_matrix.py` which exposes `build_readiness_matrix(repo_root, catalog_path=..., ros_available=...)` and emits a JSON-ready report including `schema_version`, `scene_count`, `totals`, `scenes` with `category_statuses`, `blocker_reasons`, `recommended_next_action`, and `command_records`.
- The matrix evaluates required artifacts (package/CMake/manifest/etc.), `cell_definition.yaml` schema identity, `scene_manifest.yaml` local reference resolution, `generated/scene_visual_mesh_index.json` visual evidence and visual-quality blockers, and derives a safe fake-hardware launch command that enforces or injects `use_fake_hardware:=true` when needed.
- Launch-smoke steps are recorded as command records and are safely skipped when ROS Humble is unavailable (`ros_humble_available()`); unsafe-looking launch commands are surfaced as safety blockers and not executed.
- Added `tests/test_workcell_studio_scene_readiness_matrix.py` which uses the existing `minimal_scene_factory` fixture to create temporary synthetic scene directories and a temporary `scenes/supported_scenes.yaml` catalog; it invokes the matrix callable directly instead of shelling out.
- Tests cover the requested cases: (1) healthy PASS, (2) missing `package.xml`, (3) missing `cell_definition.yaml` (schema/file blocker), (4) bad `scene_manifest.yaml` local reference, (5) missing `generated/scene_visual_mesh_index.json`, (6) visual-quality blocked scene propagates blocked visual status, (7) ROS Humble unavailable records launch smoke as safely skipped, and (8) fake-hardware launch command derivation includes `use_fake_hardware:=true`.

### Testing
- Ran Python syntax check: `python3 -m py_compile scripts/run_workcell_studio_scene_readiness_matrix.py tests/test_workcell_studio_scene_readiness_matrix.py` which succeeded. 
- Ran unit tests: `pytest -q tests/test_workcell_studio_scene_readiness_matrix.py` which passed (8 passed). 
- The test suite verifies the JSON report fields and per-scene categories and blockers and asserts the safe skip behavior when ROS Humble is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f41262fbc8331ab90c76e81f27a88)