### PR TITLE
Allow safe locked preview items in starter layouts

### DIFF
--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -1162,6 +1162,34 @@ static bool has_safe_starter_layout_metadata(const WorkcellStudioCanvasItem & pr
   return true;
 }
 
+static std::string lowercase_copy(std::string value)
+{
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c){ return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+static bool contains_any_visual_helper_token(const std::string & value)
+{
+  if (value.empty()) return false;
+  const std::string lower = lowercase_copy(value);
+  const std::array<const char *, 14> helper_tokens = {
+    "reach", "roi", "fov", "warning", "blocker", "axis", "grid",
+    "label", "overlay", "helper", "annotation", "gizmo", "marker", "safety"
+  };
+  for (const char * token : helper_tokens) {
+    if (lower.find(token) != std::string::npos) return true;
+  }
+  return false;
+}
+
+static bool is_preview_item_visual_helper_only(const WorkcellStudioCanvasItem & preview_item)
+{
+  return contains_any_visual_helper_token(preview_item.id) ||
+    contains_any_visual_helper_token(preview_item.type) ||
+    contains_any_visual_helper_token(preview_item.role) ||
+    contains_any_visual_helper_token(preview_item.category);
+}
+
 
 static YAML::Node new_workcell_studio_layout_root(const std::string & scene_name)
 {
@@ -1371,7 +1399,9 @@ static void append_environment_object_map_items(const YAML::Node & map, const st
   }
 }
 
-static YAML::Node preview_item_to_layout_item(const WorkcellStudioCanvasItem & preview_item)
+static YAML::Node preview_item_to_layout_item(
+  const WorkcellStudioCanvasItem & preview_item,
+  const std::string & source_value = "preview_model")
 {
   YAML::Node item(YAML::NodeType::Map);
   item["id"] = preview_item.id;
@@ -1394,7 +1424,8 @@ static YAML::Node preview_item_to_layout_item(const WorkcellStudioCanvasItem & p
   mesh["path"] = preview_item.mesh_path;
   mesh["source"] = preview_item.source_file;
   item["mesh"] = mesh;
-  item["source"] = "preview_model";
+  item["source"] = source_value;
+  item["provenance"] = "editable_layout";
   item["editable"] = true;
   item["locked"] = false;
   return item;
@@ -1410,41 +1441,15 @@ WorkcellStudioStarterLayoutSummary build_starter_layout_entries_from_preview(con
   root["scene_name"] = model.scene_name;
   YAML::Node items(YAML::NodeType::Sequence);
   for (const auto & preview_item : model.items) {
-    if (preview_item.locked) {
-      ++summary.skipped_locked_items;
-      continue;
-    }
     if (preview_item.provenance == WorkcellStudioItemProvenance::StaticFallbackPreview) {
       ++summary.skipped_static_fallback_items;
       continue;
     }
-    if (!has_safe_starter_layout_metadata(preview_item)) {
+    if (is_preview_item_visual_helper_only(preview_item) || !has_safe_starter_layout_metadata(preview_item)) {
       ++summary.skipped_unsafe_or_missing_metadata_items;
       continue;
     }
-    YAML::Node item(YAML::NodeType::Map);
-    item["id"] = preview_item.id;
-    item["type"] = preview_item.type;
-    item["category"] = preview_item.type;
-    YAML::Node pose(YAML::NodeType::Map);
-    pose["xyz"].push_back(preview_item.x);
-    pose["xyz"].push_back(preview_item.y);
-    pose["xyz"].push_back(preview_item.z);
-    pose["rpy"].push_back(preview_item.roll);
-    pose["rpy"].push_back(preview_item.pitch);
-    pose["rpy"].push_back(preview_item.yaw);
-    item["pose"] = pose;
-    item["dimensions"].push_back(preview_item.width);
-    item["dimensions"].push_back(preview_item.depth);
-    item["dimensions"].push_back(preview_item.height);
-    YAML::Node mesh(YAML::NodeType::Map);
-    mesh["path"] = preview_item.mesh_path;
-    mesh["source"] = preview_item.source_file;
-    item["mesh"] = mesh;
-    item["source"] = preview_item.source_file;
-    item["editable"] = true;
-    item["locked"] = false;
-    items.push_back(item);
+    items.push_back(preview_item_to_layout_item(preview_item, preview_item.source_file));
     ++summary.editable_items_created;
   }
   root["empty_layout_marker"] = summary.editable_items_created == 0;
@@ -1575,21 +1580,15 @@ WorkcellStudioEditableLayoutBootstrapResult bootstrap_editable_layout_from_scene
   YAML::Node candidate = new_workcell_studio_layout_root(scene_name);
   YAML::Node candidate_items = yaml_map_key(candidate, "items");
   std::set<std::string> ids;
-  std::size_t preview_locked = 0;
   std::size_t preview_static_fallback = 0;
   std::size_t preview_unsafe = 0;
   for (const auto & preview_item : preview_model.items) {
-    if (preview_item.locked) {
-      ++preview_locked;
-      ++result.skipped_locked_items;
-      continue;
-    }
     if (preview_item.provenance == WorkcellStudioItemProvenance::StaticFallbackPreview) {
       ++preview_static_fallback;
       ++result.skipped_static_fallback_items;
       continue;
     }
-    if (!has_safe_starter_layout_metadata(preview_item)) {
+    if (is_preview_item_visual_helper_only(preview_item) || !has_safe_starter_layout_metadata(preview_item)) {
       ++preview_unsafe;
       ++result.skipped_unsafe_or_missing_metadata_items;
       continue;
@@ -1599,13 +1598,10 @@ WorkcellStudioEditableLayoutBootstrapResult bootstrap_editable_layout_from_scene
   candidate["items"] = candidate_items;
   if (finish_if_items("preview_model", candidate)) return result;
 
-  if (!preview_model.items.empty() && preview_locked > 0 && preview_locked == preview_model.items.size()) {
-    result.blockers.push_back("preview locked-only");
-  }
-  if (!preview_model.items.empty() && preview_static_fallback > 0 && preview_static_fallback + preview_locked == preview_model.items.size()) {
+  if (!preview_model.items.empty() && preview_static_fallback > 0 && preview_static_fallback == preview_model.items.size()) {
     result.blockers.push_back("preview fallback-only");
   }
-  if (preview_unsafe > 0) result.blockers.push_back("unsafe/missing mesh metadata");
+  if (preview_unsafe > 0) result.blockers.push_back("unsafe/helper/missing mesh metadata");
 
   result.layout["empty_layout_marker"] = true;
   result.source_used.clear();

--- a/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
@@ -550,19 +550,75 @@ TEST(WorkcellStudioCanvasMesh, BuildStarterLayoutSummarizesSkipsAndEditableItems
   warning_metadata.warnings.push_back("malformed metadata warning");
   model.items.push_back(warning_metadata);
 
+  workcell_builder::WorkcellStudioCanvasItem reach_overlay = safe;
+  reach_overlay.id = "robot_reach_overlay";
+  reach_overlay.type = "reach";
+  reach_overlay.role = "overlay";
+  reach_overlay.locked = true;
+  model.items.push_back(reach_overlay);
+
   const auto summary = workcell_builder::build_starter_layout_entries_from_preview(model);
-  EXPECT_EQ(summary.total_preview_items, 6u);
-  EXPECT_EQ(summary.skipped_locked_items, 1u);
+  EXPECT_EQ(summary.total_preview_items, 7u);
+  EXPECT_EQ(summary.skipped_locked_items, 0u);
   EXPECT_EQ(summary.skipped_static_fallback_items, 1u);
-  EXPECT_EQ(summary.skipped_unsafe_or_missing_metadata_items, 3u);
-  EXPECT_EQ(summary.editable_items_created, 1u);
+  EXPECT_EQ(summary.skipped_unsafe_or_missing_metadata_items, 4u);
+  EXPECT_EQ(summary.editable_items_created, 2u);
 
   EXPECT_FALSE(summary.layout["empty_layout_marker"].as<bool>());
   const YAML::Node items = summary.layout["items"];
   ASSERT_TRUE(items && items.IsSequence());
-  ASSERT_EQ(items.size(), 1u);
+  ASSERT_EQ(items.size(), 2u);
   EXPECT_EQ(items[0]["id"].as<std::string>(), "safe_item");
   EXPECT_EQ(items[0]["mesh"]["path"].as<std::string>(), "meshes/visual/safe_item.stl");
+  EXPECT_TRUE(items[1]["editable"].as<bool>());
+  EXPECT_FALSE(items[1]["locked"].as<bool>());
+  EXPECT_EQ(items[1]["id"].as<std::string>(), "locked_item");
+  EXPECT_EQ(items[1]["provenance"].as<std::string>(), "editable_layout");
+}
+
+TEST(WorkcellStudioCanvasMesh, BootstrapPreviewFallbackCopiesSafeLockedPhysicalItemsOnly)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_bootstrap_preview_locked_physical";
+  fs::remove_all(root);
+  fs::create_directories(root);
+
+  workcell_builder::WorkcellStudioCanvasModel model;
+  model.scene_name = "demo";
+
+  workcell_builder::WorkcellStudioCanvasItem locked_physical;
+  locked_physical.id = "robot_base";
+  locked_physical.type = "robot_base";
+  locked_physical.role = "robot";
+  locked_physical.source_file = "generated/robot.urdf.xacro";
+  locked_physical.mesh_path = "meshes/visual/robot_base.stl";
+  locked_physical.has_mesh_metadata = true;
+  locked_physical.provenance = workcell_builder::WorkcellStudioItemProvenance::GeneratedOrLegacyPreview;
+  locked_physical.locked = true;
+  model.items.push_back(locked_physical);
+
+  workcell_builder::WorkcellStudioCanvasItem locked_helper = locked_physical;
+  locked_helper.id = "robot_reach";
+  locked_helper.type = "reach";
+  locked_helper.role = "overlay";
+  model.items.push_back(locked_helper);
+
+  const auto result = workcell_builder::bootstrap_editable_layout_from_scene_sources(root, "demo", model);
+  EXPECT_EQ(result.source_used, "preview_model");
+  EXPECT_EQ(result.editable_items_created, 1u);
+  EXPECT_EQ(result.skipped_locked_items, 0u);
+  EXPECT_EQ(result.skipped_unsafe_or_missing_metadata_items, 1u);
+
+  const YAML::Node items = result.layout["items"];
+  ASSERT_TRUE(items && items.IsSequence());
+  ASSERT_EQ(items.size(), 1u);
+  EXPECT_EQ(items[0]["id"].as<std::string>(), "robot_base");
+  EXPECT_TRUE(items[0]["editable"].as<bool>());
+  EXPECT_FALSE(items[0]["locked"].as<bool>());
+  EXPECT_EQ(items[0]["provenance"].as<std::string>(), "editable_layout");
+
+  EXPECT_TRUE(model.items[0].locked) << "preview fallback must not mutate the generated preview item lock guard";
+
+  fs::remove_all(root);
 }
 
 
@@ -613,7 +669,10 @@ TEST(WorkcellStudioCanvasMesh, StarterLayoutAcceptanceCopiesSceneAndFiltersUnsaf
   const std::set<std::string> after_editable_ids = editable_item_ids(after_layout);
   EXPECT_EQ(after_editable_ids.size(), starter_layout_summary.editable_items_created);
   for (const auto & id : locked_preview_ids) {
-    EXPECT_EQ(after_editable_ids.count(id), 0u) << "locked generated preview item was written editable: " << id;
+    const bool helper_locked_preview = id.find("reach") != std::string::npos || id.find("warning") != std::string::npos;
+    if (helper_locked_preview) {
+      EXPECT_EQ(after_editable_ids.count(id), 0u) << "helper/overlay locked preview item was written editable: " << id;
+    }
   }
 
   const fs::path fallback_scene = temp_root / (scene_name + "_fallback_only");


### PR DESCRIPTION
### Motivation
- Replace the blanket `if (preview_item.locked) continue;` behavior so safe physical generated/legacy preview items are not silently excluded when bootstrapping an editable layout.
- Skip only true static-fallback previews and non-placeable visualization helpers (reach/roi/fov/overlay/warning/etc.) while ensuring items with valid mesh/source metadata can become editable copies.
- Preserve the scene preview lock guard by never mutating the original preview items when producing editable YAML entries.

### Description
- Added helper functions to classify preview items: `lowercase_copy`, `contains_any_visual_helper_token`, and `is_preview_item_visual_helper_only` to identify helper/overlay-only entries (tokens: reach, roi, fov, warning, blocker, axis, grid, label, overlay, helper, annotation, gizmo, marker, safety).
- Reworked `preview_item_to_layout_item(...)` to produce a new YAML node with `editable: true`, `locked: false`, and `provenance: editable_layout`, and to accept the source file string when building the copied node so the original preview model is not modified.
- Replaced the blanket locked skip in `build_starter_layout_entries_from_preview(...)` with a safer filter that: continues skipping `StaticFallbackPreview` and helper/overlay-only items, rejects items missing safe starter-layout metadata, and allows physical generated/legacy preview items (even if locked in the preview model) to be copied as new editable items.
- Applied the same safer filtering in the preview fallback branch of `bootstrap_editable_layout_from_scene_sources(...)`, and preserved the existing static-fallback and unsafe/missing-metadata counting fields.
- Added/adjusted unit test coverage in `test/workcell_studio_canvas_model_mesh_test.cpp` to assert that safe locked physical preview items are copied into editable layout YAML, helpers are skipped, and the original preview item's `locked` flag remains unchanged.

### Testing
- Ran `git diff --check` to validate no whitespace/merge errors and it passed.
- Attempted to run a workspace build (`colcon build --packages-select workcell_builder`) but it could not be executed in this container because `/opt/ros/humble/setup.bash` is not available.
- Attempted a local syntax-only compile (`g++ -std=c++17 -Iworkcell_builder/workcell_builder/include -fsyntax-only ...`) but it could not complete due to missing Boost headers in the build environment; no unit tests were executed in-container for the same reason.
- Updated unit tests in `workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp` to cover the new behavior but they were not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a208aab2d108331ac36f6802fdc617d)