### PR TITLE
Track Scene3D runtime availability and treat static counts as diagnostic context

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -53,6 +53,69 @@ def _write_json(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
+def _ros_humble_available() -> bool:
+    return Path("/opt/ros/humble/setup.bash").is_file() or os.environ.get("ROS_DISTRO") == "humble"
+
+
+def _as_int(value: Any) -> int:
+    try:
+        if value is None or isinstance(value, bool):
+            return 0
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _counter(payload: dict[str, Any], *keys: str) -> int:
+    sources = [payload]
+    for nested_key in ("counters", "render_debug_counters"):
+        nested = payload.get(nested_key)
+        if isinstance(nested, dict):
+            sources.append(nested)
+    for source in sources:
+        for key in keys:
+            if key in source:
+                return _as_int(source.get(key))
+    return 0
+
+
+def _physical_rendered_count(payload: dict[str, Any]) -> int:
+    mesh_count = _counter(payload, "physical_mesh_items_rendered", "mesh_rendered_count", "mesh_backed_count")
+    primitive_count = _counter(
+        payload,
+        "primitive_fallback_items_rendered",
+        "primitive_rendered_count",
+        "urdf_primitive_rendered_count",
+        "valid_physical_fallback_count",
+        "physical_fallback_count",
+        "physical_fallback_rendered_count",
+        "collision_primitive_rendered_count",
+    )
+    physical_total = _counter(payload, "physical_rendered_count", "credible_physical_rendered_count")
+    return max(physical_total, mesh_count + primitive_count)
+
+
+def _mark_runtime_available(payload: dict[str, Any], runtime_available: bool) -> None:
+    payload["runtime_available"] = runtime_available
+    counters = payload.setdefault("render_debug_counters", {})
+    if isinstance(counters, dict):
+        counters["runtime_available"] = runtime_available
+
+
+def _enforce_physical_render_evidence(payload: dict[str, Any]) -> dict[str, Any]:
+    _mark_runtime_available(payload, True)
+    if _physical_rendered_count(payload) > 0:
+        return payload
+    blockers = payload.get("blockers")
+    if not isinstance(blockers, list):
+        blockers = []
+    if "scene_rendered_no_physical_items" not in blockers:
+        blockers.append("scene_rendered_no_physical_items")
+    payload["blockers"] = blockers
+    payload["status"] = "FAIL"
+    payload["physical_rendered_count"] = 0
+    return payload
+
 
 def _resolve_single_scene_dir(repo_root: Path, scene: str | None, scene_path: Path | None) -> Path | None:
     if scene_path:
@@ -201,7 +264,8 @@ def main() -> int:
         static_evidence = _static_scene3d_visual_evidence(scene_dir)
         fail_payload = {
             "schema": EXPECTED_SCHEMA,
-            "status": "FAIL",
+            "status": "BLOCKED",
+            "runtime_available": False,
             "scene": args.scene or (args.scene_path.name if args.scene_path else None),
             "repo_root": str(repo_root),
             "workspace_root": str(workspace_root),
@@ -226,8 +290,41 @@ def main() -> int:
             },
         }
         _write_json(args.output, fail_payload)
-        print("status=FAIL smoke_status=MISSING_EXECUTABLE")
+        print("status=BLOCKED smoke_status=MISSING_EXECUTABLE")
         print("searched_paths=" + " | ".join(searched))
+        return 1
+
+    if not _ros_humble_available() and not args.all_scenes:
+        scene_dir = _resolve_single_scene_dir(repo_root, args.scene, args.scene_path)
+        static_evidence = _static_scene3d_visual_evidence(scene_dir)
+        fail_payload = {
+            "schema": EXPECTED_SCHEMA,
+            "status": "BLOCKED",
+            "runtime_available": False,
+            "scene": args.scene or (args.scene_path.name if args.scene_path else None),
+            "repo_root": str(repo_root),
+            "workspace_root": str(workspace_root),
+            "executable": str(exe),
+            "blockers": ["ros_humble_unavailable"],
+            "warnings": ["runtime_gui_unavailable_static_scene3d_visual_evidence_recorded"],
+            "screenshot_available": False,
+            "scene_dir": str(scene_dir) if scene_dir else None,
+            "static_scene3d_visual_evidence": static_evidence,
+            "render_debug_counters": {
+                "runtime_available": False,
+                "physical_mesh_items_rendered": 0,
+                "primitive_fallback_items_rendered": 0,
+                "zones_overlays_rendered": 0,
+                "skipped_helper_static_fallback_items": static_evidence.get("skipped_helper_static_fallback_items", 0),
+                "unresolved_transform_items": static_evidence.get("unresolved_transform_items", 0),
+                "missing_mesh_items": static_evidence.get("missing_mesh_items", 0),
+                "static_physical_mesh_items_renderable": static_evidence.get("physical_mesh_items_renderable", 0),
+                "static_primitive_fallback_items_renderable": static_evidence.get("primitive_fallback_items_renderable", 0),
+                "static_zones_overlays_renderable": static_evidence.get("zones_overlays_renderable", 0),
+            },
+        }
+        _write_json(args.output, fail_payload)
+        print("status=BLOCKED smoke_status=ROS_HUMBLE_UNAVAILABLE")
         return 1
 
     if args.all_scenes:
@@ -265,7 +362,10 @@ def main() -> int:
                 except Exception:
                     payload = {}
             smoke_status = str(payload.get("status", "FAIL")).upper()
-            result_status = "PASS" if (proc.returncode == 0 and smoke_status in {"PASS", "OK"}) else "FAIL"
+            if smoke_status == "BLOCKED":
+                result_status = "BLOCKED"
+            else:
+                result_status = "PASS" if (proc.returncode == 0 and smoke_status in {"PASS", "OK"}) else "FAIL"
             blockers = list(payload.get("blockers", [])) if isinstance(payload.get("blockers"), list) else []
             blockers.extend(item.get("blockers", []))
             if item["scene_status"] == "BLOCKED":
@@ -316,6 +416,7 @@ def main() -> int:
             fail_payload = {
                 "schema": EXPECTED_SCHEMA,
                 "status": "FAIL",
+                "runtime_available": False,
                 "scene": args.scene or sp.name,
                 "scene_path": str(sp),
                 "blockers": [f"scene_path_missing_required_files:{','.join(missing)}"],
@@ -339,6 +440,7 @@ def main() -> int:
     child_env.update(extra_env)
     diag = {
         "schema": EXPECTED_SCHEMA,
+        "runtime_available": True,
         "scene": args.scene or (args.scene_path.name if args.scene_path else None),
         "scene_path": str(args.scene_path) if args.scene_path else None,
         "repo_root": str(repo_root),
@@ -388,7 +490,9 @@ def main() -> int:
         payload: dict[str, Any] = {}
         try:
             payload=json.loads(args.output.read_text(encoding="utf-8"))
+            payload = _enforce_physical_render_evidence(payload)
             app_status=payload.get("status","UNKNOWN")
+            _write_json(args.output, payload)
         except Exception:
             payload = {}
         if args.scene_path:
@@ -405,11 +509,12 @@ def main() -> int:
                 _write_json(args.output, payload)
                 print(f"status=FAIL smoke_status=EXPLICIT_SCENE_PATH_MISMATCH expected_scene_path={expected_scene_path} actual_scene_path={actual_scene_path}")
                 return 1
-        print(f"status=PASS smoke_status=APP_JSON_PRESENT wrapper_status=PASS app_status={app_status} returncode={rc} timed_out={timed_out}")
+        wrapper_status = "PASS" if rc == 0 and str(app_status).upper() in {"PASS", "OK"} else "FAIL"
+        print(f"status={wrapper_status} smoke_status=APP_JSON_PRESENT wrapper_status={wrapper_status} app_status={app_status} returncode={rc} timed_out={timed_out}")
         print("child_command=" + diag["child_command"])
         print("stdout_log_path=" + str(stdout_log))
         print("stderr_log_path=" + str(stderr_log))
-        return 0 if rc == 0 else 1
+        return 0 if rc == 0 and str(app_status).upper() in {"PASS", "OK"} else 1
 
     blockers.append("app_smoke_json_missing")
     if "--scene3d-smoke" in diag["child_command"] and "--smoke-output" in diag["child_command"]:

--- a/scripts/run_workcell_studio_scene_readiness_matrix.py
+++ b/scripts/run_workcell_studio_scene_readiness_matrix.py
@@ -328,8 +328,9 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
     blockers = [str(item) for item in visual.get("blockers", [])]
     warnings = [str(item) for item in visual.get("warnings", [])]
     visual_status = str(visual.get("visual_quality_status") or "").upper()
+    runtime_available = bool(visual.get("runtime_available"))
     summary_state = PASS if visual_status == PASS else FAIL
-    if not mesh_index.is_file() or not smoke_json.is_file():
+    if visual_status == BLOCKED or not mesh_index.is_file() or not smoke_json.is_file() or not runtime_available:
         summary_state = BLOCKED
     visual_result = _result(
         summary_state,
@@ -339,6 +340,7 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
         smoke_json=str(smoke_json),
         blockers=blockers,
         warnings=warnings,
+        runtime_available=runtime_available,
         counters={
             "total_payload_count": visual.get("total_payload_count", 0),
             "mesh_source_count": visual.get("mesh_source_count", 0),
@@ -346,6 +348,7 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
             "mesh_rendered_count": visual.get("mesh_rendered_count", 0),
             "primitive_rendered_count": visual.get("primitive_rendered_count", 0),
             "physical_rendered_count": visual.get("physical_rendered_count", 0),
+            "runtime_available": runtime_available,
             "credible_physical_rendered_count": visual.get("credible_physical_rendered_count", 0),
             "helper_overlay_count": visual.get("helper_overlay_count", 0),
             "diagnostic_fallback_count": visual.get("diagnostic_fallback_count", 0),
@@ -360,6 +363,9 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
     elif not smoke_json.is_file():
         physical_state = BLOCKED
         physical_message = "Scene3D GUI smoke evidence is missing; physical rendered evidence cannot be evaluated"
+    elif not runtime_available:
+        physical_state = BLOCKED
+        physical_message = "Scene3D runtime is unavailable; physical rendered evidence is not evaluated from static renderability counts"
     elif source_count <= 0:
         physical_state = FAIL
         physical_message = "mesh index does not contain credible mesh or primitive source geometry"
@@ -377,6 +383,7 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
         physical_message,
         source_geometry_count=source_count,
         physical_rendered_count=physical_rendered,
+        runtime_available=runtime_available,
         mesh_failure_summary_by_reason_code=visual.get("mesh_failure_summary_by_reason_code", {}),
     )
     return visual_result, physical_result

--- a/scripts/validate_scene3d_visual_quality_matrix.py
+++ b/scripts/validate_scene3d_visual_quality_matrix.py
@@ -106,6 +106,26 @@ def _counter_values(payload: dict[str, Any], keys: tuple[str, ...]) -> dict[str,
     return counts
 
 
+def _runtime_available_from_smoke(payload: dict[str, Any], smoke_exists: bool) -> bool:
+    if not smoke_exists:
+        return False
+    for source in (payload, payload.get("counters"), payload.get("render_debug_counters")):
+        if isinstance(source, dict) and isinstance(source.get("runtime_available"), bool):
+            return bool(source.get("runtime_available"))
+    status = _stringify(payload.get("status"))
+    blockers = [str(item).lower() for item in payload.get("blockers", [])] if isinstance(payload.get("blockers"), list) else []
+    if status == "blocked" and any(
+        token in blocker
+        for blocker in blockers
+        for token in ("unable_to_resolve_workcell_builder_executable", "ros_humble_unavailable", "runtime_unavailable")
+    ):
+        return False
+    # Older smoke files did not carry runtime_available.  If a smoke payload exists
+    # and is not an explicit runtime-unavailable BLOCKED report, treat it as an
+    # app-launched runtime payload so legacy/synthetic fixtures remain evaluable.
+    return True
+
+
 def _helper_overlay_counts(payload: dict[str, Any]) -> tuple[dict[str, int], int]:
     counts = _counter_values(payload, HELPER_OVERLAY_COUNTERS)
     overlay_family_count = max(counts.get("overlay_helper_count", 0), counts.get("overlay_count", 0))
@@ -346,6 +366,10 @@ def evaluate_scene(
     else:
         warnings.append("smoke JSON not provided")
 
+    runtime_available = _runtime_available_from_smoke(smoke_payload, smoke_exists)
+    if not runtime_available:
+        warnings.append("Scene3D runtime unavailable; static renderability counts are diagnostic context, not GUI render proof")
+
     mesh_rendered_count = _counter(smoke_payload, "mesh_rendered_count", "mesh_backed_count")
     primitive_rendered_count = _counter(smoke_payload, "primitive_rendered_count", "urdf_primitive_rendered_count")
     # Diagnostic fallback evidence is useful for debugging viewport plumbing, but it is not
@@ -389,14 +413,23 @@ def evaluate_scene(
         + max(0, missing_geometry_box_count - placeholder_count)
     )
 
-    if mesh_source_count > 0 and mesh_rendered_count <= 0:
-        blockers.append("mesh_source_count > 0 requires mesh_rendered_count > 0")
-    if primitive_source_count > 0 and primitive_rendered_count <= 0:
-        blockers.append("primitive_source_count > 0 requires primitive_rendered_count > 0")
-    if primitive_source_count > 0 and placeholder_count > missing_geometry_count:
-        blockers.append("valid URDF primitives must not increment placeholder_count")
-    if total_payload_count > 0 and credible_source_count <= 0:
-        blockers.append("source geometry classification missing; rendered_count alone cannot prove visual quality")
+    if runtime_available:
+        if credible_source_count > 0 and physical_rendered_count <= 0:
+            add_blocker(
+                "scene_rendered_no_physical_items: Scene3D runtime launched but physical mesh/primitive render counters are zero",
+                "scene_rendered_no_physical_items",
+            )
+        if mesh_source_count > 0 and mesh_rendered_count <= 0:
+            blockers.append("mesh_source_count > 0 requires mesh_rendered_count > 0")
+        if primitive_source_count > 0 and primitive_rendered_count <= 0:
+            blockers.append("primitive_source_count > 0 requires primitive_rendered_count > 0")
+        if primitive_source_count > 0 and placeholder_count > missing_geometry_count:
+            blockers.append("valid URDF primitives must not increment placeholder_count")
+        if total_payload_count > 0 and credible_source_count <= 0:
+            blockers.append("source geometry classification missing; rendered_count alone cannot prove visual quality")
+    elif smoke_payload.get("status") == "BLOCKED" or not smoke_exists:
+        if "scene3d_runtime_unavailable" not in blocker_reasons:
+            blocker_reasons.append("scene3d_runtime_unavailable")
     if rendered_count == total_payload_count and total_payload_count > 0:
         warnings.append("rendered_count equals total_payload_count; pass still requires mesh/primitive-specific rendered counts")
 
@@ -406,7 +439,7 @@ def evaluate_scene(
         )
     if helper_overlay_count > 0:
         warnings.append("helper/overlay render evidence present; physical_rendered_count excludes helper overlays")
-    if valid_physical_fallback_dominates:
+    if runtime_available and valid_physical_fallback_dominates:
         add_blocker(
             "valid physical fallback counters dominate credible mesh/primitive render evidence; physical_rendered_count excludes them",
             "physical_fallback_dominates",
@@ -416,18 +449,19 @@ def evaluate_scene(
     for reason, count in mesh_failure_reasons.items():
         add_blocker(f"{reason}: {count} mesh-backed source item(s) could not be resolved", reason)
 
-    if helper_overlay_count > 0 and physical_rendered_count <= 0 and rendered_count > 0:
+    if runtime_available and helper_overlay_count > 0 and physical_rendered_count <= 0 and rendered_count > 0:
         add_blocker(
             "no_physical_scene_items_rendered: helper/overlay count is the only render evidence; rendered_count cannot prove Scene3D visual quality",
             "no_physical_scene_items_rendered",
         )
-    if helper_overlay_count > 0 and helper_overlay_count >= physical_rendered_count:
+    if runtime_available and helper_overlay_count > 0 and helper_overlay_count >= physical_rendered_count:
         add_blocker(
             "overlay_helper_dominates: helper/overlay count is greater than or equal to physical_rendered_count; render physical scene items instead of relying on overlays",
             "overlay_helper_dominates",
         )
     if (
-        physical_fit_bounds_count > 0
+        runtime_available
+        and physical_fit_bounds_count > 0
         and helper_overlay_fit_bounds_count >= physical_fit_bounds_count
         and helper_overlay_fit_bounds_count > 0
     ):
@@ -436,17 +470,17 @@ def evaluate_scene(
             "overlay_helper_dominates",
         )
 
-    if credible_source_count > 0 and physical_rendered_count <= 0 and raw_generated_bounds_count > 0:
+    if runtime_available and credible_source_count > 0 and physical_rendered_count <= 0 and raw_generated_bounds_count > 0:
         blockers.append("raw/generated fallback bounds are the only visible evidence despite mesh or URDF primitive sources")
-    if credible_source_count > 0 and physical_rendered_count > 0 and raw_generated_bounds_count > 0:
+    if runtime_available and credible_source_count > 0 and physical_rendered_count > 0 and raw_generated_bounds_count > 0:
         if raw_generated_bounds_count > int(physical_rendered_count * DIAGNOSTIC_FALLBACK_DOMINANCE_RATIO):
             blockers.append("raw/generated fallback bounds dominate physical render evidence despite mesh or URDF primitive sources")
-    if credible_source_count > 0 and physical_rendered_count > 0 and diagnostic_fallback_count > 0:
+    if runtime_available and credible_source_count > 0 and physical_rendered_count > 0 and diagnostic_fallback_count > 0:
         if diagnostic_fallback_count > int(physical_rendered_count * DIAGNOSTIC_FALLBACK_DOMINANCE_RATIO):
             blockers.append("diagnostic fallback evidence dominates physical render evidence despite mesh or URDF primitive sources")
 
     visible_physical_count = physical_rendered_count
-    if wireframe_fallback_count > 0 and visible_physical_count > 0:
+    if runtime_available and wireframe_fallback_count > 0 and visible_physical_count > 0:
         if wireframe_fallback_count > int(visible_physical_count * PHYSICAL_ITEM_DOMINANCE_RATIO):
             blockers.append("wireframe_fallback_count dominates visible physical items")
 
@@ -463,7 +497,7 @@ def evaluate_scene(
         if diagnostic_fallback_count != 0:
             blockers.append("synthetic fixture must render mesh and primitive without diagnostic fallback bounds or boxes")
 
-    visual_quality_status = "PASS" if not blockers else "FAIL"
+    visual_quality_status = "BLOCKED" if not runtime_available else ("PASS" if not blockers else "FAIL")
     return {
         "scene_name": scene_name,
         "scene_path": str(scene_dir),
@@ -490,6 +524,7 @@ def evaluate_scene(
         "missing_geometry_count": missing_geometry_count,
         "wireframe_fallback_count": wireframe_fallback_count,
         "rendered_count": rendered_count,
+        "runtime_available": runtime_available,
         "visual_quality_status": visual_quality_status,
         "warnings": warnings,
         "blockers": blockers,


### PR DESCRIPTION
### Motivation
- Make Scene3D smoke outputs explicit about whether the GUI/runtime actually launched so downstream readiness checks do not treat static/cached renderability counts as proof of GUI rendering. 
- Ensure missing runtime components (workcell builder executable or ROS Humble) surface as `BLOCKED` runtime evidence rather than spurious physical-render `FAIL` results.

### Description
- Added explicit `runtime_available` boolean into smoke JSON and ensured `render_debug_counters.runtime_available` is set for wrappers and app payloads in `scripts/run_workcell_builder_scene3d_gui_smoke.py`.
- If the Workcell Builder executable cannot be resolved or ROS Humble is missing, the smoke wrapper now writes `status: BLOCKED` and `runtime_available: false` while preserving static `scene_visual_mesh_index` counts as diagnostic context.
- When an app-launched smoke payload is present, the wrapper marks `runtime_available: true` and enforces that zero physical-render counters become a failure/blocker `scene_rendered_no_physical_items` to flag GUI-rendering problems.
- Updated `scripts/validate_scene3d_visual_quality_matrix.py` to infer/read `runtime_available`, treat static renderability counts as diagnostics (not proof), produce `BLOCKED` when runtime is unavailable, and only add physical-render failures when `runtime_available` is true.
- Updated `scripts/run_workcell_studio_scene_readiness_matrix.py` to propagate `runtime_available` into Scene3D categories and mark physical-render evidence as `BLOCKED` (not `FAIL`) when the runtime is unavailable.
- Modified helper counters and small plumbing utilities to compute a physical-render total from multiple possible keys and to normalize runtime reporting across outputs.

### Testing
- `python3 -m py_compile` on the three modified scripts succeeded (no syntax errors).
- Custom unit-style smoke checks using a temporary synthetic fixture verified that a smoke payload with `runtime_available: false` produces a `BLOCKED` visual-quality status and that a `runtime_available: true` payload with zero physical counters produces the `scene_rendered_no_physical_items` blocker (these checks passed).
- Manual smoke wrapper run (missing executable) produced a JSON with `status: BLOCKED` and `runtime_available: false` while preserving static mesh-index diagnostics (observed and recorded).
- Running the readiness-matrix generator produced a summary and propagated `runtime_available` into scene categories (completed successfully).
- `pytest` uncovered two existing tests that expect the older behavior (they expect missing runtime wrappers to write `FAIL`); these two tests in `tests/test_scene3d_gui_smoke_json_output_contract.py` now fail because the wrapper returns `BLOCKED` per the new contract, and test collection earlier surfaced an unrelated/previous `IndentationError` in one test file; this is noted as a validation mismatch that downstream tests/consumers should update to accept `BLOCKED` + `runtime_available: false` as the new contract.

Files changed: `scripts/run_workcell_builder_scene3d_gui_smoke.py`, `scripts/validate_scene3d_visual_quality_matrix.py`, `scripts/run_workcell_studio_scene_readiness_matrix.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e7943f6c8331b6cc3e3eaac692a1)