### PR TITLE
Add disabled camera and commissioning object to ur5_2f_test cell_definition.yaml

### DIFF
--- a/scenes/ur5_2f_test/cell_definition.yaml
+++ b/scenes/ur5_2f_test/cell_definition.yaml
@@ -14,9 +14,19 @@ end_effector:
   type: finger
   brand: robotiq
   grasp_frame: tool0
+camera:
+  enabled: false
+  camera_id: UNKNOWN_CAMERA
+  frame_id: UNKNOWN_FRAME
 environment:
   frame: world
   layout: layout/workcell_studio_layout.yaml
+objects:
+  - id: commissioning_object
+    frame: world
+    pose_xyz: [0.45, 0.25, 0.1]
+    pose_rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.05, 0.05, 0.05]
 task:
   id: default_task
   type: pick_place


### PR DESCRIPTION
### Motivation
- Ensure `scenes/ur5_2f_test/cell_definition.yaml` exposes the required top-level `camera` mapping and `objects` list so it satisfies the `scripts/validate_cell_definition.py` contract.
- Provide scene-local, fake-hardware-safe metadata that mirrors the disabled camera already present in `environment.yaml` and supplies an explicit commissioning object for offline task intent validation.
- Avoid enabling any live perception or real-hardware runtime paths while making the scene self-describing for downstream tooling.

### Description
- Added a top-level `camera` mapping with `enabled: false`, `camera_id: UNKNOWN_CAMERA`, and `frame_id: UNKNOWN_FRAME` to the scene cell definition so the cell exposes a disabled camera capability.
- Added a top-level `objects` list containing a single `commissioning_object` entry with `id: commissioning_object`, `frame: world`, `pose_xyz`, `pose_rpy`, and positive `dimensions` so the object's metadata matches `task.source_object`.
- Preserved existing `task.destinations` and `task.rules` and kept all IDs aligned with the existing destination `default_drop_zone` and task source reference.
- Limited the change to `scenes/ur5_2f_test/cell_definition.yaml` and did not enable any runtime execution, real hardware flags, or perception modes.

### Testing
- Ran `python3 scripts/validate_cell_definition.py scenes/ur5_2f_test/cell_definition.yaml --json` which completed with no errors and produced a `WARN` result only due to the existing `environment.layout` pointing to a missing `layout/workcell_studio_layout.yaml`.
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` which completed with `ok: true` and only returned existing optional/generated metadata warnings.
- No automated tests failed and the changes preserved fake-hardware-first safety (no real-hardware or perception runtime enabled).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20437dcce0833192c9d2bc5e898da3)