### PR TITLE
Resolve Workcell Builder executable from build tree

### DIFF
--- a/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json
@@ -6,9 +6,11 @@
   "workspace_root": "/workspace/Easy_Manipulator_Improved",
   "executable": null,
   "searched_paths": [
-    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder",
     "/workspace/Easy_Manipulator_Improved/install/workcell_builder/lib/workcell_builder/workcell_builder",
-    "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder"
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/install/bin/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder/workcell_builder"
   ],
   "blockers": [
     "unable_to_resolve_workcell_builder_executable"

--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -9,7 +9,7 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 from scripts.workcell_studio_script_bootstrap import ensure_repo_root_on_sys_path
 ensure_repo_root_on_sys_path(__file__)
-from scripts.workcell_studio_path_resolver import resolve_repo_root, resolve_workspace_root, resolve_workcell_builder_executable
+from scripts.workcell_studio_path_resolver import resolve_repo_root, resolve_workspace_root, resolve_workcell_builder_executable, workcell_builder_executable_candidates
 from scripts.scene_root_resolver import resolve_scene_root
 from scripts.scene3d_scene_discovery import discover_scene3d_scenes
 
@@ -19,12 +19,8 @@ def _tail(text: str, lines: int = 40) -> str:
     parts = (text or "").splitlines()
     return "\n".join(parts[-lines:])
 
-def _resolve_executable_candidates(workspace_root: Path) -> list[Path]:
-    c = []
-    path_hit = shutil.which("workcell_builder")
-    if path_hit: c.append(Path(path_hit))
-    c.extend([workspace_root / "install/workcell_builder/bin/workcell_builder", workspace_root / "install/workcell_builder/lib/workcell_builder/workcell_builder", workspace_root / "build/workcell_builder/workcell_builder"])
-    return c
+def _resolve_executable_candidates(workspace_root: Path | None) -> list[Path]:
+    return workcell_builder_executable_candidates(workspace_root)
 
 def build_cmd(exe: Path | str, args: argparse.Namespace) -> list[str]:
     cmd = [str(exe), "--scene3d-smoke"]

--- a/scripts/workcell_studio_path_resolver.py
+++ b/scripts/workcell_studio_path_resolver.py
@@ -50,6 +50,25 @@ def resolve_install_setup(workspace_root: Path | None) -> Path | None:
     return setup if setup.exists() else None
 
 
+def workcell_builder_executable_candidates(workspace_root: Path | None) -> list[Path]:
+    candidates: list[Path] = []
+
+    path_hit = shutil.which("workcell_builder")
+    if path_hit:
+        candidates.append(Path(path_hit))
+
+    if workspace_root:
+        candidates.extend([
+            workspace_root / "install" / "workcell_builder" / "lib" / "workcell_builder" / "workcell_builder",
+            workspace_root / "install" / "workcell_builder" / "bin" / "workcell_builder",
+            workspace_root / "install" / "bin" / "workcell_builder",
+            workspace_root / "build" / "workcell_builder" / "workcell_builder",
+            workspace_root / "build" / "workcell_builder" / "workcell_builder" / "workcell_builder",
+        ])
+
+    return candidates
+
+
 def resolve_workcell_builder_executable(workspace_root: Path | None, explicit_executable: Path | str | None = None) -> Path | None:
     searched: list[Path] = []
     if explicit_executable:
@@ -58,20 +77,7 @@ def resolve_workcell_builder_executable(workspace_root: Path | None, explicit_ex
         _LAST["searched_executable_paths"] = [str(p) for p in searched]
         return exe if exe.exists() and os.access(exe, os.X_OK) else None
 
-    path_hit = shutil.which("workcell_builder")
-    if path_hit:
-        p = Path(path_hit)
-        searched.append(p)
-        if p.exists() and os.access(p, os.X_OK):
-            _LAST["searched_executable_paths"] = [str(x) for x in searched]
-            return p
-
-    if workspace_root:
-        searched.extend([
-            workspace_root / "install" / "workcell_builder" / "lib" / "workcell_builder" / "workcell_builder",
-            workspace_root / "install" / "workcell_builder" / "bin" / "workcell_builder",
-            workspace_root / "install" / "bin" / "workcell_builder",
-        ])
+    searched.extend(workcell_builder_executable_candidates(workspace_root))
     _LAST["searched_executable_paths"] = [str(p) for p in searched]
     for p in searched:
         if p.exists() and os.access(p, os.X_OK):


### PR DESCRIPTION
### Motivation
- Ensure the Workcell Builder smoke runner can find the built executable in developer build trees in addition to PATH and install-space locations.
- Keep existing PATH and install-space resolution behavior intact while making diagnostic `searched_paths` reflect real resolver behavior.
- Preserve strict executable checks so the smoke test never fabricates a PASS without a real `workcell_builder` binary.

### Description
- Add a shared helper `workcell_builder_executable_candidates(workspace_root)` that returns PATH/install candidates plus two build-tree candidates: `build/workcell_builder/workcell_builder` and `build/workcell_builder/workcell_builder/workcell_builder`.
- Refactor `resolve_workcell_builder_executable` to use the new helper and retain the requirement that a candidate `exists()` and is executable via `os.access(..., os.X_OK)` before returning it.
- Update the Scene3D GUI smoke diagnostic `_resolve_executable_candidates()` in `scripts/run_workcell_builder_scene3d_gui_smoke.py` to delegate to the shared helper so `searched_paths` are consistent with actual resolution order.
- Regenerate `scenes/ur5_2f_test/generated/scene3d_gui_smoke.json` with the existing smoke runner so the reported `searched_paths` include the new build-tree candidates.

### Testing
- `python3 -m py_compile scripts/workcell_studio_path_resolver.py scripts/run_workcell_builder_scene3d_gui_smoke.py` succeeded.
- A runtime assertion script verifying candidate order (`workcell_builder_executable_candidates` vs smoke `_resolve_executable_candidates`) passed locally and printed `candidate_order_ok`.
- Running the smoke wrapper to regenerate the `ur5_2f_test` report produced an updated `scene3d_gui_smoke.json` and correctly remained `FAIL` with blocker `unable_to_resolve_workcell_builder_executable` because no real `workcell_builder` binary exists in this container.
- Attempted `colcon build` validation is blocked in this container because `/opt/ros/humble/setup.bash` is not present, so no built executable was produced during these CI checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a204394d1b88331ab2f7c973b3fb60b)