### PR TITLE
Add selected item editing mode label

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -3187,6 +3187,16 @@ void MainWindow::refresh_selected_scene_item_labels(const SelectedSceneItemState
   const QString visual_backing = state.visual_backing_status.isEmpty() ? "unknown" : state.visual_backing_status;
   const QString type_class = state.item_type_classification.isEmpty() ? "unknown" : state.item_type_classification;
   const QString pose = state.pose_available ? (state.pose_text.isEmpty() ? QString("x=%1 y=%2 z=%3").arg(state.pose_x).arg(state.pose_y).arg(state.pose_z) : state.pose_text) : "pose unknown";
+  const bool editable_layout_contract = state.editable && state.linked_to_editable_layout_state && !state.locked;
+  const bool generated_or_preview_contract = state.generated_visual ||
+    source_layer.compare(QStringLiteral("locked_generated_urdf_visual"), Qt::CaseInsensitive) == 0 ||
+    source_layer.compare(QStringLiteral("generated_urdf_visual"), Qt::CaseInsensitive) == 0 ||
+    source_layer.compare(QStringLiteral("primitive_fallback"), Qt::CaseInsensitive) == 0 ||
+    active_visual_source.compare(QStringLiteral("locked_generated_urdf_visual"), Qt::CaseInsensitive) == 0 ||
+    active_visual_source.compare(QStringLiteral("generated_urdf_visual"), Qt::CaseInsensitive) == 0 ||
+    active_visual_source.compare(QStringLiteral("primitive_fallback"), Qt::CaseInsensitive) == 0;
+  const QString selection_contract_label = editable_layout_contract ? QStringLiteral("editable layout item") :
+    (generated_or_preview_contract ? QStringLiteral("inspection-only generated preview") : QStringLiteral("locked item cannot be edited"));
   const bool is_locked_urdf_preview = state.locked && role.contains("urdf", Qt::CaseInsensitive);
   const QString locked_line = state.locked ? QString("Locked: %1").arg(state.lock_reason.isEmpty() ? QStringLiteral("item is locked") : state.lock_reason) : QStringLiteral("Locked: no");
   inspector_lines << "";
@@ -3194,6 +3204,7 @@ void MainWindow::refresh_selected_scene_item_labels(const SelectedSceneItemState
   inspector_lines << QString("Selected item role: %1").arg(role);
   inspector_lines << QString("Selected item category: %1").arg(role);
   inspector_lines << QString("Selected item ID: %1").arg(state.id);
+  inspector_lines << QString("Selected item editing mode: %1").arg(selection_contract_label);
   inspector_lines << QString("Selected item source: %1").arg(source);
   inspector_lines << QString("Selected item source_path: %1").arg(source);
   inspector_lines << QString("Selected item source_layer: %1").arg(source_layer);


### PR DESCRIPTION
### Motivation
- Provide a concise human-readable label in the inspector that communicates whether the selected scene item is editable, an inspection-only generated preview, or otherwise locked/non-editable.
- Make the inspector easier for users to understand editing affordances without changing existing diagnostic lines or editor behavior.

### Description
- Added a derived `selection_contract_label` in `MainWindow::refresh_selected_scene_item_labels()` that resolves to `editable layout item` when `state.editable && state.linked_to_editable_layout_state && !state.locked`, to `inspection-only generated preview` when generated/preview conditions apply, and to `locked item cannot be edited` otherwise.
- Inserted an inspector line `Selected item editing mode: <label>` immediately after the selected item name/ID lines in `workcell_builder/workcell_builder/gui/mainwindow.cpp`.
- The new label is computed from existing fields (`editable`, `locked`, `generated_visual`, `source_layer`, and `active_visual_source`) and does not change any existing inspector diagnostics or UI structure.
- This is a UI-only change and does not modify launch files, controllers, runtime services, scene generation logic, or hardware defaults.

### Testing
- Ran a small assertion script that checks the modified source contains the new label string and expected classification literals, and it succeeded.
- Ran `git diff --check` to validate whitespace/patch issues and it passed.
- Attempted to run a package build (`colcon build --packages-select workcell_builder`) but it was not run because the container lacks `/opt/ros/humble/setup.bash`, so the binary build/launch smoke tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2088319c6c8331aac9dc3369386906)