### PR TITLE
Add --supported-scenes alias for readiness matrix CLI

### DIFF
--- a/scripts/run_workcell_studio_scene_readiness_matrix.py
+++ b/scripts/run_workcell_studio_scene_readiness_matrix.py
@@ -484,7 +484,14 @@ def build_matrix(repo_root: Path, catalog_path: Path, output_dir: Path) -> dict[
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo-root", type=Path, default=REPO_ROOT_DEFAULT)
-    parser.add_argument("--catalog", type=Path, default=None, help="defaults to <repo>/scenes/supported_scenes.yaml")
+    parser.add_argument(
+        "--catalog",
+        "--supported-scenes",
+        dest="catalog",
+        type=Path,
+        default=None,
+        help="supported-scene catalog path; defaults to <repo>/scenes/supported_scenes.yaml",
+    )
     parser.add_argument("--output-dir", type=Path, default=None, help="defaults to <repo>/build/workcell_studio_scene_readiness")
     return parser.parse_args(argv)
 

--- a/tests/test_workcell_studio_scene_readiness_matrix.py
+++ b/tests/test_workcell_studio_scene_readiness_matrix.py
@@ -45,6 +45,65 @@ def _only_scene(report: dict[str, Any]) -> dict[str, Any]:
     return scene
 
 
+def test_parse_args_accepts_supported_scenes_alias_for_catalog() -> None:
+    args = matrix.parse_args(["--supported-scenes", "scenes/supported_scenes.yaml"])
+
+    assert args.catalog == Path("scenes/supported_scenes.yaml")
+
+
+def test_parse_args_keeps_catalog_argument_for_backward_compatibility() -> None:
+    args = matrix.parse_args(["--catalog", "custom/catalog.yaml"])
+
+    assert args.catalog == Path("custom/catalog.yaml")
+
+
+def test_main_routes_supported_scenes_alias_to_build_matrix(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    catalog = tmp_path / "scenes" / "supported_scenes.yaml"
+    output_dir = tmp_path / "matrix_output"
+    captured: dict[str, Path] = {}
+
+    def fake_build_matrix(repo_root: Path, catalog_path: Path, output_path: Path) -> dict[str, Any]:
+        captured["repo_root"] = repo_root
+        captured["catalog_path"] = catalog_path
+        captured["output_dir"] = output_path
+        return {
+            "schema_version": matrix.SCHEMA_VERSION,
+            "generated_at": "2026-06-02T00:00:00+00:00",
+            "repo_root": str(repo_root),
+            "workspace_root": str(repo_root.parent),
+            "catalog_path": str(catalog_path),
+            "catalog_errors": [],
+            "scene_count": 0,
+            "totals": {matrix.PASS: 0, matrix.FAIL: 0, matrix.BLOCKED: 0},
+            "scenes": [],
+            "commands": {},
+            "ros_humble_available": False,
+            "workcell_builder_executable_found": False,
+        }
+
+    monkeypatch.setattr(matrix, "build_matrix", fake_build_matrix)
+    monkeypatch.setattr(matrix, "_write_markdown", lambda _payload, _path: None)
+
+    result = matrix.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--supported-scenes",
+            str(catalog),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert result == 0
+    assert captured["repo_root"] == tmp_path.resolve()
+    assert captured["catalog_path"] == catalog.resolve()
+    assert captured["output_dir"] == output_dir.resolve()
+
+
 def test_fully_healthy_synthetic_scene_produces_overall_pass(tmp_path: Path, minimal_scene_factory: Any) -> None:
     report = _single_scene_report(tmp_path, minimal_scene_factory, "healthy_scene")
 


### PR DESCRIPTION
### Motivation
- Provide a backwards-compatible CLI alias so users can pass `--supported-scenes scenes/supported_scenes.yaml` as an alternative to the existing `--catalog` flag.
- Keep existing behavior and plumbing so the selected catalog still flows into the matrix generator and `build_matrix` unchanged.

### Description
- Updated `parse_args` in `scripts/run_workcell_studio_scene_readiness_matrix.py` to accept `--supported-scenes` as an alias for `--catalog` by registering both flags with `dest="catalog"` so they populate the same attribute.
- Preserved the existing `main()` catalog resolution path so the resolved `catalog_path` continues to be passed to `build_matrix(repo_root, catalog_path, output_dir)`.
- Added three focused tests in `tests/test_workcell_studio_scene_readiness_matrix.py`: `test_parse_args_accepts_supported_scenes_alias_for_catalog`, `test_parse_args_keeps_catalog_argument_for_backward_compatibility`, and `test_main_routes_supported_scenes_alias_to_build_matrix` to cover the new alias and routing into `build_matrix`.

### Testing
- Ran the three new unit tests with `pytest -q tests/test_workcell_studio_scene_readiness_matrix.py::test_parse_args_accepts_supported_scenes_alias_for_catalog tests/test_workcell_studio_scene_readiness_matrix.py::test_parse_args_keeps_catalog_argument_for_backward_compatibility tests/test_workcell_studio_scene_readiness_matrix.py::test_main_routes_supported_scenes_alias_to_build_matrix` and they all passed.
- Executed the CLI end-to-end with `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --supported-scenes scenes/supported_scenes.yaml --output-dir build/workcell_studio_scene_readiness_alias_check` and it produced the JSON and Markdown outputs successfully.
- Ran the full test module `pytest -q tests/test_workcell_studio_scene_readiness_matrix.py`; the three new alias tests pass but several pre-existing tests in that module still fail due to an unrelated missing `matrix.build_readiness_matrix(...)` symbol in the module-level API (these failures are pre-existing and outside the scope of this CLI compatibility change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f4613dd1083319f6b96e80335c633)