### PR TITLE
Fix Scene3D smoke path resolution

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -165,8 +165,8 @@ def _discover_scene_targets(repo_root: Path) -> list[dict[str, Any]]:
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--repo-root", type=Path, default=_REPO_ROOT)
-    ap.add_argument("--workspace-root", type=Path, default=_REPO_ROOT)
+    ap.add_argument("--repo-root", type=Path, default=None)
+    ap.add_argument("--workspace-root", type=Path, default=None)
     ap.add_argument("--executable", type=Path, default=None)
     ap.add_argument("--scene", default=None)
     ap.add_argument("--all-scenes", action="store_true")
@@ -192,11 +192,17 @@ def main() -> int:
     if not args.all_scenes and args.output is None:
         raise SystemExit("--output is required unless --all-scenes is used")
 
-    repo_root = resolve_repo_root(explicit_repo_root=args.repo_root)
+    repo_root = resolve_repo_root(start=Path.cwd(), explicit_repo_root=args.repo_root)
     workspace_root = resolve_workspace_root(repo_root, args.workspace_root)
+    workspace_root_inference_failed = workspace_root is None
+    workspace_root_json = str(workspace_root) if workspace_root is not None else None
+    resolution_warnings = []
+    if workspace_root_inference_failed:
+        resolution_warnings.append("workspace_root_inference_failed_path_only_executable_search")
     exe = args.executable or resolve_workcell_builder_executable(workspace_root)
     if exe is None and not args.all_scenes:
-        searched = [str(p) for p in _resolve_executable_candidates(workspace_root or repo_root)]
+        searched = [str(p) for p in _resolve_executable_candidates(workspace_root)]
+        warnings = ["runtime_gui_unavailable_static_scene3d_visual_evidence_recorded", *resolution_warnings]
         scene_dir = _resolve_single_scene_dir(repo_root, args.scene, args.scene_path)
         static_evidence = _static_scene3d_visual_evidence(scene_dir)
         fail_payload = {
@@ -204,11 +210,11 @@ def main() -> int:
             "status": "FAIL",
             "scene": args.scene or (args.scene_path.name if args.scene_path else None),
             "repo_root": str(repo_root),
-            "workspace_root": str(workspace_root),
+            "workspace_root": workspace_root_json,
             "executable": None,
             "searched_paths": searched,
             "blockers": ["unable_to_resolve_workcell_builder_executable"],
-            "warnings": ["runtime_gui_unavailable_static_scene3d_visual_evidence_recorded"],
+            "warnings": warnings,
             "screenshot_available": False,
             "scene_dir": str(scene_dir) if scene_dir else None,
             "static_scene3d_visual_evidence": static_evidence,
@@ -249,9 +255,11 @@ def main() -> int:
             scene_json = out_dir / f"scene3d_gui_smoke_{scene_name}.json"
             scene_png = out_dir / f"scene3d_gui_smoke_{scene_name}.png"
             cmd = [
-                sys.executable, str(Path(__file__).resolve()), "--repo-root", str(repo_root), "--workspace-root", str(workspace_root),
+                sys.executable, str(Path(__file__).resolve()), "--repo-root", str(repo_root),
                 "--scene", scene_name, "--output", str(scene_json), "--screenshot", str(scene_png),
             ]
+            if workspace_root is not None:
+                cmd += ["--workspace-root", str(workspace_root)]
             if exe:
                 cmd += ["--executable", str(exe)]
             cmd += ["--timeout-sec", str(args.timeout_sec)]
@@ -285,7 +293,7 @@ def main() -> int:
                 payload["scene_level_blockers"] = blockers
                 _write_json(scene_json, payload)
         summary = {
-            "schema": EXPECTED_SCHEMA, "mode": "all_scenes", "output_dir": str(out_dir), "totals": totals, "results": per_scene,
+            "schema": EXPECTED_SCHEMA, "mode": "all_scenes", "repo_root": str(repo_root), "workspace_root": workspace_root_json, "output_dir": str(out_dir), "totals": totals, "results": per_scene,
             "supported_scene_count": len(per_scene),
             "legacy_incomplete_count": len(legacy_incomplete),
             "ignored_non_scene_count": len(ignored_non_scenes),
@@ -318,6 +326,8 @@ def main() -> int:
                 "status": "FAIL",
                 "scene": args.scene or sp.name,
                 "scene_path": str(sp),
+                "repo_root": str(repo_root),
+                "workspace_root": workspace_root_json,
                 "blockers": [f"scene_path_missing_required_files:{','.join(missing)}"],
                 "warnings": [],
             }
@@ -342,7 +352,7 @@ def main() -> int:
         "scene": args.scene or (args.scene_path.name if args.scene_path else None),
         "scene_path": str(args.scene_path) if args.scene_path else None,
         "repo_root": str(repo_root),
-        "workspace_root": str(workspace_root),
+        "workspace_root": workspace_root_json,
         "executable": str(exe),
         "child_command": " ".join(shlex.quote(x) for x in cmd),
         "cwd": str(repo_root),
@@ -351,6 +361,7 @@ def main() -> int:
         "stdout_log_path": str(stdout_log),
         "stderr_log_path": str(stderr_log),
         "screenshot_path": str(args.screenshot) if args.screenshot else None,
+        "resolution_warnings": resolution_warnings,
     }
 
     timed_out = False
@@ -389,6 +400,13 @@ def main() -> int:
         try:
             payload=json.loads(args.output.read_text(encoding="utf-8"))
             app_status=payload.get("status","UNKNOWN")
+            payload["repo_root"] = str(repo_root)
+            payload["workspace_root"] = workspace_root_json
+            payload.setdefault("executable", str(exe))
+            if resolution_warnings:
+                existing_warnings = payload.get("warnings") if isinstance(payload.get("warnings"), list) else []
+                payload["warnings"] = [*existing_warnings, *[w for w in resolution_warnings if w not in existing_warnings]]
+            _write_json(args.output, payload)
         except Exception:
             payload = {}
         if args.scene_path:

--- a/tests/test_scene3d_cli_contracts_pr2042.py
+++ b/tests/test_scene3d_cli_contracts_pr2042.py
@@ -107,8 +107,13 @@ def test_gui_smoke_accepts_scene_path(monkeypatch, tmp_path: Path):
         calls.append(cmd)
         return type("P", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
+    for rel in ["package.xml", "scene_manifest.yaml", "cell_definition.yaml", "launch/demo.launch.py"]:
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x", encoding="utf-8")
+
     monkeypatch.setattr(smoke.subprocess, "run", fake_run)
-    monkeypatch.setattr(smoke, "resolve_repo_root", lambda explicit_repo_root=None: tmp_path)
+    monkeypatch.setattr(smoke, "resolve_repo_root", lambda start=None, explicit_repo_root=None: tmp_path)
     monkeypatch.setattr(smoke, "resolve_workspace_root", lambda repo_root, explicit_workspace_root=None: tmp_path)
     monkeypatch.setattr(smoke, "resolve_workcell_builder_executable", lambda workspace_root: Path("/bin/true"))
     monkeypatch.setattr(smoke.sys, "argv", ["prog", "--scene-path", str(tmp_path), "--output", str(out), "--screenshot", str(shot), "--timeout-sec", "1"])
@@ -132,7 +137,7 @@ def test_gui_smoke_fails_if_explicit_scene_path_not_loaded(monkeypatch, tmp_path
         return type('P', (), {'returncode': 0, 'stdout': '', 'stderr': ''})()
 
     monkeypatch.setattr(smoke.subprocess, 'run', fake_run)
-    monkeypatch.setattr(smoke, 'resolve_repo_root', lambda explicit_repo_root=None: tmp_path)
+    monkeypatch.setattr(smoke, 'resolve_repo_root', lambda start=None, explicit_repo_root=None: tmp_path)
     monkeypatch.setattr(smoke, 'resolve_workspace_root', lambda repo_root, explicit_workspace_root=None: tmp_path)
     monkeypatch.setattr(smoke, 'resolve_workcell_builder_executable', lambda workspace_root: Path('/bin/true'))
     monkeypatch.setattr(smoke.sys, 'argv', ['prog', '--scene-path', str(pkg), '--output', str(out), '--screenshot', str(shot), '--timeout-sec', '1'])

--- a/tests/test_scene3d_gui_smoke_runner_setup_errors.py
+++ b/tests/test_scene3d_gui_smoke_runner_setup_errors.py
@@ -54,3 +54,29 @@ def test_gui_smoke_explicit_workspace_no_unboundlocalerror(tmp_path):
     proc = subprocess.run(cmd, capture_output=True, text=True)
     combined = (proc.stdout or "") + (proc.stderr or "")
     assert "UnboundLocalError" not in combined
+
+
+def test_gui_smoke_unresolved_workspace_records_null_and_path_search(tmp_path, monkeypatch):
+    repo = Path(__file__).resolve().parents[1]
+    out = tmp_path / "smoke.json"
+    shot = tmp_path / "smoke.png"
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    cmd = [
+        "python3",
+        str(repo / "scripts/run_workcell_builder_scene3d_gui_smoke.py"),
+        "--repo-root",
+        str(repo),
+        "--scene",
+        "ur5_2f_test",
+        "--output",
+        str(out),
+        "--screenshot",
+        str(shot),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, cwd=tmp_path)
+    assert proc.returncode != 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["repo_root"] == str(repo)
+    assert payload["workspace_root"] is None
+    assert "workspace_root_inference_failed_path_only_executable_search" in payload["warnings"]
+    assert all("install/workcell_builder" not in p for p in payload["searched_paths"])


### PR DESCRIPTION
### Motivation
- Make repo/workspace resolution for the Scene3D GUI smoke wrapper more robust when not passed explicitly and surface clear JSON evidence when workspace inference fails.

### Description
- Change CLI defaults so `--repo-root` and `--workspace-root` are optional and resolve the repo root with `resolve_repo_root(start=Path.cwd(), explicit_repo_root=args.repo_root)` while keeping explicit `--repo-root` authoritative.
- Resolve the workspace root using `resolve_workspace_root(repo_root, args.workspace_root)` and preserve explicit `--workspace-root` when provided, while recording `workspace_root: null` in JSON when inference fails.
- When workspace inference fails, still search PATH-only executable candidates and record a `workspace_root_inference_failed_path_only_executable_search` warning alongside `runtime_gui_unavailable_static_scene3d_visual_evidence_recorded`, and avoid passing `--workspace-root None` to child invocations by omitting the flag when unresolved.
- Include `repo_root` and nullable `workspace_root` consistently in single-scene failure payloads, all-scenes summaries, wrapper diagnostics, and inlined app payloads, and add/adjust tests to cover the new resolve_repo_root signature and unresolved-workspace behavior.

### Testing
- Ran the scene-smoke related unit tests: `pytest -q tests/test_scene3d_gui_smoke_runner_setup_errors.py` and targeted tests from `tests/test_scene3d_cli_contracts_pr2042.py` covering `test_gui_smoke_accepts_scene_path`, `test_gui_smoke_fails_if_explicit_scene_path_not_loaded`, and `test_gui_smoke_all_scenes_output_dir_without_output_parses`, all of which passed.
- Compiled the updated script with `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py`, which succeeded.
- Automated smoke-run behaviors (child invocation, JSON output cases, PATH-only executable search, and scene-path validation) were exercised by the tests and validated as passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e76fa1448331aad3f555d3c1ff1c)