### PR TITLE
Save layout: import legacy layouts and write canonical layout/workcell_studio_layout.yaml

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -5542,6 +5542,50 @@ static void write_dimensions_preserving_existing_shape(YAML::Node item, double w
   item["dimensions"] = yaml_sequence_from3(width, depth, height);
 }
 
+
+static YAML::Node normalize_imported_layout_to_canonical_items(const YAML::Node & imported_root, const std::string & scene_name, const fs::path & scene_dir)
+{
+  YAML::Node root = (imported_root && imported_root.IsMap()) ? YAML::Clone(imported_root) : YAML::Node(YAML::NodeType::Map);
+  YAML::Node canonical_items(YAML::NodeType::Sequence);
+  QSet<QString> seen_ids;
+
+  auto append_item = [&](const YAML::Node & source) {
+    if (!source || !source.IsMap()) return;
+    YAML::Node item = YAML::Clone(source);
+    const QString id = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(item, "id")).trimmed();
+    if (!id.isEmpty()) {
+      if (seen_ids.contains(id)) return;
+      seen_ids.insert(id);
+    }
+    if (!item["scene_name"] || !item["scene_name"].IsScalar()) item["scene_name"] = scene_name;
+    if (!item["scene_path"] || !item["scene_path"].IsScalar()) item["scene_path"] = scene_dir.string();
+    canonical_items.push_back(item);
+  };
+
+  const std::array<const char *, 6> legacy_sequence_keys = {
+    "items", "assets", "placed_assets", "objects", "zones", "targets"
+  };
+  for (const char * key : legacy_sequence_keys) {
+    const YAML::Node seq = root[key];
+    if (!seq || !seq.IsSequence()) continue;
+    for (std::size_t i = 0; i < seq.size(); ++i) append_item(seq[i]);
+  }
+  const YAML::Node camera = root["camera"];
+  if (camera && camera.IsMap()) append_item(camera);
+
+  for (const char * key : legacy_sequence_keys) root.remove(key);
+  root.remove("camera");
+  root["schema_version"] = "workcell_studio_layout/v1";
+  root["schema"] = "workcell_studio_layout/v1";
+  root["scene_name"] = scene_name;
+  root["scene_path"] = scene_dir.string();
+  root["items"] = canonical_items;
+  YAML::Node meta = ensure_map_node(root, "metadata");
+  meta["canonical_layout_path"] = "layout/workcell_studio_layout.yaml";
+  meta["legacy_import_normalized_keys"] = "items,assets,placed_assets,objects,zones,targets,camera";
+  return root;
+}
+
 static YAML::Node serialized_editable_canvas_item(QGraphicsItem * gi, const YAML::Node & existing)
 {
   YAML::Node item = (existing && existing.IsMap()) ? YAML::Clone(existing) : YAML::Node(YAML::NodeType::Map);
@@ -5581,10 +5625,10 @@ void MainWindow::save_layout_changes(){
   }
   const QString stable_selected_id_before_refresh = selected_preview_id.trimmed();
   if (!digital_twin_scene_) return;
-  const fs::path layout_path = selected_scene_environment_layout_path(scene_browser_result_, selected_scene_index_);
-  if (layout_path.empty()) return;
   if (selected_scene_index_ < 0 || selected_scene_index_ >= static_cast<int>(scene_browser_result_.scenes.size())) return;
   const fs::path scene_dir = scene_browser_result_.scenes[static_cast<size_t>(selected_scene_index_)].scene_dir;
+  const fs::path canonical_layout_path = scene_dir / "layout" / "workcell_studio_layout.yaml";
+  const fs::path layout_path = canonical_layout_path;
   const std::array<const char *, 4> required_dirs = {"layout", "task", "generated", "plan_preview"};
   for (const char * dir_name : required_dirs) {
     boost::system::error_code mk_ec;
@@ -5600,57 +5644,68 @@ void MainWindow::save_layout_changes(){
   YAML::Node root;
   bool existing_layout_file = false;
   bool malformed_existing = false;
-  if (fs::exists(layout_path)) {
+  fs::path imported_layout_path;
+  if (fs::exists(canonical_layout_path)) {
     existing_layout_file = true;
     try {
-      root = YAML::LoadFile(layout_path.string());
+      root = YAML::LoadFile(canonical_layout_path.string());
     } catch (const YAML::Exception &) {
       malformed_existing = true;
     } catch (const std::exception &) {
       malformed_existing = true;
     }
+  } else {
+    std::vector<fs::path> import_candidates;
+    const fs::path manifest_layout = manifest_declared_layout_path(scene_dir);
+    if (!manifest_layout.empty() && manifest_layout != canonical_layout_path) import_candidates.push_back(manifest_layout);
+    import_candidates.push_back(scene_dir / "environment_layout.yaml");
+
+    for (const auto & candidate : import_candidates) {
+      if (candidate.empty() || candidate == canonical_layout_path || !fs::exists(candidate)) continue;
+      try {
+        root = normalize_imported_layout_to_canonical_items(YAML::LoadFile(candidate.string()), scene_name, scene_dir);
+        imported_layout_path = candidate;
+        break;
+      } catch (const YAML::Exception & exc) {
+        append_studio_log(QString("Save Layout: cannot import malformed legacy layout from %1 (%2).")
+          .arg(QString::fromStdString(candidate.string()), QString::fromStdString(exc.what())));
+      } catch (const std::exception & exc) {
+        append_studio_log(QString("Save Layout: cannot import legacy layout from %1 (%2).")
+          .arg(QString::fromStdString(candidate.string()), QString::fromStdString(exc.what())));
+      }
+    }
   }
   if (malformed_existing) {
     const QString stamp = QDateTime::currentDateTimeUtc().toString("yyyyMMdd_HHmmss_zzz");
-    const fs::path backup = layout_path.parent_path() / (layout_path.filename().string() + ".malformed_backup_" + stamp.toStdString());
+    const fs::path backup = canonical_layout_path.parent_path() / (canonical_layout_path.filename().string() + ".malformed_backup_" + stamp.toStdString());
     boost::system::error_code ec;
-    fs::copy_file(layout_path, backup, fs::copy_option::overwrite_if_exists, ec);
+    fs::copy_file(canonical_layout_path, backup, fs::copy_option::overwrite_if_exists, ec);
     if (ec) {
       append_studio_log(QString("Malformed layout YAML detected at %1; backup failed (%2). Save aborted.")
-        .arg(QString::fromStdString(layout_path.string()), QString::fromStdString(ec.message())));
-      QMessageBox::warning(this, "Save Layout", "Malformed layout YAML backup failed. Not overwriting.");
+        .arg(QString::fromStdString(canonical_layout_path.string()), QString::fromStdString(ec.message())));
+      QMessageBox::warning(this, "Save Layout", "Malformed canonical layout YAML backup failed. Not overwriting.");
       return;
     }
     append_studio_log(QString("Malformed layout YAML backed up to %1").arg(QString::fromStdString(backup.string())));
     root = YAML::Node();
   }
-  const bool target_is_workcell_layout = layout_path.filename().string() == "workcell_studio_layout.yaml" ||
-    layout_path.parent_path().filename().string() == "layout";
   if (!root || !root.IsMap()) {
-    if (target_is_workcell_layout) {
-      root = YAML::Node(YAML::NodeType::Map);
-      root["schema_version"] = "workcell_studio_layout/v1";
-      root["schema"] = "workcell_studio_layout/v1";
-      root["items"] = YAML::Node(YAML::NodeType::Sequence);
-    } else {
-      root = minimal_environment_layout(scene_name);
-    }
+    root = YAML::Node(YAML::NodeType::Map);
+    root["items"] = YAML::Node(YAML::NodeType::Sequence);
+  } else {
+    root = normalize_imported_layout_to_canonical_items(root, scene_name, scene_dir);
   }
-  if (target_is_workcell_layout) {
-    root["schema_version"] = "workcell_studio_layout/v1";
-    if (!root["schema"] || !root["schema"].IsScalar()) root["schema"] = "workcell_studio_layout/v1";
-  } else if (!root["schema_version"] || !root["schema_version"].IsScalar()) {
-    root["schema_version"] = "environment_layout/v1";
-  }
-  if (!root["scene_name"] || !root["scene_name"].IsScalar()) {
-    root["scene_name"] = scene_name;
-  }
+  root["schema_version"] = "workcell_studio_layout/v1";
+  root["schema"] = "workcell_studio_layout/v1";
+  if (!root["scene_name"] || !root["scene_name"].IsScalar()) root["scene_name"] = scene_name;
+  if (!root["scene_path"] || !root["scene_path"].IsScalar()) root["scene_path"] = scene_dir.string();
+
   const QString backup_stamp = QDateTime::currentDateTimeUtc().toString("yyyyMMdd_HHmmss_zzz");
-  const fs::path layout_backup = layout_path.parent_path() /
-    (layout_path.filename().string() + "." + backup_stamp.toStdString() + ".bak.yaml");
+  const fs::path layout_backup = canonical_layout_path.parent_path() /
+    (canonical_layout_path.filename().string() + "." + backup_stamp.toStdString() + ".bak.yaml");
   if (existing_layout_file) {
     boost::system::error_code ec;
-    fs::copy_file(layout_path, layout_backup, fs::copy_option::overwrite_if_exists, ec);
+    fs::copy_file(canonical_layout_path, layout_backup, fs::copy_option::overwrite_if_exists, ec);
     if (!ec) {
       append_studio_log(QString("Backup before write created: %1").arg(QString::fromStdString(layout_backup.string())));
     } else {
@@ -5695,6 +5750,9 @@ void MainWindow::save_layout_changes(){
   if (saving_workcell_layout || saving_placed_assets_layout) {
     const char * item_key = saving_workcell_layout ? "items" : "placed_assets";
     YAML::Node existing_by_id = existing_items_by_id(root[item_key]);
+    if (!imported_layout_path.empty() && editable_canvas_items.empty() && root[item_key] && root[item_key].IsSequence()) {
+      updated_placed = YAML::Clone(root[item_key]);
+    }
     for (auto * gi : editable_canvas_items) {
       const std::string item_id = gi->data(RoleId).toString().toStdString();
       YAML::Node item = serialized_editable_canvas_item(gi, existing_by_id[item_id]);
@@ -5753,6 +5811,9 @@ void MainWindow::save_layout_changes(){
     }
   }
 
+  if (!imported_layout_path.empty() && editable_canvas_items.empty() && updated_placed && updated_placed.IsSequence()) {
+    root["items"] = updated_placed;
+  }
   std::ofstream out(layout_path.string());
   out << root;
   out.close();
@@ -5761,9 +5822,17 @@ void MainWindow::save_layout_changes(){
   validation_stale_ = true;
   launch_artifacts_ready_ = false;
   if (layout_state_label_) layout_state_label_->setText("Unsaved Layout Edits: none");
-  append_studio_log(QString("Saved scene layout metadata to %1").arg(QString::fromStdString(layout_path.string())));
+  if (!imported_layout_path.empty()) {
+    append_studio_log(QString("Save Layout: imported legacy layout from %1; wrote canonical layout to %2")
+      .arg(QString::fromStdString(imported_layout_path.string()), QString::fromStdString(canonical_layout_path.string())));
+  } else if (updated_placed.size() == 0) {
+    append_studio_log(QString("Save Layout: saved empty editable layout metadata to %1")
+      .arg(QString::fromStdString(canonical_layout_path.string())));
+  } else {
+    append_studio_log(QString("Save Layout: wrote canonical layout to %1")
+      .arg(QString::fromStdString(canonical_layout_path.string())));
+  }
   if (updated_placed.size() == 0) {
-    append_studio_log("Saved layout file, but no editable layout items exist. Use Create editable layout from preview or add an item.");
     QMessageBox::information(this, "Save Layout", "Saved layout file, but no editable layout items exist. Use Create editable layout from preview or add an item.");
   }
 


### PR DESCRIPTION
### Motivation

- Ensure the editor always writes the editable layout to a single canonical path and make imports from legacy layouts explicit and deterministic.
- Preserve stable IDs, poses, mesh references and other metadata when normalizing older layout formats into the canonical editor format.
- Provide clear logs and user-visible outcomes for import/write actions so users and automated validation can see exactly what happened.

### Description

- Always compute and write the editable layout to `scene_dir / "layout" / "workcell_studio_layout.yaml"` and ensure the `layout/` directory is created before writing. (modified `workcell_builder/workcell_builder/gui/mainwindow.cpp`).
- When the canonical file is missing, attempt imports in this order: safe manifest-declared layout (if present and not canonical), then `scene_dir / "environment_layout.yaml"`, and normalize the imported content into canonical `items`.
- Added `normalize_imported_layout_to_canonical_items()` to convert legacy sequences (`items`, `assets`, `placed_assets`, `objects`, `zones`, `targets`) and `camera` into canonical `items`, preserving IDs, pose `xyz/rpy`, dimensions/size, mesh `path`/`source_package`, display names/labels, type/category/role, and scene metadata where available.
- Preserve existing per-item maps when possible, back up malformed canonical files before overwrite, preserve imported items when no editable canvas edits exist, and emit the requested clear log messages: `Save Layout: imported legacy layout from <path>; wrote canonical layout to <path>`, `Save Layout: wrote canonical layout to <path>`, or `Save Layout: saved empty editable layout metadata to <path>`.

### Testing

- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` and it succeeded (report returned OK). 
- Attempted `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder` but it was blocked in this container because `/opt/ros/humble/setup.bash` is not present. 
- Attempted a `yaml-cpp` pkg-config probe but it was blocked because `yaml-cpp` pkg-config metadata is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a204e39ebe083319cd0a4d3cd1e06a5)