### PR TITLE
Add static camera and commissioning object contracts for blocked scenes

### DIFF
--- a/scenes/supported_scenes.yaml
+++ b/scenes/supported_scenes.yaml
@@ -49,7 +49,7 @@ scenes:
     scene_path: scenes/ur10_2f_test
     support_level: supported
     status: blocked
-    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
+    known_blocker: "post-regeneration readiness matrix: static cell_definition camera/object contract has been restored; Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur10_2f_test --json
@@ -61,7 +61,7 @@ scenes:
     scene_path: scenes/ur3_suction_test
     support_level: supported
     status: blocked
-    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
+    known_blocker: "post-regeneration readiness matrix: static cell_definition camera/object contract has been restored; Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur3_suction_test --json
@@ -73,7 +73,7 @@ scenes:
     scene_path: scenes/ur5_2f_builder_pick_place_demo
     support_level: supported
     status: blocked
-    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
+    known_blocker: "post-regeneration readiness matrix: static cell_definition camera/object contract has been restored; Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_builder_pick_place_demo --json
@@ -85,7 +85,7 @@ scenes:
     scene_path: scenes/ur5_2f_sorting_test
     support_level: supported
     status: blocked
-    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
+    known_blocker: "post-regeneration readiness matrix: static cell_definition camera/object contract has been restored; Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_sorting_test --json
@@ -109,7 +109,7 @@ scenes:
     scene_path: scenes/ur5_3f_test
     support_level: supported
     status: blocked
-    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
+    known_blocker: "post-regeneration readiness matrix: static cell_definition camera/object contract has been restored; Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_3f_test --json
@@ -121,7 +121,7 @@ scenes:
     scene_path: scenes/ur5_airpick4_test
     support_level: supported
     status: blocked
-    known_blocker: "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
+    known_blocker: "post-regeneration readiness matrix: static cell_definition camera/object contract has been restored; Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_airpick4_test --json

--- a/scenes/ur10_2f_test/cell_definition.yaml
+++ b/scenes/ur10_2f_test/cell_definition.yaml
@@ -14,9 +14,19 @@ end_effector:
   type: finger
   brand: robotiq
   grasp_frame: tool0
+camera:
+  enabled: false
+  camera_id: UNKNOWN_CAMERA
+  frame_id: UNKNOWN_FRAME
 environment:
   frame: world
   layout: layout/workcell_studio_layout.yaml
+objects:
+  - id: commissioning_object
+    frame: world
+    pose_xyz: [0.45, 0.25, 0.1]
+    pose_rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.05, 0.05, 0.05]
 task:
   id: default_task
   type: pick_place

--- a/scenes/ur3_suction_test/cell_definition.yaml
+++ b/scenes/ur3_suction_test/cell_definition.yaml
@@ -14,9 +14,19 @@ end_effector:
   type: suction
   brand: generic
   grasp_frame: tool0
+camera:
+  enabled: false
+  camera_id: UNKNOWN_CAMERA
+  frame_id: UNKNOWN_FRAME
 environment:
   frame: world
   layout: layout/workcell_studio_layout.yaml
+objects:
+  - id: commissioning_object
+    frame: world
+    pose_xyz: [0.43, 0.04, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.05, 0.05, 0.05]
 task:
   id: default_task
   type: pick_place

--- a/scenes/ur5_2f_builder_pick_place_demo/cell_definition.yaml
+++ b/scenes/ur5_2f_builder_pick_place_demo/cell_definition.yaml
@@ -14,9 +14,19 @@ end_effector:
   type: finger
   brand: robotiq
   grasp_frame: tool0
+camera:
+  enabled: false
+  camera_id: UNKNOWN_CAMERA
+  frame_id: UNKNOWN_FRAME
 environment:
   frame: world
   layout: layout/workcell_studio_layout.yaml
+objects:
+  - id: commissioning_object
+    frame: world
+    pose_xyz: [0.45, 0.0, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.05, 0.05, 0.05]
 task:
   id: default_task
   type: pick_place

--- a/scenes/ur5_2f_sorting_test/cell_definition.yaml
+++ b/scenes/ur5_2f_sorting_test/cell_definition.yaml
@@ -14,9 +14,19 @@ end_effector:
   type: finger
   brand: robotiq
   grasp_frame: tool0
+camera:
+  enabled: false
+  camera_id: UNKNOWN_CAMERA
+  frame_id: UNKNOWN_FRAME
 environment:
   frame: world
   layout: layout/workcell_studio_layout.yaml
+objects:
+  - id: commissioning_object
+    frame: world
+    pose_xyz: [0.45, 0.0, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.05, 0.05, 0.05]
 task:
   id: default_task
   type: pick_place

--- a/scenes/ur5_3f_test/cell_definition.yaml
+++ b/scenes/ur5_3f_test/cell_definition.yaml
@@ -14,9 +14,19 @@ end_effector:
   type: finger
   brand: robotiq
   grasp_frame: tool0
+camera:
+  enabled: false
+  camera_id: UNKNOWN_CAMERA
+  frame_id: UNKNOWN_FRAME
 environment:
   frame: world
   layout: layout/workcell_studio_layout.yaml
+objects:
+  - id: commissioning_object
+    frame: world
+    pose_xyz: [0.44, -0.02, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.05, 0.05, 0.05]
 task:
   id: default_task
   type: pick_place

--- a/scenes/ur5_airpick4_test/cell_definition.yaml
+++ b/scenes/ur5_airpick4_test/cell_definition.yaml
@@ -14,9 +14,19 @@ end_effector:
   type: suction
   brand: onrobot
   grasp_frame: tool0
+camera:
+  enabled: false
+  camera_id: UNKNOWN_CAMERA
+  frame_id: UNKNOWN_FRAME
 environment:
   frame: world
   layout: layout/workcell_studio_layout.yaml
+objects:
+  - id: commissioning_object
+    frame: world
+    pose_xyz: [0.46, 0.03, 0.08]
+    pose_rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.05, 0.05, 0.05]
 task:
   id: default_task
   type: pick_place


### PR DESCRIPTION
### Motivation
- Several supported scenes failed cell_definition validation because top-level `camera` and `objects` keys were missing, which blocks downstream Scene3D and validation tooling; the change restores a canonical static contract derived from scene-local metadata so validators can proceed without inventing runtime readiness.
- Keep safety/readiness semantics unchanged by using a disabled camera entry and a static commissioning object for offline validation rather than enabling live perception or runtime execution.

### Description
- Added a static disabled `camera:` block (`enabled: false`, `camera_id: UNKNOWN_CAMERA`, `frame_id: UNKNOWN_FRAME`) to the following `cell_definition.yaml` files: `scenes/ur10_2f_test`, `scenes/ur3_suction_test`, `scenes/ur5_2f_builder_pick_place_demo`, `scenes/ur5_2f_sorting_test`, `scenes/ur5_3f_test`, and `scenes/ur5_airpick4_test`.
- Added an `objects:` list containing a canonical `commissioning_object` entry (with `frame`, `pose_xyz`, `pose_rpy`, and `dimensions`) populated from scene-local `environment`/`scene_manifest`/layout/task commissioning values to each of the above `cell_definition.yaml` files.
- Updated `scenes/supported_scenes.yaml` known blocker messages for the affected scenes to reflect that the static `cell_definition` camera/object contract has been restored while Scene3D smoke evidence remains blocked.
- Affected files: `scenes/ur10_2f_test/cell_definition.yaml`, `scenes/ur3_suction_test/cell_definition.yaml`, `scenes/ur5_2f_builder_pick_place_demo/cell_definition.yaml`, `scenes/ur5_2f_sorting_test/cell_definition.yaml`, `scenes/ur5_3f_test/cell_definition.yaml`, `scenes/ur5_airpick4_test/cell_definition.yaml`, and `scenes/supported_scenes.yaml`.

### Testing
- Ran validation for each modified cell with `python3 scripts/validate_cell_definition.py scenes/<scene>/cell_definition.yaml --json` for all six scenes and observed `WARN` results with `errors=0` for each (i.e., validation no longer fails for missing top-level `camera`/`objects`).
- Confirmed catalog entries for the six scenes remain `status: blocked` using the supported scenes manifest inspection command (`python3 - <<'PY' ... PY`) to avoid marking any scene PASS prematurely.
- Ran unit tests: `python3 -m pytest tests/test_cell_definition_generation_flow.py`, which passed (6 tests).
- Ran repository checks (`git diff --check`) to confirm no whitespace or diff issues were introduced and there were no CI-critical diffs reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a4a3ae008331aba8963b7cdab811)