### PR TITLE
Align ur5_3f_test with Robotiq 3F capability and surface precise Scene3D smoke blocker

### DIFF
--- a/scenes/supported_scenes.yaml
+++ b/scenes/supported_scenes.yaml
@@ -109,7 +109,7 @@ scenes:
     scene_path: scenes/ur5_3f_test
     support_level: supported
     status: blocked
-    known_blocker: "post-regeneration readiness matrix: static cell_definition camera/object contract has been restored; Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable. The scene_visual_mesh_index.json artifact has been regenerated with repo-local xacro-lite expansion and is no longer the catalog blocker."
+    known_blocker: "3F contract aligned across manifest, cell_definition, environment, and URDF using the bundled robotiq_3f capability/assets; remaining blocker is Scene3D runtime smoke evidence because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable, so install/source the ROS Humble workcell_builder executable and rerun the scene smoke/readiness matrix."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_3f_test --json

--- a/scenes/ur5_3f_test/cell_definition.yaml
+++ b/scenes/ur5_3f_test/cell_definition.yaml
@@ -4,6 +4,7 @@ cell:
   name: ur5_3f_test
 robot:
   model: ur5
+  capability: ur5
   planning_group: manipulator
   base_frame: world
   tool_link: tool0
@@ -11,6 +12,7 @@ robot:
   safe_joint_state: []
 end_effector:
   id: robotiq_3f
+  capability: robotiq_3f
   type: finger
   brand: robotiq
   grasp_frame: tool0

--- a/scenes/ur5_3f_test/environment.yaml
+++ b/scenes/ur5_3f_test/environment.yaml
@@ -6,12 +6,13 @@ robot:
   id: ur5
   profile: ur5
 tool:
-  id: robotiq_2f
-  profile: robotiq_2f
+  id: robotiq_3f
+  profile: robotiq_3f
+  capability: robotiq_3f
 compatibility:
   status: COMPATIBLE
   robot: ur5
-  tool: robotiq_2f
+  tool: robotiq_3f
 placed_objects:
 camera:
   enabled: false

--- a/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_3f_test/generated/scene_visual_mesh_index.json
@@ -1,35 +1,762 @@
 {
   "scene_name": "ur5_3f_test",
-  "visual_count": 2,
-  "resolved": 2,
+  "visual_count": 15,
+  "resolved": 15,
   "unresolved": 0,
-  "generated_at": "2026-06-03T14:54:14.601633+00:00",
+  "generated_at": "2026-06-04T16:24:48.253653+00:00",
   "extractor_version": "2.5",
   "extraction_mode": "xacro_lite_expanded",
   "xacro_available": false,
   "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_3f_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1780498117.494885,
+  "source_mtime": 1780590219.221703,
   "source_expanded_urdf_path": "",
   "fallback_reason": "xacro executable unavailable; used safe repo-local xacro-lite expansion; skipped unresolved macros: ur_robot",
   "safe_for_preview": true,
   "unresolved_placeholder_count": 0,
-  "has_transform_collapse_warning": true,
-  "candidate_mesh_count": 2,
-  "emitted_visual_count": 2,
+  "has_transform_collapse_warning": false,
+  "candidate_mesh_count": 15,
+  "emitted_visual_count": 15,
   "transform_status_counts": {
+    "unresolved": 13,
     "resolved": 2
   },
   "mesh_format_counts": {
-    ".stl": 1,
-    ".dae": 1
+    ".dae": 14,
+    ".stl": 1
   },
-  "renderable_mesh_count": 2,
-  "renderable_item_count": 2,
+  "renderable_mesh_count": 15,
+  "renderable_item_count": 15,
   "stale_index": false,
   "stale_reasons": [],
   "visual_items": [
     {
-      "id": "urdf_visual_0_table_None",
+      "id": "urdf_visual_0_finger_1_link_0_visual_0",
+      "link": "finger_1_link_0",
+      "visual": "visual_0",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.045515926534214234,
+          0.04139999365809699,
+          0.03600014692820413
+        ],
+        "rpy": [
+          3.141592653589793,
+          -7.3464102067096675e-06,
+          1.5715926535897933
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.02,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "green",
+        "color": [
+          0.0,
+          1.0,
+          0.0,
+          1.0
+        ]
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->palm(fixed)",
+        "palm->finger_1_link_0(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae",
+      "source_path": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_1_finger_1_link_1_visual_1",
+      "link": "finger_1_link_1",
+      "visual": "visual_1",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.07355573399184119,
+          0.09137768065543894,
+          0.03600051424871446
+        ],
+        "rpy": [
+          3.141589003304477,
+          -6.37535567914814e-06,
+          2.0915926536014293
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.05,
+          -0.028,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          -0.52
+        ]
+      },
+      "material": {
+        "name": "green",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->palm(fixed)",
+        "palm->finger_1_link_0(revolute)",
+        "finger_1_link_0->finger_1_link_1(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae",
+      "source_path": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_2_finger_1_link_2_visual_2",
+      "link": "finger_1_link_2",
+      "visual": "visual_2",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.09296100490349389,
+          0.12520724155075139,
+          0.028500762887788335
+        ],
+        "rpy": [
+          3.141589003304477,
+          -6.37535567914814e-06,
+          2.0915926536014293
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.039,
+          0.0,
+          0.0075
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "green",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->palm(fixed)",
+        "palm->finger_1_link_0(revolute)",
+        "finger_1_link_0->finger_1_link_1(revolute)",
+        "finger_1_link_1->finger_1_link_2(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae",
+      "source_path": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_3_finger_1_link_3_visual_3",
+      "link": "finger_1_link_3",
+      "visual": "visual_3",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.09296100485961782,
+          0.1252071864526923,
+          0.03600076288758595
+        ],
+        "rpy": [
+          3.141592653589793,
+          -7.3464102067096675e-06,
+          1.5715926535897933
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.52
+        ]
+      },
+      "material": {
+        "name": "green",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->palm(fixed)",
+        "palm->finger_1_link_0(revolute)",
+        "finger_1_link_0->finger_1_link_1(revolute)",
+        "finger_1_link_1->finger_1_link_2(revolute)",
+        "finger_1_link_2->finger_1_link_3(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae",
+      "source_path": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_4_finger_2_link_0_visual_4",
+      "link": "finger_2_link_0",
+      "visual": "visual_4",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.045515926534214234,
+          0.04139999365809699,
+          -0.035999853071795866
+        ],
+        "rpy": [
+          3.141592653589793,
+          -7.3464102067096675e-06,
+          1.5715926535897933
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.02,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "green",
+        "color": [
+          0.0,
+          1.0,
+          0.0,
+          1.0
+        ]
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->palm(fixed)",
+        "palm->finger_2_link_0(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae",
+      "source_path": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_5_finger_2_link_1_visual_5",
+      "link": "finger_2_link_1",
+      "visual": "visual_5",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.07355573399184119,
+          0.09137768065543894,
+          -0.03599948575128553
+        ],
+        "rpy": [
+          3.141589003304477,
+          -6.37535567914814e-06,
+          2.0915926536014293
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.05,
+          -0.028,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          -0.52
+        ]
+      },
+      "material": {
+        "name": "green",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->palm(fixed)",
+        "palm->finger_2_link_0(revolute)",
+        "finger_2_link_0->finger_2_link_1(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae",
+      "source_path": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_6_finger_2_link_2_visual_6",
+      "link": "finger_2_link_2",
+      "visual": "visual_6",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.09296100490349389,
+          0.12520724155075139,
+          -0.04349923711221166
+        ],
+        "rpy": [
+          3.141589003304477,
+          -6.37535567914814e-06,
+          2.0915926536014293
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.039,
+          0.0,
+          0.0075
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "green",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->palm(fixed)",
+        "palm->finger_2_link_0(revolute)",
+        "finger_2_link_0->finger_2_link_1(revolute)",
+        "finger_2_link_1->finger_2_link_2(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae",
+      "source_path": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_7_finger_2_link_3_visual_7",
+      "link": "finger_2_link_3",
+      "visual": "visual_7",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          -0.09296100485961782,
+          0.1252071864526923,
+          -0.03599923711241405
+        ],
+        "rpy": [
+          3.141592653589793,
+          -7.3464102067096675e-06,
+          1.5715926535897933
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.52
+        ]
+      },
+      "material": {
+        "name": "green",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->palm(fixed)",
+        "palm->finger_2_link_0(revolute)",
+        "finger_2_link_0->finger_2_link_1(revolute)",
+        "finger_2_link_1->finger_2_link_2(revolute)",
+        "finger_2_link_2->finger_2_link_3(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae",
+      "source_path": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_8_finger_middle_link_0_visual_8",
+      "link": "finger_middle_link_0",
+      "visual": "visual_8",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.045515926534214664,
+          0.04139999365863669,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          1.57
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.02,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "green",
+        "color": [
+          0.0,
+          1.0,
+          0.0,
+          1.0
+        ]
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->palm(fixed)",
+        "palm->finger_middle_link_0(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae",
+      "source_path": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_0.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_9_finger_middle_link_1_visual_9",
+      "link": "finger_middle_link_1",
+      "visual": "visual_9",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.0735557339918427,
+          0.09137768065732789,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          1.05
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.05,
+          -0.028,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          -0.52
+        ]
+      },
+      "material": {
+        "name": "green",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->palm(fixed)",
+        "palm->finger_middle_link_0(fixed)",
+        "finger_middle_link_0->finger_middle_link_1(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae",
+      "source_path": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_1.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_10_finger_middle_link_2_visual_10",
+      "link": "finger_middle_link_2",
+      "visual": "visual_10",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.09296100485962006,
+          0.12520718645549456,
+          0.0075
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          1.05
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.039,
+          0.0,
+          0.0075
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "green",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->palm(fixed)",
+        "palm->finger_middle_link_0(fixed)",
+        "finger_middle_link_0->finger_middle_link_1(revolute)",
+        "finger_middle_link_1->finger_middle_link_2(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae",
+      "source_path": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_2.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_11_finger_middle_link_3_visual_11",
+      "link": "finger_middle_link_3",
+      "visual": "visual_11",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.09296100485962006,
+          0.12520718645549456,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          1.57
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.52
+        ]
+      },
+      "material": {
+        "name": "green",
+        "color": null
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->palm(fixed)",
+        "palm->finger_middle_link_0(fixed)",
+        "finger_middle_link_0->finger_middle_link_1(revolute)",
+        "finger_middle_link_1->finger_middle_link_2(revolute)",
+        "finger_middle_link_2->finger_middle_link_3(revolute)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae",
+      "source_path": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/link_3.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_12_palm_visual_12",
+      "link": "palm",
+      "visual": "visual_12",
+      "parent_link": "tool0",
+      "pose": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          -0.0,
+          0.0
+        ]
+      },
+      "visual_origin": {
+        "xyz": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "rpy": [
+          0.0,
+          0.0,
+          0.0
+        ]
+      },
+      "material": {
+        "name": "green",
+        "color": [
+          0.0,
+          1.0,
+          0.0,
+          1.0
+        ]
+      },
+      "link_transform_status": "unresolved",
+      "transform_status": "unresolved",
+      "transform_chain": [
+        "tool0->palm(fixed)"
+      ],
+      "render_expected": true,
+      "geometry_type": "mesh",
+      "package_uri": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/palm.dae",
+      "source_path": "package://robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/palm.dae",
+      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/meshes/robotiq-3f-gripper_articulated/visual/palm.dae",
+      "resolved": true,
+      "mesh_scale": [
+        1.0,
+        1.0,
+        1.0
+      ],
+      "render_skip_reason": "",
+      "warning": "missing_parent:tool0"
+    },
+    {
+      "id": "urdf_visual_13_table_None",
       "link": "table_",
       "visual": "None_",
       "parent_link": "world",
@@ -86,9 +813,9 @@
       "warning": ""
     },
     {
-      "id": "urdf_visual_1_camera_link_visual_1",
+      "id": "urdf_visual_14_camera_link_visual_14",
       "link": "camera_link",
-      "visual": "visual_1",
+      "visual": "visual_14",
       "parent_link": "world",
       "pose": {
         "xyz": [
@@ -147,10 +874,10 @@
   "package_resolution_diagnostics": {
     "resolved_packages": [
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "table_clamp_camera_mount_description",
@@ -159,10 +886,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "simple_conveyor_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description/package.xml"
       },
       {
         "package_name": "realsense2_description",
@@ -171,16 +898,16 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
-      },
-      {
         "package_name": "workbench_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "overhead_camera_gantry_description",
@@ -189,40 +916,28 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
-      },
-      {
         "package_name": "sorting_bin_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
       },
       {
-        "package_name": "simple_conveyor_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
       },
       {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
       },
       {
         "package_name": "ur10_moveit_config",
@@ -243,10 +958,16 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur5_moveit_config/package.xml"
       },
       {
-        "package_name": "fanuc_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
       },
       {
         "package_name": "fanuc_description",
@@ -255,22 +976,10 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "package_name": "fanuc_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
       },
       {
         "package_name": "single_suction_description",
@@ -279,16 +988,34 @@
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
       },
       {
         "package_name": "onrobot_airpick4_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
         "source_tier": "repo_assets",
         "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets",
+        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
       },
       {
         "package_name": "robotiq_3f_gripper_description",
@@ -306,8 +1033,8 @@
     "shadowed_packages": [],
     "resolution_paths": [
       {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -316,8 +1043,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
+        "package_name": "simple_conveyor_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
         "source_tier": "repo_assets"
       },
       {
@@ -326,13 +1053,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
+        "package_name": "workbench_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "workbench_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
@@ -341,33 +1068,23 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets"
-      },
-      {
         "package_name": "sorting_bin_description",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "simple_conveyor_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
+        "package_name": "flat_plate_camera_bracket_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
+        "package_name": "table_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
         "source_tier": "repo_assets"
       },
       {
@@ -386,8 +1103,13 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "fanuc_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
+        "package_name": "panda_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
         "source_tier": "repo_assets"
       },
       {
@@ -396,18 +1118,8 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "package_name": "fanuc_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets"
       },
       {
@@ -416,13 +1128,28 @@
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "package_name": "single_suction_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "onrobot_airpick4_moveit_config",
         "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
         "source_tier": "repo_assets"
       },
       {

--- a/scenes/ur5_3f_test/scene_manifest.yaml
+++ b/scenes/ur5_3f_test/scene_manifest.yaml
@@ -16,15 +16,29 @@ robot:
   model: ur5
   planning_group: manipulator
   base_frame: base_link
-  ee_link: tool0
+  ee_link: palm
   home_named_target: home
 
 end_effector:
-  type: none
-  brand: universal_robot
-  grasp_frame: tool0
+  type: finger
+  brand: robotiq_3f_gripper
+  model: robotiq_3f
+  capability: robotiq_3f
+  grasp_frame: palm
   allowed_touch_links:
-    - tool0
+    - palm
+    - finger_1_link_0
+    - finger_1_link_1
+    - finger_1_link_2
+    - finger_1_link_3
+    - finger_2_link_0
+    - finger_2_link_1
+    - finger_2_link_2
+    - finger_2_link_3
+    - finger_middle_link_0
+    - finger_middle_link_1
+    - finger_middle_link_2
+    - finger_middle_link_3
 
 environment:
   support_surface_link: table

--- a/scenes/ur5_3f_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_3f_test/urdf/scene.urdf.xacro
@@ -23,8 +23,11 @@
   use_fake_hardware="$(arg use_fake_hardware)">
   <origin xyz="0 0 0" rpy="0 0 0"/>
 </xacro:ur_robot>
-   
- <!-- Arm-only hardware variant: no physical gripper attached to tool0. -->
+
+ <xacro:include filename="$(find robotiq_3f_gripper_description)/urdf/robotiq-3f-gripper_articulated.urdf.xacro"/>
+ <xacro:robotiq-3f-gripper_articulated prefix="" parent="tool0">
+	<origin xyz="0 0 0" rpy="0 0 0"/>
+ </xacro:robotiq-3f-gripper_articulated>
 
  <xacro:include filename="$(find workbench_description)/urdf/table.urdf.xacro"/>
  <xacro:table prefix="" parent="world">
@@ -39,9 +42,9 @@
 
  <link name="ee_palm" />
  <joint name="base_to_palm" type="fixed">
-    <parent link="tool0"/>
+    <parent link="palm"/>
     <child link="ee_palm"/>
-    <origin xyz="0 0 0.18" rpy="0 0 0"/>
+    <origin xyz="0 0 0.0875" rpy="0 0 0"/>
  </joint>
 
 </robot>


### PR DESCRIPTION
### Motivation
- Resolve a mismatched scene contract where `ur5_3f_test` previously referenced arm-only/tool-2F metadata while a bundled Robotiq 3F asset exists in the repo, and avoid a scene-specific hack by choosing an honest, consistent 3F contract. 
- Ensure authoring and generated artifacts (`scene_manifest.yaml`, `cell_definition.yaml`, `environment.yaml`, `urdf/scene.urdf.xacro`, and `generated/scene_visual_mesh_index.json`) agree about the end-effector capability so downstream validators and tooling can make deterministic decisions. 
- Preserve safe defaults (fake-hardware-first) and keep a single actionable blocker that is specific and fixable rather than hiding the mismatch behind a vague pass/warn state.

### Description
- Updated `scenes/ur5_3f_test/scene_manifest.yaml` to describe a `robotiq_3f` finger end-effector, set `ee_link: palm`, and list the 3F `allowed_touch_links` matching the bundled 3F URDF. 
- Updated `scenes/ur5_3f_test/cell_definition.yaml` to include `capability: ur5` on the robot and `capability: robotiq_3f` on the end-effector so capability-driven validators resolve correctly. 
- Updated `scenes/ur5_3f_test/environment.yaml` to reference `robotiq_3f` as the `tool`/`profile` and added the capability marker so environment and cell metadata match. 
- Replaced arm-only preview in `scenes/ur5_3f_test/urdf/scene.urdf.xacro` with the bundled `robotiq-3f-gripper_articulated` xacro attached at `tool0` and adjusted the palm attach transform; regenerated `scenes/ur5_3f_test/generated/scene_visual_mesh_index.json` to reflect the 3F meshes. 
- Made an explicit, actionable `known_blocker` entry in `scenes/supported_scenes.yaml` for `ur5_3f_test` that states the remaining blocker is Scene3D smoke evidence tied to an unavailable `workcell_builder` executable rather than an ambiguous catalog message. 
- Preserved safety: `use_fake_hardware` remains `true` and no real-hardware flags or runtime send behavior were enabled.

### Testing
- Ran `python3 scripts/regenerate_scene_visual_mesh_indexes.py --scene ur5_3f_test --portable` which completed successfully and produced a mesh-backed index (15 visual mesh items) for the 3F gripper. 
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_3f_test --json` which completed and reported `readiness: physical_scene_only` with existing task-intent warnings (no new errors). 
- Ran `python3 scripts/validate_cell_definition.py scenes/ur5_3f_test/cell_definition.yaml --json` which resolved the `ur5` and `robotiq_3f` capabilities and returned only the pre-existing layout warning (no capability errors). 
- Ran the catalog-backed matrix `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --supported-scenes scenes/supported_scenes.yaml --output-dir build/workcell_studio_scene_readiness` which completed and shows `ur5_3f_test` static/package/mesh checks PASS and the remaining catalog `BLOCKED` reason is the explicit Scene3D smoke executable blocker. 
- Ran `python3 scripts/validate_supported_scenes_readiness.py --repo-root . --workspace-root . --skip-build --skip-launch-smoke --json` which returned non-zero because the supported catalog intentionally contains blocked scenes (expected); `ur5_3f_test` static/package/mesh checks passed and the reported blocker is the Scene3D smoke executable issue. 
- Ran focused unit tests `python3 -m pytest tests/test_scene_urdf_visual_mesh_index.py tests/test_all_workcell_studio_scene_reproducibility.py -q` which passed; a broader trio including an unrelated `ur5_2f_test` resolution assertion failed in a prior unrelated test, and that failure did not originate from the `ur5_3f_test` contract alignment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a5f2a4108331afd8c0a9803074db)