### PR TITLE
Add commissioning object and disabled-camera metadata to suction_test cell_definition

### DIFF
--- a/scenes/suction_test/cell_definition.yaml
+++ b/scenes/suction_test/cell_definition.yaml
@@ -14,9 +14,19 @@ end_effector:
   type: suction
   brand: generic
   grasp_frame: tool0
+camera:
+  enabled: false
+  camera_id: UNKNOWN_CAMERA
+  frame_id: UNKNOWN_FRAME
 environment:
   frame: world
   layout: layout/workcell_studio_layout.yaml
+objects:
+  - id: commissioning_object
+    frame: world
+    pose_xyz: [0.43, 0.04, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.05, 0.05, 0.05]
 task:
   id: default_task
   type: pick_place


### PR DESCRIPTION
### Motivation
- Ensure `task.source_object` resolves for offline commissioning and align `suction_test` with the safe disabled-camera convention used by other scenes.

### Description
- Add a top-level `camera` block with `enabled: false`, `camera_id: UNKNOWN_CAMERA`, and `frame_id: UNKNOWN_FRAME`.
- Add a top-level `objects` list containing an object with `id: commissioning_object` and safe offline commissioning metadata: `frame: world`, `pose_xyz: [0.43, 0.04, 0.08]`, `pose_rpy: [0.0, 0.0, 0.0]`, and `dimensions: [0.05, 0.05, 0.05]`.
- Preserve `task.source_object: commissioning_object` so the task resolves to the newly added object ID.

### Testing
- Ran `python3 scripts/validate_cell_definition.py scenes/suction_test/cell_definition.yaml --json` which completed with exit code 0 and returned `"errors": []` indicating no hard schema errors.
- The validator still reports a pre-existing warning `environment.layout path not found: layout/workcell_studio_layout.yaml` when run from the repo root, which did not block validation.
- No runtime, launch, controller, or hardware settings were changed and no additional automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a204a03ac6c83319f6e759b3527de27)