### PR TITLE
Treat missing workcell_builder executable as BLOCKED with explicit blocker and non-runtime evidence

### DIFF
--- a/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json
+++ b/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json
@@ -1,6 +1,6 @@
 {
   "schema": "workcell_studio_scene3d_gui_smoke/v1",
-  "status": "FAIL",
+  "status": "BLOCKED",
   "scene": "ur5_2f_test",
   "repo_root": "/workspace/Easy_Manipulator_Improved",
   "workspace_root": "/workspace/Easy_Manipulator_Improved",
@@ -12,8 +12,10 @@
     "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder",
     "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder/workcell_builder"
   ],
+  "message": "workcell_builder executable was not found; build workcell_builder in a ROS Humble workspace and source install/setup.bash, or pass --executable",
+  "smoke_status": "MISSING_EXECUTABLE",
   "blockers": [
-    "unable_to_resolve_workcell_builder_executable"
+    "workcell_builder_executable_missing"
   ],
   "warnings": [
     "runtime_gui_unavailable_static_scene3d_visual_evidence_recorded"
@@ -32,9 +34,17 @@
     "primitive_fallback_items_renderable": 7,
     "zones_overlays_renderable": 0,
     "source": "generated/scene_visual_mesh_index.json",
+    "evidence_kind": "non_runtime_static_headless_renderability",
     "notes": [
       "runtime executable unavailable; counts are static/headless renderability evidence, not GUI-render PASS evidence"
     ]
+  },
+  "non_runtime_static_headless_renderability_counts": {
+    "runtime_available": false,
+    "physical_mesh_items_renderable": 11,
+    "primitive_fallback_items_renderable": 7,
+    "zones_overlays_renderable": 0,
+    "note": "Static/headless renderability counts are non-runtime evidence and do not prove GUI rendering passed."
   },
   "render_debug_counters": {
     "runtime_available": false,

--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -90,6 +90,7 @@ def _static_scene3d_visual_evidence(scene_dir: Path | None) -> dict[str, Any]:
         'primitive_fallback_items_renderable': 0,
         'zones_overlays_renderable': 0,
         'source': 'generated/scene_visual_mesh_index.json',
+        'evidence_kind': 'non_runtime_static_headless_renderability',
         'notes': ['runtime executable unavailable; counts are static/headless renderability evidence, not GUI-render PASS evidence'],
     }
     if scene_dir is None:
@@ -199,19 +200,32 @@ def main() -> int:
         searched = [str(p) for p in _resolve_executable_candidates(workspace_root or repo_root)]
         scene_dir = _resolve_single_scene_dir(repo_root, args.scene, args.scene_path)
         static_evidence = _static_scene3d_visual_evidence(scene_dir)
+        message = (
+            "workcell_builder executable was not found; build workcell_builder in a ROS Humble "
+            "workspace and source install/setup.bash, or pass --executable"
+        )
         fail_payload = {
             "schema": EXPECTED_SCHEMA,
-            "status": "FAIL",
+            "status": "BLOCKED",
             "scene": args.scene or (args.scene_path.name if args.scene_path else None),
             "repo_root": str(repo_root),
             "workspace_root": str(workspace_root),
             "executable": None,
             "searched_paths": searched,
-            "blockers": ["unable_to_resolve_workcell_builder_executable"],
+            "message": message,
+            "smoke_status": "MISSING_EXECUTABLE",
+            "blockers": ["workcell_builder_executable_missing"],
             "warnings": ["runtime_gui_unavailable_static_scene3d_visual_evidence_recorded"],
             "screenshot_available": False,
             "scene_dir": str(scene_dir) if scene_dir else None,
             "static_scene3d_visual_evidence": static_evidence,
+            "non_runtime_static_headless_renderability_counts": {
+                "runtime_available": False,
+                "physical_mesh_items_renderable": static_evidence.get("physical_mesh_items_renderable", 0),
+                "primitive_fallback_items_renderable": static_evidence.get("primitive_fallback_items_renderable", 0),
+                "zones_overlays_renderable": static_evidence.get("zones_overlays_renderable", 0),
+                "note": "Static/headless renderability counts are non-runtime evidence and do not prove GUI rendering passed.",
+            },
             "render_debug_counters": {
                 "runtime_available": False,
                 "physical_mesh_items_rendered": 0,
@@ -226,7 +240,7 @@ def main() -> int:
             },
         }
         _write_json(args.output, fail_payload)
-        print("status=FAIL smoke_status=MISSING_EXECUTABLE")
+        print("status=BLOCKED smoke_status=MISSING_EXECUTABLE")
         print("searched_paths=" + " | ".join(searched))
         return 1
 
@@ -265,7 +279,10 @@ def main() -> int:
                 except Exception:
                     payload = {}
             smoke_status = str(payload.get("status", "FAIL")).upper()
-            result_status = "PASS" if (proc.returncode == 0 and smoke_status in {"PASS", "OK"}) else "FAIL"
+            if smoke_status == "BLOCKED":
+                result_status = "BLOCKED"
+            else:
+                result_status = "PASS" if (proc.returncode == 0 and smoke_status in {"PASS", "OK"}) else "FAIL"
             blockers = list(payload.get("blockers", [])) if isinstance(payload.get("blockers"), list) else []
             blockers.extend(item.get("blockers", []))
             if item["scene_status"] == "BLOCKED":

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -1,4 +1,4 @@
-import json, subprocess
+import json, os, subprocess, sys
 from pathlib import Path
 
 
@@ -35,6 +35,33 @@ def test_wrapper_does_not_reuse_stale_success_json(tmp_path):
     assert payload['status'] == 'FAIL'
     assert 'app_smoke_json_missing' in payload['blockers']
     assert payload.get('screenshot_available') is False
+
+
+def test_missing_executable_is_blocked_with_static_non_runtime_evidence(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    out = tmp_path / 'smoke.json'
+    shot = tmp_path / 'shot.png'
+    cmd = [
+        sys.executable, str(repo / 'scripts/run_workcell_builder_scene3d_gui_smoke.py'),
+        '--repo-root', str(repo), '--workspace-root', str(tmp_path), '--scene', 'ur5_2f_test',
+        '--output', str(out), '--screenshot', str(shot), '--timeout-sec', '2',
+    ]
+    env = os.environ.copy()
+    env['PATH'] = str(tmp_path)
+    rc = subprocess.run(cmd, text=True, capture_output=True, env=env)
+    assert rc.returncode != 0
+    assert 'status=BLOCKED smoke_status=MISSING_EXECUTABLE' in rc.stdout
+    payload = json.loads(out.read_text(encoding='utf-8'))
+    assert payload['status'] == 'BLOCKED'
+    assert payload['smoke_status'] == 'MISSING_EXECUTABLE'
+    assert 'workcell_builder_executable_missing' in payload['blockers']
+    assert payload['searched_paths']
+    assert 'build workcell_builder in a ROS Humble workspace' in payload['message']
+    assert payload['static_scene3d_visual_evidence']['evidence_kind'] == 'non_runtime_static_headless_renderability'
+    assert 'not GUI-render PASS evidence' in payload['static_scene3d_visual_evidence']['notes'][0]
+    counts = payload['non_runtime_static_headless_renderability_counts']
+    assert counts['runtime_available'] is False
+    assert 'non-runtime evidence' in counts['note']
 
 
 def test_main_cpp_contract_contains_scene3d_counter_keys():


### PR DESCRIPTION
### Motivation
- When the Workcell Builder runtime is unavailable the smoke runner should record a clear, non-failing classification that preserves diagnostic evidence and gives a remediation path instead of a generic FAIL.
- Downstream aggregators need a specific blocker to differentiate missing runtime executables from other runtime failures for clearer gating and UX.

### Description
- Changed the single-scene missing-executable branch in `scripts/run_workcell_builder_scene3d_gui_smoke.py` to write `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e754cfb48331868c1bf60d475310)