### PR TITLE
docs: add ur5_2f_test Scene3D GUI evidence steps

### DIFF
--- a/docs/manuals/WORKCELL_STUDIO_SCENE_READINESS.md
+++ b/docs/manuals/WORKCELL_STUDIO_SCENE_READINESS.md
@@ -33,6 +33,42 @@ Use the JSON output for CI, dashboards, and machine-readable regression checks.
 Use the Markdown output for quick human triage in PRs, demo-readiness reviews,
 and scene owner handoffs.
 
+## `ur5_2f_test` real-workspace Scene3D GUI evidence
+
+Use this focused smoke path when a PR needs real-workspace Workcell Builder
+Scene3D evidence for the supported `ur5_2f_test` scene. Run it from the ROS
+workspace layout used for Workcell Studio validation, not from an unrelated
+temporary checkout.
+
+Build and source the builder package first:
+
+```bash
+cd /home/user/workcell_ws
+source /opt/ros/humble/setup.bash
+colcon build --symlink-install --packages-select workcell_builder
+source install/setup.bash
+```
+
+Then run the Scene3D GUI smoke capture against `ur5_2f_test`:
+
+```bash
+cd /home/user/workcell_ws/src/easy_manipulation_deployment
+python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --repo-root "$PWD" --workspace-root /home/user/workcell_ws --scene ur5_2f_test --output "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json" --screenshot "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.png" --timeout-sec 30
+```
+
+Expected evidence files:
+
+- `scenes/ur5_2f_test/generated/scene3d_gui_smoke.json`
+- `scenes/ur5_2f_test/generated/scene3d_gui_smoke.png`
+- stdout and stderr tail log paths recorded in the JSON evidence file
+
+This evidence confirms that the Workcell Builder Scene3D GUI smoke path could
+open the selected scene and record visual/log artifacts in that workspace. It
+does **not** launch real hardware, does **not** enable real robot motion, and
+does **not** prove fake-hardware RViz/MoveIt readiness by itself. Treat it as
+Scene3D GUI evidence that complements, but does not replace, the fake-hardware
+RViz/MoveIt launch validation and broader scene readiness matrix.
+
 ## Status definitions
 
 The matrix uses these status values:


### PR DESCRIPTION
### Motivation
- Provide a focused, reproducible smoke path for collecting Workcell Builder Scene3D GUI evidence for the `ur5_2f_test` supported scene so PRs can include visual/log artifacts without implying any real-hardware or fake-hardware RViz/MoveIt readiness.

### Description
- Updated `docs/manuals/WORKCELL_STUDIO_SCENE_READINESS.md` to add a `ur5_2f_test` real-workspace Scene3D GUI evidence section that documents the required Workcell Builder build/source steps (`cd /home/user/workcell_ws` / `source /opt/ros/humble/setup.bash` / `colcon build --symlink-install --packages-select workcell_builder` / `source install/setup.bash`), the exact smoke command to run (`python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --repo-root "$PWD" --workspace-root /home/user/workcell_ws --scene ur5_2f_test --output "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json" --screenshot "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.png" --timeout-sec 30`), the expected evidence files (`scenes/ur5_2f_test/generated/scene3d_gui_smoke.json` and `.png` plus stdout/stderr tail paths recorded in the JSON), and an explicit note that this does not launch real hardware or by itself prove fake-hardware RViz/MoveIt readiness.

### Testing
- Ran `git diff --check` which produced no issues and inspected the resulting file content changes, and validated repository status with `git status --short`; no ROS builds or GUI smoke runs were executed as this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e7be75c08331a42da8cab84ecb80)