### PR TITLE
Update ur5_2f_test known_blocker to remove stale cell_definition message

### DIFF
--- a/scenes/supported_scenes.yaml
+++ b/scenes/supported_scenes.yaml
@@ -97,7 +97,7 @@ scenes:
     scene_path: scenes/ur5_2f_test
     support_level: supported
     status: blocked
-    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
+    known_blocker: "Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable, indicating the ROS Humble/ament workcell_builder executable is unavailable in this container."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json


### PR DESCRIPTION
### Motivation
- The `ur5_2f_test` supported-scene entry still referenced a stale `cell_definition_validation FAIL` message about missing `camera` and `objects` even though the generated `cell_definition.yaml` now validates, so the catalog text needed to be updated to reflect the real remaining blocker. 
- Preserve the `blocked` status because the runtime/Scene3D GUI smoke evidence is still unavailable in this environment due to the `workcell_builder` executable resolution issue.

### Description
- Edited `scenes/supported_scenes.yaml` to remove the `post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects)` portion of the `known_blocker` for the entry with `scene_name: ur5_2f_test` and replaced it with a concise description of the remaining Scene3D runtime smoke blocker. 
- Kept `status: blocked` for `ur5_2f_test` and did not change any launch, runtime, or safety defaults.
- No other files or runtime behavior were modified; this is a metadata/catalog text change only.

### Testing
- Ran `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --supported-scenes scenes/supported_scenes.yaml --output-dir build/workcell_studio_scene_readiness` and the job completed successfully with summary `PASS=0 FAIL=0 BLOCKED=8`.
- Inspected `build/workcell_studio_scene_readiness/scene_readiness_summary.json` and confirmed the `ur5_2f_test` record reports `cell_definition_validation`/`cell_definition_status` as `PASS` and the `known_blocker` no longer mentions missing `camera` or `objects`.
- Checked the generated Markdown `build/workcell_studio_scene_readiness/scene_readiness_summary.md` and verified `ur5_2f_test` is now blocked only for Scene3D visual-quality/runtime evidence (the `workcell_builder` executable resolution issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a04a4cb48331b8442d1f95efa6ce)