### PR TITLE
Record ROS Humble blockers in Scene3D GUI smoke

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -15,6 +15,64 @@ from scripts.scene3d_scene_discovery import discover_scene3d_scenes
 
 EXPECTED_SCHEMA = "workcell_studio_scene3d_gui_smoke/v1"
 
+ROS_HUMBLE_SETUP_PATH = Path("/opt/ros/humble/setup.bash")
+ROS_HUMBLE_MISSING_MESSAGE = (
+    "ROS Humble is not available: /opt/ros/humble/setup.bash was not found "
+    "and ROS_DISTRO is not humble"
+)
+
+
+def _ros_humble_available() -> bool:
+    return ROS_HUMBLE_SETUP_PATH.is_file() or os.environ.get("ROS_DISTRO") == "humble"
+
+
+def _ros_humble_environment() -> dict[str, Any]:
+    return {
+        "ros_humble_available": _ros_humble_available(),
+        "ros_distro": os.environ.get("ROS_DISTRO", ""),
+        "ros_humble_setup_path": str(ROS_HUMBLE_SETUP_PATH),
+    }
+
+
+def _add_ros_humble_context(payload: dict[str, Any]) -> dict[str, Any]:
+    payload.update(_ros_humble_environment())
+    return payload
+
+
+def _append_unique(values: list[str], value: str) -> None:
+    if value not in values:
+        values.append(value)
+
+
+def _record_ros_humble_missing(payload: dict[str, Any], *, as_blocker: bool) -> None:
+    _add_ros_humble_context(payload)
+    if payload.get("ros_humble_available") is True:
+        return
+    messages = payload.get("blocker_messages")
+    if not isinstance(messages, dict):
+        messages = {}
+    messages["ros_humble_missing"] = ROS_HUMBLE_MISSING_MESSAGE
+    payload["blocker_messages"] = messages
+    target_key = "blockers" if as_blocker else "warnings"
+    values = payload.get(target_key)
+    if not isinstance(values, list):
+        values = []
+    _append_unique(values, "ros_humble_missing")
+    payload[target_key] = values
+    warning_messages = payload.get("warning_messages")
+    if not isinstance(warning_messages, dict):
+        warning_messages = {}
+    warning_messages["ros_humble_missing"] = ROS_HUMBLE_MISSING_MESSAGE
+    payload["warning_messages"] = warning_messages
+
+
+def _executable_can_run(exe: Path | str) -> bool:
+    exe_str = str(exe)
+    if os.sep not in exe_str and shutil.which(exe_str):
+        return True
+    path = Path(exe_str)
+    return path.is_file() and os.access(path, os.X_OK)
+
 def _tail(text: str, lines: int = 40) -> str:
     parts = (text or "").splitlines()
     return "\n".join(parts[-lines:])
@@ -194,6 +252,7 @@ def main() -> int:
 
     repo_root = resolve_repo_root(explicit_repo_root=args.repo_root)
     workspace_root = resolve_workspace_root(repo_root, args.workspace_root)
+    ros_env = _ros_humble_environment()
     exe = args.executable or resolve_workcell_builder_executable(workspace_root)
     if exe is None and not args.all_scenes:
         searched = [str(p) for p in _resolve_executable_candidates(workspace_root or repo_root)]
@@ -225,6 +284,9 @@ def main() -> int:
                 "static_zones_overlays_renderable": static_evidence.get("zones_overlays_renderable", 0),
             },
         }
+        _add_ros_humble_context(fail_payload)
+        if not ros_env["ros_humble_available"]:
+            _record_ros_humble_missing(fail_payload, as_blocker=True)
         _write_json(args.output, fail_payload)
         print("status=FAIL smoke_status=MISSING_EXECUTABLE")
         print("searched_paths=" + " | ".join(searched))
@@ -292,6 +354,9 @@ def main() -> int:
             "legacy_incomplete_scenes": legacy_incomplete,
             "ignored_non_scene_folders": ignored_non_scenes,
         }
+        _add_ros_humble_context(summary)
+        if not ros_env["ros_humble_available"] and exe is None:
+            _record_ros_humble_missing(summary, as_blocker=True)
         _write_json(out_dir / "scene3d_gui_smoke_summary.json", summary)
         md = ["# Scene3D GUI Smoke Summary", "",
               f"- supported_scene_count: {len(per_scene)}",
@@ -321,10 +386,34 @@ def main() -> int:
                 "blockers": [f"scene_path_missing_required_files:{','.join(missing)}"],
                 "warnings": [],
             }
+            _add_ros_humble_context(fail_payload)
+            if not ros_env["ros_humble_available"]:
+                _record_ros_humble_missing(fail_payload, as_blocker=False)
             _write_json(args.output, fail_payload)
             print("status=FAIL smoke_status=SCENE_PATH_INVALID")
             return 1
         args.scene_path = sp
+
+    if exe is not None and not _executable_can_run(exe):
+        fail_payload = {
+            "schema": EXPECTED_SCHEMA,
+            "status": "FAIL",
+            "scene": args.scene or (args.scene_path.name if args.scene_path else None),
+            "scene_path": str(args.scene_path) if args.scene_path else None,
+            "repo_root": str(repo_root),
+            "workspace_root": str(workspace_root),
+            "executable": str(exe),
+            "blockers": ["explicit_workcell_builder_executable_not_runnable" if args.executable else "resolved_workcell_builder_executable_not_runnable"],
+            "warnings": [],
+            "screenshot_available": False,
+        }
+        _add_ros_humble_context(fail_payload)
+        if not ros_env["ros_humble_available"]:
+            _record_ros_humble_missing(fail_payload, as_blocker=True)
+        _write_json(args.output, fail_payload)
+        print("status=FAIL smoke_status=EXECUTABLE_NOT_RUNNABLE")
+        print("executable=" + str(exe))
+        return 1
 
     cmd = build_cmd(exe, args)
     cmd, xwarn, extra_env = with_xvfb(cmd, args.xvfb)
@@ -344,6 +433,7 @@ def main() -> int:
         "repo_root": str(repo_root),
         "workspace_root": str(workspace_root),
         "executable": str(exe),
+        **ros_env,
         "child_command": " ".join(shlex.quote(x) for x in cmd),
         "cwd": str(repo_root),
         "env": {k: child_env.get(k, "") for k in ["DISPLAY", "WAYLAND_DISPLAY", "QT_QPA_PLATFORM", "QT_OPENGL", "LIBGL_ALWAYS_SOFTWARE", "XDG_SESSION_TYPE"]},
@@ -380,6 +470,8 @@ def main() -> int:
 
     blockers = list(xwarn)
     warnings: list[str] = []
+    if not ros_env["ros_humble_available"]:
+        _append_unique(warnings, "ros_humble_missing")
     if timed_out: blockers.append("child_process_timed_out")
     if rc not in (0, None): blockers.append("child_process_returned_nonzero")
 
@@ -391,6 +483,11 @@ def main() -> int:
             app_status=payload.get("status","UNKNOWN")
         except Exception:
             payload = {}
+        _add_ros_humble_context(payload)
+        if not ros_env["ros_humble_available"]:
+            _record_ros_humble_missing(payload, as_blocker=True)
+            payload["status"] = "FAIL"
+            app_status = "FAIL"
         if args.scene_path:
             expected_scene_path = str(args.scene_path.resolve())
             counters = payload.get("counters") if isinstance(payload.get("counters"), dict) else {}
@@ -405,11 +502,14 @@ def main() -> int:
                 _write_json(args.output, payload)
                 print(f"status=FAIL smoke_status=EXPLICIT_SCENE_PATH_MISMATCH expected_scene_path={expected_scene_path} actual_scene_path={actual_scene_path}")
                 return 1
-        print(f"status=PASS smoke_status=APP_JSON_PRESENT wrapper_status=PASS app_status={app_status} returncode={rc} timed_out={timed_out}")
+        _write_json(args.output, payload)
+        wrapper_pass = rc == 0 and ros_env["ros_humble_available"]
+        status_label = "PASS" if wrapper_pass else "FAIL"
+        print(f"status={status_label} smoke_status=APP_JSON_PRESENT wrapper_status={status_label} app_status={app_status} returncode={rc} timed_out={timed_out}")
         print("child_command=" + diag["child_command"])
         print("stdout_log_path=" + str(stdout_log))
         print("stderr_log_path=" + str(stderr_log))
-        return 0 if rc == 0 else 1
+        return 0 if wrapper_pass else 1
 
     blockers.append("app_smoke_json_missing")
     if "--scene3d-smoke" in diag["child_command"] and "--smoke-output" in diag["child_command"]:
@@ -423,6 +523,8 @@ def main() -> int:
         "blockers": blockers,
         "warnings": warnings,
     }
+    if not ros_env["ros_humble_available"]:
+        _record_ros_humble_missing(fail_payload, as_blocker=bool(args.executable))
     _write_json(args.output, fail_payload)
     print("status=FAIL smoke_status=WRAPPER_FAIL_JSON")
     print("child_command=" + diag["child_command"])

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -16,6 +16,11 @@ def test_wrapper_writes_fail_json_with_child_diagnostics(tmp_path):
     payload = json.loads(out.read_text(encoding='utf-8'))
     assert payload['status'] == 'FAIL'
     assert 'blockers' in payload and 'app_smoke_json_missing' in payload['blockers']
+    assert 'ros_humble_available' in payload
+    assert payload.get('ros_humble_setup_path') == '/opt/ros/humble/setup.bash'
+    if payload.get('ros_humble_available') is False:
+        assert 'ros_humble_missing' in payload['blockers']
+        assert 'ROS Humble is not available' in payload['blocker_messages']['ros_humble_missing']
 
 
 def test_wrapper_does_not_reuse_stale_success_json(tmp_path):
@@ -35,6 +40,37 @@ def test_wrapper_does_not_reuse_stale_success_json(tmp_path):
     assert payload['status'] == 'FAIL'
     assert 'app_smoke_json_missing' in payload['blockers']
     assert payload.get('screenshot_available') is False
+
+
+def test_wrapper_records_ros_missing_when_explicit_executable_writes_pass(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    fake_builder = tmp_path / 'fake_builder'
+    fake_builder.write_text(
+        '#!/usr/bin/env bash\n'
+        'out=""\n'
+        'while [[ $# -gt 0 ]]; do\n'
+        '  if [[ "$1" == "--smoke-output" ]]; then out="$2"; shift 2; else shift; fi\n'
+        'done\n'
+        'printf \'{"schema":"workcell_studio_scene3d_gui_smoke/v1","status":"PASS"}\\n\' > "$out"\n',
+        encoding='utf-8',
+    )
+    fake_builder.chmod(0o755)
+    out = tmp_path / 'smoke.json'
+    cmd = [
+        'python3', str(repo / 'scripts/run_workcell_builder_scene3d_gui_smoke.py'),
+        '--repo-root', str(repo), '--workspace-root', str(tmp_path), '--scene', 'ur5_2f_test',
+        '--output', str(out), '--executable', str(fake_builder), '--timeout-sec', '2',
+    ]
+    rc = subprocess.run(cmd, text=True, capture_output=True)
+    payload = json.loads(out.read_text(encoding='utf-8'))
+    if payload.get('ros_humble_available') is False:
+        assert rc.returncode != 0
+        assert payload['status'] == 'FAIL'
+        assert 'ros_humble_missing' in payload['blockers']
+        assert 'ROS Humble is not available' in payload['blocker_messages']['ros_humble_missing']
+    else:
+        assert rc.returncode == 0
+        assert payload['status'] == 'PASS'
 
 
 def test_main_cpp_contract_contains_scene3d_counter_keys():

--- a/tests/test_scene3d_gui_smoke_runner_setup_errors.py
+++ b/tests/test_scene3d_gui_smoke_runner_setup_errors.py
@@ -33,6 +33,12 @@ def test_gui_smoke_missing_workspace_writes_fail_json(tmp_path):
     assert "executable" in payload
     assert "searched_paths" in payload
     assert payload.get("screenshot_available") is False
+    assert "ros_humble_available" in payload
+    assert "ros_distro" in payload
+    assert payload.get("ros_humble_setup_path") == "/opt/ros/humble/setup.bash"
+    if payload.get("ros_humble_available") is False:
+        assert "ros_humble_missing" in payload["blockers"]
+        assert "ROS Humble is not available" in payload["blocker_messages"]["ros_humble_missing"]
 
 
 def test_gui_smoke_explicit_workspace_no_unboundlocalerror(tmp_path):


### PR DESCRIPTION
### Motivation
- Prevent misleading PASS smoke reports by surfacing whether ROS 2 Humble is available and clearly recording a blocker when it is not.
- Make smoke JSONs more actionable by including the ROS distro context (`ros_humble_available`, `ros_distro`, `ros_humble_setup_path`) for downstream readiness/reporting logic.

### Description
- Added ROS Humble helpers and constants (`ROS_HUMBLE_SETUP_PATH`, `_ros_humble_available()`, `_ros_humble_environment()`, `_add_ros_humble_context()`, `_record_ros_humble_missing()`, and `_executable_can_run()`) and included the ROS context in wrapper diagnostics and JSON payloads in `scripts/run_workcell_builder_scene3d_gui_smoke.py`.
- Record `ros_humble_available`, `ros_distro`, and `ros_humble_setup_path` in all smoke JSON outputs and summary payloads via the new helper functions.
- When ROS Humble is missing, insert blocker/warning `ros_humble_missing` and attach a clear message: `ROS Humble is not available: /opt/ros/humble/setup.bash was not found and ROS_DISTRO is not humble`.
- Validate explicit/resolved executables with `_executable_can_run()` and fail early with a clear blocker if an explicit executable is not runnable; if an explicit executable writes a success JSON but ROS Humble is unavailable the wrapper will not treat it as success and will record the environment blocker.
- Added/updated unit tests to assert the new JSON fields and behaviors (`tests/test_scene3d_gui_smoke_runner_setup_errors.py` and `tests/test_scene3d_gui_smoke_json_output_contract.py`) and added a test covering an explicit executable that emits `PASS` when ROS Humble is missing.

### Testing
- Ran `python3 -m pytest tests/test_scene3d_gui_smoke_runner_setup_errors.py tests/test_scene3d_gui_smoke_json_output_contract.py` and all tests passed (`7 passed`).
- Verified script syntax with `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py` which succeeded.
- Exercised runtime scenarios manually: running the wrapper against a missing workspace produced a FAIL JSON containing the new `ros_humble_*` fields and the `ros_humble_missing` blocker, and running with an explicit fake builder that writes `PASS` produced a wrapper FAIL when ROS Humble was absent (ensuring we do not fake success without the required ROS environment).
- Attempted to run `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder` but could not complete because `/opt/ros/humble/setup.bash` is not present in this container; this is expected and the change records that blocker rather than suppressing it.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e79b39cc833194536a2b8b1dda5b)