### PR TITLE
Handle invalid Workcell Builder executable smoke evidence

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -9,7 +9,7 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 from scripts.workcell_studio_script_bootstrap import ensure_repo_root_on_sys_path
 ensure_repo_root_on_sys_path(__file__)
-from scripts.workcell_studio_path_resolver import resolve_repo_root, resolve_workspace_root, resolve_workcell_builder_executable, workcell_builder_executable_candidates
+from scripts.workcell_studio_path_resolver import resolve_repo_root, resolve_workspace_root, resolve_workcell_builder_executable, workcell_builder_executable_candidates, describe_resolution
 from scripts.scene_root_resolver import resolve_scene_root
 from scripts.scene3d_scene_discovery import discover_scene3d_scenes
 
@@ -52,6 +52,62 @@ def _write_json(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
+
+def _subprocess_exception_to_text(exc: FileNotFoundError | PermissionError) -> str:
+    return f"{type(exc).__name__}: {exc}"
+
+
+def _executable_guidance() -> list[str]:
+    return [
+        "Build and source the ROS 2 workspace so workcell_builder is installed and on PATH.",
+        "Or pass --executable with the absolute path to an executable workcell_builder binary.",
+    ]
+
+
+def _write_blocked_executable_payload(
+    output: Path,
+    *,
+    repo_root: Path,
+    workspace_root: Path | None,
+    args: argparse.Namespace,
+    searched: list[str],
+    blocker: str,
+    exception: str | None = None,
+    status: str = "BLOCKED",
+) -> None:
+    scene_dir = _resolve_single_scene_dir(repo_root, args.scene, args.scene_path)
+    static_evidence = _static_scene3d_visual_evidence(scene_dir)
+    payload: dict[str, Any] = {
+        "schema": EXPECTED_SCHEMA,
+        "status": status,
+        "scene": args.scene or (args.scene_path.name if args.scene_path else None),
+        "repo_root": str(repo_root),
+        "workspace_root": str(workspace_root) if workspace_root else None,
+        "executable": None,
+        "explicit_executable": str(args.executable) if args.executable else None,
+        "searched_paths": searched,
+        "blockers": [blocker],
+        "guidance": _executable_guidance(),
+        "warnings": ["runtime_gui_unavailable_static_scene3d_visual_evidence_recorded"],
+        "screenshot_available": False,
+        "scene_dir": str(scene_dir) if scene_dir else None,
+        "static_scene3d_visual_evidence": static_evidence,
+        "render_debug_counters": {
+            "runtime_available": False,
+            "physical_mesh_items_rendered": 0,
+            "primitive_fallback_items_rendered": 0,
+            "zones_overlays_rendered": 0,
+            "skipped_helper_static_fallback_items": static_evidence.get("skipped_helper_static_fallback_items", 0),
+            "unresolved_transform_items": static_evidence.get("unresolved_transform_items", 0),
+            "missing_mesh_items": static_evidence.get("missing_mesh_items", 0),
+            "static_physical_mesh_items_renderable": static_evidence.get("physical_mesh_items_renderable", 0),
+            "static_primitive_fallback_items_renderable": static_evidence.get("primitive_fallback_items_renderable", 0),
+            "static_zones_overlays_renderable": static_evidence.get("zones_overlays_renderable", 0),
+        },
+    }
+    if exception:
+        payload["subprocess_exception"] = exception
+    _write_json(output, payload)
 
 
 def _resolve_single_scene_dir(repo_root: Path, scene: str | None, scene_path: Path | None) -> Path | None:
@@ -194,39 +250,55 @@ def main() -> int:
 
     repo_root = resolve_repo_root(explicit_repo_root=args.repo_root)
     workspace_root = resolve_workspace_root(repo_root, args.workspace_root)
-    exe = args.executable or resolve_workcell_builder_executable(workspace_root)
+    if args.executable:
+        exe = resolve_workcell_builder_executable(workspace_root, explicit_executable=args.executable)
+    else:
+        exe = resolve_workcell_builder_executable(workspace_root)
+
     if exe is None and not args.all_scenes:
-        searched = [str(p) for p in _resolve_executable_candidates(workspace_root or repo_root)]
-        scene_dir = _resolve_single_scene_dir(repo_root, args.scene, args.scene_path)
-        static_evidence = _static_scene3d_visual_evidence(scene_dir)
-        fail_payload = {
+        resolution = describe_resolution()
+        searched = list(resolution.get("searched_executable_paths") or [])
+        if not searched:
+            searched = [str(p) for p in _resolve_executable_candidates(workspace_root or repo_root)]
+        blocker = (
+            "explicit_workcell_builder_executable_missing_or_not_executable"
+            if args.executable
+            else "unable_to_resolve_workcell_builder_executable"
+        )
+        _write_blocked_executable_payload(
+            args.output,
+            repo_root=repo_root,
+            workspace_root=workspace_root,
+            args=args,
+            searched=searched,
+            blocker=blocker,
+            status="BLOCKED" if args.executable else "FAIL",
+        )
+        status_label = "BLOCKED" if args.executable else "FAIL"
+        print(f"status={status_label} smoke_status={blocker}")
+        print("searched_paths=" + " | ".join(searched))
+        return 1
+
+    if exe is None and args.all_scenes and args.executable:
+        out_dir = args.output_dir.resolve()
+        searched = list(describe_resolution().get("searched_executable_paths") or [])
+        blocker = "explicit_workcell_builder_executable_missing_or_not_executable"
+        summary = {
             "schema": EXPECTED_SCHEMA,
-            "status": "FAIL",
-            "scene": args.scene or (args.scene_path.name if args.scene_path else None),
+            "mode": "all_scenes",
+            "status": "BLOCKED",
+            "output_dir": str(out_dir),
             "repo_root": str(repo_root),
-            "workspace_root": str(workspace_root),
-            "executable": None,
+            "workspace_root": str(workspace_root) if workspace_root else None,
+            "explicit_executable": str(args.executable),
             "searched_paths": searched,
-            "blockers": ["unable_to_resolve_workcell_builder_executable"],
-            "warnings": ["runtime_gui_unavailable_static_scene3d_visual_evidence_recorded"],
-            "screenshot_available": False,
-            "scene_dir": str(scene_dir) if scene_dir else None,
-            "static_scene3d_visual_evidence": static_evidence,
-            "render_debug_counters": {
-                "runtime_available": False,
-                "physical_mesh_items_rendered": 0,
-                "primitive_fallback_items_rendered": 0,
-                "zones_overlays_rendered": 0,
-                "skipped_helper_static_fallback_items": static_evidence.get("skipped_helper_static_fallback_items", 0),
-                "unresolved_transform_items": static_evidence.get("unresolved_transform_items", 0),
-                "missing_mesh_items": static_evidence.get("missing_mesh_items", 0),
-                "static_physical_mesh_items_renderable": static_evidence.get("physical_mesh_items_renderable", 0),
-                "static_primitive_fallback_items_renderable": static_evidence.get("primitive_fallback_items_renderable", 0),
-                "static_zones_overlays_renderable": static_evidence.get("zones_overlays_renderable", 0),
-            },
+            "blockers": [blocker],
+            "guidance": _executable_guidance(),
+            "totals": {"PASS": 0, "FAIL": 0, "BLOCKED": 1, "LEGACY_INCOMPLETE": 0},
+            "results": [],
         }
-        _write_json(args.output, fail_payload)
-        print("status=FAIL smoke_status=MISSING_EXECUTABLE")
+        _write_json(out_dir / "scene3d_gui_smoke_summary.json", summary)
+        print(f"status=BLOCKED smoke_status={blocker}")
         print("searched_paths=" + " | ".join(searched))
         return 1
 
@@ -257,7 +329,26 @@ def main() -> int:
             cmd += ["--timeout-sec", str(args.timeout_sec)]
             if args.xvfb:
                 cmd.append("--xvfb")
-            proc = subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True, check=False)
+            proc = None
+            run_exception: str | None = None
+            try:
+                proc = subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True, check=False)
+            except (FileNotFoundError, PermissionError) as exc:
+                run_exception = _subprocess_exception_to_text(exc)
+                _write_blocked_executable_payload(
+                    scene_json,
+                    repo_root=repo_root,
+                    workspace_root=workspace_root,
+                    args=argparse.Namespace(
+                        scene=scene_name,
+                        scene_path=None,
+                        executable=args.executable,
+                        screenshot=scene_png,
+                    ),
+                    searched=list(describe_resolution().get("searched_executable_paths") or []),
+                    blocker="child_process_spawn_failed",
+                    exception=run_exception,
+                )
             payload: dict[str, Any] = {}
             if scene_json.exists():
                 try:
@@ -265,7 +356,10 @@ def main() -> int:
                 except Exception:
                     payload = {}
             smoke_status = str(payload.get("status", "FAIL")).upper()
-            result_status = "PASS" if (proc.returncode == 0 and smoke_status in {"PASS", "OK"}) else "FAIL"
+            returncode = proc.returncode if proc is not None else None
+            result_status = "PASS" if (returncode == 0 and smoke_status in {"PASS", "OK"}) else "FAIL"
+            if run_exception or smoke_status == "BLOCKED":
+                result_status = "BLOCKED"
             blockers = list(payload.get("blockers", [])) if isinstance(payload.get("blockers"), list) else []
             blockers.extend(item.get("blockers", []))
             if item["scene_status"] == "BLOCKED":
@@ -274,7 +368,7 @@ def main() -> int:
             per_scene.append({
                 "scene": scene_name,
                 "status": result_status,
-                "returncode": proc.returncode,
+                "returncode": returncode,
                 "smoke_json": str(scene_json),
                 "smoke_png": str(scene_png),
                 "scene_metadata": item,
@@ -357,6 +451,7 @@ def main() -> int:
     rc = None
     stdout = ""
     stderr = ""
+    subprocess_exception: str | None = None
     try:
         proc = subprocess.run(cmd, cwd=repo_root, env=child_env, text=True, capture_output=True, timeout=max(0.1, args.timeout_sec), check=False)
         rc = proc.returncode
@@ -369,6 +464,11 @@ def main() -> int:
             stdout = stdout.decode("utf-8", errors="replace")
         if isinstance(stderr, bytes):
             stderr = stderr.decode("utf-8", errors="replace")
+    except (FileNotFoundError, PermissionError) as exc:
+        rc = None
+        stdout = ""
+        stderr = _subprocess_exception_to_text(exc)
+        subprocess_exception = stderr
 
     stdout_log.parent.mkdir(parents=True, exist_ok=True)
     stdout_log.write_text(stdout, encoding="utf-8")
@@ -381,6 +481,12 @@ def main() -> int:
     blockers = list(xwarn)
     warnings: list[str] = []
     if timed_out: blockers.append("child_process_timed_out")
+    if subprocess_exception:
+        blockers.append("child_process_spawn_failed")
+        if isinstance(subprocess_exception, str) and subprocess_exception.startswith("FileNotFoundError"):
+            blockers.append("workcell_builder_executable_not_found_at_run_time")
+        elif isinstance(subprocess_exception, str) and subprocess_exception.startswith("PermissionError"):
+            blockers.append("workcell_builder_executable_permission_denied_at_run_time")
     if rc not in (0, None): blockers.append("child_process_returned_nonzero")
 
     if args.output.exists():
@@ -419,10 +525,13 @@ def main() -> int:
 
     fail_payload = {
         **diag,
-        "status": "FAIL",
+        "status": "BLOCKED" if subprocess_exception else "FAIL",
         "blockers": blockers,
         "warnings": warnings,
     }
+    if subprocess_exception:
+        fail_payload["subprocess_exception"] = subprocess_exception
+        fail_payload["guidance"] = _executable_guidance()
     _write_json(args.output, fail_payload)
     print("status=FAIL smoke_status=WRAPPER_FAIL_JSON")
     print("child_command=" + diag["child_command"])

--- a/scripts/workcell_studio_path_resolver.py
+++ b/scripts/workcell_studio_path_resolver.py
@@ -74,9 +74,15 @@ def resolve_workcell_builder_executable(workspace_root: Path | None, explicit_ex
     if explicit_executable:
         exe = Path(explicit_executable).expanduser().resolve()
         searched.append(exe)
+        _LAST["explicit_executable"] = str(exe)
         _LAST["searched_executable_paths"] = [str(p) for p in searched]
-        return exe if exe.exists() and os.access(exe, os.X_OK) else None
+        _LAST["explicit_executable_exists"] = exe.exists()
+        _LAST["explicit_executable_is_executable"] = exe.exists() and os.access(exe, os.X_OK)
+        return exe if _LAST["explicit_executable_is_executable"] else None
 
+    _LAST.pop("explicit_executable", None)
+    _LAST.pop("explicit_executable_exists", None)
+    _LAST.pop("explicit_executable_is_executable", None)
     searched.extend(workcell_builder_executable_candidates(workspace_root))
     _LAST["searched_executable_paths"] = [str(p) for p in searched]
     for p in searched:

--- a/tests/test_scene3d_gui_smoke_runner_setup_errors.py
+++ b/tests/test_scene3d_gui_smoke_runner_setup_errors.py
@@ -54,3 +54,35 @@ def test_gui_smoke_explicit_workspace_no_unboundlocalerror(tmp_path):
     proc = subprocess.run(cmd, capture_output=True, text=True)
     combined = (proc.stdout or "") + (proc.stderr or "")
     assert "UnboundLocalError" not in combined
+
+
+def test_gui_smoke_invalid_explicit_executable_writes_blocked_json(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    out = tmp_path / "smoke.json"
+    bad_exe = tmp_path / "not_executable_workcell_builder"
+    bad_exe.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    bad_exe.chmod(0o644)
+
+    cmd = [
+        "python3",
+        str(repo / "scripts/run_workcell_builder_scene3d_gui_smoke.py"),
+        "--repo-root",
+        str(repo),
+        "--workspace-root",
+        str(repo),
+        "--executable",
+        str(bad_exe),
+        "--scene",
+        "ur5_2f_test",
+        "--output",
+        str(out),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert out.exists()
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["status"] == "BLOCKED"
+    assert payload["explicit_executable"] == str(bad_exe)
+    assert payload["searched_paths"] == [str(bad_exe.resolve())]
+    assert payload["blockers"] == ["explicit_workcell_builder_executable_missing_or_not_executable"]
+    assert "guidance" in payload

--- a/tests/test_workcell_studio_path_resolver.py
+++ b/tests/test_workcell_studio_path_resolver.py
@@ -16,3 +16,18 @@ def test_missing_executable_reports_searched_paths(tmp_path):
     exe = resolve_workcell_builder_executable(ws)
     assert exe is None
     assert describe_resolution().get('searched_executable_paths')
+
+def test_invalid_explicit_executable_reports_only_explicit_path(tmp_path):
+    ws = tmp_path / 'robot_ws'
+    ws.mkdir()
+    missing = tmp_path / 'missing_workcell_builder'
+
+    assert resolve_workcell_builder_executable(ws, explicit_executable=missing) is None
+    assert describe_resolution().get('searched_executable_paths') == [str(missing.resolve())]
+
+    not_executable = tmp_path / 'workcell_builder'
+    not_executable.write_text('#!/bin/sh\nexit 0\n', encoding='utf-8')
+    not_executable.chmod(0o644)
+
+    assert resolve_workcell_builder_executable(ws, explicit_executable=not_executable) is None
+    assert describe_resolution().get('searched_executable_paths') == [str(not_executable.resolve())]


### PR DESCRIPTION
### Motivation

- Make explicit `--executable` handling deterministic by resolving it through the shared resolver and provide clear, machine-readable BLOCKED evidence when the provided path is missing or not executable.
- Avoid unhandled `FileNotFoundError`/`PermissionError` from `subprocess.run()` and convert such failures into structured smoke JSON so automation and operators receive actionable guidance.

### Description

- Route explicit executable resolution through `resolve_workcell_builder_executable(workspace_root, explicit_executable=args.executable)` and extend the resolver to record `explicit_executable` metadata (`scripts/workcell_studio_path_resolver.py`).
- Add `_write_blocked_executable_payload`, `_executable_guidance`, and `_subprocess_exception_to_text` helpers and emit a `BLOCKED` smoke JSON when an explicit executable is missing or not executable, including `explicit_executable`, `searched_paths`, the blocker `explicit_workcell_builder_executable_missing_or_not_executable`, and guidance for the operator (`scripts/run_workcell_builder_scene3d_gui_smoke.py`).
- Catch `FileNotFoundError` and `PermissionError` around `subprocess.run()` for both single-scene and all-scenes child runs and convert them to structured `BLOCKED` evidence (with `child_process_spawn_failed` / runtime-specific blockers) instead of allowing an unhandled exception to propagate (`scripts/run_workcell_builder_scene3d_gui_smoke.py`).
- Add focused unit tests for invalid explicit executable handling: `test_invalid_explicit_executable_reports_only_explicit_path` and `test_gui_smoke_invalid_explicit_executable_writes_blocked_json` (`tests/test_workcell_studio_path_resolver.py`, `tests/test_scene3d_gui_smoke_runner_setup_errors.py`).

### Testing

- Ran `pytest -q tests/test_workcell_studio_path_resolver.py tests/test_scene3d_gui_smoke_runner_setup_errors.py` and all tests passed (`7 passed`).
- Verified Python syntax for changed scripts with `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py scripts/workcell_studio_path_resolver.py` which succeeded. 
- Ran additional sanity checks `pytest -q tests/test_no_hardcoded_workspace_paths.py tests/test_script_direct_execution_imports.py` which passed (`3 passed`).
- Noted a broader CLI-contract test run including `tests/test_scene3d_cli_contracts_pr2042.py` failed in unrelated existing expectations during iterative debugging; this failure is orthogonal to the executable-resolution changes and remains to be investigated separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e758011c8331864daf0edd75dc80)