### PR TITLE
Record generated evidence artifacts in scene manifests

### DIFF
--- a/scenes/suction_test/scene_manifest.yaml
+++ b/scenes/suction_test/scene_manifest.yaml
@@ -9,6 +9,8 @@ files:
   layout: layout/workcell_studio_layout.yaml
   launch: launch/demo.launch.py
   urdf_xacro: urdf/scene.urdf.xacro
+  visual_mesh_index: generated/scene_visual_mesh_index.json
+  scene3d_gui_smoke: generated/scene3d_gui_smoke.json
 
 robot:
   model: ur5

--- a/scenes/ur10_2f_test/scene_manifest.yaml
+++ b/scenes/ur10_2f_test/scene_manifest.yaml
@@ -9,6 +9,8 @@ files:
   layout: layout/workcell_studio_layout.yaml
   launch: launch/demo.launch.py
   urdf_xacro: urdf/scene.urdf.xacro
+  visual_mesh_index: generated/scene_visual_mesh_index.json
+  scene3d_gui_smoke: generated/scene3d_gui_smoke.json
 
 robot:
   model: ur10

--- a/scenes/ur3_suction_test/scene_manifest.yaml
+++ b/scenes/ur3_suction_test/scene_manifest.yaml
@@ -9,6 +9,8 @@ files:
   layout: layout/workcell_studio_layout.yaml
   launch: launch/demo.launch.py
   urdf_xacro: urdf/scene.urdf.xacro
+  visual_mesh_index: generated/scene_visual_mesh_index.json
+  scene3d_gui_smoke: generated/scene3d_gui_smoke.json
 
 robot:
   model: ur3

--- a/scenes/ur5_2f_builder_pick_place_demo/scene_manifest.yaml
+++ b/scenes/ur5_2f_builder_pick_place_demo/scene_manifest.yaml
@@ -9,6 +9,8 @@ files:
   layout: layout/workcell_studio_layout.yaml
   launch: launch/demo.launch.py
   urdf_xacro: urdf/scene.urdf.xacro
+  visual_mesh_index: generated/scene_visual_mesh_index.json
+  scene3d_gui_smoke: generated/scene3d_gui_smoke.json
 
 robot:
   model: ur5

--- a/scenes/ur5_2f_sorting_test/scene_manifest.yaml
+++ b/scenes/ur5_2f_sorting_test/scene_manifest.yaml
@@ -9,6 +9,8 @@ files:
   layout: layout/workcell_studio_layout.yaml
   launch: launch/demo.launch.py
   urdf_xacro: urdf/scene.urdf.xacro
+  visual_mesh_index: generated/scene_visual_mesh_index.json
+  scene3d_gui_smoke: generated/scene3d_gui_smoke.json
 
 robot:
   model: ur5

--- a/scenes/ur5_2f_test/scene_manifest.yaml
+++ b/scenes/ur5_2f_test/scene_manifest.yaml
@@ -9,6 +9,8 @@ files:
   layout: layout/workcell_studio_layout.yaml
   launch: launch/demo.launch.py
   urdf_xacro: urdf/scene.urdf.xacro
+  visual_mesh_index: generated/scene_visual_mesh_index.json
+  scene3d_gui_smoke: generated/scene3d_gui_smoke.json
 
 robot:
   model: ur5

--- a/scenes/ur5_3f_test/scene_manifest.yaml
+++ b/scenes/ur5_3f_test/scene_manifest.yaml
@@ -9,6 +9,8 @@ files:
   layout: layout/workcell_studio_layout.yaml
   launch: launch/demo.launch.py
   urdf_xacro: urdf/scene.urdf.xacro
+  visual_mesh_index: generated/scene_visual_mesh_index.json
+  scene3d_gui_smoke: generated/scene3d_gui_smoke.json
 
 robot:
   model: ur5

--- a/scenes/ur5_airpick4_test/scene_manifest.yaml
+++ b/scenes/ur5_airpick4_test/scene_manifest.yaml
@@ -9,6 +9,8 @@ files:
   layout: layout/workcell_studio_layout.yaml
   launch: launch/demo.launch.py
   urdf_xacro: urdf/scene.urdf.xacro
+  visual_mesh_index: generated/scene_visual_mesh_index.json
+  scene3d_gui_smoke: generated/scene3d_gui_smoke.json
 
 robot:
   model: ur5


### PR DESCRIPTION
### Motivation
- Make manifest-local evidence explicit so readiness and reproducibility tooling can resolve the generated Scene3D smoke and visual-mesh index artifacts referenced by supported scenes.
- Only add references where the corresponding generated files already exist to avoid introducing broken manifest references.

### Description
- Added `visual_mesh_index: generated/scene_visual_mesh_index.json` and `scene3d_gui_smoke: generated/scene3d_gui_smoke.json` under the `files:` mapping in the following scene manifests: `suction_test`, `ur10_2f_test`, `ur3_suction_test`, `ur5_2f_builder_pick_place_demo`, `ur5_2f_sorting_test`, `ur5_2f_test`, `ur5_3f_test`, and `ur5_airpick4_test`.
- Limited the change to manifest entries only; no launch files, execution nodes, controllers, runtime services, or hardware parameters were modified.
- Preserved fake-hardware defaults and existing readiness blockers; this is a metadata-only update to improve evidence resolution.

### Testing
- Ran `git diff --check` to validate no whitespace/format issues and it passed.
- Executed `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --repo-root . --catalog scenes/supported_scenes.yaml`, which completed and wrote JSON/Markdown readiness summaries (`build/workcell_studio_scene_readiness/scene_readiness_summary.*`) with overall `PASS=0 FAIL=0 BLOCKED=8` (existing blockers unchanged).
- Inspected `build/workcell_studio_scene_readiness/scene_readiness_summary.json` and confirmed each modified scene reports `manifest_local_file_references` (or equivalent category) as `PASS` with 7 checked references, indicating all manifest-local file references resolve successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a4c79168833189a45af1dd47edeb)