### PR TITLE
Refresh supported scene readiness artifacts and add tool metadata consistency check

### DIFF
--- a/scenes/suction_test/generated/scene_package_readiness.json
+++ b/scenes/suction_test/generated/scene_package_readiness.json
@@ -1,0 +1,1779 @@
+{
+  "blockers": [
+    {
+      "category": "supported_scene_catalog",
+      "message": "local Scene3D GUI smoke cannot run because ROS Humble/ament/workcell_builder executable is unavailable in the container; generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable.",
+      "status": "BLOCKED"
+    },
+    {
+      "category": "ros_launch_smoke_skip_evaluation_state",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    }
+  ],
+  "build_package_name": "suction_test",
+  "builder_generated_scene_validation": {
+    "checks": [
+      {
+        "check": "package.xml exists",
+        "ok": true
+      },
+      {
+        "check": "CMakeLists.txt exists",
+        "ok": true
+      },
+      {
+        "check": "environment.yaml exists",
+        "ok": true
+      },
+      {
+        "check": "workcell_builder_metadata.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/cell_definition.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/environment_layout.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/workcell_builder_task_intent.yaml present",
+        "ok": true,
+        "optional": true
+      }
+    ],
+    "discovered": {
+      "end_effector_capability_id": null,
+      "end_effector_name": "single_suction",
+      "grasp_strategy_id": null,
+      "object_count": 1,
+      "robot_capability_id": null,
+      "robot_name": "ur5",
+      "sensor_capability_id": null
+    },
+    "errors": [],
+    "export_validation": {},
+    "ok": true,
+    "readiness": "task_intent_ready_offline",
+    "readiness_classification": "task_intent_ready_offline",
+    "runtime_readiness": "runtime_blocked_or_preview_only",
+    "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test",
+    "suggested_next_actions": [
+      "Generate task recipe from builder task intent."
+    ],
+    "task_flow_summary": {
+      "approach_axis": null,
+      "approach_distance_m": null,
+      "errors": [],
+      "grasp_strategy": "suction_top_basic",
+      "missing_required_fields": [],
+      "pick_source_id": "pick_zone_main",
+      "pick_source_type": "zone",
+      "place_target_id": "default_drop_zone",
+      "readiness_classification": "task_intent_ready_offline",
+      "release_strategy": "tool_release",
+      "retreat_axis": null,
+      "retreat_distance_m": null,
+      "routing_rule_count": 1,
+      "routing_rules": [
+        {
+          "destination": "default_drop_zone",
+          "id": "default_place",
+          "when": {
+            "always": true
+          }
+        }
+      ],
+      "safety": {
+        "metadata_only": true,
+        "motion_started": false,
+        "ros_launch_started": false,
+        "runtime_io_applied": false
+      },
+      "status": "PASS",
+      "suggested_next_actions": [
+        "",
+        "",
+        "",
+        "Generate task recipe from task intent."
+      ],
+      "task_id": "default_task",
+      "task_type": "pick_place",
+      "visual_resolution": {
+        "approximate_coordinates_used": false,
+        "notes": [],
+        "pick_coordinates_resolved": true,
+        "place_coordinates_resolved": true
+      },
+      "warnings": []
+    },
+    "task_intent": {
+      "errors": [],
+      "missing_required_fields": [],
+      "pick_source": {
+        "id": "pick_zone_main",
+        "type": "zone"
+      },
+      "place_target": {
+        "id": "default_drop_zone",
+        "type": "destination"
+      },
+      "readiness_classification": "task_intent_ready_offline",
+      "resolved_grasp_strategy": null,
+      "safety": {
+        "execution_mode": "simulation_preview",
+        "metadata_only": true,
+        "motion_started": false,
+        "no_robot_motion": true,
+        "preview_only": true,
+        "ros_launch_started": false,
+        "runtime_io_applied": false,
+        "use_fake_hardware": true
+      },
+      "status": "PASS",
+      "suggested_next_actions": [
+        "Generate task recipe from task intent."
+      ],
+      "task_intent": {
+        "grasp": {
+          "approach_axis": "z_down",
+          "approach_distance_m": 0.12,
+          "retreat_axis": "z_up",
+          "retreat_distance_m": 0.1,
+          "strategy_ref": "suction_top_basic"
+        },
+        "pick": {
+          "source": {
+            "id": "pick_zone_main",
+            "type": "zone"
+          }
+        },
+        "place": {
+          "release_strategy": "tool_release",
+          "retreat_axis": "z_up",
+          "retreat_distance_m": 0.1,
+          "target": {
+            "id": "default_drop_zone",
+            "type": "destination"
+          }
+        },
+        "provenance": {
+          "mode": "generated_readiness_metadata",
+          "sources": [
+            "cell_definition.yaml",
+            "config/task_recipe.yaml",
+            "environment_layout.yaml"
+          ]
+        },
+        "routing": {
+          "rules": [
+            {
+              "destination": "default_drop_zone",
+              "id": "default_place",
+              "when": {
+                "always": true
+              }
+            }
+          ]
+        },
+        "safety": {
+          "execution_mode": "simulation_preview",
+          "metadata_only": true,
+          "motion_started": false,
+          "no_robot_motion": true,
+          "preview_only": true,
+          "ros_launch_started": false,
+          "runtime_io_applied": false,
+          "use_fake_hardware": true
+        },
+        "scene_package": "scenes/suction_test",
+        "schema": "workcell_builder_task_intent/v1",
+        "task": {
+          "family": "pick_place",
+          "id": "default_task",
+          "mode": "simulation_preview",
+          "type": "pick_place"
+        }
+      },
+      "warnings": []
+    },
+    "warnings": [
+      "workcell_builder_metadata.yaml missing (optional)",
+      "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+      "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
+    ]
+  },
+  "catalog_status": "blocked",
+  "categories": {
+    "cell_definition_validation": {
+      "capabilities": {
+        "capability_refs": {
+          "end_effector": null,
+          "environment_assets": [],
+          "robot": null,
+          "sensors": [],
+          "task": null
+        },
+        "checks": {
+          "events": [],
+          "status": "WARN"
+        },
+        "resolved": {}
+      },
+      "environment_layout": {},
+      "errors": [],
+      "grasp_strategy": {
+        "mode": "none",
+        "ref": null,
+        "resolved_path": null,
+        "status": "PASS"
+      },
+      "message": "cell_definition.yaml validates",
+      "notes": [],
+      "parser": "pyyaml",
+      "status": "PASS",
+      "warnings": [
+        "environment.layout path not found: layout/workcell_studio_layout.yaml"
+      ]
+    },
+    "cell_definition_yaml": {
+      "message": "cell_definition.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/cell_definition.yaml",
+      "status": "PASS"
+    },
+    "cmakelists_txt": {
+      "message": "CMakeLists.txt exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/CMakeLists.txt",
+      "status": "PASS"
+    },
+    "credible_physical_visual_evidence": {
+      "mesh_failure_summary_by_reason_code": {},
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "physical_rendered_count": 0,
+      "source_geometry_count": 3,
+      "status": "FAIL"
+    },
+    "environment_yaml": {
+      "message": "environment.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/environment.yaml",
+      "status": "PASS"
+    },
+    "fake_hardware_launch_command_derivation": {
+      "build_package_name": "suction_test",
+      "command": "ros2 launch suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "safe fake-hardware launch command recorded",
+      "package_name": "suction_test",
+      "safety": "not executed; fake hardware explicitly required",
+      "status": "PASS",
+      "warnings": []
+    },
+    "generated_scene_package_readiness_json": {
+      "message": "generated/scene_package_readiness.json is present and parseable",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene_package_readiness.json",
+      "status": "PASS",
+      "summary": {
+        "blockers": [
+          {
+            "category": "supported_scene_catalog",
+            "message": "local Scene3D GUI smoke cannot run because ROS Humble/ament/workcell_builder executable is unavailable in the container; generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable.",
+            "status": "BLOCKED"
+          },
+          {
+            "category": "ros_launch_smoke_skip_evaluation_state",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          }
+        ],
+        "build_package_name": "suction_test",
+        "builder_generated_scene_validation": {
+          "checks": [
+            {
+              "check": "package.xml exists",
+              "ok": true
+            },
+            {
+              "check": "CMakeLists.txt exists",
+              "ok": true
+            },
+            {
+              "check": "environment.yaml exists",
+              "ok": true
+            },
+            {
+              "check": "workcell_builder_metadata.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/cell_definition.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/environment_layout.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/workcell_builder_task_intent.yaml present",
+              "ok": true,
+              "optional": true
+            }
+          ],
+          "discovered": {
+            "end_effector_capability_id": null,
+            "end_effector_name": "single_suction",
+            "grasp_strategy_id": null,
+            "object_count": 1,
+            "robot_capability_id": null,
+            "robot_name": "ur5",
+            "sensor_capability_id": null
+          },
+          "errors": [],
+          "export_validation": {},
+          "ok": true,
+          "readiness": "task_intent_ready_offline",
+          "readiness_classification": "task_intent_ready_offline",
+          "runtime_readiness": "runtime_blocked_or_preview_only",
+          "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test",
+          "suggested_next_actions": [
+            "Generate task recipe from builder task intent."
+          ],
+          "task_flow_summary": {
+            "approach_axis": null,
+            "approach_distance_m": null,
+            "errors": [],
+            "grasp_strategy": "suction_top_basic",
+            "missing_required_fields": [],
+            "pick_source_id": "pick_zone_main",
+            "pick_source_type": "zone",
+            "place_target_id": "default_drop_zone",
+            "readiness_classification": "task_intent_ready_offline",
+            "release_strategy": "tool_release",
+            "retreat_axis": null,
+            "retreat_distance_m": null,
+            "routing_rule_count": 1,
+            "routing_rules": [
+              {
+                "destination": "default_drop_zone",
+                "id": "default_place",
+                "when": {
+                  "always": true
+                }
+              }
+            ],
+            "safety": {
+              "metadata_only": true,
+              "motion_started": false,
+              "ros_launch_started": false,
+              "runtime_io_applied": false
+            },
+            "status": "PASS",
+            "suggested_next_actions": [
+              "",
+              "",
+              "",
+              "Generate task recipe from task intent."
+            ],
+            "task_id": "default_task",
+            "task_type": "pick_place",
+            "visual_resolution": {
+              "approximate_coordinates_used": false,
+              "notes": [],
+              "pick_coordinates_resolved": true,
+              "place_coordinates_resolved": true
+            },
+            "warnings": []
+          },
+          "task_intent": {
+            "errors": [],
+            "missing_required_fields": [],
+            "pick_source": {
+              "id": "pick_zone_main",
+              "type": "zone"
+            },
+            "place_target": {
+              "id": "default_drop_zone",
+              "type": "destination"
+            },
+            "readiness_classification": "task_intent_ready_offline",
+            "resolved_grasp_strategy": null,
+            "safety": {
+              "execution_mode": "simulation_preview",
+              "metadata_only": true,
+              "motion_started": false,
+              "no_robot_motion": true,
+              "preview_only": true,
+              "ros_launch_started": false,
+              "runtime_io_applied": false,
+              "use_fake_hardware": true
+            },
+            "status": "PASS",
+            "suggested_next_actions": [
+              "Generate task recipe from task intent."
+            ],
+            "task_intent": {
+              "grasp": {
+                "approach_axis": "z_down",
+                "approach_distance_m": 0.12,
+                "retreat_axis": "z_up",
+                "retreat_distance_m": 0.1,
+                "strategy_ref": "suction_top_basic"
+              },
+              "pick": {
+                "source": {
+                  "id": "pick_zone_main",
+                  "type": "zone"
+                }
+              },
+              "place": {
+                "release_strategy": "tool_release",
+                "retreat_axis": "z_up",
+                "retreat_distance_m": 0.1,
+                "target": {
+                  "id": "default_drop_zone",
+                  "type": "destination"
+                }
+              },
+              "provenance": {
+                "mode": "generated_readiness_metadata",
+                "sources": [
+                  "cell_definition.yaml",
+                  "config/task_recipe.yaml",
+                  "environment_layout.yaml"
+                ]
+              },
+              "routing": {
+                "rules": [
+                  {
+                    "destination": "default_drop_zone",
+                    "id": "default_place",
+                    "when": {
+                      "always": true
+                    }
+                  }
+                ]
+              },
+              "safety": {
+                "execution_mode": "simulation_preview",
+                "metadata_only": true,
+                "motion_started": false,
+                "no_robot_motion": true,
+                "preview_only": true,
+                "ros_launch_started": false,
+                "runtime_io_applied": false,
+                "use_fake_hardware": true
+              },
+              "scene_package": "scenes/suction_test",
+              "schema": "workcell_builder_task_intent/v1",
+              "task": {
+                "family": "pick_place",
+                "id": "default_task",
+                "mode": "simulation_preview",
+                "type": "pick_place"
+              }
+            },
+            "warnings": []
+          },
+          "warnings": [
+            "workcell_builder_metadata.yaml missing (optional)",
+            "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+            "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
+          ]
+        },
+        "catalog_status": "blocked",
+        "categories": {
+          "cell_definition_validation": {
+            "capabilities": {
+              "capability_refs": {
+                "end_effector": null,
+                "environment_assets": [],
+                "robot": null,
+                "sensors": [],
+                "task": null
+              },
+              "checks": {
+                "events": [],
+                "status": "WARN"
+              },
+              "resolved": {}
+            },
+            "environment_layout": {},
+            "errors": [],
+            "grasp_strategy": {
+              "mode": "none",
+              "ref": null,
+              "resolved_path": null,
+              "status": "PASS"
+            },
+            "message": "cell_definition.yaml validates",
+            "notes": [],
+            "parser": "pyyaml",
+            "status": "PASS",
+            "warnings": [
+              "environment.layout path not found: layout/workcell_studio_layout.yaml"
+            ]
+          },
+          "cell_definition_yaml": {
+            "message": "cell_definition.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/cell_definition.yaml",
+            "status": "PASS"
+          },
+          "cmakelists_txt": {
+            "message": "CMakeLists.txt exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/CMakeLists.txt",
+            "status": "PASS"
+          },
+          "credible_physical_visual_evidence": {
+            "mesh_failure_summary_by_reason_code": {},
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "physical_rendered_count": 0,
+            "source_geometry_count": 3,
+            "status": "FAIL"
+          },
+          "environment_yaml": {
+            "message": "environment.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/environment.yaml",
+            "status": "PASS"
+          },
+          "fake_hardware_launch_command_derivation": {
+            "build_package_name": "suction_test",
+            "command": "ros2 launch suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "safe fake-hardware launch command recorded",
+            "package_name": "suction_test",
+            "safety": "not executed; fake hardware explicitly required",
+            "status": "PASS",
+            "warnings": []
+          },
+          "generated_scene_package_readiness_json": {
+            "message": "generated/scene_package_readiness.json is present and parseable",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene_package_readiness.json",
+            "status": "PASS",
+            "summary": {
+              "blockers": [
+                {
+                  "category": "supported_scene_catalog",
+                  "message": "local Scene3D GUI smoke cannot run because ROS Humble/ament/workcell_builder executable is unavailable in the container; generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable.",
+                  "status": "BLOCKED"
+                },
+                {
+                  "category": "ros_launch_smoke_skip_evaluation_state",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                }
+              ],
+              "build_package_name": "suction_test",
+              "builder_generated_scene_validation": {
+                "checks": [
+                  {
+                    "check": "package.xml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "CMakeLists.txt exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "environment.yaml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "workcell_builder_metadata.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/cell_definition.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/environment_layout.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/workcell_builder_task_intent.yaml present",
+                    "ok": true,
+                    "optional": true
+                  }
+                ],
+                "discovered": {
+                  "end_effector_capability_id": null,
+                  "end_effector_name": "single_suction",
+                  "grasp_strategy_id": null,
+                  "object_count": 1,
+                  "robot_capability_id": null,
+                  "robot_name": "ur5",
+                  "sensor_capability_id": null
+                },
+                "errors": [],
+                "export_validation": {},
+                "ok": true,
+                "readiness": "task_intent_ready_offline",
+                "readiness_classification": "task_intent_ready_offline",
+                "runtime_readiness": "runtime_blocked_or_preview_only",
+                "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test",
+                "suggested_next_actions": [
+                  "Generate task recipe from builder task intent."
+                ],
+                "task_flow_summary": {
+                  "approach_axis": null,
+                  "approach_distance_m": null,
+                  "errors": [],
+                  "grasp_strategy": "suction_top_basic",
+                  "missing_required_fields": [],
+                  "pick_source_id": "pick_zone_main",
+                  "pick_source_type": "zone",
+                  "place_target_id": "default_drop_zone",
+                  "readiness_classification": "task_intent_ready_offline",
+                  "release_strategy": "tool_release",
+                  "retreat_axis": null,
+                  "retreat_distance_m": null,
+                  "routing_rule_count": 1,
+                  "routing_rules": [
+                    {
+                      "destination": "default_drop_zone",
+                      "id": "default_place",
+                      "when": {
+                        "always": true
+                      }
+                    }
+                  ],
+                  "safety": {
+                    "metadata_only": true,
+                    "motion_started": false,
+                    "ros_launch_started": false,
+                    "runtime_io_applied": false
+                  },
+                  "status": "PASS",
+                  "suggested_next_actions": [
+                    "",
+                    "",
+                    "",
+                    "Generate task recipe from task intent."
+                  ],
+                  "task_id": "default_task",
+                  "task_type": "pick_place",
+                  "visual_resolution": {
+                    "approximate_coordinates_used": false,
+                    "notes": [],
+                    "pick_coordinates_resolved": true,
+                    "place_coordinates_resolved": true
+                  },
+                  "warnings": []
+                },
+                "task_intent": {
+                  "errors": [],
+                  "missing_required_fields": [],
+                  "pick_source": {
+                    "id": "pick_zone_main",
+                    "type": "zone"
+                  },
+                  "place_target": {
+                    "id": "default_drop_zone",
+                    "type": "destination"
+                  },
+                  "readiness_classification": "task_intent_ready_offline",
+                  "resolved_grasp_strategy": null,
+                  "safety": {
+                    "execution_mode": "simulation_preview",
+                    "metadata_only": true,
+                    "motion_started": false,
+                    "no_robot_motion": true,
+                    "preview_only": true,
+                    "ros_launch_started": false,
+                    "runtime_io_applied": false,
+                    "use_fake_hardware": true
+                  },
+                  "status": "PASS",
+                  "suggested_next_actions": [
+                    "Generate task recipe from task intent."
+                  ],
+                  "task_intent": {
+                    "grasp": {
+                      "approach_axis": "z_down",
+                      "approach_distance_m": 0.12,
+                      "retreat_axis": "z_up",
+                      "retreat_distance_m": 0.1,
+                      "strategy_ref": "suction_top_basic"
+                    },
+                    "pick": {
+                      "source": {
+                        "id": "pick_zone_main",
+                        "type": "zone"
+                      }
+                    },
+                    "place": {
+                      "release_strategy": "tool_release",
+                      "retreat_axis": "z_up",
+                      "retreat_distance_m": 0.1,
+                      "target": {
+                        "id": "default_drop_zone",
+                        "type": "destination"
+                      }
+                    },
+                    "provenance": {
+                      "mode": "generated_readiness_metadata",
+                      "sources": [
+                        "cell_definition.yaml",
+                        "config/task_recipe.yaml",
+                        "environment_layout.yaml"
+                      ]
+                    },
+                    "routing": {
+                      "rules": [
+                        {
+                          "destination": "default_drop_zone",
+                          "id": "default_place",
+                          "when": {
+                            "always": true
+                          }
+                        }
+                      ]
+                    },
+                    "safety": {
+                      "execution_mode": "simulation_preview",
+                      "metadata_only": true,
+                      "motion_started": false,
+                      "no_robot_motion": true,
+                      "preview_only": true,
+                      "ros_launch_started": false,
+                      "runtime_io_applied": false,
+                      "use_fake_hardware": true
+                    },
+                    "scene_package": "scenes/suction_test",
+                    "schema": "workcell_builder_task_intent/v1",
+                    "task": {
+                      "family": "pick_place",
+                      "id": "default_task",
+                      "mode": "simulation_preview",
+                      "type": "pick_place"
+                    }
+                  },
+                  "warnings": []
+                },
+                "warnings": [
+                  "workcell_builder_metadata.yaml missing (optional)",
+                  "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+                  "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
+                ]
+              },
+              "catalog_status": "blocked",
+              "categories": {
+                "cell_definition_validation": {
+                  "capabilities": {
+                    "capability_refs": {
+                      "end_effector": null,
+                      "environment_assets": [],
+                      "robot": null,
+                      "sensors": [],
+                      "task": null
+                    },
+                    "checks": {
+                      "events": [],
+                      "status": "WARN"
+                    },
+                    "resolved": {}
+                  },
+                  "environment_layout": {},
+                  "errors": [],
+                  "grasp_strategy": {
+                    "mode": "none",
+                    "ref": null,
+                    "resolved_path": null,
+                    "status": "PASS"
+                  },
+                  "message": "cell_definition.yaml validates",
+                  "notes": [],
+                  "parser": "pyyaml",
+                  "status": "PASS",
+                  "warnings": [
+                    "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                  ]
+                },
+                "cell_definition_yaml": {
+                  "message": "cell_definition.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/cell_definition.yaml",
+                  "status": "PASS"
+                },
+                "cmakelists_txt": {
+                  "message": "CMakeLists.txt exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/CMakeLists.txt",
+                  "status": "PASS"
+                },
+                "credible_physical_visual_evidence": {
+                  "mesh_failure_summary_by_reason_code": {},
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "physical_rendered_count": 0,
+                  "source_geometry_count": 3,
+                  "status": "FAIL"
+                },
+                "environment_yaml": {
+                  "message": "environment.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/environment.yaml",
+                  "status": "PASS"
+                },
+                "fake_hardware_launch_command_derivation": {
+                  "build_package_name": "suction_test",
+                  "command": "ros2 launch suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "safe fake-hardware launch command recorded",
+                  "package_name": "suction_test",
+                  "safety": "not executed; fake hardware explicitly required",
+                  "status": "PASS",
+                  "warnings": []
+                },
+                "generated_scene_package_readiness_json": {
+                  "message": "optional/generated-if-present readiness JSON is not present",
+                  "optional": true,
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene_package_readiness.json",
+                  "status": "PASS"
+                },
+                "generated_scene_visual_mesh_index_json": {
+                  "message": "generated/scene_visual_mesh_index.json exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene_visual_mesh_index.json",
+                  "status": "PASS"
+                },
+                "launch_demo_launch_py": {
+                  "message": "launch/demo.launch.py exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/launch/demo.launch.py",
+                  "status": "PASS"
+                },
+                "layout_workcell_studio_layout_yaml": {
+                  "message": "layout/workcell_studio_layout.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/layout/workcell_studio_layout.yaml",
+                  "status": "PASS"
+                },
+                "manifest_local_file_references": {
+                  "checked": [
+                    {
+                      "field": "files.environment",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/environment.yaml",
+                      "reference": "environment.yaml"
+                    },
+                    {
+                      "field": "files.cell_definition",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/cell_definition.yaml",
+                      "reference": "cell_definition.yaml"
+                    },
+                    {
+                      "field": "files.layout",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/layout/workcell_studio_layout.yaml",
+                      "reference": "layout/workcell_studio_layout.yaml"
+                    },
+                    {
+                      "field": "files.launch",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/launch/demo.launch.py",
+                      "reference": "launch/demo.launch.py"
+                    },
+                    {
+                      "field": "files.urdf_xacro",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro",
+                      "reference": "urdf/scene.urdf.xacro"
+                    },
+                    {
+                      "field": "files.visual_mesh_index",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene_visual_mesh_index.json",
+                      "reference": "generated/scene_visual_mesh_index.json"
+                    },
+                    {
+                      "field": "files.scene3d_gui_smoke",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene3d_gui_smoke.json",
+                      "reference": "generated/scene3d_gui_smoke.json"
+                    }
+                  ],
+                  "message": "manifest local-file references resolved (7 checked)",
+                  "status": "PASS"
+                },
+                "package_xml": {
+                  "message": "package.xml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/package.xml",
+                  "status": "PASS"
+                },
+                "ros_launch_smoke_skip_evaluation_state": {
+                  "command": "ros2 launch suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                },
+                "scene3d_visual_quality_summary": {
+                  "blockers": [
+                    "mesh_source_count > 0 requires mesh_rendered_count > 0"
+                  ],
+                  "counters": {
+                    "credible_physical_rendered_count": 0,
+                    "diagnostic_fallback_count": 0,
+                    "helper_overlay_count": 0,
+                    "mesh_rendered_count": 0,
+                    "mesh_source_count": 3,
+                    "physical_rendered_count": 0,
+                    "primitive_rendered_count": 0,
+                    "primitive_source_count": 0,
+                    "total_payload_count": 3
+                  },
+                  "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene_visual_mesh_index.json",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene3d_gui_smoke.json",
+                  "status": "FAIL",
+                  "visual_quality_status": "FAIL",
+                  "warnings": []
+                },
+                "scene_manifest_yaml": {
+                  "message": "scene_manifest.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/scene_manifest.yaml",
+                  "status": "PASS"
+                },
+                "scene_package_exists": {
+                  "message": "scene package directory exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test",
+                  "status": "PASS"
+                },
+                "tool_metadata_consistency": {
+                  "errors": [
+                    "Tool metadata mismatch: cell_definition.yaml end_effector.id 'suction' does not match environment.yaml tool.id/profile 'single_suction'."
+                  ],
+                  "message": "tool/end-effector metadata is inconsistent",
+                  "observed": {
+                    "cell_definition_end_effector_id": "suction",
+                    "environment_tool_id": "single_suction",
+                    "manifest_end_effector_brand": "single_suction_gripper",
+                    "manifest_end_effector_type": "suction"
+                  },
+                  "status": "FAIL"
+                },
+                "urdf_scene_urdf_xacro": {
+                  "message": "urdf/scene.urdf.xacro exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro",
+                  "status": "PASS"
+                }
+              },
+              "commands": {
+                "build_command": "colcon build --symlink-install --packages-select suction_test",
+                "fake_hardware_launch_command": "ros2 launch suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/suction_test --json"
+              },
+              "failures": [
+                {
+                  "category": "credible_physical_visual_evidence",
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "scene3d_visual_quality_summary",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "tool_metadata_consistency",
+                  "message": "tool/end-effector metadata is inconsistent",
+                  "status": "FAIL"
+                }
+              ],
+              "generated_at": "2026-06-04T16:21:59.245618+00:00",
+              "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+              "offline_scene_readiness": {
+                "errors": [],
+                "inputs": {
+                  "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/suction_test",
+                  "workcell_root": null
+                },
+                "notes": [
+                  "ROS scene package detected (package.xml present)."
+                ],
+                "result": "WARN",
+                "scene_reports": [
+                  {
+                    "candidates": {
+                      "gripper": [
+                        "CMakeLists.txt",
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "environment_layout.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene3d_gui_smoke.json",
+                        "scene_manifest.yaml",
+                        "scene_visual_mesh_index.json",
+                        "workcell_builder_task_intent.yaml"
+                      ],
+                      "robot": [
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene_manifest.yaml",
+                        "scene_visual_mesh_index.json",
+                        "workcell_builder_task_intent.yaml",
+                        "workcell_studio_layout.generated.yaml",
+                        "workcell_studio_layout.yaml"
+                      ],
+                      "sensor": [
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "environment_assets.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro"
+                      ]
+                    },
+                    "counts": {
+                      "files": 18,
+                      "meshes": 0,
+                      "urdf_xacro": 2
+                    },
+                    "errors": [],
+                    "frames": {
+                      "base_link": 7,
+                      "camera_link": 2,
+                      "tool0": 12,
+                      "world": 27
+                    },
+                    "mesh_extensions_detected": [],
+                    "notes": [
+                      "ROS scene package detected (package.xml present)."
+                    ],
+                    "placed_objects": {
+                      "absolute_external_mesh_warnings": [],
+                      "count": 0,
+                      "found_in_generated_urdf_xacro": false,
+                      "found_names": [],
+                      "invalid_mesh_warnings": [],
+                      "missing_collision_mesh_warnings": [],
+                      "missing_names": []
+                    },
+                    "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/suction_test",
+                    "task_zones": {
+                      "duplicate_ids": [],
+                      "invalid_dimensions": [],
+                      "pick": 0,
+                      "place": 0,
+                      "total": 0,
+                      "zone_ids": []
+                    },
+                    "warnings": [
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find single_suction_moveit_config)/config/single_suction_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find single_suction_description)/urdf/single_suction_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find table_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                      "Task intent place.target.id not found in task_zones: default_drop_zone",
+                      "Legacy compatibility: robot_mount missing.",
+                      "Legacy compatibility: tool_attachment missing.",
+                      "Legacy compatibility: recommended gripper orientation not used."
+                    ]
+                  }
+                ],
+                "strict": false,
+                "summary": {
+                  "errors": 0,
+                  "scene_packages_checked": 1,
+                  "warnings": 14
+                },
+                "warnings": [
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                  "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find single_suction_moveit_config)/config/single_suction_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find single_suction_description)/urdf/single_suction_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find table_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                  "Task intent place.target.id not found in task_zones: default_drop_zone",
+                  "Legacy compatibility: robot_mount missing.",
+                  "Legacy compatibility: tool_attachment missing.",
+                  "Legacy compatibility: recommended gripper orientation not used."
+                ]
+              },
+              "overall_status": "BLOCKED",
+              "package_name": "suction_test",
+              "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+              "readiness_status": "BLOCKED",
+              "ros_humble_available": false,
+              "safe_command_warnings": [],
+              "safety": {
+                "fake_hardware_default": true,
+                "motion_command_sent": false,
+                "real_hardware_enabled": false,
+                "ros_launch_executed_by_matrix": false,
+                "runtime_execution_called": false,
+                "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+              },
+              "scene_name": "suction_test",
+              "scene_path": "scenes/suction_test",
+              "schema_version": "workcell_studio_scene_package_readiness/v1",
+              "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+              "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+              "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+              "support_level": "supported",
+              "warnings": [
+                {
+                  "category": "cell_definition_validation",
+                  "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                }
+              ],
+              "workcell_builder_executable_found": false
+            }
+          },
+          "generated_scene_visual_mesh_index_json": {
+            "message": "generated/scene_visual_mesh_index.json exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene_visual_mesh_index.json",
+            "status": "PASS"
+          },
+          "launch_demo_launch_py": {
+            "message": "launch/demo.launch.py exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/launch/demo.launch.py",
+            "status": "PASS"
+          },
+          "layout_workcell_studio_layout_yaml": {
+            "message": "layout/workcell_studio_layout.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/layout/workcell_studio_layout.yaml",
+            "status": "PASS"
+          },
+          "manifest_local_file_references": {
+            "checked": [
+              {
+                "field": "files.environment",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/environment.yaml",
+                "reference": "environment.yaml"
+              },
+              {
+                "field": "files.cell_definition",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/cell_definition.yaml",
+                "reference": "cell_definition.yaml"
+              },
+              {
+                "field": "files.layout",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/layout/workcell_studio_layout.yaml",
+                "reference": "layout/workcell_studio_layout.yaml"
+              },
+              {
+                "field": "files.launch",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/launch/demo.launch.py",
+                "reference": "launch/demo.launch.py"
+              },
+              {
+                "field": "files.urdf_xacro",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro",
+                "reference": "urdf/scene.urdf.xacro"
+              },
+              {
+                "field": "files.visual_mesh_index",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene_visual_mesh_index.json",
+                "reference": "generated/scene_visual_mesh_index.json"
+              },
+              {
+                "field": "files.scene3d_gui_smoke",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene3d_gui_smoke.json",
+                "reference": "generated/scene3d_gui_smoke.json"
+              }
+            ],
+            "message": "manifest local-file references resolved (7 checked)",
+            "status": "PASS"
+          },
+          "package_xml": {
+            "message": "package.xml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/package.xml",
+            "status": "PASS"
+          },
+          "ros_launch_smoke_skip_evaluation_state": {
+            "command": "ros2 launch suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          },
+          "scene3d_visual_quality_summary": {
+            "blockers": [
+              "mesh_source_count > 0 requires mesh_rendered_count > 0"
+            ],
+            "counters": {
+              "credible_physical_rendered_count": 0,
+              "diagnostic_fallback_count": 0,
+              "helper_overlay_count": 0,
+              "mesh_rendered_count": 0,
+              "mesh_source_count": 3,
+              "physical_rendered_count": 0,
+              "primitive_rendered_count": 0,
+              "primitive_source_count": 0,
+              "total_payload_count": 3
+            },
+            "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene_visual_mesh_index.json",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene3d_gui_smoke.json",
+            "status": "FAIL",
+            "visual_quality_status": "FAIL",
+            "warnings": []
+          },
+          "scene_manifest_yaml": {
+            "message": "scene_manifest.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/scene_manifest.yaml",
+            "status": "PASS"
+          },
+          "scene_package_exists": {
+            "message": "scene package directory exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test",
+            "status": "PASS"
+          },
+          "tool_metadata_consistency": {
+            "errors": [
+              "Tool metadata mismatch: cell_definition.yaml end_effector.id 'suction' does not match environment.yaml tool.id/profile 'single_suction'."
+            ],
+            "message": "tool/end-effector metadata is inconsistent",
+            "observed": {
+              "cell_definition_end_effector_id": "suction",
+              "environment_tool_id": "single_suction",
+              "manifest_end_effector_brand": "single_suction_gripper",
+              "manifest_end_effector_type": "suction"
+            },
+            "status": "FAIL"
+          },
+          "urdf_scene_urdf_xacro": {
+            "message": "urdf/scene.urdf.xacro exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro",
+            "status": "PASS"
+          }
+        },
+        "commands": {
+          "build_command": "colcon build --symlink-install --packages-select suction_test",
+          "fake_hardware_launch_command": "ros2 launch suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+          "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/suction_test --json"
+        },
+        "failures": [
+          {
+            "category": "credible_physical_visual_evidence",
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "status": "FAIL"
+          },
+          {
+            "category": "scene3d_visual_quality_summary",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "status": "FAIL"
+          },
+          {
+            "category": "tool_metadata_consistency",
+            "message": "tool/end-effector metadata is inconsistent",
+            "status": "FAIL"
+          }
+        ],
+        "generated_at": "2026-06-04T16:23:19.093332+00:00",
+        "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+        "offline_scene_readiness": {
+          "errors": [],
+          "inputs": {
+            "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/suction_test",
+            "workcell_root": null
+          },
+          "notes": [
+            "ROS scene package detected (package.xml present)."
+          ],
+          "result": "WARN",
+          "scene_reports": [
+            {
+              "candidates": {
+                "gripper": [
+                  "CMakeLists.txt",
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "environment_layout.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene3d_gui_smoke.json",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json",
+                  "workcell_builder_task_intent.yaml"
+                ],
+                "robot": [
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json",
+                  "workcell_builder_task_intent.yaml",
+                  "workcell_studio_layout.generated.yaml",
+                  "workcell_studio_layout.yaml"
+                ],
+                "sensor": [
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "environment_assets.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene_package_readiness.json"
+                ]
+              },
+              "counts": {
+                "files": 19,
+                "meshes": 0,
+                "urdf_xacro": 2
+              },
+              "errors": [],
+              "frames": {
+                "base_link": 8,
+                "camera_link": 3,
+                "tool0": 13,
+                "world": 28
+              },
+              "mesh_extensions_detected": [],
+              "notes": [
+                "ROS scene package detected (package.xml present)."
+              ],
+              "placed_objects": {
+                "absolute_external_mesh_warnings": [],
+                "count": 0,
+                "found_in_generated_urdf_xacro": false,
+                "found_names": [],
+                "invalid_mesh_warnings": [],
+                "missing_collision_mesh_warnings": [],
+                "missing_names": []
+              },
+              "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/suction_test",
+              "task_zones": {
+                "duplicate_ids": [],
+                "invalid_dimensions": [],
+                "pick": 0,
+                "place": 0,
+                "total": 0,
+                "zone_ids": []
+              },
+              "warnings": [
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find single_suction_moveit_config)/config/single_suction_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find single_suction_description)/urdf/single_suction_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find table_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                "Task intent place.target.id not found in task_zones: default_drop_zone",
+                "Legacy compatibility: robot_mount missing.",
+                "Legacy compatibility: tool_attachment missing.",
+                "Legacy compatibility: recommended gripper orientation not used."
+              ]
+            }
+          ],
+          "strict": false,
+          "summary": {
+            "errors": 0,
+            "scene_packages_checked": 1,
+            "warnings": 20
+          },
+          "warnings": [
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find single_suction_moveit_config)/config/single_suction_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find single_suction_description)/urdf/single_suction_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find table_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Task intent pick.source.id not found in task_zones: pick_zone_main",
+            "Task intent place.target.id not found in task_zones: default_drop_zone",
+            "Legacy compatibility: robot_mount missing.",
+            "Legacy compatibility: tool_attachment missing.",
+            "Legacy compatibility: recommended gripper orientation not used."
+          ]
+        },
+        "overall_status": "BLOCKED",
+        "package_name": "suction_test",
+        "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+        "readiness_status": "BLOCKED",
+        "ros_humble_available": false,
+        "safe_command_warnings": [],
+        "safety": {
+          "fake_hardware_default": true,
+          "motion_command_sent": false,
+          "real_hardware_enabled": false,
+          "ros_launch_executed_by_matrix": false,
+          "runtime_execution_called": false,
+          "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+        },
+        "scene_name": "suction_test",
+        "scene_path": "scenes/suction_test",
+        "schema_version": "workcell_studio_scene_package_readiness/v1",
+        "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+        "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+        "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+        "support_level": "supported",
+        "warnings": [
+          {
+            "category": "cell_definition_validation",
+            "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+          }
+        ],
+        "workcell_builder_executable_found": false
+      }
+    },
+    "generated_scene_visual_mesh_index_json": {
+      "message": "generated/scene_visual_mesh_index.json exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene_visual_mesh_index.json",
+      "status": "PASS"
+    },
+    "launch_demo_launch_py": {
+      "message": "launch/demo.launch.py exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/launch/demo.launch.py",
+      "status": "PASS"
+    },
+    "layout_workcell_studio_layout_yaml": {
+      "message": "layout/workcell_studio_layout.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/layout/workcell_studio_layout.yaml",
+      "status": "PASS"
+    },
+    "manifest_local_file_references": {
+      "checked": [
+        {
+          "field": "files.environment",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/environment.yaml",
+          "reference": "environment.yaml"
+        },
+        {
+          "field": "files.cell_definition",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/cell_definition.yaml",
+          "reference": "cell_definition.yaml"
+        },
+        {
+          "field": "files.layout",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/layout/workcell_studio_layout.yaml",
+          "reference": "layout/workcell_studio_layout.yaml"
+        },
+        {
+          "field": "files.launch",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/launch/demo.launch.py",
+          "reference": "launch/demo.launch.py"
+        },
+        {
+          "field": "files.urdf_xacro",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro",
+          "reference": "urdf/scene.urdf.xacro"
+        },
+        {
+          "field": "files.visual_mesh_index",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene_visual_mesh_index.json",
+          "reference": "generated/scene_visual_mesh_index.json"
+        },
+        {
+          "field": "files.scene3d_gui_smoke",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene3d_gui_smoke.json",
+          "reference": "generated/scene3d_gui_smoke.json"
+        }
+      ],
+      "message": "manifest local-file references resolved (7 checked)",
+      "status": "PASS"
+    },
+    "package_xml": {
+      "message": "package.xml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/package.xml",
+      "status": "PASS"
+    },
+    "ros_launch_smoke_skip_evaluation_state": {
+      "command": "ros2 launch suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    },
+    "scene3d_visual_quality_summary": {
+      "blockers": [
+        "mesh_source_count > 0 requires mesh_rendered_count > 0"
+      ],
+      "counters": {
+        "credible_physical_rendered_count": 0,
+        "diagnostic_fallback_count": 0,
+        "helper_overlay_count": 0,
+        "mesh_rendered_count": 0,
+        "mesh_source_count": 3,
+        "physical_rendered_count": 0,
+        "primitive_rendered_count": 0,
+        "primitive_source_count": 0,
+        "total_payload_count": 3
+      },
+      "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene_visual_mesh_index.json",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/generated/scene3d_gui_smoke.json",
+      "status": "FAIL",
+      "visual_quality_status": "FAIL",
+      "warnings": []
+    },
+    "scene_manifest_yaml": {
+      "message": "scene_manifest.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/scene_manifest.yaml",
+      "status": "PASS"
+    },
+    "scene_package_exists": {
+      "message": "scene package directory exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test",
+      "status": "PASS"
+    },
+    "tool_metadata_consistency": {
+      "message": "tool/end-effector metadata has no explicit contradictions",
+      "observed": {
+        "cell_definition_end_effector_id": "suction",
+        "cell_definition_family": "suction",
+        "environment_tool_family": "suction",
+        "environment_tool_id": "single_suction",
+        "manifest_end_effector_brand": "single_suction_gripper",
+        "manifest_end_effector_family": "suction",
+        "manifest_end_effector_type": "suction"
+      },
+      "status": "PASS",
+      "warnings": [
+        "Tool metadata names differ but resolve to the same broad family: cell_definition.yaml end_effector.id 'suction', environment.yaml tool.id/profile 'single_suction'."
+      ]
+    },
+    "urdf_scene_urdf_xacro": {
+      "message": "urdf/scene.urdf.xacro exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/suction_test/urdf/scene.urdf.xacro",
+      "status": "PASS"
+    }
+  },
+  "commands": {
+    "build_command": "colcon build --symlink-install --packages-select suction_test",
+    "fake_hardware_launch_command": "ros2 launch suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+    "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/suction_test --json"
+  },
+  "failures": [
+    {
+      "category": "credible_physical_visual_evidence",
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "status": "FAIL"
+    },
+    {
+      "category": "scene3d_visual_quality_summary",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "status": "FAIL"
+    }
+  ],
+  "generated_at": "2026-06-04T16:24:50.479471+00:00",
+  "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+  "offline_scene_readiness": {
+    "errors": [],
+    "inputs": {
+      "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/suction_test",
+      "workcell_root": null
+    },
+    "notes": [
+      "ROS scene package detected (package.xml present)."
+    ],
+    "result": "WARN",
+    "scene_reports": [
+      {
+        "candidates": {
+          "gripper": [
+            "CMakeLists.txt",
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "environment_layout.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene3d_gui_smoke.json",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json",
+            "scene_visual_mesh_index.json",
+            "workcell_builder_task_intent.yaml"
+          ],
+          "robot": [
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json",
+            "scene_visual_mesh_index.json",
+            "workcell_builder_task_intent.yaml",
+            "workcell_studio_layout.generated.yaml",
+            "workcell_studio_layout.yaml"
+          ],
+          "sensor": [
+            "cell_definition.yaml",
+            "environment.yaml",
+            "environment_assets.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene_package_readiness.json"
+          ]
+        },
+        "counts": {
+          "files": 19,
+          "meshes": 0,
+          "urdf_xacro": 2
+        },
+        "errors": [],
+        "frames": {
+          "base_link": 9,
+          "camera_link": 4,
+          "tool0": 14,
+          "world": 29
+        },
+        "mesh_extensions_detected": [],
+        "notes": [
+          "ROS scene package detected (package.xml present)."
+        ],
+        "placed_objects": {
+          "absolute_external_mesh_warnings": [],
+          "count": 0,
+          "found_in_generated_urdf_xacro": false,
+          "found_names": [],
+          "invalid_mesh_warnings": [],
+          "missing_collision_mesh_warnings": [],
+          "missing_names": []
+        },
+        "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/suction_test",
+        "task_zones": {
+          "duplicate_ids": [],
+          "invalid_dimensions": [],
+          "pick": 0,
+          "place": 0,
+          "total": 0,
+          "zone_ids": []
+        },
+        "warnings": [
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find single_suction_moveit_config)/config/single_suction_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find single_suction_description)/urdf/single_suction_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find table_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Task intent pick.source.id not found in task_zones: pick_zone_main",
+          "Task intent place.target.id not found in task_zones: default_drop_zone",
+          "Legacy compatibility: robot_mount missing.",
+          "Legacy compatibility: tool_attachment missing.",
+          "Legacy compatibility: recommended gripper orientation not used."
+        ]
+      }
+    ],
+    "strict": false,
+    "summary": {
+      "errors": 0,
+      "scene_packages_checked": 1,
+      "warnings": 38
+    },
+    "warnings": [
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find single_suction_moveit_config)/config/single_suction_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find single_suction_description)/urdf/single_suction_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find table_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+      "Task intent place.target.id not found in task_zones: default_drop_zone",
+      "Legacy compatibility: robot_mount missing.",
+      "Legacy compatibility: tool_attachment missing.",
+      "Legacy compatibility: recommended gripper orientation not used."
+    ]
+  },
+  "overall_status": "BLOCKED",
+  "package_name": "suction_test",
+  "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+  "readiness_status": "BLOCKED",
+  "ros_humble_available": false,
+  "safe_command_warnings": [],
+  "safety": {
+    "fake_hardware_default": true,
+    "motion_command_sent": false,
+    "real_hardware_enabled": false,
+    "ros_launch_executed_by_matrix": false,
+    "runtime_execution_called": false,
+    "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+  },
+  "scene_name": "suction_test",
+  "scene_path": "scenes/suction_test",
+  "schema_version": "workcell_studio_scene_package_readiness/v1",
+  "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+  "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+  "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+  "support_level": "supported",
+  "warnings": [
+    {
+      "category": "cell_definition_validation",
+      "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+    },
+    {
+      "category": "tool_metadata_consistency",
+      "message": "Tool metadata names differ but resolve to the same broad family: cell_definition.yaml end_effector.id 'suction', environment.yaml tool.id/profile 'single_suction'."
+    }
+  ],
+  "workcell_builder_executable_found": false
+}

--- a/scenes/ur10_2f_test/generated/scene_package_readiness.json
+++ b/scenes/ur10_2f_test/generated/scene_package_readiness.json
@@ -1,0 +1,1578 @@
+{
+  "blockers": [
+    {
+      "category": "supported_scene_catalog",
+      "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+      "status": "BLOCKED"
+    },
+    {
+      "category": "ros_launch_smoke_skip_evaluation_state",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    }
+  ],
+  "build_package_name": "ur10_2f_test",
+  "builder_generated_scene_validation": {
+    "checks": [
+      {
+        "check": "package.xml exists",
+        "ok": true
+      },
+      {
+        "check": "CMakeLists.txt exists",
+        "ok": true
+      },
+      {
+        "check": "environment.yaml exists",
+        "ok": true
+      },
+      {
+        "check": "workcell_builder_metadata.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/cell_definition.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/environment_layout.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/workcell_builder_task_intent.yaml present",
+        "ok": false,
+        "optional": true
+      }
+    ],
+    "discovered": {
+      "end_effector_capability_id": null,
+      "end_effector_name": "robotiq_85",
+      "grasp_strategy_id": null,
+      "object_count": 1,
+      "robot_capability_id": null,
+      "robot_name": "ur10",
+      "sensor_capability_id": null
+    },
+    "errors": [],
+    "export_validation": {},
+    "ok": true,
+    "readiness": "physical_scene_only",
+    "readiness_classification": "physical_scene_only",
+    "runtime_readiness": "runtime_blocked_or_preview_only",
+    "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test",
+    "suggested_next_actions": [
+      "Create builder task intent to define pick/place/grasp."
+    ],
+    "task_flow_summary": {},
+    "task_intent": {},
+    "warnings": [
+      "workcell_builder_metadata.yaml missing (optional)",
+      "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+      "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+      "Task intent missing: physical scene only."
+    ]
+  },
+  "catalog_status": "blocked",
+  "categories": {
+    "cell_definition_validation": {
+      "capabilities": {
+        "capability_refs": {
+          "end_effector": null,
+          "environment_assets": [],
+          "robot": null,
+          "sensors": [],
+          "task": null
+        },
+        "checks": {
+          "events": [],
+          "status": "FAIL"
+        },
+        "resolved": {}
+      },
+      "environment_layout": {},
+      "errors": [
+        "Missing required top-level key: camera",
+        "Missing required top-level key: objects"
+      ],
+      "grasp_strategy": {
+        "mode": "none",
+        "ref": null,
+        "resolved_path": null,
+        "status": "PASS"
+      },
+      "message": "cell_definition.yaml has validation errors",
+      "notes": [],
+      "parser": "pyyaml",
+      "status": "FAIL",
+      "warnings": [
+        "environment.layout path not found: layout/workcell_studio_layout.yaml"
+      ]
+    },
+    "cell_definition_yaml": {
+      "message": "cell_definition.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/cell_definition.yaml",
+      "status": "PASS"
+    },
+    "cmakelists_txt": {
+      "message": "CMakeLists.txt exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/CMakeLists.txt",
+      "status": "PASS"
+    },
+    "credible_physical_visual_evidence": {
+      "mesh_failure_summary_by_reason_code": {},
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "physical_rendered_count": 0,
+      "source_geometry_count": 11,
+      "status": "FAIL"
+    },
+    "environment_yaml": {
+      "message": "environment.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/environment.yaml",
+      "status": "PASS"
+    },
+    "fake_hardware_launch_command_derivation": {
+      "build_package_name": "ur10_2f_test",
+      "command": "ros2 launch ur10_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "safe fake-hardware launch command recorded",
+      "package_name": "ur10_2f_test",
+      "safety": "not executed; fake hardware explicitly required",
+      "status": "PASS",
+      "warnings": []
+    },
+    "generated_scene_package_readiness_json": {
+      "message": "generated/scene_package_readiness.json is present and parseable",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene_package_readiness.json",
+      "status": "PASS",
+      "summary": {
+        "blockers": [
+          {
+            "category": "supported_scene_catalog",
+            "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+            "status": "BLOCKED"
+          },
+          {
+            "category": "ros_launch_smoke_skip_evaluation_state",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          }
+        ],
+        "build_package_name": "ur10_2f_test",
+        "builder_generated_scene_validation": {
+          "checks": [
+            {
+              "check": "package.xml exists",
+              "ok": true
+            },
+            {
+              "check": "CMakeLists.txt exists",
+              "ok": true
+            },
+            {
+              "check": "environment.yaml exists",
+              "ok": true
+            },
+            {
+              "check": "workcell_builder_metadata.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/cell_definition.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/environment_layout.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/workcell_builder_task_intent.yaml present",
+              "ok": false,
+              "optional": true
+            }
+          ],
+          "discovered": {
+            "end_effector_capability_id": null,
+            "end_effector_name": "robotiq_85",
+            "grasp_strategy_id": null,
+            "object_count": 1,
+            "robot_capability_id": null,
+            "robot_name": "ur10",
+            "sensor_capability_id": null
+          },
+          "errors": [],
+          "export_validation": {},
+          "ok": true,
+          "readiness": "physical_scene_only",
+          "readiness_classification": "physical_scene_only",
+          "runtime_readiness": "runtime_blocked_or_preview_only",
+          "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test",
+          "suggested_next_actions": [
+            "Create builder task intent to define pick/place/grasp."
+          ],
+          "task_flow_summary": {},
+          "task_intent": {},
+          "warnings": [
+            "workcell_builder_metadata.yaml missing (optional)",
+            "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+            "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+            "Task intent missing: physical scene only."
+          ]
+        },
+        "catalog_status": "blocked",
+        "categories": {
+          "cell_definition_validation": {
+            "capabilities": {
+              "capability_refs": {
+                "end_effector": null,
+                "environment_assets": [],
+                "robot": null,
+                "sensors": [],
+                "task": null
+              },
+              "checks": {
+                "events": [],
+                "status": "FAIL"
+              },
+              "resolved": {}
+            },
+            "environment_layout": {},
+            "errors": [
+              "Missing required top-level key: camera",
+              "Missing required top-level key: objects"
+            ],
+            "grasp_strategy": {
+              "mode": "none",
+              "ref": null,
+              "resolved_path": null,
+              "status": "PASS"
+            },
+            "message": "cell_definition.yaml has validation errors",
+            "notes": [],
+            "parser": "pyyaml",
+            "status": "FAIL",
+            "warnings": [
+              "environment.layout path not found: layout/workcell_studio_layout.yaml"
+            ]
+          },
+          "cell_definition_yaml": {
+            "message": "cell_definition.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/cell_definition.yaml",
+            "status": "PASS"
+          },
+          "cmakelists_txt": {
+            "message": "CMakeLists.txt exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/CMakeLists.txt",
+            "status": "PASS"
+          },
+          "credible_physical_visual_evidence": {
+            "mesh_failure_summary_by_reason_code": {},
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "physical_rendered_count": 0,
+            "source_geometry_count": 11,
+            "status": "FAIL"
+          },
+          "environment_yaml": {
+            "message": "environment.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/environment.yaml",
+            "status": "PASS"
+          },
+          "fake_hardware_launch_command_derivation": {
+            "build_package_name": "ur10_2f_test",
+            "command": "ros2 launch ur10_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "safe fake-hardware launch command recorded",
+            "package_name": "ur10_2f_test",
+            "safety": "not executed; fake hardware explicitly required",
+            "status": "PASS",
+            "warnings": []
+          },
+          "generated_scene_package_readiness_json": {
+            "message": "generated/scene_package_readiness.json is present and parseable",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene_package_readiness.json",
+            "status": "PASS",
+            "summary": {
+              "blockers": [
+                {
+                  "category": "supported_scene_catalog",
+                  "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+                  "status": "BLOCKED"
+                },
+                {
+                  "category": "ros_launch_smoke_skip_evaluation_state",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                }
+              ],
+              "build_package_name": "ur10_2f_test",
+              "builder_generated_scene_validation": {
+                "checks": [
+                  {
+                    "check": "package.xml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "CMakeLists.txt exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "environment.yaml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "workcell_builder_metadata.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/cell_definition.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/environment_layout.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/workcell_builder_task_intent.yaml present",
+                    "ok": false,
+                    "optional": true
+                  }
+                ],
+                "discovered": {
+                  "end_effector_capability_id": null,
+                  "end_effector_name": "robotiq_85",
+                  "grasp_strategy_id": null,
+                  "object_count": 1,
+                  "robot_capability_id": null,
+                  "robot_name": "ur10",
+                  "sensor_capability_id": null
+                },
+                "errors": [],
+                "export_validation": {},
+                "ok": true,
+                "readiness": "physical_scene_only",
+                "readiness_classification": "physical_scene_only",
+                "runtime_readiness": "runtime_blocked_or_preview_only",
+                "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test",
+                "suggested_next_actions": [
+                  "Create builder task intent to define pick/place/grasp."
+                ],
+                "task_flow_summary": {},
+                "task_intent": {},
+                "warnings": [
+                  "workcell_builder_metadata.yaml missing (optional)",
+                  "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+                  "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+                  "Task intent missing: physical scene only."
+                ]
+              },
+              "catalog_status": "blocked",
+              "categories": {
+                "cell_definition_validation": {
+                  "capabilities": {
+                    "capability_refs": {
+                      "end_effector": null,
+                      "environment_assets": [],
+                      "robot": null,
+                      "sensors": [],
+                      "task": null
+                    },
+                    "checks": {
+                      "events": [],
+                      "status": "FAIL"
+                    },
+                    "resolved": {}
+                  },
+                  "environment_layout": {},
+                  "errors": [
+                    "Missing required top-level key: camera",
+                    "Missing required top-level key: objects"
+                  ],
+                  "grasp_strategy": {
+                    "mode": "none",
+                    "ref": null,
+                    "resolved_path": null,
+                    "status": "PASS"
+                  },
+                  "message": "cell_definition.yaml has validation errors",
+                  "notes": [],
+                  "parser": "pyyaml",
+                  "status": "FAIL",
+                  "warnings": [
+                    "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                  ]
+                },
+                "cell_definition_yaml": {
+                  "message": "cell_definition.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/cell_definition.yaml",
+                  "status": "PASS"
+                },
+                "cmakelists_txt": {
+                  "message": "CMakeLists.txt exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/CMakeLists.txt",
+                  "status": "PASS"
+                },
+                "credible_physical_visual_evidence": {
+                  "mesh_failure_summary_by_reason_code": {},
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "physical_rendered_count": 0,
+                  "source_geometry_count": 11,
+                  "status": "FAIL"
+                },
+                "environment_yaml": {
+                  "message": "environment.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/environment.yaml",
+                  "status": "PASS"
+                },
+                "fake_hardware_launch_command_derivation": {
+                  "build_package_name": "ur10_2f_test",
+                  "command": "ros2 launch ur10_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "safe fake-hardware launch command recorded",
+                  "package_name": "ur10_2f_test",
+                  "safety": "not executed; fake hardware explicitly required",
+                  "status": "PASS",
+                  "warnings": []
+                },
+                "generated_scene_package_readiness_json": {
+                  "message": "optional/generated-if-present readiness JSON is not present",
+                  "optional": true,
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene_package_readiness.json",
+                  "status": "PASS"
+                },
+                "generated_scene_visual_mesh_index_json": {
+                  "message": "generated/scene_visual_mesh_index.json exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json",
+                  "status": "PASS"
+                },
+                "launch_demo_launch_py": {
+                  "message": "launch/demo.launch.py exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/launch/demo.launch.py",
+                  "status": "PASS"
+                },
+                "layout_workcell_studio_layout_yaml": {
+                  "message": "layout/workcell_studio_layout.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/layout/workcell_studio_layout.yaml",
+                  "status": "PASS"
+                },
+                "manifest_local_file_references": {
+                  "checked": [
+                    {
+                      "field": "files.environment",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/environment.yaml",
+                      "reference": "environment.yaml"
+                    },
+                    {
+                      "field": "files.cell_definition",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/cell_definition.yaml",
+                      "reference": "cell_definition.yaml"
+                    },
+                    {
+                      "field": "files.layout",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/layout/workcell_studio_layout.yaml",
+                      "reference": "layout/workcell_studio_layout.yaml"
+                    },
+                    {
+                      "field": "files.launch",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/launch/demo.launch.py",
+                      "reference": "launch/demo.launch.py"
+                    },
+                    {
+                      "field": "files.urdf_xacro",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
+                      "reference": "urdf/scene.urdf.xacro"
+                    },
+                    {
+                      "field": "files.visual_mesh_index",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json",
+                      "reference": "generated/scene_visual_mesh_index.json"
+                    },
+                    {
+                      "field": "files.scene3d_gui_smoke",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene3d_gui_smoke.json",
+                      "reference": "generated/scene3d_gui_smoke.json"
+                    }
+                  ],
+                  "message": "manifest local-file references resolved (7 checked)",
+                  "status": "PASS"
+                },
+                "package_xml": {
+                  "message": "package.xml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/package.xml",
+                  "status": "PASS"
+                },
+                "ros_launch_smoke_skip_evaluation_state": {
+                  "command": "ros2 launch ur10_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                },
+                "scene3d_visual_quality_summary": {
+                  "blockers": [
+                    "mesh_source_count > 0 requires mesh_rendered_count > 0"
+                  ],
+                  "counters": {
+                    "credible_physical_rendered_count": 0,
+                    "diagnostic_fallback_count": 0,
+                    "helper_overlay_count": 0,
+                    "mesh_rendered_count": 0,
+                    "mesh_source_count": 11,
+                    "physical_rendered_count": 0,
+                    "primitive_rendered_count": 0,
+                    "primitive_source_count": 0,
+                    "total_payload_count": 11
+                  },
+                  "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene3d_gui_smoke.json",
+                  "status": "FAIL",
+                  "visual_quality_status": "FAIL",
+                  "warnings": []
+                },
+                "scene_manifest_yaml": {
+                  "message": "scene_manifest.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/scene_manifest.yaml",
+                  "status": "PASS"
+                },
+                "scene_package_exists": {
+                  "message": "scene package directory exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test",
+                  "status": "PASS"
+                },
+                "tool_metadata_consistency": {
+                  "message": "tool/end-effector metadata has no explicit contradictions",
+                  "observed": {
+                    "cell_definition_end_effector_id": "robotiq_2f",
+                    "environment_tool_id": null,
+                    "manifest_end_effector_brand": "robotiq_85_gripper",
+                    "manifest_end_effector_type": "finger"
+                  },
+                  "status": "PASS"
+                },
+                "urdf_scene_urdf_xacro": {
+                  "message": "urdf/scene.urdf.xacro exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
+                  "status": "PASS"
+                }
+              },
+              "commands": {
+                "build_command": "colcon build --symlink-install --packages-select ur10_2f_test",
+                "fake_hardware_launch_command": "ros2 launch ur10_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur10_2f_test --json"
+              },
+              "failures": [
+                {
+                  "category": "cell_definition_validation",
+                  "message": "cell_definition.yaml has validation errors",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "credible_physical_visual_evidence",
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "scene3d_visual_quality_summary",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "status": "FAIL"
+                }
+              ],
+              "generated_at": "2026-06-04T16:21:59.245618+00:00",
+              "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+              "offline_scene_readiness": {
+                "errors": [],
+                "inputs": {
+                  "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test",
+                  "workcell_root": null
+                },
+                "notes": [
+                  "ROS scene package detected (package.xml present)."
+                ],
+                "result": "WARN",
+                "scene_reports": [
+                  {
+                    "candidates": {
+                      "gripper": [
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene_manifest.yaml",
+                        "scene_visual_mesh_index.json"
+                      ],
+                      "robot": [
+                        "CMakeLists.txt",
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene3d_gui_smoke.json",
+                        "scene_manifest.yaml",
+                        "scene_visual_mesh_index.json",
+                        "workcell_builder_task_intent.yaml",
+                        "workcell_studio_layout.generated.yaml",
+                        "workcell_studio_layout.yaml"
+                      ],
+                      "sensor": [
+                        "environment_assets.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro"
+                      ]
+                    },
+                    "counts": {
+                      "files": 16,
+                      "meshes": 0,
+                      "urdf_xacro": 2
+                    },
+                    "errors": [],
+                    "frames": {
+                      "base_link": 6,
+                      "camera_link": 3,
+                      "tool0": 35,
+                      "world": 13
+                    },
+                    "mesh_extensions_detected": [],
+                    "notes": [
+                      "ROS scene package detected (package.xml present)."
+                    ],
+                    "placed_objects": {
+                      "absolute_external_mesh_warnings": [],
+                      "count": 0,
+                      "found_in_generated_urdf_xacro": false,
+                      "found_names": [],
+                      "invalid_mesh_warnings": [],
+                      "missing_collision_mesh_warnings": [],
+                      "missing_names": []
+                    },
+                    "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test",
+                    "task_zones": {
+                      "duplicate_ids": [],
+                      "invalid_dimensions": [],
+                      "pick": 0,
+                      "place": 0,
+                      "total": 0,
+                      "zone_ids": []
+                    },
+                    "warnings": [
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                      "Referenced mesh path not found: $(find ur10_moveit_config)/config/ur10.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                      "Task intent place.target.id not found in task_zones: place_zone_main",
+                      "Legacy compatibility: robot_mount missing.",
+                      "Legacy compatibility: tool_attachment missing.",
+                      "Legacy compatibility: recommended gripper orientation not used."
+                    ]
+                  }
+                ],
+                "strict": false,
+                "summary": {
+                  "errors": 0,
+                  "scene_packages_checked": 1,
+                  "warnings": 22
+                },
+                "warnings": [
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                  "Referenced mesh path not found: $(find ur10_moveit_config)/config/ur10.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                  "Task intent place.target.id not found in task_zones: place_zone_main",
+                  "Legacy compatibility: robot_mount missing.",
+                  "Legacy compatibility: tool_attachment missing.",
+                  "Legacy compatibility: recommended gripper orientation not used."
+                ]
+              },
+              "overall_status": "BLOCKED",
+              "package_name": "ur10_2f_test",
+              "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+              "readiness_status": "BLOCKED",
+              "ros_humble_available": false,
+              "safe_command_warnings": [],
+              "safety": {
+                "fake_hardware_default": true,
+                "motion_command_sent": false,
+                "real_hardware_enabled": false,
+                "ros_launch_executed_by_matrix": false,
+                "runtime_execution_called": false,
+                "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+              },
+              "scene_name": "ur10_2f_test",
+              "scene_path": "scenes/ur10_2f_test",
+              "schema_version": "workcell_studio_scene_package_readiness/v1",
+              "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+              "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+              "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+              "support_level": "supported",
+              "warnings": [
+                {
+                  "category": "cell_definition_validation",
+                  "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                }
+              ],
+              "workcell_builder_executable_found": false
+            }
+          },
+          "generated_scene_visual_mesh_index_json": {
+            "message": "generated/scene_visual_mesh_index.json exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json",
+            "status": "PASS"
+          },
+          "launch_demo_launch_py": {
+            "message": "launch/demo.launch.py exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/launch/demo.launch.py",
+            "status": "PASS"
+          },
+          "layout_workcell_studio_layout_yaml": {
+            "message": "layout/workcell_studio_layout.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/layout/workcell_studio_layout.yaml",
+            "status": "PASS"
+          },
+          "manifest_local_file_references": {
+            "checked": [
+              {
+                "field": "files.environment",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/environment.yaml",
+                "reference": "environment.yaml"
+              },
+              {
+                "field": "files.cell_definition",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/cell_definition.yaml",
+                "reference": "cell_definition.yaml"
+              },
+              {
+                "field": "files.layout",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/layout/workcell_studio_layout.yaml",
+                "reference": "layout/workcell_studio_layout.yaml"
+              },
+              {
+                "field": "files.launch",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/launch/demo.launch.py",
+                "reference": "launch/demo.launch.py"
+              },
+              {
+                "field": "files.urdf_xacro",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
+                "reference": "urdf/scene.urdf.xacro"
+              },
+              {
+                "field": "files.visual_mesh_index",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json",
+                "reference": "generated/scene_visual_mesh_index.json"
+              },
+              {
+                "field": "files.scene3d_gui_smoke",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene3d_gui_smoke.json",
+                "reference": "generated/scene3d_gui_smoke.json"
+              }
+            ],
+            "message": "manifest local-file references resolved (7 checked)",
+            "status": "PASS"
+          },
+          "package_xml": {
+            "message": "package.xml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/package.xml",
+            "status": "PASS"
+          },
+          "ros_launch_smoke_skip_evaluation_state": {
+            "command": "ros2 launch ur10_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          },
+          "scene3d_visual_quality_summary": {
+            "blockers": [
+              "mesh_source_count > 0 requires mesh_rendered_count > 0"
+            ],
+            "counters": {
+              "credible_physical_rendered_count": 0,
+              "diagnostic_fallback_count": 0,
+              "helper_overlay_count": 0,
+              "mesh_rendered_count": 0,
+              "mesh_source_count": 11,
+              "physical_rendered_count": 0,
+              "primitive_rendered_count": 0,
+              "primitive_source_count": 0,
+              "total_payload_count": 11
+            },
+            "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene3d_gui_smoke.json",
+            "status": "FAIL",
+            "visual_quality_status": "FAIL",
+            "warnings": []
+          },
+          "scene_manifest_yaml": {
+            "message": "scene_manifest.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/scene_manifest.yaml",
+            "status": "PASS"
+          },
+          "scene_package_exists": {
+            "message": "scene package directory exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test",
+            "status": "PASS"
+          },
+          "tool_metadata_consistency": {
+            "message": "tool/end-effector metadata has no explicit contradictions",
+            "observed": {
+              "cell_definition_end_effector_id": "robotiq_2f",
+              "environment_tool_id": null,
+              "manifest_end_effector_brand": "robotiq_85_gripper",
+              "manifest_end_effector_type": "finger"
+            },
+            "status": "PASS"
+          },
+          "urdf_scene_urdf_xacro": {
+            "message": "urdf/scene.urdf.xacro exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
+            "status": "PASS"
+          }
+        },
+        "commands": {
+          "build_command": "colcon build --symlink-install --packages-select ur10_2f_test",
+          "fake_hardware_launch_command": "ros2 launch ur10_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+          "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur10_2f_test --json"
+        },
+        "failures": [
+          {
+            "category": "cell_definition_validation",
+            "message": "cell_definition.yaml has validation errors",
+            "status": "FAIL"
+          },
+          {
+            "category": "credible_physical_visual_evidence",
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "status": "FAIL"
+          },
+          {
+            "category": "scene3d_visual_quality_summary",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "status": "FAIL"
+          }
+        ],
+        "generated_at": "2026-06-04T16:23:19.093332+00:00",
+        "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+        "offline_scene_readiness": {
+          "errors": [],
+          "inputs": {
+            "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test",
+            "workcell_root": null
+          },
+          "notes": [
+            "ROS scene package detected (package.xml present)."
+          ],
+          "result": "WARN",
+          "scene_reports": [
+            {
+              "candidates": {
+                "gripper": [
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json"
+                ],
+                "robot": [
+                  "CMakeLists.txt",
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene3d_gui_smoke.json",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json",
+                  "workcell_builder_task_intent.yaml",
+                  "workcell_studio_layout.generated.yaml",
+                  "workcell_studio_layout.yaml"
+                ],
+                "sensor": [
+                  "environment_assets.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene_package_readiness.json"
+                ]
+              },
+              "counts": {
+                "files": 17,
+                "meshes": 0,
+                "urdf_xacro": 2
+              },
+              "errors": [],
+              "frames": {
+                "base_link": 7,
+                "camera_link": 4,
+                "tool0": 36,
+                "world": 14
+              },
+              "mesh_extensions_detected": [],
+              "notes": [
+                "ROS scene package detected (package.xml present)."
+              ],
+              "placed_objects": {
+                "absolute_external_mesh_warnings": [],
+                "count": 0,
+                "found_in_generated_urdf_xacro": false,
+                "found_names": [],
+                "invalid_mesh_warnings": [],
+                "missing_collision_mesh_warnings": [],
+                "missing_names": []
+              },
+              "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test",
+              "task_zones": {
+                "duplicate_ids": [],
+                "invalid_dimensions": [],
+                "pick": 0,
+                "place": 0,
+                "total": 0,
+                "zone_ids": []
+              },
+              "warnings": [
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Referenced mesh path not found: $(find ur10_moveit_config)/config/ur10.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                "Task intent place.target.id not found in task_zones: place_zone_main",
+                "Legacy compatibility: robot_mount missing.",
+                "Legacy compatibility: tool_attachment missing.",
+                "Legacy compatibility: recommended gripper orientation not used."
+              ]
+            }
+          ],
+          "strict": false,
+          "summary": {
+            "errors": 0,
+            "scene_packages_checked": 1,
+            "warnings": 44
+          },
+          "warnings": [
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Referenced mesh path not found: $(find ur10_moveit_config)/config/ur10.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Task intent pick.source.id not found in task_zones: pick_zone_main",
+            "Task intent place.target.id not found in task_zones: place_zone_main",
+            "Legacy compatibility: robot_mount missing.",
+            "Legacy compatibility: tool_attachment missing.",
+            "Legacy compatibility: recommended gripper orientation not used."
+          ]
+        },
+        "overall_status": "BLOCKED",
+        "package_name": "ur10_2f_test",
+        "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+        "readiness_status": "BLOCKED",
+        "ros_humble_available": false,
+        "safe_command_warnings": [],
+        "safety": {
+          "fake_hardware_default": true,
+          "motion_command_sent": false,
+          "real_hardware_enabled": false,
+          "ros_launch_executed_by_matrix": false,
+          "runtime_execution_called": false,
+          "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+        },
+        "scene_name": "ur10_2f_test",
+        "scene_path": "scenes/ur10_2f_test",
+        "schema_version": "workcell_studio_scene_package_readiness/v1",
+        "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+        "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+        "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+        "support_level": "supported",
+        "warnings": [
+          {
+            "category": "cell_definition_validation",
+            "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+          }
+        ],
+        "workcell_builder_executable_found": false
+      }
+    },
+    "generated_scene_visual_mesh_index_json": {
+      "message": "generated/scene_visual_mesh_index.json exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json",
+      "status": "PASS"
+    },
+    "launch_demo_launch_py": {
+      "message": "launch/demo.launch.py exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/launch/demo.launch.py",
+      "status": "PASS"
+    },
+    "layout_workcell_studio_layout_yaml": {
+      "message": "layout/workcell_studio_layout.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/layout/workcell_studio_layout.yaml",
+      "status": "PASS"
+    },
+    "manifest_local_file_references": {
+      "checked": [
+        {
+          "field": "files.environment",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/environment.yaml",
+          "reference": "environment.yaml"
+        },
+        {
+          "field": "files.cell_definition",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/cell_definition.yaml",
+          "reference": "cell_definition.yaml"
+        },
+        {
+          "field": "files.layout",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/layout/workcell_studio_layout.yaml",
+          "reference": "layout/workcell_studio_layout.yaml"
+        },
+        {
+          "field": "files.launch",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/launch/demo.launch.py",
+          "reference": "launch/demo.launch.py"
+        },
+        {
+          "field": "files.urdf_xacro",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
+          "reference": "urdf/scene.urdf.xacro"
+        },
+        {
+          "field": "files.visual_mesh_index",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json",
+          "reference": "generated/scene_visual_mesh_index.json"
+        },
+        {
+          "field": "files.scene3d_gui_smoke",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene3d_gui_smoke.json",
+          "reference": "generated/scene3d_gui_smoke.json"
+        }
+      ],
+      "message": "manifest local-file references resolved (7 checked)",
+      "status": "PASS"
+    },
+    "package_xml": {
+      "message": "package.xml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/package.xml",
+      "status": "PASS"
+    },
+    "ros_launch_smoke_skip_evaluation_state": {
+      "command": "ros2 launch ur10_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    },
+    "scene3d_visual_quality_summary": {
+      "blockers": [
+        "mesh_source_count > 0 requires mesh_rendered_count > 0"
+      ],
+      "counters": {
+        "credible_physical_rendered_count": 0,
+        "diagnostic_fallback_count": 0,
+        "helper_overlay_count": 0,
+        "mesh_rendered_count": 0,
+        "mesh_source_count": 11,
+        "physical_rendered_count": 0,
+        "primitive_rendered_count": 0,
+        "primitive_source_count": 0,
+        "total_payload_count": 11
+      },
+      "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene_visual_mesh_index.json",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/generated/scene3d_gui_smoke.json",
+      "status": "FAIL",
+      "visual_quality_status": "FAIL",
+      "warnings": []
+    },
+    "scene_manifest_yaml": {
+      "message": "scene_manifest.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/scene_manifest.yaml",
+      "status": "PASS"
+    },
+    "scene_package_exists": {
+      "message": "scene package directory exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test",
+      "status": "PASS"
+    },
+    "tool_metadata_consistency": {
+      "message": "tool/end-effector metadata has no explicit contradictions",
+      "observed": {
+        "cell_definition_end_effector_id": "robotiq_2f",
+        "cell_definition_family": "two_finger_gripper",
+        "environment_tool_family": null,
+        "environment_tool_id": null,
+        "manifest_end_effector_brand": "robotiq_85_gripper",
+        "manifest_end_effector_family": "finger_gripper",
+        "manifest_end_effector_type": "finger"
+      },
+      "status": "PASS",
+      "warnings": []
+    },
+    "urdf_scene_urdf_xacro": {
+      "message": "urdf/scene.urdf.xacro exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test/urdf/scene.urdf.xacro",
+      "status": "PASS"
+    }
+  },
+  "commands": {
+    "build_command": "colcon build --symlink-install --packages-select ur10_2f_test",
+    "fake_hardware_launch_command": "ros2 launch ur10_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+    "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur10_2f_test --json"
+  },
+  "failures": [
+    {
+      "category": "cell_definition_validation",
+      "message": "cell_definition.yaml has validation errors",
+      "status": "FAIL"
+    },
+    {
+      "category": "credible_physical_visual_evidence",
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "status": "FAIL"
+    },
+    {
+      "category": "scene3d_visual_quality_summary",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "status": "FAIL"
+    }
+  ],
+  "generated_at": "2026-06-04T16:24:50.479471+00:00",
+  "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+  "offline_scene_readiness": {
+    "errors": [],
+    "inputs": {
+      "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test",
+      "workcell_root": null
+    },
+    "notes": [
+      "ROS scene package detected (package.xml present)."
+    ],
+    "result": "WARN",
+    "scene_reports": [
+      {
+        "candidates": {
+          "gripper": [
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json",
+            "scene_visual_mesh_index.json"
+          ],
+          "robot": [
+            "CMakeLists.txt",
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene3d_gui_smoke.json",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json",
+            "scene_visual_mesh_index.json",
+            "workcell_builder_task_intent.yaml",
+            "workcell_studio_layout.generated.yaml",
+            "workcell_studio_layout.yaml"
+          ],
+          "sensor": [
+            "environment_assets.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene_package_readiness.json"
+          ]
+        },
+        "counts": {
+          "files": 17,
+          "meshes": 0,
+          "urdf_xacro": 2
+        },
+        "errors": [],
+        "frames": {
+          "base_link": 8,
+          "camera_link": 5,
+          "tool0": 37,
+          "world": 15
+        },
+        "mesh_extensions_detected": [],
+        "notes": [
+          "ROS scene package detected (package.xml present)."
+        ],
+        "placed_objects": {
+          "absolute_external_mesh_warnings": [],
+          "count": 0,
+          "found_in_generated_urdf_xacro": false,
+          "found_names": [],
+          "invalid_mesh_warnings": [],
+          "missing_collision_mesh_warnings": [],
+          "missing_names": []
+        },
+        "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur10_2f_test",
+        "task_zones": {
+          "duplicate_ids": [],
+          "invalid_dimensions": [],
+          "pick": 0,
+          "place": 0,
+          "total": 0,
+          "zone_ids": []
+        },
+        "warnings": [
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Referenced mesh path not found: $(find ur10_moveit_config)/config/ur10.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Task intent pick.source.id not found in task_zones: pick_zone_main",
+          "Task intent place.target.id not found in task_zones: place_zone_main",
+          "Legacy compatibility: robot_mount missing.",
+          "Legacy compatibility: tool_attachment missing.",
+          "Legacy compatibility: recommended gripper orientation not used."
+        ]
+      }
+    ],
+    "strict": false,
+    "summary": {
+      "errors": 0,
+      "scene_packages_checked": 1,
+      "warnings": 110
+    },
+    "warnings": [
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Referenced mesh path not found: $(find ur10_moveit_config)/config/ur10.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+      "Task intent place.target.id not found in task_zones: place_zone_main",
+      "Legacy compatibility: robot_mount missing.",
+      "Legacy compatibility: tool_attachment missing.",
+      "Legacy compatibility: recommended gripper orientation not used."
+    ]
+  },
+  "overall_status": "BLOCKED",
+  "package_name": "ur10_2f_test",
+  "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+  "readiness_status": "BLOCKED",
+  "ros_humble_available": false,
+  "safe_command_warnings": [],
+  "safety": {
+    "fake_hardware_default": true,
+    "motion_command_sent": false,
+    "real_hardware_enabled": false,
+    "ros_launch_executed_by_matrix": false,
+    "runtime_execution_called": false,
+    "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+  },
+  "scene_name": "ur10_2f_test",
+  "scene_path": "scenes/ur10_2f_test",
+  "schema_version": "workcell_studio_scene_package_readiness/v1",
+  "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+  "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+  "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+  "support_level": "supported",
+  "warnings": [
+    {
+      "category": "cell_definition_validation",
+      "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+    }
+  ],
+  "workcell_builder_executable_found": false
+}

--- a/scenes/ur3_suction_test/generated/scene_package_readiness.json
+++ b/scenes/ur3_suction_test/generated/scene_package_readiness.json
@@ -1,0 +1,1379 @@
+{
+  "blockers": [
+    {
+      "category": "supported_scene_catalog",
+      "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+      "status": "BLOCKED"
+    },
+    {
+      "category": "ros_launch_smoke_skip_evaluation_state",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    }
+  ],
+  "build_package_name": "ur3_suction_test",
+  "builder_generated_scene_validation": {
+    "checks": [
+      {
+        "check": "package.xml exists",
+        "ok": true
+      },
+      {
+        "check": "CMakeLists.txt exists",
+        "ok": true
+      },
+      {
+        "check": "environment.yaml exists",
+        "ok": true
+      },
+      {
+        "check": "workcell_builder_metadata.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/cell_definition.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/environment_layout.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/workcell_builder_task_intent.yaml present",
+        "ok": false,
+        "optional": true
+      }
+    ],
+    "discovered": {
+      "end_effector_capability_id": null,
+      "end_effector_name": "single_suction",
+      "grasp_strategy_id": null,
+      "object_count": 1,
+      "robot_capability_id": null,
+      "robot_name": "ur3",
+      "sensor_capability_id": null
+    },
+    "errors": [],
+    "export_validation": {},
+    "ok": true,
+    "readiness": "physical_scene_only",
+    "readiness_classification": "physical_scene_only",
+    "runtime_readiness": "runtime_blocked_or_preview_only",
+    "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test",
+    "suggested_next_actions": [
+      "Create builder task intent to define pick/place/grasp."
+    ],
+    "task_flow_summary": {},
+    "task_intent": {},
+    "warnings": [
+      "workcell_builder_metadata.yaml missing (optional)",
+      "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+      "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+      "Task intent missing: physical scene only."
+    ]
+  },
+  "catalog_status": "blocked",
+  "categories": {
+    "cell_definition_validation": {
+      "capabilities": {
+        "capability_refs": {
+          "end_effector": null,
+          "environment_assets": [],
+          "robot": null,
+          "sensors": [],
+          "task": null
+        },
+        "checks": {
+          "events": [],
+          "status": "FAIL"
+        },
+        "resolved": {}
+      },
+      "environment_layout": {},
+      "errors": [
+        "Missing required top-level key: camera",
+        "Missing required top-level key: objects"
+      ],
+      "grasp_strategy": {
+        "mode": "none",
+        "ref": null,
+        "resolved_path": null,
+        "status": "PASS"
+      },
+      "message": "cell_definition.yaml has validation errors",
+      "notes": [],
+      "parser": "pyyaml",
+      "status": "FAIL",
+      "warnings": [
+        "environment.layout path not found: layout/workcell_studio_layout.yaml"
+      ]
+    },
+    "cell_definition_yaml": {
+      "message": "cell_definition.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/cell_definition.yaml",
+      "status": "PASS"
+    },
+    "cmakelists_txt": {
+      "message": "CMakeLists.txt exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/CMakeLists.txt",
+      "status": "PASS"
+    },
+    "credible_physical_visual_evidence": {
+      "mesh_failure_summary_by_reason_code": {},
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "physical_rendered_count": 0,
+      "source_geometry_count": 3,
+      "status": "FAIL"
+    },
+    "environment_yaml": {
+      "message": "environment.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/environment.yaml",
+      "status": "PASS"
+    },
+    "fake_hardware_launch_command_derivation": {
+      "build_package_name": "ur3_suction_test",
+      "command": "ros2 launch ur3_suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "safe fake-hardware launch command recorded",
+      "package_name": "ur3_suction_test",
+      "safety": "not executed; fake hardware explicitly required",
+      "status": "PASS",
+      "warnings": []
+    },
+    "generated_scene_package_readiness_json": {
+      "message": "generated/scene_package_readiness.json is present and parseable",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene_package_readiness.json",
+      "status": "PASS",
+      "summary": {
+        "blockers": [
+          {
+            "category": "supported_scene_catalog",
+            "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+            "status": "BLOCKED"
+          },
+          {
+            "category": "ros_launch_smoke_skip_evaluation_state",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          }
+        ],
+        "build_package_name": "ur3_suction_test",
+        "builder_generated_scene_validation": {
+          "checks": [
+            {
+              "check": "package.xml exists",
+              "ok": true
+            },
+            {
+              "check": "CMakeLists.txt exists",
+              "ok": true
+            },
+            {
+              "check": "environment.yaml exists",
+              "ok": true
+            },
+            {
+              "check": "workcell_builder_metadata.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/cell_definition.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/environment_layout.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/workcell_builder_task_intent.yaml present",
+              "ok": false,
+              "optional": true
+            }
+          ],
+          "discovered": {
+            "end_effector_capability_id": null,
+            "end_effector_name": "single_suction",
+            "grasp_strategy_id": null,
+            "object_count": 1,
+            "robot_capability_id": null,
+            "robot_name": "ur3",
+            "sensor_capability_id": null
+          },
+          "errors": [],
+          "export_validation": {},
+          "ok": true,
+          "readiness": "physical_scene_only",
+          "readiness_classification": "physical_scene_only",
+          "runtime_readiness": "runtime_blocked_or_preview_only",
+          "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test",
+          "suggested_next_actions": [
+            "Create builder task intent to define pick/place/grasp."
+          ],
+          "task_flow_summary": {},
+          "task_intent": {},
+          "warnings": [
+            "workcell_builder_metadata.yaml missing (optional)",
+            "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+            "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+            "Task intent missing: physical scene only."
+          ]
+        },
+        "catalog_status": "blocked",
+        "categories": {
+          "cell_definition_validation": {
+            "capabilities": {
+              "capability_refs": {
+                "end_effector": null,
+                "environment_assets": [],
+                "robot": null,
+                "sensors": [],
+                "task": null
+              },
+              "checks": {
+                "events": [],
+                "status": "FAIL"
+              },
+              "resolved": {}
+            },
+            "environment_layout": {},
+            "errors": [
+              "Missing required top-level key: camera",
+              "Missing required top-level key: objects"
+            ],
+            "grasp_strategy": {
+              "mode": "none",
+              "ref": null,
+              "resolved_path": null,
+              "status": "PASS"
+            },
+            "message": "cell_definition.yaml has validation errors",
+            "notes": [],
+            "parser": "pyyaml",
+            "status": "FAIL",
+            "warnings": [
+              "environment.layout path not found: layout/workcell_studio_layout.yaml"
+            ]
+          },
+          "cell_definition_yaml": {
+            "message": "cell_definition.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/cell_definition.yaml",
+            "status": "PASS"
+          },
+          "cmakelists_txt": {
+            "message": "CMakeLists.txt exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/CMakeLists.txt",
+            "status": "PASS"
+          },
+          "credible_physical_visual_evidence": {
+            "mesh_failure_summary_by_reason_code": {},
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "physical_rendered_count": 0,
+            "source_geometry_count": 3,
+            "status": "FAIL"
+          },
+          "environment_yaml": {
+            "message": "environment.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/environment.yaml",
+            "status": "PASS"
+          },
+          "fake_hardware_launch_command_derivation": {
+            "build_package_name": "ur3_suction_test",
+            "command": "ros2 launch ur3_suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "safe fake-hardware launch command recorded",
+            "package_name": "ur3_suction_test",
+            "safety": "not executed; fake hardware explicitly required",
+            "status": "PASS",
+            "warnings": []
+          },
+          "generated_scene_package_readiness_json": {
+            "message": "generated/scene_package_readiness.json is present and parseable",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene_package_readiness.json",
+            "status": "PASS",
+            "summary": {
+              "blockers": [
+                {
+                  "category": "supported_scene_catalog",
+                  "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+                  "status": "BLOCKED"
+                },
+                {
+                  "category": "ros_launch_smoke_skip_evaluation_state",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                }
+              ],
+              "build_package_name": "ur3_suction_test",
+              "builder_generated_scene_validation": {
+                "checks": [
+                  {
+                    "check": "package.xml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "CMakeLists.txt exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "environment.yaml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "workcell_builder_metadata.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/cell_definition.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/environment_layout.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/workcell_builder_task_intent.yaml present",
+                    "ok": false,
+                    "optional": true
+                  }
+                ],
+                "discovered": {
+                  "end_effector_capability_id": null,
+                  "end_effector_name": "single_suction",
+                  "grasp_strategy_id": null,
+                  "object_count": 1,
+                  "robot_capability_id": null,
+                  "robot_name": "ur3",
+                  "sensor_capability_id": null
+                },
+                "errors": [],
+                "export_validation": {},
+                "ok": true,
+                "readiness": "physical_scene_only",
+                "readiness_classification": "physical_scene_only",
+                "runtime_readiness": "runtime_blocked_or_preview_only",
+                "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test",
+                "suggested_next_actions": [
+                  "Create builder task intent to define pick/place/grasp."
+                ],
+                "task_flow_summary": {},
+                "task_intent": {},
+                "warnings": [
+                  "workcell_builder_metadata.yaml missing (optional)",
+                  "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+                  "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+                  "Task intent missing: physical scene only."
+                ]
+              },
+              "catalog_status": "blocked",
+              "categories": {
+                "cell_definition_validation": {
+                  "capabilities": {
+                    "capability_refs": {
+                      "end_effector": null,
+                      "environment_assets": [],
+                      "robot": null,
+                      "sensors": [],
+                      "task": null
+                    },
+                    "checks": {
+                      "events": [],
+                      "status": "FAIL"
+                    },
+                    "resolved": {}
+                  },
+                  "environment_layout": {},
+                  "errors": [
+                    "Missing required top-level key: camera",
+                    "Missing required top-level key: objects"
+                  ],
+                  "grasp_strategy": {
+                    "mode": "none",
+                    "ref": null,
+                    "resolved_path": null,
+                    "status": "PASS"
+                  },
+                  "message": "cell_definition.yaml has validation errors",
+                  "notes": [],
+                  "parser": "pyyaml",
+                  "status": "FAIL",
+                  "warnings": [
+                    "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                  ]
+                },
+                "cell_definition_yaml": {
+                  "message": "cell_definition.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/cell_definition.yaml",
+                  "status": "PASS"
+                },
+                "cmakelists_txt": {
+                  "message": "CMakeLists.txt exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/CMakeLists.txt",
+                  "status": "PASS"
+                },
+                "credible_physical_visual_evidence": {
+                  "mesh_failure_summary_by_reason_code": {},
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "physical_rendered_count": 0,
+                  "source_geometry_count": 3,
+                  "status": "FAIL"
+                },
+                "environment_yaml": {
+                  "message": "environment.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/environment.yaml",
+                  "status": "PASS"
+                },
+                "fake_hardware_launch_command_derivation": {
+                  "build_package_name": "ur3_suction_test",
+                  "command": "ros2 launch ur3_suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "safe fake-hardware launch command recorded",
+                  "package_name": "ur3_suction_test",
+                  "safety": "not executed; fake hardware explicitly required",
+                  "status": "PASS",
+                  "warnings": []
+                },
+                "generated_scene_package_readiness_json": {
+                  "message": "optional/generated-if-present readiness JSON is not present",
+                  "optional": true,
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene_package_readiness.json",
+                  "status": "PASS"
+                },
+                "generated_scene_visual_mesh_index_json": {
+                  "message": "generated/scene_visual_mesh_index.json exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json",
+                  "status": "PASS"
+                },
+                "launch_demo_launch_py": {
+                  "message": "launch/demo.launch.py exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/launch/demo.launch.py",
+                  "status": "PASS"
+                },
+                "layout_workcell_studio_layout_yaml": {
+                  "message": "layout/workcell_studio_layout.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/layout/workcell_studio_layout.yaml",
+                  "status": "PASS"
+                },
+                "manifest_local_file_references": {
+                  "checked": [
+                    {
+                      "field": "files.environment",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/environment.yaml",
+                      "reference": "environment.yaml"
+                    },
+                    {
+                      "field": "files.cell_definition",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/cell_definition.yaml",
+                      "reference": "cell_definition.yaml"
+                    },
+                    {
+                      "field": "files.layout",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/layout/workcell_studio_layout.yaml",
+                      "reference": "layout/workcell_studio_layout.yaml"
+                    },
+                    {
+                      "field": "files.launch",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/launch/demo.launch.py",
+                      "reference": "launch/demo.launch.py"
+                    },
+                    {
+                      "field": "files.urdf_xacro",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
+                      "reference": "urdf/scene.urdf.xacro"
+                    },
+                    {
+                      "field": "files.visual_mesh_index",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json",
+                      "reference": "generated/scene_visual_mesh_index.json"
+                    },
+                    {
+                      "field": "files.scene3d_gui_smoke",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene3d_gui_smoke.json",
+                      "reference": "generated/scene3d_gui_smoke.json"
+                    }
+                  ],
+                  "message": "manifest local-file references resolved (7 checked)",
+                  "status": "PASS"
+                },
+                "package_xml": {
+                  "message": "package.xml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/package.xml",
+                  "status": "PASS"
+                },
+                "ros_launch_smoke_skip_evaluation_state": {
+                  "command": "ros2 launch ur3_suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                },
+                "scene3d_visual_quality_summary": {
+                  "blockers": [
+                    "mesh_source_count > 0 requires mesh_rendered_count > 0"
+                  ],
+                  "counters": {
+                    "credible_physical_rendered_count": 0,
+                    "diagnostic_fallback_count": 0,
+                    "helper_overlay_count": 0,
+                    "mesh_rendered_count": 0,
+                    "mesh_source_count": 3,
+                    "physical_rendered_count": 0,
+                    "primitive_rendered_count": 0,
+                    "primitive_source_count": 0,
+                    "total_payload_count": 3
+                  },
+                  "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene3d_gui_smoke.json",
+                  "status": "FAIL",
+                  "visual_quality_status": "FAIL",
+                  "warnings": []
+                },
+                "scene_manifest_yaml": {
+                  "message": "scene_manifest.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/scene_manifest.yaml",
+                  "status": "PASS"
+                },
+                "scene_package_exists": {
+                  "message": "scene package directory exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test",
+                  "status": "PASS"
+                },
+                "tool_metadata_consistency": {
+                  "message": "tool/end-effector metadata has no explicit contradictions",
+                  "observed": {
+                    "cell_definition_end_effector_id": "suction",
+                    "environment_tool_id": null,
+                    "manifest_end_effector_brand": "single_suction_gripper",
+                    "manifest_end_effector_type": "suction"
+                  },
+                  "status": "PASS"
+                },
+                "urdf_scene_urdf_xacro": {
+                  "message": "urdf/scene.urdf.xacro exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
+                  "status": "PASS"
+                }
+              },
+              "commands": {
+                "build_command": "colcon build --symlink-install --packages-select ur3_suction_test",
+                "fake_hardware_launch_command": "ros2 launch ur3_suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur3_suction_test --json"
+              },
+              "failures": [
+                {
+                  "category": "cell_definition_validation",
+                  "message": "cell_definition.yaml has validation errors",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "credible_physical_visual_evidence",
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "scene3d_visual_quality_summary",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "status": "FAIL"
+                }
+              ],
+              "generated_at": "2026-06-04T16:21:59.245618+00:00",
+              "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+              "offline_scene_readiness": {
+                "errors": [],
+                "inputs": {
+                  "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test",
+                  "workcell_root": null
+                },
+                "notes": [
+                  "ROS scene package detected (package.xml present)."
+                ],
+                "result": "WARN",
+                "scene_reports": [
+                  {
+                    "candidates": {
+                      "gripper": [
+                        "CMakeLists.txt",
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene3d_gui_smoke.json",
+                        "scene_manifest.yaml",
+                        "scene_visual_mesh_index.json",
+                        "workcell_builder_task_intent.yaml"
+                      ],
+                      "robot": [
+                        "CMakeLists.txt",
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene3d_gui_smoke.json",
+                        "scene_manifest.yaml",
+                        "scene_visual_mesh_index.json",
+                        "workcell_builder_task_intent.yaml",
+                        "workcell_studio_layout.generated.yaml",
+                        "workcell_studio_layout.yaml"
+                      ],
+                      "sensor": [
+                        "environment_assets.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro"
+                      ]
+                    },
+                    "counts": {
+                      "files": 16,
+                      "meshes": 0,
+                      "urdf_xacro": 2
+                    },
+                    "errors": [],
+                    "frames": {
+                      "base_link": 6,
+                      "camera_link": 2,
+                      "tool0": 9,
+                      "world": 13
+                    },
+                    "mesh_extensions_detected": [],
+                    "notes": [
+                      "ROS scene package detected (package.xml present)."
+                    ],
+                    "placed_objects": {
+                      "absolute_external_mesh_warnings": [],
+                      "count": 0,
+                      "found_in_generated_urdf_xacro": false,
+                      "found_names": [],
+                      "invalid_mesh_warnings": [],
+                      "missing_collision_mesh_warnings": [],
+                      "missing_names": []
+                    },
+                    "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test",
+                    "task_zones": {
+                      "duplicate_ids": [],
+                      "invalid_dimensions": [],
+                      "pick": 0,
+                      "place": 0,
+                      "total": 0,
+                      "zone_ids": []
+                    },
+                    "warnings": [
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                      "Referenced mesh path not found: $(find ur3_moveit_config)/config/ur3.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find single_suction_moveit_config)/config/single_suction_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find single_suction_description)/urdf/single_suction_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find table_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                      "Task intent place.target.id not found in task_zones: place_zone_main",
+                      "Legacy compatibility: robot_mount missing.",
+                      "Legacy compatibility: tool_attachment missing.",
+                      "Legacy compatibility: recommended gripper orientation not used."
+                    ]
+                  }
+                ],
+                "strict": false,
+                "summary": {
+                  "errors": 0,
+                  "scene_packages_checked": 1,
+                  "warnings": 14
+                },
+                "warnings": [
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                  "Referenced mesh path not found: $(find ur3_moveit_config)/config/ur3.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find single_suction_moveit_config)/config/single_suction_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find single_suction_description)/urdf/single_suction_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find table_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                  "Task intent place.target.id not found in task_zones: place_zone_main",
+                  "Legacy compatibility: robot_mount missing.",
+                  "Legacy compatibility: tool_attachment missing.",
+                  "Legacy compatibility: recommended gripper orientation not used."
+                ]
+              },
+              "overall_status": "BLOCKED",
+              "package_name": "ur3_suction_test",
+              "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+              "readiness_status": "BLOCKED",
+              "ros_humble_available": false,
+              "safe_command_warnings": [],
+              "safety": {
+                "fake_hardware_default": true,
+                "motion_command_sent": false,
+                "real_hardware_enabled": false,
+                "ros_launch_executed_by_matrix": false,
+                "runtime_execution_called": false,
+                "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+              },
+              "scene_name": "ur3_suction_test",
+              "scene_path": "scenes/ur3_suction_test",
+              "schema_version": "workcell_studio_scene_package_readiness/v1",
+              "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+              "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+              "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+              "support_level": "supported",
+              "warnings": [
+                {
+                  "category": "cell_definition_validation",
+                  "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                }
+              ],
+              "workcell_builder_executable_found": false
+            }
+          },
+          "generated_scene_visual_mesh_index_json": {
+            "message": "generated/scene_visual_mesh_index.json exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json",
+            "status": "PASS"
+          },
+          "launch_demo_launch_py": {
+            "message": "launch/demo.launch.py exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/launch/demo.launch.py",
+            "status": "PASS"
+          },
+          "layout_workcell_studio_layout_yaml": {
+            "message": "layout/workcell_studio_layout.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/layout/workcell_studio_layout.yaml",
+            "status": "PASS"
+          },
+          "manifest_local_file_references": {
+            "checked": [
+              {
+                "field": "files.environment",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/environment.yaml",
+                "reference": "environment.yaml"
+              },
+              {
+                "field": "files.cell_definition",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/cell_definition.yaml",
+                "reference": "cell_definition.yaml"
+              },
+              {
+                "field": "files.layout",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/layout/workcell_studio_layout.yaml",
+                "reference": "layout/workcell_studio_layout.yaml"
+              },
+              {
+                "field": "files.launch",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/launch/demo.launch.py",
+                "reference": "launch/demo.launch.py"
+              },
+              {
+                "field": "files.urdf_xacro",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
+                "reference": "urdf/scene.urdf.xacro"
+              },
+              {
+                "field": "files.visual_mesh_index",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json",
+                "reference": "generated/scene_visual_mesh_index.json"
+              },
+              {
+                "field": "files.scene3d_gui_smoke",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene3d_gui_smoke.json",
+                "reference": "generated/scene3d_gui_smoke.json"
+              }
+            ],
+            "message": "manifest local-file references resolved (7 checked)",
+            "status": "PASS"
+          },
+          "package_xml": {
+            "message": "package.xml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/package.xml",
+            "status": "PASS"
+          },
+          "ros_launch_smoke_skip_evaluation_state": {
+            "command": "ros2 launch ur3_suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          },
+          "scene3d_visual_quality_summary": {
+            "blockers": [
+              "mesh_source_count > 0 requires mesh_rendered_count > 0"
+            ],
+            "counters": {
+              "credible_physical_rendered_count": 0,
+              "diagnostic_fallback_count": 0,
+              "helper_overlay_count": 0,
+              "mesh_rendered_count": 0,
+              "mesh_source_count": 3,
+              "physical_rendered_count": 0,
+              "primitive_rendered_count": 0,
+              "primitive_source_count": 0,
+              "total_payload_count": 3
+            },
+            "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene3d_gui_smoke.json",
+            "status": "FAIL",
+            "visual_quality_status": "FAIL",
+            "warnings": []
+          },
+          "scene_manifest_yaml": {
+            "message": "scene_manifest.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/scene_manifest.yaml",
+            "status": "PASS"
+          },
+          "scene_package_exists": {
+            "message": "scene package directory exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test",
+            "status": "PASS"
+          },
+          "tool_metadata_consistency": {
+            "message": "tool/end-effector metadata has no explicit contradictions",
+            "observed": {
+              "cell_definition_end_effector_id": "suction",
+              "environment_tool_id": null,
+              "manifest_end_effector_brand": "single_suction_gripper",
+              "manifest_end_effector_type": "suction"
+            },
+            "status": "PASS"
+          },
+          "urdf_scene_urdf_xacro": {
+            "message": "urdf/scene.urdf.xacro exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
+            "status": "PASS"
+          }
+        },
+        "commands": {
+          "build_command": "colcon build --symlink-install --packages-select ur3_suction_test",
+          "fake_hardware_launch_command": "ros2 launch ur3_suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+          "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur3_suction_test --json"
+        },
+        "failures": [
+          {
+            "category": "cell_definition_validation",
+            "message": "cell_definition.yaml has validation errors",
+            "status": "FAIL"
+          },
+          {
+            "category": "credible_physical_visual_evidence",
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "status": "FAIL"
+          },
+          {
+            "category": "scene3d_visual_quality_summary",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "status": "FAIL"
+          }
+        ],
+        "generated_at": "2026-06-04T16:23:19.093332+00:00",
+        "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+        "offline_scene_readiness": {
+          "errors": [],
+          "inputs": {
+            "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test",
+            "workcell_root": null
+          },
+          "notes": [
+            "ROS scene package detected (package.xml present)."
+          ],
+          "result": "WARN",
+          "scene_reports": [
+            {
+              "candidates": {
+                "gripper": [
+                  "CMakeLists.txt",
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene3d_gui_smoke.json",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json",
+                  "workcell_builder_task_intent.yaml"
+                ],
+                "robot": [
+                  "CMakeLists.txt",
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene3d_gui_smoke.json",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json",
+                  "workcell_builder_task_intent.yaml",
+                  "workcell_studio_layout.generated.yaml",
+                  "workcell_studio_layout.yaml"
+                ],
+                "sensor": [
+                  "environment_assets.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene_package_readiness.json"
+                ]
+              },
+              "counts": {
+                "files": 17,
+                "meshes": 0,
+                "urdf_xacro": 2
+              },
+              "errors": [],
+              "frames": {
+                "base_link": 7,
+                "camera_link": 3,
+                "tool0": 10,
+                "world": 14
+              },
+              "mesh_extensions_detected": [],
+              "notes": [
+                "ROS scene package detected (package.xml present)."
+              ],
+              "placed_objects": {
+                "absolute_external_mesh_warnings": [],
+                "count": 0,
+                "found_in_generated_urdf_xacro": false,
+                "found_names": [],
+                "invalid_mesh_warnings": [],
+                "missing_collision_mesh_warnings": [],
+                "missing_names": []
+              },
+              "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test",
+              "task_zones": {
+                "duplicate_ids": [],
+                "invalid_dimensions": [],
+                "pick": 0,
+                "place": 0,
+                "total": 0,
+                "zone_ids": []
+              },
+              "warnings": [
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Referenced mesh path not found: $(find ur3_moveit_config)/config/ur3.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find single_suction_moveit_config)/config/single_suction_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find single_suction_description)/urdf/single_suction_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find table_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                "Task intent place.target.id not found in task_zones: place_zone_main",
+                "Legacy compatibility: robot_mount missing.",
+                "Legacy compatibility: tool_attachment missing.",
+                "Legacy compatibility: recommended gripper orientation not used."
+              ]
+            }
+          ],
+          "strict": false,
+          "summary": {
+            "errors": 0,
+            "scene_packages_checked": 1,
+            "warnings": 20
+          },
+          "warnings": [
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Referenced mesh path not found: $(find ur3_moveit_config)/config/ur3.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find single_suction_moveit_config)/config/single_suction_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find single_suction_description)/urdf/single_suction_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find table_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Task intent pick.source.id not found in task_zones: pick_zone_main",
+            "Task intent place.target.id not found in task_zones: place_zone_main",
+            "Legacy compatibility: robot_mount missing.",
+            "Legacy compatibility: tool_attachment missing.",
+            "Legacy compatibility: recommended gripper orientation not used."
+          ]
+        },
+        "overall_status": "BLOCKED",
+        "package_name": "ur3_suction_test",
+        "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+        "readiness_status": "BLOCKED",
+        "ros_humble_available": false,
+        "safe_command_warnings": [],
+        "safety": {
+          "fake_hardware_default": true,
+          "motion_command_sent": false,
+          "real_hardware_enabled": false,
+          "ros_launch_executed_by_matrix": false,
+          "runtime_execution_called": false,
+          "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+        },
+        "scene_name": "ur3_suction_test",
+        "scene_path": "scenes/ur3_suction_test",
+        "schema_version": "workcell_studio_scene_package_readiness/v1",
+        "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+        "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+        "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+        "support_level": "supported",
+        "warnings": [
+          {
+            "category": "cell_definition_validation",
+            "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+          }
+        ],
+        "workcell_builder_executable_found": false
+      }
+    },
+    "generated_scene_visual_mesh_index_json": {
+      "message": "generated/scene_visual_mesh_index.json exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json",
+      "status": "PASS"
+    },
+    "launch_demo_launch_py": {
+      "message": "launch/demo.launch.py exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/launch/demo.launch.py",
+      "status": "PASS"
+    },
+    "layout_workcell_studio_layout_yaml": {
+      "message": "layout/workcell_studio_layout.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/layout/workcell_studio_layout.yaml",
+      "status": "PASS"
+    },
+    "manifest_local_file_references": {
+      "checked": [
+        {
+          "field": "files.environment",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/environment.yaml",
+          "reference": "environment.yaml"
+        },
+        {
+          "field": "files.cell_definition",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/cell_definition.yaml",
+          "reference": "cell_definition.yaml"
+        },
+        {
+          "field": "files.layout",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/layout/workcell_studio_layout.yaml",
+          "reference": "layout/workcell_studio_layout.yaml"
+        },
+        {
+          "field": "files.launch",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/launch/demo.launch.py",
+          "reference": "launch/demo.launch.py"
+        },
+        {
+          "field": "files.urdf_xacro",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
+          "reference": "urdf/scene.urdf.xacro"
+        },
+        {
+          "field": "files.visual_mesh_index",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json",
+          "reference": "generated/scene_visual_mesh_index.json"
+        },
+        {
+          "field": "files.scene3d_gui_smoke",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene3d_gui_smoke.json",
+          "reference": "generated/scene3d_gui_smoke.json"
+        }
+      ],
+      "message": "manifest local-file references resolved (7 checked)",
+      "status": "PASS"
+    },
+    "package_xml": {
+      "message": "package.xml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/package.xml",
+      "status": "PASS"
+    },
+    "ros_launch_smoke_skip_evaluation_state": {
+      "command": "ros2 launch ur3_suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    },
+    "scene3d_visual_quality_summary": {
+      "blockers": [
+        "mesh_source_count > 0 requires mesh_rendered_count > 0"
+      ],
+      "counters": {
+        "credible_physical_rendered_count": 0,
+        "diagnostic_fallback_count": 0,
+        "helper_overlay_count": 0,
+        "mesh_rendered_count": 0,
+        "mesh_source_count": 3,
+        "physical_rendered_count": 0,
+        "primitive_rendered_count": 0,
+        "primitive_source_count": 0,
+        "total_payload_count": 3
+      },
+      "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene_visual_mesh_index.json",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/generated/scene3d_gui_smoke.json",
+      "status": "FAIL",
+      "visual_quality_status": "FAIL",
+      "warnings": []
+    },
+    "scene_manifest_yaml": {
+      "message": "scene_manifest.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/scene_manifest.yaml",
+      "status": "PASS"
+    },
+    "scene_package_exists": {
+      "message": "scene package directory exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test",
+      "status": "PASS"
+    },
+    "tool_metadata_consistency": {
+      "message": "tool/end-effector metadata has no explicit contradictions",
+      "observed": {
+        "cell_definition_end_effector_id": "suction",
+        "cell_definition_family": "suction",
+        "environment_tool_family": null,
+        "environment_tool_id": null,
+        "manifest_end_effector_brand": "single_suction_gripper",
+        "manifest_end_effector_family": "suction",
+        "manifest_end_effector_type": "suction"
+      },
+      "status": "PASS",
+      "warnings": []
+    },
+    "urdf_scene_urdf_xacro": {
+      "message": "urdf/scene.urdf.xacro exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test/urdf/scene.urdf.xacro",
+      "status": "PASS"
+    }
+  },
+  "commands": {
+    "build_command": "colcon build --symlink-install --packages-select ur3_suction_test",
+    "fake_hardware_launch_command": "ros2 launch ur3_suction_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+    "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur3_suction_test --json"
+  },
+  "failures": [
+    {
+      "category": "cell_definition_validation",
+      "message": "cell_definition.yaml has validation errors",
+      "status": "FAIL"
+    },
+    {
+      "category": "credible_physical_visual_evidence",
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "status": "FAIL"
+    },
+    {
+      "category": "scene3d_visual_quality_summary",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "status": "FAIL"
+    }
+  ],
+  "generated_at": "2026-06-04T16:24:50.479471+00:00",
+  "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+  "offline_scene_readiness": {
+    "errors": [],
+    "inputs": {
+      "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test",
+      "workcell_root": null
+    },
+    "notes": [
+      "ROS scene package detected (package.xml present)."
+    ],
+    "result": "WARN",
+    "scene_reports": [
+      {
+        "candidates": {
+          "gripper": [
+            "CMakeLists.txt",
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene3d_gui_smoke.json",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json",
+            "scene_visual_mesh_index.json",
+            "workcell_builder_task_intent.yaml"
+          ],
+          "robot": [
+            "CMakeLists.txt",
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene3d_gui_smoke.json",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json",
+            "scene_visual_mesh_index.json",
+            "workcell_builder_task_intent.yaml",
+            "workcell_studio_layout.generated.yaml",
+            "workcell_studio_layout.yaml"
+          ],
+          "sensor": [
+            "environment_assets.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene_package_readiness.json"
+          ]
+        },
+        "counts": {
+          "files": 17,
+          "meshes": 0,
+          "urdf_xacro": 2
+        },
+        "errors": [],
+        "frames": {
+          "base_link": 8,
+          "camera_link": 4,
+          "tool0": 11,
+          "world": 15
+        },
+        "mesh_extensions_detected": [],
+        "notes": [
+          "ROS scene package detected (package.xml present)."
+        ],
+        "placed_objects": {
+          "absolute_external_mesh_warnings": [],
+          "count": 0,
+          "found_in_generated_urdf_xacro": false,
+          "found_names": [],
+          "invalid_mesh_warnings": [],
+          "missing_collision_mesh_warnings": [],
+          "missing_names": []
+        },
+        "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur3_suction_test",
+        "task_zones": {
+          "duplicate_ids": [],
+          "invalid_dimensions": [],
+          "pick": 0,
+          "place": 0,
+          "total": 0,
+          "zone_ids": []
+        },
+        "warnings": [
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Referenced mesh path not found: $(find ur3_moveit_config)/config/ur3.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find single_suction_moveit_config)/config/single_suction_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find single_suction_description)/urdf/single_suction_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find table_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Task intent pick.source.id not found in task_zones: pick_zone_main",
+          "Task intent place.target.id not found in task_zones: place_zone_main",
+          "Legacy compatibility: robot_mount missing.",
+          "Legacy compatibility: tool_attachment missing.",
+          "Legacy compatibility: recommended gripper orientation not used."
+        ]
+      }
+    ],
+    "strict": false,
+    "summary": {
+      "errors": 0,
+      "scene_packages_checked": 1,
+      "warnings": 38
+    },
+    "warnings": [
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/meshes/wrist_fixture.STL",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/table_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Referenced mesh path not found: $(find ur3_moveit_config)/config/ur3.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find single_suction_moveit_config)/config/single_suction_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find single_suction_description)/urdf/single_suction_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find table_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+      "Task intent place.target.id not found in task_zones: place_zone_main",
+      "Legacy compatibility: robot_mount missing.",
+      "Legacy compatibility: tool_attachment missing.",
+      "Legacy compatibility: recommended gripper orientation not used."
+    ]
+  },
+  "overall_status": "BLOCKED",
+  "package_name": "ur3_suction_test",
+  "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+  "readiness_status": "BLOCKED",
+  "ros_humble_available": false,
+  "safe_command_warnings": [],
+  "safety": {
+    "fake_hardware_default": true,
+    "motion_command_sent": false,
+    "real_hardware_enabled": false,
+    "ros_launch_executed_by_matrix": false,
+    "runtime_execution_called": false,
+    "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+  },
+  "scene_name": "ur3_suction_test",
+  "scene_path": "scenes/ur3_suction_test",
+  "schema_version": "workcell_studio_scene_package_readiness/v1",
+  "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+  "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+  "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+  "support_level": "supported",
+  "warnings": [
+    {
+      "category": "cell_definition_validation",
+      "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+    }
+  ],
+  "workcell_builder_executable_found": false
+}

--- a/scenes/ur5_2f_builder_pick_place_demo/generated/scene_package_readiness.json
+++ b/scenes/ur5_2f_builder_pick_place_demo/generated/scene_package_readiness.json
@@ -1,0 +1,1950 @@
+{
+  "blockers": [
+    {
+      "category": "supported_scene_catalog",
+      "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+      "status": "BLOCKED"
+    },
+    {
+      "category": "ros_launch_smoke_skip_evaluation_state",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    }
+  ],
+  "build_package_name": "ur5_2f_builder_pick_place_demo",
+  "builder_generated_scene_validation": {
+    "checks": [
+      {
+        "check": "package.xml exists",
+        "ok": true
+      },
+      {
+        "check": "CMakeLists.txt exists",
+        "ok": true
+      },
+      {
+        "check": "environment.yaml exists",
+        "ok": true
+      },
+      {
+        "check": "workcell_builder_metadata.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/cell_definition.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/environment_layout.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/workcell_builder_task_intent.yaml present",
+        "ok": true,
+        "optional": true
+      }
+    ],
+    "discovered": {
+      "end_effector_capability_id": null,
+      "end_effector_name": "robotiq_85",
+      "grasp_strategy_id": null,
+      "object_count": 1,
+      "robot_capability_id": null,
+      "robot_name": "ur5",
+      "sensor_capability_id": null
+    },
+    "errors": [],
+    "export_validation": {},
+    "ok": true,
+    "readiness": "task_intent_ready_offline",
+    "readiness_classification": "task_intent_ready_offline",
+    "runtime_readiness": "runtime_blocked_or_preview_only",
+    "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo",
+    "suggested_next_actions": [
+      "Generate task recipe from builder task intent."
+    ],
+    "task_flow_summary": {
+      "approach_axis": null,
+      "approach_distance_m": null,
+      "errors": [],
+      "grasp_strategy": "finger_pinch_basic",
+      "missing_required_fields": [],
+      "pick_source_id": "pick_zone_main",
+      "pick_source_type": "zone",
+      "place_target_id": "bin_red",
+      "readiness_classification": "task_intent_ready_offline",
+      "release_strategy": "tool_release",
+      "retreat_axis": null,
+      "retreat_distance_m": null,
+      "routing_rule_count": 1,
+      "routing_rules": [
+        {
+          "destination": "bin_red",
+          "id": "route_red_box_to_bin_red",
+          "when": {
+            "object_class": "box",
+            "object_color": "red"
+          }
+        }
+      ],
+      "safety": {
+        "metadata_only": true,
+        "motion_started": false,
+        "ros_launch_started": false,
+        "runtime_io_applied": false
+      },
+      "status": "PASS",
+      "suggested_next_actions": [
+        "",
+        "",
+        "",
+        "Generate task recipe from task intent."
+      ],
+      "task_id": "sorting_task_001",
+      "task_type": "pick_place",
+      "visual_resolution": {
+        "approximate_coordinates_used": false,
+        "notes": [],
+        "pick_coordinates_resolved": true,
+        "place_coordinates_resolved": true
+      },
+      "warnings": []
+    },
+    "task_intent": {
+      "errors": [],
+      "missing_required_fields": [],
+      "pick_source": {
+        "id": "pick_zone_main",
+        "type": "zone"
+      },
+      "place_target": {
+        "id": "bin_red",
+        "type": "destination"
+      },
+      "readiness_classification": "task_intent_ready_offline",
+      "resolved_grasp_strategy": null,
+      "safety": {
+        "metadata_only": true,
+        "motion_started": false,
+        "ros_launch_started": false,
+        "runtime_io_applied": false
+      },
+      "status": "PASS",
+      "suggested_next_actions": [
+        "Generate task recipe from task intent."
+      ],
+      "task_intent": {
+        "grasp": {
+          "approach_axis": "z_down",
+          "approach_distance_m": 0.12,
+          "retreat_axis": "z_up",
+          "retreat_distance_m": 0.1,
+          "strategy_ref": "finger_pinch_basic"
+        },
+        "pick": {
+          "object_filter": {
+            "class_id": "box",
+            "color": "red"
+          },
+          "source": {
+            "id": "pick_zone_main",
+            "type": "zone"
+          }
+        },
+        "place": {
+          "release_strategy": "tool_release",
+          "retreat_axis": "z_up",
+          "retreat_distance_m": 0.1,
+          "target": {
+            "id": "bin_red",
+            "type": "destination"
+          }
+        },
+        "routing": {
+          "rules": [
+            {
+              "destination": "bin_red",
+              "id": "route_red_box_to_bin_red",
+              "when": {
+                "object_class": "box",
+                "object_color": "red"
+              }
+            }
+          ]
+        },
+        "safety": {
+          "metadata_only": true,
+          "motion_started": false,
+          "ros_launch_started": false,
+          "runtime_io_applied": false
+        },
+        "scene_package": "scenes/ur5_2f_builder_pick_place_demo",
+        "schema": "workcell_builder_task_intent/v1",
+        "task": {
+          "id": "sorting_task_001",
+          "mode": "offline_preview",
+          "type": "pick_place"
+        }
+      },
+      "warnings": []
+    },
+    "warnings": [
+      "workcell_builder_metadata.yaml missing (optional)",
+      "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+      "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
+    ]
+  },
+  "catalog_status": "blocked",
+  "categories": {
+    "cell_definition_validation": {
+      "capabilities": {
+        "capability_refs": {
+          "end_effector": null,
+          "environment_assets": [],
+          "robot": null,
+          "sensors": [],
+          "task": null
+        },
+        "checks": {
+          "events": [],
+          "status": "FAIL"
+        },
+        "resolved": {}
+      },
+      "environment_layout": {},
+      "errors": [
+        "Missing required top-level key: camera",
+        "Missing required top-level key: objects"
+      ],
+      "grasp_strategy": {
+        "mode": "none",
+        "ref": null,
+        "resolved_path": null,
+        "status": "PASS"
+      },
+      "message": "cell_definition.yaml has validation errors",
+      "notes": [],
+      "parser": "pyyaml",
+      "status": "FAIL",
+      "warnings": [
+        "environment.layout path not found: layout/workcell_studio_layout.yaml"
+      ]
+    },
+    "cell_definition_yaml": {
+      "message": "cell_definition.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/cell_definition.yaml",
+      "status": "PASS"
+    },
+    "cmakelists_txt": {
+      "message": "CMakeLists.txt exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/CMakeLists.txt",
+      "status": "PASS"
+    },
+    "credible_physical_visual_evidence": {
+      "mesh_failure_summary_by_reason_code": {},
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "physical_rendered_count": 0,
+      "source_geometry_count": 11,
+      "status": "FAIL"
+    },
+    "environment_yaml": {
+      "message": "environment.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/environment.yaml",
+      "status": "PASS"
+    },
+    "fake_hardware_launch_command_derivation": {
+      "build_package_name": "ur5_2f_builder_pick_place_demo",
+      "command": "ros2 launch ur5_2f_builder_pick_place_demo demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "safe fake-hardware launch command recorded",
+      "package_name": "ur5_2f_builder_pick_place_demo",
+      "safety": "not executed; fake hardware explicitly required",
+      "status": "PASS",
+      "warnings": []
+    },
+    "generated_scene_package_readiness_json": {
+      "message": "generated/scene_package_readiness.json is present and parseable",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene_package_readiness.json",
+      "status": "PASS",
+      "summary": {
+        "blockers": [
+          {
+            "category": "supported_scene_catalog",
+            "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+            "status": "BLOCKED"
+          },
+          {
+            "category": "ros_launch_smoke_skip_evaluation_state",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          }
+        ],
+        "build_package_name": "ur5_2f_builder_pick_place_demo",
+        "builder_generated_scene_validation": {
+          "checks": [
+            {
+              "check": "package.xml exists",
+              "ok": true
+            },
+            {
+              "check": "CMakeLists.txt exists",
+              "ok": true
+            },
+            {
+              "check": "environment.yaml exists",
+              "ok": true
+            },
+            {
+              "check": "workcell_builder_metadata.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/cell_definition.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/environment_layout.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/workcell_builder_task_intent.yaml present",
+              "ok": true,
+              "optional": true
+            }
+          ],
+          "discovered": {
+            "end_effector_capability_id": null,
+            "end_effector_name": "robotiq_85",
+            "grasp_strategy_id": null,
+            "object_count": 1,
+            "robot_capability_id": null,
+            "robot_name": "ur5",
+            "sensor_capability_id": null
+          },
+          "errors": [],
+          "export_validation": {},
+          "ok": true,
+          "readiness": "task_intent_ready_offline",
+          "readiness_classification": "task_intent_ready_offline",
+          "runtime_readiness": "runtime_blocked_or_preview_only",
+          "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo",
+          "suggested_next_actions": [
+            "Generate task recipe from builder task intent."
+          ],
+          "task_flow_summary": {
+            "approach_axis": null,
+            "approach_distance_m": null,
+            "errors": [],
+            "grasp_strategy": "finger_pinch_basic",
+            "missing_required_fields": [],
+            "pick_source_id": "pick_zone_main",
+            "pick_source_type": "zone",
+            "place_target_id": "bin_red",
+            "readiness_classification": "task_intent_ready_offline",
+            "release_strategy": "tool_release",
+            "retreat_axis": null,
+            "retreat_distance_m": null,
+            "routing_rule_count": 1,
+            "routing_rules": [
+              {
+                "destination": "bin_red",
+                "id": "route_red_box_to_bin_red",
+                "when": {
+                  "object_class": "box",
+                  "object_color": "red"
+                }
+              }
+            ],
+            "safety": {
+              "metadata_only": true,
+              "motion_started": false,
+              "ros_launch_started": false,
+              "runtime_io_applied": false
+            },
+            "status": "PASS",
+            "suggested_next_actions": [
+              "",
+              "",
+              "",
+              "Generate task recipe from task intent."
+            ],
+            "task_id": "sorting_task_001",
+            "task_type": "pick_place",
+            "visual_resolution": {
+              "approximate_coordinates_used": false,
+              "notes": [],
+              "pick_coordinates_resolved": true,
+              "place_coordinates_resolved": true
+            },
+            "warnings": []
+          },
+          "task_intent": {
+            "errors": [],
+            "missing_required_fields": [],
+            "pick_source": {
+              "id": "pick_zone_main",
+              "type": "zone"
+            },
+            "place_target": {
+              "id": "bin_red",
+              "type": "destination"
+            },
+            "readiness_classification": "task_intent_ready_offline",
+            "resolved_grasp_strategy": null,
+            "safety": {
+              "metadata_only": true,
+              "motion_started": false,
+              "ros_launch_started": false,
+              "runtime_io_applied": false
+            },
+            "status": "PASS",
+            "suggested_next_actions": [
+              "Generate task recipe from task intent."
+            ],
+            "task_intent": {
+              "grasp": {
+                "approach_axis": "z_down",
+                "approach_distance_m": 0.12,
+                "retreat_axis": "z_up",
+                "retreat_distance_m": 0.1,
+                "strategy_ref": "finger_pinch_basic"
+              },
+              "pick": {
+                "object_filter": {
+                  "class_id": "box",
+                  "color": "red"
+                },
+                "source": {
+                  "id": "pick_zone_main",
+                  "type": "zone"
+                }
+              },
+              "place": {
+                "release_strategy": "tool_release",
+                "retreat_axis": "z_up",
+                "retreat_distance_m": 0.1,
+                "target": {
+                  "id": "bin_red",
+                  "type": "destination"
+                }
+              },
+              "routing": {
+                "rules": [
+                  {
+                    "destination": "bin_red",
+                    "id": "route_red_box_to_bin_red",
+                    "when": {
+                      "object_class": "box",
+                      "object_color": "red"
+                    }
+                  }
+                ]
+              },
+              "safety": {
+                "metadata_only": true,
+                "motion_started": false,
+                "ros_launch_started": false,
+                "runtime_io_applied": false
+              },
+              "scene_package": "scenes/ur5_2f_builder_pick_place_demo",
+              "schema": "workcell_builder_task_intent/v1",
+              "task": {
+                "id": "sorting_task_001",
+                "mode": "offline_preview",
+                "type": "pick_place"
+              }
+            },
+            "warnings": []
+          },
+          "warnings": [
+            "workcell_builder_metadata.yaml missing (optional)",
+            "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+            "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
+          ]
+        },
+        "catalog_status": "blocked",
+        "categories": {
+          "cell_definition_validation": {
+            "capabilities": {
+              "capability_refs": {
+                "end_effector": null,
+                "environment_assets": [],
+                "robot": null,
+                "sensors": [],
+                "task": null
+              },
+              "checks": {
+                "events": [],
+                "status": "FAIL"
+              },
+              "resolved": {}
+            },
+            "environment_layout": {},
+            "errors": [
+              "Missing required top-level key: camera",
+              "Missing required top-level key: objects"
+            ],
+            "grasp_strategy": {
+              "mode": "none",
+              "ref": null,
+              "resolved_path": null,
+              "status": "PASS"
+            },
+            "message": "cell_definition.yaml has validation errors",
+            "notes": [],
+            "parser": "pyyaml",
+            "status": "FAIL",
+            "warnings": [
+              "environment.layout path not found: layout/workcell_studio_layout.yaml"
+            ]
+          },
+          "cell_definition_yaml": {
+            "message": "cell_definition.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/cell_definition.yaml",
+            "status": "PASS"
+          },
+          "cmakelists_txt": {
+            "message": "CMakeLists.txt exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/CMakeLists.txt",
+            "status": "PASS"
+          },
+          "credible_physical_visual_evidence": {
+            "mesh_failure_summary_by_reason_code": {},
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "physical_rendered_count": 0,
+            "source_geometry_count": 11,
+            "status": "FAIL"
+          },
+          "environment_yaml": {
+            "message": "environment.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/environment.yaml",
+            "status": "PASS"
+          },
+          "fake_hardware_launch_command_derivation": {
+            "build_package_name": "ur5_2f_builder_pick_place_demo",
+            "command": "ros2 launch ur5_2f_builder_pick_place_demo demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "safe fake-hardware launch command recorded",
+            "package_name": "ur5_2f_builder_pick_place_demo",
+            "safety": "not executed; fake hardware explicitly required",
+            "status": "PASS",
+            "warnings": []
+          },
+          "generated_scene_package_readiness_json": {
+            "message": "generated/scene_package_readiness.json is present and parseable",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene_package_readiness.json",
+            "status": "PASS",
+            "summary": {
+              "blockers": [
+                {
+                  "category": "supported_scene_catalog",
+                  "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+                  "status": "BLOCKED"
+                },
+                {
+                  "category": "ros_launch_smoke_skip_evaluation_state",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                }
+              ],
+              "build_package_name": "ur5_2f_builder_pick_place_demo",
+              "builder_generated_scene_validation": {
+                "checks": [
+                  {
+                    "check": "package.xml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "CMakeLists.txt exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "environment.yaml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "workcell_builder_metadata.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/cell_definition.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/environment_layout.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/workcell_builder_task_intent.yaml present",
+                    "ok": true,
+                    "optional": true
+                  }
+                ],
+                "discovered": {
+                  "end_effector_capability_id": null,
+                  "end_effector_name": "robotiq_85",
+                  "grasp_strategy_id": null,
+                  "object_count": 1,
+                  "robot_capability_id": null,
+                  "robot_name": "ur5",
+                  "sensor_capability_id": null
+                },
+                "errors": [],
+                "export_validation": {},
+                "ok": true,
+                "readiness": "task_intent_ready_offline",
+                "readiness_classification": "task_intent_ready_offline",
+                "runtime_readiness": "runtime_blocked_or_preview_only",
+                "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo",
+                "suggested_next_actions": [
+                  "Generate task recipe from builder task intent."
+                ],
+                "task_flow_summary": {
+                  "approach_axis": null,
+                  "approach_distance_m": null,
+                  "errors": [],
+                  "grasp_strategy": "finger_pinch_basic",
+                  "missing_required_fields": [],
+                  "pick_source_id": "pick_zone_main",
+                  "pick_source_type": "zone",
+                  "place_target_id": "bin_red",
+                  "readiness_classification": "task_intent_ready_offline",
+                  "release_strategy": "tool_release",
+                  "retreat_axis": null,
+                  "retreat_distance_m": null,
+                  "routing_rule_count": 1,
+                  "routing_rules": [
+                    {
+                      "destination": "bin_red",
+                      "id": "route_red_box_to_bin_red",
+                      "when": {
+                        "object_class": "box",
+                        "object_color": "red"
+                      }
+                    }
+                  ],
+                  "safety": {
+                    "metadata_only": true,
+                    "motion_started": false,
+                    "ros_launch_started": false,
+                    "runtime_io_applied": false
+                  },
+                  "status": "PASS",
+                  "suggested_next_actions": [
+                    "",
+                    "",
+                    "",
+                    "Generate task recipe from task intent."
+                  ],
+                  "task_id": "sorting_task_001",
+                  "task_type": "pick_place",
+                  "visual_resolution": {
+                    "approximate_coordinates_used": false,
+                    "notes": [],
+                    "pick_coordinates_resolved": true,
+                    "place_coordinates_resolved": true
+                  },
+                  "warnings": []
+                },
+                "task_intent": {
+                  "errors": [],
+                  "missing_required_fields": [],
+                  "pick_source": {
+                    "id": "pick_zone_main",
+                    "type": "zone"
+                  },
+                  "place_target": {
+                    "id": "bin_red",
+                    "type": "destination"
+                  },
+                  "readiness_classification": "task_intent_ready_offline",
+                  "resolved_grasp_strategy": null,
+                  "safety": {
+                    "metadata_only": true,
+                    "motion_started": false,
+                    "ros_launch_started": false,
+                    "runtime_io_applied": false
+                  },
+                  "status": "PASS",
+                  "suggested_next_actions": [
+                    "Generate task recipe from task intent."
+                  ],
+                  "task_intent": {
+                    "grasp": {
+                      "approach_axis": "z_down",
+                      "approach_distance_m": 0.12,
+                      "retreat_axis": "z_up",
+                      "retreat_distance_m": 0.1,
+                      "strategy_ref": "finger_pinch_basic"
+                    },
+                    "pick": {
+                      "object_filter": {
+                        "class_id": "box",
+                        "color": "red"
+                      },
+                      "source": {
+                        "id": "pick_zone_main",
+                        "type": "zone"
+                      }
+                    },
+                    "place": {
+                      "release_strategy": "tool_release",
+                      "retreat_axis": "z_up",
+                      "retreat_distance_m": 0.1,
+                      "target": {
+                        "id": "bin_red",
+                        "type": "destination"
+                      }
+                    },
+                    "routing": {
+                      "rules": [
+                        {
+                          "destination": "bin_red",
+                          "id": "route_red_box_to_bin_red",
+                          "when": {
+                            "object_class": "box",
+                            "object_color": "red"
+                          }
+                        }
+                      ]
+                    },
+                    "safety": {
+                      "metadata_only": true,
+                      "motion_started": false,
+                      "ros_launch_started": false,
+                      "runtime_io_applied": false
+                    },
+                    "scene_package": "scenes/ur5_2f_builder_pick_place_demo",
+                    "schema": "workcell_builder_task_intent/v1",
+                    "task": {
+                      "id": "sorting_task_001",
+                      "mode": "offline_preview",
+                      "type": "pick_place"
+                    }
+                  },
+                  "warnings": []
+                },
+                "warnings": [
+                  "workcell_builder_metadata.yaml missing (optional)",
+                  "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+                  "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
+                ]
+              },
+              "catalog_status": "blocked",
+              "categories": {
+                "cell_definition_validation": {
+                  "capabilities": {
+                    "capability_refs": {
+                      "end_effector": null,
+                      "environment_assets": [],
+                      "robot": null,
+                      "sensors": [],
+                      "task": null
+                    },
+                    "checks": {
+                      "events": [],
+                      "status": "FAIL"
+                    },
+                    "resolved": {}
+                  },
+                  "environment_layout": {},
+                  "errors": [
+                    "Missing required top-level key: camera",
+                    "Missing required top-level key: objects"
+                  ],
+                  "grasp_strategy": {
+                    "mode": "none",
+                    "ref": null,
+                    "resolved_path": null,
+                    "status": "PASS"
+                  },
+                  "message": "cell_definition.yaml has validation errors",
+                  "notes": [],
+                  "parser": "pyyaml",
+                  "status": "FAIL",
+                  "warnings": [
+                    "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                  ]
+                },
+                "cell_definition_yaml": {
+                  "message": "cell_definition.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/cell_definition.yaml",
+                  "status": "PASS"
+                },
+                "cmakelists_txt": {
+                  "message": "CMakeLists.txt exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/CMakeLists.txt",
+                  "status": "PASS"
+                },
+                "credible_physical_visual_evidence": {
+                  "mesh_failure_summary_by_reason_code": {},
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "physical_rendered_count": 0,
+                  "source_geometry_count": 11,
+                  "status": "FAIL"
+                },
+                "environment_yaml": {
+                  "message": "environment.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/environment.yaml",
+                  "status": "PASS"
+                },
+                "fake_hardware_launch_command_derivation": {
+                  "build_package_name": "ur5_2f_builder_pick_place_demo",
+                  "command": "ros2 launch ur5_2f_builder_pick_place_demo demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "safe fake-hardware launch command recorded",
+                  "package_name": "ur5_2f_builder_pick_place_demo",
+                  "safety": "not executed; fake hardware explicitly required",
+                  "status": "PASS",
+                  "warnings": []
+                },
+                "generated_scene_package_readiness_json": {
+                  "message": "optional/generated-if-present readiness JSON is not present",
+                  "optional": true,
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene_package_readiness.json",
+                  "status": "PASS"
+                },
+                "generated_scene_visual_mesh_index_json": {
+                  "message": "generated/scene_visual_mesh_index.json exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json",
+                  "status": "PASS"
+                },
+                "launch_demo_launch_py": {
+                  "message": "launch/demo.launch.py exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/launch/demo.launch.py",
+                  "status": "PASS"
+                },
+                "layout_workcell_studio_layout_yaml": {
+                  "message": "layout/workcell_studio_layout.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/layout/workcell_studio_layout.yaml",
+                  "status": "PASS"
+                },
+                "manifest_local_file_references": {
+                  "checked": [
+                    {
+                      "field": "files.environment",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/environment.yaml",
+                      "reference": "environment.yaml"
+                    },
+                    {
+                      "field": "files.cell_definition",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/cell_definition.yaml",
+                      "reference": "cell_definition.yaml"
+                    },
+                    {
+                      "field": "files.layout",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/layout/workcell_studio_layout.yaml",
+                      "reference": "layout/workcell_studio_layout.yaml"
+                    },
+                    {
+                      "field": "files.launch",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/launch/demo.launch.py",
+                      "reference": "launch/demo.launch.py"
+                    },
+                    {
+                      "field": "files.urdf_xacro",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro",
+                      "reference": "urdf/scene.urdf.xacro"
+                    },
+                    {
+                      "field": "files.visual_mesh_index",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json",
+                      "reference": "generated/scene_visual_mesh_index.json"
+                    },
+                    {
+                      "field": "files.scene3d_gui_smoke",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene3d_gui_smoke.json",
+                      "reference": "generated/scene3d_gui_smoke.json"
+                    }
+                  ],
+                  "message": "manifest local-file references resolved (7 checked)",
+                  "status": "PASS"
+                },
+                "package_xml": {
+                  "message": "package.xml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/package.xml",
+                  "status": "PASS"
+                },
+                "ros_launch_smoke_skip_evaluation_state": {
+                  "command": "ros2 launch ur5_2f_builder_pick_place_demo demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                },
+                "scene3d_visual_quality_summary": {
+                  "blockers": [
+                    "mesh_source_count > 0 requires mesh_rendered_count > 0"
+                  ],
+                  "counters": {
+                    "credible_physical_rendered_count": 0,
+                    "diagnostic_fallback_count": 0,
+                    "helper_overlay_count": 0,
+                    "mesh_rendered_count": 0,
+                    "mesh_source_count": 11,
+                    "physical_rendered_count": 0,
+                    "primitive_rendered_count": 0,
+                    "primitive_source_count": 0,
+                    "total_payload_count": 11
+                  },
+                  "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene3d_gui_smoke.json",
+                  "status": "FAIL",
+                  "visual_quality_status": "FAIL",
+                  "warnings": []
+                },
+                "scene_manifest_yaml": {
+                  "message": "scene_manifest.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/scene_manifest.yaml",
+                  "status": "PASS"
+                },
+                "scene_package_exists": {
+                  "message": "scene package directory exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo",
+                  "status": "PASS"
+                },
+                "tool_metadata_consistency": {
+                  "message": "tool/end-effector metadata has no explicit contradictions",
+                  "observed": {
+                    "cell_definition_end_effector_id": "robotiq_2f",
+                    "environment_tool_id": null,
+                    "manifest_end_effector_brand": "robotiq_85_gripper",
+                    "manifest_end_effector_type": "finger"
+                  },
+                  "status": "PASS"
+                },
+                "urdf_scene_urdf_xacro": {
+                  "message": "urdf/scene.urdf.xacro exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro",
+                  "status": "PASS"
+                }
+              },
+              "commands": {
+                "build_command": "colcon build --symlink-install --packages-select ur5_2f_builder_pick_place_demo",
+                "fake_hardware_launch_command": "ros2 launch ur5_2f_builder_pick_place_demo demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_builder_pick_place_demo --json"
+              },
+              "failures": [
+                {
+                  "category": "cell_definition_validation",
+                  "message": "cell_definition.yaml has validation errors",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "credible_physical_visual_evidence",
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "scene3d_visual_quality_summary",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "status": "FAIL"
+                }
+              ],
+              "generated_at": "2026-06-04T16:21:59.245618+00:00",
+              "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+              "offline_scene_readiness": {
+                "errors": [],
+                "inputs": {
+                  "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo",
+                  "workcell_root": null
+                },
+                "notes": [
+                  "ROS scene package detected (package.xml present)."
+                ],
+                "result": "WARN",
+                "scene_reports": [
+                  {
+                    "candidates": {
+                      "gripper": [
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene_manifest.yaml",
+                        "scene_visual_mesh_index.json"
+                      ],
+                      "robot": [
+                        "CMakeLists.txt",
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "environment_layout.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene3d_gui_smoke.json",
+                        "scene_manifest.yaml",
+                        "scene_visual_mesh_index.json",
+                        "workcell_builder_task_intent.yaml",
+                        "workcell_studio_layout.generated.yaml",
+                        "workcell_studio_layout.yaml"
+                      ],
+                      "sensor": [
+                        "environment_assets.yaml",
+                        "environment_layout.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro"
+                      ]
+                    },
+                    "counts": {
+                      "files": 18,
+                      "meshes": 0,
+                      "urdf_xacro": 2
+                    },
+                    "errors": [],
+                    "frames": {
+                      "base_link": 7,
+                      "camera_link": 3,
+                      "tool0": 34,
+                      "world": 24
+                    },
+                    "mesh_extensions_detected": [],
+                    "notes": [
+                      "ROS scene package detected (package.xml present)."
+                    ],
+                    "placed_objects": {
+                      "absolute_external_mesh_warnings": [],
+                      "count": 0,
+                      "found_in_generated_urdf_xacro": false,
+                      "found_names": [],
+                      "invalid_mesh_warnings": [],
+                      "missing_collision_mesh_warnings": [],
+                      "missing_names": []
+                    },
+                    "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo",
+                    "task_zones": {
+                      "duplicate_ids": [],
+                      "invalid_dimensions": [],
+                      "pick": 0,
+                      "place": 0,
+                      "total": 0,
+                      "zone_ids": []
+                    },
+                    "warnings": [
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                      "Task intent place.target.id not found in task_zones: place_zone_main",
+                      "Legacy compatibility: robot_mount missing.",
+                      "Legacy compatibility: tool_attachment missing.",
+                      "Legacy compatibility: recommended gripper orientation not used."
+                    ]
+                  }
+                ],
+                "strict": false,
+                "summary": {
+                  "errors": 0,
+                  "scene_packages_checked": 1,
+                  "warnings": 22
+                },
+                "warnings": [
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                  "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                  "Task intent place.target.id not found in task_zones: place_zone_main",
+                  "Legacy compatibility: robot_mount missing.",
+                  "Legacy compatibility: tool_attachment missing.",
+                  "Legacy compatibility: recommended gripper orientation not used."
+                ]
+              },
+              "overall_status": "BLOCKED",
+              "package_name": "ur5_2f_builder_pick_place_demo",
+              "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+              "readiness_status": "BLOCKED",
+              "ros_humble_available": false,
+              "safe_command_warnings": [],
+              "safety": {
+                "fake_hardware_default": true,
+                "motion_command_sent": false,
+                "real_hardware_enabled": false,
+                "ros_launch_executed_by_matrix": false,
+                "runtime_execution_called": false,
+                "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+              },
+              "scene_name": "ur5_2f_builder_pick_place_demo",
+              "scene_path": "scenes/ur5_2f_builder_pick_place_demo",
+              "schema_version": "workcell_studio_scene_package_readiness/v1",
+              "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+              "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+              "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+              "support_level": "supported",
+              "warnings": [
+                {
+                  "category": "cell_definition_validation",
+                  "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                }
+              ],
+              "workcell_builder_executable_found": false
+            }
+          },
+          "generated_scene_visual_mesh_index_json": {
+            "message": "generated/scene_visual_mesh_index.json exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json",
+            "status": "PASS"
+          },
+          "launch_demo_launch_py": {
+            "message": "launch/demo.launch.py exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/launch/demo.launch.py",
+            "status": "PASS"
+          },
+          "layout_workcell_studio_layout_yaml": {
+            "message": "layout/workcell_studio_layout.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/layout/workcell_studio_layout.yaml",
+            "status": "PASS"
+          },
+          "manifest_local_file_references": {
+            "checked": [
+              {
+                "field": "files.environment",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/environment.yaml",
+                "reference": "environment.yaml"
+              },
+              {
+                "field": "files.cell_definition",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/cell_definition.yaml",
+                "reference": "cell_definition.yaml"
+              },
+              {
+                "field": "files.layout",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/layout/workcell_studio_layout.yaml",
+                "reference": "layout/workcell_studio_layout.yaml"
+              },
+              {
+                "field": "files.launch",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/launch/demo.launch.py",
+                "reference": "launch/demo.launch.py"
+              },
+              {
+                "field": "files.urdf_xacro",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro",
+                "reference": "urdf/scene.urdf.xacro"
+              },
+              {
+                "field": "files.visual_mesh_index",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json",
+                "reference": "generated/scene_visual_mesh_index.json"
+              },
+              {
+                "field": "files.scene3d_gui_smoke",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene3d_gui_smoke.json",
+                "reference": "generated/scene3d_gui_smoke.json"
+              }
+            ],
+            "message": "manifest local-file references resolved (7 checked)",
+            "status": "PASS"
+          },
+          "package_xml": {
+            "message": "package.xml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/package.xml",
+            "status": "PASS"
+          },
+          "ros_launch_smoke_skip_evaluation_state": {
+            "command": "ros2 launch ur5_2f_builder_pick_place_demo demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          },
+          "scene3d_visual_quality_summary": {
+            "blockers": [
+              "mesh_source_count > 0 requires mesh_rendered_count > 0"
+            ],
+            "counters": {
+              "credible_physical_rendered_count": 0,
+              "diagnostic_fallback_count": 0,
+              "helper_overlay_count": 0,
+              "mesh_rendered_count": 0,
+              "mesh_source_count": 11,
+              "physical_rendered_count": 0,
+              "primitive_rendered_count": 0,
+              "primitive_source_count": 0,
+              "total_payload_count": 11
+            },
+            "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene3d_gui_smoke.json",
+            "status": "FAIL",
+            "visual_quality_status": "FAIL",
+            "warnings": []
+          },
+          "scene_manifest_yaml": {
+            "message": "scene_manifest.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/scene_manifest.yaml",
+            "status": "PASS"
+          },
+          "scene_package_exists": {
+            "message": "scene package directory exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo",
+            "status": "PASS"
+          },
+          "tool_metadata_consistency": {
+            "message": "tool/end-effector metadata has no explicit contradictions",
+            "observed": {
+              "cell_definition_end_effector_id": "robotiq_2f",
+              "environment_tool_id": null,
+              "manifest_end_effector_brand": "robotiq_85_gripper",
+              "manifest_end_effector_type": "finger"
+            },
+            "status": "PASS"
+          },
+          "urdf_scene_urdf_xacro": {
+            "message": "urdf/scene.urdf.xacro exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro",
+            "status": "PASS"
+          }
+        },
+        "commands": {
+          "build_command": "colcon build --symlink-install --packages-select ur5_2f_builder_pick_place_demo",
+          "fake_hardware_launch_command": "ros2 launch ur5_2f_builder_pick_place_demo demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+          "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_builder_pick_place_demo --json"
+        },
+        "failures": [
+          {
+            "category": "cell_definition_validation",
+            "message": "cell_definition.yaml has validation errors",
+            "status": "FAIL"
+          },
+          {
+            "category": "credible_physical_visual_evidence",
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "status": "FAIL"
+          },
+          {
+            "category": "scene3d_visual_quality_summary",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "status": "FAIL"
+          }
+        ],
+        "generated_at": "2026-06-04T16:23:19.093332+00:00",
+        "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+        "offline_scene_readiness": {
+          "errors": [],
+          "inputs": {
+            "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo",
+            "workcell_root": null
+          },
+          "notes": [
+            "ROS scene package detected (package.xml present)."
+          ],
+          "result": "WARN",
+          "scene_reports": [
+            {
+              "candidates": {
+                "gripper": [
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json"
+                ],
+                "robot": [
+                  "CMakeLists.txt",
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "environment_layout.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene3d_gui_smoke.json",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json",
+                  "workcell_builder_task_intent.yaml",
+                  "workcell_studio_layout.generated.yaml",
+                  "workcell_studio_layout.yaml"
+                ],
+                "sensor": [
+                  "environment_assets.yaml",
+                  "environment_layout.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene_package_readiness.json"
+                ]
+              },
+              "counts": {
+                "files": 19,
+                "meshes": 0,
+                "urdf_xacro": 2
+              },
+              "errors": [],
+              "frames": {
+                "base_link": 8,
+                "camera_link": 4,
+                "tool0": 35,
+                "world": 25
+              },
+              "mesh_extensions_detected": [],
+              "notes": [
+                "ROS scene package detected (package.xml present)."
+              ],
+              "placed_objects": {
+                "absolute_external_mesh_warnings": [],
+                "count": 0,
+                "found_in_generated_urdf_xacro": false,
+                "found_names": [],
+                "invalid_mesh_warnings": [],
+                "missing_collision_mesh_warnings": [],
+                "missing_names": []
+              },
+              "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo",
+              "task_zones": {
+                "duplicate_ids": [],
+                "invalid_dimensions": [],
+                "pick": 0,
+                "place": 0,
+                "total": 0,
+                "zone_ids": []
+              },
+              "warnings": [
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                "Task intent place.target.id not found in task_zones: place_zone_main",
+                "Legacy compatibility: robot_mount missing.",
+                "Legacy compatibility: tool_attachment missing.",
+                "Legacy compatibility: recommended gripper orientation not used."
+              ]
+            }
+          ],
+          "strict": false,
+          "summary": {
+            "errors": 0,
+            "scene_packages_checked": 1,
+            "warnings": 44
+          },
+          "warnings": [
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Task intent pick.source.id not found in task_zones: pick_zone_main",
+            "Task intent place.target.id not found in task_zones: place_zone_main",
+            "Legacy compatibility: robot_mount missing.",
+            "Legacy compatibility: tool_attachment missing.",
+            "Legacy compatibility: recommended gripper orientation not used."
+          ]
+        },
+        "overall_status": "BLOCKED",
+        "package_name": "ur5_2f_builder_pick_place_demo",
+        "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+        "readiness_status": "BLOCKED",
+        "ros_humble_available": false,
+        "safe_command_warnings": [],
+        "safety": {
+          "fake_hardware_default": true,
+          "motion_command_sent": false,
+          "real_hardware_enabled": false,
+          "ros_launch_executed_by_matrix": false,
+          "runtime_execution_called": false,
+          "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+        },
+        "scene_name": "ur5_2f_builder_pick_place_demo",
+        "scene_path": "scenes/ur5_2f_builder_pick_place_demo",
+        "schema_version": "workcell_studio_scene_package_readiness/v1",
+        "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+        "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+        "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+        "support_level": "supported",
+        "warnings": [
+          {
+            "category": "cell_definition_validation",
+            "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+          }
+        ],
+        "workcell_builder_executable_found": false
+      }
+    },
+    "generated_scene_visual_mesh_index_json": {
+      "message": "generated/scene_visual_mesh_index.json exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json",
+      "status": "PASS"
+    },
+    "launch_demo_launch_py": {
+      "message": "launch/demo.launch.py exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/launch/demo.launch.py",
+      "status": "PASS"
+    },
+    "layout_workcell_studio_layout_yaml": {
+      "message": "layout/workcell_studio_layout.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/layout/workcell_studio_layout.yaml",
+      "status": "PASS"
+    },
+    "manifest_local_file_references": {
+      "checked": [
+        {
+          "field": "files.environment",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/environment.yaml",
+          "reference": "environment.yaml"
+        },
+        {
+          "field": "files.cell_definition",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/cell_definition.yaml",
+          "reference": "cell_definition.yaml"
+        },
+        {
+          "field": "files.layout",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/layout/workcell_studio_layout.yaml",
+          "reference": "layout/workcell_studio_layout.yaml"
+        },
+        {
+          "field": "files.launch",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/launch/demo.launch.py",
+          "reference": "launch/demo.launch.py"
+        },
+        {
+          "field": "files.urdf_xacro",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro",
+          "reference": "urdf/scene.urdf.xacro"
+        },
+        {
+          "field": "files.visual_mesh_index",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json",
+          "reference": "generated/scene_visual_mesh_index.json"
+        },
+        {
+          "field": "files.scene3d_gui_smoke",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene3d_gui_smoke.json",
+          "reference": "generated/scene3d_gui_smoke.json"
+        }
+      ],
+      "message": "manifest local-file references resolved (7 checked)",
+      "status": "PASS"
+    },
+    "package_xml": {
+      "message": "package.xml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/package.xml",
+      "status": "PASS"
+    },
+    "ros_launch_smoke_skip_evaluation_state": {
+      "command": "ros2 launch ur5_2f_builder_pick_place_demo demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    },
+    "scene3d_visual_quality_summary": {
+      "blockers": [
+        "mesh_source_count > 0 requires mesh_rendered_count > 0"
+      ],
+      "counters": {
+        "credible_physical_rendered_count": 0,
+        "diagnostic_fallback_count": 0,
+        "helper_overlay_count": 0,
+        "mesh_rendered_count": 0,
+        "mesh_source_count": 11,
+        "physical_rendered_count": 0,
+        "primitive_rendered_count": 0,
+        "primitive_source_count": 0,
+        "total_payload_count": 11
+      },
+      "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene_visual_mesh_index.json",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/generated/scene3d_gui_smoke.json",
+      "status": "FAIL",
+      "visual_quality_status": "FAIL",
+      "warnings": []
+    },
+    "scene_manifest_yaml": {
+      "message": "scene_manifest.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/scene_manifest.yaml",
+      "status": "PASS"
+    },
+    "scene_package_exists": {
+      "message": "scene package directory exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo",
+      "status": "PASS"
+    },
+    "tool_metadata_consistency": {
+      "message": "tool/end-effector metadata has no explicit contradictions",
+      "observed": {
+        "cell_definition_end_effector_id": "robotiq_2f",
+        "cell_definition_family": "two_finger_gripper",
+        "environment_tool_family": null,
+        "environment_tool_id": null,
+        "manifest_end_effector_brand": "robotiq_85_gripper",
+        "manifest_end_effector_family": "finger_gripper",
+        "manifest_end_effector_type": "finger"
+      },
+      "status": "PASS",
+      "warnings": []
+    },
+    "urdf_scene_urdf_xacro": {
+      "message": "urdf/scene.urdf.xacro exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo/urdf/scene.urdf.xacro",
+      "status": "PASS"
+    }
+  },
+  "commands": {
+    "build_command": "colcon build --symlink-install --packages-select ur5_2f_builder_pick_place_demo",
+    "fake_hardware_launch_command": "ros2 launch ur5_2f_builder_pick_place_demo demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+    "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_builder_pick_place_demo --json"
+  },
+  "failures": [
+    {
+      "category": "cell_definition_validation",
+      "message": "cell_definition.yaml has validation errors",
+      "status": "FAIL"
+    },
+    {
+      "category": "credible_physical_visual_evidence",
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "status": "FAIL"
+    },
+    {
+      "category": "scene3d_visual_quality_summary",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "status": "FAIL"
+    }
+  ],
+  "generated_at": "2026-06-04T16:24:50.479471+00:00",
+  "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+  "offline_scene_readiness": {
+    "errors": [],
+    "inputs": {
+      "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo",
+      "workcell_root": null
+    },
+    "notes": [
+      "ROS scene package detected (package.xml present)."
+    ],
+    "result": "WARN",
+    "scene_reports": [
+      {
+        "candidates": {
+          "gripper": [
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json",
+            "scene_visual_mesh_index.json"
+          ],
+          "robot": [
+            "CMakeLists.txt",
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "environment_layout.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene3d_gui_smoke.json",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json",
+            "scene_visual_mesh_index.json",
+            "workcell_builder_task_intent.yaml",
+            "workcell_studio_layout.generated.yaml",
+            "workcell_studio_layout.yaml"
+          ],
+          "sensor": [
+            "environment_assets.yaml",
+            "environment_layout.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene_package_readiness.json"
+          ]
+        },
+        "counts": {
+          "files": 19,
+          "meshes": 0,
+          "urdf_xacro": 2
+        },
+        "errors": [],
+        "frames": {
+          "base_link": 9,
+          "camera_link": 5,
+          "tool0": 36,
+          "world": 26
+        },
+        "mesh_extensions_detected": [],
+        "notes": [
+          "ROS scene package detected (package.xml present)."
+        ],
+        "placed_objects": {
+          "absolute_external_mesh_warnings": [],
+          "count": 0,
+          "found_in_generated_urdf_xacro": false,
+          "found_names": [],
+          "invalid_mesh_warnings": [],
+          "missing_collision_mesh_warnings": [],
+          "missing_names": []
+        },
+        "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_builder_pick_place_demo",
+        "task_zones": {
+          "duplicate_ids": [],
+          "invalid_dimensions": [],
+          "pick": 0,
+          "place": 0,
+          "total": 0,
+          "zone_ids": []
+        },
+        "warnings": [
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Task intent pick.source.id not found in task_zones: pick_zone_main",
+          "Task intent place.target.id not found in task_zones: place_zone_main",
+          "Legacy compatibility: robot_mount missing.",
+          "Legacy compatibility: tool_attachment missing.",
+          "Legacy compatibility: recommended gripper orientation not used."
+        ]
+      }
+    ],
+    "strict": false,
+    "summary": {
+      "errors": 0,
+      "scene_packages_checked": 1,
+      "warnings": 110
+    },
+    "warnings": [
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+      "Task intent place.target.id not found in task_zones: place_zone_main",
+      "Legacy compatibility: robot_mount missing.",
+      "Legacy compatibility: tool_attachment missing.",
+      "Legacy compatibility: recommended gripper orientation not used."
+    ]
+  },
+  "overall_status": "BLOCKED",
+  "package_name": "ur5_2f_builder_pick_place_demo",
+  "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+  "readiness_status": "BLOCKED",
+  "ros_humble_available": false,
+  "safe_command_warnings": [],
+  "safety": {
+    "fake_hardware_default": true,
+    "motion_command_sent": false,
+    "real_hardware_enabled": false,
+    "ros_launch_executed_by_matrix": false,
+    "runtime_execution_called": false,
+    "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+  },
+  "scene_name": "ur5_2f_builder_pick_place_demo",
+  "scene_path": "scenes/ur5_2f_builder_pick_place_demo",
+  "schema_version": "workcell_studio_scene_package_readiness/v1",
+  "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+  "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+  "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+  "support_level": "supported",
+  "warnings": [
+    {
+      "category": "cell_definition_validation",
+      "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+    }
+  ],
+  "workcell_builder_executable_found": false
+}

--- a/scenes/ur5_2f_sorting_test/generated/scene_package_readiness.json
+++ b/scenes/ur5_2f_sorting_test/generated/scene_package_readiness.json
@@ -1,0 +1,1546 @@
+{
+  "blockers": [
+    {
+      "category": "supported_scene_catalog",
+      "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+      "status": "BLOCKED"
+    },
+    {
+      "category": "ros_launch_smoke_skip_evaluation_state",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    }
+  ],
+  "build_package_name": "ur5_2f_sorting_test",
+  "builder_generated_scene_validation": {
+    "checks": [
+      {
+        "check": "package.xml exists",
+        "ok": true
+      },
+      {
+        "check": "CMakeLists.txt exists",
+        "ok": true
+      },
+      {
+        "check": "environment.yaml exists",
+        "ok": true
+      },
+      {
+        "check": "workcell_builder_metadata.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/cell_definition.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/environment_layout.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/workcell_builder_task_intent.yaml present",
+        "ok": false,
+        "optional": true
+      }
+    ],
+    "discovered": {
+      "end_effector_capability_id": null,
+      "end_effector_name": "robotiq_85",
+      "grasp_strategy_id": null,
+      "object_count": 1,
+      "robot_capability_id": null,
+      "robot_name": "ur5",
+      "sensor_capability_id": null
+    },
+    "errors": [],
+    "export_validation": {},
+    "ok": true,
+    "readiness": "physical_scene_only",
+    "readiness_classification": "physical_scene_only",
+    "runtime_readiness": "runtime_blocked_or_preview_only",
+    "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test",
+    "suggested_next_actions": [
+      "Create builder task intent to define pick/place/grasp."
+    ],
+    "task_flow_summary": {},
+    "task_intent": {},
+    "warnings": [
+      "workcell_builder_metadata.yaml missing (optional)",
+      "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+      "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+      "Task intent missing: physical scene only."
+    ]
+  },
+  "catalog_status": "blocked",
+  "categories": {
+    "cell_definition_validation": {
+      "capabilities": {
+        "capability_refs": {
+          "end_effector": null,
+          "environment_assets": [],
+          "robot": null,
+          "sensors": [],
+          "task": null
+        },
+        "checks": {
+          "events": [],
+          "status": "FAIL"
+        },
+        "resolved": {}
+      },
+      "environment_layout": {},
+      "errors": [
+        "Missing required top-level key: camera",
+        "Missing required top-level key: objects"
+      ],
+      "grasp_strategy": {
+        "mode": "none",
+        "ref": null,
+        "resolved_path": null,
+        "status": "PASS"
+      },
+      "message": "cell_definition.yaml has validation errors",
+      "notes": [],
+      "parser": "pyyaml",
+      "status": "FAIL",
+      "warnings": [
+        "environment.layout path not found: layout/workcell_studio_layout.yaml"
+      ]
+    },
+    "cell_definition_yaml": {
+      "message": "cell_definition.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/cell_definition.yaml",
+      "status": "PASS"
+    },
+    "cmakelists_txt": {
+      "message": "CMakeLists.txt exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/CMakeLists.txt",
+      "status": "PASS"
+    },
+    "credible_physical_visual_evidence": {
+      "mesh_failure_summary_by_reason_code": {},
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "physical_rendered_count": 0,
+      "source_geometry_count": 32,
+      "status": "FAIL"
+    },
+    "environment_yaml": {
+      "message": "environment.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/environment.yaml",
+      "status": "PASS"
+    },
+    "fake_hardware_launch_command_derivation": {
+      "build_package_name": "ur5_2f_sorting_test",
+      "command": "ros2 launch ur5_2f_sorting_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "safe fake-hardware launch command recorded",
+      "package_name": "ur5_2f_sorting_test",
+      "safety": "not executed; fake hardware explicitly required",
+      "status": "PASS",
+      "warnings": []
+    },
+    "generated_scene_package_readiness_json": {
+      "message": "generated/scene_package_readiness.json is present and parseable",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene_package_readiness.json",
+      "status": "PASS",
+      "summary": {
+        "blockers": [
+          {
+            "category": "supported_scene_catalog",
+            "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+            "status": "BLOCKED"
+          },
+          {
+            "category": "ros_launch_smoke_skip_evaluation_state",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          }
+        ],
+        "build_package_name": "ur5_2f_sorting_test",
+        "builder_generated_scene_validation": {
+          "checks": [
+            {
+              "check": "package.xml exists",
+              "ok": true
+            },
+            {
+              "check": "CMakeLists.txt exists",
+              "ok": true
+            },
+            {
+              "check": "environment.yaml exists",
+              "ok": true
+            },
+            {
+              "check": "workcell_builder_metadata.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/cell_definition.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/environment_layout.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/workcell_builder_task_intent.yaml present",
+              "ok": false,
+              "optional": true
+            }
+          ],
+          "discovered": {
+            "end_effector_capability_id": null,
+            "end_effector_name": "robotiq_85",
+            "grasp_strategy_id": null,
+            "object_count": 1,
+            "robot_capability_id": null,
+            "robot_name": "ur5",
+            "sensor_capability_id": null
+          },
+          "errors": [],
+          "export_validation": {},
+          "ok": true,
+          "readiness": "physical_scene_only",
+          "readiness_classification": "physical_scene_only",
+          "runtime_readiness": "runtime_blocked_or_preview_only",
+          "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test",
+          "suggested_next_actions": [
+            "Create builder task intent to define pick/place/grasp."
+          ],
+          "task_flow_summary": {},
+          "task_intent": {},
+          "warnings": [
+            "workcell_builder_metadata.yaml missing (optional)",
+            "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+            "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+            "Task intent missing: physical scene only."
+          ]
+        },
+        "catalog_status": "blocked",
+        "categories": {
+          "cell_definition_validation": {
+            "capabilities": {
+              "capability_refs": {
+                "end_effector": null,
+                "environment_assets": [],
+                "robot": null,
+                "sensors": [],
+                "task": null
+              },
+              "checks": {
+                "events": [],
+                "status": "FAIL"
+              },
+              "resolved": {}
+            },
+            "environment_layout": {},
+            "errors": [
+              "Missing required top-level key: camera",
+              "Missing required top-level key: objects"
+            ],
+            "grasp_strategy": {
+              "mode": "none",
+              "ref": null,
+              "resolved_path": null,
+              "status": "PASS"
+            },
+            "message": "cell_definition.yaml has validation errors",
+            "notes": [],
+            "parser": "pyyaml",
+            "status": "FAIL",
+            "warnings": [
+              "environment.layout path not found: layout/workcell_studio_layout.yaml"
+            ]
+          },
+          "cell_definition_yaml": {
+            "message": "cell_definition.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/cell_definition.yaml",
+            "status": "PASS"
+          },
+          "cmakelists_txt": {
+            "message": "CMakeLists.txt exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/CMakeLists.txt",
+            "status": "PASS"
+          },
+          "credible_physical_visual_evidence": {
+            "mesh_failure_summary_by_reason_code": {},
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "physical_rendered_count": 0,
+            "source_geometry_count": 32,
+            "status": "FAIL"
+          },
+          "environment_yaml": {
+            "message": "environment.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/environment.yaml",
+            "status": "PASS"
+          },
+          "fake_hardware_launch_command_derivation": {
+            "build_package_name": "ur5_2f_sorting_test",
+            "command": "ros2 launch ur5_2f_sorting_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "safe fake-hardware launch command recorded",
+            "package_name": "ur5_2f_sorting_test",
+            "safety": "not executed; fake hardware explicitly required",
+            "status": "PASS",
+            "warnings": []
+          },
+          "generated_scene_package_readiness_json": {
+            "message": "generated/scene_package_readiness.json is present and parseable",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene_package_readiness.json",
+            "status": "PASS",
+            "summary": {
+              "blockers": [
+                {
+                  "category": "supported_scene_catalog",
+                  "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+                  "status": "BLOCKED"
+                },
+                {
+                  "category": "ros_launch_smoke_skip_evaluation_state",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                }
+              ],
+              "build_package_name": "ur5_2f_sorting_test",
+              "builder_generated_scene_validation": {
+                "checks": [
+                  {
+                    "check": "package.xml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "CMakeLists.txt exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "environment.yaml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "workcell_builder_metadata.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/cell_definition.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/environment_layout.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/workcell_builder_task_intent.yaml present",
+                    "ok": false,
+                    "optional": true
+                  }
+                ],
+                "discovered": {
+                  "end_effector_capability_id": null,
+                  "end_effector_name": "robotiq_85",
+                  "grasp_strategy_id": null,
+                  "object_count": 1,
+                  "robot_capability_id": null,
+                  "robot_name": "ur5",
+                  "sensor_capability_id": null
+                },
+                "errors": [],
+                "export_validation": {},
+                "ok": true,
+                "readiness": "physical_scene_only",
+                "readiness_classification": "physical_scene_only",
+                "runtime_readiness": "runtime_blocked_or_preview_only",
+                "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test",
+                "suggested_next_actions": [
+                  "Create builder task intent to define pick/place/grasp."
+                ],
+                "task_flow_summary": {},
+                "task_intent": {},
+                "warnings": [
+                  "workcell_builder_metadata.yaml missing (optional)",
+                  "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+                  "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+                  "Task intent missing: physical scene only."
+                ]
+              },
+              "catalog_status": "blocked",
+              "categories": {
+                "cell_definition_validation": {
+                  "capabilities": {
+                    "capability_refs": {
+                      "end_effector": null,
+                      "environment_assets": [],
+                      "robot": null,
+                      "sensors": [],
+                      "task": null
+                    },
+                    "checks": {
+                      "events": [],
+                      "status": "FAIL"
+                    },
+                    "resolved": {}
+                  },
+                  "environment_layout": {},
+                  "errors": [
+                    "Missing required top-level key: camera",
+                    "Missing required top-level key: objects"
+                  ],
+                  "grasp_strategy": {
+                    "mode": "none",
+                    "ref": null,
+                    "resolved_path": null,
+                    "status": "PASS"
+                  },
+                  "message": "cell_definition.yaml has validation errors",
+                  "notes": [],
+                  "parser": "pyyaml",
+                  "status": "FAIL",
+                  "warnings": [
+                    "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                  ]
+                },
+                "cell_definition_yaml": {
+                  "message": "cell_definition.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/cell_definition.yaml",
+                  "status": "PASS"
+                },
+                "cmakelists_txt": {
+                  "message": "CMakeLists.txt exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/CMakeLists.txt",
+                  "status": "PASS"
+                },
+                "credible_physical_visual_evidence": {
+                  "mesh_failure_summary_by_reason_code": {},
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "physical_rendered_count": 0,
+                  "source_geometry_count": 32,
+                  "status": "FAIL"
+                },
+                "environment_yaml": {
+                  "message": "environment.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/environment.yaml",
+                  "status": "PASS"
+                },
+                "fake_hardware_launch_command_derivation": {
+                  "build_package_name": "ur5_2f_sorting_test",
+                  "command": "ros2 launch ur5_2f_sorting_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "safe fake-hardware launch command recorded",
+                  "package_name": "ur5_2f_sorting_test",
+                  "safety": "not executed; fake hardware explicitly required",
+                  "status": "PASS",
+                  "warnings": []
+                },
+                "generated_scene_package_readiness_json": {
+                  "message": "optional/generated-if-present readiness JSON is not present",
+                  "optional": true,
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene_package_readiness.json",
+                  "status": "PASS"
+                },
+                "generated_scene_visual_mesh_index_json": {
+                  "message": "generated/scene_visual_mesh_index.json exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json",
+                  "status": "PASS"
+                },
+                "launch_demo_launch_py": {
+                  "message": "launch/demo.launch.py exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/launch/demo.launch.py",
+                  "status": "PASS"
+                },
+                "layout_workcell_studio_layout_yaml": {
+                  "message": "layout/workcell_studio_layout.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/layout/workcell_studio_layout.yaml",
+                  "status": "PASS"
+                },
+                "manifest_local_file_references": {
+                  "checked": [
+                    {
+                      "field": "files.environment",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/environment.yaml",
+                      "reference": "environment.yaml"
+                    },
+                    {
+                      "field": "files.cell_definition",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/cell_definition.yaml",
+                      "reference": "cell_definition.yaml"
+                    },
+                    {
+                      "field": "files.layout",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/layout/workcell_studio_layout.yaml",
+                      "reference": "layout/workcell_studio_layout.yaml"
+                    },
+                    {
+                      "field": "files.launch",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/launch/demo.launch.py",
+                      "reference": "launch/demo.launch.py"
+                    },
+                    {
+                      "field": "files.urdf_xacro",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro",
+                      "reference": "urdf/scene.urdf.xacro"
+                    },
+                    {
+                      "field": "files.visual_mesh_index",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json",
+                      "reference": "generated/scene_visual_mesh_index.json"
+                    },
+                    {
+                      "field": "files.scene3d_gui_smoke",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene3d_gui_smoke.json",
+                      "reference": "generated/scene3d_gui_smoke.json"
+                    }
+                  ],
+                  "message": "manifest local-file references resolved (7 checked)",
+                  "status": "PASS"
+                },
+                "package_xml": {
+                  "message": "package.xml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/package.xml",
+                  "status": "PASS"
+                },
+                "ros_launch_smoke_skip_evaluation_state": {
+                  "command": "ros2 launch ur5_2f_sorting_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                },
+                "scene3d_visual_quality_summary": {
+                  "blockers": [
+                    "mesh_source_count > 0 requires mesh_rendered_count > 0",
+                    "primitive_source_count > 0 requires primitive_rendered_count > 0"
+                  ],
+                  "counters": {
+                    "credible_physical_rendered_count": 0,
+                    "diagnostic_fallback_count": 0,
+                    "helper_overlay_count": 0,
+                    "mesh_rendered_count": 0,
+                    "mesh_source_count": 10,
+                    "physical_rendered_count": 0,
+                    "primitive_rendered_count": 0,
+                    "primitive_source_count": 22,
+                    "total_payload_count": 32
+                  },
+                  "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene3d_gui_smoke.json",
+                  "status": "FAIL",
+                  "visual_quality_status": "FAIL",
+                  "warnings": []
+                },
+                "scene_manifest_yaml": {
+                  "message": "scene_manifest.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/scene_manifest.yaml",
+                  "status": "PASS"
+                },
+                "scene_package_exists": {
+                  "message": "scene package directory exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test",
+                  "status": "PASS"
+                },
+                "tool_metadata_consistency": {
+                  "message": "tool/end-effector metadata has no explicit contradictions",
+                  "observed": {
+                    "cell_definition_end_effector_id": "robotiq_2f",
+                    "environment_tool_id": null,
+                    "manifest_end_effector_brand": "robotiq_85_gripper",
+                    "manifest_end_effector_type": "finger"
+                  },
+                  "status": "PASS"
+                },
+                "urdf_scene_urdf_xacro": {
+                  "message": "urdf/scene.urdf.xacro exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro",
+                  "status": "PASS"
+                }
+              },
+              "commands": {
+                "build_command": "colcon build --symlink-install --packages-select ur5_2f_sorting_test",
+                "fake_hardware_launch_command": "ros2 launch ur5_2f_sorting_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_sorting_test --json"
+              },
+              "failures": [
+                {
+                  "category": "cell_definition_validation",
+                  "message": "cell_definition.yaml has validation errors",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "credible_physical_visual_evidence",
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "scene3d_visual_quality_summary",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "status": "FAIL"
+                }
+              ],
+              "generated_at": "2026-06-04T16:21:59.245618+00:00",
+              "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+              "offline_scene_readiness": {
+                "errors": [],
+                "inputs": {
+                  "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test",
+                  "workcell_root": null
+                },
+                "notes": [
+                  "ROS scene package detected (package.xml present)."
+                ],
+                "result": "WARN",
+                "scene_reports": [
+                  {
+                    "candidates": {
+                      "gripper": [
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "package.xml",
+                        "scene_manifest.yaml"
+                      ],
+                      "robot": [
+                        "CMakeLists.txt",
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene3d_gui_smoke.json",
+                        "scene_manifest.yaml",
+                        "scene_visual_mesh_index.json",
+                        "sorting_manifest.yaml",
+                        "workcell_builder_task_intent.yaml",
+                        "workcell_studio_layout.generated.yaml",
+                        "workcell_studio_layout.yaml"
+                      ],
+                      "sensor": [
+                        "detected_objects_sample.json",
+                        "environment_assets.yaml",
+                        "package.xml"
+                      ]
+                    },
+                    "counts": {
+                      "files": 51,
+                      "meshes": 0,
+                      "urdf_xacro": 2
+                    },
+                    "errors": [],
+                    "frames": {
+                      "base_link": 7,
+                      "camera_link": 3,
+                      "tool0": 34,
+                      "world": 61
+                    },
+                    "mesh_extensions_detected": [],
+                    "notes": [
+                      "ROS scene package detected (package.xml present)."
+                    ],
+                    "placed_objects": {
+                      "absolute_external_mesh_warnings": [],
+                      "count": 0,
+                      "found_in_generated_urdf_xacro": false,
+                      "found_names": [],
+                      "invalid_mesh_warnings": [],
+                      "missing_collision_mesh_warnings": [],
+                      "missing_names": []
+                    },
+                    "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test",
+                    "task_zones": {
+                      "duplicate_ids": [],
+                      "invalid_dimensions": [],
+                      "pick": 0,
+                      "place": 0,
+                      "total": 0,
+                      "zone_ids": []
+                    },
+                    "warnings": [
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                      "Task intent place.target.id not found in task_zones: place_zone_main",
+                      "Legacy compatibility: robot_mount missing.",
+                      "Legacy compatibility: tool_attachment missing.",
+                      "Legacy compatibility: recommended gripper orientation not used."
+                    ]
+                  }
+                ],
+                "strict": false,
+                "summary": {
+                  "errors": 0,
+                  "scene_packages_checked": 1,
+                  "warnings": 20
+                },
+                "warnings": [
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                  "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                  "Task intent place.target.id not found in task_zones: place_zone_main",
+                  "Legacy compatibility: robot_mount missing.",
+                  "Legacy compatibility: tool_attachment missing.",
+                  "Legacy compatibility: recommended gripper orientation not used."
+                ]
+              },
+              "overall_status": "BLOCKED",
+              "package_name": "ur5_2f_sorting_test",
+              "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+              "readiness_status": "BLOCKED",
+              "ros_humble_available": false,
+              "safe_command_warnings": [],
+              "safety": {
+                "fake_hardware_default": true,
+                "motion_command_sent": false,
+                "real_hardware_enabled": false,
+                "ros_launch_executed_by_matrix": false,
+                "runtime_execution_called": false,
+                "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+              },
+              "scene_name": "ur5_2f_sorting_test",
+              "scene_path": "scenes/ur5_2f_sorting_test",
+              "schema_version": "workcell_studio_scene_package_readiness/v1",
+              "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+              "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+              "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+              "support_level": "supported",
+              "warnings": [
+                {
+                  "category": "cell_definition_validation",
+                  "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                }
+              ],
+              "workcell_builder_executable_found": false
+            }
+          },
+          "generated_scene_visual_mesh_index_json": {
+            "message": "generated/scene_visual_mesh_index.json exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json",
+            "status": "PASS"
+          },
+          "launch_demo_launch_py": {
+            "message": "launch/demo.launch.py exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/launch/demo.launch.py",
+            "status": "PASS"
+          },
+          "layout_workcell_studio_layout_yaml": {
+            "message": "layout/workcell_studio_layout.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/layout/workcell_studio_layout.yaml",
+            "status": "PASS"
+          },
+          "manifest_local_file_references": {
+            "checked": [
+              {
+                "field": "files.environment",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/environment.yaml",
+                "reference": "environment.yaml"
+              },
+              {
+                "field": "files.cell_definition",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/cell_definition.yaml",
+                "reference": "cell_definition.yaml"
+              },
+              {
+                "field": "files.layout",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/layout/workcell_studio_layout.yaml",
+                "reference": "layout/workcell_studio_layout.yaml"
+              },
+              {
+                "field": "files.launch",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/launch/demo.launch.py",
+                "reference": "launch/demo.launch.py"
+              },
+              {
+                "field": "files.urdf_xacro",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro",
+                "reference": "urdf/scene.urdf.xacro"
+              },
+              {
+                "field": "files.visual_mesh_index",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json",
+                "reference": "generated/scene_visual_mesh_index.json"
+              },
+              {
+                "field": "files.scene3d_gui_smoke",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene3d_gui_smoke.json",
+                "reference": "generated/scene3d_gui_smoke.json"
+              }
+            ],
+            "message": "manifest local-file references resolved (7 checked)",
+            "status": "PASS"
+          },
+          "package_xml": {
+            "message": "package.xml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/package.xml",
+            "status": "PASS"
+          },
+          "ros_launch_smoke_skip_evaluation_state": {
+            "command": "ros2 launch ur5_2f_sorting_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          },
+          "scene3d_visual_quality_summary": {
+            "blockers": [
+              "mesh_source_count > 0 requires mesh_rendered_count > 0",
+              "primitive_source_count > 0 requires primitive_rendered_count > 0"
+            ],
+            "counters": {
+              "credible_physical_rendered_count": 0,
+              "diagnostic_fallback_count": 0,
+              "helper_overlay_count": 0,
+              "mesh_rendered_count": 0,
+              "mesh_source_count": 10,
+              "physical_rendered_count": 0,
+              "primitive_rendered_count": 0,
+              "primitive_source_count": 22,
+              "total_payload_count": 32
+            },
+            "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene3d_gui_smoke.json",
+            "status": "FAIL",
+            "visual_quality_status": "FAIL",
+            "warnings": []
+          },
+          "scene_manifest_yaml": {
+            "message": "scene_manifest.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/scene_manifest.yaml",
+            "status": "PASS"
+          },
+          "scene_package_exists": {
+            "message": "scene package directory exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test",
+            "status": "PASS"
+          },
+          "tool_metadata_consistency": {
+            "message": "tool/end-effector metadata has no explicit contradictions",
+            "observed": {
+              "cell_definition_end_effector_id": "robotiq_2f",
+              "environment_tool_id": null,
+              "manifest_end_effector_brand": "robotiq_85_gripper",
+              "manifest_end_effector_type": "finger"
+            },
+            "status": "PASS"
+          },
+          "urdf_scene_urdf_xacro": {
+            "message": "urdf/scene.urdf.xacro exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro",
+            "status": "PASS"
+          }
+        },
+        "commands": {
+          "build_command": "colcon build --symlink-install --packages-select ur5_2f_sorting_test",
+          "fake_hardware_launch_command": "ros2 launch ur5_2f_sorting_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+          "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_sorting_test --json"
+        },
+        "failures": [
+          {
+            "category": "cell_definition_validation",
+            "message": "cell_definition.yaml has validation errors",
+            "status": "FAIL"
+          },
+          {
+            "category": "credible_physical_visual_evidence",
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "status": "FAIL"
+          },
+          {
+            "category": "scene3d_visual_quality_summary",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "status": "FAIL"
+          }
+        ],
+        "generated_at": "2026-06-04T16:23:19.093332+00:00",
+        "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+        "offline_scene_readiness": {
+          "errors": [],
+          "inputs": {
+            "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test",
+            "workcell_root": null
+          },
+          "notes": [
+            "ROS scene package detected (package.xml present)."
+          ],
+          "result": "WARN",
+          "scene_reports": [
+            {
+              "candidates": {
+                "gripper": [
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "package.xml",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json"
+                ],
+                "robot": [
+                  "CMakeLists.txt",
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene3d_gui_smoke.json",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json",
+                  "sorting_manifest.yaml",
+                  "workcell_builder_task_intent.yaml",
+                  "workcell_studio_layout.generated.yaml",
+                  "workcell_studio_layout.yaml"
+                ],
+                "sensor": [
+                  "detected_objects_sample.json",
+                  "environment_assets.yaml",
+                  "package.xml",
+                  "scene_package_readiness.json"
+                ]
+              },
+              "counts": {
+                "files": 52,
+                "meshes": 0,
+                "urdf_xacro": 2
+              },
+              "errors": [],
+              "frames": {
+                "base_link": 8,
+                "camera_link": 4,
+                "tool0": 35,
+                "world": 62
+              },
+              "mesh_extensions_detected": [],
+              "notes": [
+                "ROS scene package detected (package.xml present)."
+              ],
+              "placed_objects": {
+                "absolute_external_mesh_warnings": [],
+                "count": 0,
+                "found_in_generated_urdf_xacro": false,
+                "found_names": [],
+                "invalid_mesh_warnings": [],
+                "missing_collision_mesh_warnings": [],
+                "missing_names": []
+              },
+              "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test",
+              "task_zones": {
+                "duplicate_ids": [],
+                "invalid_dimensions": [],
+                "pick": 0,
+                "place": 0,
+                "total": 0,
+                "zone_ids": []
+              },
+              "warnings": [
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                "Task intent place.target.id not found in task_zones: place_zone_main",
+                "Legacy compatibility: robot_mount missing.",
+                "Legacy compatibility: tool_attachment missing.",
+                "Legacy compatibility: recommended gripper orientation not used."
+              ]
+            }
+          ],
+          "strict": false,
+          "summary": {
+            "errors": 0,
+            "scene_packages_checked": 1,
+            "warnings": 40
+          },
+          "warnings": [
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Task intent pick.source.id not found in task_zones: pick_zone_main",
+            "Task intent place.target.id not found in task_zones: place_zone_main",
+            "Legacy compatibility: robot_mount missing.",
+            "Legacy compatibility: tool_attachment missing.",
+            "Legacy compatibility: recommended gripper orientation not used."
+          ]
+        },
+        "overall_status": "BLOCKED",
+        "package_name": "ur5_2f_sorting_test",
+        "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+        "readiness_status": "BLOCKED",
+        "ros_humble_available": false,
+        "safe_command_warnings": [],
+        "safety": {
+          "fake_hardware_default": true,
+          "motion_command_sent": false,
+          "real_hardware_enabled": false,
+          "ros_launch_executed_by_matrix": false,
+          "runtime_execution_called": false,
+          "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+        },
+        "scene_name": "ur5_2f_sorting_test",
+        "scene_path": "scenes/ur5_2f_sorting_test",
+        "schema_version": "workcell_studio_scene_package_readiness/v1",
+        "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+        "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+        "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+        "support_level": "supported",
+        "warnings": [
+          {
+            "category": "cell_definition_validation",
+            "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+          }
+        ],
+        "workcell_builder_executable_found": false
+      }
+    },
+    "generated_scene_visual_mesh_index_json": {
+      "message": "generated/scene_visual_mesh_index.json exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json",
+      "status": "PASS"
+    },
+    "launch_demo_launch_py": {
+      "message": "launch/demo.launch.py exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/launch/demo.launch.py",
+      "status": "PASS"
+    },
+    "layout_workcell_studio_layout_yaml": {
+      "message": "layout/workcell_studio_layout.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/layout/workcell_studio_layout.yaml",
+      "status": "PASS"
+    },
+    "manifest_local_file_references": {
+      "checked": [
+        {
+          "field": "files.environment",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/environment.yaml",
+          "reference": "environment.yaml"
+        },
+        {
+          "field": "files.cell_definition",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/cell_definition.yaml",
+          "reference": "cell_definition.yaml"
+        },
+        {
+          "field": "files.layout",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/layout/workcell_studio_layout.yaml",
+          "reference": "layout/workcell_studio_layout.yaml"
+        },
+        {
+          "field": "files.launch",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/launch/demo.launch.py",
+          "reference": "launch/demo.launch.py"
+        },
+        {
+          "field": "files.urdf_xacro",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro",
+          "reference": "urdf/scene.urdf.xacro"
+        },
+        {
+          "field": "files.visual_mesh_index",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json",
+          "reference": "generated/scene_visual_mesh_index.json"
+        },
+        {
+          "field": "files.scene3d_gui_smoke",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene3d_gui_smoke.json",
+          "reference": "generated/scene3d_gui_smoke.json"
+        }
+      ],
+      "message": "manifest local-file references resolved (7 checked)",
+      "status": "PASS"
+    },
+    "package_xml": {
+      "message": "package.xml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/package.xml",
+      "status": "PASS"
+    },
+    "ros_launch_smoke_skip_evaluation_state": {
+      "command": "ros2 launch ur5_2f_sorting_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    },
+    "scene3d_visual_quality_summary": {
+      "blockers": [
+        "mesh_source_count > 0 requires mesh_rendered_count > 0",
+        "primitive_source_count > 0 requires primitive_rendered_count > 0"
+      ],
+      "counters": {
+        "credible_physical_rendered_count": 0,
+        "diagnostic_fallback_count": 0,
+        "helper_overlay_count": 0,
+        "mesh_rendered_count": 0,
+        "mesh_source_count": 10,
+        "physical_rendered_count": 0,
+        "primitive_rendered_count": 0,
+        "primitive_source_count": 22,
+        "total_payload_count": 32
+      },
+      "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene_visual_mesh_index.json",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/generated/scene3d_gui_smoke.json",
+      "status": "FAIL",
+      "visual_quality_status": "FAIL",
+      "warnings": []
+    },
+    "scene_manifest_yaml": {
+      "message": "scene_manifest.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/scene_manifest.yaml",
+      "status": "PASS"
+    },
+    "scene_package_exists": {
+      "message": "scene package directory exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test",
+      "status": "PASS"
+    },
+    "tool_metadata_consistency": {
+      "message": "tool/end-effector metadata has no explicit contradictions",
+      "observed": {
+        "cell_definition_end_effector_id": "robotiq_2f",
+        "cell_definition_family": "two_finger_gripper",
+        "environment_tool_family": null,
+        "environment_tool_id": null,
+        "manifest_end_effector_brand": "robotiq_85_gripper",
+        "manifest_end_effector_family": "finger_gripper",
+        "manifest_end_effector_type": "finger"
+      },
+      "status": "PASS",
+      "warnings": []
+    },
+    "urdf_scene_urdf_xacro": {
+      "message": "urdf/scene.urdf.xacro exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test/urdf/scene.urdf.xacro",
+      "status": "PASS"
+    }
+  },
+  "commands": {
+    "build_command": "colcon build --symlink-install --packages-select ur5_2f_sorting_test",
+    "fake_hardware_launch_command": "ros2 launch ur5_2f_sorting_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+    "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_sorting_test --json"
+  },
+  "failures": [
+    {
+      "category": "cell_definition_validation",
+      "message": "cell_definition.yaml has validation errors",
+      "status": "FAIL"
+    },
+    {
+      "category": "credible_physical_visual_evidence",
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "status": "FAIL"
+    },
+    {
+      "category": "scene3d_visual_quality_summary",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "status": "FAIL"
+    }
+  ],
+  "generated_at": "2026-06-04T16:24:50.479471+00:00",
+  "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+  "offline_scene_readiness": {
+    "errors": [],
+    "inputs": {
+      "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test",
+      "workcell_root": null
+    },
+    "notes": [
+      "ROS scene package detected (package.xml present)."
+    ],
+    "result": "WARN",
+    "scene_reports": [
+      {
+        "candidates": {
+          "gripper": [
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "package.xml",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json"
+          ],
+          "robot": [
+            "CMakeLists.txt",
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene3d_gui_smoke.json",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json",
+            "scene_visual_mesh_index.json",
+            "sorting_manifest.yaml",
+            "workcell_builder_task_intent.yaml",
+            "workcell_studio_layout.generated.yaml",
+            "workcell_studio_layout.yaml"
+          ],
+          "sensor": [
+            "detected_objects_sample.json",
+            "environment_assets.yaml",
+            "package.xml",
+            "scene_package_readiness.json"
+          ]
+        },
+        "counts": {
+          "files": 52,
+          "meshes": 0,
+          "urdf_xacro": 2
+        },
+        "errors": [],
+        "frames": {
+          "base_link": 9,
+          "camera_link": 5,
+          "tool0": 36,
+          "world": 63
+        },
+        "mesh_extensions_detected": [],
+        "notes": [
+          "ROS scene package detected (package.xml present)."
+        ],
+        "placed_objects": {
+          "absolute_external_mesh_warnings": [],
+          "count": 0,
+          "found_in_generated_urdf_xacro": false,
+          "found_names": [],
+          "invalid_mesh_warnings": [],
+          "missing_collision_mesh_warnings": [],
+          "missing_names": []
+        },
+        "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_sorting_test",
+        "task_zones": {
+          "duplicate_ids": [],
+          "invalid_dimensions": [],
+          "pick": 0,
+          "place": 0,
+          "total": 0,
+          "zone_ids": []
+        },
+        "warnings": [
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Task intent pick.source.id not found in task_zones: pick_zone_main",
+          "Task intent place.target.id not found in task_zones: place_zone_main",
+          "Legacy compatibility: robot_mount missing.",
+          "Legacy compatibility: tool_attachment missing.",
+          "Legacy compatibility: recommended gripper orientation not used."
+        ]
+      }
+    ],
+    "strict": false,
+    "summary": {
+      "errors": 0,
+      "scene_packages_checked": 1,
+      "warnings": 100
+    },
+    "warnings": [
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+      "Task intent place.target.id not found in task_zones: place_zone_main",
+      "Legacy compatibility: robot_mount missing.",
+      "Legacy compatibility: tool_attachment missing.",
+      "Legacy compatibility: recommended gripper orientation not used."
+    ]
+  },
+  "overall_status": "BLOCKED",
+  "package_name": "ur5_2f_sorting_test",
+  "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+  "readiness_status": "BLOCKED",
+  "ros_humble_available": false,
+  "safe_command_warnings": [],
+  "safety": {
+    "fake_hardware_default": true,
+    "motion_command_sent": false,
+    "real_hardware_enabled": false,
+    "ros_launch_executed_by_matrix": false,
+    "runtime_execution_called": false,
+    "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+  },
+  "scene_name": "ur5_2f_sorting_test",
+  "scene_path": "scenes/ur5_2f_sorting_test",
+  "schema_version": "workcell_studio_scene_package_readiness/v1",
+  "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+  "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+  "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+  "support_level": "supported",
+  "warnings": [
+    {
+      "category": "cell_definition_validation",
+      "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+    }
+  ],
+  "workcell_builder_executable_found": false
+}

--- a/scenes/ur5_2f_test/generated/scene_package_readiness.json
+++ b/scenes/ur5_2f_test/generated/scene_package_readiness.json
@@ -1,0 +1,1935 @@
+{
+  "blockers": [
+    {
+      "category": "supported_scene_catalog",
+      "message": "Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable, indicating the ROS Humble/ament workcell_builder executable is unavailable in this container.",
+      "status": "BLOCKED"
+    },
+    {
+      "category": "ros_launch_smoke_skip_evaluation_state",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    }
+  ],
+  "build_package_name": "ur5_2f_test",
+  "builder_generated_scene_validation": {
+    "checks": [
+      {
+        "check": "package.xml exists",
+        "ok": true
+      },
+      {
+        "check": "CMakeLists.txt exists",
+        "ok": true
+      },
+      {
+        "check": "environment.yaml exists",
+        "ok": true
+      },
+      {
+        "check": "workcell_builder_metadata.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/cell_definition.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/environment_layout.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/workcell_builder_task_intent.yaml present",
+        "ok": true,
+        "optional": true
+      }
+    ],
+    "discovered": {
+      "end_effector_capability_id": null,
+      "end_effector_name": null,
+      "grasp_strategy_id": null,
+      "object_count": 0,
+      "robot_capability_id": null,
+      "robot_name": null,
+      "sensor_capability_id": null
+    },
+    "errors": [],
+    "export_validation": {},
+    "ok": true,
+    "readiness": "task_intent_ready_offline",
+    "readiness_classification": "task_intent_ready_offline",
+    "runtime_readiness": "runtime_blocked_or_preview_only",
+    "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+    "suggested_next_actions": [
+      "Generate task recipe from builder task intent."
+    ],
+    "task_flow_summary": {
+      "approach_axis": null,
+      "approach_distance_m": null,
+      "errors": [],
+      "grasp_strategy": "finger_pinch_basic",
+      "missing_required_fields": [],
+      "pick_source_id": "pick_zone_main",
+      "pick_source_type": "zone",
+      "place_target_id": "bin_red",
+      "readiness_classification": "task_intent_ready_offline",
+      "release_strategy": "tool_release",
+      "retreat_axis": null,
+      "retreat_distance_m": null,
+      "routing_rule_count": 1,
+      "routing_rules": [
+        {
+          "destination": "bin_red",
+          "id": "route_red_box_to_bin_red",
+          "when": {
+            "object_class": "box",
+            "object_color": "red"
+          }
+        }
+      ],
+      "safety": {
+        "metadata_only": true,
+        "motion_started": false,
+        "ros_launch_started": false,
+        "runtime_io_applied": false
+      },
+      "status": "PASS",
+      "suggested_next_actions": [
+        "",
+        "",
+        "",
+        "Generate task recipe from task intent."
+      ],
+      "task_id": "sorting_task_001",
+      "task_type": "pick_place",
+      "visual_resolution": {
+        "approximate_coordinates_used": false,
+        "notes": [],
+        "pick_coordinates_resolved": true,
+        "place_coordinates_resolved": true
+      },
+      "warnings": []
+    },
+    "task_intent": {
+      "errors": [],
+      "missing_required_fields": [],
+      "pick_source": {
+        "id": "pick_zone_main",
+        "type": "zone"
+      },
+      "place_target": {
+        "id": "bin_red",
+        "type": "destination"
+      },
+      "readiness_classification": "task_intent_ready_offline",
+      "resolved_grasp_strategy": null,
+      "safety": {
+        "metadata_only": true,
+        "motion_started": false,
+        "ros_launch_started": false,
+        "runtime_io_applied": false
+      },
+      "status": "PASS",
+      "suggested_next_actions": [
+        "Generate task recipe from task intent."
+      ],
+      "task_intent": {
+        "grasp": {
+          "approach_axis": "z_down",
+          "approach_distance_m": 0.12,
+          "retreat_axis": "z_up",
+          "retreat_distance_m": 0.1,
+          "strategy_ref": "finger_pinch_basic"
+        },
+        "pick": {
+          "object_filter": {
+            "class_id": "box",
+            "color": "red"
+          },
+          "source": {
+            "id": "pick_zone_main",
+            "type": "zone"
+          }
+        },
+        "place": {
+          "release_strategy": "tool_release",
+          "retreat_axis": "z_up",
+          "retreat_distance_m": 0.1,
+          "target": {
+            "id": "bin_red",
+            "type": "destination"
+          }
+        },
+        "routing": {
+          "rules": [
+            {
+              "destination": "bin_red",
+              "id": "route_red_box_to_bin_red",
+              "when": {
+                "object_class": "box",
+                "object_color": "red"
+              }
+            }
+          ]
+        },
+        "safety": {
+          "metadata_only": true,
+          "motion_started": false,
+          "ros_launch_started": false,
+          "runtime_io_applied": false
+        },
+        "scene_package": "scenes/ur5_2f_test",
+        "schema": "workcell_builder_task_intent/v1",
+        "task": {
+          "id": "sorting_task_001",
+          "mode": "offline_preview",
+          "type": "pick_place"
+        }
+      },
+      "warnings": []
+    },
+    "warnings": [
+      "workcell_builder_metadata.yaml missing (optional)",
+      "End-effector metadata not present in environment.yaml",
+      "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+      "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
+    ]
+  },
+  "catalog_status": "blocked",
+  "categories": {
+    "cell_definition_validation": {
+      "capabilities": {
+        "capability_refs": {
+          "end_effector": null,
+          "environment_assets": [],
+          "robot": null,
+          "sensors": [],
+          "task": null
+        },
+        "checks": {
+          "events": [],
+          "status": "WARN"
+        },
+        "resolved": {}
+      },
+      "environment_layout": {},
+      "errors": [],
+      "grasp_strategy": {
+        "mode": "none",
+        "ref": null,
+        "resolved_path": null,
+        "status": "PASS"
+      },
+      "message": "cell_definition.yaml validates",
+      "notes": [],
+      "parser": "pyyaml",
+      "status": "PASS",
+      "warnings": [
+        "environment.layout path not found: layout/workcell_studio_layout.yaml"
+      ]
+    },
+    "cell_definition_yaml": {
+      "message": "cell_definition.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/cell_definition.yaml",
+      "status": "PASS"
+    },
+    "cmakelists_txt": {
+      "message": "CMakeLists.txt exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/CMakeLists.txt",
+      "status": "PASS"
+    },
+    "credible_physical_visual_evidence": {
+      "mesh_failure_summary_by_reason_code": {},
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "physical_rendered_count": 0,
+      "source_geometry_count": 11,
+      "status": "FAIL"
+    },
+    "environment_yaml": {
+      "message": "environment.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/environment.yaml",
+      "status": "PASS"
+    },
+    "fake_hardware_launch_command_derivation": {
+      "build_package_name": "ur5_2f_test",
+      "command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "safe fake-hardware launch command recorded",
+      "package_name": "ur5_2f_test",
+      "safety": "not executed; fake hardware explicitly required",
+      "status": "PASS",
+      "warnings": []
+    },
+    "generated_scene_package_readiness_json": {
+      "message": "generated/scene_package_readiness.json is present and parseable",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_package_readiness.json",
+      "status": "PASS",
+      "summary": {
+        "blockers": [
+          {
+            "category": "supported_scene_catalog",
+            "message": "Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable, indicating the ROS Humble/ament workcell_builder executable is unavailable in this container.",
+            "status": "BLOCKED"
+          },
+          {
+            "category": "ros_launch_smoke_skip_evaluation_state",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          }
+        ],
+        "build_package_name": "ur5_2f_test",
+        "builder_generated_scene_validation": {
+          "checks": [
+            {
+              "check": "package.xml exists",
+              "ok": true
+            },
+            {
+              "check": "CMakeLists.txt exists",
+              "ok": true
+            },
+            {
+              "check": "environment.yaml exists",
+              "ok": true
+            },
+            {
+              "check": "workcell_builder_metadata.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/cell_definition.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/environment_layout.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/workcell_builder_task_intent.yaml present",
+              "ok": true,
+              "optional": true
+            }
+          ],
+          "discovered": {
+            "end_effector_capability_id": null,
+            "end_effector_name": null,
+            "grasp_strategy_id": null,
+            "object_count": 0,
+            "robot_capability_id": null,
+            "robot_name": null,
+            "sensor_capability_id": null
+          },
+          "errors": [],
+          "export_validation": {},
+          "ok": true,
+          "readiness": "task_intent_ready_offline",
+          "readiness_classification": "task_intent_ready_offline",
+          "runtime_readiness": "runtime_blocked_or_preview_only",
+          "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+          "suggested_next_actions": [
+            "Generate task recipe from builder task intent."
+          ],
+          "task_flow_summary": {
+            "approach_axis": null,
+            "approach_distance_m": null,
+            "errors": [],
+            "grasp_strategy": "finger_pinch_basic",
+            "missing_required_fields": [],
+            "pick_source_id": "pick_zone_main",
+            "pick_source_type": "zone",
+            "place_target_id": "bin_red",
+            "readiness_classification": "task_intent_ready_offline",
+            "release_strategy": "tool_release",
+            "retreat_axis": null,
+            "retreat_distance_m": null,
+            "routing_rule_count": 1,
+            "routing_rules": [
+              {
+                "destination": "bin_red",
+                "id": "route_red_box_to_bin_red",
+                "when": {
+                  "object_class": "box",
+                  "object_color": "red"
+                }
+              }
+            ],
+            "safety": {
+              "metadata_only": true,
+              "motion_started": false,
+              "ros_launch_started": false,
+              "runtime_io_applied": false
+            },
+            "status": "PASS",
+            "suggested_next_actions": [
+              "",
+              "",
+              "",
+              "Generate task recipe from task intent."
+            ],
+            "task_id": "sorting_task_001",
+            "task_type": "pick_place",
+            "visual_resolution": {
+              "approximate_coordinates_used": false,
+              "notes": [],
+              "pick_coordinates_resolved": true,
+              "place_coordinates_resolved": true
+            },
+            "warnings": []
+          },
+          "task_intent": {
+            "errors": [],
+            "missing_required_fields": [],
+            "pick_source": {
+              "id": "pick_zone_main",
+              "type": "zone"
+            },
+            "place_target": {
+              "id": "bin_red",
+              "type": "destination"
+            },
+            "readiness_classification": "task_intent_ready_offline",
+            "resolved_grasp_strategy": null,
+            "safety": {
+              "metadata_only": true,
+              "motion_started": false,
+              "ros_launch_started": false,
+              "runtime_io_applied": false
+            },
+            "status": "PASS",
+            "suggested_next_actions": [
+              "Generate task recipe from task intent."
+            ],
+            "task_intent": {
+              "grasp": {
+                "approach_axis": "z_down",
+                "approach_distance_m": 0.12,
+                "retreat_axis": "z_up",
+                "retreat_distance_m": 0.1,
+                "strategy_ref": "finger_pinch_basic"
+              },
+              "pick": {
+                "object_filter": {
+                  "class_id": "box",
+                  "color": "red"
+                },
+                "source": {
+                  "id": "pick_zone_main",
+                  "type": "zone"
+                }
+              },
+              "place": {
+                "release_strategy": "tool_release",
+                "retreat_axis": "z_up",
+                "retreat_distance_m": 0.1,
+                "target": {
+                  "id": "bin_red",
+                  "type": "destination"
+                }
+              },
+              "routing": {
+                "rules": [
+                  {
+                    "destination": "bin_red",
+                    "id": "route_red_box_to_bin_red",
+                    "when": {
+                      "object_class": "box",
+                      "object_color": "red"
+                    }
+                  }
+                ]
+              },
+              "safety": {
+                "metadata_only": true,
+                "motion_started": false,
+                "ros_launch_started": false,
+                "runtime_io_applied": false
+              },
+              "scene_package": "scenes/ur5_2f_test",
+              "schema": "workcell_builder_task_intent/v1",
+              "task": {
+                "id": "sorting_task_001",
+                "mode": "offline_preview",
+                "type": "pick_place"
+              }
+            },
+            "warnings": []
+          },
+          "warnings": [
+            "workcell_builder_metadata.yaml missing (optional)",
+            "End-effector metadata not present in environment.yaml",
+            "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+            "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
+          ]
+        },
+        "catalog_status": "blocked",
+        "categories": {
+          "cell_definition_validation": {
+            "capabilities": {
+              "capability_refs": {
+                "end_effector": null,
+                "environment_assets": [],
+                "robot": null,
+                "sensors": [],
+                "task": null
+              },
+              "checks": {
+                "events": [],
+                "status": "WARN"
+              },
+              "resolved": {}
+            },
+            "environment_layout": {},
+            "errors": [],
+            "grasp_strategy": {
+              "mode": "none",
+              "ref": null,
+              "resolved_path": null,
+              "status": "PASS"
+            },
+            "message": "cell_definition.yaml validates",
+            "notes": [],
+            "parser": "pyyaml",
+            "status": "PASS",
+            "warnings": [
+              "environment.layout path not found: layout/workcell_studio_layout.yaml"
+            ]
+          },
+          "cell_definition_yaml": {
+            "message": "cell_definition.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/cell_definition.yaml",
+            "status": "PASS"
+          },
+          "cmakelists_txt": {
+            "message": "CMakeLists.txt exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/CMakeLists.txt",
+            "status": "PASS"
+          },
+          "credible_physical_visual_evidence": {
+            "mesh_failure_summary_by_reason_code": {},
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "physical_rendered_count": 0,
+            "source_geometry_count": 11,
+            "status": "FAIL"
+          },
+          "environment_yaml": {
+            "message": "environment.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/environment.yaml",
+            "status": "PASS"
+          },
+          "fake_hardware_launch_command_derivation": {
+            "build_package_name": "ur5_2f_test",
+            "command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "safe fake-hardware launch command recorded",
+            "package_name": "ur5_2f_test",
+            "safety": "not executed; fake hardware explicitly required",
+            "status": "PASS",
+            "warnings": []
+          },
+          "generated_scene_package_readiness_json": {
+            "message": "generated/scene_package_readiness.json is present and parseable",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_package_readiness.json",
+            "status": "PASS",
+            "summary": {
+              "blockers": [
+                {
+                  "category": "supported_scene_catalog",
+                  "message": "Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable, indicating the ROS Humble/ament workcell_builder executable is unavailable in this container.",
+                  "status": "BLOCKED"
+                },
+                {
+                  "category": "ros_launch_smoke_skip_evaluation_state",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                }
+              ],
+              "build_package_name": "ur5_2f_test",
+              "builder_generated_scene_validation": {
+                "checks": [
+                  {
+                    "check": "package.xml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "CMakeLists.txt exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "environment.yaml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "workcell_builder_metadata.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/cell_definition.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/environment_layout.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/workcell_builder_task_intent.yaml present",
+                    "ok": true,
+                    "optional": true
+                  }
+                ],
+                "discovered": {
+                  "end_effector_capability_id": null,
+                  "end_effector_name": null,
+                  "grasp_strategy_id": null,
+                  "object_count": 0,
+                  "robot_capability_id": null,
+                  "robot_name": null,
+                  "sensor_capability_id": null
+                },
+                "errors": [],
+                "export_validation": {},
+                "ok": true,
+                "readiness": "task_intent_ready_offline",
+                "readiness_classification": "task_intent_ready_offline",
+                "runtime_readiness": "runtime_blocked_or_preview_only",
+                "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+                "suggested_next_actions": [
+                  "Generate task recipe from builder task intent."
+                ],
+                "task_flow_summary": {
+                  "approach_axis": null,
+                  "approach_distance_m": null,
+                  "errors": [],
+                  "grasp_strategy": "finger_pinch_basic",
+                  "missing_required_fields": [],
+                  "pick_source_id": "pick_zone_main",
+                  "pick_source_type": "zone",
+                  "place_target_id": "bin_red",
+                  "readiness_classification": "task_intent_ready_offline",
+                  "release_strategy": "tool_release",
+                  "retreat_axis": null,
+                  "retreat_distance_m": null,
+                  "routing_rule_count": 1,
+                  "routing_rules": [
+                    {
+                      "destination": "bin_red",
+                      "id": "route_red_box_to_bin_red",
+                      "when": {
+                        "object_class": "box",
+                        "object_color": "red"
+                      }
+                    }
+                  ],
+                  "safety": {
+                    "metadata_only": true,
+                    "motion_started": false,
+                    "ros_launch_started": false,
+                    "runtime_io_applied": false
+                  },
+                  "status": "PASS",
+                  "suggested_next_actions": [
+                    "",
+                    "",
+                    "",
+                    "Generate task recipe from task intent."
+                  ],
+                  "task_id": "sorting_task_001",
+                  "task_type": "pick_place",
+                  "visual_resolution": {
+                    "approximate_coordinates_used": false,
+                    "notes": [],
+                    "pick_coordinates_resolved": true,
+                    "place_coordinates_resolved": true
+                  },
+                  "warnings": []
+                },
+                "task_intent": {
+                  "errors": [],
+                  "missing_required_fields": [],
+                  "pick_source": {
+                    "id": "pick_zone_main",
+                    "type": "zone"
+                  },
+                  "place_target": {
+                    "id": "bin_red",
+                    "type": "destination"
+                  },
+                  "readiness_classification": "task_intent_ready_offline",
+                  "resolved_grasp_strategy": null,
+                  "safety": {
+                    "metadata_only": true,
+                    "motion_started": false,
+                    "ros_launch_started": false,
+                    "runtime_io_applied": false
+                  },
+                  "status": "PASS",
+                  "suggested_next_actions": [
+                    "Generate task recipe from task intent."
+                  ],
+                  "task_intent": {
+                    "grasp": {
+                      "approach_axis": "z_down",
+                      "approach_distance_m": 0.12,
+                      "retreat_axis": "z_up",
+                      "retreat_distance_m": 0.1,
+                      "strategy_ref": "finger_pinch_basic"
+                    },
+                    "pick": {
+                      "object_filter": {
+                        "class_id": "box",
+                        "color": "red"
+                      },
+                      "source": {
+                        "id": "pick_zone_main",
+                        "type": "zone"
+                      }
+                    },
+                    "place": {
+                      "release_strategy": "tool_release",
+                      "retreat_axis": "z_up",
+                      "retreat_distance_m": 0.1,
+                      "target": {
+                        "id": "bin_red",
+                        "type": "destination"
+                      }
+                    },
+                    "routing": {
+                      "rules": [
+                        {
+                          "destination": "bin_red",
+                          "id": "route_red_box_to_bin_red",
+                          "when": {
+                            "object_class": "box",
+                            "object_color": "red"
+                          }
+                        }
+                      ]
+                    },
+                    "safety": {
+                      "metadata_only": true,
+                      "motion_started": false,
+                      "ros_launch_started": false,
+                      "runtime_io_applied": false
+                    },
+                    "scene_package": "scenes/ur5_2f_test",
+                    "schema": "workcell_builder_task_intent/v1",
+                    "task": {
+                      "id": "sorting_task_001",
+                      "mode": "offline_preview",
+                      "type": "pick_place"
+                    }
+                  },
+                  "warnings": []
+                },
+                "warnings": [
+                  "workcell_builder_metadata.yaml missing (optional)",
+                  "End-effector metadata not present in environment.yaml",
+                  "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+                  "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
+                ]
+              },
+              "catalog_status": "blocked",
+              "categories": {
+                "cell_definition_validation": {
+                  "capabilities": {
+                    "capability_refs": {
+                      "end_effector": null,
+                      "environment_assets": [],
+                      "robot": null,
+                      "sensors": [],
+                      "task": null
+                    },
+                    "checks": {
+                      "events": [],
+                      "status": "WARN"
+                    },
+                    "resolved": {}
+                  },
+                  "environment_layout": {},
+                  "errors": [],
+                  "grasp_strategy": {
+                    "mode": "none",
+                    "ref": null,
+                    "resolved_path": null,
+                    "status": "PASS"
+                  },
+                  "message": "cell_definition.yaml validates",
+                  "notes": [],
+                  "parser": "pyyaml",
+                  "status": "PASS",
+                  "warnings": [
+                    "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                  ]
+                },
+                "cell_definition_yaml": {
+                  "message": "cell_definition.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/cell_definition.yaml",
+                  "status": "PASS"
+                },
+                "cmakelists_txt": {
+                  "message": "CMakeLists.txt exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/CMakeLists.txt",
+                  "status": "PASS"
+                },
+                "credible_physical_visual_evidence": {
+                  "mesh_failure_summary_by_reason_code": {},
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "physical_rendered_count": 0,
+                  "source_geometry_count": 11,
+                  "status": "FAIL"
+                },
+                "environment_yaml": {
+                  "message": "environment.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/environment.yaml",
+                  "status": "PASS"
+                },
+                "fake_hardware_launch_command_derivation": {
+                  "build_package_name": "ur5_2f_test",
+                  "command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "safe fake-hardware launch command recorded",
+                  "package_name": "ur5_2f_test",
+                  "safety": "not executed; fake hardware explicitly required",
+                  "status": "PASS",
+                  "warnings": []
+                },
+                "generated_scene_package_readiness_json": {
+                  "message": "optional/generated-if-present readiness JSON is not present",
+                  "optional": true,
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_package_readiness.json",
+                  "status": "PASS"
+                },
+                "generated_scene_visual_mesh_index_json": {
+                  "message": "generated/scene_visual_mesh_index.json exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+                  "status": "PASS"
+                },
+                "launch_demo_launch_py": {
+                  "message": "launch/demo.launch.py exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/launch/demo.launch.py",
+                  "status": "PASS"
+                },
+                "layout_workcell_studio_layout_yaml": {
+                  "message": "layout/workcell_studio_layout.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
+                  "status": "PASS"
+                },
+                "manifest_local_file_references": {
+                  "checked": [
+                    {
+                      "field": "files.environment",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/environment.yaml",
+                      "reference": "environment.yaml"
+                    },
+                    {
+                      "field": "files.cell_definition",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/cell_definition.yaml",
+                      "reference": "cell_definition.yaml"
+                    },
+                    {
+                      "field": "files.layout",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
+                      "reference": "layout/workcell_studio_layout.yaml"
+                    },
+                    {
+                      "field": "files.launch",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/launch/demo.launch.py",
+                      "reference": "launch/demo.launch.py"
+                    },
+                    {
+                      "field": "files.urdf_xacro",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+                      "reference": "urdf/scene.urdf.xacro"
+                    },
+                    {
+                      "field": "files.visual_mesh_index",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+                      "reference": "generated/scene_visual_mesh_index.json"
+                    },
+                    {
+                      "field": "files.scene3d_gui_smoke",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
+                      "reference": "generated/scene3d_gui_smoke.json"
+                    }
+                  ],
+                  "message": "manifest local-file references resolved (7 checked)",
+                  "status": "PASS"
+                },
+                "package_xml": {
+                  "message": "package.xml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/package.xml",
+                  "status": "PASS"
+                },
+                "ros_launch_smoke_skip_evaluation_state": {
+                  "command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                },
+                "scene3d_visual_quality_summary": {
+                  "blockers": [
+                    "mesh_source_count > 0 requires mesh_rendered_count > 0"
+                  ],
+                  "counters": {
+                    "credible_physical_rendered_count": 0,
+                    "diagnostic_fallback_count": 0,
+                    "helper_overlay_count": 0,
+                    "mesh_rendered_count": 0,
+                    "mesh_source_count": 11,
+                    "physical_rendered_count": 0,
+                    "primitive_rendered_count": 0,
+                    "primitive_source_count": 0,
+                    "total_payload_count": 11
+                  },
+                  "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
+                  "status": "FAIL",
+                  "visual_quality_status": "FAIL",
+                  "warnings": []
+                },
+                "scene_manifest_yaml": {
+                  "message": "scene_manifest.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/scene_manifest.yaml",
+                  "status": "PASS"
+                },
+                "scene_package_exists": {
+                  "message": "scene package directory exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+                  "status": "PASS"
+                },
+                "tool_metadata_consistency": {
+                  "message": "tool/end-effector metadata has no explicit contradictions",
+                  "observed": {
+                    "cell_definition_end_effector_id": "robotiq_2f",
+                    "environment_tool_id": "robotiq_2f",
+                    "manifest_end_effector_brand": "robotiq_85_gripper",
+                    "manifest_end_effector_type": "finger"
+                  },
+                  "status": "PASS"
+                },
+                "urdf_scene_urdf_xacro": {
+                  "message": "urdf/scene.urdf.xacro exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+                  "status": "PASS"
+                }
+              },
+              "commands": {
+                "build_command": "colcon build --symlink-install --packages-select ur5_2f_test",
+                "fake_hardware_launch_command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json"
+              },
+              "failures": [
+                {
+                  "category": "credible_physical_visual_evidence",
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "scene3d_visual_quality_summary",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "status": "FAIL"
+                }
+              ],
+              "generated_at": "2026-06-04T16:21:59.245618+00:00",
+              "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+              "offline_scene_readiness": {
+                "errors": [],
+                "inputs": {
+                  "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+                  "workcell_root": null
+                },
+                "notes": [
+                  "ROS scene package detected (package.xml present)."
+                ],
+                "result": "WARN",
+                "scene_reports": [
+                  {
+                    "candidates": {
+                      "gripper": [
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene_manifest.yaml",
+                        "scene_visual_mesh_index.json"
+                      ],
+                      "robot": [
+                        "CMakeLists.txt",
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "environment_layout.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene3d_gui_smoke.json",
+                        "scene_manifest.yaml",
+                        "scene_visual_mesh_index.json",
+                        "workcell_builder_task_intent.yaml",
+                        "workcell_studio_layout.generated.yaml",
+                        "workcell_studio_layout.yaml"
+                      ],
+                      "sensor": [
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "environment_assets.yaml",
+                        "environment_layout.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro"
+                      ]
+                    },
+                    "counts": {
+                      "files": 18,
+                      "meshes": 0,
+                      "urdf_xacro": 2
+                    },
+                    "errors": [],
+                    "frames": {
+                      "base_link": 3,
+                      "camera_link": 3,
+                      "tool0": 32,
+                      "world": 23
+                    },
+                    "mesh_extensions_detected": [],
+                    "notes": [
+                      "ROS scene package detected (package.xml present)."
+                    ],
+                    "placed_objects": {
+                      "absolute_external_mesh_warnings": [],
+                      "count": 0,
+                      "found_in_generated_urdf_xacro": false,
+                      "found_names": [],
+                      "invalid_mesh_warnings": [],
+                      "missing_collision_mesh_warnings": [],
+                      "missing_names": []
+                    },
+                    "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+                    "task_zones": {
+                      "duplicate_ids": [],
+                      "invalid_dimensions": [],
+                      "pick": 0,
+                      "place": 0,
+                      "total": 0,
+                      "zone_ids": []
+                    },
+                    "warnings": [
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                      "Task intent place.target.id not found in task_zones: bin_red",
+                      "Legacy compatibility: robot_mount missing.",
+                      "Legacy compatibility: tool_attachment missing.",
+                      "Legacy compatibility: recommended gripper orientation not used."
+                    ]
+                  }
+                ],
+                "strict": false,
+                "summary": {
+                  "errors": 0,
+                  "scene_packages_checked": 1,
+                  "warnings": 22
+                },
+                "warnings": [
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                  "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                  "Task intent place.target.id not found in task_zones: bin_red",
+                  "Legacy compatibility: robot_mount missing.",
+                  "Legacy compatibility: tool_attachment missing.",
+                  "Legacy compatibility: recommended gripper orientation not used."
+                ]
+              },
+              "overall_status": "BLOCKED",
+              "package_name": "ur5_2f_test",
+              "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+              "readiness_status": "BLOCKED",
+              "ros_humble_available": false,
+              "safe_command_warnings": [],
+              "safety": {
+                "fake_hardware_default": true,
+                "motion_command_sent": false,
+                "real_hardware_enabled": false,
+                "ros_launch_executed_by_matrix": false,
+                "runtime_execution_called": false,
+                "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+              },
+              "scene_name": "ur5_2f_test",
+              "scene_path": "scenes/ur5_2f_test",
+              "schema_version": "workcell_studio_scene_package_readiness/v1",
+              "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+              "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+              "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+              "support_level": "supported",
+              "warnings": [
+                {
+                  "category": "cell_definition_validation",
+                  "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                }
+              ],
+              "workcell_builder_executable_found": false
+            }
+          },
+          "generated_scene_visual_mesh_index_json": {
+            "message": "generated/scene_visual_mesh_index.json exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+            "status": "PASS"
+          },
+          "launch_demo_launch_py": {
+            "message": "launch/demo.launch.py exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/launch/demo.launch.py",
+            "status": "PASS"
+          },
+          "layout_workcell_studio_layout_yaml": {
+            "message": "layout/workcell_studio_layout.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
+            "status": "PASS"
+          },
+          "manifest_local_file_references": {
+            "checked": [
+              {
+                "field": "files.environment",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/environment.yaml",
+                "reference": "environment.yaml"
+              },
+              {
+                "field": "files.cell_definition",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/cell_definition.yaml",
+                "reference": "cell_definition.yaml"
+              },
+              {
+                "field": "files.layout",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
+                "reference": "layout/workcell_studio_layout.yaml"
+              },
+              {
+                "field": "files.launch",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/launch/demo.launch.py",
+                "reference": "launch/demo.launch.py"
+              },
+              {
+                "field": "files.urdf_xacro",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+                "reference": "urdf/scene.urdf.xacro"
+              },
+              {
+                "field": "files.visual_mesh_index",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+                "reference": "generated/scene_visual_mesh_index.json"
+              },
+              {
+                "field": "files.scene3d_gui_smoke",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
+                "reference": "generated/scene3d_gui_smoke.json"
+              }
+            ],
+            "message": "manifest local-file references resolved (7 checked)",
+            "status": "PASS"
+          },
+          "package_xml": {
+            "message": "package.xml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/package.xml",
+            "status": "PASS"
+          },
+          "ros_launch_smoke_skip_evaluation_state": {
+            "command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          },
+          "scene3d_visual_quality_summary": {
+            "blockers": [
+              "mesh_source_count > 0 requires mesh_rendered_count > 0"
+            ],
+            "counters": {
+              "credible_physical_rendered_count": 0,
+              "diagnostic_fallback_count": 0,
+              "helper_overlay_count": 0,
+              "mesh_rendered_count": 0,
+              "mesh_source_count": 11,
+              "physical_rendered_count": 0,
+              "primitive_rendered_count": 0,
+              "primitive_source_count": 0,
+              "total_payload_count": 11
+            },
+            "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
+            "status": "FAIL",
+            "visual_quality_status": "FAIL",
+            "warnings": []
+          },
+          "scene_manifest_yaml": {
+            "message": "scene_manifest.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/scene_manifest.yaml",
+            "status": "PASS"
+          },
+          "scene_package_exists": {
+            "message": "scene package directory exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+            "status": "PASS"
+          },
+          "tool_metadata_consistency": {
+            "message": "tool/end-effector metadata has no explicit contradictions",
+            "observed": {
+              "cell_definition_end_effector_id": "robotiq_2f",
+              "environment_tool_id": "robotiq_2f",
+              "manifest_end_effector_brand": "robotiq_85_gripper",
+              "manifest_end_effector_type": "finger"
+            },
+            "status": "PASS"
+          },
+          "urdf_scene_urdf_xacro": {
+            "message": "urdf/scene.urdf.xacro exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+            "status": "PASS"
+          }
+        },
+        "commands": {
+          "build_command": "colcon build --symlink-install --packages-select ur5_2f_test",
+          "fake_hardware_launch_command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+          "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json"
+        },
+        "failures": [
+          {
+            "category": "credible_physical_visual_evidence",
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "status": "FAIL"
+          },
+          {
+            "category": "scene3d_visual_quality_summary",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "status": "FAIL"
+          }
+        ],
+        "generated_at": "2026-06-04T16:23:19.093332+00:00",
+        "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+        "offline_scene_readiness": {
+          "errors": [],
+          "inputs": {
+            "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+            "workcell_root": null
+          },
+          "notes": [
+            "ROS scene package detected (package.xml present)."
+          ],
+          "result": "WARN",
+          "scene_reports": [
+            {
+              "candidates": {
+                "gripper": [
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json"
+                ],
+                "robot": [
+                  "CMakeLists.txt",
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "environment_layout.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene3d_gui_smoke.json",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json",
+                  "workcell_builder_task_intent.yaml",
+                  "workcell_studio_layout.generated.yaml",
+                  "workcell_studio_layout.yaml"
+                ],
+                "sensor": [
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "environment_assets.yaml",
+                  "environment_layout.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene_package_readiness.json"
+                ]
+              },
+              "counts": {
+                "files": 19,
+                "meshes": 0,
+                "urdf_xacro": 2
+              },
+              "errors": [],
+              "frames": {
+                "base_link": 4,
+                "camera_link": 4,
+                "tool0": 33,
+                "world": 24
+              },
+              "mesh_extensions_detected": [],
+              "notes": [
+                "ROS scene package detected (package.xml present)."
+              ],
+              "placed_objects": {
+                "absolute_external_mesh_warnings": [],
+                "count": 0,
+                "found_in_generated_urdf_xacro": false,
+                "found_names": [],
+                "invalid_mesh_warnings": [],
+                "missing_collision_mesh_warnings": [],
+                "missing_names": []
+              },
+              "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+              "task_zones": {
+                "duplicate_ids": [],
+                "invalid_dimensions": [],
+                "pick": 0,
+                "place": 0,
+                "total": 0,
+                "zone_ids": []
+              },
+              "warnings": [
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                "Task intent place.target.id not found in task_zones: bin_red",
+                "Legacy compatibility: robot_mount missing.",
+                "Legacy compatibility: tool_attachment missing.",
+                "Legacy compatibility: recommended gripper orientation not used."
+              ]
+            }
+          ],
+          "strict": false,
+          "summary": {
+            "errors": 0,
+            "scene_packages_checked": 1,
+            "warnings": 44
+          },
+          "warnings": [
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Task intent pick.source.id not found in task_zones: pick_zone_main",
+            "Task intent place.target.id not found in task_zones: bin_red",
+            "Legacy compatibility: robot_mount missing.",
+            "Legacy compatibility: tool_attachment missing.",
+            "Legacy compatibility: recommended gripper orientation not used."
+          ]
+        },
+        "overall_status": "BLOCKED",
+        "package_name": "ur5_2f_test",
+        "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+        "readiness_status": "BLOCKED",
+        "ros_humble_available": false,
+        "safe_command_warnings": [],
+        "safety": {
+          "fake_hardware_default": true,
+          "motion_command_sent": false,
+          "real_hardware_enabled": false,
+          "ros_launch_executed_by_matrix": false,
+          "runtime_execution_called": false,
+          "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+        },
+        "scene_name": "ur5_2f_test",
+        "scene_path": "scenes/ur5_2f_test",
+        "schema_version": "workcell_studio_scene_package_readiness/v1",
+        "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+        "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+        "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+        "support_level": "supported",
+        "warnings": [
+          {
+            "category": "cell_definition_validation",
+            "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+          }
+        ],
+        "workcell_builder_executable_found": false
+      }
+    },
+    "generated_scene_visual_mesh_index_json": {
+      "message": "generated/scene_visual_mesh_index.json exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+      "status": "PASS"
+    },
+    "launch_demo_launch_py": {
+      "message": "launch/demo.launch.py exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/launch/demo.launch.py",
+      "status": "PASS"
+    },
+    "layout_workcell_studio_layout_yaml": {
+      "message": "layout/workcell_studio_layout.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
+      "status": "PASS"
+    },
+    "manifest_local_file_references": {
+      "checked": [
+        {
+          "field": "files.environment",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/environment.yaml",
+          "reference": "environment.yaml"
+        },
+        {
+          "field": "files.cell_definition",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/cell_definition.yaml",
+          "reference": "cell_definition.yaml"
+        },
+        {
+          "field": "files.layout",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
+          "reference": "layout/workcell_studio_layout.yaml"
+        },
+        {
+          "field": "files.launch",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/launch/demo.launch.py",
+          "reference": "launch/demo.launch.py"
+        },
+        {
+          "field": "files.urdf_xacro",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+          "reference": "urdf/scene.urdf.xacro"
+        },
+        {
+          "field": "files.visual_mesh_index",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+          "reference": "generated/scene_visual_mesh_index.json"
+        },
+        {
+          "field": "files.scene3d_gui_smoke",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
+          "reference": "generated/scene3d_gui_smoke.json"
+        }
+      ],
+      "message": "manifest local-file references resolved (7 checked)",
+      "status": "PASS"
+    },
+    "package_xml": {
+      "message": "package.xml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/package.xml",
+      "status": "PASS"
+    },
+    "ros_launch_smoke_skip_evaluation_state": {
+      "command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    },
+    "scene3d_visual_quality_summary": {
+      "blockers": [
+        "mesh_source_count > 0 requires mesh_rendered_count > 0"
+      ],
+      "counters": {
+        "credible_physical_rendered_count": 0,
+        "diagnostic_fallback_count": 0,
+        "helper_overlay_count": 0,
+        "mesh_rendered_count": 0,
+        "mesh_source_count": 11,
+        "physical_rendered_count": 0,
+        "primitive_rendered_count": 0,
+        "primitive_source_count": 0,
+        "total_payload_count": 11
+      },
+      "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
+      "status": "FAIL",
+      "visual_quality_status": "FAIL",
+      "warnings": []
+    },
+    "scene_manifest_yaml": {
+      "message": "scene_manifest.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/scene_manifest.yaml",
+      "status": "PASS"
+    },
+    "scene_package_exists": {
+      "message": "scene package directory exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+      "status": "PASS"
+    },
+    "tool_metadata_consistency": {
+      "message": "tool/end-effector metadata has no explicit contradictions",
+      "observed": {
+        "cell_definition_end_effector_id": "robotiq_2f",
+        "cell_definition_family": "two_finger_gripper",
+        "environment_tool_family": "two_finger_gripper",
+        "environment_tool_id": "robotiq_2f",
+        "manifest_end_effector_brand": "robotiq_85_gripper",
+        "manifest_end_effector_family": "finger_gripper",
+        "manifest_end_effector_type": "finger"
+      },
+      "status": "PASS",
+      "warnings": []
+    },
+    "urdf_scene_urdf_xacro": {
+      "message": "urdf/scene.urdf.xacro exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+      "status": "PASS"
+    }
+  },
+  "commands": {
+    "build_command": "colcon build --symlink-install --packages-select ur5_2f_test",
+    "fake_hardware_launch_command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+    "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json"
+  },
+  "failures": [
+    {
+      "category": "credible_physical_visual_evidence",
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "status": "FAIL"
+    },
+    {
+      "category": "scene3d_visual_quality_summary",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "status": "FAIL"
+    }
+  ],
+  "generated_at": "2026-06-04T16:24:50.479471+00:00",
+  "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+  "offline_scene_readiness": {
+    "errors": [],
+    "inputs": {
+      "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+      "workcell_root": null
+    },
+    "notes": [
+      "ROS scene package detected (package.xml present)."
+    ],
+    "result": "WARN",
+    "scene_reports": [
+      {
+        "candidates": {
+          "gripper": [
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json",
+            "scene_visual_mesh_index.json"
+          ],
+          "robot": [
+            "CMakeLists.txt",
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "environment_layout.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene3d_gui_smoke.json",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json",
+            "scene_visual_mesh_index.json",
+            "workcell_builder_task_intent.yaml",
+            "workcell_studio_layout.generated.yaml",
+            "workcell_studio_layout.yaml"
+          ],
+          "sensor": [
+            "cell_definition.yaml",
+            "environment.yaml",
+            "environment_assets.yaml",
+            "environment_layout.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene_package_readiness.json"
+          ]
+        },
+        "counts": {
+          "files": 19,
+          "meshes": 0,
+          "urdf_xacro": 2
+        },
+        "errors": [],
+        "frames": {
+          "base_link": 5,
+          "camera_link": 5,
+          "tool0": 34,
+          "world": 25
+        },
+        "mesh_extensions_detected": [],
+        "notes": [
+          "ROS scene package detected (package.xml present)."
+        ],
+        "placed_objects": {
+          "absolute_external_mesh_warnings": [],
+          "count": 0,
+          "found_in_generated_urdf_xacro": false,
+          "found_names": [],
+          "invalid_mesh_warnings": [],
+          "missing_collision_mesh_warnings": [],
+          "missing_names": []
+        },
+        "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+        "task_zones": {
+          "duplicate_ids": [],
+          "invalid_dimensions": [],
+          "pick": 0,
+          "place": 0,
+          "total": 0,
+          "zone_ids": []
+        },
+        "warnings": [
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Task intent pick.source.id not found in task_zones: pick_zone_main",
+          "Task intent place.target.id not found in task_zones: bin_red",
+          "Legacy compatibility: robot_mount missing.",
+          "Legacy compatibility: tool_attachment missing.",
+          "Legacy compatibility: recommended gripper orientation not used."
+        ]
+      }
+    ],
+    "strict": false,
+    "summary": {
+      "errors": 0,
+      "scene_packages_checked": 1,
+      "warnings": 110
+    },
+    "warnings": [
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+      "Task intent place.target.id not found in task_zones: bin_red",
+      "Legacy compatibility: robot_mount missing.",
+      "Legacy compatibility: tool_attachment missing.",
+      "Legacy compatibility: recommended gripper orientation not used."
+    ]
+  },
+  "overall_status": "BLOCKED",
+  "package_name": "ur5_2f_test",
+  "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+  "readiness_status": "BLOCKED",
+  "ros_humble_available": false,
+  "safe_command_warnings": [],
+  "safety": {
+    "fake_hardware_default": true,
+    "motion_command_sent": false,
+    "real_hardware_enabled": false,
+    "ros_launch_executed_by_matrix": false,
+    "runtime_execution_called": false,
+    "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+  },
+  "scene_name": "ur5_2f_test",
+  "scene_path": "scenes/ur5_2f_test",
+  "schema_version": "workcell_studio_scene_package_readiness/v1",
+  "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+  "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+  "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+  "support_level": "supported",
+  "warnings": [
+    {
+      "category": "cell_definition_validation",
+      "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+    }
+  ],
+  "workcell_builder_executable_found": false
+}

--- a/scenes/ur5_3f_test/generated/scene_package_readiness.json
+++ b/scenes/ur5_3f_test/generated/scene_package_readiness.json
@@ -1,0 +1,1359 @@
+{
+  "blockers": [
+    {
+      "category": "supported_scene_catalog",
+      "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+      "status": "BLOCKED"
+    },
+    {
+      "category": "ros_launch_smoke_skip_evaluation_state",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    }
+  ],
+  "build_package_name": "ur5_3f_test",
+  "builder_generated_scene_validation": {
+    "checks": [
+      {
+        "check": "package.xml exists",
+        "ok": true
+      },
+      {
+        "check": "CMakeLists.txt exists",
+        "ok": true
+      },
+      {
+        "check": "environment.yaml exists",
+        "ok": true
+      },
+      {
+        "check": "workcell_builder_metadata.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/cell_definition.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/environment_layout.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/workcell_builder_task_intent.yaml present",
+        "ok": false,
+        "optional": true
+      }
+    ],
+    "discovered": {
+      "end_effector_capability_id": null,
+      "end_effector_name": null,
+      "grasp_strategy_id": null,
+      "object_count": 0,
+      "robot_capability_id": null,
+      "robot_name": null,
+      "sensor_capability_id": null
+    },
+    "errors": [],
+    "export_validation": {},
+    "ok": true,
+    "readiness": "physical_scene_only",
+    "readiness_classification": "physical_scene_only",
+    "runtime_readiness": "runtime_blocked_or_preview_only",
+    "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test",
+    "suggested_next_actions": [
+      "Create builder task intent to define pick/place/grasp."
+    ],
+    "task_flow_summary": {},
+    "task_intent": {},
+    "warnings": [
+      "workcell_builder_metadata.yaml missing (optional)",
+      "End-effector metadata not present in environment.yaml",
+      "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+      "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+      "Task intent missing: physical scene only."
+    ]
+  },
+  "catalog_status": "blocked",
+  "categories": {
+    "cell_definition_validation": {
+      "capabilities": {
+        "capability_refs": {
+          "end_effector": null,
+          "environment_assets": [],
+          "robot": null,
+          "sensors": [],
+          "task": null
+        },
+        "checks": {
+          "events": [],
+          "status": "FAIL"
+        },
+        "resolved": {}
+      },
+      "environment_layout": {},
+      "errors": [
+        "Missing required top-level key: camera",
+        "Missing required top-level key: objects"
+      ],
+      "grasp_strategy": {
+        "mode": "none",
+        "ref": null,
+        "resolved_path": null,
+        "status": "PASS"
+      },
+      "message": "cell_definition.yaml has validation errors",
+      "notes": [],
+      "parser": "pyyaml",
+      "status": "FAIL",
+      "warnings": [
+        "environment.layout path not found: layout/workcell_studio_layout.yaml"
+      ]
+    },
+    "cell_definition_yaml": {
+      "message": "cell_definition.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/cell_definition.yaml",
+      "status": "PASS"
+    },
+    "cmakelists_txt": {
+      "message": "CMakeLists.txt exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/CMakeLists.txt",
+      "status": "PASS"
+    },
+    "credible_physical_visual_evidence": {
+      "mesh_failure_summary_by_reason_code": {},
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "physical_rendered_count": 0,
+      "source_geometry_count": 2,
+      "status": "FAIL"
+    },
+    "environment_yaml": {
+      "message": "environment.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/environment.yaml",
+      "status": "PASS"
+    },
+    "fake_hardware_launch_command_derivation": {
+      "build_package_name": "ur5_3f_test",
+      "command": "ros2 launch ur5_3f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "safe fake-hardware launch command recorded",
+      "package_name": "ur5_3f_test",
+      "safety": "not executed; fake hardware explicitly required",
+      "status": "PASS",
+      "warnings": []
+    },
+    "generated_scene_package_readiness_json": {
+      "message": "generated/scene_package_readiness.json is present and parseable",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene_package_readiness.json",
+      "status": "PASS",
+      "summary": {
+        "blockers": [
+          {
+            "category": "supported_scene_catalog",
+            "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+            "status": "BLOCKED"
+          },
+          {
+            "category": "ros_launch_smoke_skip_evaluation_state",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          }
+        ],
+        "build_package_name": "ur5_3f_test",
+        "builder_generated_scene_validation": {
+          "checks": [
+            {
+              "check": "package.xml exists",
+              "ok": true
+            },
+            {
+              "check": "CMakeLists.txt exists",
+              "ok": true
+            },
+            {
+              "check": "environment.yaml exists",
+              "ok": true
+            },
+            {
+              "check": "workcell_builder_metadata.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/cell_definition.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/environment_layout.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/workcell_builder_task_intent.yaml present",
+              "ok": false,
+              "optional": true
+            }
+          ],
+          "discovered": {
+            "end_effector_capability_id": null,
+            "end_effector_name": null,
+            "grasp_strategy_id": null,
+            "object_count": 0,
+            "robot_capability_id": null,
+            "robot_name": null,
+            "sensor_capability_id": null
+          },
+          "errors": [],
+          "export_validation": {},
+          "ok": true,
+          "readiness": "physical_scene_only",
+          "readiness_classification": "physical_scene_only",
+          "runtime_readiness": "runtime_blocked_or_preview_only",
+          "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test",
+          "suggested_next_actions": [
+            "Create builder task intent to define pick/place/grasp."
+          ],
+          "task_flow_summary": {},
+          "task_intent": {},
+          "warnings": [
+            "workcell_builder_metadata.yaml missing (optional)",
+            "End-effector metadata not present in environment.yaml",
+            "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+            "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+            "Task intent missing: physical scene only."
+          ]
+        },
+        "catalog_status": "blocked",
+        "categories": {
+          "cell_definition_validation": {
+            "capabilities": {
+              "capability_refs": {
+                "end_effector": null,
+                "environment_assets": [],
+                "robot": null,
+                "sensors": [],
+                "task": null
+              },
+              "checks": {
+                "events": [],
+                "status": "FAIL"
+              },
+              "resolved": {}
+            },
+            "environment_layout": {},
+            "errors": [
+              "Missing required top-level key: camera",
+              "Missing required top-level key: objects"
+            ],
+            "grasp_strategy": {
+              "mode": "none",
+              "ref": null,
+              "resolved_path": null,
+              "status": "PASS"
+            },
+            "message": "cell_definition.yaml has validation errors",
+            "notes": [],
+            "parser": "pyyaml",
+            "status": "FAIL",
+            "warnings": [
+              "environment.layout path not found: layout/workcell_studio_layout.yaml"
+            ]
+          },
+          "cell_definition_yaml": {
+            "message": "cell_definition.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/cell_definition.yaml",
+            "status": "PASS"
+          },
+          "cmakelists_txt": {
+            "message": "CMakeLists.txt exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/CMakeLists.txt",
+            "status": "PASS"
+          },
+          "credible_physical_visual_evidence": {
+            "mesh_failure_summary_by_reason_code": {},
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "physical_rendered_count": 0,
+            "source_geometry_count": 2,
+            "status": "FAIL"
+          },
+          "environment_yaml": {
+            "message": "environment.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/environment.yaml",
+            "status": "PASS"
+          },
+          "fake_hardware_launch_command_derivation": {
+            "build_package_name": "ur5_3f_test",
+            "command": "ros2 launch ur5_3f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "safe fake-hardware launch command recorded",
+            "package_name": "ur5_3f_test",
+            "safety": "not executed; fake hardware explicitly required",
+            "status": "PASS",
+            "warnings": []
+          },
+          "generated_scene_package_readiness_json": {
+            "message": "generated/scene_package_readiness.json is present and parseable",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene_package_readiness.json",
+            "status": "PASS",
+            "summary": {
+              "blockers": [
+                {
+                  "category": "supported_scene_catalog",
+                  "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+                  "status": "BLOCKED"
+                },
+                {
+                  "category": "ros_launch_smoke_skip_evaluation_state",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                }
+              ],
+              "build_package_name": "ur5_3f_test",
+              "builder_generated_scene_validation": {
+                "checks": [
+                  {
+                    "check": "package.xml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "CMakeLists.txt exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "environment.yaml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "workcell_builder_metadata.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/cell_definition.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/environment_layout.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/workcell_builder_task_intent.yaml present",
+                    "ok": false,
+                    "optional": true
+                  }
+                ],
+                "discovered": {
+                  "end_effector_capability_id": null,
+                  "end_effector_name": null,
+                  "grasp_strategy_id": null,
+                  "object_count": 0,
+                  "robot_capability_id": null,
+                  "robot_name": null,
+                  "sensor_capability_id": null
+                },
+                "errors": [],
+                "export_validation": {},
+                "ok": true,
+                "readiness": "physical_scene_only",
+                "readiness_classification": "physical_scene_only",
+                "runtime_readiness": "runtime_blocked_or_preview_only",
+                "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test",
+                "suggested_next_actions": [
+                  "Create builder task intent to define pick/place/grasp."
+                ],
+                "task_flow_summary": {},
+                "task_intent": {},
+                "warnings": [
+                  "workcell_builder_metadata.yaml missing (optional)",
+                  "End-effector metadata not present in environment.yaml",
+                  "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+                  "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+                  "Task intent missing: physical scene only."
+                ]
+              },
+              "catalog_status": "blocked",
+              "categories": {
+                "cell_definition_validation": {
+                  "capabilities": {
+                    "capability_refs": {
+                      "end_effector": null,
+                      "environment_assets": [],
+                      "robot": null,
+                      "sensors": [],
+                      "task": null
+                    },
+                    "checks": {
+                      "events": [],
+                      "status": "FAIL"
+                    },
+                    "resolved": {}
+                  },
+                  "environment_layout": {},
+                  "errors": [
+                    "Missing required top-level key: camera",
+                    "Missing required top-level key: objects"
+                  ],
+                  "grasp_strategy": {
+                    "mode": "none",
+                    "ref": null,
+                    "resolved_path": null,
+                    "status": "PASS"
+                  },
+                  "message": "cell_definition.yaml has validation errors",
+                  "notes": [],
+                  "parser": "pyyaml",
+                  "status": "FAIL",
+                  "warnings": [
+                    "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                  ]
+                },
+                "cell_definition_yaml": {
+                  "message": "cell_definition.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/cell_definition.yaml",
+                  "status": "PASS"
+                },
+                "cmakelists_txt": {
+                  "message": "CMakeLists.txt exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/CMakeLists.txt",
+                  "status": "PASS"
+                },
+                "credible_physical_visual_evidence": {
+                  "mesh_failure_summary_by_reason_code": {},
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "physical_rendered_count": 0,
+                  "source_geometry_count": 2,
+                  "status": "FAIL"
+                },
+                "environment_yaml": {
+                  "message": "environment.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/environment.yaml",
+                  "status": "PASS"
+                },
+                "fake_hardware_launch_command_derivation": {
+                  "build_package_name": "ur5_3f_test",
+                  "command": "ros2 launch ur5_3f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "safe fake-hardware launch command recorded",
+                  "package_name": "ur5_3f_test",
+                  "safety": "not executed; fake hardware explicitly required",
+                  "status": "PASS",
+                  "warnings": []
+                },
+                "generated_scene_package_readiness_json": {
+                  "message": "optional/generated-if-present readiness JSON is not present",
+                  "optional": true,
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene_package_readiness.json",
+                  "status": "PASS"
+                },
+                "generated_scene_visual_mesh_index_json": {
+                  "message": "generated/scene_visual_mesh_index.json exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json",
+                  "status": "PASS"
+                },
+                "launch_demo_launch_py": {
+                  "message": "launch/demo.launch.py exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/launch/demo.launch.py",
+                  "status": "PASS"
+                },
+                "layout_workcell_studio_layout_yaml": {
+                  "message": "layout/workcell_studio_layout.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/layout/workcell_studio_layout.yaml",
+                  "status": "PASS"
+                },
+                "manifest_local_file_references": {
+                  "checked": [
+                    {
+                      "field": "files.environment",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/environment.yaml",
+                      "reference": "environment.yaml"
+                    },
+                    {
+                      "field": "files.cell_definition",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/cell_definition.yaml",
+                      "reference": "cell_definition.yaml"
+                    },
+                    {
+                      "field": "files.layout",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/layout/workcell_studio_layout.yaml",
+                      "reference": "layout/workcell_studio_layout.yaml"
+                    },
+                    {
+                      "field": "files.launch",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/launch/demo.launch.py",
+                      "reference": "launch/demo.launch.py"
+                    },
+                    {
+                      "field": "files.urdf_xacro",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
+                      "reference": "urdf/scene.urdf.xacro"
+                    },
+                    {
+                      "field": "files.visual_mesh_index",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json",
+                      "reference": "generated/scene_visual_mesh_index.json"
+                    },
+                    {
+                      "field": "files.scene3d_gui_smoke",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene3d_gui_smoke.json",
+                      "reference": "generated/scene3d_gui_smoke.json"
+                    }
+                  ],
+                  "message": "manifest local-file references resolved (7 checked)",
+                  "status": "PASS"
+                },
+                "package_xml": {
+                  "message": "package.xml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/package.xml",
+                  "status": "PASS"
+                },
+                "ros_launch_smoke_skip_evaluation_state": {
+                  "command": "ros2 launch ur5_3f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                },
+                "scene3d_visual_quality_summary": {
+                  "blockers": [
+                    "mesh_source_count > 0 requires mesh_rendered_count > 0"
+                  ],
+                  "counters": {
+                    "credible_physical_rendered_count": 0,
+                    "diagnostic_fallback_count": 0,
+                    "helper_overlay_count": 0,
+                    "mesh_rendered_count": 0,
+                    "mesh_source_count": 2,
+                    "physical_rendered_count": 0,
+                    "primitive_rendered_count": 0,
+                    "primitive_source_count": 0,
+                    "total_payload_count": 2
+                  },
+                  "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene3d_gui_smoke.json",
+                  "status": "FAIL",
+                  "visual_quality_status": "FAIL",
+                  "warnings": []
+                },
+                "scene_manifest_yaml": {
+                  "message": "scene_manifest.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/scene_manifest.yaml",
+                  "status": "PASS"
+                },
+                "scene_package_exists": {
+                  "message": "scene package directory exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test",
+                  "status": "PASS"
+                },
+                "tool_metadata_consistency": {
+                  "errors": [
+                    "Tool metadata mismatch: cell_definition.yaml end_effector.id 'robotiq_3f' does not match environment.yaml tool.id/profile 'robotiq_2f'.",
+                    "Tool metadata mismatch: scene_manifest.yaml end_effector.type is 'none' while scene-local tool/end_effector metadata declares a tool."
+                  ],
+                  "message": "tool/end-effector metadata is inconsistent",
+                  "observed": {
+                    "cell_definition_end_effector_id": "robotiq_3f",
+                    "environment_tool_id": "robotiq_2f",
+                    "manifest_end_effector_brand": "universal_robot",
+                    "manifest_end_effector_type": "none"
+                  },
+                  "status": "FAIL"
+                },
+                "urdf_scene_urdf_xacro": {
+                  "message": "urdf/scene.urdf.xacro exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
+                  "status": "PASS"
+                }
+              },
+              "commands": {
+                "build_command": "colcon build --symlink-install --packages-select ur5_3f_test",
+                "fake_hardware_launch_command": "ros2 launch ur5_3f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_3f_test --json"
+              },
+              "failures": [
+                {
+                  "category": "cell_definition_validation",
+                  "message": "cell_definition.yaml has validation errors",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "credible_physical_visual_evidence",
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "scene3d_visual_quality_summary",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "tool_metadata_consistency",
+                  "message": "tool/end-effector metadata is inconsistent",
+                  "status": "FAIL"
+                }
+              ],
+              "generated_at": "2026-06-04T16:21:59.245618+00:00",
+              "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+              "offline_scene_readiness": {
+                "errors": [],
+                "inputs": {
+                  "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test",
+                  "workcell_root": null
+                },
+                "notes": [
+                  "ROS scene package detected (package.xml present)."
+                ],
+                "result": "WARN",
+                "scene_reports": [
+                  {
+                    "candidates": {
+                      "gripper": [
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene_manifest.yaml"
+                      ],
+                      "robot": [
+                        "CMakeLists.txt",
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene3d_gui_smoke.json",
+                        "scene_manifest.yaml",
+                        "scene_visual_mesh_index.json",
+                        "workcell_builder_task_intent.yaml",
+                        "workcell_studio_layout.generated.yaml",
+                        "workcell_studio_layout.yaml"
+                      ],
+                      "sensor": [
+                        "environment.yaml",
+                        "environment_assets.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro"
+                      ]
+                    },
+                    "counts": {
+                      "files": 16,
+                      "meshes": 0,
+                      "urdf_xacro": 2
+                    },
+                    "errors": [],
+                    "frames": {
+                      "base_link": 2,
+                      "camera_link": 2,
+                      "tool0": 7,
+                      "world": 16
+                    },
+                    "mesh_extensions_detected": [],
+                    "notes": [
+                      "ROS scene package detected (package.xml present)."
+                    ],
+                    "placed_objects": {
+                      "absolute_external_mesh_warnings": [],
+                      "count": 0,
+                      "found_in_generated_urdf_xacro": false,
+                      "found_names": [],
+                      "invalid_mesh_warnings": [],
+                      "missing_collision_mesh_warnings": [],
+                      "missing_names": []
+                    },
+                    "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test",
+                    "task_zones": {
+                      "duplicate_ids": [],
+                      "invalid_dimensions": [],
+                      "pick": 0,
+                      "place": 0,
+                      "total": 0,
+                      "zone_ids": []
+                    },
+                    "warnings": [
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                      "Task intent place.target.id not found in task_zones: place_zone_main",
+                      "Legacy compatibility: robot_mount missing.",
+                      "Legacy compatibility: tool_attachment missing.",
+                      "Legacy compatibility: recommended gripper orientation not used."
+                    ]
+                  }
+                ],
+                "strict": false,
+                "summary": {
+                  "errors": 0,
+                  "scene_packages_checked": 1,
+                  "warnings": 11
+                },
+                "warnings": [
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                  "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                  "Task intent place.target.id not found in task_zones: place_zone_main",
+                  "Legacy compatibility: robot_mount missing.",
+                  "Legacy compatibility: tool_attachment missing.",
+                  "Legacy compatibility: recommended gripper orientation not used."
+                ]
+              },
+              "overall_status": "BLOCKED",
+              "package_name": "ur5_3f_test",
+              "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+              "readiness_status": "BLOCKED",
+              "ros_humble_available": false,
+              "safe_command_warnings": [],
+              "safety": {
+                "fake_hardware_default": true,
+                "motion_command_sent": false,
+                "real_hardware_enabled": false,
+                "ros_launch_executed_by_matrix": false,
+                "runtime_execution_called": false,
+                "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+              },
+              "scene_name": "ur5_3f_test",
+              "scene_path": "scenes/ur5_3f_test",
+              "schema_version": "workcell_studio_scene_package_readiness/v1",
+              "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+              "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+              "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+              "support_level": "supported",
+              "warnings": [
+                {
+                  "category": "cell_definition_validation",
+                  "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                }
+              ],
+              "workcell_builder_executable_found": false
+            }
+          },
+          "generated_scene_visual_mesh_index_json": {
+            "message": "generated/scene_visual_mesh_index.json exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json",
+            "status": "PASS"
+          },
+          "launch_demo_launch_py": {
+            "message": "launch/demo.launch.py exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/launch/demo.launch.py",
+            "status": "PASS"
+          },
+          "layout_workcell_studio_layout_yaml": {
+            "message": "layout/workcell_studio_layout.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/layout/workcell_studio_layout.yaml",
+            "status": "PASS"
+          },
+          "manifest_local_file_references": {
+            "checked": [
+              {
+                "field": "files.environment",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/environment.yaml",
+                "reference": "environment.yaml"
+              },
+              {
+                "field": "files.cell_definition",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/cell_definition.yaml",
+                "reference": "cell_definition.yaml"
+              },
+              {
+                "field": "files.layout",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/layout/workcell_studio_layout.yaml",
+                "reference": "layout/workcell_studio_layout.yaml"
+              },
+              {
+                "field": "files.launch",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/launch/demo.launch.py",
+                "reference": "launch/demo.launch.py"
+              },
+              {
+                "field": "files.urdf_xacro",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
+                "reference": "urdf/scene.urdf.xacro"
+              },
+              {
+                "field": "files.visual_mesh_index",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json",
+                "reference": "generated/scene_visual_mesh_index.json"
+              },
+              {
+                "field": "files.scene3d_gui_smoke",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene3d_gui_smoke.json",
+                "reference": "generated/scene3d_gui_smoke.json"
+              }
+            ],
+            "message": "manifest local-file references resolved (7 checked)",
+            "status": "PASS"
+          },
+          "package_xml": {
+            "message": "package.xml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/package.xml",
+            "status": "PASS"
+          },
+          "ros_launch_smoke_skip_evaluation_state": {
+            "command": "ros2 launch ur5_3f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          },
+          "scene3d_visual_quality_summary": {
+            "blockers": [
+              "mesh_source_count > 0 requires mesh_rendered_count > 0"
+            ],
+            "counters": {
+              "credible_physical_rendered_count": 0,
+              "diagnostic_fallback_count": 0,
+              "helper_overlay_count": 0,
+              "mesh_rendered_count": 0,
+              "mesh_source_count": 2,
+              "physical_rendered_count": 0,
+              "primitive_rendered_count": 0,
+              "primitive_source_count": 0,
+              "total_payload_count": 2
+            },
+            "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene3d_gui_smoke.json",
+            "status": "FAIL",
+            "visual_quality_status": "FAIL",
+            "warnings": []
+          },
+          "scene_manifest_yaml": {
+            "message": "scene_manifest.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/scene_manifest.yaml",
+            "status": "PASS"
+          },
+          "scene_package_exists": {
+            "message": "scene package directory exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test",
+            "status": "PASS"
+          },
+          "tool_metadata_consistency": {
+            "errors": [
+              "Tool metadata mismatch: cell_definition.yaml end_effector.id 'robotiq_3f' does not match environment.yaml tool.id/profile 'robotiq_2f'.",
+              "Tool metadata mismatch: scene_manifest.yaml end_effector.type is 'none' while scene-local tool/end_effector metadata declares a tool."
+            ],
+            "message": "tool/end-effector metadata is inconsistent",
+            "observed": {
+              "cell_definition_end_effector_id": "robotiq_3f",
+              "environment_tool_id": "robotiq_2f",
+              "manifest_end_effector_brand": "universal_robot",
+              "manifest_end_effector_type": "none"
+            },
+            "status": "FAIL"
+          },
+          "urdf_scene_urdf_xacro": {
+            "message": "urdf/scene.urdf.xacro exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
+            "status": "PASS"
+          }
+        },
+        "commands": {
+          "build_command": "colcon build --symlink-install --packages-select ur5_3f_test",
+          "fake_hardware_launch_command": "ros2 launch ur5_3f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+          "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_3f_test --json"
+        },
+        "failures": [
+          {
+            "category": "cell_definition_validation",
+            "message": "cell_definition.yaml has validation errors",
+            "status": "FAIL"
+          },
+          {
+            "category": "credible_physical_visual_evidence",
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "status": "FAIL"
+          },
+          {
+            "category": "scene3d_visual_quality_summary",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "status": "FAIL"
+          },
+          {
+            "category": "tool_metadata_consistency",
+            "message": "tool/end-effector metadata is inconsistent",
+            "status": "FAIL"
+          }
+        ],
+        "generated_at": "2026-06-04T16:23:19.093332+00:00",
+        "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+        "offline_scene_readiness": {
+          "errors": [],
+          "inputs": {
+            "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test",
+            "workcell_root": null
+          },
+          "notes": [
+            "ROS scene package detected (package.xml present)."
+          ],
+          "result": "WARN",
+          "scene_reports": [
+            {
+              "candidates": {
+                "gripper": [
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json"
+                ],
+                "robot": [
+                  "CMakeLists.txt",
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene3d_gui_smoke.json",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json",
+                  "workcell_builder_task_intent.yaml",
+                  "workcell_studio_layout.generated.yaml",
+                  "workcell_studio_layout.yaml"
+                ],
+                "sensor": [
+                  "environment.yaml",
+                  "environment_assets.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene_package_readiness.json"
+                ]
+              },
+              "counts": {
+                "files": 17,
+                "meshes": 0,
+                "urdf_xacro": 2
+              },
+              "errors": [],
+              "frames": {
+                "base_link": 3,
+                "camera_link": 3,
+                "tool0": 8,
+                "world": 17
+              },
+              "mesh_extensions_detected": [],
+              "notes": [
+                "ROS scene package detected (package.xml present)."
+              ],
+              "placed_objects": {
+                "absolute_external_mesh_warnings": [],
+                "count": 0,
+                "found_in_generated_urdf_xacro": false,
+                "found_names": [],
+                "invalid_mesh_warnings": [],
+                "missing_collision_mesh_warnings": [],
+                "missing_names": []
+              },
+              "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test",
+              "task_zones": {
+                "duplicate_ids": [],
+                "invalid_dimensions": [],
+                "pick": 0,
+                "place": 0,
+                "total": 0,
+                "zone_ids": []
+              },
+              "warnings": [
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                "Task intent place.target.id not found in task_zones: place_zone_main",
+                "Legacy compatibility: robot_mount missing.",
+                "Legacy compatibility: tool_attachment missing.",
+                "Legacy compatibility: recommended gripper orientation not used."
+              ]
+            }
+          ],
+          "strict": false,
+          "summary": {
+            "errors": 0,
+            "scene_packages_checked": 1,
+            "warnings": 15
+          },
+          "warnings": [
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Task intent pick.source.id not found in task_zones: pick_zone_main",
+            "Task intent place.target.id not found in task_zones: place_zone_main",
+            "Legacy compatibility: robot_mount missing.",
+            "Legacy compatibility: tool_attachment missing.",
+            "Legacy compatibility: recommended gripper orientation not used."
+          ]
+        },
+        "overall_status": "BLOCKED",
+        "package_name": "ur5_3f_test",
+        "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+        "readiness_status": "BLOCKED",
+        "ros_humble_available": false,
+        "safe_command_warnings": [],
+        "safety": {
+          "fake_hardware_default": true,
+          "motion_command_sent": false,
+          "real_hardware_enabled": false,
+          "ros_launch_executed_by_matrix": false,
+          "runtime_execution_called": false,
+          "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+        },
+        "scene_name": "ur5_3f_test",
+        "scene_path": "scenes/ur5_3f_test",
+        "schema_version": "workcell_studio_scene_package_readiness/v1",
+        "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+        "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+        "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+        "support_level": "supported",
+        "warnings": [
+          {
+            "category": "cell_definition_validation",
+            "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+          }
+        ],
+        "workcell_builder_executable_found": false
+      }
+    },
+    "generated_scene_visual_mesh_index_json": {
+      "message": "generated/scene_visual_mesh_index.json exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json",
+      "status": "PASS"
+    },
+    "launch_demo_launch_py": {
+      "message": "launch/demo.launch.py exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/launch/demo.launch.py",
+      "status": "PASS"
+    },
+    "layout_workcell_studio_layout_yaml": {
+      "message": "layout/workcell_studio_layout.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/layout/workcell_studio_layout.yaml",
+      "status": "PASS"
+    },
+    "manifest_local_file_references": {
+      "checked": [
+        {
+          "field": "files.environment",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/environment.yaml",
+          "reference": "environment.yaml"
+        },
+        {
+          "field": "files.cell_definition",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/cell_definition.yaml",
+          "reference": "cell_definition.yaml"
+        },
+        {
+          "field": "files.layout",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/layout/workcell_studio_layout.yaml",
+          "reference": "layout/workcell_studio_layout.yaml"
+        },
+        {
+          "field": "files.launch",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/launch/demo.launch.py",
+          "reference": "launch/demo.launch.py"
+        },
+        {
+          "field": "files.urdf_xacro",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
+          "reference": "urdf/scene.urdf.xacro"
+        },
+        {
+          "field": "files.visual_mesh_index",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json",
+          "reference": "generated/scene_visual_mesh_index.json"
+        },
+        {
+          "field": "files.scene3d_gui_smoke",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene3d_gui_smoke.json",
+          "reference": "generated/scene3d_gui_smoke.json"
+        }
+      ],
+      "message": "manifest local-file references resolved (7 checked)",
+      "status": "PASS"
+    },
+    "package_xml": {
+      "message": "package.xml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/package.xml",
+      "status": "PASS"
+    },
+    "ros_launch_smoke_skip_evaluation_state": {
+      "command": "ros2 launch ur5_3f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    },
+    "scene3d_visual_quality_summary": {
+      "blockers": [
+        "mesh_source_count > 0 requires mesh_rendered_count > 0"
+      ],
+      "counters": {
+        "credible_physical_rendered_count": 0,
+        "diagnostic_fallback_count": 0,
+        "helper_overlay_count": 0,
+        "mesh_rendered_count": 0,
+        "mesh_source_count": 2,
+        "physical_rendered_count": 0,
+        "primitive_rendered_count": 0,
+        "primitive_source_count": 0,
+        "total_payload_count": 2
+      },
+      "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/generated/scene3d_gui_smoke.json",
+      "status": "FAIL",
+      "visual_quality_status": "FAIL",
+      "warnings": []
+    },
+    "scene_manifest_yaml": {
+      "message": "scene_manifest.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/scene_manifest.yaml",
+      "status": "PASS"
+    },
+    "scene_package_exists": {
+      "message": "scene package directory exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test",
+      "status": "PASS"
+    },
+    "tool_metadata_consistency": {
+      "errors": [
+        "Tool metadata mismatch: cell_definition.yaml end_effector.id 'robotiq_3f' resolves to 'three_finger_gripper' but environment.yaml tool.id/profile 'robotiq_2f' resolves to 'two_finger_gripper'.",
+        "Tool metadata mismatch: scene_manifest.yaml end_effector.type is 'none' while scene-local tool/end_effector metadata declares a tool."
+      ],
+      "message": "tool/end-effector metadata is inconsistent",
+      "observed": {
+        "cell_definition_end_effector_id": "robotiq_3f",
+        "cell_definition_family": "three_finger_gripper",
+        "environment_tool_family": "two_finger_gripper",
+        "environment_tool_id": "robotiq_2f",
+        "manifest_end_effector_brand": "universal_robot",
+        "manifest_end_effector_family": "none",
+        "manifest_end_effector_type": "none"
+      },
+      "status": "FAIL",
+      "warnings": []
+    },
+    "urdf_scene_urdf_xacro": {
+      "message": "urdf/scene.urdf.xacro exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
+      "status": "PASS"
+    }
+  },
+  "commands": {
+    "build_command": "colcon build --symlink-install --packages-select ur5_3f_test",
+    "fake_hardware_launch_command": "ros2 launch ur5_3f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+    "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_3f_test --json"
+  },
+  "failures": [
+    {
+      "category": "cell_definition_validation",
+      "message": "cell_definition.yaml has validation errors",
+      "status": "FAIL"
+    },
+    {
+      "category": "credible_physical_visual_evidence",
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "status": "FAIL"
+    },
+    {
+      "category": "scene3d_visual_quality_summary",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "status": "FAIL"
+    },
+    {
+      "category": "tool_metadata_consistency",
+      "message": "tool/end-effector metadata is inconsistent",
+      "status": "FAIL"
+    }
+  ],
+  "generated_at": "2026-06-04T16:24:50.479471+00:00",
+  "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+  "offline_scene_readiness": {
+    "errors": [],
+    "inputs": {
+      "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test",
+      "workcell_root": null
+    },
+    "notes": [
+      "ROS scene package detected (package.xml present)."
+    ],
+    "result": "WARN",
+    "scene_reports": [
+      {
+        "candidates": {
+          "gripper": [
+            "cell_definition.yaml",
+            "environment.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json"
+          ],
+          "robot": [
+            "CMakeLists.txt",
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene3d_gui_smoke.json",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json",
+            "scene_visual_mesh_index.json",
+            "workcell_builder_task_intent.yaml",
+            "workcell_studio_layout.generated.yaml",
+            "workcell_studio_layout.yaml"
+          ],
+          "sensor": [
+            "environment.yaml",
+            "environment_assets.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene_package_readiness.json"
+          ]
+        },
+        "counts": {
+          "files": 17,
+          "meshes": 0,
+          "urdf_xacro": 2
+        },
+        "errors": [],
+        "frames": {
+          "base_link": 4,
+          "camera_link": 4,
+          "tool0": 9,
+          "world": 18
+        },
+        "mesh_extensions_detected": [],
+        "notes": [
+          "ROS scene package detected (package.xml present)."
+        ],
+        "placed_objects": {
+          "absolute_external_mesh_warnings": [],
+          "count": 0,
+          "found_in_generated_urdf_xacro": false,
+          "found_names": [],
+          "invalid_mesh_warnings": [],
+          "missing_collision_mesh_warnings": [],
+          "missing_names": []
+        },
+        "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test",
+        "task_zones": {
+          "duplicate_ids": [],
+          "invalid_dimensions": [],
+          "pick": 0,
+          "place": 0,
+          "total": 0,
+          "zone_ids": []
+        },
+        "warnings": [
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Task intent pick.source.id not found in task_zones: pick_zone_main",
+          "Task intent place.target.id not found in task_zones: place_zone_main",
+          "Legacy compatibility: robot_mount missing.",
+          "Legacy compatibility: tool_attachment missing.",
+          "Legacy compatibility: recommended gripper orientation not used."
+        ]
+      }
+    ],
+    "strict": false,
+    "summary": {
+      "errors": 0,
+      "scene_packages_checked": 1,
+      "warnings": 27
+    },
+    "warnings": [
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+      "Task intent place.target.id not found in task_zones: place_zone_main",
+      "Legacy compatibility: robot_mount missing.",
+      "Legacy compatibility: tool_attachment missing.",
+      "Legacy compatibility: recommended gripper orientation not used."
+    ]
+  },
+  "overall_status": "BLOCKED",
+  "package_name": "ur5_3f_test",
+  "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+  "readiness_status": "BLOCKED",
+  "ros_humble_available": false,
+  "safe_command_warnings": [],
+  "safety": {
+    "fake_hardware_default": true,
+    "motion_command_sent": false,
+    "real_hardware_enabled": false,
+    "ros_launch_executed_by_matrix": false,
+    "runtime_execution_called": false,
+    "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+  },
+  "scene_name": "ur5_3f_test",
+  "scene_path": "scenes/ur5_3f_test",
+  "schema_version": "workcell_studio_scene_package_readiness/v1",
+  "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+  "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+  "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+  "support_level": "supported",
+  "warnings": [
+    {
+      "category": "cell_definition_validation",
+      "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+    }
+  ],
+  "workcell_builder_executable_found": false
+}

--- a/scenes/ur5_airpick4_test/generated/scene_package_readiness.json
+++ b/scenes/ur5_airpick4_test/generated/scene_package_readiness.json
@@ -1,0 +1,1415 @@
+{
+  "blockers": [
+    {
+      "category": "supported_scene_catalog",
+      "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+      "status": "BLOCKED"
+    },
+    {
+      "category": "ros_launch_smoke_skip_evaluation_state",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    }
+  ],
+  "build_package_name": "ur5_airpick4_test",
+  "builder_generated_scene_validation": {
+    "checks": [
+      {
+        "check": "package.xml exists",
+        "ok": true
+      },
+      {
+        "check": "CMakeLists.txt exists",
+        "ok": true
+      },
+      {
+        "check": "environment.yaml exists",
+        "ok": true
+      },
+      {
+        "check": "workcell_builder_metadata.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/cell_definition.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/environment_layout.yaml present",
+        "ok": false,
+        "optional": true
+      },
+      {
+        "check": "generated/workcell_builder_task_intent.yaml present",
+        "ok": false,
+        "optional": true
+      }
+    ],
+    "discovered": {
+      "end_effector_capability_id": null,
+      "end_effector_name": null,
+      "grasp_strategy_id": null,
+      "object_count": 0,
+      "robot_capability_id": null,
+      "robot_name": null,
+      "sensor_capability_id": null
+    },
+    "errors": [],
+    "export_validation": {},
+    "ok": true,
+    "readiness": "physical_scene_only",
+    "readiness_classification": "physical_scene_only",
+    "runtime_readiness": "runtime_blocked_or_preview_only",
+    "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test",
+    "suggested_next_actions": [
+      "Create builder task intent to define pick/place/grasp."
+    ],
+    "task_flow_summary": {},
+    "task_intent": {},
+    "warnings": [
+      "workcell_builder_metadata.yaml missing (optional)",
+      "End-effector metadata not present in environment.yaml",
+      "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+      "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+      "Task intent missing: physical scene only."
+    ]
+  },
+  "catalog_status": "blocked",
+  "categories": {
+    "cell_definition_validation": {
+      "capabilities": {
+        "capability_refs": {
+          "end_effector": null,
+          "environment_assets": [],
+          "robot": null,
+          "sensors": [],
+          "task": null
+        },
+        "checks": {
+          "events": [],
+          "status": "FAIL"
+        },
+        "resolved": {}
+      },
+      "environment_layout": {},
+      "errors": [
+        "Missing required top-level key: camera",
+        "Missing required top-level key: objects"
+      ],
+      "grasp_strategy": {
+        "mode": "none",
+        "ref": null,
+        "resolved_path": null,
+        "status": "PASS"
+      },
+      "message": "cell_definition.yaml has validation errors",
+      "notes": [],
+      "parser": "pyyaml",
+      "status": "FAIL",
+      "warnings": [
+        "environment.layout path not found: layout/workcell_studio_layout.yaml"
+      ]
+    },
+    "cell_definition_yaml": {
+      "message": "cell_definition.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/cell_definition.yaml",
+      "status": "PASS"
+    },
+    "cmakelists_txt": {
+      "message": "CMakeLists.txt exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/CMakeLists.txt",
+      "status": "PASS"
+    },
+    "credible_physical_visual_evidence": {
+      "mesh_failure_summary_by_reason_code": {},
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "physical_rendered_count": 0,
+      "source_geometry_count": 3,
+      "status": "FAIL"
+    },
+    "environment_yaml": {
+      "message": "environment.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/environment.yaml",
+      "status": "PASS"
+    },
+    "fake_hardware_launch_command_derivation": {
+      "build_package_name": "ur5_airpick4_test",
+      "command": "ros2 launch ur5_airpick4_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "safe fake-hardware launch command recorded",
+      "package_name": "ur5_airpick4_test",
+      "safety": "not executed; fake hardware explicitly required",
+      "status": "PASS",
+      "warnings": []
+    },
+    "generated_scene_package_readiness_json": {
+      "message": "generated/scene_package_readiness.json is present and parseable",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene_package_readiness.json",
+      "status": "PASS",
+      "summary": {
+        "blockers": [
+          {
+            "category": "supported_scene_catalog",
+            "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+            "status": "BLOCKED"
+          },
+          {
+            "category": "ros_launch_smoke_skip_evaluation_state",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          }
+        ],
+        "build_package_name": "ur5_airpick4_test",
+        "builder_generated_scene_validation": {
+          "checks": [
+            {
+              "check": "package.xml exists",
+              "ok": true
+            },
+            {
+              "check": "CMakeLists.txt exists",
+              "ok": true
+            },
+            {
+              "check": "environment.yaml exists",
+              "ok": true
+            },
+            {
+              "check": "workcell_builder_metadata.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/cell_definition.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/environment_layout.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/workcell_builder_task_intent.yaml present",
+              "ok": false,
+              "optional": true
+            }
+          ],
+          "discovered": {
+            "end_effector_capability_id": null,
+            "end_effector_name": null,
+            "grasp_strategy_id": null,
+            "object_count": 0,
+            "robot_capability_id": null,
+            "robot_name": null,
+            "sensor_capability_id": null
+          },
+          "errors": [],
+          "export_validation": {},
+          "ok": true,
+          "readiness": "physical_scene_only",
+          "readiness_classification": "physical_scene_only",
+          "runtime_readiness": "runtime_blocked_or_preview_only",
+          "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test",
+          "suggested_next_actions": [
+            "Create builder task intent to define pick/place/grasp."
+          ],
+          "task_flow_summary": {},
+          "task_intent": {},
+          "warnings": [
+            "workcell_builder_metadata.yaml missing (optional)",
+            "End-effector metadata not present in environment.yaml",
+            "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+            "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+            "Task intent missing: physical scene only."
+          ]
+        },
+        "catalog_status": "blocked",
+        "categories": {
+          "cell_definition_validation": {
+            "capabilities": {
+              "capability_refs": {
+                "end_effector": null,
+                "environment_assets": [],
+                "robot": null,
+                "sensors": [],
+                "task": null
+              },
+              "checks": {
+                "events": [],
+                "status": "FAIL"
+              },
+              "resolved": {}
+            },
+            "environment_layout": {},
+            "errors": [
+              "Missing required top-level key: camera",
+              "Missing required top-level key: objects"
+            ],
+            "grasp_strategy": {
+              "mode": "none",
+              "ref": null,
+              "resolved_path": null,
+              "status": "PASS"
+            },
+            "message": "cell_definition.yaml has validation errors",
+            "notes": [],
+            "parser": "pyyaml",
+            "status": "FAIL",
+            "warnings": [
+              "environment.layout path not found: layout/workcell_studio_layout.yaml"
+            ]
+          },
+          "cell_definition_yaml": {
+            "message": "cell_definition.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/cell_definition.yaml",
+            "status": "PASS"
+          },
+          "cmakelists_txt": {
+            "message": "CMakeLists.txt exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/CMakeLists.txt",
+            "status": "PASS"
+          },
+          "credible_physical_visual_evidence": {
+            "mesh_failure_summary_by_reason_code": {},
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "physical_rendered_count": 0,
+            "source_geometry_count": 3,
+            "status": "FAIL"
+          },
+          "environment_yaml": {
+            "message": "environment.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/environment.yaml",
+            "status": "PASS"
+          },
+          "fake_hardware_launch_command_derivation": {
+            "build_package_name": "ur5_airpick4_test",
+            "command": "ros2 launch ur5_airpick4_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "safe fake-hardware launch command recorded",
+            "package_name": "ur5_airpick4_test",
+            "safety": "not executed; fake hardware explicitly required",
+            "status": "PASS",
+            "warnings": []
+          },
+          "generated_scene_package_readiness_json": {
+            "message": "generated/scene_package_readiness.json is present and parseable",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene_package_readiness.json",
+            "status": "PASS",
+            "summary": {
+              "blockers": [
+                {
+                  "category": "supported_scene_catalog",
+                  "message": "post-regeneration readiness matrix: cell_definition_validation FAIL (cell_definition.yaml missing required top-level keys: camera, objects); Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker.",
+                  "status": "BLOCKED"
+                },
+                {
+                  "category": "ros_launch_smoke_skip_evaluation_state",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                }
+              ],
+              "build_package_name": "ur5_airpick4_test",
+              "builder_generated_scene_validation": {
+                "checks": [
+                  {
+                    "check": "package.xml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "CMakeLists.txt exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "environment.yaml exists",
+                    "ok": true
+                  },
+                  {
+                    "check": "workcell_builder_metadata.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/cell_definition.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/environment_layout.yaml present",
+                    "ok": false,
+                    "optional": true
+                  },
+                  {
+                    "check": "generated/workcell_builder_task_intent.yaml present",
+                    "ok": false,
+                    "optional": true
+                  }
+                ],
+                "discovered": {
+                  "end_effector_capability_id": null,
+                  "end_effector_name": null,
+                  "grasp_strategy_id": null,
+                  "object_count": 0,
+                  "robot_capability_id": null,
+                  "robot_name": null,
+                  "sensor_capability_id": null
+                },
+                "errors": [],
+                "export_validation": {},
+                "ok": true,
+                "readiness": "physical_scene_only",
+                "readiness_classification": "physical_scene_only",
+                "runtime_readiness": "runtime_blocked_or_preview_only",
+                "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test",
+                "suggested_next_actions": [
+                  "Create builder task intent to define pick/place/grasp."
+                ],
+                "task_flow_summary": {},
+                "task_intent": {},
+                "warnings": [
+                  "workcell_builder_metadata.yaml missing (optional)",
+                  "End-effector metadata not present in environment.yaml",
+                  "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+                  "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+                  "Task intent missing: physical scene only."
+                ]
+              },
+              "catalog_status": "blocked",
+              "categories": {
+                "cell_definition_validation": {
+                  "capabilities": {
+                    "capability_refs": {
+                      "end_effector": null,
+                      "environment_assets": [],
+                      "robot": null,
+                      "sensors": [],
+                      "task": null
+                    },
+                    "checks": {
+                      "events": [],
+                      "status": "FAIL"
+                    },
+                    "resolved": {}
+                  },
+                  "environment_layout": {},
+                  "errors": [
+                    "Missing required top-level key: camera",
+                    "Missing required top-level key: objects"
+                  ],
+                  "grasp_strategy": {
+                    "mode": "none",
+                    "ref": null,
+                    "resolved_path": null,
+                    "status": "PASS"
+                  },
+                  "message": "cell_definition.yaml has validation errors",
+                  "notes": [],
+                  "parser": "pyyaml",
+                  "status": "FAIL",
+                  "warnings": [
+                    "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                  ]
+                },
+                "cell_definition_yaml": {
+                  "message": "cell_definition.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/cell_definition.yaml",
+                  "status": "PASS"
+                },
+                "cmakelists_txt": {
+                  "message": "CMakeLists.txt exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/CMakeLists.txt",
+                  "status": "PASS"
+                },
+                "credible_physical_visual_evidence": {
+                  "mesh_failure_summary_by_reason_code": {},
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "physical_rendered_count": 0,
+                  "source_geometry_count": 3,
+                  "status": "FAIL"
+                },
+                "environment_yaml": {
+                  "message": "environment.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/environment.yaml",
+                  "status": "PASS"
+                },
+                "fake_hardware_launch_command_derivation": {
+                  "build_package_name": "ur5_airpick4_test",
+                  "command": "ros2 launch ur5_airpick4_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "safe fake-hardware launch command recorded",
+                  "package_name": "ur5_airpick4_test",
+                  "safety": "not executed; fake hardware explicitly required",
+                  "status": "PASS",
+                  "warnings": []
+                },
+                "generated_scene_package_readiness_json": {
+                  "message": "optional/generated-if-present readiness JSON is not present",
+                  "optional": true,
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene_package_readiness.json",
+                  "status": "PASS"
+                },
+                "generated_scene_visual_mesh_index_json": {
+                  "message": "generated/scene_visual_mesh_index.json exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json",
+                  "status": "PASS"
+                },
+                "launch_demo_launch_py": {
+                  "message": "launch/demo.launch.py exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/launch/demo.launch.py",
+                  "status": "PASS"
+                },
+                "layout_workcell_studio_layout_yaml": {
+                  "message": "layout/workcell_studio_layout.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/layout/workcell_studio_layout.yaml",
+                  "status": "PASS"
+                },
+                "manifest_local_file_references": {
+                  "checked": [
+                    {
+                      "field": "files.environment",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/environment.yaml",
+                      "reference": "environment.yaml"
+                    },
+                    {
+                      "field": "files.cell_definition",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/cell_definition.yaml",
+                      "reference": "cell_definition.yaml"
+                    },
+                    {
+                      "field": "files.layout",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/layout/workcell_studio_layout.yaml",
+                      "reference": "layout/workcell_studio_layout.yaml"
+                    },
+                    {
+                      "field": "files.launch",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/launch/demo.launch.py",
+                      "reference": "launch/demo.launch.py"
+                    },
+                    {
+                      "field": "files.urdf_xacro",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
+                      "reference": "urdf/scene.urdf.xacro"
+                    },
+                    {
+                      "field": "files.visual_mesh_index",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json",
+                      "reference": "generated/scene_visual_mesh_index.json"
+                    },
+                    {
+                      "field": "files.scene3d_gui_smoke",
+                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene3d_gui_smoke.json",
+                      "reference": "generated/scene3d_gui_smoke.json"
+                    }
+                  ],
+                  "message": "manifest local-file references resolved (7 checked)",
+                  "status": "PASS"
+                },
+                "package_xml": {
+                  "message": "package.xml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/package.xml",
+                  "status": "PASS"
+                },
+                "ros_launch_smoke_skip_evaluation_state": {
+                  "command": "ros2 launch ur5_airpick4_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+                  "status": "BLOCKED"
+                },
+                "scene3d_visual_quality_summary": {
+                  "blockers": [
+                    "mesh_source_count > 0 requires mesh_rendered_count > 0"
+                  ],
+                  "counters": {
+                    "credible_physical_rendered_count": 0,
+                    "diagnostic_fallback_count": 0,
+                    "helper_overlay_count": 0,
+                    "mesh_rendered_count": 0,
+                    "mesh_source_count": 3,
+                    "physical_rendered_count": 0,
+                    "primitive_rendered_count": 0,
+                    "primitive_source_count": 0,
+                    "total_payload_count": 3
+                  },
+                  "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene3d_gui_smoke.json",
+                  "status": "FAIL",
+                  "visual_quality_status": "FAIL",
+                  "warnings": []
+                },
+                "scene_manifest_yaml": {
+                  "message": "scene_manifest.yaml exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/scene_manifest.yaml",
+                  "status": "PASS"
+                },
+                "scene_package_exists": {
+                  "message": "scene package directory exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test",
+                  "status": "PASS"
+                },
+                "tool_metadata_consistency": {
+                  "errors": [
+                    "Tool metadata mismatch: cell_definition.yaml end_effector.id 'suction' does not match environment.yaml tool.id/profile 'robotiq_2f'."
+                  ],
+                  "message": "tool/end-effector metadata is inconsistent",
+                  "observed": {
+                    "cell_definition_end_effector_id": "suction",
+                    "environment_tool_id": "robotiq_2f",
+                    "manifest_end_effector_brand": "onrobot_airpick4_description",
+                    "manifest_end_effector_type": "suction"
+                  },
+                  "status": "FAIL"
+                },
+                "urdf_scene_urdf_xacro": {
+                  "message": "urdf/scene.urdf.xacro exists",
+                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
+                  "status": "PASS"
+                }
+              },
+              "commands": {
+                "build_command": "colcon build --symlink-install --packages-select ur5_airpick4_test",
+                "fake_hardware_launch_command": "ros2 launch ur5_airpick4_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+                "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_airpick4_test --json"
+              },
+              "failures": [
+                {
+                  "category": "cell_definition_validation",
+                  "message": "cell_definition.yaml has validation errors",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "credible_physical_visual_evidence",
+                  "message": "no credible physical mesh/primitive render evidence was recorded",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "scene3d_visual_quality_summary",
+                  "message": "Scene3D visual-quality evidence is blocked or failing",
+                  "status": "FAIL"
+                },
+                {
+                  "category": "tool_metadata_consistency",
+                  "message": "tool/end-effector metadata is inconsistent",
+                  "status": "FAIL"
+                }
+              ],
+              "generated_at": "2026-06-04T16:21:59.245618+00:00",
+              "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+              "offline_scene_readiness": {
+                "errors": [],
+                "inputs": {
+                  "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test",
+                  "workcell_root": null
+                },
+                "notes": [
+                  "ROS scene package detected (package.xml present)."
+                ],
+                "result": "WARN",
+                "scene_reports": [
+                  {
+                    "candidates": {
+                      "gripper": [
+                        "CMakeLists.txt",
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene3d_gui_smoke.json",
+                        "scene_manifest.yaml",
+                        "scene_visual_mesh_index.json",
+                        "workcell_builder_task_intent.yaml"
+                      ],
+                      "robot": [
+                        "CMakeLists.txt",
+                        "arm_hand.srdf.xacro",
+                        "cell_definition.yaml",
+                        "environment.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro",
+                        "scene3d_gui_smoke.json",
+                        "scene_manifest.yaml",
+                        "scene_visual_mesh_index.json",
+                        "workcell_builder_task_intent.yaml",
+                        "workcell_studio_layout.generated.yaml",
+                        "workcell_studio_layout.yaml"
+                      ],
+                      "sensor": [
+                        "environment.yaml",
+                        "environment_assets.yaml",
+                        "package.xml",
+                        "scene.urdf.xacro"
+                      ]
+                    },
+                    "counts": {
+                      "files": 16,
+                      "meshes": 0,
+                      "urdf_xacro": 2
+                    },
+                    "errors": [],
+                    "frames": {
+                      "base_link": 3,
+                      "camera_link": 2,
+                      "tool0": 8,
+                      "world": 16
+                    },
+                    "mesh_extensions_detected": [],
+                    "notes": [
+                      "ROS scene package detected (package.xml present)."
+                    ],
+                    "placed_objects": {
+                      "absolute_external_mesh_warnings": [],
+                      "count": 0,
+                      "found_in_generated_urdf_xacro": false,
+                      "found_names": [],
+                      "invalid_mesh_warnings": [],
+                      "missing_collision_mesh_warnings": [],
+                      "missing_names": []
+                    },
+                    "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test",
+                    "task_zones": {
+                      "duplicate_ids": [],
+                      "invalid_dimensions": [],
+                      "pick": 0,
+                      "place": 0,
+                      "total": 0,
+                      "zone_ids": []
+                    },
+                    "warnings": [
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+                      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find onrobot_airpick4_moveit_config)/config/onrobot_airpick4_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Referenced mesh path not found: $(find onrobot_airpick4_description)/urdf/onrobot_airpick4_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                      "Task intent place.target.id not found in task_zones: place_zone_main",
+                      "Legacy compatibility: robot_mount missing.",
+                      "Legacy compatibility: tool_attachment missing.",
+                      "Legacy compatibility: recommended gripper orientation not used."
+                    ]
+                  }
+                ],
+                "strict": false,
+                "summary": {
+                  "errors": 0,
+                  "scene_packages_checked": 1,
+                  "warnings": 15
+                },
+                "warnings": [
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+                  "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find onrobot_airpick4_moveit_config)/config/onrobot_airpick4_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                  "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Referenced mesh path not found: $(find onrobot_airpick4_description)/urdf/onrobot_airpick4_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                  "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                  "Task intent place.target.id not found in task_zones: place_zone_main",
+                  "Legacy compatibility: robot_mount missing.",
+                  "Legacy compatibility: tool_attachment missing.",
+                  "Legacy compatibility: recommended gripper orientation not used."
+                ]
+              },
+              "overall_status": "BLOCKED",
+              "package_name": "ur5_airpick4_test",
+              "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+              "readiness_status": "BLOCKED",
+              "ros_humble_available": false,
+              "safe_command_warnings": [],
+              "safety": {
+                "fake_hardware_default": true,
+                "motion_command_sent": false,
+                "real_hardware_enabled": false,
+                "ros_launch_executed_by_matrix": false,
+                "runtime_execution_called": false,
+                "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+              },
+              "scene_name": "ur5_airpick4_test",
+              "scene_path": "scenes/ur5_airpick4_test",
+              "schema_version": "workcell_studio_scene_package_readiness/v1",
+              "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+              "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+              "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+              "support_level": "supported",
+              "warnings": [
+                {
+                  "category": "cell_definition_validation",
+                  "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+                }
+              ],
+              "workcell_builder_executable_found": false
+            }
+          },
+          "generated_scene_visual_mesh_index_json": {
+            "message": "generated/scene_visual_mesh_index.json exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json",
+            "status": "PASS"
+          },
+          "launch_demo_launch_py": {
+            "message": "launch/demo.launch.py exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/launch/demo.launch.py",
+            "status": "PASS"
+          },
+          "layout_workcell_studio_layout_yaml": {
+            "message": "layout/workcell_studio_layout.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/layout/workcell_studio_layout.yaml",
+            "status": "PASS"
+          },
+          "manifest_local_file_references": {
+            "checked": [
+              {
+                "field": "files.environment",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/environment.yaml",
+                "reference": "environment.yaml"
+              },
+              {
+                "field": "files.cell_definition",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/cell_definition.yaml",
+                "reference": "cell_definition.yaml"
+              },
+              {
+                "field": "files.layout",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/layout/workcell_studio_layout.yaml",
+                "reference": "layout/workcell_studio_layout.yaml"
+              },
+              {
+                "field": "files.launch",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/launch/demo.launch.py",
+                "reference": "launch/demo.launch.py"
+              },
+              {
+                "field": "files.urdf_xacro",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
+                "reference": "urdf/scene.urdf.xacro"
+              },
+              {
+                "field": "files.visual_mesh_index",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json",
+                "reference": "generated/scene_visual_mesh_index.json"
+              },
+              {
+                "field": "files.scene3d_gui_smoke",
+                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene3d_gui_smoke.json",
+                "reference": "generated/scene3d_gui_smoke.json"
+              }
+            ],
+            "message": "manifest local-file references resolved (7 checked)",
+            "status": "PASS"
+          },
+          "package_xml": {
+            "message": "package.xml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/package.xml",
+            "status": "PASS"
+          },
+          "ros_launch_smoke_skip_evaluation_state": {
+            "command": "ros2 launch ur5_airpick4_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          },
+          "scene3d_visual_quality_summary": {
+            "blockers": [
+              "mesh_source_count > 0 requires mesh_rendered_count > 0"
+            ],
+            "counters": {
+              "credible_physical_rendered_count": 0,
+              "diagnostic_fallback_count": 0,
+              "helper_overlay_count": 0,
+              "mesh_rendered_count": 0,
+              "mesh_source_count": 3,
+              "physical_rendered_count": 0,
+              "primitive_rendered_count": 0,
+              "primitive_source_count": 0,
+              "total_payload_count": 3
+            },
+            "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene3d_gui_smoke.json",
+            "status": "FAIL",
+            "visual_quality_status": "FAIL",
+            "warnings": []
+          },
+          "scene_manifest_yaml": {
+            "message": "scene_manifest.yaml exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/scene_manifest.yaml",
+            "status": "PASS"
+          },
+          "scene_package_exists": {
+            "message": "scene package directory exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test",
+            "status": "PASS"
+          },
+          "tool_metadata_consistency": {
+            "errors": [
+              "Tool metadata mismatch: cell_definition.yaml end_effector.id 'suction' does not match environment.yaml tool.id/profile 'robotiq_2f'."
+            ],
+            "message": "tool/end-effector metadata is inconsistent",
+            "observed": {
+              "cell_definition_end_effector_id": "suction",
+              "environment_tool_id": "robotiq_2f",
+              "manifest_end_effector_brand": "onrobot_airpick4_description",
+              "manifest_end_effector_type": "suction"
+            },
+            "status": "FAIL"
+          },
+          "urdf_scene_urdf_xacro": {
+            "message": "urdf/scene.urdf.xacro exists",
+            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
+            "status": "PASS"
+          }
+        },
+        "commands": {
+          "build_command": "colcon build --symlink-install --packages-select ur5_airpick4_test",
+          "fake_hardware_launch_command": "ros2 launch ur5_airpick4_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+          "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_airpick4_test --json"
+        },
+        "failures": [
+          {
+            "category": "cell_definition_validation",
+            "message": "cell_definition.yaml has validation errors",
+            "status": "FAIL"
+          },
+          {
+            "category": "credible_physical_visual_evidence",
+            "message": "no credible physical mesh/primitive render evidence was recorded",
+            "status": "FAIL"
+          },
+          {
+            "category": "scene3d_visual_quality_summary",
+            "message": "Scene3D visual-quality evidence is blocked or failing",
+            "status": "FAIL"
+          },
+          {
+            "category": "tool_metadata_consistency",
+            "message": "tool/end-effector metadata is inconsistent",
+            "status": "FAIL"
+          }
+        ],
+        "generated_at": "2026-06-04T16:23:19.093332+00:00",
+        "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+        "offline_scene_readiness": {
+          "errors": [],
+          "inputs": {
+            "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test",
+            "workcell_root": null
+          },
+          "notes": [
+            "ROS scene package detected (package.xml present)."
+          ],
+          "result": "WARN",
+          "scene_reports": [
+            {
+              "candidates": {
+                "gripper": [
+                  "CMakeLists.txt",
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene3d_gui_smoke.json",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json",
+                  "workcell_builder_task_intent.yaml"
+                ],
+                "robot": [
+                  "CMakeLists.txt",
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene3d_gui_smoke.json",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json",
+                  "workcell_builder_task_intent.yaml",
+                  "workcell_studio_layout.generated.yaml",
+                  "workcell_studio_layout.yaml"
+                ],
+                "sensor": [
+                  "environment.yaml",
+                  "environment_assets.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene_package_readiness.json"
+                ]
+              },
+              "counts": {
+                "files": 17,
+                "meshes": 0,
+                "urdf_xacro": 2
+              },
+              "errors": [],
+              "frames": {
+                "base_link": 4,
+                "camera_link": 3,
+                "tool0": 9,
+                "world": 17
+              },
+              "mesh_extensions_detected": [],
+              "notes": [
+                "ROS scene package detected (package.xml present)."
+              ],
+              "placed_objects": {
+                "absolute_external_mesh_warnings": [],
+                "count": 0,
+                "found_in_generated_urdf_xacro": false,
+                "found_names": [],
+                "invalid_mesh_warnings": [],
+                "missing_collision_mesh_warnings": [],
+                "missing_names": []
+              },
+              "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test",
+              "task_zones": {
+                "duplicate_ids": [],
+                "invalid_dimensions": [],
+                "pick": 0,
+                "place": 0,
+                "total": 0,
+                "zone_ids": []
+              },
+              "warnings": [
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+                "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find onrobot_airpick4_moveit_config)/config/onrobot_airpick4_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find onrobot_airpick4_description)/urdf/onrobot_airpick4_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Task intent pick.source.id not found in task_zones: pick_zone_main",
+                "Task intent place.target.id not found in task_zones: place_zone_main",
+                "Legacy compatibility: robot_mount missing.",
+                "Legacy compatibility: tool_attachment missing.",
+                "Legacy compatibility: recommended gripper orientation not used."
+              ]
+            }
+          ],
+          "strict": false,
+          "summary": {
+            "errors": 0,
+            "scene_packages_checked": 1,
+            "warnings": 21
+          },
+          "warnings": [
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+            "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find onrobot_airpick4_moveit_config)/config/onrobot_airpick4_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find onrobot_airpick4_description)/urdf/onrobot_airpick4_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Task intent pick.source.id not found in task_zones: pick_zone_main",
+            "Task intent place.target.id not found in task_zones: place_zone_main",
+            "Legacy compatibility: robot_mount missing.",
+            "Legacy compatibility: tool_attachment missing.",
+            "Legacy compatibility: recommended gripper orientation not used."
+          ]
+        },
+        "overall_status": "BLOCKED",
+        "package_name": "ur5_airpick4_test",
+        "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+        "readiness_status": "BLOCKED",
+        "ros_humble_available": false,
+        "safe_command_warnings": [],
+        "safety": {
+          "fake_hardware_default": true,
+          "motion_command_sent": false,
+          "real_hardware_enabled": false,
+          "ros_launch_executed_by_matrix": false,
+          "runtime_execution_called": false,
+          "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+        },
+        "scene_name": "ur5_airpick4_test",
+        "scene_path": "scenes/ur5_airpick4_test",
+        "schema_version": "workcell_studio_scene_package_readiness/v1",
+        "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+        "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+        "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+        "support_level": "supported",
+        "warnings": [
+          {
+            "category": "cell_definition_validation",
+            "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+          }
+        ],
+        "workcell_builder_executable_found": false
+      }
+    },
+    "generated_scene_visual_mesh_index_json": {
+      "message": "generated/scene_visual_mesh_index.json exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json",
+      "status": "PASS"
+    },
+    "launch_demo_launch_py": {
+      "message": "launch/demo.launch.py exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/launch/demo.launch.py",
+      "status": "PASS"
+    },
+    "layout_workcell_studio_layout_yaml": {
+      "message": "layout/workcell_studio_layout.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/layout/workcell_studio_layout.yaml",
+      "status": "PASS"
+    },
+    "manifest_local_file_references": {
+      "checked": [
+        {
+          "field": "files.environment",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/environment.yaml",
+          "reference": "environment.yaml"
+        },
+        {
+          "field": "files.cell_definition",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/cell_definition.yaml",
+          "reference": "cell_definition.yaml"
+        },
+        {
+          "field": "files.layout",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/layout/workcell_studio_layout.yaml",
+          "reference": "layout/workcell_studio_layout.yaml"
+        },
+        {
+          "field": "files.launch",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/launch/demo.launch.py",
+          "reference": "launch/demo.launch.py"
+        },
+        {
+          "field": "files.urdf_xacro",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
+          "reference": "urdf/scene.urdf.xacro"
+        },
+        {
+          "field": "files.visual_mesh_index",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json",
+          "reference": "generated/scene_visual_mesh_index.json"
+        },
+        {
+          "field": "files.scene3d_gui_smoke",
+          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene3d_gui_smoke.json",
+          "reference": "generated/scene3d_gui_smoke.json"
+        }
+      ],
+      "message": "manifest local-file references resolved (7 checked)",
+      "status": "PASS"
+    },
+    "package_xml": {
+      "message": "package.xml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/package.xml",
+      "status": "PASS"
+    },
+    "ros_launch_smoke_skip_evaluation_state": {
+      "command": "ros2 launch ur5_airpick4_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+      "status": "BLOCKED"
+    },
+    "scene3d_visual_quality_summary": {
+      "blockers": [
+        "mesh_source_count > 0 requires mesh_rendered_count > 0"
+      ],
+      "counters": {
+        "credible_physical_rendered_count": 0,
+        "diagnostic_fallback_count": 0,
+        "helper_overlay_count": 0,
+        "mesh_rendered_count": 0,
+        "mesh_source_count": 3,
+        "physical_rendered_count": 0,
+        "primitive_rendered_count": 0,
+        "primitive_source_count": 0,
+        "total_payload_count": 3
+      },
+      "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene_visual_mesh_index.json",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/generated/scene3d_gui_smoke.json",
+      "status": "FAIL",
+      "visual_quality_status": "FAIL",
+      "warnings": []
+    },
+    "scene_manifest_yaml": {
+      "message": "scene_manifest.yaml exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/scene_manifest.yaml",
+      "status": "PASS"
+    },
+    "scene_package_exists": {
+      "message": "scene package directory exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test",
+      "status": "PASS"
+    },
+    "tool_metadata_consistency": {
+      "errors": [
+        "Tool metadata mismatch: cell_definition.yaml end_effector.id 'suction' resolves to 'suction' but environment.yaml tool.id/profile 'robotiq_2f' resolves to 'two_finger_gripper'."
+      ],
+      "message": "tool/end-effector metadata is inconsistent",
+      "observed": {
+        "cell_definition_end_effector_id": "suction",
+        "cell_definition_family": "suction",
+        "environment_tool_family": "two_finger_gripper",
+        "environment_tool_id": "robotiq_2f",
+        "manifest_end_effector_brand": "onrobot_airpick4_description",
+        "manifest_end_effector_family": "suction",
+        "manifest_end_effector_type": "suction"
+      },
+      "status": "FAIL",
+      "warnings": []
+    },
+    "urdf_scene_urdf_xacro": {
+      "message": "urdf/scene.urdf.xacro exists",
+      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test/urdf/scene.urdf.xacro",
+      "status": "PASS"
+    }
+  },
+  "commands": {
+    "build_command": "colcon build --symlink-install --packages-select ur5_airpick4_test",
+    "fake_hardware_launch_command": "ros2 launch ur5_airpick4_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+    "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_airpick4_test --json"
+  },
+  "failures": [
+    {
+      "category": "cell_definition_validation",
+      "message": "cell_definition.yaml has validation errors",
+      "status": "FAIL"
+    },
+    {
+      "category": "credible_physical_visual_evidence",
+      "message": "no credible physical mesh/primitive render evidence was recorded",
+      "status": "FAIL"
+    },
+    {
+      "category": "scene3d_visual_quality_summary",
+      "message": "Scene3D visual-quality evidence is blocked or failing",
+      "status": "FAIL"
+    },
+    {
+      "category": "tool_metadata_consistency",
+      "message": "tool/end-effector metadata is inconsistent",
+      "status": "FAIL"
+    }
+  ],
+  "generated_at": "2026-06-04T16:24:50.479471+00:00",
+  "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+  "offline_scene_readiness": {
+    "errors": [],
+    "inputs": {
+      "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test",
+      "workcell_root": null
+    },
+    "notes": [
+      "ROS scene package detected (package.xml present)."
+    ],
+    "result": "WARN",
+    "scene_reports": [
+      {
+        "candidates": {
+          "gripper": [
+            "CMakeLists.txt",
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene3d_gui_smoke.json",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json",
+            "scene_visual_mesh_index.json",
+            "workcell_builder_task_intent.yaml"
+          ],
+          "robot": [
+            "CMakeLists.txt",
+            "arm_hand.srdf.xacro",
+            "cell_definition.yaml",
+            "environment.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene3d_gui_smoke.json",
+            "scene_manifest.yaml",
+            "scene_package_readiness.json",
+            "scene_visual_mesh_index.json",
+            "workcell_builder_task_intent.yaml",
+            "workcell_studio_layout.generated.yaml",
+            "workcell_studio_layout.yaml"
+          ],
+          "sensor": [
+            "environment.yaml",
+            "environment_assets.yaml",
+            "package.xml",
+            "scene.urdf.xacro",
+            "scene_package_readiness.json"
+          ]
+        },
+        "counts": {
+          "files": 17,
+          "meshes": 0,
+          "urdf_xacro": 2
+        },
+        "errors": [],
+        "frames": {
+          "base_link": 5,
+          "camera_link": 4,
+          "tool0": 10,
+          "world": 18
+        },
+        "mesh_extensions_detected": [],
+        "notes": [
+          "ROS scene package detected (package.xml present)."
+        ],
+        "placed_objects": {
+          "absolute_external_mesh_warnings": [],
+          "count": 0,
+          "found_in_generated_urdf_xacro": false,
+          "found_names": [],
+          "invalid_mesh_warnings": [],
+          "missing_collision_mesh_warnings": [],
+          "missing_names": []
+        },
+        "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_airpick4_test",
+        "task_zones": {
+          "duplicate_ids": [],
+          "invalid_dimensions": [],
+          "pick": 0,
+          "place": 0,
+          "total": 0,
+          "zone_ids": []
+        },
+        "warnings": [
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+          "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find onrobot_airpick4_moveit_config)/config/onrobot_airpick4_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find onrobot_airpick4_description)/urdf/onrobot_airpick4_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Task intent pick.source.id not found in task_zones: pick_zone_main",
+          "Task intent place.target.id not found in task_zones: place_zone_main",
+          "Legacy compatibility: robot_mount missing.",
+          "Legacy compatibility: tool_attachment missing.",
+          "Legacy compatibility: recommended gripper orientation not used."
+        ]
+      }
+    ],
+    "strict": false,
+    "summary": {
+      "errors": 0,
+      "scene_packages_checked": 1,
+      "warnings": 39
+    },
+    "warnings": [
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/meshes/airpick4.stl",
+      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find onrobot_airpick4_moveit_config)/config/onrobot_airpick4_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find onrobot_airpick4_description)/urdf/onrobot_airpick4_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Task intent pick.source.id not found in task_zones: pick_zone_main",
+      "Task intent place.target.id not found in task_zones: place_zone_main",
+      "Legacy compatibility: robot_mount missing.",
+      "Legacy compatibility: tool_attachment missing.",
+      "Legacy compatibility: recommended gripper orientation not used."
+    ]
+  },
+  "overall_status": "BLOCKED",
+  "package_name": "ur5_airpick4_test",
+  "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+  "readiness_status": "BLOCKED",
+  "ros_humble_available": false,
+  "safe_command_warnings": [],
+  "safety": {
+    "fake_hardware_default": true,
+    "motion_command_sent": false,
+    "real_hardware_enabled": false,
+    "ros_launch_executed_by_matrix": false,
+    "runtime_execution_called": false,
+    "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+  },
+  "scene_name": "ur5_airpick4_test",
+  "scene_path": "scenes/ur5_airpick4_test",
+  "schema_version": "workcell_studio_scene_package_readiness/v1",
+  "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
+  "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+  "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+  "support_level": "supported",
+  "warnings": [
+    {
+      "category": "cell_definition_validation",
+      "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+    }
+  ],
+  "workcell_builder_executable_found": false
+}

--- a/scripts/run_workcell_studio_scene_readiness_matrix.py
+++ b/scripts/run_workcell_studio_scene_readiness_matrix.py
@@ -210,6 +210,89 @@ def _check_manifest_refs(scene_dir: Path) -> dict[str, Any]:
     return _result(PASS, f"manifest local-file references resolved ({len(checked)} checked)", checked=checked)
 
 
+def _check_tool_metadata_consistency(scene_dir: Path) -> dict[str, Any]:
+    """Check that scene-local tool declarations do not contradict each other.
+
+    This is intentionally metadata-only and does not resolve ROS packages.  It
+    preserves known blocked/failing states such as a scene folder declaring one
+    end effector in cell_definition.yaml while environment.yaml or
+    scene_manifest.yaml advertises another/no tool.
+    """
+    observed: dict[str, Any] = {}
+    errors: list[str] = []
+
+    cell_path = scene_dir / "cell_definition.yaml"
+    env_path = scene_dir / "environment.yaml"
+    manifest_path = scene_dir / "scene_manifest.yaml"
+
+    cell, cell_error = _load_yaml_file(cell_path) if cell_path.is_file() else ({}, None)
+    env, env_error = _load_yaml_file(env_path) if env_path.is_file() else ({}, None)
+    manifest, manifest_error = _load_yaml_file(manifest_path) if manifest_path.is_file() else ({}, None)
+
+    for label, error in (("cell_definition.yaml", cell_error), ("environment.yaml", env_error), ("scene_manifest.yaml", manifest_error)):
+        if error:
+            errors.append(f"{label} is not parseable for tool consistency check: {error}")
+
+    cell_ee = cell.get("end_effector") if isinstance(cell, dict) and isinstance(cell.get("end_effector"), dict) else {}
+    env_tool = env.get("tool") if isinstance(env, dict) and isinstance(env.get("tool"), dict) else {}
+    manifest_ee = manifest.get("end_effector") if isinstance(manifest, dict) and isinstance(manifest.get("end_effector"), dict) else {}
+
+    cell_ee_id = str(cell_ee.get("id") or cell_ee.get("capability") or "").strip()
+    env_tool_id = str(env_tool.get("id") or env_tool.get("profile") or "").strip()
+    manifest_ee_type = str(manifest_ee.get("type") or "").strip()
+    manifest_ee_brand = str(manifest_ee.get("brand") or "").strip()
+
+    def family(value: str) -> str | None:
+        lowered = value.lower()
+        if "3f" in lowered or "three" in lowered:
+            return "three_finger_gripper"
+        if "2f" in lowered or "two" in lowered:
+            return "two_finger_gripper"
+        if "suction" in lowered or "vacuum" in lowered or "airpick" in lowered:
+            return "suction"
+        if "finger" in lowered or "gripper" in lowered:
+            return "finger_gripper"
+        if lowered == "none":
+            return "none"
+        return None
+
+    cell_family = family(cell_ee_id)
+    env_family = family(env_tool_id)
+    manifest_family = family(manifest_ee_type)
+    warnings: list[str] = []
+    observed = {
+        "cell_definition_end_effector_id": cell_ee_id or None,
+        "environment_tool_id": env_tool_id or None,
+        "manifest_end_effector_type": manifest_ee_type or None,
+        "manifest_end_effector_brand": manifest_ee_brand or None,
+        "cell_definition_family": cell_family,
+        "environment_tool_family": env_family,
+        "manifest_end_effector_family": manifest_family,
+    }
+
+    if cell_ee_id and env_tool_id and cell_ee_id != env_tool_id:
+        if cell_family and env_family and cell_family != env_family:
+            errors.append(
+                "Tool metadata mismatch: cell_definition.yaml end_effector.id "
+                f"'{cell_ee_id}' resolves to '{cell_family}' but environment.yaml tool.id/profile "
+                f"'{env_tool_id}' resolves to '{env_family}'."
+            )
+        else:
+            warnings.append(
+                "Tool metadata names differ but resolve to the same broad family: "
+                f"cell_definition.yaml end_effector.id '{cell_ee_id}', environment.yaml tool.id/profile '{env_tool_id}'."
+            )
+    if manifest_family == "none" and (cell_ee_id or env_tool_id):
+        errors.append(
+            "Tool metadata mismatch: scene_manifest.yaml end_effector.type is 'none' "
+            "while scene-local tool/end_effector metadata declares a tool."
+        )
+
+    if errors:
+        return _result(FAIL, "tool/end-effector metadata is inconsistent", observed=observed, errors=errors, warnings=warnings)
+    return _result(PASS, "tool/end-effector metadata has no explicit contradictions", observed=observed, warnings=warnings)
+
+
 def _check_cell_definition(scene_dir: Path) -> dict[str, Any]:
     path = scene_dir / "cell_definition.yaml"
     if not path.is_file():
@@ -355,6 +438,7 @@ def _evaluate_scene(repo_root: Path, entry: Any, ros_available: bool) -> dict[st
         categories[key] = _check_readiness_json(scene_dir) if key == "generated_scene_package_readiness_json" else _check_file(scene_dir, rel_path, required=required)
 
     categories["cell_definition_validation"] = _check_cell_definition(scene_dir)
+    categories["tool_metadata_consistency"] = _check_tool_metadata_consistency(scene_dir)
     categories["manifest_local_file_references"] = _check_manifest_refs(scene_dir)
 
     scene3d_summary, physical_visual = _check_scene3d(entry.scene_name, scene_dir)


### PR DESCRIPTION
### Motivation
- Ensure each supported scene has an up-to-date `generated/scene_package_readiness.json` that records the actual current readiness evidence rather than flipping states to PASS. 
- Preserve known BLOCKED/FAIL conditions such as missing ROS Humble, unavailable `workcell_builder` executable, missing `camera`/`objects` keys, and the `ur5_3f_test` tool mismatch. 
- Surface simple scene-local tool/end-effector contradictions in the matrix so those failures are not hidden by higher-level summary logic.

### Description
- Added a metadata-only `_check_tool_metadata_consistency` function to `scripts/run_workcell_studio_scene_readiness_matrix.py` that compares `cell_definition.yaml`, `environment.yaml`, and `scene_manifest.yaml` tool/end-effector declarations and reports PASS/WARN/FAIL accordingly. 
- Plumbed the new `tool_metadata_consistency` category into the matrix evaluation so it appears alongside `cell_definition_validation` and other categories. 
- Used the existing scene-readiness matrix output to write or refresh `scenes/<scene>/generated/scene_package_readiness.json` for the requested supported scenes, embedding category-level evidence and an explicit `pass_policy` that a scene may only be marked PASS if the source matrix reports PASS. 
- Affected scenes: `suction_test`, `ur10_2f_test`, `ur3_suction_test`, `ur5_2f_builder_pick_place_demo`, `ur5_2f_sorting_test`, `ur5_2f_test`, `ur5_3f_test`, and `ur5_airpick4_test`.

### Testing
- Ran `python3 -m py_compile scripts/run_workcell_studio_scene_readiness_matrix.py` and the script compiled successfully. 
- Ran `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --supported-scenes scenes/supported_scenes.yaml --output-dir build/workcell_studio_scene_readiness` and it wrote the summary JSON/MD and reported `PASS=0 FAIL=0 BLOCKED=8`. 
- Generated per-scene artifacts with a validation script that asserted each `scenes/<name>/generated/scene_package_readiness.json` is parseable, does not convert non-PASS matrix statuses to PASS, and preserves the `ur5_3f_test` tool mismatch as a FAIL; these checks passed. 
- Verified the artifacts explicitly record unsafe-to-execute conditions (missing ROS Humble / missing `workcell_builder` executable) and preserve `cell_definition.yaml` validation failures where present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a59df060833198fa15788c514f1a)