### PR TITLE
Guard Scene3D gizmo edits to unlocked `editable_layout` items

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -1619,6 +1619,15 @@ void MainWindow::setup_studio_shell()
       if (!digital_twin_scene_) return;
       for (auto * item : digital_twin_scene_->items()) {
         if (item->data(RoleId).toString() != id) continue;
+        const bool locked_item = item->data(RoleLocked).toBool();
+        const QString source_layer = item->data(RoleSourceLayer).toString().trimmed();
+        const bool editable_source_layer =
+          source_layer.compare(QStringLiteral("editable_layout"), Qt::CaseInsensitive) == 0;
+        if (locked_item || !editable_source_layer) {
+          append_studio_log(QStringLiteral("Scene3D transform edit blocked: locked item cannot be edited or source layer is not editable_layout (id=%1, source_layer=%2)")
+              .arg(id, source_layer));
+          return;
+        }
         item->setPos(x * 100.0, y * 100.0);
         item->setData(RolePoseZ, z);
         item->setData(RoleRoll, r);

--- a/workcell_builder/workcell_builder/test/layout_serialization_contract_test.cpp
+++ b/workcell_builder/workcell_builder/test/layout_serialization_contract_test.cpp
@@ -60,6 +60,19 @@ TEST(LayoutSerializationContractTest, SelectionTransformEditorSupportsStateWitho
   EXPECT_NE(src.find("state.pose_available"), std::string::npos);
 }
 
+
+TEST(LayoutSerializationContractTest, Scene3DGizmoEditsOnlyEditableLayoutItems)
+{
+  const std::string src = load_file("gui/mainwindow.cpp");
+  EXPECT_NE(src.find("scene3d_viewport->transform_changed_cb"), std::string::npos);
+  EXPECT_NE(src.find("const bool locked_item = item->data(RoleLocked).toBool()"), std::string::npos);
+  EXPECT_NE(src.find("item->data(RoleSourceLayer).toString().trimmed()"), std::string::npos);
+  EXPECT_NE(src.find("source_layer.compare(QStringLiteral(\"editable_layout\"), Qt::CaseInsensitive) == 0"), std::string::npos);
+  EXPECT_NE(src.find("if (locked_item || !editable_source_layer)"), std::string::npos);
+  EXPECT_NE(src.find("Scene3D transform edit blocked: locked item cannot be edited"), std::string::npos);
+  EXPECT_NE(src.find("mark_layout_dirty(\"Scene3D Gizmo Transform\")"), std::string::npos);
+}
+
 TEST(LayoutSerializationContractTest, SaveLayoutForSceneWithOnlyLegacyEnvironmentLayoutWritesCanonical)
 {
   const std::string src = load_file("gui/mainwindow.cpp");


### PR DESCRIPTION
### Motivation
- Prevent accidental or unauthorized Scene3D gizmo edits to locked or non-editable-layer canvas items by validating item metadata before mutating position/pose/dirtiness state.

### Description
- In `mainwindow.cpp` updated the `scene3d_viewport->transform_changed_cb` lambda to read `RoleLocked` and `RoleSourceLayer` and require: `!locked` AND `source_layer.compare("editable_layout", Qt::CaseInsensitive) == 0` before mutating the matching `QGraphicsItem`.
- If the checks fail the code appends a clear log message (`Scene3D transform edit blocked: locked item cannot be edited or source layer is not editable_layout (id=%1, source_layer=%2)`) and returns without changing position, role metadata, selection editor state, or calling `mark_layout_dirty`.
- Kept the existing successful path unchanged so unlocked `editable_layout` items continue to update `setPos`, `RolePoseZ/Roll/Pitch/Yaw`, `refresh_selection_transform_editor_from_item`, and `mark_layout_dirty` as before.
- Added focused static/unit coverage in `workcell_builder/workcell_builder/test/layout_serialization_contract_test.cpp` to assert the presence of the new guard and related log/marker text in `gui/mainwindow.cpp`.

### Testing
- Ran a source-level static check that verified the new guard and ordering of `return` before `item->setPos` and `mark_layout_dirty` succeeded.
- Ran `git diff --check` which produced no whitespace or patch errors.
- Added a focused test assertion in `test/layout_serialization_contract_test.cpp` that checks for the presence of the new callback guard and log message; the file change is included in the PR.
- Attempted to run full package build (`colcon build --packages-select workcell_builder`) but it was not executed here because `/opt/ros/humble/setup.bash` is not present in this container; recommend running the build and tests in the ROS-enabled CI environment prior to merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20882d301c8331896efa5bc8017575)