### PR TITLE
Align suction_test manifest commissioning task metadata

### DIFF
--- a/scenes/suction_test/scene_manifest.yaml
+++ b/scenes/suction_test/scene_manifest.yaml
@@ -38,7 +38,7 @@ self_test:
   # Tune these values for each physical workcell before production.
   enabled: true
   object:
-    id: commissioning_box
+    id: commissioning_object
     shape: box
     dimensions: [0.05, 0.05, 0.05]
     frame_id: world
@@ -54,40 +54,30 @@ self_test:
     allow_simulated_execution: true
 
 task_recipe:
-  # Future runtime/UI contract example plus commissioning defaults.
-  # Metadata-only in this release: validation/reporting only.
-  id: reject_or_place_demo
-  name: Reject Or Place Demo
-  type: reject
+  # Mirrors cell_definition.yaml and config/task_recipe.yaml for offline commissioning preview.
+  # Metadata-only in this release: no runtime, GUI, replay, live EPD, or perception-backed routing readiness is claimed here.
+  id: default_task
+  name: Default Pick Place Commissioning Task
+  type: pick_place
   enabled: true
   inputs:
-    perception_source: epd
-    required_attributes: [class, quality]
+    perception_mode: off
   pick:
-    object_source: perception
+    object_source: self_test
+    source_object: commissioning_object
     grasp_strategy: suction_only
     allowed_grasp_methods: [suction]
   decision_rules:
-    - id: accepted_to_good_bin
+    - id: default_place
       when:
-        attribute: quality
-        equals: accepted
-      destination: good_bin
-    - id: default_reject
-      when:
-        default: true
-      destination: reject_bin
+        always: true
+      destination: default_drop_zone
   destinations:
-    - id: good_bin
+    - id: default_drop_zone
       frame_id: world
-      pose_xyz: [0.32, 0.22, 0.12]
+      pose_xyz: [0.5, -0.3, 0.1]
       pose_rpy: [0.0, 0.0, 0.0]
       action: place
-    - id: reject_bin
-      frame_id: world
-      pose_xyz: [0.20, -0.02, 0.12]
-      pose_rpy: [0.0, 0.0, 0.0]
-      action: reject
   expected:
     allow_offline_validation: true
     min_valid_destinations: 1


### PR DESCRIPTION
### Motivation

- Ensure the suction_test manifest matches the repo-side commissioning/cell definitions and does not claim unsupported runtime/perception readiness.
- Make offline commissioning dry-runs and generated-scene validators resolve deterministically against the scene's `cell_definition.yaml` and `config/task_recipe.yaml` semantics.

### Description

- Updated `scenes/suction_test/scene_manifest.yaml` to rename `self_test.object.id` from `commissioning_box` to `commissioning_object` to match the repo-side commissioning object identifier.
- Replaced the previous reject/perception-style `task_recipe` with a `default_task` `pick_place` recipe that sets `inputs.perception_mode: off`, `pick.object_source: self_test`, and `pick.source_object: commissioning_object` to reflect offline commissioning semantics.
- Aligned `task_recipe.decision_rules` and `task_recipe.destinations` to use `default_place` -> `default_drop_zone` with pose `pose_xyz: [0.5, -0.3, 0.1]` so manifest destinations match `task.destinations` in `cell_definition.yaml`.
- Left the manifest as metadata-only and explicitly avoided claiming live EPD, replay, GUI, or runtime-perception readiness in the manifest text.

### Testing

- Ran `python3 scripts/validate_scene_contract.py scenes/suction_test/scene_manifest.yaml` and it returned `PASS` for the updated manifest.
- Ran `python3 scripts/dry_run_task_recipe.py suction_test --check` and it returned `PASS` resolving rule `default_place` to `default_drop_zone`.
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/suction_test --json` and it passed with existing optional generated-metadata warnings and a `runtime_preview-only` classification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a204a0571348331a0984090deb225ad)