### PR TITLE
Derive editable state and lock generated/preview items in 2D canvas

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -4939,17 +4939,26 @@ void MainWindow::rebuild_digital_twin_canvas()
 
   for (const auto & entry : model.items) {
     const QString category = QString::fromStdString(entry.type);
+    const bool is_editable_layout_item =
+      entry.provenance == workcell_builder::WorkcellStudioItemProvenance::EditableLayout && !entry.locked;
+    const bool is_editable_layout_provenance =
+      entry.provenance == workcell_builder::WorkcellStudioItemProvenance::EditableLayout;
+    const bool locked_for_canvas = !is_editable_layout_item;
+    const QString canvas_access_label = is_editable_layout_item
+      ? QStringLiteral("editable layout item")
+      : (is_editable_layout_provenance ? QStringLiteral("locked editable layout item") : QStringLiteral("inspection-only preview"));
     auto * item = new DraggableCanvasItem(QRectF(0, 0, std::max(20.0, entry.width * 100.0), std::max(20.0, entry.depth * 100.0)));
     item->setPos(entry.x * 100.0, entry.y * 100.0);
     item->setPen(QPen(category_color(category).lighter(130), 2));
     item->setBrush(QBrush(category_color(category), Qt::SolidPattern));
-    item->setToolTip(QString("%1 (%2)").arg(QString::fromStdString(entry.label), category));
+    item->setToolTip(QString("%1 (%2) — %3")
+      .arg(QString::fromStdString(entry.label), category, canvas_access_label));
     item->setData(RoleId, QString::fromStdString(entry.id));
     item->setData(RoleDisplayName, QString::fromStdString(entry.label));
     item->setData(RoleType, QString::fromStdString(entry.type));
     item->setData(RoleCategory, QString::fromStdString(entry.type));
     item->setData(RoleRole, QString::fromStdString(entry.role));
-    item->setData(RoleLocked, entry.locked);
+    item->setData(RoleLocked, locked_for_canvas);
     item->setData(RolePoseZ, entry.z);
     item->setData(RoleRoll, entry.roll); item->setData(RolePitch, entry.pitch); item->setData(RoleYaw, entry.yaw);
     item->setData(RoleSource, QString::fromStdString(entry.source_file));
@@ -4973,17 +4982,18 @@ void MainWindow::rebuild_digital_twin_canvas()
         break;
     }
     item->setData(RoleSourceLayer, source_layer);
-    item->setZValue(canvas_item_z_value(category, QString::fromStdString(entry.role), source_layer, entry.locked));
-    item->setFlags(QGraphicsItem::ItemIsSelectable | QGraphicsItem::ItemSendsGeometryChanges | (entry.locked ? QGraphicsItem::GraphicsItemFlag(0) : QGraphicsItem::ItemIsMovable));
+    item->setZValue(canvas_item_z_value(category, QString::fromStdString(entry.role), source_layer, locked_for_canvas));
+    item->setFlags(QGraphicsItem::ItemIsSelectable | QGraphicsItem::ItemSendsGeometryChanges | (is_editable_layout_item ? QGraphicsItem::ItemIsMovable : QGraphicsItem::GraphicsItemFlag(0)));
     item->position_filter = [this](const QPointF & p){ return snap_canvas_position(p); };
     digital_twin_scene_->addItem(item);
     add_physical_bounds(item->sceneBoundingRect());
 
     if (toggle_labels_box_ && toggle_labels_box_->isChecked()) {
-      const bool secondary_label = entry.locked || source_layer != QStringLiteral("editable_layout");
+      const bool secondary_label = !is_editable_layout_item;
       const bool visible_by_default = should_show_2d_label(entry, preserved_selected_id);
       QString label_text = QString::fromStdString(entry.label);
       if (label_text.trimmed().isEmpty()) label_text = QString::fromStdString(entry.id);
+      if (!is_editable_layout_item) label_text = QStringLiteral("🔒 ") + label_text;
       auto * txt = digital_twin_scene_->addSimpleText(compact_canvas_label(label_text));
       QFont label_font = txt->font();
       label_font.setPointSize(secondary_label ? 7 : 8);


### PR DESCRIPTION
### Motivation
- Ensure 2D canvas editability is derived from provenance and explicit lock state so only true authoring items are movable.
- Prevent generated or fallback preview geometry from becoming editable or being serialized as canonical layout.
- Make canvas labels/tooltips clearly convey inspection-only vs authoring-backed items.

### Description
- Added a derived boolean `is_editable_layout_item` computed as `entry.provenance == workcell_builder::WorkcellStudioItemProvenance::EditableLayout && !entry.locked` and computed `locked_for_canvas = !is_editable_layout_item` in `rebuild_digital_twin_canvas()`.
- Used `locked_for_canvas` to set the `RoleLocked` data, the item movement flags (`ItemIsMovable`), and the `canvas_item_z_value()` call so z-ordering reflects canvas lock state.
- Forced preview-only provenance (`GeneratedOrLegacyPreview` and `StaticFallbackPreview`) into inspection-only/locked behavior even when the source entry was not pre-locked.
- Updated tooltips and 2D labels to reflect `editable layout item` vs `locked editable layout item` vs `inspection-only preview`, and prefixed non-editable labels with a lock badge emoji where applicable.
- Kept save filtering unchanged by preserving the existing rule that only items with `RoleSourceLayer == "editable_layout"` are collected for serialization so generated preview geometry is never written as canonical editable layout.
- Modified file: `workcell_builder/workcell_builder/gui/mainwindow.cpp` (2D canvas construction and label logic).

### Testing
- Ran whitespace/patch checks with `git diff --check`, which passed with no issues.
- Attempted to build `workcell_builder` via the recommended `colcon` flow, but `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder` could not be executed in this environment because `/opt/ros/humble/setup.bash` is not available (build not run here).
- No other automated tests were present or executed for this change in the current container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20690c64e48331b45d823f2f84c95a)