### PR TITLE
Record ur5 Scene3D smoke environment blocker

### DIFF
--- a/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json
@@ -11,8 +11,19 @@
     "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder"
   ],
   "blockers": [
-    "unable_to_resolve_workcell_builder_executable"
+    "environment_missing_ros_ament_cmake_prevents_workcell_builder_build_and_scene3d_gui_smoke"
   ],
   "warnings": [],
-  "screenshot_available": false
+  "screenshot_available": false,
+  "build_attempt": {
+    "command": "colcon build --symlink-install --packages-select workcell_builder --cmake-args -DBUILD_TESTING=OFF",
+    "cwd": "/workspace/Easy_Manipulator_Improved",
+    "returncode": 1,
+    "stderr_tail": "CMake Error at CMakeLists.txt:27 (find_package): By not providing Findament_cmake.cmake in CMAKE_MODULE_PATH this project has asked CMake to find a package configuration file provided by ament_cmake, but CMake did not find one. Could not find a package configuration file provided by ament_cmake with any of the following names: ament_cmakeConfig.cmake, ament_cmake-config.cmake."
+  },
+  "smoke_runner_attempt": {
+    "command": "python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --scene ur5_2f_test --output scenes/ur5_2f_test/generated/scene3d_gui_smoke.json --screenshot scenes/ur5_2f_test/generated/scene3d_gui_smoke.png --xvfb",
+    "returncode": 1,
+    "stdout_tail": "status=FAIL smoke_status=MISSING_EXECUTABLE\nsearched_paths=/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder | /workspace/Easy_Manipulator_Improved/install/workcell_builder/lib/workcell_builder/workcell_builder | /workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder"
+  }
 }


### PR DESCRIPTION
### Motivation
- Attempted to regenerate the Scene3D GUI smoke evidence for `ur5_2f_test`, but the container could not build or run the real `workcell_builder` executable due to missing ROS/ament environment, so the smoke JSON must truthfully record an environment-only blocker.

### Description
- Update `scenes/ur5_2f_test/generated/scene3d_gui_smoke.json` to preserve the `workcell_studio_scene3d_gui_smoke/v1` schema, set `status: FAIL`, include `searched_paths` and a clear `blockers` entry `environment_missing_ros_ament_cmake_prevents_workcell_builder_build_and_scene3d_gui_smoke`, and embed a `build_attempt` (attempted `colcon` command + stderr tail) and `smoke_runner_attempt` (wrapper command + stdout tail) so the failure is reproducible and auditable.

### Testing
- Ran `python3 -m pip install -q colcon-common-extensions` which succeeded to enable the build attempt. 
- Ran `colcon build --symlink-install --packages-select workcell_builder --cmake-args -DBUILD_TESTING=OFF` which failed due to missing `ament_cmake` (environment blocker). 
- Ran `python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --scene ur5_2f_test --output scenes/ur5_2f_test/generated/scene3d_gui_smoke.json --screenshot scenes/ur5_2f_test/generated/scene3d_gui_smoke.png --xvfb` which failed truthfully because no `workcell_builder` executable was available. 
- Verified the updated JSON with `python3 -m json.tool scenes/ur5_2f_test/generated/scene3d_gui_smoke.json` (succeeded). 
- Ran `python3 scripts/validate_scene3d_visual_quality_matrix.py` with a synthetic fixture which failed as expected because GUI render counters (e.g. `mesh_rendered_count`) could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a204398121c8331ad43ce1e1d92d367)