### PR TITLE
Update ur5_2f_test authoring metadata to reflect authored layout and task intent

### DIFF
--- a/scenes/ur5_2f_test/config/workcell_builder_task_intent.yaml
+++ b/scenes/ur5_2f_test/config/workcell_builder_task_intent.yaml
@@ -1,5 +1,5 @@
 schema: workcell_builder_task_intent/v1
-scene_package: /workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test
+scene_package: scenes/ur5_2f_test
 task:
   id: ur5_2f_test_preview_task
   type: pick_place
@@ -11,18 +11,24 @@ pick:
     id: pick_zone_main
 place:
   target:
-    type: zone
-    id: place_zone_main
+    type: destination
+    id: bin_red
   release_strategy: tool_release
 grasp:
-  strategy: tool_profile_default
+  strategy_ref: finger_pinch_basic
   approach_axis: z_down
+  approach_distance_m: 0.12
   retreat_axis: z_up
+  retreat_distance_m: 0.10
 safety:
   preview_only: true
   use_fake_hardware: true
   execution_mode: simulation_preview
   no_robot_motion: true
+  metadata_only: true
+  runtime_io_applied: false
+  motion_started: false
+  ros_launch_started: false
 provenance:
   mode: generated_readiness_metadata
   sources:

--- a/scenes/ur5_2f_test/environment.yaml
+++ b/scenes/ur5_2f_test/environment.yaml
@@ -30,12 +30,12 @@ camera:
 task:
   template: pick_place
   pick:
-    source_ref: 
-    object_ref: 
+    source_ref: pick_zone_main
+    object_ref: red_box_001
   place:
-    target_ref: 
+    target_ref: bin_red
   grasp:
-    strategy: auto
+    strategy: finger_pinch_basic
     approach_axis: z_down
     orientation_mode: vertical
     approach_distance_m: 0.12
@@ -79,10 +79,4 @@ metadata:
   scene_schema_version: workcell_scene/v1
   scene_schema_warnings:
     - camera disabled: no camera selection
-  scene_schema_blockers:
-    - Support surface/table must be selected
-    - Pick area must be selected
-    - Place target must be selected
-    - Grasp strategy must be selected
-    - Pick source is required
-    - Place target is required
+  scene_schema_blockers: []


### PR DESCRIPTION
### Motivation
- Align the scene authoring metadata with the actual `ur5_2f_test` layout and task intent so builder validators report truthful readiness. 
- Remove stale schema blockers that are now satisfied by existing `layout/workcell_studio_layout.yaml` and `config/workcell_builder_task_intent.yaml` entries. 
- Preserve safety-first defaults and keep camera/perception runtime disabled.

### Description
- Updated `scenes/ur5_2f_test/environment.yaml` to set `task.pick.source_ref` to `pick_zone_main`, `task.pick.object_ref` to `red_box_001`, `task.place.target_ref` to `bin_red`, and `task.grasp.strategy` to `finger_pinch_basic`. 
- Cleared obsolete `metadata.scene_schema_blockers` (now `scene_schema_blockers: []`) since pick/place/grasp are authoritatively defined via layout/task intent. 
- Updated `scenes/ur5_2f_test/config/workcell_builder_task_intent.yaml` to normalize `scene_package` path, change the place binding to `destination: bin_red`, set `grasp.strategy_ref: finger_pinch_basic` with approach/retreat distances, and add preview-safe safety flags (`metadata_only`, `runtime_io_applied`, `motion_started`, `ros_launch_started`). 
- Safety and camera settings remain unchanged: `safety.fake_hardware_first: true`, `safety.real_hardware_enabled: false`, `safety.runtime_execution_enabled: false`, and `camera.enabled: false`.

### Testing
- Ran `python3 scripts/validate_builder_task_intent.py scenes/ur5_2f_test/config/workcell_builder_task_intent.yaml --scene-package scenes/ur5_2f_test --json` which returned PASS and no missing required fields. 
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` which passed with only existing optional/export warnings about missing generated export artifacts. 
- Ran `git diff --check` to ensure no whitespace or index issues; it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20439fc2a483318314cdc1fec37ade)