### PR TITLE
Add canvas preview->editable round-trip contract test and fix layout reload handling

### DIFF
--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -457,14 +457,16 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
     if (camera && camera.IsMap()) items->push_back(YAML::Clone(camera));
   };
 
-  const std::string canonical_schema_version = layout_status.loaded ?
+  const std::string canonical_schema_version = canonical_layout_status.loaded ?
     read_string_or_warn(yaml_map_key(layout, "schema_version"), "schema_version", "") : "";
-  const YAML::Node canonical_layout_items = layout_status.loaded ? yaml_map_key(layout, "items") : YAML::Node();
+  const YAML::Node canonical_layout_items = canonical_layout_status.loaded ? yaml_map_key(layout, "items") : YAML::Node();
   const bool canonical_schema_current = (canonical_schema_version == "workcell_studio_layout/v1");
   const bool canonical_schema_legacy = canonical_schema_version.empty() && canonical_layout_items.IsSequence();
-  const bool canonical_layout_usable = layout_status.loaded && (canonical_schema_current || canonical_schema_legacy);
+  const bool canonical_layout_usable = canonical_layout_status.loaded && (canonical_schema_current || canonical_schema_legacy);
 
   YAML::Node effective_layout;
+  bool layout_source_is_environment_layout = false;
+  std::string layout_source_file = "layout/workcell_studio_layout.yaml";
   if (canonical_layout_usable) {
     effective_layout = layout;
     layout_ok = true;
@@ -475,11 +477,11 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
       "Loaded empty canonical layout metadata from " :
       "Loaded canonical layout from ") + layout_path.string());
   } else {
-    if (layout_status.exists) {
-      const std::string reason = layout_status.loaded ?
-        "invalid or missing schema_version" : layout_parse_reason(layout_status);
+    if (canonical_layout_status.exists) {
+      const std::string reason = canonical_layout_status.loaded ?
+        "invalid or missing schema_version" : layout_parse_reason(canonical_layout_status);
       append_layout_load_message("Failed to load layout " + layout_path.string() + ": " + reason + "; using next fallback");
-      const std::string parse_reason = layout_status.parse_warning ? (": " + layout_status.reason) : "";
+      const std::string parse_reason = canonical_layout_status.parse_warning ? (": " + canonical_layout_status.reason) : "";
       m.warnings.push_back("Malformed layout/workcell_studio_layout.yaml (" + layout_path.string() + ")" + parse_reason +
                            "; falling back safely. Repair guidance: run YAML validation (e.g., `yamllint`) and fix syntax/indentation.");
     }
@@ -499,6 +501,8 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
         layout_ok = true;
         m.layout_source_path = legacy_layout_path.string();
         m.layout_source_kind = "legacy";
+        layout_source_is_environment_layout = true;
+        layout_source_file = "environment_layout.yaml";
         append_layout_load_message("Imported legacy layout from " + legacy_layout_path.string());
       }
     } else if (legacy_layout_status.exists) {
@@ -513,7 +517,7 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
     m.layout_source_path.clear();
     m.layout_source_kind = "locked_preview_fallback";
     append_layout_load_message("No editable layout source found; using locked preview fallback");
-    if (layout_status.exists) enable_deterministic_fallback("layout/workcell_studio_layout.yaml is malformed");
+    if (canonical_layout_status.exists) enable_deterministic_fallback("layout/workcell_studio_layout.yaml is malformed");
     else enable_deterministic_fallback("layout/workcell_studio_layout.yaml is missing");
   }
 
@@ -587,59 +591,60 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
             }
           }
         }
-      }
-      if (!matched_existing) {
-        WorkcellStudioCanvasItem extra;
-        extra.id = id;
-        extra.type = read_string_or_warn(yaml_map_key(node, "type"), "items[].type", "object");
-        extra.role = read_string_or_warn(yaml_map_key(node, "role"), "items[].role", "preview");
-        const auto category = read_string_or_warn(yaml_map_key(node, "category"), "items[].category", "Custom / Imported");
-        if (category == "Pick/Place Zones") extra.type = "zone";
-        std::string label = read_string_or_warn(yaml_map_key(node, "display_name"), "items[].display_name", "");
-        if (label.empty()) label = read_string_or_warn(yaml_map_key(node, "name"), "items[].name", id);
-        extra.label = label.empty() ? id : label;
-        std::string source_file = read_string_or_warn(yaml_map_key(node, "source_path"), "items[].source_path", "");
-        if (source_file.empty()) source_file = read_string_or_warn(yaml_map_key(node, "source_layer"), "items[].source_layer", layout_source_file);
-        extra.source_file = source_file.empty() ? layout_source_file : source_file;
-        extra.provenance = WorkcellStudioItemProvenance::EditableLayout;
-        copy_primitive_metadata(extra, node);
-        YAML::Node pose = yaml_map_key(node, "pose");
-        if (pose.IsDefined() && pose.IsMap()) {
-          YAML::Node xyz = yaml_map_key(pose, "xyz");
-          if (xyz.IsDefined() && xyz.IsSequence()) {
-            extra.x = read_double_or_warn(yaml_seq_index(xyz, 0), "items[].pose.xyz[0]", extra.x);
-            extra.y = read_double_or_warn(yaml_seq_index(xyz, 1), "items[].pose.xyz[1]", extra.y);
-            extra.z = read_double_or_warn(yaml_seq_index(xyz, 2), "items[].pose.xyz[2]", extra.z);
-          } else if (xyz.IsDefined()) add_warning("items[].pose.xyz", "expected sequence; using defaults");
-          YAML::Node rpy = yaml_map_key(pose, "rpy");
-          if (rpy.IsDefined() && rpy.IsSequence()) {
-            extra.roll = read_double_or_warn(yaml_seq_index(rpy, 0), "items[].pose.rpy[0]", extra.roll);
-            extra.pitch = read_double_or_warn(yaml_seq_index(rpy, 1), "items[].pose.rpy[1]", extra.pitch);
-            extra.yaw = read_double_or_warn(yaml_seq_index(rpy, 2), "items[].pose.rpy[2]", extra.yaw);
-          } else if (rpy.IsDefined()) add_warning("items[].pose.rpy", "expected sequence; using defaults");
-        } else if (pose.IsDefined()) add_warning("items[].pose", "expected map; using defaults");
-        YAML::Node size = yaml_map_key(node, "size");
-        if (yaml_node_is_defined(size)) {
-          if (yaml_node_is_map(size)) {
-            extra.width = read_double_or_warn(yaml_map_key(size, "width"), "items[].size.width", extra.width);
-            extra.depth = read_double_or_warn(yaml_map_key(size, "depth"), "items[].size.depth", extra.depth);
-            extra.height = read_double_or_warn(yaml_map_key(size, "height"), "items[].size.height", extra.height);
-          } else if (yaml_node_is_sequence(size)) {
-            extra.width = read_double_or_warn(yaml_seq_index(size, 0), "items[].size[0]", extra.width);
-            extra.depth = read_double_or_warn(yaml_seq_index(size, 1), "items[].size[1]", extra.depth);
-            extra.height = read_double_or_warn(yaml_seq_index(size, 2), "items[].size[2]", extra.height);
+        if (!matched_existing) {
+          WorkcellStudioCanvasItem extra;
+          extra.id = id;
+          extra.type = read_string_or_warn(yaml_map_key(node, "type"), "items[].type", "object");
+          extra.role = read_string_or_warn(yaml_map_key(node, "role"), "items[].role", "preview");
+          const auto category = read_string_or_warn(yaml_map_key(node, "category"), "items[].category", "Custom / Imported");
+          extra.category = category;
+          if (category == "Pick/Place Zones") extra.type = "zone";
+          std::string label = read_string_or_warn(yaml_map_key(node, "display_name"), "items[].display_name", "");
+          if (label.empty()) label = read_string_or_warn(yaml_map_key(node, "name"), "items[].name", id);
+          extra.label = label.empty() ? id : label;
+          std::string source_file = read_string_or_warn(yaml_map_key(node, "source_path"), "items[].source_path", "");
+          if (source_file.empty()) source_file = read_string_or_warn(yaml_map_key(node, "source_layer"), "items[].source_layer", layout_source_file);
+          extra.source_file = source_file.empty() ? layout_source_file : source_file;
+          extra.provenance = WorkcellStudioItemProvenance::EditableLayout;
+          copy_primitive_metadata(extra, node);
+          YAML::Node pose = yaml_map_key(node, "pose");
+          if (pose.IsDefined() && pose.IsMap()) {
+            YAML::Node xyz = yaml_map_key(pose, "xyz");
+            if (xyz.IsDefined() && xyz.IsSequence()) {
+              extra.x = read_double_or_warn(yaml_seq_index(xyz, 0), "items[].pose.xyz[0]", extra.x);
+              extra.y = read_double_or_warn(yaml_seq_index(xyz, 1), "items[].pose.xyz[1]", extra.y);
+              extra.z = read_double_or_warn(yaml_seq_index(xyz, 2), "items[].pose.xyz[2]", extra.z);
+            } else if (xyz.IsDefined()) add_warning("items[].pose.xyz", "expected sequence; using defaults");
+            YAML::Node rpy = yaml_map_key(pose, "rpy");
+            if (rpy.IsDefined() && rpy.IsSequence()) {
+              extra.roll = read_double_or_warn(yaml_seq_index(rpy, 0), "items[].pose.rpy[0]", extra.roll);
+              extra.pitch = read_double_or_warn(yaml_seq_index(rpy, 1), "items[].pose.rpy[1]", extra.pitch);
+              extra.yaw = read_double_or_warn(yaml_seq_index(rpy, 2), "items[].pose.rpy[2]", extra.yaw);
+            } else if (rpy.IsDefined()) add_warning("items[].pose.rpy", "expected sequence; using defaults");
+          } else if (pose.IsDefined()) add_warning("items[].pose", "expected map; using defaults");
+          YAML::Node size = yaml_map_key(node, "size");
+          if (yaml_node_is_defined(size)) {
+            if (yaml_node_is_map(size)) {
+              extra.width = read_double_or_warn(yaml_map_key(size, "width"), "items[].size.width", extra.width);
+              extra.depth = read_double_or_warn(yaml_map_key(size, "depth"), "items[].size.depth", extra.depth);
+              extra.height = read_double_or_warn(yaml_map_key(size, "height"), "items[].size.height", extra.height);
+            } else if (yaml_node_is_sequence(size)) {
+              extra.width = read_double_or_warn(yaml_seq_index(size, 0), "items[].size[0]", extra.width);
+              extra.depth = read_double_or_warn(yaml_seq_index(size, 1), "items[].size[1]", extra.depth);
+              extra.height = read_double_or_warn(yaml_seq_index(size, 2), "items[].size[2]", extra.height);
+            } else {
+              add_warning("items[].size", "expected map or sequence; using defaults");
+            }
           } else {
-            add_warning("items[].size", "expected map or sequence; using defaults");
+            const YAML::Node dimensions = yaml_map_key(node, "dimensions");
+            if (yaml_node_is_sequence(dimensions)) {
+              extra.width = read_double_or_warn(yaml_seq_index(dimensions, 0), "items[].dimensions[0]", extra.width);
+              extra.depth = read_double_or_warn(yaml_seq_index(dimensions, 1), "items[].dimensions[1]", extra.depth);
+              extra.height = read_double_or_warn(yaml_seq_index(dimensions, 2), "items[].dimensions[2]", extra.height);
+            }
           }
-        } else {
-          const YAML::Node dimensions = yaml_map_key(node, "dimensions");
-          if (yaml_node_is_sequence(dimensions)) {
-            extra.width = read_double_or_warn(yaml_seq_index(dimensions, 0), "items[].dimensions[0]", extra.width);
-            extra.depth = read_double_or_warn(yaml_seq_index(dimensions, 1), "items[].dimensions[1]", extra.depth);
-            extra.height = read_double_or_warn(yaml_seq_index(dimensions, 2), "items[].dimensions[2]", extra.height);
-          }
+          m.items.push_back(extra);
         }
-        m.items.push_back(extra);
       }
     }
     if (incomplete_placement_metadata) {

--- a/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
@@ -576,6 +576,141 @@ TEST(WorkcellStudioCanvasMesh, BuildStarterLayoutSummarizesSkipsAndEditableItems
   EXPECT_EQ(items[1]["provenance"]["copy_kind"].as<std::string>(), "editable_layout_copy");
 }
 
+TEST(WorkcellStudioCanvasMesh, PreviewToEditableLayoutRoundTripKeepsGeneratedPreviewLocked)
+{
+  const fs::path root = fs::temp_directory_path() / "wc_preview_to_editable_round_trip";
+  fs::remove_all(root);
+  fs::create_directories(root / "layout");
+
+  write_file(root / "environment.yaml", "robot: ur5\nend_effector: robotiq_2f\n");
+  write_file(root / "scene_manifest.yaml", "template_name: demo\n");
+  write_file(root / "config" / "task_recipe.yaml", "pick_source: generated_fixture\nplace_target: bin_a\n");
+
+  workcell_builder::WorkcellStudioCanvasModel preview;
+  preview.scene_name = "demo";
+
+  workcell_builder::WorkcellStudioCanvasItem generated_fixture;
+  generated_fixture.id = "generated_fixture";
+  generated_fixture.label = "Generated Fixture";
+  generated_fixture.type = "fixture";
+  generated_fixture.category = "fixtures";
+  generated_fixture.role = "workholding";
+  generated_fixture.x = 0.11;
+  generated_fixture.y = -0.22;
+  generated_fixture.z = 0.33;
+  generated_fixture.roll = 0.44;
+  generated_fixture.pitch = -0.55;
+  generated_fixture.yaw = 0.66;
+  generated_fixture.width = 0.77;
+  generated_fixture.depth = 0.88;
+  generated_fixture.height = 0.99;
+  generated_fixture.source_file = "urdf/scene.urdf.xacro";
+  generated_fixture.source_package = "generated_scene_pkg";
+  generated_fixture.mesh_path = "package://fixture_asset_pkg/meshes/visual/generated_fixture.stl";
+  generated_fixture.mesh_source_package = "fixture_asset_pkg";
+  generated_fixture.mesh_scale_x = 1.1;
+  generated_fixture.mesh_scale_y = 1.2;
+  generated_fixture.mesh_scale_z = 1.3;
+  generated_fixture.has_mesh_metadata = true;
+  generated_fixture.locked = true;
+  generated_fixture.editable = false;
+  generated_fixture.provenance = workcell_builder::WorkcellStudioItemProvenance::GeneratedOrLegacyPreview;
+  preview.items.push_back(generated_fixture);
+
+  workcell_builder::WorkcellStudioCanvasItem static_fallback = generated_fixture;
+  static_fallback.id = "static_fallback_fixture";
+  static_fallback.provenance = workcell_builder::WorkcellStudioItemProvenance::StaticFallbackPreview;
+  preview.items.push_back(static_fallback);
+
+  workcell_builder::WorkcellStudioCanvasItem overlay_helper = generated_fixture;
+  overlay_helper.id = "reach_overlay_helper";
+  overlay_helper.type = "reach";
+  overlay_helper.category = "overlay";
+  overlay_helper.role = "overlay";
+  preview.items.push_back(overlay_helper);
+
+  const auto result = workcell_builder::bootstrap_editable_layout_from_scene_sources(root, "demo", preview);
+  EXPECT_EQ(result.source_used, "preview_model");
+  EXPECT_EQ(result.editable_items_created, 1u);
+  EXPECT_EQ(result.skipped_static_fallback_items, 1u);
+  EXPECT_EQ(result.skipped_unsafe_or_missing_metadata_items, 1u);
+  EXPECT_EQ(result.skipped_locked_items, 0u);
+
+  write_yaml_file(root / "layout" / "workcell_studio_layout.yaml", result.layout);
+  const YAML::Node saved = load_yaml_file(root / "layout" / "workcell_studio_layout.yaml");
+  const YAML::Node saved_items = saved["items"];
+  ASSERT_TRUE(saved_items && saved_items.IsSequence());
+  ASSERT_EQ(saved_items.size(), 1u);
+
+  const YAML::Node copied = saved_items[0];
+  ASSERT_TRUE(copied && copied.IsMap());
+  EXPECT_EQ(copied["id"].as<std::string>(), "generated_fixture__editable_copy");
+  EXPECT_NE(copied["id"].as<std::string>(), generated_fixture.id);
+  EXPECT_EQ(copied["source_layer"].as<std::string>(), "editable_layout");
+  EXPECT_TRUE(copied["editable"].as<bool>());
+  EXPECT_FALSE(copied["locked"].as<bool>());
+  EXPECT_EQ(copied["display_name"].as<std::string>(), generated_fixture.label);
+  EXPECT_EQ(copied["type"].as<std::string>(), generated_fixture.type);
+  EXPECT_EQ(copied["category"].as<std::string>(), generated_fixture.category);
+  EXPECT_EQ(copied["role"].as<std::string>(), generated_fixture.role);
+  EXPECT_DOUBLE_EQ(copied["pose"]["xyz"][0].as<double>(), generated_fixture.x);
+  EXPECT_DOUBLE_EQ(copied["pose"]["xyz"][1].as<double>(), generated_fixture.y);
+  EXPECT_DOUBLE_EQ(copied["pose"]["xyz"][2].as<double>(), generated_fixture.z);
+  EXPECT_DOUBLE_EQ(copied["pose"]["rpy"][0].as<double>(), generated_fixture.roll);
+  EXPECT_DOUBLE_EQ(copied["pose"]["rpy"][1].as<double>(), generated_fixture.pitch);
+  EXPECT_DOUBLE_EQ(copied["pose"]["rpy"][2].as<double>(), generated_fixture.yaw);
+  EXPECT_DOUBLE_EQ(copied["dimensions"][0].as<double>(), generated_fixture.width);
+  EXPECT_DOUBLE_EQ(copied["dimensions"][1].as<double>(), generated_fixture.depth);
+  EXPECT_DOUBLE_EQ(copied["dimensions"][2].as<double>(), generated_fixture.height);
+  EXPECT_EQ(copied["mesh"]["path"].as<std::string>(), generated_fixture.mesh_path);
+  EXPECT_EQ(copied["mesh"]["source"].as<std::string>(), generated_fixture.source_file);
+  EXPECT_EQ(copied["mesh"]["source_package"].as<std::string>(), generated_fixture.mesh_source_package);
+  EXPECT_DOUBLE_EQ(copied["mesh"]["scale"][0].as<double>(), generated_fixture.mesh_scale_x);
+  EXPECT_DOUBLE_EQ(copied["mesh"]["scale"][1].as<double>(), generated_fixture.mesh_scale_y);
+  EXPECT_DOUBLE_EQ(copied["mesh"]["scale"][2].as<double>(), generated_fixture.mesh_scale_z);
+  EXPECT_EQ(copied["source_package"].as<std::string>(), generated_fixture.source_package);
+  EXPECT_EQ(copied["mesh_source_package"].as<std::string>(), generated_fixture.mesh_source_package);
+  EXPECT_EQ(copied["preview_source_id"].as<std::string>(), generated_fixture.id);
+  EXPECT_EQ(copied["provenance"]["original_source_id"].as<std::string>(), generated_fixture.id);
+  EXPECT_EQ(copied["provenance"]["preview_source_id"].as<std::string>(), generated_fixture.id);
+  EXPECT_EQ(copied["provenance"]["original_source_layer"].as<std::string>(), "locked_generated_urdf_visual");
+  EXPECT_EQ(copied["provenance"]["original_source_file"].as<std::string>(), generated_fixture.source_file);
+
+  const auto reloaded = workcell_builder::build_workcell_studio_canvas_model(root, "demo");
+  bool found_reloaded_copy = false;
+  for (const auto & item : reloaded.items) {
+    if (item.id != "generated_fixture__editable_copy") continue;
+    found_reloaded_copy = true;
+    EXPECT_EQ(item.provenance, workcell_builder::WorkcellStudioItemProvenance::EditableLayout);
+    EXPECT_TRUE(item.editable);
+    EXPECT_FALSE(item.locked);
+    EXPECT_EQ(item.source_file, "editable_layout");
+    EXPECT_EQ(item.label, generated_fixture.label);
+    EXPECT_EQ(item.type, generated_fixture.type);
+    EXPECT_EQ(item.category, generated_fixture.category);
+    EXPECT_EQ(item.role, generated_fixture.role);
+    EXPECT_DOUBLE_EQ(item.x, generated_fixture.x);
+    EXPECT_DOUBLE_EQ(item.y, generated_fixture.y);
+    EXPECT_DOUBLE_EQ(item.z, generated_fixture.z);
+    EXPECT_DOUBLE_EQ(item.roll, generated_fixture.roll);
+    EXPECT_DOUBLE_EQ(item.pitch, generated_fixture.pitch);
+    EXPECT_DOUBLE_EQ(item.yaw, generated_fixture.yaw);
+    EXPECT_DOUBLE_EQ(item.width, generated_fixture.width);
+    EXPECT_DOUBLE_EQ(item.depth, generated_fixture.depth);
+    EXPECT_DOUBLE_EQ(item.height, generated_fixture.height);
+    EXPECT_EQ(item.mesh_source_package, generated_fixture.mesh_source_package);
+    EXPECT_TRUE(item.has_mesh_metadata);
+  }
+  EXPECT_TRUE(found_reloaded_copy);
+
+  ASSERT_EQ(preview.items[0].id, generated_fixture.id);
+  EXPECT_TRUE(preview.items[0].locked);
+  EXPECT_FALSE(preview.items[0].editable);
+  EXPECT_EQ(preview.items[0].provenance, workcell_builder::WorkcellStudioItemProvenance::GeneratedOrLegacyPreview);
+
+  fs::remove_all(root);
+}
+
 TEST(WorkcellStudioCanvasMesh, BootstrapPreviewFallbackCopiesSafeLockedPhysicalItemsOnly)
 {
   const fs::path root = fs::temp_directory_path() / "wc_bootstrap_preview_locked_physical";


### PR DESCRIPTION
### Motivation
- Provide a focused contract test that verifies a generated/locked preview item is copied to an editable layout, persisted to canonical YAML, and reloaded as an editable item while preserving the original preview (locked) provenance.
- Ensure the canvas model correctly classifies and loads editable entries from canonical/legacy layout sources so the round-trip test can compile and run and to reduce brittle reload behavior.

### Description
- Added a new test `PreviewToEditableLayoutRoundTripKeepsGeneratedPreviewLocked` in `test/workcell_studio_canvas_model_mesh_test.cpp` that: creates a temp scene, constructs an in-memory preview model with a locked generated preview, a static fallback, and an overlay helper, bootstraps the editable layout, writes `layout/workcell_studio_layout.yaml`, reloads via `build_workcell_studio_canvas_model(...)`, and asserts copied editable item identity, metadata, provenance, and that the original preview remains locked.
- Adjusted canvas model loading code in `src_workcell_studio_canvas_model.cpp` to use the canonical layout load status variables consistently, track `layout_source_file` and `layout_source_is_environment_layout`, and preserve category/source handling for unmatched editable layout entries so reload classification and provenance are stable.
- Kept changes minimal and localized to the `workcell_builder` package; no runtime/launch/hardware code was modified.

### Testing
- Compiled the relevant test and supporting sources with `g++` and ran the single test binary filter for `WorkcellStudioCanvasMesh.PreviewToEditableLayoutRoundTripKeepsGeneratedPreviewLocked`; the focused test passed. 
- Executed the full test binary locally; the new focused test passed but there remain 4 pre-existing failing canvas-model expectations unrelated to this change. 
- Attempted `colcon build` for `workcell_builder` but the container lacks `/opt/ros/humble/setup.bash`, so an integrated ROS build was blocked and not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2096199be88331a082485906ebe954)