### PR TITLE
Resolve Workcell Builder executable consistently

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -9,7 +9,7 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 from scripts.workcell_studio_script_bootstrap import ensure_repo_root_on_sys_path
 ensure_repo_root_on_sys_path(__file__)
-from scripts.workcell_studio_path_resolver import resolve_repo_root, resolve_workspace_root, resolve_workcell_builder_executable, workcell_builder_executable_candidates
+from scripts.workcell_studio_path_resolver import describe_resolution, resolve_repo_root, resolve_workspace_root, resolve_workcell_builder_executable, workcell_builder_executable_candidates
 from scripts.scene_root_resolver import resolve_scene_root
 from scripts.scene3d_scene_discovery import discover_scene3d_scenes
 
@@ -166,7 +166,7 @@ def _discover_scene_targets(repo_root: Path) -> list[dict[str, Any]]:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--repo-root", type=Path, default=_REPO_ROOT)
-    ap.add_argument("--workspace-root", type=Path, default=_REPO_ROOT)
+    ap.add_argument("--workspace-root", type=Path, default=None)
     ap.add_argument("--executable", type=Path, default=None)
     ap.add_argument("--scene", default=None)
     ap.add_argument("--all-scenes", action="store_true")
@@ -193,10 +193,11 @@ def main() -> int:
         raise SystemExit("--output is required unless --all-scenes is used")
 
     repo_root = resolve_repo_root(explicit_repo_root=args.repo_root)
-    workspace_root = resolve_workspace_root(repo_root, args.workspace_root)
-    exe = args.executable or resolve_workcell_builder_executable(workspace_root)
+    workspace_root = resolve_workspace_root(repo_root, args.workspace_root) or repo_root
+    exe = resolve_workcell_builder_executable(workspace_root, args.executable)
+    executable_resolution = describe_resolution()
     if exe is None and not args.all_scenes:
-        searched = [str(p) for p in _resolve_executable_candidates(workspace_root or repo_root)]
+        searched = list(executable_resolution.get("searched_executable_paths") or [str(p) for p in _resolve_executable_candidates(workspace_root)])
         scene_dir = _resolve_single_scene_dir(repo_root, args.scene, args.scene_path)
         static_evidence = _static_scene3d_visual_evidence(scene_dir)
         fail_payload = {
@@ -207,6 +208,7 @@ def main() -> int:
             "workspace_root": str(workspace_root),
             "executable": None,
             "searched_paths": searched,
+            "executable_resolution": executable_resolution,
             "blockers": ["unable_to_resolve_workcell_builder_executable"],
             "warnings": ["runtime_gui_unavailable_static_scene3d_visual_evidence_recorded"],
             "screenshot_available": False,
@@ -286,6 +288,8 @@ def main() -> int:
                 _write_json(scene_json, payload)
         summary = {
             "schema": EXPECTED_SCHEMA, "mode": "all_scenes", "output_dir": str(out_dir), "totals": totals, "results": per_scene,
+            "repo_root": str(repo_root), "workspace_root": str(workspace_root), "executable": str(exe) if exe else None,
+            "executable_resolution": executable_resolution,
             "supported_scene_count": len(per_scene),
             "legacy_incomplete_count": len(legacy_incomplete),
             "ignored_non_scene_count": len(ignored_non_scenes),
@@ -344,6 +348,8 @@ def main() -> int:
         "repo_root": str(repo_root),
         "workspace_root": str(workspace_root),
         "executable": str(exe),
+        "searched_paths": list(executable_resolution.get("searched_executable_paths") or []),
+        "executable_resolution": executable_resolution,
         "child_command": " ".join(shlex.quote(x) for x in cmd),
         "cwd": str(repo_root),
         "env": {k: child_env.get(k, "") for k in ["DISPLAY", "WAYLAND_DISPLAY", "QT_QPA_PLATFORM", "QT_OPENGL", "LIBGL_ALWAYS_SOFTWARE", "XDG_SESSION_TYPE"]},

--- a/scripts/run_workcell_studio_scene_readiness_matrix.py
+++ b/scripts/run_workcell_studio_scene_readiness_matrix.py
@@ -12,7 +12,6 @@ import argparse
 import json
 import os
 import shlex
-import shutil
 import sys
 from collections import Counter
 from datetime import datetime, timezone
@@ -25,6 +24,8 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT_DEFAULT = SCRIPT_DIR.parents[0]
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
+if str(REPO_ROOT_DEFAULT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT_DEFAULT))
 
 from check_scene_readiness import check_readiness  # noqa: E402
 from supported_scene_catalog import default_catalog_path, load_supported_scene_catalog  # noqa: E402
@@ -32,6 +33,7 @@ from validate_builder_generated_scene import validate_scene as validate_builder_
 from validate_cell_definition import load_yaml as load_cell_yaml  # noqa: E402
 from validate_cell_definition import validate_cell_definition  # noqa: E402
 from validate_scene3d_visual_quality_matrix import evaluate_scene as evaluate_scene3d_visual_quality  # noqa: E402
+from workcell_studio_path_resolver import describe_resolution, resolve_workspace_root, resolve_workcell_builder_executable  # noqa: E402
 
 SCHEMA_VERSION = "workcell_studio_scene_readiness_matrix/v1"
 PASS = "PASS"
@@ -396,16 +398,10 @@ def _ros_humble_available() -> bool:
     return Path("/opt/ros/humble/setup.bash").is_file() or os.environ.get("ROS_DISTRO") == "humble"
 
 
-def _workcell_builder_executable_found(repo_root: Path) -> bool:
-    if shutil.which("workcell_builder"):
-        return True
-    for candidate in (
-        repo_root / "install" / "workcell_builder" / "lib" / "workcell_builder" / "workcell_builder",
-        repo_root / "build" / "workcell_builder" / "workcell_builder",
-    ):
-        if candidate.is_file() and os.access(candidate, os.X_OK):
-            return True
-    return False
+def _resolve_workcell_builder_executable_evidence(workspace_root: Path | None) -> tuple[bool, dict[str, Any]]:
+    executable = resolve_workcell_builder_executable(workspace_root)
+    evidence = describe_resolution()
+    return executable is not None, evidence
 
 
 def _ros_launch_smoke_state(ros_available: bool, launch_check: dict[str, Any]) -> dict[str, Any]:
@@ -524,10 +520,10 @@ def _write_markdown(payload: dict[str, Any], path: Path) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def build_matrix(repo_root: Path, catalog_path: Path, output_dir: Path) -> dict[str, Any]:
+def build_matrix(repo_root: Path, workspace_root: Path | None, catalog_path: Path, output_dir: Path) -> dict[str, Any]:
     catalog, entries, catalog_errors = load_supported_scene_catalog(catalog_path)
     ros_available = _ros_humble_available()
-    builder_found = _workcell_builder_executable_found(repo_root)
+    builder_found, builder_evidence = _resolve_workcell_builder_executable_evidence(workspace_root)
 
     enabled_supported_entries = [
         entry
@@ -552,7 +548,7 @@ def build_matrix(repo_root: Path, catalog_path: Path, output_dir: Path) -> dict[
         "schema_version": SCHEMA_VERSION,
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "repo_root": str(repo_root),
-        "workspace_root": str(repo_root.parent),
+        "workspace_root": str(workspace_root) if workspace_root else None,
         "catalog_path": str(catalog_path),
         "catalog_schema_version": catalog.get("schema_version"),
         "catalog_errors": catalog_errors,
@@ -562,12 +558,19 @@ def build_matrix(repo_root: Path, catalog_path: Path, output_dir: Path) -> dict[
         "commands": commands,
         "ros_humble_available": ros_available,
         "workcell_builder_executable_found": builder_found,
+        "workcell_builder_executable_resolution": builder_evidence,
     }
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo-root", type=Path, default=REPO_ROOT_DEFAULT)
+    parser.add_argument(
+        "--workspace-root",
+        type=Path,
+        default=None,
+        help="ROS workspace root; inferred from --repo-root when omitted",
+    )
     parser.add_argument(
         "--catalog",
         "--supported-scenes",
@@ -583,11 +586,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     repo_root = args.repo_root.resolve()
+    workspace_root = resolve_workspace_root(repo_root, args.workspace_root) or repo_root
     catalog_path = (args.catalog.resolve() if args.catalog else default_catalog_path(repo_root).resolve())
     output_dir = (args.output_dir.resolve() if args.output_dir else (repo_root / "build" / "workcell_studio_scene_readiness").resolve())
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    payload = build_matrix(repo_root, catalog_path, output_dir)
+    payload = build_matrix(repo_root, workspace_root, catalog_path, output_dir)
     json_path = output_dir / "scene_readiness_summary.json"
     md_path = output_dir / "scene_readiness_summary.md"
     json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/scripts/workcell_studio_path_resolver.py
+++ b/scripts/workcell_studio_path_resolver.py
@@ -53,15 +53,19 @@ def resolve_install_setup(workspace_root: Path | None) -> Path | None:
 def workcell_builder_executable_candidates(workspace_root: Path | None) -> list[Path]:
     candidates: list[Path] = []
 
+    if workspace_root:
+        candidates.extend([
+            workspace_root / "install" / "workcell_builder" / "bin" / "workcell_builder",
+            workspace_root / "install" / "workcell_builder" / "lib" / "workcell_builder" / "workcell_builder",
+            workspace_root / "install" / "bin" / "workcell_builder",
+        ])
+
     path_hit = shutil.which("workcell_builder")
     if path_hit:
         candidates.append(Path(path_hit))
 
     if workspace_root:
         candidates.extend([
-            workspace_root / "install" / "workcell_builder" / "lib" / "workcell_builder" / "workcell_builder",
-            workspace_root / "install" / "workcell_builder" / "bin" / "workcell_builder",
-            workspace_root / "install" / "bin" / "workcell_builder",
             workspace_root / "build" / "workcell_builder" / "workcell_builder",
             workspace_root / "build" / "workcell_builder" / "workcell_builder" / "workcell_builder",
         ])
@@ -69,19 +73,36 @@ def workcell_builder_executable_candidates(workspace_root: Path | None) -> list[
     return candidates
 
 
+def _record_executable_search(searched: list[Path], resolved: Path | None) -> None:
+    _LAST["searched_executable_paths"] = [str(p) for p in searched]
+    _LAST["workcell_builder_executable_candidates"] = [
+        {
+            "path": str(p),
+            "exists": p.exists(),
+            "is_file": p.is_file(),
+            "executable": os.access(p, os.X_OK),
+            "selected": resolved is not None and p == resolved,
+        }
+        for p in searched
+    ]
+    _LAST["resolved_workcell_builder_executable"] = str(resolved) if resolved else None
+
+
 def resolve_workcell_builder_executable(workspace_root: Path | None, explicit_executable: Path | str | None = None) -> Path | None:
     searched: list[Path] = []
     if explicit_executable:
         exe = Path(explicit_executable).expanduser().resolve()
         searched.append(exe)
-        _LAST["searched_executable_paths"] = [str(p) for p in searched]
-        return exe if exe.exists() and os.access(exe, os.X_OK) else None
+        resolved = exe if exe.exists() and os.access(exe, os.X_OK) else None
+        _record_executable_search(searched, resolved)
+        return resolved
 
     searched.extend(workcell_builder_executable_candidates(workspace_root))
-    _LAST["searched_executable_paths"] = [str(p) for p in searched]
     for p in searched:
         if p.exists() and os.access(p, os.X_OK):
+            _record_executable_search(searched, p)
             return p
+    _record_executable_search(searched, None)
     return None
 
 


### PR DESCRIPTION
### Motivation
- Make Workcell Builder resolution deterministic and prefer installed workspace executables over build-tree fallbacks so sourced workspaces behave as expected.
- Surface full executable search evidence in JSON reports to aid debugging when the runtime GUI cannot be found.
- Reuse a single resolver across the smoke runner and the offline readiness matrix so both tools infer the same `workspace_root` and executable candidates.

### Description
- Reordered candidates in `workcell_builder_executable_candidates(workspace_root)` to try `<workspace_root>/install/workcell_builder/bin/workcell_builder`, then `<workspace_root>/install/workcell_builder/lib/workcell_builder/workcell_builder`, then `<workspace_root>/install/bin/workcell_builder`, then `shutil.which("workcell_builder")`, then existing build-tree fallbacks. (`scripts/workcell_studio_path_resolver.py`).
- Added `_record_executable_search()` and expanded `resolve_workcell_builder_executable()` to record every searched candidate and selection metadata into `_LAST` so `describe_resolution()` returns complete evidence for JSON outputs. (`scripts/workcell_studio_path_resolver.py`).
- Updated the Scene3D GUI smoke runner to use the shared resolver, infer `workspace_root` consistently (falling back to `repo_root`), and include `executable_resolution` and `searched_paths` in fail, per-scene, and summary JSON payloads. (`scripts/run_workcell_builder_scene3d_gui_smoke.py`).
- Replaced the readiness-matrix local probe with the shared resolver evidence, added a `--workspace-root` CLI option (and inference when omitted), and exposed `workcell_builder_executable_resolution` in the generated matrix JSON/Markdown. (`scripts/run_workcell_studio_scene_readiness_matrix.py`).
- Preserved PATH support for already-sourced `install/setup.bash` via `shutil.which("workcell_builder")`, and kept all behavior fake-hardware-first and offline for the matrix.

### Testing
- Ran `python3 -m py_compile scripts/workcell_studio_path_resolver.py scripts/run_workcell_builder_scene3d_gui_smoke.py scripts/run_workcell_studio_scene_readiness_matrix.py` and compilation passed. 
- Executed `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --repo-root /workspace/Easy_Manipulator_Improved --output-dir /tmp/workcell_matrix_check2` and it produced JSON/Markdown outputs with `workcell_builder_executable_resolution` evidence as expected. 
- Executed the smoke runner `python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --repo-root /workspace/Easy_Manipulator_Improved --scene ur5_2f_test --output /tmp/workcell_smoke_missing2.json` which returned the expected missing-executable failure in this environment and wrote `searched_paths` plus `executable_resolution` into the smoke JSON for diagnosis. 
- Ran a lightweight candidates print (invoking `workcell_builder_executable_candidates`) to verify candidate ordering and it printed the workspace install candidates first; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e7785d8083318e80da77aad419e5)