### PR TITLE
Stabilize editable preview copy IDs and add provenance metadata

### DIFF
--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -1191,6 +1191,32 @@ static bool is_preview_item_visual_helper_only(const WorkcellStudioCanvasItem & 
 }
 
 
+
+static std::string sanitize_preview_id_for_editable_layout_id(const std::string & preview_id)
+{
+  std::string sanitized;
+  sanitized.reserve(preview_id.size());
+  bool last_was_separator = false;
+  for (const unsigned char c : preview_id) {
+    if (std::isalnum(c)) {
+      sanitized.push_back(static_cast<char>(std::tolower(c)));
+      last_was_separator = false;
+    } else if (!last_was_separator) {
+      sanitized.push_back('_');
+      last_was_separator = true;
+    }
+  }
+  while (!sanitized.empty() && sanitized.front() == '_') sanitized.erase(sanitized.begin());
+  while (!sanitized.empty() && sanitized.back() == '_') sanitized.pop_back();
+  if (sanitized.empty()) sanitized = "preview_item";
+  return sanitized;
+}
+
+static std::string editable_layout_copy_id_from_preview_id(const std::string & preview_id)
+{
+  return "editable_" + sanitize_preview_id_for_editable_layout_id(preview_id);
+}
+
 static YAML::Node new_workcell_studio_layout_root(const std::string & scene_name)
 {
   YAML::Node root(YAML::NodeType::Map);
@@ -1408,14 +1434,14 @@ static std::string preview_source_layer_for_provenance(const WorkcellStudioCanva
       return "static_fallback_preview";
     case WorkcellStudioItemProvenance::GeneratedOrLegacyPreview:
     default:
-      return "generated_or_legacy_preview";
+      return "locked_generated_urdf_visual";
   }
 }
 
 static YAML::Node preview_item_to_layout_item(const WorkcellStudioCanvasItem & preview_item)
 {
   YAML::Node item(YAML::NodeType::Map);
-  item["id"] = preview_item.id;
+  item["id"] = editable_layout_copy_id_from_preview_id(preview_item.id);
   item["type"] = preview_item.type;
   if (!preview_item.category.empty()) item["category"] = preview_item.category;
   else item["category"] = preview_item.type;
@@ -1452,15 +1478,20 @@ static YAML::Node preview_item_to_layout_item(const WorkcellStudioCanvasItem & p
   if (!preview_item.source_package.empty()) item["source_package"] = preview_item.source_package;
   if (!preview_item.mesh_source_package.empty()) item["mesh_source_package"] = preview_item.mesh_source_package;
   item["source"] = "preview_model";
+  item["preview_source_id"] = preview_item.id;
   item["source_layer"] = "editable_layout";
   item["editable"] = true;
   item["locked"] = false;
 
   YAML::Node provenance(YAML::NodeType::Map);
+  const std::string source_layer = preview_source_layer_for_provenance(preview_item);
+  provenance["mode"] = "created_from_generated_preview";
+  provenance["source_layer"] = source_layer;
+  provenance["preview_source_id"] = preview_item.id;
   provenance["copy_kind"] = "editable_layout_copy";
   provenance["editable_layout_copy"] = true;
   provenance["original_source_id"] = preview_item.id;
-  provenance["original_source_layer"] = preview_source_layer_for_provenance(preview_item);
+  provenance["original_source_layer"] = source_layer;
   if (!preview_item.source_file.empty()) provenance["original_source_file"] = preview_item.source_file;
   provenance["copied_from"] = "preview_model";
   item["provenance"] = provenance;
@@ -1476,6 +1507,7 @@ WorkcellStudioStarterLayoutSummary build_starter_layout_entries_from_preview(con
   root["schema_version"] = "workcell_studio_layout/v1";
   root["scene_name"] = model.scene_name;
   YAML::Node items(YAML::NodeType::Sequence);
+  std::set<std::string> ids;
   for (const auto & preview_item : model.items) {
     if (preview_item.provenance == WorkcellStudioItemProvenance::StaticFallbackPreview) {
       ++summary.skipped_static_fallback_items;
@@ -1485,8 +1517,9 @@ WorkcellStudioStarterLayoutSummary build_starter_layout_entries_from_preview(con
       ++summary.skipped_unsafe_or_missing_metadata_items;
       continue;
     }
-    items.push_back(preview_item_to_layout_item(preview_item, preview_item.source_file));
-    ++summary.editable_items_created;
+    if (append_unique_item(&items, preview_item_to_layout_item(preview_item), &ids)) {
+      ++summary.editable_items_created;
+    }
   }
   root["empty_layout_marker"] = summary.editable_items_created == 0;
   root["items"] = items;

--- a/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
@@ -568,12 +568,44 @@ TEST(WorkcellStudioCanvasMesh, BuildStarterLayoutSummarizesSkipsAndEditableItems
   const YAML::Node items = summary.layout["items"];
   ASSERT_TRUE(items && items.IsSequence());
   ASSERT_EQ(items.size(), 2u);
-  EXPECT_EQ(items[0]["id"].as<std::string>(), "safe_item");
+  EXPECT_EQ(items[0]["id"].as<std::string>(), "editable_safe_item");
   EXPECT_EQ(items[0]["mesh"]["path"].as<std::string>(), "meshes/visual/safe_item.stl");
   EXPECT_TRUE(items[1]["editable"].as<bool>());
   EXPECT_FALSE(items[1]["locked"].as<bool>());
-  EXPECT_EQ(items[1]["id"].as<std::string>(), "locked_item");
-  EXPECT_EQ(items[1]["provenance"].as<std::string>(), "editable_layout");
+  EXPECT_EQ(items[1]["id"].as<std::string>(), "editable_locked_item");
+  EXPECT_EQ(items[1]["preview_source_id"].as<std::string>(), "locked_item");
+  EXPECT_EQ(items[1]["provenance"]["mode"].as<std::string>(), "created_from_generated_preview");
+}
+
+TEST(WorkcellStudioCanvasMesh, PreviewCopyIdsAreStableSanitizedAndDeduplicated)
+{
+  workcell_builder::WorkcellStudioCanvasModel model;
+  model.scene_name = "demo";
+
+  workcell_builder::WorkcellStudioCanvasItem preview;
+  preview.id = "Generated/Fixture A";
+  preview.type = "fixture";
+  preview.source_file = "urdf/scene.urdf.xacro";
+  preview.mesh_path = "meshes/visual/fixture_a.stl";
+  preview.has_mesh_metadata = true;
+  preview.provenance = workcell_builder::WorkcellStudioItemProvenance::GeneratedOrLegacyPreview;
+
+  workcell_builder::WorkcellStudioCanvasItem duplicate = preview;
+  model.items = {preview, duplicate};
+
+  const auto summary = workcell_builder::build_starter_layout_entries_from_preview(model);
+  EXPECT_EQ(summary.total_preview_items, 2u);
+  EXPECT_EQ(summary.editable_items_created, 1u);
+
+  const YAML::Node items = summary.layout["items"];
+  ASSERT_TRUE(items && items.IsSequence());
+  ASSERT_EQ(items.size(), 1u);
+  EXPECT_EQ(items[0]["id"].as<std::string>(), "editable_generated_fixture_a");
+  EXPECT_EQ(items[0]["preview_source_id"].as<std::string>(), "Generated/Fixture A");
+  EXPECT_EQ(items[0]["source_layer"].as<std::string>(), "editable_layout");
+  EXPECT_EQ(items[0]["provenance"]["mode"].as<std::string>(), "created_from_generated_preview");
+  EXPECT_EQ(items[0]["provenance"]["source_layer"].as<std::string>(), "locked_generated_urdf_visual");
+  EXPECT_EQ(items[0]["provenance"]["preview_source_id"].as<std::string>(), "Generated/Fixture A");
 }
 
 TEST(WorkcellStudioCanvasMesh, BootstrapPreviewFallbackCopiesSafeLockedPhysicalItemsOnly)
@@ -611,10 +643,11 @@ TEST(WorkcellStudioCanvasMesh, BootstrapPreviewFallbackCopiesSafeLockedPhysicalI
   const YAML::Node items = result.layout["items"];
   ASSERT_TRUE(items && items.IsSequence());
   ASSERT_EQ(items.size(), 1u);
-  EXPECT_EQ(items[0]["id"].as<std::string>(), "robot_base");
+  EXPECT_EQ(items[0]["id"].as<std::string>(), "editable_robot_base");
   EXPECT_TRUE(items[0]["editable"].as<bool>());
   EXPECT_FALSE(items[0]["locked"].as<bool>());
-  EXPECT_EQ(items[0]["provenance"].as<std::string>(), "editable_layout");
+  EXPECT_EQ(items[0]["preview_source_id"].as<std::string>(), "robot_base");
+  EXPECT_EQ(items[0]["provenance"]["source_layer"].as<std::string>(), "locked_generated_urdf_visual");
 
   EXPECT_TRUE(model.items[0].locked) << "preview fallback must not mutate the generated preview item lock guard";
 
@@ -1074,12 +1107,17 @@ TEST(WorkcellStudioCanvasMesh, BootstrapEditableLayoutFallsBackThroughSourcesAnd
   EXPECT_EQ(copied["mesh"]["scale"][1].as<double>(), 2.5);
   EXPECT_EQ(copied["source_package"].as<std::string>(), "generated_scene_pkg");
   EXPECT_EQ(copied["mesh_source_package"].as<std::string>(), "asset_pkg");
+  EXPECT_EQ(copied["id"].as<std::string>(), "editable_safe_preview");
+  EXPECT_EQ(copied["preview_source_id"].as<std::string>(), "safe_preview");
   EXPECT_EQ(copied["source_layer"].as<std::string>(), "editable_layout");
   EXPECT_TRUE(copied["editable"].as<bool>());
   EXPECT_FALSE(copied["locked"].as<bool>());
+  EXPECT_EQ(copied["provenance"]["mode"].as<std::string>(), "created_from_generated_preview");
+  EXPECT_EQ(copied["provenance"]["source_layer"].as<std::string>(), "locked_generated_urdf_visual");
+  EXPECT_EQ(copied["provenance"]["preview_source_id"].as<std::string>(), "safe_preview");
   EXPECT_EQ(copied["provenance"]["copy_kind"].as<std::string>(), "editable_layout_copy");
   EXPECT_EQ(copied["provenance"]["original_source_id"].as<std::string>(), "safe_preview");
-  EXPECT_EQ(copied["provenance"]["original_source_layer"].as<std::string>(), "generated_or_legacy_preview");
+  EXPECT_EQ(copied["provenance"]["original_source_layer"].as<std::string>(), "locked_generated_urdf_visual");
   EXPECT_EQ(copied["provenance"]["original_source_file"].as<std::string>(), "urdf/scene.urdf.xacro");
   EXPECT_FALSE(copied["confidence"].IsDefined());
   EXPECT_FALSE(copied["tracking_id"].IsDefined());


### PR DESCRIPTION
### Motivation
- Make preview->editable conversion deterministic by generating stable editable IDs instead of reusing generated preview IDs to avoid duplicates and fragile IDs.
- Preserve original preview identity and source information so downstream tooling can still trace back to the generated preview.
- Provide clear provenance metadata and source-layer semantics for editable copies so the UI, validation, and dedup logic can operate reliably.

### Description
- Added deterministic sanitization and ID helpers: `sanitize_preview_id_for_editable_layout_id(...)` and `editable_layout_copy_id_from_preview_id(...)` and used them to produce `editable_<sanitized_preview_id>` as layout IDs in `preview_item_to_layout_item(...)` in `workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp`.
- Preserved original preview ID and layer via top-level `preview_source_id` and `source_layer: editable_layout` on the editable copy and added a richer `provenance` map including `mode: created_from_generated_preview`, `source_layer`, and `preview_source_id` in `preview_item_to_layout_item(...)`.
- Adjusted preview source-layer canonicalization (returning `locked_generated_urdf_visual` for generated previews) and ensured provenance fields use the best-available source-layer token via `preview_source_layer_for_provenance(...)`.
- Ensured deterministic deduplication by collecting editable IDs and using `append_unique_item(...)` when converting preview items so duplicates are skipped rather than duplicated; updated `build_starter_layout_entries_from_preview(...)` to maintain the `ids` set and use `append_unique_item(...)`.
- Updated unit tests in `workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp` to assert stable sanitized IDs, the presence of `preview_source_id`, and the expanded provenance semantics, and added a test that duplicate preview items deduplicate to a single editable item.

### Testing
- Verified presence of the new stable-ID and provenance tokens in the modified source with a small token-check script, which passed.
- Ran Python unit checks `python3 -m pytest tests/test_workcell_studio_canvas_model.py tests/test_workcell_studio_layout_save_reload.py -q`, yielding 3 tests passed and 1 existing token-check test failing because the expected static token string `Using deterministic 3D fallback layout because layout metadata is incomplete.` was not present in this build of the source (this is a pre-existing/static-token expectation, not a behavior regression from the change).
- Ran `git diff --check` and a source-token verification script successfully; attempted a C++ syntax-only check (`g++ -fsyntax-only`) which was blocked in this container by missing system headers (Boost), so a full compile was not performed here.
- Updated tests that assert preview->editable conversion behavior to cover stable IDs, `preview_source_id`, `source_layer`, provenance fields, and duplicate suppression; those test expectations were added to `workcell_studio_canvas_model_mesh_test.cpp`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a208e1e437c8331aea07254ff6c1563)