### PR TITLE
Resolve canvas editable layout sources deterministically

### DIFF
--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -128,6 +128,166 @@ static fs::path resolve_mesh_candidate(const std::string & c, const fs::path & s
   return path;
 }
 
+
+static bool is_safe_scene_relative_path(const fs::path & candidate)
+{
+  if (candidate.empty() || candidate.is_absolute()) return false;
+  for (const auto & part : candidate) {
+    if (part.string() == "..") return false;
+  }
+  return true;
+}
+
+static double yaml_double_or_default(const YAML::Node & node, double fallback)
+{
+  double out = fallback;
+  return yaml_read_double(node, &out) ? out : fallback;
+}
+
+static fs::path manifest_declared_canvas_layout_path(const fs::path & scene_dir, const YAML::Node & manifest)
+{
+  try {
+    const YAML::Node files = yaml_map_key(manifest, "files");
+    std::string declared;
+    if (files && files.IsMap()) {
+      declared = yaml_map_value_or_empty(files, "layout");
+      if (declared.empty()) declared = yaml_map_value_or_empty(files, "editable_layout");
+      if (declared.empty()) declared = yaml_map_value_or_empty(files, "workcell_studio_layout");
+    }
+    if (declared.empty()) declared = yaml_map_value_or_empty(manifest, "layout");
+    const fs::path relative(declared);
+    if (!is_safe_scene_relative_path(relative)) return {};
+    return scene_dir / relative;
+  } catch (const YAML::Exception &) {
+    return {};
+  } catch (const std::exception &) {
+    return {};
+  }
+}
+
+static std::string canvas_item_id_from_node(const YAML::Node & node, const std::string & fallback_prefix, std::size_t index)
+{
+  std::string id = yaml_map_value_or_empty(node, "id");
+  if (id.empty()) id = yaml_map_value_or_empty(node, "name");
+  if (id.empty()) id = yaml_map_value_or_empty(node, "asset_id");
+  if (id.empty()) id = yaml_map_value_or_empty(node, "object_id");
+  if (id.empty()) id = yaml_map_value_or_empty(node, "target_id");
+  if (id.empty()) id = fallback_prefix + "_" + std::to_string(index + 1);
+  return id;
+}
+
+static void copy_canvas_pose_from_environment_node(const YAML::Node & source, YAML::Node * target)
+{
+  YAML::Node pose = yaml_map_key(source, "pose");
+  YAML::Node xyz;
+  YAML::Node rpy;
+  if (yaml_node_is_map(pose)) {
+    xyz = yaml_map_key(pose, "xyz");
+    rpy = yaml_map_key(pose, "rpy");
+  } else if (yaml_node_is_sequence(pose)) {
+    xyz = pose;
+  }
+  if (!yaml_node_is_defined(xyz)) {
+    const YAML::Node position = yaml_map_key(source, "position");
+    if (yaml_node_is_sequence(position)) xyz = position;
+    else if (yaml_node_is_map(position)) {
+      YAML::Node synthesized(YAML::NodeType::Sequence);
+      synthesized.push_back(yaml_double_or_default(yaml_map_key(position, "x"), 0.0));
+      synthesized.push_back(yaml_double_or_default(yaml_map_key(position, "y"), 0.0));
+      synthesized.push_back(yaml_double_or_default(yaml_map_key(position, "z"), 0.0));
+      xyz = synthesized;
+    }
+  }
+  if (!yaml_node_is_defined(rpy)) {
+    const YAML::Node orientation = yaml_map_key(source, "rpy");
+    if (yaml_node_is_sequence(orientation)) rpy = orientation;
+  }
+
+  YAML::Node out_pose(YAML::NodeType::Map);
+  out_pose["xyz"].push_back(yaml_double_or_default(yaml_seq_index(xyz, 0), 0.0));
+  out_pose["xyz"].push_back(yaml_double_or_default(yaml_seq_index(xyz, 1), 0.0));
+  out_pose["xyz"].push_back(yaml_double_or_default(yaml_seq_index(xyz, 2), 0.0));
+  out_pose["rpy"].push_back(yaml_double_or_default(yaml_seq_index(rpy, 0), 0.0));
+  out_pose["rpy"].push_back(yaml_double_or_default(yaml_seq_index(rpy, 1), 0.0));
+  out_pose["rpy"].push_back(yaml_double_or_default(yaml_seq_index(rpy, 2), 0.0));
+  (*target)["pose"] = out_pose;
+}
+
+static void copy_canvas_size_from_environment_node(const YAML::Node & source, YAML::Node * target)
+{
+  YAML::Node size = yaml_map_key(source, "size");
+  if (!yaml_node_is_defined(size)) size = yaml_map_key(source, "dimensions");
+  if (!yaml_node_is_defined(size)) size = yaml_map_key(source, "scale");
+  YAML::Node out_size(YAML::NodeType::Map);
+  if (yaml_node_is_map(size)) {
+    out_size["width"] = yaml_double_or_default(yaml_map_key(size, "width"), yaml_double_or_default(yaml_map_key(size, "x"), 0.25));
+    out_size["depth"] = yaml_double_or_default(yaml_map_key(size, "depth"), yaml_double_or_default(yaml_map_key(size, "y"), 0.25));
+    out_size["height"] = yaml_double_or_default(yaml_map_key(size, "height"), yaml_double_or_default(yaml_map_key(size, "z"), 0.25));
+  } else {
+    out_size["width"] = yaml_double_or_default(yaml_seq_index(size, 0), 0.25);
+    out_size["depth"] = yaml_double_or_default(yaml_seq_index(size, 1), 0.25);
+    out_size["height"] = yaml_double_or_default(yaml_seq_index(size, 2), 0.25);
+  }
+  (*target)["size"] = out_size;
+}
+
+static bool append_environment_layout_canvas_item(const YAML::Node & source, const std::string & section, std::size_t index, YAML::Node * items)
+{
+  if (!yaml_node_is_map(source)) return false;
+  YAML::Node item(YAML::NodeType::Map);
+  item["id"] = canvas_item_id_from_node(source, section, index);
+  std::string type = yaml_map_value_or_empty(source, "type");
+  if (type.empty()) type = yaml_map_value_or_empty(source, "role");
+  if (type.empty()) type = section == "camera" ? "camera" : (section == "zones" || section == "targets" ? "zone" : "object");
+  item["type"] = type;
+  item["role"] = yaml_map_value_or_empty(source, "role").empty() ? type : yaml_map_value_or_empty(source, "role");
+  const std::string display_name = yaml_map_value_or_empty(source, "display_name");
+  if (!display_name.empty()) item["display_name"] = display_name;
+  const std::string name = yaml_map_value_or_empty(source, "name");
+  if (!name.empty()) item["name"] = name;
+  item["category"] = section;
+  item["source_path"] = "environment_layout.yaml";
+  item["editable"] = true;
+  bool locked = false;
+  if (yaml_read_bool(yaml_map_key(source, "locked"), &locked)) item["locked"] = locked;
+  else item["locked"] = false;
+  copy_canvas_pose_from_environment_node(source, &item);
+  copy_canvas_size_from_environment_node(source, &item);
+  const YAML::Node mesh = yaml_map_key(source, "mesh");
+  if (yaml_node_is_defined(mesh)) item["mesh"] = YAML::Clone(mesh);
+  items->push_back(item);
+  return true;
+}
+
+static YAML::Node normalize_environment_layout_canvas_items(const YAML::Node & environment_layout)
+{
+  YAML::Node normalized(YAML::NodeType::Map);
+  normalized["schema_version"] = "workcell_studio_layout/v1";
+  YAML::Node items(YAML::NodeType::Sequence);
+  const std::array<const char *, 6> sequence_keys = {"items", "assets", "placed_assets", "objects", "zones", "targets"};
+  for (const char * key : sequence_keys) {
+    const YAML::Node section = yaml_map_key(environment_layout, key);
+    if (!yaml_node_is_sequence(section)) continue;
+    std::size_t index = 0;
+    for (const auto & node : section) {
+      append_environment_layout_canvas_item(node, key, index, &items);
+      ++index;
+    }
+  }
+  const YAML::Node camera = yaml_map_key(environment_layout, "camera");
+  if (yaml_node_is_map(camera)) {
+    append_environment_layout_canvas_item(camera, "camera", 0, &items);
+  } else if (yaml_node_is_sequence(camera)) {
+    std::size_t index = 0;
+    for (const auto & node : camera) {
+      append_environment_layout_canvas_item(node, "camera", index, &items);
+      ++index;
+    }
+  }
+  normalized["items"] = items;
+  return normalized;
+}
+
 static void probe_mesh_candidates(const fs::path & scene_dir, std::vector<fs::path> * visuals, std::vector<fs::path> * collisions)
 {
   const std::vector<fs::path> roots = {
@@ -182,17 +342,75 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   const fs::path manifest_path = scene_dir / "scene_manifest.yaml";
   const fs::path task_path = scene_dir / "config" / "task_recipe.yaml";
   const fs::path layout_path = scene_dir / "layout" / "workcell_studio_layout.yaml";
+  const fs::path legacy_layout_path = scene_dir / "environment_layout.yaml";
   const YamlLoadStatus env_status = read_yaml(env_path, &env);
   const YamlLoadStatus manifest_status = read_yaml(manifest_path, &manifest);
   const YamlLoadStatus task_status = read_yaml(task_path, &task);
-  const YamlLoadStatus layout_status = read_yaml(layout_path, &layout);
+  const YamlLoadStatus canonical_layout_status = read_yaml(layout_path, &layout);
   const bool env_ok = env_status.loaded;
   const bool manifest_ok = manifest_status.loaded;
   const bool task_ok = task_status.loaded;
-  const bool layout_ok = layout_status.loaded;
+  bool layout_ok = false;
+  bool layout_source_is_environment_layout = false;
+  std::string layout_source_file = "layout/workcell_studio_layout.yaml";
+
+  const auto layout_node_valid = [](const YAML::Node & candidate) {
+    const std::string schema_version = yaml_map_value_or_empty(candidate, "schema_version");
+    const YAML::Node items = yaml_map_key(candidate, "items");
+    const bool schema_current = (schema_version == "workcell_studio_layout/v1");
+    const bool schema_legacy = schema_version.empty() && yaml_node_is_sequence(items);
+    return (schema_current || schema_legacy) && yaml_node_is_sequence(items);
+  };
+  const auto warn_bad_layout = [&m](const std::string & label, const fs::path & path, const YamlLoadStatus & status) {
+    if (!status.exists) return;
+    if (status.parse_warning) {
+      m.warnings.push_back("Malformed " + label + " (" + path.string() + "): " + status.reason +
+                           "; trying next editable layout source before static preview fallback.");
+    } else if (status.loaded) {
+      m.warnings.push_back(label + " (" + path.string() + ") has invalid or missing editable layout schema/items; trying next editable layout source before static preview fallback.");
+    }
+  };
+
+  if (canonical_layout_status.loaded && layout_node_valid(layout)) {
+    layout_ok = true;
+  } else {
+    warn_bad_layout("layout/workcell_studio_layout.yaml", layout_path, canonical_layout_status);
+    YAML::Node legacy_layout;
+    const YamlLoadStatus legacy_layout_status = read_yaml(legacy_layout_path, &legacy_layout);
+    if (legacy_layout_status.loaded) {
+      YAML::Node normalized_legacy_layout = normalize_environment_layout_canvas_items(legacy_layout);
+      if (layout_node_valid(normalized_legacy_layout) && yaml_map_key(normalized_legacy_layout, "items").size() > 0) {
+        layout = normalized_legacy_layout;
+        layout_ok = true;
+        layout_source_is_environment_layout = true;
+        layout_source_file = "environment_layout.yaml";
+      } else {
+        warn_bad_layout("environment_layout.yaml", legacy_layout_path, legacy_layout_status);
+      }
+    } else {
+      warn_bad_layout("environment_layout.yaml", legacy_layout_path, legacy_layout_status);
+    }
+
+    if (!layout_ok && !canonical_layout_status.exists && !legacy_layout_status.exists && manifest_ok) {
+      const fs::path manifest_layout_path = manifest_declared_canvas_layout_path(scene_dir, manifest);
+      if (!manifest_layout_path.empty() && manifest_layout_path != layout_path && manifest_layout_path != legacy_layout_path) {
+        YAML::Node manifest_layout;
+        const YamlLoadStatus manifest_layout_status = read_yaml(manifest_layout_path, &manifest_layout);
+        if (manifest_layout_status.loaded && layout_node_valid(manifest_layout)) {
+          layout = manifest_layout;
+          layout_ok = true;
+          layout_source_file = manifest_layout_path.lexically_relative(scene_dir).generic_string();
+        } else {
+          warn_bad_layout("manifest-declared layout", manifest_layout_path, manifest_layout_status);
+        }
+      }
+    }
+  }
+
   if (!layout_ok) {
-    if (layout_status.exists) enable_deterministic_fallback("layout/workcell_studio_layout.yaml is malformed");
-    else enable_deterministic_fallback("layout/workcell_studio_layout.yaml is missing");
+    if (canonical_layout_status.exists) enable_deterministic_fallback("all editable layout sources are missing or invalid; layout/workcell_studio_layout.yaml is invalid");
+    else if (fs::exists(legacy_layout_path)) enable_deterministic_fallback("all editable layout sources are missing or invalid; environment_layout.yaml is invalid");
+    else enable_deterministic_fallback("all editable layout sources are missing");
   }
   if (!env_ok) m.warnings.push_back(env_status.parse_warning ?
     ("environment.yaml parse warning (" + env_path.string() + "): " + env_status.reason + ". Validate YAML syntax (e.g., `yamllint`) and retry.") :
@@ -203,11 +421,6 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   if (!task_ok) m.warnings.push_back(task_status.parse_warning ?
     ("task_recipe.yaml parse warning (" + task_path.string() + "): " + task_status.reason + ". Validate YAML syntax (e.g., `yamllint`) and retry.") :
     "Task intent missing");
-  if (!layout_ok && layout_status.exists) {
-    const std::string parse_reason = layout_status.parse_warning ? (": " + layout_status.reason) : "";
-    m.warnings.push_back("Malformed layout/workcell_studio_layout.yaml (" + layout_path.string() + ")" + parse_reason +
-                         "; falling back safely. Repair guidance: run YAML validation (e.g., `yamllint`) and fix syntax/indentation.");
-  }
 
   m.template_name = manifest_ok ? yaml_map_value_or_empty(manifest, "template_name") : "";
   if (m.template_name.empty()) m.template_name = "unknown_template";
@@ -297,6 +510,11 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
         if (item.id == id) {
           matched_existing = true;
           item.provenance = WorkcellStudioItemProvenance::EditableLayout;
+          if (layout_source_is_environment_layout) {
+            item.source_file = "environment_layout.yaml";
+            bool locked = false;
+            item.locked = yaml_read_bool(yaml_map_key(node, "locked"), &locked) ? locked : false;
+          }
           copy_primitive_metadata(item, node);
           YAML::Node pose = yaml_map_key(node, "pose");
           if (pose.IsDefined() && pose.IsMap()) {
@@ -322,6 +540,20 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
           } else {
             incomplete_placement_metadata = true;
           }
+          YAML::Node size = yaml_map_key(node, "size");
+          if (yaml_node_is_defined(size)) {
+            if (yaml_node_is_map(size)) {
+              item.width = read_double_or_warn(yaml_map_key(size, "width"), "items[].size.width", item.width);
+              item.depth = read_double_or_warn(yaml_map_key(size, "depth"), "items[].size.depth", item.depth);
+              item.height = read_double_or_warn(yaml_map_key(size, "height"), "items[].size.height", item.height);
+            } else if (yaml_node_is_sequence(size)) {
+              item.width = read_double_or_warn(yaml_seq_index(size, 0), "items[].size[0]", item.width);
+              item.depth = read_double_or_warn(yaml_seq_index(size, 1), "items[].size[1]", item.depth);
+              item.height = read_double_or_warn(yaml_seq_index(size, 2), "items[].size[2]", item.height);
+            } else {
+              add_warning("items[].size", "expected map or sequence; using defaults");
+            }
+          }
         }
       }
       if (!matched_existing) {
@@ -335,8 +567,8 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
         if (label.empty()) label = read_string_or_warn(yaml_map_key(node, "name"), "items[].name", id);
         extra.label = label.empty() ? id : label;
         std::string source_file = read_string_or_warn(yaml_map_key(node, "source_path"), "items[].source_path", "");
-        if (source_file.empty()) source_file = read_string_or_warn(yaml_map_key(node, "source_layer"), "items[].source_layer", "layout/workcell_studio_layout.yaml");
-        extra.source_file = source_file.empty() ? "layout/workcell_studio_layout.yaml" : source_file;
+        if (source_file.empty()) source_file = read_string_or_warn(yaml_map_key(node, "source_layer"), "items[].source_layer", layout_source_file);
+        extra.source_file = source_file.empty() ? layout_source_file : source_file;
         extra.provenance = WorkcellStudioItemProvenance::EditableLayout;
         copy_primitive_metadata(extra, node);
         YAML::Node pose = yaml_map_key(node, "pose");
@@ -377,10 +609,10 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
     }
     if (incomplete_placement_metadata) {
       warned_incomplete_placement_metadata = true;
-      enable_deterministic_fallback("layout/workcell_studio_layout.yaml has incomplete placement metadata");
+      enable_deterministic_fallback(layout_source_file + " has incomplete placement metadata");
     }
   } else if (layout_ok) {
-    enable_deterministic_fallback("layout/workcell_studio_layout.yaml has invalid or missing schema_version");
+    enable_deterministic_fallback(layout_source_file + " has invalid or missing schema_version");
   }
 
   if (deterministic_fallback_layout) {
@@ -396,7 +628,7 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
       else if (item.id == "home_pose" || item.role.find("safety") != std::string::npos) { item.x = 0.0; item.y = 0.95; item.z = 0.0; item.roll = 0.0; item.pitch = 0.0; item.yaw = 0.0; }
       else if (item.id == "object_a" || item.role == "object") { item.x = -0.25; item.y = 0.10; item.z = 0.0; item.roll = 0.0; item.pitch = 0.0; item.yaw = 0.0; }
     }
-    m.warnings.push_back("Using deterministic 3D fallback layout because layout metadata is incomplete.");
+    m.warnings.push_back("Using deterministic 3D fallback layout because all editable layout sources are missing or invalid.");
     if (!deterministic_fallback_reason.empty() && !warned_incomplete_placement_metadata) m.warnings.push_back("Fallback detail: " + deterministic_fallback_reason + ".");
   }
 
@@ -641,12 +873,6 @@ bool is_save_layout_workflow_ready(const fs::path & scene_dir)
     fs::exists(scene_dir / "environment.yaml");
 }
 
-
-static double yaml_double_or_default(const YAML::Node & node, double fallback)
-{
-  double out = fallback;
-  return yaml_read_double(node, &out) ? out : fallback;
-}
 
 static std::string canonical_item_id_from_node(const YAML::Node & node)
 {

--- a/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
@@ -133,6 +133,129 @@ TEST(WorkcellStudioCanvasMesh, MissingFileProducesDeterministicWarning)
   EXPECT_TRUE(found);
 }
 
+TEST(WorkcellStudioCanvasMesh, UsesEnvironmentLayoutAsEditableFallback)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_canvas_env_layout_fallback";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "environment.yaml", "robot: ur5\nend_effector: gripper\n");
+  write_file(root / "scene_manifest.yaml", "template_name: demo\n");
+  write_file(root / "config" / "task_recipe.yaml", "pick_source: a\nplace_target: b\n");
+  write_file(root / "environment_layout.yaml",
+    "schema_version: environment_layout/v1\n"
+    "items:\n"
+    "  - id: table\n"
+    "    type: table\n"
+    "    pose: {xyz: [1.0, 2.0, 3.0], rpy: [0.1, 0.2, 0.3]}\n"
+    "    size: {width: 1.1, depth: 1.2, height: 1.3}\n"
+    "assets:\n"
+    "  - id: asset_a\n"
+    "    type: fixture\n"
+    "placed_assets:\n"
+    "  - id: placed_a\n"
+    "    type: bin\n"
+    "objects:\n"
+    "  - id: object_b\n"
+    "    type: part\n"
+    "zones:\n"
+    "  - id: zone_a\n"
+    "    type: zone\n"
+    "targets:\n"
+    "  - id: target_a\n"
+    "    type: target\n"
+    "camera:\n"
+    "  id: camera\n"
+    "  type: camera\n"
+    "  locked: true\n");
+
+  const auto model = workcell_builder::build_workcell_studio_canvas_model(root, "demo");
+  std::set<std::string> editable_ids;
+  bool saw_table = false;
+  bool saw_camera = false;
+  for (const auto & item : model.items) {
+    if (item.provenance != workcell_builder::WorkcellStudioItemProvenance::EditableLayout) continue;
+    editable_ids.insert(item.id);
+    EXPECT_EQ(item.source_file, "environment_layout.yaml");
+    if (item.id == "table") {
+      saw_table = true;
+      EXPECT_FALSE(item.locked);
+      EXPECT_DOUBLE_EQ(item.x, 1.0);
+      EXPECT_DOUBLE_EQ(item.y, 2.0);
+      EXPECT_DOUBLE_EQ(item.z, 3.0);
+      EXPECT_DOUBLE_EQ(item.roll, 0.1);
+      EXPECT_DOUBLE_EQ(item.pitch, 0.2);
+      EXPECT_DOUBLE_EQ(item.yaw, 0.3);
+      EXPECT_DOUBLE_EQ(item.width, 1.1);
+      EXPECT_DOUBLE_EQ(item.depth, 1.2);
+      EXPECT_DOUBLE_EQ(item.height, 1.3);
+    }
+    if (item.id == "camera") {
+      saw_camera = true;
+      EXPECT_TRUE(item.locked);
+    }
+  }
+  EXPECT_TRUE(saw_table);
+  EXPECT_TRUE(saw_camera);
+  EXPECT_EQ(editable_ids.count("asset_a"), 1u);
+  EXPECT_EQ(editable_ids.count("placed_a"), 1u);
+  EXPECT_EQ(editable_ids.count("object_b"), 1u);
+  EXPECT_EQ(editable_ids.count("zone_a"), 1u);
+  EXPECT_EQ(editable_ids.count("target_a"), 1u);
+}
+
+TEST(WorkcellStudioCanvasMesh, UsesSafeManifestLayoutOnlyAfterCanonicalAndLegacyMissing)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_canvas_manifest_layout_fallback";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "environment.yaml", "robot: ur5\nend_effector: gripper\n");
+  write_file(root / "scene_manifest.yaml",
+    "template_name: demo\n"
+    "files:\n"
+    "  editable_layout: generated/editor_layout.yaml\n");
+  write_file(root / "config" / "task_recipe.yaml", "pick_source: a\nplace_target: b\n");
+  write_file(root / "generated" / "editor_layout.yaml",
+    "schema_version: workcell_studio_layout/v1\n"
+    "items:\n"
+    "  - id: manifest_item\n"
+    "    type: fixture\n"
+    "    pose: {xyz: [0.4, 0.5, 0.6], rpy: [0.0, 0.0, 0.0]}\n");
+
+  const auto model = workcell_builder::build_workcell_studio_canvas_model(root, "demo");
+  bool found = false;
+  for (const auto & item : model.items) {
+    if (item.id != "manifest_item") continue;
+    found = true;
+    EXPECT_EQ(item.provenance, workcell_builder::WorkcellStudioItemProvenance::EditableLayout);
+    EXPECT_EQ(item.source_file, "generated/editor_layout.yaml");
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST(WorkcellStudioCanvasMesh, RejectsUnsafeManifestLayoutPath)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_canvas_manifest_layout_unsafe";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "environment.yaml", "robot: ur5\nend_effector: gripper\n");
+  write_file(root / "scene_manifest.yaml",
+    "template_name: demo\n"
+    "files:\n"
+    "  editable_layout: ../outside.yaml\n");
+  write_file(root / "config" / "task_recipe.yaml", "pick_source: a\nplace_target: b\n");
+
+  const auto model = workcell_builder::build_workcell_studio_canvas_model(root, "demo");
+  for (const auto & item : model.items) {
+    EXPECT_NE(item.id, "outside_item");
+    if (item.id == "table") {
+      EXPECT_EQ(item.provenance, workcell_builder::WorkcellStudioItemProvenance::StaticFallbackPreview);
+    }
+  }
+}
+
 TEST(WorkcellStudioCanvasMesh, LegacyMeshShapesNeverThrowAndFallbackSafely)
 {
   const std::vector<std::string> mesh_variants = {
@@ -417,6 +540,7 @@ TEST(WorkcellStudioCanvasMesh, StarterLayoutAcceptanceCopiesSceneAndFiltersUnsaf
   const YAML::Node fallback_before_layout = load_yaml_file(fallback_layout_path);
   ASSERT_TRUE(fallback_before_layout && fallback_before_layout.IsMap());
   fs::remove(fallback_layout_path);
+  fs::remove(fallback_scene / "environment_layout.yaml");
 
   const auto fallback_model = workcell_builder::build_workcell_studio_canvas_model(fallback_scene, scene_name);
   std::set<std::string> static_fallback_ids;
@@ -425,7 +549,7 @@ TEST(WorkcellStudioCanvasMesh, StarterLayoutAcceptanceCopiesSceneAndFiltersUnsaf
       static_fallback_ids.insert(item.id);
     }
   }
-  ASSERT_FALSE(static_fallback_ids.empty()) << "missing layout should force static fallback-only preview metadata";
+  ASSERT_FALSE(static_fallback_ids.empty()) << "missing editable layout sources should force static fallback-only preview metadata";
   const auto fallback_starter_layout_summary = workcell_builder::build_starter_layout_entries_from_preview(fallback_model);
   EXPECT_EQ(fallback_starter_layout_summary.editable_items_created, 0u);
   EXPECT_TRUE(fallback_starter_layout_summary.layout["empty_layout_marker"].as<bool>());


### PR DESCRIPTION
### Motivation
- Make editable layout resolution deterministic and safer by preferring canonical editor files, then legacy authoring, and only using manifest-declared layout as a last safe-resort.
- Ensure legacy `environment_layout.yaml` can be used as an editable source by normalizing its sections into the canvas item shape instead of immediately falling back to static preview.
- Prevent unsafe manifest-declared paths from being used by enforcing the same safety rules as `manifest_declared_layout_path()` in the main window code.

### Description
- Updated `build_workcell_studio_canvas_model()` to resolve editable layout input in the order: `scene_dir/layout/workcell_studio_layout.yaml`, `scene_dir/environment_layout.yaml` (normalized), then a safe manifest-declared layout path only when both canonical and legacy sources are missing or absent.
- Added a canvas-local safe manifest resolver `manifest_declared_canvas_layout_path()` that rejects empty, absolute, or `..` paths (same safety rules as the existing `manifest_declared_layout_path()` in `mainwindow.cpp`).
- Added normalization helpers `normalize_environment_layout_canvas_items()` and supporting functions to convert `items`, `assets`, `placed_assets`, `objects`, `zones`, `targets`, and `camera` entries from `environment_layout.yaml` into `workcell_studio_layout/v1`-style items; normalized items are produced with `provenance = EditableLayout`, `source_file = "environment_layout.yaml"`, and `locked = false` unless explicitly locked.
- Preserved static deterministic fallback behavior and only apply static-preview fallback after all editable layout sources are missing or invalid, with clearer fallback warnings and provenance handling.
- Adjusted item population to copy `size`/`pose`/`locked` correctly from legacy normalized entries and to propagate `source_file` to items coming from non-canonical sources.
- Added/updated unit tests in `test/workcell_studio_canvas_model_mesh_test.cpp` to cover: environment-layout normalization fallback, safe manifest-declared layout fallback, rejection of unsafe manifest paths, and fallback-only starter layout acceptance behavior.

### Testing
- Built and compiled the modified code with `g++` and headers from `workcell_builder/workcell_builder/include` and required libs, and compiled the test binary successfully; compilation succeeded.
- Ran the canvas model unit test suite (`workcell_studio_canvas_model_mesh_test`) by building and executing the test binary; all tests passed (23/23).
- `colcon build` with ROS workspace was not executed because `/opt/ros/humble/setup.bash` is not available in this container, so full ROS/Humble build was not performed.  
- `git diff --check` returned clean with no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a206905a8b0833194af97cd5f80a4a2)