### PR TITLE
Add scene layout reload status logging

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -4914,6 +4914,11 @@ void MainWindow::rebuild_digital_twin_canvas()
   }
   const auto & s = scene_browser_result_.scenes[(size_t)selected_scene_index_];
   auto model = workcell_builder::build_workcell_studio_canvas_model(s.scene_dir, s.scene_name);
+  const QString layout_load_message = QString::fromStdString(model.layout_load_message).trimmed();
+  if (!layout_load_message.isEmpty() && layout_load_message != last_layout_load_message_log_) {
+    append_studio_log(layout_load_message);
+    last_layout_load_message_log_ = layout_load_message;
+  }
 
   QVector<QRectF> occupied_label_rects;
   QRectF physical_bounds;
@@ -6897,6 +6902,11 @@ void MainWindow::populate_scene_hierarchy()
   const auto & s = scene_browser_result_.scenes[static_cast<size_t>(selected_scene_state_.index)];
   const fs::path d = s.scene_dir;
   const auto model = workcell_builder::build_workcell_studio_canvas_model(s.scene_dir, s.scene_name);
+  const QString layout_load_message = QString::fromStdString(model.layout_load_message).trimmed();
+  if (!layout_load_message.isEmpty() && layout_load_message != last_layout_load_message_log_) {
+    append_studio_log(layout_load_message);
+    last_layout_load_message_log_ = layout_load_message;
+  }
 
   auto normalize_role = [](const QString & raw_role, const QString & fallback_text) {
     const QString lower = (raw_role + " " + fallback_text).toLower();

--- a/workcell_builder/workcell_builder/gui/mainwindow.h
+++ b/workcell_builder/workcell_builder/gui/mainwindow.h
@@ -686,6 +686,7 @@ private:
   QString last_perception_summary_log_;
   QString last_camera_summary_log_;
   QString last_preview_summary_log_;
+  QString last_layout_load_message_log_;
   QSet<QString> emitted_scene_diagnostic_log_keys_;
   int scene_diagnostic_payload_revision_{ 0 };
   QString visual_index_script_missing_reported_scene_key_;

--- a/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
+++ b/workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp
@@ -52,6 +52,7 @@ struct WorkcellStudioCanvasItem {
 };
 struct WorkcellStudioCanvasModel {
   std::string scene_name, template_name, robot_summary, tool_summary, status;
+  std::string layout_source_path, layout_source_kind, layout_load_message;
   bool fake_hardware_first{true}, no_robot_motion{true}, has_warnings{false};
   std::string pick_source, grasp_strategy, place_target, release_strategy;
   WorkcellStudioProvenanceStatus provenance_status;

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -182,6 +182,7 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   const fs::path manifest_path = scene_dir / "scene_manifest.yaml";
   const fs::path task_path = scene_dir / "config" / "task_recipe.yaml";
   const fs::path layout_path = scene_dir / "layout" / "workcell_studio_layout.yaml";
+  const fs::path legacy_layout_path = scene_dir / "environment_layout.yaml";
   const YamlLoadStatus env_status = read_yaml(env_path, &env);
   const YamlLoadStatus manifest_status = read_yaml(manifest_path, &manifest);
   const YamlLoadStatus task_status = read_yaml(task_path, &task);
@@ -189,11 +190,7 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   const bool env_ok = env_status.loaded;
   const bool manifest_ok = manifest_status.loaded;
   const bool task_ok = task_status.loaded;
-  const bool layout_ok = layout_status.loaded;
-  if (!layout_ok) {
-    if (layout_status.exists) enable_deterministic_fallback("layout/workcell_studio_layout.yaml is malformed");
-    else enable_deterministic_fallback("layout/workcell_studio_layout.yaml is missing");
-  }
+  bool layout_ok = false;
   if (!env_ok) m.warnings.push_back(env_status.parse_warning ?
     ("environment.yaml parse warning (" + env_path.string() + "): " + env_status.reason + ". Validate YAML syntax (e.g., `yamllint`) and retry.") :
     "Malformed or missing environment.yaml");
@@ -203,12 +200,6 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   if (!task_ok) m.warnings.push_back(task_status.parse_warning ?
     ("task_recipe.yaml parse warning (" + task_path.string() + "): " + task_status.reason + ". Validate YAML syntax (e.g., `yamllint`) and retry.") :
     "Task intent missing");
-  if (!layout_ok && layout_status.exists) {
-    const std::string parse_reason = layout_status.parse_warning ? (": " + layout_status.reason) : "";
-    m.warnings.push_back("Malformed layout/workcell_studio_layout.yaml (" + layout_path.string() + ")" + parse_reason +
-                         "; falling back safely. Repair guidance: run YAML validation (e.g., `yamllint`) and fix syntax/indentation.");
-  }
-
   m.template_name = manifest_ok ? yaml_map_value_or_empty(manifest, "template_name") : "";
   if (m.template_name.empty()) m.template_name = "unknown_template";
   m.robot_summary = env_ok ? yaml_named_or_scalar(yaml_map_key(env, "robot"), "name") : "";
@@ -279,8 +270,93 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
     }
   };
 
-  const std::string schema_version = read_string_or_warn(yaml_map_key(layout, "schema_version"), "schema_version", "");
-  YAML::Node layout_items = yaml_map_key(layout, "items");
+  const auto append_layout_load_message = [&m](const std::string & message) {
+    if (message.empty()) return;
+    if (!m.layout_load_message.empty()) m.layout_load_message += "\n";
+    m.layout_load_message += message;
+  };
+  const auto layout_parse_reason = [](const YamlLoadStatus & status) {
+    if (!status.reason.empty()) return status.reason;
+    return std::string("unknown parse error");
+  };
+  const auto append_legacy_source_items = [](const YAML::Node & root, YAML::Node * items) {
+    if (!root || !root.IsMap() || items == nullptr) return;
+    const std::array<const char *, 6> legacy_sequence_keys = {
+      "items", "assets", "placed_assets", "objects", "zones", "targets"
+    };
+    for (const char * key : legacy_sequence_keys) {
+      const YAML::Node seq = yaml_map_key(root, key);
+      if (!seq || !seq.IsSequence()) continue;
+      for (const auto & node : seq) {
+        if (node && node.IsMap()) items->push_back(YAML::Clone(node));
+      }
+    }
+    const YAML::Node camera = yaml_map_key(root, "camera");
+    if (camera && camera.IsMap()) items->push_back(YAML::Clone(camera));
+  };
+
+  const std::string canonical_schema_version = layout_status.loaded ?
+    read_string_or_warn(yaml_map_key(layout, "schema_version"), "schema_version", "") : "";
+  const YAML::Node canonical_layout_items = layout_status.loaded ? yaml_map_key(layout, "items") : YAML::Node();
+  const bool canonical_schema_current = (canonical_schema_version == "workcell_studio_layout/v1");
+  const bool canonical_schema_legacy = canonical_schema_version.empty() && canonical_layout_items.IsSequence();
+  const bool canonical_layout_usable = layout_status.loaded && (canonical_schema_current || canonical_schema_legacy);
+
+  YAML::Node effective_layout;
+  if (canonical_layout_usable) {
+    effective_layout = layout;
+    layout_ok = true;
+    m.layout_source_path = layout_path.string();
+    m.layout_source_kind = "canonical";
+    const bool empty_items = !canonical_layout_items.IsSequence() || canonical_layout_items.size() == 0;
+    append_layout_load_message((empty_items ?
+      "Loaded empty canonical layout metadata from " :
+      "Loaded canonical layout from ") + layout_path.string());
+  } else {
+    if (layout_status.exists) {
+      const std::string reason = layout_status.loaded ?
+        "invalid or missing schema_version" : layout_parse_reason(layout_status);
+      append_layout_load_message("Failed to load layout " + layout_path.string() + ": " + reason + "; using next fallback");
+      const std::string parse_reason = layout_status.parse_warning ? (": " + layout_status.reason) : "";
+      m.warnings.push_back("Malformed layout/workcell_studio_layout.yaml (" + layout_path.string() + ")" + parse_reason +
+                           "; falling back safely. Repair guidance: run YAML validation (e.g., `yamllint`) and fix syntax/indentation.");
+    }
+
+    YAML::Node legacy_layout;
+    const YamlLoadStatus legacy_layout_status = read_yaml(legacy_layout_path, &legacy_layout);
+    if (legacy_layout_status.loaded) {
+      YAML::Node legacy_items(YAML::NodeType::Sequence);
+      append_legacy_source_items(legacy_layout, &legacy_items);
+      if (legacy_items.size() > 0) {
+        effective_layout = YAML::Node(YAML::NodeType::Map);
+        effective_layout["schema_version"] = "workcell_studio_layout/v1";
+        effective_layout["schema"] = "workcell_studio_layout/v1";
+        effective_layout["scene_name"] = scene_name;
+        effective_layout["scene_path"] = scene_dir.string();
+        effective_layout["items"] = legacy_items;
+        layout_ok = true;
+        m.layout_source_path = legacy_layout_path.string();
+        m.layout_source_kind = "legacy";
+        append_layout_load_message("Imported legacy layout from " + legacy_layout_path.string());
+      }
+    } else if (legacy_layout_status.exists) {
+      append_layout_load_message("Failed to load layout " + legacy_layout_path.string() + ": " +
+                                 layout_parse_reason(legacy_layout_status) + "; using next fallback");
+    }
+  }
+
+  if (layout_ok) {
+    layout = effective_layout;
+  } else {
+    m.layout_source_path.clear();
+    m.layout_source_kind = "locked_preview_fallback";
+    append_layout_load_message("No editable layout source found; using locked preview fallback");
+    if (layout_status.exists) enable_deterministic_fallback("layout/workcell_studio_layout.yaml is malformed");
+    else enable_deterministic_fallback("layout/workcell_studio_layout.yaml is missing");
+  }
+
+  const std::string schema_version = layout_ok ? read_string_or_warn(yaml_map_key(layout, "schema_version"), "schema_version", "") : "";
+  YAML::Node layout_items = layout_ok ? yaml_map_key(layout, "items") : YAML::Node();
   const bool schema_current = (schema_version == "workcell_studio_layout/v1");
   const bool schema_legacy = schema_version.empty() && layout_items.IsSequence();
   if (layout_ok && (schema_current || schema_legacy)) {

--- a/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
@@ -56,6 +56,89 @@ static std::set<std::string> editable_item_ids(const YAML::Node & layout)
   return ids;
 }
 
+
+TEST(WorkcellStudioCanvasModelLayoutStatus, ReportsCanonicalLayoutSource)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_canvas_layout_status_canonical";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "environment.yaml", "robot: ur5\n");
+  write_file(root / "scene_manifest.yaml", "template_name: demo\n");
+  write_file(root / "config" / "task_recipe.yaml", "pick_source: a\nplace_target: b\n");
+  write_file(root / "layout" / "workcell_studio_layout.yaml",
+    "schema_version: workcell_studio_layout/v1\n"
+    "items:\n"
+    "  - id: table\n"
+    "    type: table\n"
+    "    role: table\n"
+    "    editable: true\n"
+    "    pose: {xyz: [0.1, 0.2, 0.0], rpy: [0.0, 0.0, 0.0]}\n");
+
+  const auto model = workcell_builder::build_workcell_studio_canvas_model(root, "demo");
+  EXPECT_EQ(model.layout_source_kind, "canonical");
+  EXPECT_EQ(model.layout_source_path, (root / "layout" / "workcell_studio_layout.yaml").string());
+  EXPECT_EQ(model.layout_load_message, "Loaded canonical layout from " + (root / "layout" / "workcell_studio_layout.yaml").string());
+}
+
+TEST(WorkcellStudioCanvasModelLayoutStatus, ReportsEmptyCanonicalLayoutMetadata)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_canvas_layout_status_empty_canonical";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "environment.yaml", "robot: ur5\n");
+  write_file(root / "scene_manifest.yaml", "template_name: demo\n");
+  write_file(root / "config" / "task_recipe.yaml", "pick_source: a\nplace_target: b\n");
+  write_file(root / "layout" / "workcell_studio_layout.yaml", "schema_version: workcell_studio_layout/v1\nitems: []\n");
+
+  const auto model = workcell_builder::build_workcell_studio_canvas_model(root, "demo");
+  EXPECT_EQ(model.layout_source_kind, "canonical");
+  EXPECT_EQ(model.layout_load_message, "Loaded empty canonical layout metadata from " + (root / "layout" / "workcell_studio_layout.yaml").string());
+}
+
+TEST(WorkcellStudioCanvasModelLayoutStatus, ReportsCanonicalFailureThenLegacyImport)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_canvas_layout_status_legacy";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "environment.yaml", "robot: ur5\n");
+  write_file(root / "scene_manifest.yaml", "template_name: demo\n");
+  write_file(root / "config" / "task_recipe.yaml", "pick_source: a\nplace_target: b\n");
+  write_file(root / "layout" / "workcell_studio_layout.yaml", "schema_version: [not valid YAML\n");
+  write_file(root / "environment_layout.yaml",
+    "schema_version: environment_layout/v1\n"
+    "placed_assets:\n"
+    "  - id: legacy_table\n"
+    "    type: table\n"
+    "    role: table\n"
+    "    editable: true\n"
+    "    pose: {xyz: [0.0, 0.0, 0.0], rpy: [0.0, 0.0, 0.0]}\n");
+
+  const auto model = workcell_builder::build_workcell_studio_canvas_model(root, "demo");
+  EXPECT_EQ(model.layout_source_kind, "legacy");
+  EXPECT_EQ(model.layout_source_path, (root / "environment_layout.yaml").string());
+  EXPECT_NE(model.layout_load_message.find("Failed to load layout " + (root / "layout" / "workcell_studio_layout.yaml").string() + ": "), std::string::npos);
+  EXPECT_NE(model.layout_load_message.find("; using next fallback"), std::string::npos);
+  EXPECT_NE(model.layout_load_message.find("Imported legacy layout from " + (root / "environment_layout.yaml").string()), std::string::npos);
+}
+
+TEST(WorkcellStudioCanvasModelLayoutStatus, ReportsLockedPreviewFallbackWhenNoLayoutSourceExists)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_canvas_layout_status_no_source";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  write_file(root / "environment.yaml", "robot: ur5\n");
+  write_file(root / "scene_manifest.yaml", "template_name: demo\n");
+  write_file(root / "config" / "task_recipe.yaml", "pick_source: a\nplace_target: b\n");
+
+  const auto model = workcell_builder::build_workcell_studio_canvas_model(root, "demo");
+  EXPECT_EQ(model.layout_source_kind, "locked_preview_fallback");
+  EXPECT_EQ(model.layout_load_message, "No editable layout source found; using locked preview fallback");
+}
+
 TEST(WorkcellStudioCanvasMesh, ResolvesAbsoluteAndPackagePaths)
 {
   const fs::path root = fs::temp_directory_path() / "wc_canvas_mesh_abs_pkg";


### PR DESCRIPTION
### Motivation
- Provide explicit, user-visible status about which editable layout source was used when opening or refreshing a scene preview to make layout fallbacks and imports transparent. 
- Help authors understand whether the canonical `layout/workcell_studio_layout.yaml`, a legacy `environment_layout.yaml`, or the locked preview fallback was used when building the scene canvas.

### Description
- Added three new fields to the canvas model: `layout_source_path`, `layout_source_kind`, and `layout_load_message` on `WorkcellStudioCanvasModel` (`workcell_builder/workcell_builder/include/workcell_studio_canvas_model.hpp`).
- Extended `build_workcell_studio_canvas_model()` to detect and report layout source and parse/fallback outcomes, including canonical load, empty canonical metadata, canonical parse/schema failure, legacy `environment_layout.yaml` import, and locked-preview fallback, and to populate `layout_*` fields and precise messages (`workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp`).
- Appended the model `layout_load_message` into the Studio activity log from scene/preview refresh paths after `build_workcell_studio_canvas_model()` is called in both `populate_scene_hierarchy()` and `rebuild_digital_twin_canvas()`, with a `last_layout_load_message_log_` guard to avoid duplicate log noise (`workcell_builder/workcell_builder/gui/mainwindow.cpp` / `.h`).
- Added unit-style checks to the canvas test file covering canonical, empty canonical, canonical-failure→legacy import, and no-source fallback message expectations (`workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp`).
- Messages emitted include exact-path text such as `Loaded canonical layout from <scene>/layout/workcell_studio_layout.yaml`, `Imported legacy layout from <scene>/environment_layout.yaml`, `Loaded empty canonical layout metadata from <scene>/layout/workcell_studio_layout.yaml`, `Failed to load layout <path>: <parse reason>; using next fallback`, and `No editable layout source found; using locked preview fallback` and are produced without triggering any runtime IO, ROS launch, or robot motion.

### Testing
- Ran static/syntax checks on the changed canvas model source with `g++ -std=c++17 -fsyntax-only -Iworkcell_builder/workcell_builder/include workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp` which passed. 
- Compiled and ran a small smoke helper (`/tmp/layout_status_check`) that exercises `build_workcell_studio_canvas_model()` across canonical, legacy, and no-source scenarios and observed the expected `layout_load_message` strings and benign loader warnings, indicating the new status logic works as intended (success).
- Added tests to `test/workcell_studio_canvas_model_mesh_test.cpp` covering the new layout-status cases but did not run the full test suite via `colcon` here because `/opt/ros/humble/setup.bash` and `colcon` are not available in this environment. 
- Attempted a UI syntax/compile check for `mainwindow.cpp` but it was blocked in this container by missing ROS/ament headers (`ament_index_cpp`), so the log-append integration was validated by local compilation/smoke checks and code review (partial pass; blocked for full UI build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20690f7c7c8331b2183af2198b736b)