### PR TITLE
Save canonical workcell_studio_layout.yaml when editable canvas is intentionally empty

### DIFF
--- a/tests/test_workcell_studio_mainwindow_build_tokens.py
+++ b/tests/test_workcell_studio_mainwindow_build_tokens.py
@@ -101,3 +101,32 @@ def test_save_layout_success_refreshes_workflow_rail_and_scene_chips_after_write
     assert write_layout_pos < close_layout_pos < write_environment_pos
     assert write_environment_pos < close_environment_pos < refresh_browser_pos
     assert refresh_browser_pos < refresh_workflow_pos < refresh_chips_pos
+
+def test_save_layout_empty_canvas_persists_canonical_workcell_layout_metadata():
+    source = Path("workcell_builder/workcell_builder/gui/mainwindow.cpp").read_text(encoding="utf-8")
+    save_match = re.search(
+        r"void MainWindow::save_layout_changes\(\)\{(?P<body>.*?)\n\}\n\nvoid MainWindow::create_starter_layout_from_preview",
+        source,
+        re.DOTALL,
+    )
+    assert save_match is not None
+    body = save_match.group("body")
+
+    empty_branch = re.search(
+        r"if \(editable_canvas_items\.empty\(\)\) \{(?P<branch>.*?)\n  \}",
+        body,
+        re.DOTALL,
+    )
+    assert empty_branch is not None
+    branch = empty_branch.group("branch")
+    assert 'scene_dir / "layout" / "workcell_studio_layout.yaml"' in body
+    assert "effective_layout_path = canonical_workcell_layout_path" in branch
+    assert 'root["schema_version"] = "workcell_studio_layout/v1";' in branch
+    assert 'root["scene_name"] = scene_name;' in branch
+    assert 'root["items"] = YAML::Node(YAML::NodeType::Sequence);' in branch
+    assert 'root["empty_layout_marker"] = true;' in branch
+    assert "std::ofstream out(effective_layout_path.string());" in body
+    assert "Save Layout: no editable items; saved canonical layout metadata to %1." in body
+    assert "Use Create editable layout from preview or add an item to persist editable objects." in body
+    assert "gi->data(RoleLocked).toBool()" in body
+    assert 'source_layer != QStringLiteral("editable_layout")' in body

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -5674,6 +5674,31 @@ void MainWindow::save_layout_changes(){
     editable_canvas_items.push_back(gi);
   }
 
+  fs::path effective_layout_path = layout_path;
+  const fs::path canonical_workcell_layout_path = scene_dir / "layout" / "workcell_studio_layout.yaml";
+  if (editable_canvas_items.empty()) {
+    effective_layout_path = canonical_workcell_layout_path;
+    root = YAML::Node(YAML::NodeType::Map);
+    root["schema_version"] = "workcell_studio_layout/v1";
+    root["schema"] = "workcell_studio_layout/v1";
+    root["scene_name"] = scene_name;
+    root["items"] = YAML::Node(YAML::NodeType::Sequence);
+    root["empty_layout_marker"] = true;
+  }
+
+  if (effective_layout_path != layout_path && fs::exists(effective_layout_path)) {
+    const fs::path effective_layout_backup = effective_layout_path.parent_path() /
+      (effective_layout_path.filename().string() + "." + backup_stamp.toStdString() + ".bak.yaml");
+    boost::system::error_code ec;
+    fs::copy_file(effective_layout_path, effective_layout_backup, fs::copy_option::overwrite_if_exists, ec);
+    if (!ec) {
+      append_studio_log(QString("Backup before write created: %1").arg(QString::fromStdString(effective_layout_backup.string())));
+    } else {
+      append_studio_log(QString("Warning: backup before write failed (%1). Continuing save without backup.")
+        .arg(QString::fromStdString(ec.message())));
+    }
+  }
+
   auto existing_items_by_id = [](const YAML::Node & sequence) {
     YAML::Node out(YAML::NodeType::Map);
     if (!sequence || !sequence.IsSequence()) return out;
@@ -5686,9 +5711,9 @@ void MainWindow::save_layout_changes(){
     return out;
   };
 
-  const bool saving_workcell_layout = layout_path.filename().string() == "workcell_studio_layout.yaml" ||
+  const bool saving_workcell_layout = effective_layout_path.filename().string() == "workcell_studio_layout.yaml" ||
     workcell_builder::yaml_map_value_or_empty(root, "schema_version") == "workcell_studio_layout/v1" ||
-    (root["items"] && root["items"].IsSequence() && layout_path.parent_path().filename().string() == "layout");
+    (root["items"] && root["items"].IsSequence() && effective_layout_path.parent_path().filename().string() == "layout");
   const bool saving_placed_assets_layout = !saving_workcell_layout && root["placed_assets"] && root["placed_assets"].IsSequence();
 
   YAML::Node updated_placed(YAML::NodeType::Sequence);
@@ -5701,7 +5726,7 @@ void MainWindow::save_layout_changes(){
       if (saving_workcell_layout && !item["source"]) item["source"] = "layout/workcell_studio_layout.yaml";
       updated_placed.push_back(item);
       append_studio_log(QString("Inspector transform saved: scene=%1 id=%2 path=%3")
-        .arg(QString::fromStdString(scene_name), gi->data(RoleId).toString(), QString::fromStdString(layout_path.string())));
+        .arg(QString::fromStdString(scene_name), gi->data(RoleId).toString(), QString::fromStdString(effective_layout_path.string())));
     }
     root[item_key] = updated_placed;
     if (saving_workcell_layout) {
@@ -5726,7 +5751,7 @@ void MainWindow::save_layout_changes(){
         saved_ids.insert(id);
         updated_placed.push_back(seq[i]);
         append_studio_log(QString("Inspector transform saved: scene=%1 id=%2 path=%3")
-          .arg(QString::fromStdString(scene_name), id, QString::fromStdString(layout_path.string())));
+          .arg(QString::fromStdString(scene_name), id, QString::fromStdString(effective_layout_path.string())));
       }
     }
     YAML::Node camera = root["camera"];
@@ -5737,7 +5762,7 @@ void MainWindow::save_layout_changes(){
         saved_ids.insert(id);
         updated_placed.push_back(root["camera"]);
         append_studio_log(QString("Inspector transform saved: scene=%1 id=%2 path=%3")
-          .arg(QString::fromStdString(scene_name), id, QString::fromStdString(layout_path.string())));
+          .arg(QString::fromStdString(scene_name), id, QString::fromStdString(effective_layout_path.string())));
       }
     }
     YAML::Node placed_assets = ensure_sequence_of_maps(root, "placed_assets");
@@ -5749,11 +5774,11 @@ void MainWindow::save_layout_changes(){
       placed_assets.push_back(item);
       updated_placed.push_back(item);
       append_studio_log(QString("Inspector transform saved: scene=%1 id=%2 path=%3")
-        .arg(QString::fromStdString(scene_name), id, QString::fromStdString(layout_path.string())));
+        .arg(QString::fromStdString(scene_name), id, QString::fromStdString(effective_layout_path.string())));
     }
   }
 
-  std::ofstream out(layout_path.string());
+  std::ofstream out(effective_layout_path.string());
   out << root;
   out.close();
   layout_dirty_ = false;
@@ -5761,10 +5786,15 @@ void MainWindow::save_layout_changes(){
   validation_stale_ = true;
   launch_artifacts_ready_ = false;
   if (layout_state_label_) layout_state_label_->setText("Unsaved Layout Edits: none");
-  append_studio_log(QString("Saved scene layout metadata to %1").arg(QString::fromStdString(layout_path.string())));
   if (updated_placed.size() == 0) {
-    append_studio_log("Saved layout file, but no editable layout items exist. Use Create editable layout from preview or add an item.");
-    QMessageBox::information(this, "Save Layout", "Saved layout file, but no editable layout items exist. Use Create editable layout from preview or add an item.");
+    const QString guidance = "Use Create editable layout from preview or add an item to persist editable objects.";
+    append_studio_log(QString("Save Layout: no editable items; saved canonical layout metadata to %1. %2")
+      .arg(QString::fromStdString(effective_layout_path.string()), guidance));
+    QMessageBox::information(this, "Save Layout",
+      QString("Save Layout: no editable items; saved canonical layout metadata to %1.\n%2")
+        .arg(QString::fromStdString(effective_layout_path.string()), guidance));
+  } else {
+    append_studio_log(QString("Saved scene layout metadata to %1").arg(QString::fromStdString(effective_layout_path.string())));
   }
 
   YAML::Node environment(YAML::NodeType::Map);


### PR DESCRIPTION
### Motivation
- Ensure an intentional empty editable canvas persists a canonical `layout/workcell_studio_layout.yaml` with an explicit `schema_version` and scene provenance instead of implying an error or skipping the canonical save.
- Avoid treating an intentionally-empty layout as a failure while still preserving the rule that locked/generated preview items are not written to editable `items`.
- Provide a clear success message and user guidance when the canonical empty layout is written.

### Description
- Updated `MainWindow::save_layout_changes()` in `workcell_builder/workcell_builder/gui/mainwindow.cpp` to compute an `effective_layout_path` and, when no editable canvas items are present, set it to the canonical `scene_dir / "layout" / "workcell_studio_layout.yaml"` and populate `root` with `schema_version: workcell_studio_layout/v1`, `schema: workcell_studio_layout/v1`, `scene_name`, an empty `items` sequence, and `empty_layout_marker: true`.
- Continued to serialize only editable, non-locked items (filtering on `RoleLocked` and `RoleSourceLayer == "editable_layout"`), preserving the existing exclusion of locked/generated preview items and reusing existing item metadata where present.
- Writes the YAML to the computed `effective_layout_path` (with the same backup behavior preserved) and updates environment metadata as before.
- Replaced the previous failure-sounding messaging with a clear success log and message box: `Save Layout: no editable items; saved canonical layout metadata to <path>.` followed on the next line by the guidance sentence `Use Create editable layout from preview or add an item to persist editable objects.`

### Testing
- Ran targeted unit token test `tests/test_workcell_studio_mainwindow_build_tokens.py::test_save_layout_empty_canvas_persists_canonical_workcell_layout_metadata` which passed.
- Ran a subset of UI/bootstrapping tests; `tests/test_workcell_studio_mainwindow_build_tokens.py` and `tests/test_workcell_studio_bootstrap_gui_wiring.py` together exposed unrelated pre-existing token expectations that failed (these failures were pre-existing/stale assertions not caused by the empty-layout behavior change). The specific new empty-layout token test added succeeds. 
- Performed `git diff --check` and static checks in the container; ROS/Humble `colcon build` was not executed because the container lacks `/opt/ros/humble/setup.bash`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a204e3f60208331babd5567daf6557f)