### PR TITLE
Block Scene3D readiness on unavailable GUI smoke and attach smoke/runtime evidence to categories

### DIFF
--- a/scripts/run_workcell_studio_scene_readiness_matrix.py
+++ b/scripts/run_workcell_studio_scene_readiness_matrix.py
@@ -316,9 +316,65 @@ def _check_cell_definition(scene_dir: Path) -> dict[str, Any]:
     )
 
 
+def _extract_scene3d_smoke_evidence(smoke_json: Path) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    smoke_error: str | None = None
+    if smoke_json.is_file():
+        loaded, smoke_error = _load_json_file(smoke_json)
+        if isinstance(loaded, dict):
+            payload = loaded
+
+    def nested_value(*keys: str) -> Any:
+        sources = [payload]
+        for nested_key in ("result", "render_debug_counters", "static_scene3d_visual_evidence"):
+            nested = payload.get(nested_key)
+            if isinstance(nested, dict):
+                sources.append(nested)
+        for source in sources:
+            for key in keys:
+                if key in source and source.get(key) is not None:
+                    return source.get(key)
+        return None
+
+    def optional_bool(value: Any) -> bool | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "1", "yes", "y"}:
+                return True
+            if normalized in {"false", "0", "no", "n"}:
+                return False
+        return bool(value)
+
+    runtime_available = optional_bool(nested_value("runtime_available"))
+    screenshot_available = optional_bool(nested_value("screenshot_available"))
+    default_status = "INVALID" if smoke_error else "MISSING" if not smoke_json.is_file() else "UNKNOWN"
+    smoke_status = str(nested_value("status") or default_status).upper()
+    resolved_executable = nested_value("resolved_executable", "executable")
+    searched_paths_raw = nested_value("searched_paths")
+    searched_paths = [str(item) for item in searched_paths_raw] if isinstance(searched_paths_raw, list) else []
+    if runtime_available is None and smoke_json.is_file():
+        blockers = nested_value("blockers")
+        blocker_text = " ".join(str(item) for item in blockers) if isinstance(blockers, list) else str(blockers or "")
+        if resolved_executable:
+            runtime_available = True
+        elif searched_paths or "unable_to_resolve_workcell_builder_executable" in blocker_text:
+            runtime_available = False
+    return {
+        "smoke_status": smoke_status,
+        "runtime_available": runtime_available,
+        "screenshot_available": screenshot_available,
+        "resolved_executable": str(resolved_executable) if resolved_executable else None,
+        "searched_paths": searched_paths,
+        "smoke_load_error": smoke_error,
+    }
+
+
 def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], dict[str, Any]]:
     mesh_index = scene_dir / "generated" / "scene_visual_mesh_index.json"
     smoke_json = scene_dir / "generated" / "scene3d_gui_smoke.json"
+    smoke_evidence = _extract_scene3d_smoke_evidence(smoke_json)
     visual = evaluate_scene3d_visual_quality(
         scene_name=scene_name,
         scene_dir=scene_dir,
@@ -328,12 +384,19 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
     blockers = [str(item) for item in visual.get("blockers", [])]
     warnings = [str(item) for item in visual.get("warnings", [])]
     visual_status = str(visual.get("visual_quality_status") or "").upper()
+    runtime_blocked = smoke_evidence["smoke_status"] == BLOCKED or smoke_evidence["runtime_available"] is False
     summary_state = PASS if visual_status == PASS else FAIL
-    if not mesh_index.is_file() or not smoke_json.is_file():
+    if not mesh_index.is_file() or not smoke_json.is_file() or runtime_blocked:
         summary_state = BLOCKED
+    if summary_state == PASS:
+        summary_message = "Scene3D visual-quality evidence passes"
+    elif runtime_blocked:
+        summary_message = "Scene3D runtime GUI evidence is blocked or unavailable; visual evidence cannot be evaluated as a failure"
+    else:
+        summary_message = "Scene3D visual-quality evidence is blocked or failing"
     visual_result = _result(
         summary_state,
-        "Scene3D visual-quality evidence passes" if summary_state == PASS else "Scene3D visual-quality evidence is blocked or failing",
+        summary_message,
         visual_quality_status=visual.get("visual_quality_status"),
         mesh_index_path=str(mesh_index),
         smoke_json=str(smoke_json),
@@ -350,6 +413,7 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
             "helper_overlay_count": visual.get("helper_overlay_count", 0),
             "diagnostic_fallback_count": visual.get("diagnostic_fallback_count", 0),
         },
+        **smoke_evidence,
     )
 
     source_count = int(visual.get("mesh_source_count") or 0) + int(visual.get("primitive_source_count") or 0)
@@ -360,6 +424,9 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
     elif not smoke_json.is_file():
         physical_state = BLOCKED
         physical_message = "Scene3D GUI smoke evidence is missing; physical rendered evidence cannot be evaluated"
+    elif runtime_blocked:
+        physical_state = BLOCKED
+        physical_message = "Scene3D runtime GUI evidence is blocked or unavailable; physical rendered evidence cannot be evaluated as a failure"
     elif source_count <= 0:
         physical_state = FAIL
         physical_message = "mesh index does not contain credible mesh or primitive source geometry"
@@ -378,6 +445,7 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
         source_geometry_count=source_count,
         physical_rendered_count=physical_rendered,
         mesh_failure_summary_by_reason_code=visual.get("mesh_failure_summary_by_reason_code", {}),
+        **smoke_evidence,
     )
     return visual_result, physical_result
 

--- a/tests/test_workcell_studio_scene_readiness_matrix.py
+++ b/tests/test_workcell_studio_scene_readiness_matrix.py
@@ -135,6 +135,15 @@ def _only_scene(report: dict[str, Any]) -> dict[str, Any]:
 
 
 def test_ready_scene_records_launch_smoke_as_blocked_without_execution(tmp_path: Path, minimal_scene_factory: Any) -> None:
+    report = _single_scene_report(tmp_path, minimal_scene_factory, "ready_scene")
+
+    scene = _only_scene(report)
+    assert scene["overall_status"] == "BLOCKED"
+    launch_state = scene["categories"]["ros_launch_smoke_skip_evaluation_state"]
+    assert launch_state["status"] == "BLOCKED"
+    assert "does not execute ros2 launch" in launch_state["message"]
+
+
 def test_parse_args_accepts_supported_scenes_alias_for_catalog() -> None:
     args = matrix.parse_args(["--supported-scenes", "scenes/supported_scenes.yaml"])
 
@@ -304,6 +313,83 @@ def test_visual_quality_failure_propagates_current_visual_category_status(
     assert scene["categories"]["scene3d_visual_quality_summary"]["visual_quality_status"] == "FAIL"
     assert scene["categories"]["scene3d_visual_quality_summary"]["blockers"]
 
+
+def test_scene3d_runtime_unavailable_blocks_runtime_visual_evidence(
+    tmp_path: Path,
+    minimal_scene_factory: Any,
+) -> None:
+    scene_dir, entry = minimal_scene_factory(
+        "scene3d_runtime_unavailable",
+        repo_root=tmp_path,
+        mesh_index_payload={"items": [{"id": "fixture_box", "primitive_type": "box"}]},
+    )
+    _write_valid_cell_definition(scene_dir, "scene3d_runtime_unavailable")
+    (scene_dir / "generated" / "scene3d_gui_smoke.json").write_text(
+        json.dumps(
+            {
+                "schema": "workcell_studio_scene3d_gui_smoke/v1",
+                "status": "FAIL",
+                "runtime_available": False,
+                "screenshot_available": False,
+                "resolved_executable": None,
+                "searched_paths": ["/missing/workcell_builder"],
+                "render_debug_counters": {"runtime_available": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+    catalog = _write_catalog(tmp_path, [entry])
+
+    report = _build_matrix(tmp_path, catalog, ros_available=True)
+
+    scene = _only_scene(report)
+    visual_summary = scene["categories"]["scene3d_visual_quality_summary"]
+    physical_evidence = scene["categories"]["credible_physical_visual_evidence"]
+    assert visual_summary["status"] == "BLOCKED"
+    assert physical_evidence["status"] == "BLOCKED"
+    for category in (visual_summary, physical_evidence):
+        assert category["smoke_status"] == "FAIL"
+        assert category["runtime_available"] is False
+        assert category["screenshot_available"] is False
+        assert category["resolved_executable"] is None
+        assert category["searched_paths"] == ["/missing/workcell_builder"]
+
+
+def test_scene3d_blocked_smoke_status_blocks_visual_summary(
+    tmp_path: Path,
+    minimal_scene_factory: Any,
+) -> None:
+    scene_dir, entry = minimal_scene_factory(
+        "scene3d_blocked_smoke_status",
+        repo_root=tmp_path,
+        mesh_index_payload={"items": [{"id": "fixture_box", "primitive_type": "box"}]},
+    )
+    _write_valid_cell_definition(scene_dir, "scene3d_blocked_smoke_status")
+    (scene_dir / "generated" / "scene3d_gui_smoke.json").write_text(
+        json.dumps(
+            {
+                "schema": "workcell_studio_scene3d_gui_smoke/v1",
+                "status": "BLOCKED",
+                "runtime_available": True,
+                "screenshot_available": True,
+                "resolved_executable": "/tmp/workcell_builder",
+                "searched_paths": ["/tmp/workcell_builder"],
+                "primitive_rendered_count": 1,
+                "rendered_count": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    catalog = _write_catalog(tmp_path, [entry])
+
+    report = _build_matrix(tmp_path, catalog, ros_available=True)
+
+    scene = _only_scene(report)
+    visual_summary = scene["categories"]["scene3d_visual_quality_summary"]
+    assert visual_summary["status"] == "BLOCKED"
+    assert visual_summary["visual_quality_status"] == "PASS"
+    assert visual_summary["smoke_status"] == "BLOCKED"
+    assert visual_summary["runtime_available"] is True
 
 def test_ros_humble_unavailable_records_launch_smoke_as_safely_skipped(
     tmp_path: Path,


### PR DESCRIPTION
### Motivation
- Make Scene3D readiness classification resilient to environment-blocked GUI smoke evidence by treating blocked/no-runtime smoke as BLOCKED (not FAIL) and surfacing smoke/runtime details in the matrix. 
- Preserve the separation between source mesh-index contract checks and runtime GUI evidence so missing/invalid mesh indexes still fail while runtime GUI problems are reported as BLOCKED.

### Description
- Load `generated/scene3d_gui_smoke.json` directly in `_check_scene3d()` and extract `smoke_status`, `runtime_available`, `screenshot_available`, `resolved_executable`, and `searched_paths` into the Scene3D category payload. (modified `scripts/run_workcell_studio_scene_readiness_matrix.py`)
- Treat scenes whose smoke JSON reports `status == BLOCKED` or `runtime_available == False` as runtime-blocked and set the Scene3D visual/physical categories to `BLOCKED` instead of `FAIL`. 
- Keep mesh-index/source-geometry contract checks separate so mesh-index absence or mesh contract failures still produce `FAIL` or `BLOCKED` as appropriate. 
- Do not force `overall_status` to `PASS`; leave overall computation unchanged so PASS only occurs when all required categories pass. 
- Preserved fake-hardware launch derivation and ROS launch smoke skip behavior unchanged. 
- Added tests exercising runtime-unavailable and blocked-smoke scenarios and a small test asserting the existing offline ROS launch-skip behavior. (modified `tests/test_workcell_studio_scene_readiness_matrix.py`)

### Testing
- Ran Python compile check with `python3 -m py_compile scripts/run_workcell_studio_scene_readiness_matrix.py` which succeeded. 
- Ran unit tests `pytest -q tests/test_workcell_studio_scene_readiness_matrix.py` which succeeded (all tests passed). 
- Ran broader test suites `pytest -q tests/test_validate_supported_scenes_readiness.py tests/test_all_scene_reproducibility.py` which succeeded (all tests passed). 
- Executed the script end-to-end `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --repo-root /workspace/Easy_Manipulator_Improved --supported-scenes scenes/supported_scenes.yaml --output-dir /tmp/workcell_scene_readiness_matrix_check` which wrote JSON/Markdown outputs and reported summary PASS=0 FAIL=0 BLOCKED=8.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e7a316c48331b068aaff4b7bf179)