### PR TITLE
Add contract tests for workcell generator and preserve authoring files on regenerate

### DIFF
--- a/scripts/generate_workcell_from_cell_definition.py
+++ b/scripts/generate_workcell_from_cell_definition.py
@@ -180,6 +180,84 @@ def _render_package_xml(package_name: str) -> str:
 """
 
 
+def _snapshot_input_file(path: Path | None) -> tuple[Path, str] | None:
+    if path is None or not path.is_file():
+        return None
+    return path, path.read_text(encoding="utf-8")
+
+
+def _write_snapshot(snapshot: tuple[Path, str] | None, destination: Path) -> bool:
+    if snapshot is None:
+        return False
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(snapshot[1], encoding="utf-8")
+    return True
+
+
+def _source_environment_yaml_path(cell_definition_path: Path) -> Path | None:
+    candidate = cell_definition_path.parent / "environment.yaml"
+    return candidate if candidate.is_file() else None
+
+
+def _source_workcell_studio_layout_path(cell_definition_path: Path) -> Path | None:
+    candidate = cell_definition_path.parent / "layout" / "workcell_studio_layout.yaml"
+    return candidate if candidate.is_file() else None
+
+
+def _render_environment_yaml(cell_def: dict[str, Any], scene_generator: Any, cell_definition_path: Path) -> str:
+    environment = cell_def.get("environment", {}) if isinstance(cell_def.get("environment"), dict) else {}
+    cell = cell_def.get("cell", {}) if isinstance(cell_def.get("cell"), dict) else {}
+    payload = {
+        "schema_version": "workcell_environment/v1",
+        "generated_from": str(cell_definition_path),
+        "frame": environment.get("frame", cell.get("planning_frame", "world")),
+        "robot": cell_def.get("robot", {}),
+        "end_effector": cell_def.get("end_effector", {}),
+        "camera": cell_def.get("camera", {}),
+        "environment": environment,
+        "objects": cell_def.get("objects", []),
+        "support_surfaces": environment.get("support_surfaces", []),
+        "assets": environment.get("assets", []),
+        "fake_hardware_first": True,
+        "runtime_execution_enabled": False,
+    }
+    return _header_yaml(cell_definition_path) + _yaml_text_from(scene_generator, payload)
+
+
+def _render_scene_urdf_xacro(package_name: str, cell_def: dict[str, Any], cell_definition_path: Path) -> str:
+    environment = cell_def.get("environment", {}) if isinstance(cell_def.get("environment"), dict) else {}
+    cell = cell_def.get("cell", {}) if isinstance(cell_def.get("cell"), dict) else {}
+    robot = cell_def.get("robot", {}) if isinstance(cell_def.get("robot"), dict) else {}
+    frame = str(environment.get("frame") or cell.get("planning_frame") or "world")
+    robot_model = str(robot.get("model") or "unknown_robot")
+    return (
+        '<?xml version="1.0"?>\n'
+        f'<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Generated from {cell_definition_path} -->\n'
+        f'<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="{package_name}">\n'
+        f'  <!-- Offline-safe placeholder URDF for Workcell Studio review; robot_model={robot_model}. -->\n'
+        f'  <link name="{frame}"/>\n'
+        '</robot>\n'
+    )
+
+
+def _render_scene_visual_mesh_index(package_name: str, cell_definition_path: Path) -> dict[str, Any]:
+    return {
+        "schema_version": "scene_visual_mesh_index/v1",
+        "scene_name": package_name,
+        "visual_count": 0,
+        "resolved": 0,
+        "unresolved": 0,
+        "safe_for_preview": True,
+        "source_urdf_xacro_path": "urdf/scene.urdf.xacro",
+        "generator": "scripts/generate_workcell_from_cell_definition.py",
+        "source_cell_definition": str(cell_definition_path),
+        "visual_items": [],
+        "notes": [
+            "Generated placeholder visual mesh index; regenerate from expanded URDF when approved mesh assets are available."
+        ],
+    }
+
+
 def _render_cmakelists(package_name: str) -> str:
     template_path = TEMPLATE_DIR / "CMakeLists_example.txt"
     if template_path.is_file():
@@ -575,6 +653,16 @@ def generate_package(
         print(f"FAIL: Output package already exists: {package_dir} (use --force to overwrite)")
         return 1
 
+    source_environment_snapshot = _snapshot_input_file(_source_environment_yaml_path(cell_definition_path))
+    resolved_layout_path = None
+    environment = loaded.get("environment", {}) if isinstance(loaded.get("environment"), dict) else {}
+    layout_ref = environment.get("layout")
+    if isinstance(layout_ref, str) and layout_ref.strip():
+        resolved_layout_path = _resolve_layout_path(layout_ref, cell_definition_path)
+    source_environment_layout_snapshot = _snapshot_input_file(resolved_layout_path)
+    source_workcell_layout_snapshot = _snapshot_input_file(_source_workcell_studio_layout_path(cell_definition_path))
+    source_cell_definition_snapshot = _snapshot_input_file(cell_definition_path)
+
     if dry_run:
         print(f"PASS: dry-run successful for package '{package_name}'")
         print(f"WARN count: {len(warnings)}")
@@ -592,18 +680,18 @@ def generate_package(
     (package_dir / "urdf").mkdir(parents=True, exist_ok=True)
     (package_dir / "generated").mkdir(parents=True, exist_ok=True)
 
-    environment = loaded.get("environment", {}) if isinstance(loaded.get("environment"), dict) else {}
-    layout_ref = environment.get("layout")
-    if isinstance(layout_ref, str) and layout_ref.strip():
-        resolved_layout = _resolve_layout_path(layout_ref, cell_definition_path)
-        if resolved_layout and resolved_layout.is_file():
-            with resolved_layout.open("r", encoding="utf-8") as handle:
-                loaded_layout = yaml.safe_load(handle)
+    if not _write_snapshot(source_workcell_layout_snapshot, package_dir / "layout" / "workcell_studio_layout.yaml"):
+        layout_source = source_environment_layout_snapshot
+        if layout_source is not None:
+            loaded_layout = yaml.safe_load(layout_source[1])
             normalized_layout = _normalize_workcell_studio_layout(loaded_layout)
             (package_dir / "layout" / "workcell_studio_layout.yaml").write_text(
                 yaml.safe_dump(normalized_layout, sort_keys=False),
                 encoding="utf-8",
             )
+    if source_environment_layout_snapshot is not None:
+        _write_snapshot(source_environment_layout_snapshot, package_dir / "environment_layout.yaml")
+        _write_snapshot(source_environment_layout_snapshot, package_dir / "generated" / "environment_layout.yaml")
 
     scene_manifest_path = package_dir / "scene_manifest.yaml"
     workcell_yaml_path = package_dir / "workcell.yaml"
@@ -614,6 +702,10 @@ def generate_package(
 
     (package_dir / "package.xml").write_text(_render_package_xml(package_name), encoding="utf-8")
     (package_dir / "CMakeLists.txt").write_text(_render_cmakelists(package_name), encoding="utf-8")
+    if not _write_snapshot(source_environment_snapshot, package_dir / "environment.yaml"):
+        (package_dir / "environment.yaml").write_text(
+            _render_environment_yaml(loaded, scene_generator, cell_definition_path), encoding="utf-8"
+        )
     scene_manifest_path.write_text(scene_manifest_text, encoding="utf-8")
     workcell_yaml_path.write_text(scene_manifest_text, encoding="utf-8")
     task_recipe_path.write_text(task_recipe_text, encoding="utf-8")
@@ -632,7 +724,8 @@ def generate_package(
         encoding="utf-8",
     )
 
-    shutil.copy2(cell_definition_path, package_dir / "cell_definition.yaml")
+    if not _write_snapshot(source_cell_definition_snapshot, package_dir / "cell_definition.yaml"):
+        shutil.copy2(cell_definition_path, package_dir / "cell_definition.yaml")
 
     (package_dir / "launch" / "demo.launch.py").write_text(
         _render_demo_launch(package_name, cell_definition_path),
@@ -647,6 +740,14 @@ def generate_package(
     (package_dir / "urdf" / "README.md").write_text(
         _header_markdown(cell_definition_path)
         + "# URDF placeholders\n\nReview and connect approved robot/environment geometry assets manually.\n",
+        encoding="utf-8",
+    )
+    (package_dir / "urdf" / "scene.urdf.xacro").write_text(
+        _render_scene_urdf_xacro(package_name, loaded, cell_definition_path),
+        encoding="utf-8",
+    )
+    (package_dir / "generated" / "scene_visual_mesh_index.json").write_text(
+        json.dumps(_render_scene_visual_mesh_index(package_name, cell_definition_path), indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
     (package_dir / "urdf" / "generated_asset_metadata.yaml").write_text(

--- a/tests/test_generate_workcell_from_cell_definition_contract.py
+++ b/tests/test_generate_workcell_from_cell_definition_contract.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from scripts.generate_workcell_from_cell_definition import generate_package
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "generate_workcell_from_cell_definition.py"
+
+REQUIRED_GENERATED_FILES = [
+    "package.xml",
+    "CMakeLists.txt",
+    "environment.yaml",
+    "cell_definition.yaml",
+    "scene_manifest.yaml",
+    "layout/workcell_studio_layout.yaml",
+    "launch/demo.launch.py",
+    "urdf/scene.urdf.xacro",
+    "generated/scene_visual_mesh_index.json",
+]
+
+READINESS_METADATA_FILES = [
+    "generated/commissioning_summary.md",
+    "generated/validation_report.md",
+    "generated/generated_workcell_summary.json",
+    "generated/generated_gated_dry_run_command.sh",
+    "generated/generated_detected_objects_example.yaml",
+    "generated/generated_environment_objects.yaml",
+    "generated/generated_destinations.yaml",
+]
+
+REAL_HARDWARE_DRIVER_ACTIVATION_STRINGS = [
+    "ur_robot_driver",
+    "external_control",
+    "dashboard_client",
+    "ros2_control_node",
+    "controller_manager",
+    "scaled_joint_trajectory_controller",
+]
+
+
+def _write_minimal_scene(scene_dir: Path) -> Path:
+    (scene_dir / "layout").mkdir(parents=True, exist_ok=True)
+    (scene_dir / "environment.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "workcell_environment/v1",
+                "robot": {"name": "ur5"},
+                "end_effector": {"name": "robotiq_2f"},
+                "objects": {"part": {"class": "box"}},
+                "fake_hardware_first": True,
+                "runtime_execution_enabled": False,
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (scene_dir / "environment_layout.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "environment_layout/v1",
+                "assets": [
+                    {
+                        "id": "robot_base",
+                        "type": "robot_base",
+                        "pose": {"xyz": [0.0, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
+                    },
+                    {
+                        "id": "table_main",
+                        "type": "table",
+                        "pose": {"xyz": [0.45, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
+                    },
+                ],
+                "zones": [
+                    {
+                        "id": "pick_zone",
+                        "type": "pick_area",
+                        "pose": {"xyz": [0.45, 0.0, 0.08], "rpy": [0.0, 0.0, 0.0]},
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (scene_dir / "layout" / "workcell_studio_layout.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "workcell_studio_layout/v1",
+                "items": [
+                    {
+                        "id": "editable_table_main",
+                        "type": "table",
+                        "pose": {"xyz": [0.45, 0.0, 0.0], "rpy": [0.0, 0.0, 0.0]},
+                    }
+                ],
+                "test_sentinel": "source workcell studio layout preserved",
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    cell_definition = {
+        "schema_version": "cell_definition/v1",
+        "cell": {
+            "id": "contract_cell",
+            "name": "Contract Test Cell",
+            "planning_frame": "world",
+        },
+        "robot": {
+            "model": "ur5",
+            "planning_group": "manipulator",
+            "base_frame": "world",
+            "tool_link": "tool0",
+            "home_named_target": "home",
+            "safe_joint_state": [],
+        },
+        "end_effector": {
+            "id": "robotiq_2f",
+            "type": "finger",
+            "brand": "robotiq",
+            "grasp_frame": "tool0",
+            "allowed_touch_links": ["left_inner_finger", "right_inner_finger"],
+        },
+        "camera": {
+            "id": "realsense_d435i",
+            "type": "depth_camera",
+            "frame": "camera_depth_optical_frame",
+        },
+        "environment": {
+            "frame": "world",
+            "layout": "environment_layout.yaml",
+            "support_surfaces": [
+                {
+                    "id": "table_main",
+                    "type": "table",
+                    "frame": "world",
+                    "pose_xyz": [0.0, 0.0, 0.0],
+                    "pose_rpy": [0.0, 0.0, 0.0],
+                    "dimensions": [1.0, 1.0, 0.05],
+                }
+            ],
+        },
+        "objects": [
+            {
+                "id": "part",
+                "class": "box",
+                "shape": "box",
+                "color": "blue",
+                "material": "plastic",
+                "frame": "world",
+                "dimensions": [0.05, 0.05, 0.05],
+                "pose_xyz": [0.45, 0.0, 0.08],
+                "pose_rpy": [0.0, 0.0, 0.0],
+            }
+        ],
+        "task": {
+            "id": "pick_place_task",
+            "type": "pick_place",
+            "source_object": "part",
+            "destinations": [
+                {
+                    "id": "place_target",
+                    "frame": "world",
+                    "pose_xyz": [0.6, -0.2, 0.1],
+                    "pose_rpy": [0, 0, 0],
+                }
+            ],
+            "rules": [
+                {
+                    "id": "default_place",
+                    "when": {"always": True},
+                    "destination": "place_target",
+                }
+            ],
+        },
+        "commissioning": {
+            "self_test_enabled": True,
+            "export_bundle": False,
+            "fake_hardware_default": True,
+        },
+    }
+    cell_path = scene_dir / "cell_definition.yaml"
+    cell_path.write_text(
+        yaml.safe_dump(cell_definition, sort_keys=False), encoding="utf-8"
+    )
+    return cell_path
+
+
+def _assert_generated_contract(package_dir: Path) -> None:
+    for rel_path in REQUIRED_GENERATED_FILES + READINESS_METADATA_FILES:
+        assert (
+            package_dir / rel_path
+        ).is_file(), f"missing generated contract file: {rel_path}"
+
+    launch_text = (package_dir / "launch" / "demo.launch.py").read_text(
+        encoding="utf-8"
+    )
+    assert '"use_fake_hardware"' in launch_text
+    assert 'default_value="true"' in launch_text
+    for forbidden in REAL_HARDWARE_DRIVER_ACTIVATION_STRINGS:
+        assert forbidden not in launch_text
+
+    mesh_index = json.loads(
+        (package_dir / "generated" / "scene_visual_mesh_index.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert mesh_index["safe_for_preview"] is True
+    assert mesh_index["source_urdf_xacro_path"] == "urdf/scene.urdf.xacro"
+
+    summary = json.loads(
+        (package_dir / "generated" / "generated_workcell_summary.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert summary["approval"]["status"] == "unapproved"
+    assert summary["recommended_commands"]["gated_dry_run"]
+
+
+def test_generate_package_preserves_authoring_contract_files(tmp_path: Path) -> None:
+    source_scene = tmp_path / "source_scene"
+    cell_path = _write_minimal_scene(source_scene)
+    out_dir = tmp_path / "scenes"
+
+    assert (
+        generate_package(
+            cell_path, out_dir, "contract_scene", force=True, dry_run=False
+        )
+        == 0
+    )
+
+    package_dir = out_dir / "contract_scene"
+    _assert_generated_contract(package_dir)
+    assert (package_dir / "environment.yaml").read_text(encoding="utf-8") == (
+        source_scene / "environment.yaml"
+    ).read_text(encoding="utf-8")
+    layout = yaml.safe_load(
+        (package_dir / "layout" / "workcell_studio_layout.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert layout["test_sentinel"] == "source workcell studio layout preserved"
+
+
+def test_cli_force_in_place_regeneration_keeps_source_layout_and_environment(
+    tmp_path: Path,
+) -> None:
+    scenes_dir = tmp_path / "scenes"
+    package_dir = scenes_dir / "contract_scene"
+    cell_path = _write_minimal_scene(package_dir)
+    expected_environment = (package_dir / "environment.yaml").read_text(
+        encoding="utf-8"
+    )
+    expected_environment_layout = (package_dir / "environment_layout.yaml").read_text(
+        encoding="utf-8"
+    )
+    expected_workcell_layout = (
+        package_dir / "layout" / "workcell_studio_layout.yaml"
+    ).read_text(encoding="utf-8")
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            str(cell_path),
+            "--output-dir",
+            str(scenes_dir),
+            "--package-name",
+            "contract_scene",
+            "--force",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    _assert_generated_contract(package_dir)
+    assert (package_dir / "environment.yaml").read_text(
+        encoding="utf-8"
+    ) == expected_environment
+    assert (package_dir / "environment_layout.yaml").read_text(
+        encoding="utf-8"
+    ) == expected_environment_layout
+    assert (package_dir / "layout" / "workcell_studio_layout.yaml").read_text(
+        encoding="utf-8"
+    ) == expected_workcell_layout


### PR DESCRIPTION
### Motivation

- Ensure `scripts/generate_workcell_from_cell_definition.py` produces the expected scene/package contract artifacts for Workcell Studio and that in-place `--force` regeneration does not lose source authoring files.

### Description

- Add focused contract tests in `tests/test_generate_workcell_from_cell_definition_contract.py` that create a temporary scene (with `environment.yaml`, `environment_layout.yaml`, `layout/workcell_studio_layout.yaml`, and a minimal `cell_definition.yaml`) and assert the generated package contains required artifacts and readiness metadata.
- Snapshot and restore source authoring files before destructive regeneration by adding helpers `_snapshot_input_file` and `_write_snapshot` and using them to preserve `environment.yaml`, `environment_layout.yaml`, `layout/workcell_studio_layout.yaml`, and the source `cell_definition.yaml` when generating into an existing package.
- Emit conservative review-safe artifacts when missing, including `urdf/scene.urdf.xacro` and `generated/scene_visual_mesh_index.json`, and render a fallback `environment.yaml` that preserves `fake_hardware_first` and disables runtime execution by default.
- Ensure generated `launch/demo.launch.py` keeps `use_fake_hardware` defaulted to `true` and add test checks to avoid obvious real-hardware driver activation strings in generated launch content.

### Testing

- Compiled generator: `python3 -m py_compile scripts/generate_workcell_from_cell_definition.py` — PASS.
- Ran new contract tests: `pytest -q tests/test_generate_workcell_from_cell_definition_contract.py` — PASS (2 tests).
- Ran related smoke/coverage tests: `pytest -q tests/test_workcell_bundle_approval.py tests/test_generated_workcell_visual_preview.py` — PASS (6 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21abae6c4c83319d05efb4f9d59fb9)