### PR TITLE
Update suction_test supported scene blocker

### DIFF
--- a/scenes/supported_scenes.yaml
+++ b/scenes/supported_scenes.yaml
@@ -37,7 +37,7 @@ scenes:
     scene_path: scenes/suction_test
     support_level: supported
     status: blocked
-    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
+    known_blocker: "local Scene3D GUI smoke cannot run because ROS Humble/ament/workcell_builder executable is unavailable in the container; generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/suction_test --json


### PR DESCRIPTION
### Motivation
- Remove stale catalog text that claimed `cell_definition_validation FAIL` for `suction_test` after the cell definition was fixed, and narrow the known blocker to the remaining environment-only GUI/runtime limitation.

### Description
- Updated only the `suction_test` entry in `scenes/supported_scenes.yaml` to replace the long stale blocker message with: "local Scene3D GUI smoke cannot run because ROS Humble/ament/workcell_builder executable is unavailable in the container; generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable.".
- Kept `status: blocked` for `suction_test` and preserved the existing `fake_hardware_launch_command` and other catalog fields.
- No other scene entries or generated files were modified.

### Testing
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/suction_test --json` and it completed with `ok: true` and `readiness: physical_scene_only` (passed).
- Loaded the catalog with `scripts.supported_scene_catalog.load_supported_scene_catalog` to verify the YAML parses and `suction_test` remains `blocked` with the updated `known_blocker` (passed, no catalog errors).
- Executed `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --output-dir build/workcell_studio_scene_readiness_codex_suction` which wrote readiness artifacts and showed the scene remains blocked for the stated environment-only reason (completed).
- Ran `git diff --check` to ensure no whitespace or diff issues (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a204a1d32a08331919b433d87a6948f)