### PR TITLE
Fix repo-local xacro extraction and regenerate scene visual mesh indexes

### DIFF
--- a/scenes/suction_test/generated/scene3d_gui_smoke.json
+++ b/scenes/suction_test/generated/scene3d_gui_smoke.json
@@ -1,0 +1,24 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "BLOCKED",
+  "scene": "suction_test",
+  "scene_path": "scenes/suction_test",
+  "generated_at": "2026-06-02T21:16:06.835026+00:00",
+  "evidence_mode": "offline_scene_local_blocker_record",
+  "source_mesh_index": "scenes/suction_test/generated/scene_visual_mesh_index.json",
+  "source_visual_count": 3,
+  "source_renderable_item_count": 3,
+  "mesh_source_count": 3,
+  "primitive_source_count": 0,
+  "rendered_count": 0,
+  "mesh_rendered_count": 0,
+  "primitive_rendered_count": 0,
+  "physical_rendered_count": 0,
+  "screenshot_available": false,
+  "blockers": [
+    "scene3d_gui_smoke_not_executed_in_this_offline_regeneration"
+  ],
+  "warnings": [
+    "This file is scene-local evidence that GUI smoke rendering is still blocked; it is not a rendered Scene3D pass."
+  ]
+}

--- a/scenes/suction_test/generated/scene_visual_mesh_index.json
+++ b/scenes/suction_test/generated/scene_visual_mesh_index.json
@@ -1,31 +1,201 @@
 {
   "scene_name": "suction_test",
-  "visual_count": 0,
-  "resolved": 0,
+  "visual_count": 3,
+  "resolved": 3,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:57.925467+00:00",
-  "extractor_version": "2.3",
-  "extraction_mode": "best_effort_recursive",
+  "generated_at": "2026-06-02T21:13:44.905398+00:00",
+  "extractor_version": "2.4",
+  "extraction_mode": "repo_local_xacro_expanded",
   "xacro_available": true,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6750066,
+  "source_mtime": 1780422990.547572,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro",
-  "safe_for_preview": false,
+  "fallback_reason": "repo-local xacro fallback used after xacro failure: error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene_preview.find_resolved.xacro; unresolved packages in local package map: ur_description; fallback warnings: include has unresolved substitution: $(find ur_description)/urdf/ur_macro.xacro; skipped unsupported xacro tag/macros call: ur_robot; skipped unsupported xacro tag/macros call: arg; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property",
+  "safe_for_preview": true,
   "unresolved_placeholder_count": 0,
-  "has_transform_collapse_warning": false,
-  "candidate_mesh_count": 0,
-  "emitted_visual_count": 0,
-  "transform_status_counts": {},
-  "mesh_format_counts": {},
-  "renderable_mesh_count": 0,
-  "renderable_item_count": 0,
+  "has_transform_collapse_warning": true,
+  "candidate_mesh_count": 3,
+  "emitted_visual_count": 3,
+  "transform_status_counts": {
+    "unresolved": 1,
+    "resolved": 2
+  },
+  "mesh_format_counts": {
+    ".stl": 2,
+    ".dae": 1
+  },
+  "renderable_mesh_count": 3,
+  "renderable_item_count": 3,
   "stale_index": false,
   "stale_reasons": [],
-  "visual_items": [],
+  "visual_items": [
+    {
+      "id": "urdf_visual_0_wrist_fixture_visual_0",
+      "link": "wrist_fixture",
+      "visual": "visual_0",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -1.5707
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": [
+          0.898039215686275,
+          0.917647058823529,
+          0.929411764705882,
+          1.0
+        ]
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->wrist_fixture(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://single_suction_description/meshes/wrist_fixture.STL",
+      "source_path": "package://single_suction_description/meshes/wrist_fixture.STL",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_1_table_table",
+      "link": "table_",
+      "visual": "table_",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://table_description/meshes/visual/table.stl",
+      "source_path": "package://table_description/meshes/visual/table.stl",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "resolved": true,
+      "mesh_scale": [
+        0.001,
+        0.001,
+        0.001
+      ],
+      "render_skip_reason": "",
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_2_camera_link_visual_2",
+      "link": "camera_link",
+      "visual": "visual_2",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->camera_bottom_screw_frame(fixed)",
+        "camera_bottom_screw_frame->camera_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "source_path": "package://realsense2_description/meshes/d435.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": ""
+    }
+  ],
   "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro",
+    "/root/.pyenv/versions/3.12.13/bin/xacro",
+    "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene_preview.find_resolved.xacro",
     "-o",
     "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/expanded_scene_preview.urdf",
     "use_fake_hardware:=true",
@@ -41,22 +211,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description/package.xml"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "workbench_description",
@@ -65,16 +223,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
         "package_name": "overhead_camera_gantry_description",
@@ -83,16 +235,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "pipe_camera_stand_description",
@@ -101,28 +259,28 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
       },
       {
         "package_name": "robotiq_3f_moveit_config",
@@ -137,16 +295,40 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -167,28 +349,16 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
@@ -199,18 +369,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -219,13 +379,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets"
       },
       {
@@ -234,13 +389,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -249,23 +409,23 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets"
       },
       {
@@ -279,13 +439,33 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
@@ -304,23 +484,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scenes/supported_scenes.yaml
+++ b/scenes/supported_scenes.yaml
@@ -2,128 +2,122 @@ schema_version: workcell_studio_supported_scenes/v1
 catalog_name: Workcell Studio supported scene catalog
 owner: Workcell Studio / Easy Manipulation Deployment
 source_of_truth: true
-description: >-
-  Machine-readable contract for scene packages that Workcell Studio treats as
-  supported reproducibility targets. All all-scenes readiness and
-  reproducibility tools should consume this file instead of hardcoding scene
-  names.
+description: Machine-readable contract for scene packages that Workcell Studio treats as supported reproducibility targets. All all-scenes readiness and reproducibility tools should consume this file instead of hardcoding scene names.
 required_entry_fields:
-  - scene_name
-  - package_name
-  - authoring_files
-  - generated_files
-  - validation_command
-  - build_package_name
-  - fake_hardware_launch_command
-  - status
-  - known_blocker
-update_policy: >-
-  When adding, renaming, disabling, or removing a supported scene, update this
-  catalog in the same PR as the scene change and re-run the catalog-backed
-  all-scenes validators. Use known_blocker: "" when there is no known blocker.
-common_authoring_files: &common_authoring_files
-  - environment.yaml
-  - layout/workcell_studio_layout.yaml
-common_generated_files: &common_generated_files
-  - cell_definition.yaml
-  - scene_manifest.yaml
-  - urdf/scene.urdf.xacro
-  - launch/demo.launch.py
-  - generated/scene_visual_mesh_index.json
+- scene_name
+- package_name
+- authoring_files
+- generated_files
+- validation_command
+- build_package_name
+- fake_hardware_launch_command
+- status
+- known_blocker
+update_policy: 'When adding, renaming, disabling, or removing a supported scene, update this catalog in the same PR as the scene change and re-run the catalog-backed all-scenes validators. Use known_blocker: "" when there is no known blocker.'
+common_authoring_files: &id001
+- environment.yaml
+- layout/workcell_studio_layout.yaml
+common_generated_files: &id002
+- cell_definition.yaml
+- scene_manifest.yaml
+- urdf/scene.urdf.xacro
+- launch/demo.launch.py
+- generated/scene_visual_mesh_index.json
+- generated/scene3d_gui_smoke.json
 scenes:
-  - scene_name: suction_test
-    package_name: suction_test
-    scene_path: scenes/suction_test
-    support_level: supported
-    status: blocked
-    known_blocker: "mesh-index/renderable-item contract failure: generic extractor produced 0 renderable visual_items because local xacro expansion failed (No module named 'ament_index_python')"
-    authoring_files: *common_authoring_files
-    generated_files: *common_generated_files
-    validation_command: python3 scripts/validate_builder_generated_scene.py scenes/suction_test --json
-    build_package_name: suction_test
-    build_command: colcon build --symlink-install --packages-select suction_test
-    fake_hardware_launch_command: ros2 launch suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
-  - scene_name: ur10_2f_test
-    package_name: ur10_2f_test
-    scene_path: scenes/ur10_2f_test
-    support_level: supported
-    status: blocked
-    known_blocker: "mesh-index/renderable-item contract failure: generic extractor produced 0 renderable visual_items because local xacro expansion failed (No module named 'ament_index_python')"
-    authoring_files: *common_authoring_files
-    generated_files: *common_generated_files
-    validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur10_2f_test --json
-    build_package_name: ur10_2f_test
-    build_command: colcon build --symlink-install --packages-select ur10_2f_test
-    fake_hardware_launch_command: ros2 launch ur10_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
-  - scene_name: ur3_suction_test
-    package_name: ur3_suction_test
-    scene_path: scenes/ur3_suction_test
-    support_level: supported
-    status: blocked
-    known_blocker: "mesh-index/renderable-item contract failure: generic extractor produced 0 renderable visual_items because local xacro expansion failed (No module named 'ament_index_python')"
-    authoring_files: *common_authoring_files
-    generated_files: *common_generated_files
-    validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur3_suction_test --json
-    build_package_name: ur3_suction_test
-    build_command: colcon build --symlink-install --packages-select ur3_suction_test
-    fake_hardware_launch_command: ros2 launch ur3_suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
-  - scene_name: ur5_2f_builder_pick_place_demo
-    package_name: ur5_2f_builder_pick_place_demo
-    scene_path: scenes/ur5_2f_builder_pick_place_demo
-    support_level: supported
-    status: blocked
-    known_blocker: "mesh-index/renderable-item contract failure: generic extractor produced 0 renderable visual_items because local xacro expansion failed (No module named 'ament_index_python')"
-    authoring_files: *common_authoring_files
-    generated_files: *common_generated_files
-    validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_builder_pick_place_demo --json
-    build_package_name: ur5_2f_builder_pick_place_demo
-    build_command: colcon build --symlink-install --packages-select ur5_2f_builder_pick_place_demo
-    fake_hardware_launch_command: ros2 launch ur5_2f_builder_pick_place_demo demo.launch.py use_fake_hardware:=true launch_rviz:=true
-  - scene_name: ur5_2f_sorting_test
-    package_name: ur5_2f_sorting_test
-    scene_path: scenes/ur5_2f_sorting_test
-    support_level: supported
-    status: supported
-    known_blocker: ""
-    authoring_files: *common_authoring_files
-    generated_files: *common_generated_files
-    validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_sorting_test --json
-    build_package_name: ur5_2f_sorting_test
-    build_command: colcon build --symlink-install --packages-select ur5_2f_sorting_test
-    fake_hardware_launch_command: ros2 launch ur5_2f_sorting_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
-  - scene_name: ur5_2f_test
-    package_name: ur5_2f_test
-    scene_path: scenes/ur5_2f_test
-    support_level: supported
-    status: blocked
-    known_blocker: "mesh-index/renderable-item contract failure: generic extractor produced 0 renderable visual_items because local xacro expansion failed (No module named 'ament_index_python')"
-    authoring_files: *common_authoring_files
-    generated_files: *common_generated_files
-    validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json
-    build_package_name: ur5_2f_test
-    build_command: colcon build --symlink-install --packages-select ur5_2f_test
-    fake_hardware_launch_command: ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
-  - scene_name: ur5_3f_test
-    package_name: ur5_3f_test
-    scene_path: scenes/ur5_3f_test
-    support_level: supported
-    status: blocked
-    known_blocker: "mesh-index/renderable-item contract failure: generic extractor produced 0 renderable visual_items because local xacro expansion failed (No module named 'ament_index_python')"
-    authoring_files: *common_authoring_files
-    generated_files: *common_generated_files
-    validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_3f_test --json
-    build_package_name: ur5_3f_test
-    build_command: colcon build --symlink-install --packages-select ur5_3f_test
-    fake_hardware_launch_command: ros2 launch ur5_3f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
-  - scene_name: ur5_airpick4_test
-    package_name: ur5_airpick4_test
-    scene_path: scenes/ur5_airpick4_test
-    support_level: supported
-    status: blocked
-    known_blocker: "mesh-index/renderable-item contract failure: generic extractor produced 0 renderable visual_items because local xacro expansion failed (No module named 'ament_index_python')"
-    authoring_files: *common_authoring_files
-    generated_files: *common_generated_files
-    validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_airpick4_test --json
-    build_package_name: ur5_airpick4_test
-    build_command: colcon build --symlink-install --packages-select ur5_airpick4_test
-    fake_hardware_launch_command: ros2 launch ur5_airpick4_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
+- scene_name: suction_test
+  package_name: suction_test
+  scene_path: scenes/suction_test
+  support_level: supported
+  status: blocked
+  known_blocker: Scene3D GUI smoke rendering remains blocked/not yet rerun; scene_visual_mesh_index.json now has nonzero scene-local source geometry from repo-local xacro expansion.
+  authoring_files: *id001
+  generated_files: *id002
+  validation_command: python3 scripts/validate_builder_generated_scene.py scenes/suction_test --json
+  build_package_name: suction_test
+  build_command: colcon build --symlink-install --packages-select suction_test
+  fake_hardware_launch_command: ros2 launch suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
+- scene_name: ur10_2f_test
+  package_name: ur10_2f_test
+  scene_path: scenes/ur10_2f_test
+  support_level: supported
+  status: blocked
+  known_blocker: Scene3D GUI smoke rendering remains blocked/not yet rerun; scene_visual_mesh_index.json now has nonzero scene-local source geometry from repo-local xacro expansion.
+  authoring_files: *id001
+  generated_files: *id002
+  validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur10_2f_test --json
+  build_package_name: ur10_2f_test
+  build_command: colcon build --symlink-install --packages-select ur10_2f_test
+  fake_hardware_launch_command: ros2 launch ur10_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
+- scene_name: ur3_suction_test
+  package_name: ur3_suction_test
+  scene_path: scenes/ur3_suction_test
+  support_level: supported
+  status: blocked
+  known_blocker: Scene3D GUI smoke rendering remains blocked/not yet rerun; scene_visual_mesh_index.json now has nonzero scene-local source geometry from repo-local xacro expansion.
+  authoring_files: *id001
+  generated_files: *id002
+  validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur3_suction_test --json
+  build_package_name: ur3_suction_test
+  build_command: colcon build --symlink-install --packages-select ur3_suction_test
+  fake_hardware_launch_command: ros2 launch ur3_suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
+- scene_name: ur5_2f_builder_pick_place_demo
+  package_name: ur5_2f_builder_pick_place_demo
+  scene_path: scenes/ur5_2f_builder_pick_place_demo
+  support_level: supported
+  status: blocked
+  known_blocker: Scene3D GUI smoke rendering remains blocked/not yet rerun; scene_visual_mesh_index.json now has nonzero scene-local source geometry from repo-local xacro expansion.
+  authoring_files: *id001
+  generated_files: *id002
+  validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_builder_pick_place_demo --json
+  build_package_name: ur5_2f_builder_pick_place_demo
+  build_command: colcon build --symlink-install --packages-select ur5_2f_builder_pick_place_demo
+  fake_hardware_launch_command: ros2 launch ur5_2f_builder_pick_place_demo demo.launch.py use_fake_hardware:=true launch_rviz:=true
+- scene_name: ur5_2f_sorting_test
+  package_name: ur5_2f_sorting_test
+  scene_path: scenes/ur5_2f_sorting_test
+  support_level: supported
+  status: blocked
+  known_blocker: cell_definition.yaml is missing camera and objects keys; Scene3D GUI smoke rendering remains blocked/not yet rerun although scene_visual_mesh_index.json has nonzero scene-local source geometry.
+  authoring_files: *id001
+  generated_files: *id002
+  validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_sorting_test --json
+  build_package_name: ur5_2f_sorting_test
+  build_command: colcon build --symlink-install --packages-select ur5_2f_sorting_test
+  fake_hardware_launch_command: ros2 launch ur5_2f_sorting_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
+- scene_name: ur5_2f_test
+  package_name: ur5_2f_test
+  scene_path: scenes/ur5_2f_test
+  support_level: supported
+  status: blocked
+  known_blocker: Scene3D GUI smoke rendering remains blocked/not yet rerun; scene_visual_mesh_index.json now has nonzero scene-local source geometry from repo-local xacro expansion.
+  authoring_files: *id001
+  generated_files: *id002
+  validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json
+  build_package_name: ur5_2f_test
+  build_command: colcon build --symlink-install --packages-select ur5_2f_test
+  fake_hardware_launch_command: ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
+- scene_name: ur5_3f_test
+  package_name: ur5_3f_test
+  scene_path: scenes/ur5_3f_test
+  support_level: supported
+  status: blocked
+  known_blocker: Scene3D GUI smoke rendering remains blocked/not yet rerun; scene_visual_mesh_index.json now has nonzero scene-local source geometry from repo-local xacro expansion.
+  authoring_files: *id001
+  generated_files: *id002
+  validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_3f_test --json
+  build_package_name: ur5_3f_test
+  build_command: colcon build --symlink-install --packages-select ur5_3f_test
+  fake_hardware_launch_command: ros2 launch ur5_3f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true
+- scene_name: ur5_airpick4_test
+  package_name: ur5_airpick4_test
+  scene_path: scenes/ur5_airpick4_test
+  support_level: supported
+  status: blocked
+  known_blocker: Scene3D GUI smoke rendering remains blocked/not yet rerun; scene_visual_mesh_index.json now has nonzero scene-local source geometry from repo-local xacro expansion.
+  authoring_files: *id001
+  generated_files: *id002
+  validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_airpick4_test --json
+  build_package_name: ur5_airpick4_test
+  build_command: colcon build --symlink-install --packages-select ur5_airpick4_test
+  fake_hardware_launch_command: ros2 launch ur5_airpick4_test demo.launch.py use_fake_hardware:=true launch_rviz:=true

--- a/scenes/ur10_2f_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur10_2f_test/generated/scene3d_gui_smoke.json
@@ -1,0 +1,24 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "BLOCKED",
+  "scene": "ur10_2f_test",
+  "scene_path": "scenes/ur10_2f_test",
+  "generated_at": "2026-06-02T21:16:06.835026+00:00",
+  "evidence_mode": "offline_scene_local_blocker_record",
+  "source_mesh_index": "scenes/ur10_2f_test/generated/scene_visual_mesh_index.json",
+  "source_visual_count": 11,
+  "source_renderable_item_count": 11,
+  "mesh_source_count": 11,
+  "primitive_source_count": 0,
+  "rendered_count": 0,
+  "mesh_rendered_count": 0,
+  "primitive_rendered_count": 0,
+  "physical_rendered_count": 0,
+  "screenshot_available": false,
+  "blockers": [
+    "scene3d_gui_smoke_not_executed_in_this_offline_regeneration"
+  ],
+  "warnings": [
+    "This file is scene-local evidence that GUI smoke rendering is still blocked; it is not a rendered Scene3D pass."
+  ]
+}

--- a/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json
@@ -1,31 +1,629 @@
 {
   "scene_name": "ur10_2f_test",
-  "visual_count": 0,
-  "resolved": 0,
+  "visual_count": 11,
+  "resolved": 11,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:58.055362+00:00",
-  "extractor_version": "2.3",
-  "extraction_mode": "best_effort_recursive",
+  "generated_at": "2026-06-02T21:13:46.198034+00:00",
+  "extractor_version": "2.4",
+  "extraction_mode": "repo_local_xacro_expanded",
   "xacro_available": true,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6750066,
+  "source_mtime": 1780422990.547572,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
-  "safe_for_preview": false,
+  "fallback_reason": "repo-local xacro fallback used after xacro failure: error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene_preview.find_resolved.xacro; unresolved packages in local package map: ur_description; fallback warnings: include has unresolved substitution: $(find ur_description)/urdf/ur_macro.xacro; skipped unsupported xacro tag/macros call: ur_robot; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property",
+  "safe_for_preview": true,
   "unresolved_placeholder_count": 0,
   "has_transform_collapse_warning": false,
-  "candidate_mesh_count": 0,
-  "emitted_visual_count": 0,
-  "transform_status_counts": {},
-  "mesh_format_counts": {},
-  "renderable_mesh_count": 0,
-  "renderable_item_count": 0,
+  "candidate_mesh_count": 11,
+  "emitted_visual_count": 11,
+  "transform_status_counts": {
+    "unresolved": 9,
+    "resolved": 2
+  },
+  "mesh_format_counts": {
+    ".dae": 10,
+    ".stl": 1
+  },
+  "renderable_mesh_count": 11,
+  "renderable_item_count": 11,
   "stale_index": false,
   "stale_reasons": [],
-  "visual_items": [],
+  "visual_items": [
+    {
+      "id": "urdf_visual_0_gripper_base_link_visual_0",
+      "link": "gripper_base_link",
+      "visual": "visual_0",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_1_gripper_finger1_knuckle_link_visual_1",
+      "link": "gripper_finger1_knuckle_link",
+      "visual": "visual_1",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.030595855369987067,
+          2.9477101585523277e-06,
+          0.05490746372541945
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_knuckle_link(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_2_gripper_finger2_knuckle_link_visual_2",
+      "link": "gripper_finger2_knuckle_link",
+      "visual": "visual_2",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.03060643292212599,
+          -2.9477101585523277e-06,
+          0.0549015683051297
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_knuckle_link(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_3_gripper_finger1_finger_link_visual_3",
+      "link": "gripper_finger1_finger_link",
+      "visual": "visual_3",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.0620822929733175,
+          5.980659890074578e-06,
+          0.050824972144091395
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_knuckle_link(revolute)",
+        "gripper_finger1_knuckle_link->gripper_finger1_finger_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_4_gripper_finger2_finger_link_visual_4",
+      "link": "gripper_finger2_finger_link",
+      "visual": "visual_4",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.06209208343448689,
+          -5.980659890070722e-06,
+          0.05081301082436674
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_knuckle_link(revolute)",
+        "gripper_finger2_knuckle_link->gripper_finger2_finger_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_5_gripper_finger1_inner_knuckle_link_visual_5",
+      "link": "gripper_finger1_inner_knuckle_link",
+      "visual": "visual_5",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.012694083490425183,
+          1.2233502932953727e-06,
+          0.061421223065334096
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_inner_knuckle_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_6_gripper_finger2_inner_knuckle_link_visual_6",
+      "link": "gripper_finger2_inner_knuckle_link",
+      "visual": "visual_6",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.012705916273891988,
+          -1.2233502932953727e-06,
+          0.061418776364758856
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_inner_knuckle_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_7_gripper_finger1_finger_tip_link_visual_7",
+      "link": "gripper_finger1_finger_tip_link",
+      "visual": "visual_7",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.05028934548501654,
+          4.845180770578397e-06,
+          0.10446444276611555
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_inner_knuckle_link(continuous)",
+        "gripper_finger1_inner_knuckle_link->gripper_finger1_finger_tip_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_8_gripper_finger2_finger_tip_link_visual_8",
+      "link": "gripper_finger2_finger_tip_link",
+      "visual": "visual_8",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.05030947000154197,
+          -4.845180770573793e-06,
+          0.10445475240461935
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_inner_knuckle_link(continuous)",
+        "gripper_finger2_inner_knuckle_link->gripper_finger2_finger_tip_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_9_table_None",
+      "link": "table_",
+      "visual": "None_",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "aluminum",
+        "color": [
+          0.549,
+          0.557,
+          0.529,
+          1.0
+        ]
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://workbench_description/meshes/visual/table.stl",
+      "source_path": "package://workbench_description/meshes/visual/table.stl",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "resolved": true,
+      "mesh_scale": [
+        0.001,
+        0.001,
+        0.001
+      ],
+      "render_skip_reason": "",
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_10_camera_link_visual_10",
+      "link": "camera_link",
+      "visual": "visual_10",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->camera_bottom_screw_frame(fixed)",
+        "camera_bottom_screw_frame->camera_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "source_path": "package://realsense2_description/meshes/d435.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": ""
+    }
+  ],
   "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
+    "/root/.pyenv/versions/3.12.13/bin/xacro",
+    "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene_preview.find_resolved.xacro",
     "-o",
     "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/expanded_scene_preview.urdf",
     "use_fake_hardware:=true",
@@ -41,22 +639,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description/package.xml"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "workbench_description",
@@ -65,16 +651,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
         "package_name": "overhead_camera_gantry_description",
@@ -83,16 +663,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "pipe_camera_stand_description",
@@ -101,28 +687,28 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
       },
       {
         "package_name": "robotiq_3f_moveit_config",
@@ -137,16 +723,40 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -167,28 +777,16 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
@@ -199,18 +797,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -219,13 +807,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets"
       },
       {
@@ -234,13 +817,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -249,23 +837,23 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets"
       },
       {
@@ -279,13 +867,33 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
@@ -304,23 +912,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scenes/ur3_suction_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur3_suction_test/generated/scene3d_gui_smoke.json
@@ -1,0 +1,24 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "BLOCKED",
+  "scene": "ur3_suction_test",
+  "scene_path": "scenes/ur3_suction_test",
+  "generated_at": "2026-06-02T21:16:06.835026+00:00",
+  "evidence_mode": "offline_scene_local_blocker_record",
+  "source_mesh_index": "scenes/ur3_suction_test/generated/scene_visual_mesh_index.json",
+  "source_visual_count": 3,
+  "source_renderable_item_count": 3,
+  "mesh_source_count": 3,
+  "primitive_source_count": 0,
+  "rendered_count": 0,
+  "mesh_rendered_count": 0,
+  "primitive_rendered_count": 0,
+  "physical_rendered_count": 0,
+  "screenshot_available": false,
+  "blockers": [
+    "scene3d_gui_smoke_not_executed_in_this_offline_regeneration"
+  ],
+  "warnings": [
+    "This file is scene-local evidence that GUI smoke rendering is still blocked; it is not a rendered Scene3D pass."
+  ]
+}

--- a/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json
@@ -1,31 +1,201 @@
 {
   "scene_name": "ur3_suction_test",
-  "visual_count": 0,
-  "resolved": 0,
+  "visual_count": 3,
+  "resolved": 3,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:58.185888+00:00",
-  "extractor_version": "2.3",
-  "extraction_mode": "best_effort_recursive",
+  "generated_at": "2026-06-02T21:13:47.510167+00:00",
+  "extractor_version": "2.4",
+  "extraction_mode": "repo_local_xacro_expanded",
   "xacro_available": true,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6750066,
+  "source_mtime": 1780422990.547572,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
-  "safe_for_preview": false,
+  "fallback_reason": "repo-local xacro fallback used after xacro failure: error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene_preview.find_resolved.xacro; unresolved packages in local package map: ur_description; fallback warnings: include has unresolved substitution: $(find ur_description)/urdf/ur_macro.xacro; skipped unsupported xacro tag/macros call: ur_robot; skipped unsupported xacro tag/macros call: arg; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property",
+  "safe_for_preview": true,
   "unresolved_placeholder_count": 0,
-  "has_transform_collapse_warning": false,
-  "candidate_mesh_count": 0,
-  "emitted_visual_count": 0,
-  "transform_status_counts": {},
-  "mesh_format_counts": {},
-  "renderable_mesh_count": 0,
-  "renderable_item_count": 0,
+  "has_transform_collapse_warning": true,
+  "candidate_mesh_count": 3,
+  "emitted_visual_count": 3,
+  "transform_status_counts": {
+    "unresolved": 1,
+    "resolved": 2
+  },
+  "mesh_format_counts": {
+    ".stl": 2,
+    ".dae": 1
+  },
+  "renderable_mesh_count": 3,
+  "renderable_item_count": 3,
   "stale_index": false,
   "stale_reasons": [],
-  "visual_items": [],
+  "visual_items": [
+    {
+      "id": "urdf_visual_0_wrist_fixture_visual_0",
+      "link": "wrist_fixture",
+      "visual": "visual_0",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          -1.5707
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": [
+          0.898039215686275,
+          0.917647058823529,
+          0.929411764705882,
+          1.0
+        ]
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->wrist_fixture(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://single_suction_description/meshes/wrist_fixture.STL",
+      "source_path": "package://single_suction_description/meshes/wrist_fixture.STL",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_1_table_table",
+      "link": "table_",
+      "visual": "table_",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://table_description/meshes/visual/table.stl",
+      "source_path": "package://table_description/meshes/visual/table.stl",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "resolved": true,
+      "mesh_scale": [
+        0.001,
+        0.001,
+        0.001
+      ],
+      "render_skip_reason": "",
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_2_camera_link_visual_2",
+      "link": "camera_link",
+      "visual": "visual_2",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->camera_bottom_screw_frame(fixed)",
+        "camera_bottom_screw_frame->camera_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "source_path": "package://realsense2_description/meshes/d435.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": ""
+    }
+  ],
   "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
+    "/root/.pyenv/versions/3.12.13/bin/xacro",
+    "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene_preview.find_resolved.xacro",
     "-o",
     "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/expanded_scene_preview.urdf",
     "use_fake_hardware:=true",
@@ -41,22 +211,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description/package.xml"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "workbench_description",
@@ -65,16 +223,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
         "package_name": "overhead_camera_gantry_description",
@@ -83,16 +235,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "pipe_camera_stand_description",
@@ -101,28 +259,28 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
       },
       {
         "package_name": "robotiq_3f_moveit_config",
@@ -137,16 +295,40 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -167,28 +349,16 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
@@ -199,18 +369,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -219,13 +379,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets"
       },
       {
@@ -234,13 +389,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -249,23 +409,23 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets"
       },
       {
@@ -279,13 +439,33 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
@@ -304,23 +484,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scenes/ur5_2f_builder_pick_place_demo/generated/scene3d_gui_smoke.json
+++ b/scenes/ur5_2f_builder_pick_place_demo/generated/scene3d_gui_smoke.json
@@ -1,0 +1,24 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "BLOCKED",
+  "scene": "ur5_2f_builder_pick_place_demo",
+  "scene_path": "scenes/ur5_2f_builder_pick_place_demo",
+  "generated_at": "2026-06-02T21:16:06.835026+00:00",
+  "evidence_mode": "offline_scene_local_blocker_record",
+  "source_mesh_index": "scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json",
+  "source_visual_count": 11,
+  "source_renderable_item_count": 11,
+  "mesh_source_count": 11,
+  "primitive_source_count": 0,
+  "rendered_count": 0,
+  "mesh_rendered_count": 0,
+  "primitive_rendered_count": 0,
+  "physical_rendered_count": 0,
+  "screenshot_available": false,
+  "blockers": [
+    "scene3d_gui_smoke_not_executed_in_this_offline_regeneration"
+  ],
+  "warnings": [
+    "This file is scene-local evidence that GUI smoke rendering is still blocked; it is not a rendered Scene3D pass."
+  ]
+}

--- a/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json
@@ -1,31 +1,629 @@
 {
   "scene_name": "ur5_2f_builder_pick_place_demo",
-  "visual_count": 0,
-  "resolved": 0,
+  "visual_count": 11,
+  "resolved": 11,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:58.327092+00:00",
-  "extractor_version": "2.3",
-  "extraction_mode": "best_effort_recursive",
+  "generated_at": "2026-06-02T21:13:48.891341+00:00",
+  "extractor_version": "2.4",
+  "extraction_mode": "repo_local_xacro_expanded",
   "xacro_available": true,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6750066,
+  "source_mtime": 1780422990.547572,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro",
-  "safe_for_preview": false,
+  "fallback_reason": "repo-local xacro fallback used after xacro failure: error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene_preview.find_resolved.xacro; unresolved packages in local package map: ur_description; fallback warnings: include has unresolved substitution: $(find ur_description)/urdf/ur_macro.xacro; skipped unsupported xacro tag/macros call: ur_robot; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property",
+  "safe_for_preview": true,
   "unresolved_placeholder_count": 0,
   "has_transform_collapse_warning": false,
-  "candidate_mesh_count": 0,
-  "emitted_visual_count": 0,
-  "transform_status_counts": {},
-  "mesh_format_counts": {},
-  "renderable_mesh_count": 0,
-  "renderable_item_count": 0,
+  "candidate_mesh_count": 11,
+  "emitted_visual_count": 11,
+  "transform_status_counts": {
+    "unresolved": 9,
+    "resolved": 2
+  },
+  "mesh_format_counts": {
+    ".dae": 10,
+    ".stl": 1
+  },
+  "renderable_mesh_count": 11,
+  "renderable_item_count": 11,
   "stale_index": false,
   "stale_reasons": [],
-  "visual_items": [],
+  "visual_items": [
+    {
+      "id": "urdf_visual_0_gripper_base_link_visual_0",
+      "link": "gripper_base_link",
+      "visual": "visual_0",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_1_gripper_finger1_knuckle_link_visual_1",
+      "link": "gripper_finger1_knuckle_link",
+      "visual": "visual_1",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.030595855369987067,
+          2.9477101585523277e-06,
+          0.05490746372541945
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_knuckle_link(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_2_gripper_finger2_knuckle_link_visual_2",
+      "link": "gripper_finger2_knuckle_link",
+      "visual": "visual_2",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.03060643292212599,
+          -2.9477101585523277e-06,
+          0.0549015683051297
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_knuckle_link(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_3_gripper_finger1_finger_link_visual_3",
+      "link": "gripper_finger1_finger_link",
+      "visual": "visual_3",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.0620822929733175,
+          5.980659890074578e-06,
+          0.050824972144091395
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_knuckle_link(revolute)",
+        "gripper_finger1_knuckle_link->gripper_finger1_finger_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_4_gripper_finger2_finger_link_visual_4",
+      "link": "gripper_finger2_finger_link",
+      "visual": "visual_4",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.06209208343448689,
+          -5.980659890070722e-06,
+          0.05081301082436674
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_knuckle_link(revolute)",
+        "gripper_finger2_knuckle_link->gripper_finger2_finger_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_5_gripper_finger1_inner_knuckle_link_visual_5",
+      "link": "gripper_finger1_inner_knuckle_link",
+      "visual": "visual_5",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.012694083490425183,
+          1.2233502932953727e-06,
+          0.061421223065334096
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_inner_knuckle_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_6_gripper_finger2_inner_knuckle_link_visual_6",
+      "link": "gripper_finger2_inner_knuckle_link",
+      "visual": "visual_6",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.012705916273891988,
+          -1.2233502932953727e-06,
+          0.061418776364758856
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_inner_knuckle_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_7_gripper_finger1_finger_tip_link_visual_7",
+      "link": "gripper_finger1_finger_tip_link",
+      "visual": "visual_7",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.05028934548501654,
+          4.845180770578397e-06,
+          0.10446444276611555
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_inner_knuckle_link(continuous)",
+        "gripper_finger1_inner_knuckle_link->gripper_finger1_finger_tip_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_8_gripper_finger2_finger_tip_link_visual_8",
+      "link": "gripper_finger2_finger_tip_link",
+      "visual": "visual_8",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.05030947000154197,
+          -4.845180770573793e-06,
+          0.10445475240461935
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_inner_knuckle_link(continuous)",
+        "gripper_finger2_inner_knuckle_link->gripper_finger2_finger_tip_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_9_table_None",
+      "link": "table_",
+      "visual": "None_",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "aluminum",
+        "color": [
+          0.549,
+          0.557,
+          0.529,
+          1.0
+        ]
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://workbench_description/meshes/visual/table.stl",
+      "source_path": "package://workbench_description/meshes/visual/table.stl",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "resolved": true,
+      "mesh_scale": [
+        0.001,
+        0.001,
+        0.001
+      ],
+      "render_skip_reason": "",
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_10_camera_link_visual_10",
+      "link": "camera_link",
+      "visual": "visual_10",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->camera_bottom_screw_frame(fixed)",
+        "camera_bottom_screw_frame->camera_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "source_path": "package://realsense2_description/meshes/d435.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": ""
+    }
+  ],
   "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro",
+    "/root/.pyenv/versions/3.12.13/bin/xacro",
+    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene_preview.find_resolved.xacro",
     "-o",
     "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/expanded_scene_preview.urdf",
     "use_fake_hardware:=true",
@@ -41,22 +639,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description/package.xml"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "workbench_description",
@@ -65,16 +651,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
         "package_name": "overhead_camera_gantry_description",
@@ -83,16 +663,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "pipe_camera_stand_description",
@@ -101,28 +687,28 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
       },
       {
         "package_name": "robotiq_3f_moveit_config",
@@ -137,16 +723,40 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -167,28 +777,16 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
@@ -199,18 +797,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -219,13 +807,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets"
       },
       {
@@ -234,13 +817,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -249,23 +837,23 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets"
       },
       {
@@ -279,13 +867,33 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
@@ -304,23 +912,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scenes/ur5_2f_sorting_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur5_2f_sorting_test/generated/scene3d_gui_smoke.json
@@ -1,0 +1,24 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "BLOCKED",
+  "scene": "ur5_2f_sorting_test",
+  "scene_path": "scenes/ur5_2f_sorting_test",
+  "generated_at": "2026-06-02T21:16:06.835026+00:00",
+  "evidence_mode": "offline_scene_local_blocker_record",
+  "source_mesh_index": "scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json",
+  "source_visual_count": 32,
+  "source_renderable_item_count": 32,
+  "mesh_source_count": 10,
+  "primitive_source_count": 22,
+  "rendered_count": 0,
+  "mesh_rendered_count": 0,
+  "primitive_rendered_count": 0,
+  "physical_rendered_count": 0,
+  "screenshot_available": false,
+  "blockers": [
+    "scene3d_gui_smoke_not_executed_in_this_offline_regeneration"
+  ],
+  "warnings": [
+    "This file is scene-local evidence that GUI smoke rendering is still blocked; it is not a rendered Scene3D pass."
+  ]
+}

--- a/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json
@@ -1,27 +1,30 @@
 {
   "scene_name": "ur5_2f_sorting_test",
-  "visual_count": 22,
-  "resolved": 22,
+  "visual_count": 32,
+  "resolved": 32,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:58.476932+00:00",
-  "extractor_version": "2.3",
-  "extraction_mode": "best_effort_recursive",
+  "generated_at": "2026-06-02T21:13:50.193232+00:00",
+  "extractor_version": "2.4",
+  "extraction_mode": "repo_local_xacro_expanded",
   "xacro_available": true,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6790943,
+  "source_mtime": 1780422990.551572,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro",
-  "safe_for_preview": false,
+  "fallback_reason": "repo-local xacro fallback used after xacro failure: error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene_preview.find_resolved.xacro; unresolved packages in local package map: ur_description; fallback warnings: include has unresolved substitution: $(find ur_description)/urdf/ur_macro.xacro; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: ur_robot; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property",
+  "safe_for_preview": true,
   "unresolved_placeholder_count": 0,
   "has_transform_collapse_warning": false,
-  "candidate_mesh_count": 22,
-  "emitted_visual_count": 22,
+  "candidate_mesh_count": 32,
+  "emitted_visual_count": 32,
   "transform_status_counts": {
-    "resolved": 22
+    "resolved": 23,
+    "unresolved": 9
   },
-  "mesh_format_counts": {},
-  "renderable_mesh_count": 0,
-  "renderable_item_count": 22,
+  "mesh_format_counts": {
+    ".dae": 10
+  },
+  "renderable_mesh_count": 10,
+  "renderable_item_count": 32,
   "stale_index": false,
   "stale_reasons": [],
   "visual_items": [
@@ -40,6 +43,27 @@
           0.0,
           -0.0,
           0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "TableCabinet",
+        "color": [
+          0.46,
+          0.33,
+          0.24,
+          1.0
         ]
       },
       "link_transform_status": "resolved",
@@ -74,6 +98,27 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "TableTop",
+        "color": [
+          0.55,
+          0.4,
+          0.28,
+          1.0
+        ]
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
@@ -106,6 +151,27 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "RobotPlate",
+        "color": [
+          0.25,
+          0.25,
+          0.25,
+          1.0
+        ]
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
@@ -123,20 +189,521 @@
       "warning": ""
     },
     {
-      "id": "urdf_visual_3_camera_mast_visual_3",
-      "link": "camera_mast",
+      "id": "urdf_visual_3_gripper_base_link_visual_3",
+      "link": "gripper_base_link",
       "visual": "visual_3",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_4_gripper_finger1_knuckle_link_visual_4",
+      "link": "gripper_finger1_knuckle_link",
+      "visual": "visual_4",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.030595855369987067,
+          2.9477101585523277e-06,
+          0.05490746372541945
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_knuckle_link(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_5_gripper_finger2_knuckle_link_visual_5",
+      "link": "gripper_finger2_knuckle_link",
+      "visual": "visual_5",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.03060643292212599,
+          -2.9477101585523277e-06,
+          0.0549015683051297
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_knuckle_link(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_6_gripper_finger1_finger_link_visual_6",
+      "link": "gripper_finger1_finger_link",
+      "visual": "visual_6",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.0620822929733175,
+          5.980659890074578e-06,
+          0.050824972144091395
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_knuckle_link(revolute)",
+        "gripper_finger1_knuckle_link->gripper_finger1_finger_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_7_gripper_finger2_finger_link_visual_7",
+      "link": "gripper_finger2_finger_link",
+      "visual": "visual_7",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.06209208343448689,
+          -5.980659890070722e-06,
+          0.05081301082436674
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_knuckle_link(revolute)",
+        "gripper_finger2_knuckle_link->gripper_finger2_finger_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_8_gripper_finger1_inner_knuckle_link_visual_8",
+      "link": "gripper_finger1_inner_knuckle_link",
+      "visual": "visual_8",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.012694083490425183,
+          1.2233502932953727e-06,
+          0.061421223065334096
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_inner_knuckle_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_9_gripper_finger2_inner_knuckle_link_visual_9",
+      "link": "gripper_finger2_inner_knuckle_link",
+      "visual": "visual_9",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.012705916273891988,
+          -1.2233502932953727e-06,
+          0.061418776364758856
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_inner_knuckle_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_10_gripper_finger1_finger_tip_link_visual_10",
+      "link": "gripper_finger1_finger_tip_link",
+      "visual": "visual_10",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.05028934548501654,
+          4.845180770578397e-06,
+          0.10446444276611555
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_inner_knuckle_link(continuous)",
+        "gripper_finger1_inner_knuckle_link->gripper_finger1_finger_tip_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_11_gripper_finger2_finger_tip_link_visual_11",
+      "link": "gripper_finger2_finger_tip_link",
+      "visual": "visual_11",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.05030947000154197,
+          -4.845180770573793e-06,
+          0.10445475240461935
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_inner_knuckle_link(continuous)",
+        "gripper_finger2_inner_knuckle_link->gripper_finger2_finger_tip_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_12_camera_mast_visual_12",
+      "link": "camera_mast",
+      "visual": "visual_12",
       "parent_link": "world",
       "pose": {
         "xyz": [
           -0.03,
           0.28,
-          0.32
+          0.0
         ],
         "rpy": [
           0.0,
           -0.0,
           0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.32
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "CameraMast",
+        "color": [
+          0.2,
+          0.2,
+          0.2,
+          1.0
         ]
       },
       "link_transform_status": "resolved",
@@ -153,312 +720,15 @@
       "warning": ""
     },
     {
-      "id": "urdf_visual_4_bin_a_visual_4",
-      "link": "bin_a",
-      "visual": "visual_4",
-      "parent_link": "world",
-      "pose": {
-        "xyz": [
-          0.15,
-          -0.24,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "link_transform_status": "resolved",
-      "transform_status": "resolved",
-      "transform_chain": [
-        "world->table_(fixed)",
-        "table_->bin_a(fixed)"
-      ],
-      "render_expected": true,
-      "geometry_type": "box",
-      "size": [
-        0.1,
-        0.1,
-        0.1
-      ],
-      "resolved": true,
-      "warning": ""
-    },
-    {
-      "id": "urdf_visual_5_bin_a_visual_5",
-      "link": "bin_a",
-      "visual": "visual_5",
-      "parent_link": "world",
-      "pose": {
-        "xyz": [
-          0.15,
-          -0.24,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "link_transform_status": "resolved",
-      "transform_status": "resolved",
-      "transform_chain": [
-        "world->table_(fixed)",
-        "table_->bin_a(fixed)"
-      ],
-      "render_expected": true,
-      "geometry_type": "box",
-      "size": [
-        0.1,
-        0.1,
-        0.1
-      ],
-      "resolved": true,
-      "warning": ""
-    },
-    {
-      "id": "urdf_visual_6_bin_a_visual_6",
-      "link": "bin_a",
-      "visual": "visual_6",
-      "parent_link": "world",
-      "pose": {
-        "xyz": [
-          0.15,
-          -0.24,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "link_transform_status": "resolved",
-      "transform_status": "resolved",
-      "transform_chain": [
-        "world->table_(fixed)",
-        "table_->bin_a(fixed)"
-      ],
-      "render_expected": true,
-      "geometry_type": "box",
-      "size": [
-        0.1,
-        0.1,
-        0.1
-      ],
-      "resolved": true,
-      "warning": ""
-    },
-    {
-      "id": "urdf_visual_7_bin_a_visual_7",
-      "link": "bin_a",
-      "visual": "visual_7",
-      "parent_link": "world",
-      "pose": {
-        "xyz": [
-          0.15,
-          -0.24,
-          2.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "link_transform_status": "resolved",
-      "transform_status": "resolved",
-      "transform_chain": [
-        "world->table_(fixed)",
-        "table_->bin_a(fixed)"
-      ],
-      "render_expected": true,
-      "geometry_type": "box",
-      "size": [
-        0.1,
-        0.1,
-        0.1
-      ],
-      "resolved": true,
-      "warning": ""
-    },
-    {
-      "id": "urdf_visual_8_bin_a_visual_8",
-      "link": "bin_a",
-      "visual": "visual_8",
-      "parent_link": "world",
-      "pose": {
-        "xyz": [
-          0.15,
-          -0.24,
-          2.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "link_transform_status": "resolved",
-      "transform_status": "resolved",
-      "transform_chain": [
-        "world->table_(fixed)",
-        "table_->bin_a(fixed)"
-      ],
-      "render_expected": true,
-      "geometry_type": "box",
-      "size": [
-        0.1,
-        0.1,
-        0.1
-      ],
-      "resolved": true,
-      "warning": ""
-    },
-    {
-      "id": "urdf_visual_9_bin_b_visual_9",
-      "link": "bin_b",
-      "visual": "visual_9",
-      "parent_link": "world",
-      "pose": {
-        "xyz": [
-          0.15,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "link_transform_status": "resolved",
-      "transform_status": "resolved",
-      "transform_chain": [
-        "world->table_(fixed)",
-        "table_->bin_b(fixed)"
-      ],
-      "render_expected": true,
-      "geometry_type": "box",
-      "size": [
-        0.1,
-        0.1,
-        0.1
-      ],
-      "resolved": true,
-      "warning": ""
-    },
-    {
-      "id": "urdf_visual_10_bin_b_visual_10",
-      "link": "bin_b",
-      "visual": "visual_10",
-      "parent_link": "world",
-      "pose": {
-        "xyz": [
-          0.15,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "link_transform_status": "resolved",
-      "transform_status": "resolved",
-      "transform_chain": [
-        "world->table_(fixed)",
-        "table_->bin_b(fixed)"
-      ],
-      "render_expected": true,
-      "geometry_type": "box",
-      "size": [
-        0.1,
-        0.1,
-        0.1
-      ],
-      "resolved": true,
-      "warning": ""
-    },
-    {
-      "id": "urdf_visual_11_bin_b_visual_11",
-      "link": "bin_b",
-      "visual": "visual_11",
-      "parent_link": "world",
-      "pose": {
-        "xyz": [
-          0.15,
-          0.0,
-          0.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "link_transform_status": "resolved",
-      "transform_status": "resolved",
-      "transform_chain": [
-        "world->table_(fixed)",
-        "table_->bin_b(fixed)"
-      ],
-      "render_expected": true,
-      "geometry_type": "box",
-      "size": [
-        0.1,
-        0.1,
-        0.1
-      ],
-      "resolved": true,
-      "warning": ""
-    },
-    {
-      "id": "urdf_visual_12_bin_b_visual_12",
-      "link": "bin_b",
-      "visual": "visual_12",
-      "parent_link": "world",
-      "pose": {
-        "xyz": [
-          0.15,
-          0.0,
-          2.0
-        ],
-        "rpy": [
-          0.0,
-          -0.0,
-          0.0
-        ]
-      },
-      "link_transform_status": "resolved",
-      "transform_status": "resolved",
-      "transform_chain": [
-        "world->table_(fixed)",
-        "table_->bin_b(fixed)"
-      ],
-      "render_expected": true,
-      "geometry_type": "box",
-      "size": [
-        0.1,
-        0.1,
-        0.1
-      ],
-      "resolved": true,
-      "warning": ""
-    },
-    {
-      "id": "urdf_visual_13_bin_b_visual_13",
-      "link": "bin_b",
+      "id": "urdf_visual_13_camera_link_visual_13",
+      "link": "camera_link",
       "visual": "visual_13",
       "parent_link": "world",
       "pose": {
         "xyz": [
           0.15,
           0.0,
-          2.0
+          0.0
         ],
         "rpy": [
           0.0,
@@ -466,31 +736,52 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
         "world->table_(fixed)",
-        "table_->bin_b(fixed)"
+        "table_->camera_bottom_screw_frame(fixed)",
+        "camera_bottom_screw_frame->camera_link(fixed)"
       ],
       "render_expected": true,
-      "geometry_type": "box",
-      "size": [
-        0.1,
-        0.1,
-        0.1
-      ],
+      "geometry_type": "mesh",
+      "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "source_path": "package://realsense2_description/meshes/d435.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
       "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
       "warning": ""
     },
     {
-      "id": "urdf_visual_14_reject_bin_visual_14",
-      "link": "reject_bin",
+      "id": "urdf_visual_14_bin_a_visual_14",
+      "link": "bin_a",
       "visual": "visual_14",
       "parent_link": "world",
       "pose": {
         "xyz": [
           0.15,
-          0.24,
+          -0.24,
           0.0
         ],
         "rpy": [
@@ -499,11 +790,32 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "Blue",
+        "color": [
+          0.2,
+          0.2,
+          0.8,
+          1.0
+        ]
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
         "world->table_(fixed)",
-        "table_->reject_bin(fixed)"
+        "table_->bin_a(fixed)"
       ],
       "render_expected": true,
       "geometry_type": "box",
@@ -516,14 +828,14 @@
       "warning": ""
     },
     {
-      "id": "urdf_visual_15_reject_bin_visual_15",
-      "link": "reject_bin",
+      "id": "urdf_visual_15_bin_a_visual_15",
+      "link": "bin_a",
       "visual": "visual_15",
       "parent_link": "world",
       "pose": {
         "xyz": [
           0.15,
-          0.24,
+          -0.24,
           0.0
         ],
         "rpy": [
@@ -532,11 +844,27 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
         "world->table_(fixed)",
-        "table_->reject_bin(fixed)"
+        "table_->bin_a(fixed)"
       ],
       "render_expected": true,
       "geometry_type": "box",
@@ -549,14 +877,14 @@
       "warning": ""
     },
     {
-      "id": "urdf_visual_16_reject_bin_visual_16",
-      "link": "reject_bin",
+      "id": "urdf_visual_16_bin_a_visual_16",
+      "link": "bin_a",
       "visual": "visual_16",
       "parent_link": "world",
       "pose": {
         "xyz": [
           0.15,
-          0.24,
+          -0.24,
           0.0
         ],
         "rpy": [
@@ -565,11 +893,27 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
         "world->table_(fixed)",
-        "table_->reject_bin(fixed)"
+        "table_->bin_a(fixed)"
       ],
       "render_expected": true,
       "geometry_type": "box",
@@ -582,15 +926,15 @@
       "warning": ""
     },
     {
-      "id": "urdf_visual_17_reject_bin_visual_17",
-      "link": "reject_bin",
+      "id": "urdf_visual_17_bin_a_visual_17",
+      "link": "bin_a",
       "visual": "visual_17",
       "parent_link": "world",
       "pose": {
         "xyz": [
           0.15,
-          0.24,
-          2.0
+          -0.24,
+          0.0
         ],
         "rpy": [
           0.0,
@@ -598,11 +942,27 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
         "world->table_(fixed)",
-        "table_->reject_bin(fixed)"
+        "table_->bin_a(fixed)"
       ],
       "render_expected": true,
       "geometry_type": "box",
@@ -615,15 +975,15 @@
       "warning": ""
     },
     {
-      "id": "urdf_visual_18_reject_bin_visual_18",
-      "link": "reject_bin",
+      "id": "urdf_visual_18_bin_a_visual_18",
+      "link": "bin_a",
       "visual": "visual_18",
       "parent_link": "world",
       "pose": {
         "xyz": [
           0.15,
-          0.24,
-          2.0
+          -0.24,
+          0.0
         ],
         "rpy": [
           0.0,
@@ -631,11 +991,27 @@
           0.0
         ]
       },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
       "link_transform_status": "resolved",
       "transform_status": "resolved",
       "transform_chain": [
         "world->table_(fixed)",
-        "table_->reject_bin(fixed)"
+        "table_->bin_a(fixed)"
       ],
       "render_expected": true,
       "geometry_type": "box",
@@ -648,8 +1024,8 @@
       "warning": ""
     },
     {
-      "id": "urdf_visual_19_item_red_visual_19",
-      "link": "item_red",
+      "id": "urdf_visual_19_bin_b_visual_19",
+      "link": "bin_b",
       "visual": "visual_19",
       "parent_link": "world",
       "pose": {
@@ -662,6 +1038,527 @@
           0.0,
           -0.0,
           0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "Green",
+        "color": [
+          0.2,
+          0.8,
+          0.2,
+          1.0
+        ]
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->bin_b(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "box",
+      "size": [
+        0.1,
+        0.1,
+        0.1
+      ],
+      "resolved": true,
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_20_bin_b_visual_20",
+      "link": "bin_b",
+      "visual": "visual_20",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->bin_b(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "box",
+      "size": [
+        0.1,
+        0.1,
+        0.1
+      ],
+      "resolved": true,
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_21_bin_b_visual_21",
+      "link": "bin_b",
+      "visual": "visual_21",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->bin_b(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "box",
+      "size": [
+        0.1,
+        0.1,
+        0.1
+      ],
+      "resolved": true,
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_22_bin_b_visual_22",
+      "link": "bin_b",
+      "visual": "visual_22",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->bin_b(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "box",
+      "size": [
+        0.1,
+        0.1,
+        0.1
+      ],
+      "resolved": true,
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_23_bin_b_visual_23",
+      "link": "bin_b",
+      "visual": "visual_23",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->bin_b(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "box",
+      "size": [
+        0.1,
+        0.1,
+        0.1
+      ],
+      "resolved": true,
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_24_reject_bin_visual_24",
+      "link": "reject_bin",
+      "visual": "visual_24",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.24,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "RejectBin",
+        "color": [
+          0.75,
+          0.35,
+          0.1,
+          1.0
+        ]
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->reject_bin(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "box",
+      "size": [
+        0.1,
+        0.1,
+        0.1
+      ],
+      "resolved": true,
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_25_reject_bin_visual_25",
+      "link": "reject_bin",
+      "visual": "visual_25",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.24,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->reject_bin(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "box",
+      "size": [
+        0.1,
+        0.1,
+        0.1
+      ],
+      "resolved": true,
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_26_reject_bin_visual_26",
+      "link": "reject_bin",
+      "visual": "visual_26",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.24,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->reject_bin(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "box",
+      "size": [
+        0.1,
+        0.1,
+        0.1
+      ],
+      "resolved": true,
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_27_reject_bin_visual_27",
+      "link": "reject_bin",
+      "visual": "visual_27",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.24,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->reject_bin(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "box",
+      "size": [
+        0.1,
+        0.1,
+        0.1
+      ],
+      "resolved": true,
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_28_reject_bin_visual_28",
+      "link": "reject_bin",
+      "visual": "visual_28",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.24,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          2.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->reject_bin(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "box",
+      "size": [
+        0.1,
+        0.1,
+        0.1
+      ],
+      "resolved": true,
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_29_item_red_visual_29",
+      "link": "item_red",
+      "visual": "visual_29",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.15,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "Red",
+        "color": [
+          0.9,
+          0.1,
+          0.1,
+          1.0
         ]
       },
       "link_transform_status": "resolved",
@@ -681,9 +1578,9 @@
       "warning": ""
     },
     {
-      "id": "urdf_visual_20_item_blue_visual_20",
+      "id": "urdf_visual_30_item_blue_visual_30",
       "link": "item_blue",
-      "visual": "visual_20",
+      "visual": "visual_30",
       "parent_link": "world",
       "pose": {
         "xyz": [
@@ -695,6 +1592,27 @@
           0.0,
           -0.0,
           0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "BlueItem",
+        "color": [
+          0.1,
+          0.3,
+          0.9,
+          1.0
         ]
       },
       "link_transform_status": "resolved",
@@ -711,9 +1629,9 @@
       "warning": ""
     },
     {
-      "id": "urdf_visual_21_item_green_visual_21",
+      "id": "urdf_visual_31_item_green_visual_31",
       "link": "item_green",
-      "visual": "visual_21",
+      "visual": "visual_31",
       "parent_link": "world",
       "pose": {
         "xyz": [
@@ -725,6 +1643,27 @@
           0.0,
           -0.0,
           0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "GreenItem",
+        "color": [
+          0.1,
+          0.8,
+          0.3,
+          1.0
         ]
       },
       "link_transform_status": "resolved",
@@ -741,8 +1680,8 @@
     }
   ],
   "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro",
+    "/root/.pyenv/versions/3.12.13/bin/xacro",
+    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene_preview.find_resolved.xacro",
     "-o",
     "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/expanded_scene_preview.urdf",
     "use_fake_hardware:=true",
@@ -758,22 +1697,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description/package.xml"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "workbench_description",
@@ -782,16 +1709,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
         "package_name": "overhead_camera_gantry_description",
@@ -800,16 +1721,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "pipe_camera_stand_description",
@@ -818,28 +1745,28 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
       },
       {
         "package_name": "robotiq_3f_moveit_config",
@@ -854,16 +1781,40 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -884,28 +1835,16 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
@@ -916,18 +1855,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -936,13 +1865,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets"
       },
       {
@@ -951,13 +1875,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -966,23 +1895,23 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets"
       },
       {
@@ -996,13 +1925,33 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
@@ -1021,23 +1970,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json
@@ -1,0 +1,24 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "BLOCKED",
+  "scene": "ur5_2f_test",
+  "scene_path": "scenes/ur5_2f_test",
+  "generated_at": "2026-06-02T21:16:06.835026+00:00",
+  "evidence_mode": "offline_scene_local_blocker_record",
+  "source_mesh_index": "scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+  "source_visual_count": 11,
+  "source_renderable_item_count": 11,
+  "mesh_source_count": 11,
+  "primitive_source_count": 0,
+  "rendered_count": 0,
+  "mesh_rendered_count": 0,
+  "primitive_rendered_count": 0,
+  "physical_rendered_count": 0,
+  "screenshot_available": false,
+  "blockers": [
+    "scene3d_gui_smoke_not_executed_in_this_offline_regeneration"
+  ],
+  "warnings": [
+    "This file is scene-local evidence that GUI smoke rendering is still blocked; it is not a rendered Scene3D pass."
+  ]
+}

--- a/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
@@ -1,31 +1,629 @@
 {
   "scene_name": "ur5_2f_test",
-  "visual_count": 0,
-  "resolved": 0,
+  "visual_count": 11,
+  "resolved": 11,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:59.256009+00:00",
-  "extractor_version": "2.3",
-  "extraction_mode": "best_effort_recursive",
+  "generated_at": "2026-06-02T21:13:51.433238+00:00",
+  "extractor_version": "2.4",
+  "extraction_mode": "repo_local_xacro_expanded",
   "xacro_available": true,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6790943,
+  "source_mtime": 1780422990.551572,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
-  "safe_for_preview": false,
+  "fallback_reason": "repo-local xacro fallback used after xacro failure: error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_preview.find_resolved.xacro; unresolved packages in local package map: ur_description; fallback warnings: include has unresolved substitution: $(find ur_description)/urdf/ur_macro.xacro; skipped unsupported xacro tag/macros call: ur_robot; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property",
+  "safe_for_preview": true,
   "unresolved_placeholder_count": 0,
   "has_transform_collapse_warning": false,
-  "candidate_mesh_count": 0,
-  "emitted_visual_count": 0,
-  "transform_status_counts": {},
-  "mesh_format_counts": {},
-  "renderable_mesh_count": 0,
-  "renderable_item_count": 0,
+  "candidate_mesh_count": 11,
+  "emitted_visual_count": 11,
+  "transform_status_counts": {
+    "unresolved": 9,
+    "resolved": 2
+  },
+  "mesh_format_counts": {
+    ".dae": 10,
+    ".stl": 1
+  },
+  "renderable_mesh_count": 11,
+  "renderable_item_count": 11,
   "stale_index": false,
   "stale_reasons": [],
-  "visual_items": [],
+  "visual_items": [
+    {
+      "id": "urdf_visual_0_gripper_base_link_visual_0",
+      "link": "gripper_base_link",
+      "visual": "visual_0",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_1_gripper_finger1_knuckle_link_visual_1",
+      "link": "gripper_finger1_knuckle_link",
+      "visual": "visual_1",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.030595855369987067,
+          2.9477101585523277e-06,
+          0.05490746372541945
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_knuckle_link(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_2_gripper_finger2_knuckle_link_visual_2",
+      "link": "gripper_finger2_knuckle_link",
+      "visual": "visual_2",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.03060643292212599,
+          -2.9477101585523277e-06,
+          0.0549015683051297
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_knuckle_link(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_3_gripper_finger1_finger_link_visual_3",
+      "link": "gripper_finger1_finger_link",
+      "visual": "visual_3",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.0620822929733175,
+          5.980659890074578e-06,
+          0.050824972144091395
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_knuckle_link(revolute)",
+        "gripper_finger1_knuckle_link->gripper_finger1_finger_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_4_gripper_finger2_finger_link_visual_4",
+      "link": "gripper_finger2_finger_link",
+      "visual": "visual_4",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.06209208343448689,
+          -5.980659890070722e-06,
+          0.05081301082436674
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_knuckle_link(revolute)",
+        "gripper_finger2_knuckle_link->gripper_finger2_finger_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_5_gripper_finger1_inner_knuckle_link_visual_5",
+      "link": "gripper_finger1_inner_knuckle_link",
+      "visual": "visual_5",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.012694083490425183,
+          1.2233502932953727e-06,
+          0.061421223065334096
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_inner_knuckle_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_6_gripper_finger2_inner_knuckle_link_visual_6",
+      "link": "gripper_finger2_inner_knuckle_link",
+      "visual": "visual_6",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.012705916273891988,
+          -1.2233502932953727e-06,
+          0.061418776364758856
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_inner_knuckle_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_7_gripper_finger1_finger_tip_link_visual_7",
+      "link": "gripper_finger1_finger_tip_link",
+      "visual": "visual_7",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.05028934548501654,
+          4.845180770578397e-06,
+          0.10446444276611555
+        ],
+        "rpy": [
+          -1.5708926535897934,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger1_inner_knuckle_link(continuous)",
+        "gripper_finger1_inner_knuckle_link->gripper_finger1_finger_tip_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_8_gripper_finger2_finger_tip_link_visual_8",
+      "link": "gripper_finger2_finger_tip_link",
+      "visual": "visual_8",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.05030947000154197,
+          -4.845180770573793e-06,
+          0.10445475240461935
+        ],
+        "rpy": [
+          1.5707,
+          -1.5706999999997038,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)",
+        "gripper_base_link->gripper_finger2_inner_knuckle_link(continuous)",
+        "gripper_finger2_inner_knuckle_link->gripper_finger2_finger_tip_link(continuous)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_9_table_None",
+      "link": "table_",
+      "visual": "None_",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "aluminum",
+        "color": [
+          0.549,
+          0.557,
+          0.529,
+          1.0
+        ]
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://workbench_description/meshes/visual/table.stl",
+      "source_path": "package://workbench_description/meshes/visual/table.stl",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "resolved": true,
+      "mesh_scale": [
+        0.001,
+        0.001,
+        0.001
+      ],
+      "render_skip_reason": "",
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_10_camera_link_visual_10",
+      "link": "camera_link",
+      "visual": "visual_10",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->camera_bottom_screw_frame(fixed)",
+        "camera_bottom_screw_frame->camera_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "source_path": "package://realsense2_description/meshes/d435.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": ""
+    }
+  ],
   "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+    "/root/.pyenv/versions/3.12.13/bin/xacro",
+    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_preview.find_resolved.xacro",
     "-o",
     "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/expanded_scene_preview.urdf",
     "use_fake_hardware:=true",
@@ -41,22 +639,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description/package.xml"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "workbench_description",
@@ -65,16 +651,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
         "package_name": "overhead_camera_gantry_description",
@@ -83,16 +663,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "pipe_camera_stand_description",
@@ -101,28 +687,28 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
       },
       {
         "package_name": "robotiq_3f_moveit_config",
@@ -137,16 +723,40 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -167,28 +777,16 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
@@ -199,18 +797,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -219,13 +807,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets"
       },
       {
@@ -234,13 +817,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -249,23 +837,23 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets"
       },
       {
@@ -279,13 +867,33 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
@@ -304,23 +912,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scenes/ur5_3f_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur5_3f_test/generated/scene3d_gui_smoke.json
@@ -1,0 +1,24 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "BLOCKED",
+  "scene": "ur5_3f_test",
+  "scene_path": "scenes/ur5_3f_test",
+  "generated_at": "2026-06-02T21:16:06.835026+00:00",
+  "evidence_mode": "offline_scene_local_blocker_record",
+  "source_mesh_index": "scenes/ur5_3f_test/generated/scene_visual_mesh_index.json",
+  "source_visual_count": 2,
+  "source_renderable_item_count": 2,
+  "mesh_source_count": 2,
+  "primitive_source_count": 0,
+  "rendered_count": 0,
+  "mesh_rendered_count": 0,
+  "primitive_rendered_count": 0,
+  "physical_rendered_count": 0,
+  "screenshot_available": false,
+  "blockers": [
+    "scene3d_gui_smoke_not_executed_in_this_offline_regeneration"
+  ],
+  "warnings": [
+    "This file is scene-local evidence that GUI smoke rendering is still blocked; it is not a rendered Scene3D pass."
+  ]
+}

--- a/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json
@@ -1,31 +1,148 @@
 {
   "scene_name": "ur5_3f_test",
-  "visual_count": 0,
-  "resolved": 0,
+  "visual_count": 2,
+  "resolved": 2,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:58.755546+00:00",
-  "extractor_version": "2.3",
-  "extraction_mode": "best_effort_recursive",
+  "generated_at": "2026-06-02T21:13:52.793837+00:00",
+  "extractor_version": "2.4",
+  "extraction_mode": "repo_local_xacro_expanded",
   "xacro_available": true,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6831822,
+  "source_mtime": 1780422990.551572,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
-  "safe_for_preview": false,
+  "fallback_reason": "repo-local xacro fallback used after xacro failure: error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene_preview.find_resolved.xacro; unresolved packages in local package map: ur_description; fallback warnings: include has unresolved substitution: $(find ur_description)/urdf/ur_macro.xacro; skipped unsupported xacro tag/macros call: ur_robot; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property",
+  "safe_for_preview": true,
   "unresolved_placeholder_count": 0,
-  "has_transform_collapse_warning": false,
-  "candidate_mesh_count": 0,
-  "emitted_visual_count": 0,
-  "transform_status_counts": {},
-  "mesh_format_counts": {},
-  "renderable_mesh_count": 0,
-  "renderable_item_count": 0,
+  "has_transform_collapse_warning": true,
+  "candidate_mesh_count": 2,
+  "emitted_visual_count": 2,
+  "transform_status_counts": {
+    "resolved": 2
+  },
+  "mesh_format_counts": {
+    ".stl": 1,
+    ".dae": 1
+  },
+  "renderable_mesh_count": 2,
+  "renderable_item_count": 2,
   "stale_index": false,
   "stale_reasons": [],
-  "visual_items": [],
+  "visual_items": [
+    {
+      "id": "urdf_visual_0_table_None",
+      "link": "table_",
+      "visual": "None_",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "aluminum",
+        "color": [
+          0.549,
+          0.557,
+          0.529,
+          1.0
+        ]
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://workbench_description/meshes/visual/table.stl",
+      "source_path": "package://workbench_description/meshes/visual/table.stl",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "resolved": true,
+      "mesh_scale": [
+        0.001,
+        0.001,
+        0.001
+      ],
+      "render_skip_reason": "",
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_1_camera_link_visual_1",
+      "link": "camera_link",
+      "visual": "visual_1",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->camera_bottom_screw_frame(fixed)",
+        "camera_bottom_screw_frame->camera_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "source_path": "package://realsense2_description/meshes/d435.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": ""
+    }
+  ],
   "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
+    "/root/.pyenv/versions/3.12.13/bin/xacro",
+    "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene_preview.find_resolved.xacro",
     "-o",
     "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/expanded_scene_preview.urdf",
     "use_fake_hardware:=true",
@@ -41,22 +158,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description/package.xml"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "workbench_description",
@@ -65,16 +170,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
         "package_name": "overhead_camera_gantry_description",
@@ -83,16 +182,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "pipe_camera_stand_description",
@@ -101,28 +206,28 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
       },
       {
         "package_name": "robotiq_3f_moveit_config",
@@ -137,16 +242,40 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -167,28 +296,16 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
@@ -199,18 +316,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -219,13 +326,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets"
       },
       {
@@ -234,13 +336,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -249,23 +356,23 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets"
       },
       {
@@ -279,13 +386,33 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
@@ -304,23 +431,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scenes/ur5_airpick4_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur5_airpick4_test/generated/scene3d_gui_smoke.json
@@ -1,0 +1,24 @@
+{
+  "schema": "workcell_studio_scene3d_gui_smoke/v1",
+  "status": "BLOCKED",
+  "scene": "ur5_airpick4_test",
+  "scene_path": "scenes/ur5_airpick4_test",
+  "generated_at": "2026-06-02T21:16:06.835026+00:00",
+  "evidence_mode": "offline_scene_local_blocker_record",
+  "source_mesh_index": "scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json",
+  "source_visual_count": 3,
+  "source_renderable_item_count": 3,
+  "mesh_source_count": 3,
+  "primitive_source_count": 0,
+  "rendered_count": 0,
+  "mesh_rendered_count": 0,
+  "primitive_rendered_count": 0,
+  "physical_rendered_count": 0,
+  "screenshot_available": false,
+  "blockers": [
+    "scene3d_gui_smoke_not_executed_in_this_offline_regeneration"
+  ],
+  "warnings": [
+    "This file is scene-local evidence that GUI smoke rendering is still blocked; it is not a rendered Scene3D pass."
+  ]
+}

--- a/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json
@@ -1,31 +1,201 @@
 {
   "scene_name": "ur5_airpick4_test",
-  "visual_count": 0,
-  "resolved": 0,
+  "visual_count": 3,
+  "resolved": 3,
   "unresolved": 0,
-  "generated_at": "2026-05-29T08:28:58.892638+00:00",
-  "extractor_version": "2.3",
-  "extraction_mode": "best_effort_recursive",
+  "generated_at": "2026-06-02T21:13:53.995303+00:00",
+  "extractor_version": "2.4",
+  "extraction_mode": "repo_local_xacro_expanded",
   "xacro_available": true,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780041434.6831822,
+  "source_mtime": 1780422990.551572,
   "source_expanded_urdf_path": "",
-  "fallback_reason": "error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
-  "safe_for_preview": false,
+  "fallback_reason": "repo-local xacro fallback used after xacro failure: error: substitution args not supported:  No module named 'ament_index_python'\nwhen processing file: /workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene_preview.find_resolved.xacro; unresolved packages in local package map: ur_description; fallback warnings: include has unresolved substitution: $(find ur_description)/urdf/ur_macro.xacro; skipped unsupported xacro tag/macros call: ur_robot; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property; skipped unsupported xacro tag/macros call: property",
+  "safe_for_preview": true,
   "unresolved_placeholder_count": 0,
   "has_transform_collapse_warning": false,
-  "candidate_mesh_count": 0,
-  "emitted_visual_count": 0,
-  "transform_status_counts": {},
-  "mesh_format_counts": {},
-  "renderable_mesh_count": 0,
-  "renderable_item_count": 0,
+  "candidate_mesh_count": 3,
+  "emitted_visual_count": 3,
+  "transform_status_counts": {
+    "resolved": 2,
+    "unresolved": 1
+  },
+  "mesh_format_counts": {
+    ".stl": 2,
+    ".dae": 1
+  },
+  "renderable_mesh_count": 3,
+  "renderable_item_count": 3,
   "stale_index": false,
   "stale_reasons": [],
-  "visual_items": [],
+  "visual_items": [
+    {
+      "id": "urdf_visual_0_table_None",
+      "link": "table_",
+      "visual": "None_",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "aluminum",
+        "color": [
+          0.549,
+          0.557,
+          0.529,
+          1.0
+        ]
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://workbench_description/meshes/visual/table.stl",
+      "source_path": "package://workbench_description/meshes/visual/table.stl",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "resolved": true,
+      "mesh_scale": [
+        0.001,
+        0.001,
+        0.001
+      ],
+      "render_skip_reason": "",
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_1_camera_link_visual_1",
+      "link": "camera_link",
+      "visual": "visual_1",
+      "parent_link": "world",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "resolved",
+      "transform_status": "resolved",
+      "transform_chain": [
+        "world->table_(fixed)",
+        "table_->camera_bottom_screw_frame(fixed)",
+        "camera_bottom_screw_frame->camera_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://realsense2_description/meshes/d435.dae",
+      "source_path": "package://realsense2_description/meshes/d435.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": ""
+    },
+    {
+      "id": "urdf_visual_2_gripper_base_link_visual_2",
+      "link": "gripper_base_link",
+      "visual": "visual_2",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0324
+        ],
+        "rpy": [
+          -1.5707,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->gripper_base_link(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://onrobot_airpick4_description/meshes/airpick4.stl",
+      "source_path": "package://onrobot_airpick4_description/meshes/airpick4.stl",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+      "resolved": true,
+      "mesh_scale": [
+        0.001,
+        0.001,
+        0.001
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    }
+  ],
   "xacro_command": [
-    "xacro",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
+    "/root/.pyenv/versions/3.12.13/bin/xacro",
+    "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene_preview.find_resolved.xacro",
     "-o",
     "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/expanded_scene_preview.urdf",
     "use_fake_hardware:=true",
@@ -41,22 +211,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description/package.xml"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "workbench_description",
@@ -65,16 +223,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
         "package_name": "overhead_camera_gantry_description",
@@ -83,16 +235,22 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "pipe_camera_stand_description",
@@ -101,28 +259,28 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
       },
       {
         "package_name": "robotiq_3f_moveit_config",
@@ -137,16 +295,40 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
         "package_name": "ur5_moveit_config",
@@ -167,28 +349,16 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       }
     ],
     "shadowed_packages": [],
@@ -199,18 +369,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -219,13 +379,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "table_clamp_camera_mount_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets"
       },
       {
@@ -234,13 +389,18 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "sorting_bin_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -249,23 +409,23 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "package_name": "realsense2_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets"
       },
       {
@@ -279,13 +439,33 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "single_suction_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
@@ -304,23 +484,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "fanuc_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       }
     ]

--- a/scripts/extract_scene_urdf_visual_mesh_index.py
+++ b/scripts/extract_scene_urdf_visual_mesh_index.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import argparse, json, os, re, shutil, subprocess, math, collections
+import argparse, json, os, re, shutil, subprocess, math, collections, copy, sys
 from pathlib import Path
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
@@ -10,6 +10,9 @@ ROOT = Path(__file__).resolve().parents[1]
 SCENES_ROOT = ROOT / "scenes"
 EXTRACTOR_VERSION = "2.4"
 PLACEHOLDER_RE = re.compile(r"(\$\{[^}]+\}|\$\(arg\s+[^)]+\)|\$\(find\s+[^)]+\))")
+FIND_RE = re.compile(r"\$\(find\s+([^)\s]+)\)")
+ARG_RE = re.compile(r"\$\(arg\s+([^)\s]+)\)")
+EXPR_RE = re.compile(r"\$\{([^}]+)\}")
 
 def read_yaml(path):
     try:return yaml.safe_load(Path(path).read_text()) if Path(path).exists() else None
@@ -84,34 +87,206 @@ def discover_package_map(scene_dir, workspace_root=None):
             diagnostics['resolution_paths'].append({'package_name':pkg_name,'root_path':str(pkg_dir),'source_tier':tier})
     return out, diagnostics
 
-def xacro_env(scene_dir, workspace_root=None):
+def _pythonpath_candidates():
+    candidates=[str(ROOT), str(ROOT/'scripts')]
+    for base in [Path('/opt/ros/humble/lib/python3.10/site-packages'), Path('/opt/ros/humble/local/lib/python3.10/dist-packages')]:
+        if base.exists(): candidates.append(str(base))
+    old=os.environ.get('PYTHONPATH','')
+    if old: candidates.extend(old.split(os.pathsep))
+    return [p for p in dict.fromkeys(candidates) if p]
+
+def xacro_env(scene_dir, workspace_root=None, package_map=None):
     rp=[str(ROOT),str(ROOT/'assets'),str(ROOT/'workcell_builder/workcell_builder/assets'),str(ROOT/'scenes')]
     if workspace_root:
         ws = Path(workspace_root); rp += [str(ws/'install'), str(ws/'install/share'), str(ws/'src'), str(ws/'src/easy_manipulation_deployment/assets'), str(ws/'src/assets')]
+    if package_map:
+        rp += [str(p.parent) for p in package_map.values()]
     if Path('/opt/ros/humble/share').exists(): rp.append('/opt/ros/humble/share')
     old=os.environ.get('ROS_PACKAGE_PATH','')
     if old: rp.append(old)
-    env=dict(os.environ); env['ROS_PACKAGE_PATH']=':'.join(dict.fromkeys([p for p in rp if p])); env['AMENT_PREFIX_PATH']=os.environ.get('AMENT_PREFIX_PATH',''); return env
+    env=dict(os.environ)
+    env['ROS_PACKAGE_PATH']=':'.join(dict.fromkeys([p for p in rp if p]))
+    env['PYTHONPATH']=os.pathsep.join(_pythonpath_candidates())
+    env['AMENT_PREFIX_PATH']=os.environ.get('AMENT_PREFIX_PATH','')
+    return env
 
 def discover_xacro_command():
-    if shutil.which('xacro'): return ['xacro'], True, ''
-    if Path('/opt/ros/humble/bin/xacro').exists(): return ['/opt/ros/humble/bin/xacro'], True, ''
-    mod = subprocess.run(['python3', '-m', 'xacro', '--help'], capture_output=True, text=True)
-    if mod.returncode == 0: return ['python3', '-m', 'xacro'], True, ''
-    return None, False, "xacro executable unavailable"
+    candidates=[]
+    if shutil.which('xacro'): candidates.append([shutil.which('xacro')])
+    if Path('/opt/ros/humble/bin/xacro').exists(): candidates.append(['/opt/ros/humble/bin/xacro'])
+    candidates.append([sys.executable, '-m', 'xacro'])
+    candidates.append(['python3', '-m', 'xacro'])
+    reasons=[]
+    for cmd in candidates:
+        try:
+            mod = subprocess.run(cmd + ['--help'], capture_output=True, text=True, timeout=10, env=xacro_env(ROOT))
+            if mod.returncode == 0:
+                return cmd, True, ''
+            reasons.append(' '.join(cmd)+': '+(mod.stderr or mod.stdout or f'rc={mod.returncode}').strip())
+        except Exception as e:
+            reasons.append(' '.join(cmd)+f': {e}')
+    return None, False, 'xacro executable unavailable; ' + '; '.join(reasons[:3])
+
+def _resolve_find_text(text, package_map):
+    missing=[]
+    def repl(m):
+        pkg=m.group(1)
+        if pkg in package_map:
+            return str(package_map[pkg])
+        missing.append(pkg)
+        return m.group(0)
+    return FIND_RE.sub(repl, text or ''), missing
+
+def _eval_expr(expr, context):
+    expr=str(expr).strip()
+    safe={'pi':math.pi, 'true':True, 'false':False}
+    safe.update({k:v for k,v in context.items() if re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', k)})
+    try:
+        return str(eval(expr, {'__builtins__':{}}, safe))
+    except Exception:
+        return str(context.get(expr, '${'+expr+'}'))
+
+def _subst_text(value, context, package_map):
+    text, _ = _resolve_find_text(str(value or ''), package_map)
+    text = ARG_RE.sub(lambda m: str(context.get(m.group(1), '')), text)
+    text = EXPR_RE.sub(lambda m: _eval_expr(m.group(1), context), text)
+    return text
+
+def _is_xacro(elem, local=None):
+    name=tag_name(elem)
+    if local and name != local: return False
+    return elem.tag.startswith('{') and 'xacro' in elem.tag.split('}')[0]
+
+def _clone_regular(elem, context, package_map, macros, warnings, blocks=None):
+    if _is_xacro(elem, 'insert_block'):
+        name=elem.attrib.get('name','')
+        block=(blocks or {}).get(name)
+        return [copy.deepcopy(block)] if block is not None else []
+    if _is_xacro(elem, 'if'):
+        val=_subst_text(elem.attrib.get('value',''), context, package_map).strip().lower()
+        if val not in {'true','1','yes'}: return []
+        out=[]
+        for child in list(elem): out.extend(_clone_regular(child, context, package_map, macros, warnings, blocks))
+        return out
+    if _is_xacro(elem):
+        macro=macros.get(tag_name(elem))
+        if macro is None:
+            warnings.append(f'skipped unsupported xacro tag/macros call: {tag_name(elem)}')
+            return []
+        return _expand_macro(elem, macro, context, package_map, macros, warnings)
+    new=ET.Element(tag_name(elem), {k:_subst_text(v, context, package_map) for k,v in elem.attrib.items()})
+    if elem.text and elem.text.strip(): new.text=_subst_text(elem.text, context, package_map)
+    for child in list(elem):
+        for expanded in _clone_regular(child, context, package_map, macros, warnings, blocks): new.append(expanded)
+    return [new]
+
+def _expand_macro(call, macro, parent_context, package_map, macros, warnings):
+    params, children = macro
+    context=dict(parent_context)
+    block_names=[]
+    for token in params.split():
+        if token.startswith('*'):
+            block_names.append(token[1:]); continue
+        name, _, default = token.partition(':=')
+        if name:
+            context[name]=_subst_text(call.attrib.get(name, default), parent_context, package_map)
+    for key, value in call.attrib.items(): context[key]=_subst_text(value, parent_context, package_map)
+    blocks={}
+    for child in list(call):
+        lname=tag_name(child)
+        if lname in block_names or lname == 'origin':
+            blocks[lname]=_clone_regular(child, context, package_map, macros, warnings)[0]
+    out=[]
+    for child in children:
+        out.extend(_clone_regular(child, context, package_map, macros, warnings, blocks))
+    return out
+
+def _collect_macros(path, package_map, context, macros, visited, warnings):
+    path=Path(path)
+    if path in visited: return
+    visited.add(path)
+    if not path.exists():
+        warnings.append(f'include not found: {path}')
+        return
+    try:
+        root=ET.fromstring(path.read_text(errors='ignore'))
+    except Exception as e:
+        warnings.append(f'include parse failed: {path}: {e}')
+        return
+    for child in list(root):
+        if _is_xacro(child, 'arg'):
+            context.setdefault(child.attrib.get('name',''), _subst_text(child.attrib.get('default',''), context, package_map))
+        elif _is_xacro(child, 'include'):
+            inc=_subst_text(child.attrib.get('filename',''), context, package_map)
+            if '$(' in inc:
+                warnings.append(f'include has unresolved substitution: {inc}')
+            else:
+                _collect_macros(Path(inc), package_map, context, macros, visited, warnings)
+        elif _is_xacro(child, 'macro'):
+            macros[child.attrib.get('name','')]=(child.attrib.get('params',''), [copy.deepcopy(c) for c in list(child)])
+
+def expand_xacro_repo_local(urdf_path, scene_dir, xacro_args, workspace_root=None):
+    package_map, diagnostics = discover_package_map(scene_dir, workspace_root=workspace_root)
+    warnings=[]; context={'pi':str(math.pi)}
+    context.update({k:str(v) for k,v in (xacro_args or {}).items()})
+    try:
+        root=ET.fromstring(Path(urdf_path).read_text(errors='ignore'))
+    except Exception as e:
+        return None, f'repo-local xacro parse failed: {e}', diagnostics
+    for child in list(root):
+        if _is_xacro(child, 'arg'):
+            name=child.attrib.get('name','')
+            context.setdefault(name, _subst_text(child.attrib.get('default',''), context, package_map))
+    macros={}; visited=set()
+    for child in list(root):
+        if _is_xacro(child, 'include'):
+            inc=_subst_text(child.attrib.get('filename',''), context, package_map)
+            if '$(' in inc:
+                warnings.append(f'include has unresolved substitution: {inc}')
+            else:
+                _collect_macros(Path(inc), package_map, context, macros, visited, warnings)
+    out_root=ET.Element('robot', {'name': root.attrib.get('name', scene_dir.name)})
+    for child in list(root):
+        if _is_xacro(child, 'arg') or _is_xacro(child, 'include') or _is_xacro(child, 'macro'):
+            continue
+        for expanded in _clone_regular(child, context, package_map, macros, warnings): out_root.append(expanded)
+    xml_text=ET.tostring(out_root, encoding='unicode')
+    return xml_text, '; '.join(warnings), diagnostics
 
 def expand_xacro(urdf_path, scene_dir=None, xacro_args=None, workspace_root=None):
     scene_dir = scene_dir or Path(urdf_path).parents[1]; xacro_args = xacro_args or {}
+    package_map, _ = discover_package_map(scene_dir, workspace_root=workspace_root)
     xacro_base, xacro_available, reason = discover_xacro_command()
-    if not xacro_available: return None,False,reason,None
-    cmd=xacro_base+[str(urdf_path),'-o',str(scene_dir/'generated'/'expanded_scene_preview.urdf')]
-    for k,v in xacro_args.items(): cmd.append(f'{k}:={v}')
-    try:
-        (scene_dir/'generated').mkdir(parents=True,exist_ok=True)
-        p=subprocess.run(cmd,capture_output=True,text=True,timeout=45,env=xacro_env(scene_dir, workspace_root=workspace_root))
-        if p.returncode!=0: return None,True,(p.stderr or p.stdout or 'xacro failed').strip(),cmd
-        out=scene_dir/'generated'/'expanded_scene_preview.urdf'; return out.read_text(errors='ignore'),True,'',cmd
-    except Exception as e: return None,True,f'xacro expansion failed: {e}',cmd
+    cmd=None; real_error=''
+    if xacro_available:
+        try:
+            (scene_dir/'generated').mkdir(parents=True,exist_ok=True)
+            for stale in [scene_dir/'generated'/'expanded_scene_preview.urdf', scene_dir/'generated'/'scene_preview.find_resolved.xacro']:
+                if stale.exists(): stale.unlink()
+            source_text=Path(urdf_path).read_text(errors='ignore')
+            resolved_text, missing_pkgs = _resolve_find_text(source_text, package_map)
+            input_path=scene_dir/'generated'/'scene_preview.find_resolved.xacro'
+            input_path.write_text(resolved_text, encoding='utf-8')
+            out=scene_dir/'generated'/'expanded_scene_preview.urdf'
+            cmd=xacro_base+[str(input_path),'-o',str(out)]
+            for k,v in xacro_args.items(): cmd.append(f'{k}:={v}')
+            p=subprocess.run(cmd,capture_output=True,text=True,timeout=45,env=xacro_env(scene_dir, workspace_root=workspace_root, package_map=package_map))
+            if p.returncode==0:
+                return out.read_text(errors='ignore'),True,'',cmd,'xacro_expanded'
+            real_error=(p.stderr or p.stdout or 'xacro failed').strip()
+            if input_path.exists(): input_path.unlink()
+            if missing_pkgs:
+                real_error += '; unresolved packages in local package map: ' + ', '.join(sorted(set(missing_pkgs)))
+        except Exception as e:
+            real_error=f'xacro expansion failed: {e}'
+    xml_text, local_warning, _ = expand_xacro_repo_local(urdf_path, scene_dir, xacro_args, workspace_root=workspace_root)
+    if xml_text:
+        reason_text='repo-local xacro fallback used'
+        if real_error: reason_text += f' after xacro failure: {real_error}'
+        elif reason: reason_text += f': {reason}'
+        if local_warning: reason_text += f'; fallback warnings: {local_warning}'
+        return xml_text, bool(xacro_available), reason_text, (cmd or []), 'repo_local_xacro_expanded'
+    return None,bool(xacro_available),(real_error or reason or local_warning or 'xacro failed'),(cmd or []),'best_effort_recursive'
 
 def resolve_mesh_uri(uri, package_map):
     u=(uri or '').strip()
@@ -218,7 +393,10 @@ def main():
                 expanded_result = expand_xacro(urdf_path,scene_dir,xargs,workspace_root=(a.workspace_root or None))
             except TypeError:
                 expanded_result = expand_xacro(urdf_path)
-            if isinstance(expanded_result, tuple) and len(expanded_result) >= 4:
+            if isinstance(expanded_result, tuple) and len(expanded_result) >= 5:
+                xml_text,_,err,xacro_cmd,mode_hint=expanded_result[:5]
+                if mode_hint: mode=str(mode_hint)
+            elif isinstance(expanded_result, tuple) and len(expanded_result) >= 4:
                 xml_text,_,err,xacro_cmd=expanded_result[:4]
             elif isinstance(expanded_result, tuple) and len(expanded_result) == 3:
                 xml_text,mode_hint,err=expanded_result; xacro_cmd=[]
@@ -226,16 +404,19 @@ def main():
                 if mode_hint and not xml_text: mode=str(mode_hint)
             else:
                 xml_text,err,xacro_cmd='', 'xacro expansion failed: unexpected extractor result', []
-            if xml_text: mode='xacro_expanded'; expanded_path='generated/expanded_scene_preview.urdf'
+            if xml_text:
+                if mode == 'best_effort_recursive': mode='xacro_expanded'
+                expanded_path='generated/expanded_scene_preview.urdf' if (scene_dir/'generated'/'expanded_scene_preview.urdf').exists() else ''
+                if mode != 'xacro_expanded': fallback_reason=err or missing_reason
             else: fallback_reason=err or missing_reason
-        if a.require_xacro and not xacro_avail:
-            print('xacro executable unavailable (required)'); return 2
+        if a.require_xacro and not xacro_avail and mode != 'repo_local_xacro_expanded':
+            print('xacro executable unavailable and repo-local xacro expansion failed (required)'); return 2
         if not xml_text: xml_text=(urdf_path.read_text(errors='ignore') if urdf_path.exists() else '<robot/>')
         package_map, package_diagnostics = discover_package_map(scene_dir, workspace_root=(a.workspace_root or None))
         try: items=extract_from_urdf(xml_text, package_map)
         except Exception: items=[]
         unresolved=[i for i in items if any(contains_placeholder(i.get(k,'')) for k in ('id','link','parent_link'))]
-        safe=bool(items) and (len(unresolved)==0) and (mode=='xacro_expanded')
+        safe=bool(items) and (len(unresolved)==0) and (mode in {'xacro_expanded','repo_local_xacro_expanded'})
         mesh_format_counts=dict(collections.Counter((Path(i.get('resolved_source_path') or i.get('source_path') or '').suffix.lower() or 'unknown') for i in items if i.get('geometry_type')=='mesh'))
         transform_status_counts=dict(collections.Counter(str(i.get('transform_status') or 'unknown') for i in items))
         renderable_count=sum(1 for i in items if i.get('render_expected', True))
@@ -251,8 +432,8 @@ def main():
         report['visual_count']+=len(items)
         report['resolved']+=sum(1 for i in items if i.get('resolved'))
         report['unresolved']+=sum(1 for i in items if not i.get('resolved'))
-        report['xacro_expanded_count']+=int(mode=='xacro_expanded')
-        report['best_effort_count']+=int(mode!='xacro_expanded')
+        report['xacro_expanded_count']+=int(mode in {'xacro_expanded','repo_local_xacro_expanded'})
+        report['best_effort_count']+=int(mode not in {'xacro_expanded','repo_local_xacro_expanded'})
         report.setdefault('mesh_format_counts', {})
         for ext,count in mesh_format_counts.items(): report['mesh_format_counts'][ext]=report['mesh_format_counts'].get(ext,0)+count
         report['renderable_mesh_count']=report.get('renderable_mesh_count',0)+renderable_mesh_count
@@ -261,7 +442,7 @@ def main():
         report['emitted_visual_count']=report.get('emitted_visual_count',0)+len(items)
         report['unresolved_placeholder_count']=report.get('unresolved_placeholder_count',0)+len(unresolved)
         report['scenes'].append({'scene':scene_dir.name,'extraction_mode':mode,'xacro_available':payload['xacro_available'],'expanded_urdf_written':bool(expanded_path),'safe_for_preview':safe,'unresolved_placeholder_count':len(unresolved),'mesh_backed_count':sum(1 for i in items if i.get('geometry_type')=='mesh'),'skipped_count':sum(1 for i in items if i.get('render_skip_reason')),'fallback_reason':fallback_reason,'urdf_primitive_count':sum(1 for i in items if i.get('geometry_type') in ('box','cylinder','sphere','capsule')),'primitive_fallback_count':0,'stale_index':False,'status':'PASS' if safe else 'WARN'})
-        if a.require_xacro and mode != 'xacro_expanded': return 2
+        if a.require_xacro and mode not in {'xacro_expanded','repo_local_xacro_expanded'}: return 2
     (ROOT/'build').mkdir(exist_ok=True)
     (ROOT/'build/workcell_studio_urdf_visual_mesh_index_report.json').write_text(json.dumps(report,indent=2)+'\n')
     if a.fail_on_unexpanded and report['best_effort_count']>0: return 3


### PR DESCRIPTION
### Motivation
- The generic mesh-index extractor produced stale/empty `generated/scene_visual_mesh_index.json` for many supported scenes because xacro expansion failed in this environment (missing `ament_index_python`) and `$(find ...)` package references were unresolved. 
- The intent is to allow credible repo-local resolution of package `$(find ...)` references and provide a safe fallback xacro expansion path so scene geometry can be indexed without executing ROS launches. 
- Readiness tooling requires honest scene-local evidence (mesh index and GUI-smoke artifacts) to avoid pretending scenes are Scene3D-ready. 

### Description
- Extended `scripts/extract_scene_urdf_visual_mesh_index.py` to add repo-local resolution and safe xacro fallback by introducing `FIND_RE/ARG_RE/EXPR_RE`, `expand_xacro_repo_local`, `/_resolve_find_text/_subst_text` helpers, enriched `xacro_env` to set `PYTHONPATH`, and a more flexible `discover_xacro_command` that tries multiple candidates; the extractor now resolves `$(find ...)` against a repo package map and falls back to a repo-local macro expansion when system xacro/ament paths are incomplete. 
- Updated xacro expansion/mode handling so `repo_local_xacro_expanded` counts as valid preview evidence while preserving `fallback_reason` and avoiding false claims of full ROS-expanded URDFs. 
- Regenerated scene-local artifacts for supported scenes, producing nonzero `visual_items`, `visual_count`, and `renderable_item_count` for: `suction_test`, `ur10_2f_test`, `ur3_suction_test`, `ur5_2f_builder_pick_place_demo`, `ur5_2f_test`, `ur5_3f_test`, `ur5_airpick4_test`, and `ur5_2f_sorting_test`. 
- Added honest scene-local blocker evidence `generated/scene3d_gui_smoke.json` for the affected scenes and updated `scenes/supported_scenes.yaml` to require/reflect scene-local smoke evidence and to replace the stale zero-mesh-index blocker with the remaining Scene3D smoke/cell-definition blockers. 

### Testing
- Baseline readiness matrix before changes was recorded with `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --output-dir build/readiness_before` and reported `PASS=0 FAIL=1 BLOCKED=7`. 
- After changes the readiness matrix run with `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --output-dir build/readiness_after_final` reported `PASS=0 FAIL=0 BLOCKED=8` showing mesh-index evidence is now present while GUI-smoke remains intentionally blocked. 
- Ran extraction validation and unit smoke checks: `python3 scripts/extract_scene_urdf_visual_mesh_index.py --all --fail-on-unexpanded --no-write` succeeded and `python3 -m py_compile scripts/extract_scene_urdf_visual_mesh_index.py` passed. 
- Validated regenerated artifacts for key scenes with `python3 scripts/validate_builder_generated_scene.py scenes/suction_test --json`, `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json`, and `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_sorting_test --json`, all of which passed. 
- One existing contract check remains failing and unchanged by this PR: `python3 scripts/validate_scene3d_mesh_preview_contract.py` reports a pre-existing token blocker (`FIT_PHYSICAL_ONLY_FILTER`) which is unrelated to the extractor changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f461179488331ac24e3a83fc5a458)