### PR TITLE
Update supported scene readiness blockers and regenerate Scene3D visual evidence

### DIFF
--- a/scenes/suction_test/generated/scene3d_gui_smoke.json
+++ b/scenes/suction_test/generated/scene3d_gui_smoke.json
@@ -1,0 +1,18 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "FAIL",
+  "scene": "suction_test",
+  "repo_root": "/workspace/Easy_Manipulator_Improved",
+  "workspace_root": "/workspace/Easy_Manipulator_Improved",
+  "executable": null,
+  "searched_paths": [
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/lib/workcell_builder/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder"
+  ],
+  "blockers": [
+    "unable_to_resolve_workcell_builder_executable"
+  ],
+  "warnings": [],
+  "screenshot_available": false
+}

--- a/scenes/suction_test/generated/scene_visual_mesh_index.json
+++ b/scenes/suction_test/generated/scene_visual_mesh_index.json
@@ -3,14 +3,14 @@
   "visual_count": 0,
   "resolved": 0,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:57.925467+00:00",
-  "extractor_version": "2.3",
+  "generated_at": "2026-06-02T21:08:37.779418+00:00",
+  "extractor_version": "2.4",
   "extraction_mode": "best_effort_recursive",
-  "xacro_available": true,
+  "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6750066,
+  "source_mtime": 1780423772.305283,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro",
+  "fallback_reason": "xacro executable unavailable",
   "safe_for_preview": false,
   "unresolved_placeholder_count": 0,
   "has_transform_collapse_warning": false,
@@ -23,17 +23,99 @@
   "stale_index": false,
   "stale_reasons": [],
   "visual_items": [],
-  "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro",
-    "-o",
-    "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/expanded_scene_preview.urdf",
-    "use_fake_hardware:=true",
-    "robot_prefix:=",
-    "tool_prefix:="
-  ],
+  "xacro_command": null,
   "package_resolution_diagnostics": {
     "resolved_packages": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -53,100 +135,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -167,32 +171,95 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
     "resolution_paths": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -209,83 +276,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets"
       },
       {
@@ -304,23 +306,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scenes/supported_scenes.yaml
+++ b/scenes/supported_scenes.yaml
@@ -30,13 +30,14 @@ common_generated_files: &common_generated_files
   - urdf/scene.urdf.xacro
   - launch/demo.launch.py
   - generated/scene_visual_mesh_index.json
+  - generated/scene3d_gui_smoke.json
 scenes:
   - scene_name: suction_test
     package_name: suction_test
     scene_path: scenes/suction_test
     support_level: supported
     status: blocked
-    known_blocker: "mesh-index/renderable-item contract failure: generic extractor produced 0 renderable visual_items because local xacro expansion failed (No module named 'ament_index_python')"
+    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D visual evidence FAIL because generated/scene_visual_mesh_index.json has safe_for_preview=false with 0 credible mesh/primitive source geometry after best-effort xacro fallback (xacro executable unavailable), and generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/suction_test --json
@@ -48,7 +49,7 @@ scenes:
     scene_path: scenes/ur10_2f_test
     support_level: supported
     status: blocked
-    known_blocker: "mesh-index/renderable-item contract failure: generic extractor produced 0 renderable visual_items because local xacro expansion failed (No module named 'ament_index_python')"
+    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D visual evidence FAIL because generated/scene_visual_mesh_index.json has safe_for_preview=false with 0 credible mesh/primitive source geometry after best-effort xacro fallback (xacro executable unavailable), and generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur10_2f_test --json
@@ -60,7 +61,7 @@ scenes:
     scene_path: scenes/ur3_suction_test
     support_level: supported
     status: blocked
-    known_blocker: "mesh-index/renderable-item contract failure: generic extractor produced 0 renderable visual_items because local xacro expansion failed (No module named 'ament_index_python')"
+    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D visual evidence FAIL because generated/scene_visual_mesh_index.json has safe_for_preview=false with 0 credible mesh/primitive source geometry after best-effort xacro fallback (xacro executable unavailable), and generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur3_suction_test --json
@@ -72,7 +73,7 @@ scenes:
     scene_path: scenes/ur5_2f_builder_pick_place_demo
     support_level: supported
     status: blocked
-    known_blocker: "mesh-index/renderable-item contract failure: generic extractor produced 0 renderable visual_items because local xacro expansion failed (No module named 'ament_index_python')"
+    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D visual evidence FAIL because generated/scene_visual_mesh_index.json has safe_for_preview=false with 0 credible mesh/primitive source geometry after best-effort xacro fallback (xacro executable unavailable), and generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_builder_pick_place_demo --json
@@ -83,8 +84,8 @@ scenes:
     package_name: ur5_2f_sorting_test
     scene_path: scenes/ur5_2f_sorting_test
     support_level: supported
-    status: supported
-    known_blocker: ""
+    status: blocked
+    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D visual-quality FAIL because generated/scene_visual_mesh_index.json has safe_for_preview=false, generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable, and primitive_source_count > 0 requires primitive_rendered_count > 0."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_sorting_test --json
@@ -96,7 +97,7 @@ scenes:
     scene_path: scenes/ur5_2f_test
     support_level: supported
     status: blocked
-    known_blocker: "mesh-index/renderable-item contract failure: generic extractor produced 0 renderable visual_items because local xacro expansion failed (No module named 'ament_index_python')"
+    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D visual evidence FAIL because generated/scene_visual_mesh_index.json has safe_for_preview=false with 0 credible mesh/primitive source geometry after best-effort xacro fallback (xacro executable unavailable), and generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json
@@ -108,7 +109,7 @@ scenes:
     scene_path: scenes/ur5_3f_test
     support_level: supported
     status: blocked
-    known_blocker: "mesh-index/renderable-item contract failure: generic extractor produced 0 renderable visual_items because local xacro expansion failed (No module named 'ament_index_python')"
+    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D visual evidence FAIL because generated/scene_visual_mesh_index.json has safe_for_preview=false with 0 credible mesh/primitive source geometry after best-effort xacro fallback (xacro executable unavailable), and generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_3f_test --json
@@ -120,7 +121,7 @@ scenes:
     scene_path: scenes/ur5_airpick4_test
     support_level: supported
     status: blocked
-    known_blocker: "mesh-index/renderable-item contract failure: generic extractor produced 0 renderable visual_items because local xacro expansion failed (No module named 'ament_index_python')"
+    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D visual evidence FAIL because generated/scene_visual_mesh_index.json has safe_for_preview=false with 0 credible mesh/primitive source geometry after best-effort xacro fallback (xacro executable unavailable), and generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_airpick4_test --json

--- a/scenes/ur10_2f_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur10_2f_test/generated/scene3d_gui_smoke.json
@@ -1,0 +1,18 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "FAIL",
+  "scene": "ur10_2f_test",
+  "repo_root": "/workspace/Easy_Manipulator_Improved",
+  "workspace_root": "/workspace/Easy_Manipulator_Improved",
+  "executable": null,
+  "searched_paths": [
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/lib/workcell_builder/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder"
+  ],
+  "blockers": [
+    "unable_to_resolve_workcell_builder_executable"
+  ],
+  "warnings": [],
+  "screenshot_available": false
+}

--- a/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json
@@ -3,14 +3,14 @@
   "visual_count": 0,
   "resolved": 0,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:58.055362+00:00",
-  "extractor_version": "2.3",
+  "generated_at": "2026-06-02T21:08:37.879621+00:00",
+  "extractor_version": "2.4",
   "extraction_mode": "best_effort_recursive",
-  "xacro_available": true,
+  "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6750066,
+  "source_mtime": 1780423772.305283,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
+  "fallback_reason": "xacro executable unavailable",
   "safe_for_preview": false,
   "unresolved_placeholder_count": 0,
   "has_transform_collapse_warning": false,
@@ -23,17 +23,99 @@
   "stale_index": false,
   "stale_reasons": [],
   "visual_items": [],
-  "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
-    "-o",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/expanded_scene_preview.urdf",
-    "use_fake_hardware:=true",
-    "robot_prefix:=",
-    "tool_prefix:="
-  ],
+  "xacro_command": null,
   "package_resolution_diagnostics": {
     "resolved_packages": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -53,100 +135,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -167,32 +171,95 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
     "resolution_paths": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -209,83 +276,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets"
       },
       {
@@ -304,23 +306,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scenes/ur3_suction_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur3_suction_test/generated/scene3d_gui_smoke.json
@@ -1,0 +1,18 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "FAIL",
+  "scene": "ur3_suction_test",
+  "repo_root": "/workspace/Easy_Manipulator_Improved",
+  "workspace_root": "/workspace/Easy_Manipulator_Improved",
+  "executable": null,
+  "searched_paths": [
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/lib/workcell_builder/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder"
+  ],
+  "blockers": [
+    "unable_to_resolve_workcell_builder_executable"
+  ],
+  "warnings": [],
+  "screenshot_available": false
+}

--- a/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json
@@ -3,14 +3,14 @@
   "visual_count": 0,
   "resolved": 0,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:58.185888+00:00",
-  "extractor_version": "2.3",
+  "generated_at": "2026-06-02T21:08:37.982603+00:00",
+  "extractor_version": "2.4",
   "extraction_mode": "best_effort_recursive",
-  "xacro_available": true,
+  "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6750066,
+  "source_mtime": 1780423772.305283,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
+  "fallback_reason": "xacro executable unavailable",
   "safe_for_preview": false,
   "unresolved_placeholder_count": 0,
   "has_transform_collapse_warning": false,
@@ -23,17 +23,99 @@
   "stale_index": false,
   "stale_reasons": [],
   "visual_items": [],
-  "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
-    "-o",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/expanded_scene_preview.urdf",
-    "use_fake_hardware:=true",
-    "robot_prefix:=",
-    "tool_prefix:="
-  ],
+  "xacro_command": null,
   "package_resolution_diagnostics": {
     "resolved_packages": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -53,100 +135,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -167,32 +171,95 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
     "resolution_paths": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -209,83 +276,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets"
       },
       {
@@ -304,23 +306,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scenes/ur5_2f_builder_pick_place_demo/generated/scene3d_gui_smoke.json
+++ b/scenes/ur5_2f_builder_pick_place_demo/generated/scene3d_gui_smoke.json
@@ -1,0 +1,18 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "FAIL",
+  "scene": "ur5_2f_builder_pick_place_demo",
+  "repo_root": "/workspace/Easy_Manipulator_Improved",
+  "workspace_root": "/workspace/Easy_Manipulator_Improved",
+  "executable": null,
+  "searched_paths": [
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/lib/workcell_builder/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder"
+  ],
+  "blockers": [
+    "unable_to_resolve_workcell_builder_executable"
+  ],
+  "warnings": [],
+  "screenshot_available": false
+}

--- a/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json
@@ -3,14 +3,14 @@
   "visual_count": 0,
   "resolved": 0,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:58.327092+00:00",
-  "extractor_version": "2.3",
+  "generated_at": "2026-06-02T21:08:38.082589+00:00",
+  "extractor_version": "2.4",
   "extraction_mode": "best_effort_recursive",
-  "xacro_available": true,
+  "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6750066,
+  "source_mtime": 1780423772.309283,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro",
+  "fallback_reason": "xacro executable unavailable",
   "safe_for_preview": false,
   "unresolved_placeholder_count": 0,
   "has_transform_collapse_warning": false,
@@ -23,17 +23,99 @@
   "stale_index": false,
   "stale_reasons": [],
   "visual_items": [],
-  "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro",
-    "-o",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/expanded_scene_preview.urdf",
-    "use_fake_hardware:=true",
-    "robot_prefix:=",
-    "tool_prefix:="
-  ],
+  "xacro_command": null,
   "package_resolution_diagnostics": {
     "resolved_packages": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -53,100 +135,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -167,32 +171,95 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
     "resolution_paths": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -209,83 +276,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets"
       },
       {
@@ -304,23 +306,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scenes/ur5_2f_sorting_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur5_2f_sorting_test/generated/scene3d_gui_smoke.json
@@ -1,0 +1,18 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "FAIL",
+  "scene": "ur5_2f_sorting_test",
+  "repo_root": "/workspace/Easy_Manipulator_Improved",
+  "workspace_root": "/workspace/Easy_Manipulator_Improved",
+  "executable": null,
+  "searched_paths": [
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/lib/workcell_builder/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder"
+  ],
+  "blockers": [
+    "unable_to_resolve_workcell_builder_executable"
+  ],
+  "warnings": [],
+  "screenshot_available": false
+}

--- a/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json
@@ -3,14 +3,14 @@
   "visual_count": 22,
   "resolved": 22,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:58.476932+00:00",
-  "extractor_version": "2.3",
+  "generated_at": "2026-06-02T21:08:38.190611+00:00",
+  "extractor_version": "2.4",
   "extraction_mode": "best_effort_recursive",
-  "xacro_available": true,
+  "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6790943,
+  "source_mtime": 1780423772.309283,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro",
+  "fallback_reason": "xacro executable unavailable",
   "safe_for_preview": false,
   "unresolved_placeholder_count": 0,
   "has_transform_collapse_warning": false,
@@ -40,6 +40,27 @@
           0.0,
           -0.0,
           0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "TableCabinet",
+        "color": [
+          0.46,
+          0.33,
+          0.24,
+          1.0
         ]
       },
       "link_transform_status": "resolved",
@@ -74,6 +95,27 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "TableTop",
+        "color": [
+          0.55,
+          0.4,
+          0.28,
+          1.0
+        ]
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
@@ -106,6 +148,27 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "RobotPlate",
+        "color": [
+          0.25,
+          0.25,
+          0.25,
+          1.0
+        ]
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
@@ -131,12 +194,33 @@
         "xyz": [
           -0.03,
           0.28,
-          0.32
+          0.0
         ],
         "rpy": [
           0.0,
           -0.0,
           0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.32
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "CameraMast",
+        "color": [
+          0.2,
+          0.2,
+          0.2,
+          1.0
         ]
       },
       "link_transform_status": "resolved",
@@ -167,6 +251,27 @@
           0.0,
           -0.0,
           0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "Blue",
+        "color": [
+          0.2,
+          0.2,
+          0.8,
+          1.0
         ]
       },
       "link_transform_status": "resolved",
@@ -202,6 +307,22 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
@@ -235,6 +356,22 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
@@ -260,13 +397,29 @@
         "xyz": [
           0.15,
           -0.24,
-          2.0
+          0.0
         ],
         "rpy": [
           0.0,
           -0.0,
           0.0
         ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
       },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
@@ -293,13 +446,29 @@
         "xyz": [
           0.15,
           -0.24,
-          2.0
+          0.0
         ],
         "rpy": [
           0.0,
           -0.0,
           0.0
         ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
       },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
@@ -332,6 +501,27 @@
           0.0,
           -0.0,
           0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "Green",
+        "color": [
+          0.2,
+          0.8,
+          0.2,
+          1.0
         ]
       },
       "link_transform_status": "resolved",
@@ -367,6 +557,22 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
@@ -400,6 +606,22 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
@@ -425,13 +647,29 @@
         "xyz": [
           0.15,
           0.0,
-          2.0
+          0.0
         ],
         "rpy": [
           0.0,
           -0.0,
           0.0
         ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
       },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
@@ -458,13 +696,29 @@
         "xyz": [
           0.15,
           0.0,
-          2.0
+          0.0
         ],
         "rpy": [
           0.0,
           -0.0,
           0.0
         ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
       },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
@@ -497,6 +751,27 @@
           0.0,
           -0.0,
           0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "RejectBin",
+        "color": [
+          0.75,
+          0.35,
+          0.1,
+          1.0
         ]
       },
       "link_transform_status": "resolved",
@@ -532,6 +807,22 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
@@ -565,6 +856,22 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
@@ -590,13 +897,29 @@
         "xyz": [
           0.15,
           0.24,
-          2.0
+          0.0
         ],
         "rpy": [
           0.0,
           -0.0,
           0.0
         ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
       },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
@@ -623,13 +946,29 @@
         "xyz": [
           0.15,
           0.24,
-          2.0
+          0.0
         ],
         "rpy": [
           0.0,
           -0.0,
           0.0
         ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
       },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
@@ -662,6 +1001,27 @@
           0.0,
           -0.0,
           0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "Red",
+        "color": [
+          0.9,
+          0.1,
+          0.1,
+          1.0
         ]
       },
       "link_transform_status": "resolved",
@@ -697,6 +1057,27 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "BlueItem",
+        "color": [
+          0.1,
+          0.3,
+          0.9,
+          1.0
+        ]
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
@@ -727,6 +1108,27 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "GreenItem",
+        "color": [
+          0.1,
+          0.8,
+          0.3,
+          1.0
+        ]
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
@@ -740,17 +1142,99 @@
       "warning": ""
     }
   ],
-  "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro",
-    "-o",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/expanded_scene_preview.urdf",
-    "use_fake_hardware:=true",
-    "robot_prefix:=",
-    "tool_prefix:="
-  ],
+  "xacro_command": null,
   "package_resolution_diagnostics": {
     "resolved_packages": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -770,100 +1254,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -884,32 +1290,95 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
     "resolution_paths": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -926,83 +1395,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets"
       },
       {
@@ -1021,23 +1425,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json
@@ -1,0 +1,18 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "FAIL",
+  "scene": "ur5_2f_test",
+  "repo_root": "/workspace/Easy_Manipulator_Improved",
+  "workspace_root": "/workspace/Easy_Manipulator_Improved",
+  "executable": null,
+  "searched_paths": [
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/lib/workcell_builder/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder"
+  ],
+  "blockers": [
+    "unable_to_resolve_workcell_builder_executable"
+  ],
+  "warnings": [],
+  "screenshot_available": false
+}

--- a/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
@@ -3,14 +3,14 @@
   "visual_count": 0,
   "resolved": 0,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:59.256009+00:00",
-  "extractor_version": "2.3",
+  "generated_at": "2026-06-02T21:08:38.302061+00:00",
+  "extractor_version": "2.4",
   "extraction_mode": "best_effort_recursive",
-  "xacro_available": true,
+  "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6790943,
+  "source_mtime": 1780423772.3132832,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+  "fallback_reason": "xacro executable unavailable",
   "safe_for_preview": false,
   "unresolved_placeholder_count": 0,
   "has_transform_collapse_warning": false,
@@ -23,17 +23,99 @@
   "stale_index": false,
   "stale_reasons": [],
   "visual_items": [],
-  "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
-    "-o",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/expanded_scene_preview.urdf",
-    "use_fake_hardware:=true",
-    "robot_prefix:=",
-    "tool_prefix:="
-  ],
+  "xacro_command": null,
   "package_resolution_diagnostics": {
     "resolved_packages": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -53,100 +135,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -167,32 +171,95 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
     "resolution_paths": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -209,83 +276,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets"
       },
       {
@@ -304,23 +306,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scenes/ur5_3f_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur5_3f_test/generated/scene3d_gui_smoke.json
@@ -1,0 +1,18 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "FAIL",
+  "scene": "ur5_3f_test",
+  "repo_root": "/workspace/Easy_Manipulator_Improved",
+  "workspace_root": "/workspace/Easy_Manipulator_Improved",
+  "executable": null,
+  "searched_paths": [
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/lib/workcell_builder/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder"
+  ],
+  "blockers": [
+    "unable_to_resolve_workcell_builder_executable"
+  ],
+  "warnings": [],
+  "screenshot_available": false
+}

--- a/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json
@@ -3,14 +3,14 @@
   "visual_count": 0,
   "resolved": 0,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:58.755546+00:00",
-  "extractor_version": "2.3",
+  "generated_at": "2026-06-02T21:08:38.418914+00:00",
+  "extractor_version": "2.4",
   "extraction_mode": "best_effort_recursive",
-  "xacro_available": true,
+  "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6831822,
+  "source_mtime": 1780423772.3132832,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
+  "fallback_reason": "xacro executable unavailable",
   "safe_for_preview": false,
   "unresolved_placeholder_count": 0,
   "has_transform_collapse_warning": false,
@@ -23,17 +23,99 @@
   "stale_index": false,
   "stale_reasons": [],
   "visual_items": [],
-  "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
-    "-o",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/expanded_scene_preview.urdf",
-    "use_fake_hardware:=true",
-    "robot_prefix:=",
-    "tool_prefix:="
-  ],
+  "xacro_command": null,
   "package_resolution_diagnostics": {
     "resolved_packages": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -53,100 +135,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -167,32 +171,95 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
     "resolution_paths": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -209,83 +276,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets"
       },
       {
@@ -304,23 +306,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scenes/ur5_airpick4_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur5_airpick4_test/generated/scene3d_gui_smoke.json
@@ -1,0 +1,18 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "FAIL",
+  "scene": "ur5_airpick4_test",
+  "repo_root": "/workspace/Easy_Manipulator_Improved",
+  "workspace_root": "/workspace/Easy_Manipulator_Improved",
+  "executable": null,
+  "searched_paths": [
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/lib/workcell_builder/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder"
+  ],
+  "blockers": [
+    "unable_to_resolve_workcell_builder_executable"
+  ],
+  "warnings": [],
+  "screenshot_available": false
+}

--- a/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json
@@ -3,14 +3,14 @@
   "visual_count": 0,
   "resolved": 0,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:58.892638+00:00",
-  "extractor_version": "2.3",
+  "generated_at": "2026-06-02T21:08:38.535865+00:00",
+  "extractor_version": "2.4",
   "extraction_mode": "best_effort_recursive",
-  "xacro_available": true,
+  "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6831822,
+  "source_mtime": 1780423772.3132832,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
+  "fallback_reason": "xacro executable unavailable",
   "safe_for_preview": false,
   "unresolved_placeholder_count": 0,
   "has_transform_collapse_warning": false,
@@ -23,17 +23,99 @@
   "stale_index": false,
   "stale_reasons": [],
   "visual_items": [],
-  "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
-    "-o",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/expanded_scene_preview.urdf",
-    "use_fake_hardware:=true",
-    "robot_prefix:=",
-    "tool_prefix:="
-  ],
+  "xacro_command": null,
   "package_resolution_diagnostics": {
     "resolved_packages": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -53,100 +135,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -167,32 +171,95 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
     "resolution_paths": [
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "source_tier": "repo_assets"
+      },
       {
         "package_name": "simple_conveyor_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
@@ -209,83 +276,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets"
       },
       {
@@ -304,23 +306,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]


### PR DESCRIPTION
### Motivation

- Ensure the supported-scene catalog reflects the true post-regeneration readiness matrix after regenerating scene-local visual evidence. 
- Record honest, actionable `known_blocker` messages for scenes that remain blocked (do not mark broken scenes as passing). 
- Include Scene3D smoke evidence in the catalog contract so visual-quality checks track runtime smoke JSON alongside the mesh index.

### Description

- Regenerated per-scene visual evidence by updating `generated/scene_visual_mesh_index.json` for all supported scenes; these files now reflect the extractor run in this environment (e.g., `extractor_version` bumped, `xacro_available: false`, `fallback_reason: "xacro executable unavailable"`, and `safe_for_preview: false`).
- Added per-scene `generated/scene3d_gui_smoke.json` artifacts to capture Scene3D GUI smoke results (smoke JSON records the local smoke-run blockers such as `unable_to_resolve_workcell_builder_executable`).
- Updated `scenes/supported_scenes.yaml` to add `generated/scene3d_gui_smoke.json` to the `common_generated_files` contract and to set each supported scene to `status: blocked` with a clear `known_blocker` message derived from the post-regeneration readiness matrix; `ur5_2f_sorting_test` was moved from `supported` to `blocked` and its visual-quality blocker was recorded explicitly.
- Small content normalizations in the regenerated mesh-index payloads (added `visual_origin`/`material` fields where present, normalized timestamps and extractor version).

### Testing

- Ran mesh-index regeneration and diagnostics with `python3 scripts/run_scene3d_local_xacro_smoke.py` and confirmed generation of updated mesh index reports (completed; reported 8 scenes processed, `safe_for_preview` counts reflect this environment).
- Produced per-scene GUI smoke JSON with `python3 scripts/run_workcell_builder_scene3d_gui_smoke.py` for each catalog scene; smoke JSONs were created but record `unable_to_resolve_workcell_builder_executable` in this environment (expected in this container).
- Built the offline readiness matrix with `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --repo-root /workspace/Easy_Manipulator_Improved` and confirmed the summary (`PASS=0 FAIL=0 BLOCKED=8`).
- Ran the full catalog validator `python3 scripts/validate_all_workcell_studio_scenes.py --catalog scenes/supported_scenes.yaml` and confirmed the reproducibility summary (`PASS=0 WARN=0 FAIL=0 SKIP=0 BLOCKED=8`).
- Executed unit/validation test subsets: `pytest -q tests/test_validate_supported_scenes_readiness.py tests/test_scene3d_visual_quality_matrix.py` — all tests passed (`40 passed`).
- Note: `python3 scripts/validate_supported_scenes_readiness.py --repo-root ... --skip-build --skip-launch-smoke` returned non-zero because the run correctly reports that all catalog scenes are blocked by the honest post-regeneration blockers; this is expected given the environment constraints (missing `xacro` / Workcell Builder executable) and chosen catalog update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f46176de883319612b998eb57cd18)