### PR TITLE
Enrich Scene3D GUI smoke wrapper output

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -337,6 +337,7 @@ def main() -> int:
             stale_path.unlink()
     child_env = os.environ.copy()
     child_env.update(extra_env)
+    searched_paths = [str(p) for p in _resolve_executable_candidates(workspace_root or repo_root)]
     diag = {
         "schema": EXPECTED_SCHEMA,
         "scene": args.scene or (args.scene_path.name if args.scene_path else None),
@@ -344,6 +345,8 @@ def main() -> int:
         "repo_root": str(repo_root),
         "workspace_root": str(workspace_root),
         "executable": str(exe),
+        "resolved_executable": str(exe),
+        "searched_paths": searched_paths,
         "child_command": " ".join(shlex.quote(x) for x in cmd),
         "cwd": str(repo_root),
         "env": {k: child_env.get(k, "") for k in ["DISPLAY", "WAYLAND_DISPLAY", "QT_QPA_PLATFORM", "QT_OPENGL", "LIBGL_ALWAYS_SOFTWARE", "XDG_SESSION_TYPE"]},
@@ -384,32 +387,69 @@ def main() -> int:
     if rc not in (0, None): blockers.append("child_process_returned_nonzero")
 
     if args.output.exists():
-        app_status="UNKNOWN"
-        payload: dict[str, Any] = {}
         try:
-            payload=json.loads(args.output.read_text(encoding="utf-8"))
-            app_status=payload.get("status","UNKNOWN")
-        except Exception:
-            payload = {}
+            payload = json.loads(args.output.read_text(encoding="utf-8"))
+            if not isinstance(payload, dict):
+                raise ValueError("app smoke JSON root is not an object")
+        except Exception as exc:  # noqa: BLE001
+            blockers.append(f"app_smoke_json_unreadable:{exc}")
+            fail_payload = {
+                **diag,
+                "status": "FAIL",
+                "wrapper_status": "FAIL",
+                "blockers": blockers,
+                "warnings": warnings,
+            }
+            _write_json(args.output, fail_payload)
+            print(f"status=FAIL smoke_status=APP_JSON_UNREADABLE error={exc}")
+            print("child_command=" + diag["child_command"])
+            print("stdout_log_path=" + str(stdout_log))
+            print("stderr_log_path=" + str(stderr_log))
+            return 1
+
+        app_status = str(payload.get("status", "UNKNOWN") or "UNKNOWN")
+        wrapper_status = "BLOCKED" if timed_out else ("FAIL" if rc not in (0, None) else "PASS")
+        wrapper_evidence = {
+            "wrapper_status": wrapper_status,
+            "resolved_executable": diag["resolved_executable"],
+            "searched_paths": diag["searched_paths"],
+            "repo_root": diag["repo_root"],
+            "workspace_root": diag["workspace_root"],
+            "scene_path": diag["scene_path"],
+            "child_command": diag["child_command"],
+            "child_returncode": rc,
+            "timed_out": timed_out,
+            "stdout_log_path": str(stdout_log),
+            "stderr_log_path": str(stderr_log),
+            "stdout_tail": stdout_tail,
+            "stderr_tail": stderr_tail,
+            "screenshot_path": diag["screenshot_path"],
+            "screenshot_available": diag["screenshot_available"],
+        }
+        payload.update(wrapper_evidence)
         if args.scene_path:
             expected_scene_path = str(args.scene_path.resolve())
             counters = payload.get("counters") if isinstance(payload.get("counters"), dict) else {}
             actual_scene_path = str(counters.get("inspector_scene_path") or counters.get("selected_scene_path") or "").strip()
             if Path(actual_scene_path).as_posix() != Path(expected_scene_path).as_posix():
-                blockers = list(payload.get("blockers") or [])
-                blockers.append("explicit_scene_path_not_loaded")
+                scene_path_blockers = list(payload.get("blockers") or [])
+                scene_path_blockers.append("explicit_scene_path_not_loaded")
                 payload["status"] = "FAIL"
                 payload["expected_scene_path"] = expected_scene_path
                 payload["actual_scene_path"] = actual_scene_path
-                payload["blockers"] = blockers
+                payload["blockers"] = scene_path_blockers
                 _write_json(args.output, payload)
-                print(f"status=FAIL smoke_status=EXPLICIT_SCENE_PATH_MISMATCH expected_scene_path={expected_scene_path} actual_scene_path={actual_scene_path}")
+                print(f"status=FAIL smoke_status=EXPLICIT_SCENE_PATH_MISMATCH wrapper_status={wrapper_status} expected_scene_path={expected_scene_path} actual_scene_path={actual_scene_path}")
                 return 1
-        print(f"status=PASS smoke_status=APP_JSON_PRESENT wrapper_status=PASS app_status={app_status} returncode={rc} timed_out={timed_out}")
+        _write_json(args.output, payload)
+        effective_status = app_status
+        if app_status.upper() not in {"FAIL", "BLOCKED"} and wrapper_status != "PASS":
+            effective_status = wrapper_status
+        print(f"status={effective_status} smoke_status=APP_JSON_PRESENT wrapper_status={wrapper_status} app_status={app_status} returncode={rc} timed_out={timed_out}")
         print("child_command=" + diag["child_command"])
         print("stdout_log_path=" + str(stdout_log))
         print("stderr_log_path=" + str(stderr_log))
-        return 0 if rc == 0 else 1
+        return 0 if wrapper_status == "PASS" and app_status.upper() not in {"FAIL", "BLOCKED"} else 1
 
     blockers.append("app_smoke_json_missing")
     if "--scene3d-smoke" in diag["child_command"] and "--smoke-output" in diag["child_command"]:

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -57,3 +57,75 @@ def test_smoke_fallback_render_preserves_counter_gate():
     assert 'rc_after_paint.rendered_count <= 0' in main_cpp
     assert 'last_render_counters.rendered_count = rendered_item_count' in viewport_cpp
     assert 'return rendered_item_count > 0' in viewport_cpp
+
+
+def _write_fake_smoke_executable(path: Path, status: str, exit_code: int = 0) -> None:
+    path.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, pathlib, sys\n"
+        "out = pathlib.Path(sys.argv[sys.argv.index('--smoke-output') + 1])\n"
+        "payload = {\n"
+        f"    'schema': 'workcell_studio_scene3d_gui_smoke/v1', 'status': {status!r},\n"
+        "    'counters': {'rendered_count': 7},\n"
+        "    'render_debug_counters': {'physical_mesh_items_rendered': 3},\n"
+        "}\n"
+        "out.parent.mkdir(parents=True, exist_ok=True)\n"
+        "out.write_text(json.dumps(payload) + '\\n', encoding='utf-8')\n"
+        "print('fake app stdout line')\n"
+        "print('fake app stderr line', file=sys.stderr)\n"
+        f"raise SystemExit({exit_code})\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def test_wrapper_enriches_app_json_without_replacing_app_counters(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    out = tmp_path / "smoke.json"
+    exe = tmp_path / "fake_workcell_builder.py"
+    _write_fake_smoke_executable(exe, "PASS")
+    cmd = [
+        "python3", str(repo / "scripts/run_workcell_builder_scene3d_gui_smoke.py"),
+        "--repo-root", str(repo), "--workspace-root", str(tmp_path), "--scene", "ur5_2f_test",
+        "--output", str(out), "--executable", str(exe), "--timeout-sec", "2",
+    ]
+    proc = subprocess.run(cmd, text=True, capture_output=True)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["status"] == "PASS"
+    assert payload["wrapper_status"] == "PASS"
+    assert payload["resolved_executable"] == str(exe)
+    assert isinstance(payload["searched_paths"], list)
+    assert payload["repo_root"] == str(repo)
+    assert payload["workspace_root"] == str(tmp_path)
+    assert payload["scene_path"] is None
+    assert "--scene3d-smoke" in payload["child_command"]
+    assert payload["child_returncode"] == 0
+    assert payload["timed_out"] is False
+    assert payload["stdout_log_path"].endswith(".stdout.log")
+    assert payload["stderr_log_path"].endswith(".stderr.log")
+    assert "fake app stdout line" in payload["stdout_tail"]
+    assert "fake app stderr line" in payload["stderr_tail"]
+    assert payload["screenshot_path"] is None
+    assert payload["screenshot_available"] is False
+    assert payload["counters"] == {"rendered_count": 7}
+    assert payload["render_debug_counters"] == {"physical_mesh_items_rendered": 3}
+
+
+def test_wrapper_preserves_app_fail_status_when_child_returns_zero(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    out = tmp_path / "smoke.json"
+    exe = tmp_path / "fake_workcell_builder.py"
+    _write_fake_smoke_executable(exe, "FAIL")
+    cmd = [
+        "python3", str(repo / "scripts/run_workcell_builder_scene3d_gui_smoke.py"),
+        "--repo-root", str(repo), "--workspace-root", str(tmp_path), "--scene", "ur5_2f_test",
+        "--output", str(out), "--executable", str(exe), "--timeout-sec", "2",
+    ]
+    proc = subprocess.run(cmd, text=True, capture_output=True)
+    assert proc.returncode != 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["status"] == "FAIL"
+    assert payload["wrapper_status"] == "PASS"
+    assert payload["counters"] == {"rendered_count": 7}
+    assert "status=FAIL" in proc.stdout


### PR DESCRIPTION
### Motivation
- Improve the wrapper success path to preserve and surface both app-provided smoke evidence and wrapper-level diagnostics so downstream consumers get a complete, non-destructive record.
- Ensure wrapper diagnostics (logs, return code, resolved executable, etc.) are recorded without overwriting app `counters` / `render_debug_counters` and without silently turning an app `FAIL` / `BLOCKED` into a `PASS`.

### Description
- Updated `scripts/run_workcell_builder_scene3d_gui_smoke.py` to load the app-generated smoke JSON when `args.output.exists()`, merge wrapper-level evidence fields into it, and write the enriched payload back to `args.output` while preserving app counters and render debug counters.
- The wrapper-level fields added/merged are `wrapper_status`, `resolved_executable`, `searched_paths`, `repo_root`, `workspace_root`, `scene_path`, `child_command`, `child_returncode`, `timed_out`, `stdout_log_path`, `stderr_log_path`, `stdout_tail`, `stderr_tail`, `screenshot_path`, and `screenshot_available`.
- The logic ensures the wrapper does not convert an app `FAIL` or `BLOCKED` into `PASS`; the effective exit and printed `status=` honor app `FAIL`/`BLOCKED` and return nonzero when appropriate.
- Added contract tests in `tests/test_scene3d_gui_smoke_json_output_contract.py` to validate enrichment and preservation of app fail status.

### Testing
- Ran `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py -q` and the new/modified smoke contract tests passed (all tests passed).
- Ran `python3 -m pytest tests/test_scene3d_gui_smoke_runner_setup_errors.py tests/test_scene3d_gui_smoke_json_output_contract.py tests/test_script_direct_execution_imports.py -q` and all tests passed.
- Performed `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py tests/test_scene3d_gui_smoke_json_output_contract.py` to verify syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e78021e883318fb1323a571c2de3)