### PR TITLE
Update suction_test scene3d GUI smoke blocker

### DIFF
--- a/scenes/suction_test/generated/scene3d_gui_smoke.json
+++ b/scenes/suction_test/generated/scene3d_gui_smoke.json
@@ -6,13 +6,26 @@
   "workspace_root": "/workspace/Easy_Manipulator_Improved",
   "executable": null,
   "searched_paths": [
-    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder",
     "/workspace/Easy_Manipulator_Improved/install/workcell_builder/lib/workcell_builder/workcell_builder",
-    "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder"
+    "/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/install/bin/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder",
+    "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder/workcell_builder"
   ],
   "blockers": [
-    "unable_to_resolve_workcell_builder_executable"
+    "environment_missing_colcon_and_ros_humble_setup_prevents_workcell_builder_build_and_scene3d_gui_smoke"
   ],
   "warnings": [],
-  "screenshot_available": false
+  "screenshot_available": false,
+  "build_attempt": {
+    "command": "colcon build --symlink-install --packages-select workcell_builder --cmake-args -DBUILD_TESTING=OFF",
+    "cwd": "/workspace/Easy_Manipulator_Improved",
+    "returncode": 127,
+    "stderr_tail": "/bin/sh: 1: colcon: not found"
+  },
+  "smoke_runner_attempt": {
+    "command": "python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --scene suction_test --output /tmp/suction_scene3d_gui_smoke_attempt.json --screenshot /tmp/suction_scene3d_gui_smoke.png --xvfb",
+    "returncode": 1,
+    "stdout_tail": "status=FAIL smoke_status=MISSING_EXECUTABLE\nsearched_paths=/workspace/Easy_Manipulator_Improved/install/workcell_builder/lib/workcell_builder/workcell_builder | /workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder | /workspace/Easy_Manipulator_Improved/install/bin/workcell_builder | /workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder | /workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder/workcell_builder"
+  }
 }


### PR DESCRIPTION
### Motivation
- Make the `scene3d_gui_smoke.json` for `suction_test` accurately reflect the real Codex/container environment blocker instead of a generic missing-executable message.
- Preserve truthful runtime status by keeping `status: FAIL` and `screenshot_available: false` when the GUI smoke cannot run in this environment.

### Description
- Replaced the generic blocker with `environment_missing_colcon_and_ros_humble_setup_prevents_workcell_builder_build_and_scene3d_gui_smoke` in `scenes/suction_test/generated/scene3d_gui_smoke.json`.
- Expanded `searched_paths` to match other scenes and added `build_attempt` and `smoke_runner_attempt` entries containing only commands that were actually run with their `returncode` and output tails.
- Preserved `status: FAIL`, `executable: null`, and `screenshot_available: false` to avoid fabricating renders or PASS state.

### Testing
- Attempted `colcon build --symlink-install --packages-select workcell_builder --cmake-args -DBUILD_TESTING=OFF` returned code `127` with `/bin/sh: 1: colcon: not found`, and this failure was recorded in `build_attempt`.
- Ran the smoke runner `python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --scene suction_test ... --xvfb` which returned code `1` and reported `MISSING_EXECUTABLE`, and this was recorded in `smoke_runner_attempt`.
- Validated the edited JSON with `python3 -m json.tool` which succeeded, and `python3 scripts/validate_builder_generated_scene.py scenes/suction_test --json` was executed and completed (showing existing optional warnings but no JSON/format errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a204a0ce5748331972de6c3d854b73c)