### PR TITLE
Mark missing Scene3D smoke screenshots as visual-evidence blocker

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -405,6 +405,25 @@ def main() -> int:
                 _write_json(args.output, payload)
                 print(f"status=FAIL smoke_status=EXPLICIT_SCENE_PATH_MISMATCH expected_scene_path={expected_scene_path} actual_scene_path={actual_scene_path}")
                 return 1
+        screenshot_missing = bool(args.screenshot and rc == 0 and not args.screenshot.exists())
+        if args.screenshot:
+            payload["screenshot_path"] = str(args.screenshot)
+            payload["screenshot_available"] = bool(args.screenshot.exists())
+        if screenshot_missing:
+            blockers = list(payload.get("blockers") or [])
+            if "screenshot_missing" not in blockers:
+                blockers.append("screenshot_missing")
+            payload["blockers"] = blockers
+            payload["status"] = "FAIL"
+            _write_json(args.output, payload)
+            print(f"status=FAIL smoke_status=SCREENSHOT_MISSING wrapper_status=PASS app_status={app_status} returncode={rc} timed_out={timed_out}")
+            print("child_command=" + diag["child_command"])
+            print("stdout_log_path=" + str(stdout_log))
+            print("stderr_log_path=" + str(stderr_log))
+            return 0
+
+        if args.screenshot and payload:
+            _write_json(args.output, payload)
         print(f"status=PASS smoke_status=APP_JSON_PRESENT wrapper_status=PASS app_status={app_status} returncode={rc} timed_out={timed_out}")
         print("child_command=" + diag["child_command"])
         print("stdout_log_path=" + str(stdout_log))

--- a/scripts/run_workcell_studio_scene_readiness_matrix.py
+++ b/scripts/run_workcell_studio_scene_readiness_matrix.py
@@ -316,16 +316,37 @@ def _check_cell_definition(scene_dir: Path) -> dict[str, Any]:
     )
 
 
+def _smoke_indicates_runtime_screenshot_evidence(smoke_json: Path) -> bool:
+    if not smoke_json.is_file():
+        return False
+    payload, error = _load_json_file(smoke_json)
+    if error or not isinstance(payload, dict):
+        return False
+    if bool(payload.get("screenshot_available")):
+        return True
+    if str(payload.get("screenshot_path") or "").strip():
+        return True
+    for key in ("render_debug_counters", "counters", "static_scene3d_visual_evidence"):
+        nested = payload.get(key)
+        if isinstance(nested, dict) and bool(nested.get("runtime_available")):
+            return True
+    return bool(payload.get("runtime_available"))
+
+
 def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], dict[str, Any]]:
     mesh_index = scene_dir / "generated" / "scene_visual_mesh_index.json"
     smoke_json = scene_dir / "generated" / "scene3d_gui_smoke.json"
+    screenshot_path = scene_dir / "generated" / "scene3d_gui_smoke.png" if _smoke_indicates_runtime_screenshot_evidence(smoke_json) else None
     visual = evaluate_scene3d_visual_quality(
         scene_name=scene_name,
         scene_dir=scene_dir,
         mesh_index_path=mesh_index,
         smoke_json_path=smoke_json,
+        screenshot_path=screenshot_path,
     )
     blockers = [str(item) for item in visual.get("blockers", [])]
+    visual_blocker_reasons = [str(item) for item in visual.get("blocker_reasons", [])]
+    physical_blockers = [blocker for blocker in blockers if not blocker.startswith("screenshot_missing:") and blocker != "screenshot_missing"]
     warnings = [str(item) for item in visual.get("warnings", [])]
     visual_status = str(visual.get("visual_quality_status") or "").upper()
     summary_state = PASS if visual_status == PASS else FAIL
@@ -337,7 +358,9 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
         visual_quality_status=visual.get("visual_quality_status"),
         mesh_index_path=str(mesh_index),
         smoke_json=str(smoke_json),
+        screenshot_path=str(screenshot_path) if screenshot_path is not None else None,
         blockers=blockers,
+        blocker_reasons=visual_blocker_reasons,
         warnings=warnings,
         counters={
             "total_payload_count": visual.get("total_payload_count", 0),
@@ -366,9 +389,9 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
     elif physical_rendered <= 0:
         physical_state = FAIL
         physical_message = "no credible physical mesh/primitive render evidence was recorded"
-    elif blockers:
+    elif physical_blockers:
         physical_state = FAIL
-        physical_message = "physical render evidence exists but visual-quality blockers remain"
+        physical_message = "physical render evidence exists but physical visual-quality blockers remain"
     else:
         physical_state = PASS
         physical_message = "credible physical mesh/primitive visual evidence is present"
@@ -378,6 +401,7 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
         source_geometry_count=source_count,
         physical_rendered_count=physical_rendered,
         mesh_failure_summary_by_reason_code=visual.get("mesh_failure_summary_by_reason_code", {}),
+        blockers=physical_blockers,
     )
     return visual_result, physical_result
 

--- a/tests/test_scene3d_visual_quality_matrix.py
+++ b/tests/test_scene3d_visual_quality_matrix.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import yaml
 
 import scripts.run_scene3d_visual_quality_screenshots as screenshots
+import scripts.run_workcell_studio_scene_readiness_matrix as readiness_matrix
 import scripts.validate_scene3d_visual_quality_matrix as matrix
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -736,3 +738,71 @@ def test_visual_quality_matrix_raw_generated_bounds_fixture_does_not_count_as_ph
     assert result["physical_rendered_count"] == 0
     assert result["visual_quality_status"] == "FAIL"
     assert "raw/generated fallback bounds are the only visible evidence despite mesh or URDF primitive sources" in result["blockers"]
+
+
+def test_scene3d_smoke_runner_blocks_missing_requested_screenshot(tmp_path: Path) -> None:
+    repo = ROOT
+    exe = tmp_path / "fake_workcell_builder.py"
+    exe.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        "out = sys.argv[sys.argv.index('--smoke-output') + 1]\n"
+        "payload = {'schema': 'workcell_studio_scene3d_gui_smoke/v1', 'status': 'PASS', 'blockers': [], 'counters': {'mesh_rendered_count': 1}}\n"
+        "open(out, 'w', encoding='utf-8').write(json.dumps(payload))\n",
+        encoding="utf-8",
+    )
+    exe.chmod(0o755)
+    output = tmp_path / "smoke.json"
+    screenshot = tmp_path / "missing.png"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(Path("scripts/run_workcell_builder_scene3d_gui_smoke.py")),
+            "--repo-root",
+            str(repo),
+            "--workspace-root",
+            str(repo),
+            "--executable",
+            str(exe),
+            "--scene",
+            "demo_scene",
+            "--output",
+            str(output),
+            "--screenshot",
+            str(screenshot),
+            "--timeout-sec",
+            "5",
+        ],
+        cwd=Path.cwd(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert proc.returncode == 0
+    assert payload["status"] == "FAIL"
+    assert "screenshot_missing" in payload["blockers"]
+    assert payload["screenshot_path"] == str(screenshot)
+    assert payload["screenshot_available"] is False
+    assert "child_process_returned_nonzero" not in payload["blockers"]
+    assert "explicit_scene_path_not_loaded" not in payload["blockers"]
+
+
+def test_readiness_matrix_scopes_missing_screenshot_to_scene3d_visual_category(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scene_dir = _write_scene(repo, "matrix_missing_screenshot_scene", _mesh_and_primitive_index(), _passing_smoke())
+    smoke_json = scene_dir / "generated" / "scene3d_gui_smoke.json"
+    smoke_payload = json.loads(smoke_json.read_text(encoding="utf-8"))
+    smoke_payload["screenshot_path"] = str(scene_dir / "generated" / "scene3d_gui_smoke.png")
+    smoke_payload["screenshot_available"] = False
+    smoke_json.write_text(json.dumps(smoke_payload), encoding="utf-8")
+
+    visual_result, physical_result = readiness_matrix._check_scene3d("matrix_missing_screenshot_scene", scene_dir)
+
+    assert visual_result["status"] == "FAIL"
+    assert visual_result["screenshot_path"].endswith("generated/scene3d_gui_smoke.png")
+    assert "screenshot_missing" in visual_result["blocker_reasons"]
+    assert physical_result["status"] == "PASS"
+    assert physical_result["blockers"] == []


### PR DESCRIPTION
### Motivation
- Ensure requested Scene3D GUI screenshots are recorded as explicit visual-evidence blockers when they are requested but missing after a successful smoke run, without treating the missing file as an executable or scene-open failure. 
- Surface `screenshot_path` and `screenshot_available` in the smoke JSON so downstream matrix evaluation can reason about expected runtime visual evidence. 
- Keep missing-screenshot logic scoped to Scene3D visual-quality evaluation so physical visual evidence does not fail solely because a screenshot artifact is absent.

### Description
- Updated `scripts/run_workcell_builder_scene3d_gui_smoke.py` to write `screenshot_path` and `screenshot_available` into the smoke JSON when `--screenshot` is provided, and to add a `screenshot_missing` blocker when the child process returned successfully but the requested screenshot file is not present; this does not add child-process or scene-path failure markers and preserves wrapper semantics. 
- Updated `scripts/run_workcell_studio_scene_readiness_matrix.py` to detect when a smoke JSON indicates runtime GUI/screenshot evidence was expected and, in that case, pass `scene_dir / "generated" / "scene3d_gui_smoke.png"` as `screenshot_path` into `evaluate_scene3d_visual_quality`. 
- Scoped the screenshot-missing classification so `screenshot_missing` is filtered out of the credible physical-visual blocker list (physical visual evidence category only sees physical blockers), and added `blocker_reasons` / `screenshot_path` into the Scene3D visual-quality summary. 
- Added regression tests covering: smoke-runner behavior when a requested screenshot is missing and readiness-matrix scoping that keeps screenshot-missing scoped to Scene3D visual evidence (`tests/test_scene3d_visual_quality_matrix.py`). 

### Testing
- Ran Python syntax check: `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py scripts/run_workcell_studio_scene_readiness_matrix.py` — passed. 
- Ran Scene3D visual-quality tests: `pytest -q tests/test_scene3d_visual_quality_matrix.py` — all relevant tests passed (20 passed). 
- Ran targeted smoke-runner & matrix tests: `pytest -q tests/test_scene3d_visual_quality_matrix.py::test_scene3d_smoke_runner_blocks_missing_requested_screenshot tests/test_scene3d_visual_quality_matrix.py::test_readiness_matrix_scopes_missing_screenshot_to_scene3d_visual_category` — passed. 
- Note: an earlier combined test run surfaced unrelated fixtures in `tests/test_scene3d_workspace_agnostic_smoke.py` that monkeypatch `parse_args()` without the newer `repo_root` attribute; the Scene3D visual-quality tests and the new regressions passed in the validation runs above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e78e6f9c8331b9c64fee42a981fe)