### PR TITLE
Use canonical URDF visual transform metadata

### DIFF
--- a/scripts/extract_scene_urdf_visual_mesh_index.py
+++ b/scripts/extract_scene_urdf_visual_mesh_index.py
@@ -338,7 +338,9 @@ def append_static_robot_primitive_fallbacks(items, urdf_text, fallback_reason):
             'chain_pose': {'xyz': xyz, 'rpy': rpy},
             'world_pose': {'xyz': [0.0, 0.0, 0.0], 'rpy': [0.0, 0.0, 0.0]},
             'visual_origin': {'xyz': [0.0, 0.0, 0.0], 'rpy': [0.0, 0.0, 0.0]},
+            'link_transform_status': 'static_fallback',
             'transform_status': 'static_fallback',
+            'transform_chain': [],
             'render_expected': True,
             'resolved': True,
             'primitive_fallback': True,
@@ -376,6 +378,7 @@ def resolve_static_tool0_children(items):
         item['pose'] = pose
         item['chain_pose'] = {'xyz': shifted, 'rpy': pose.get('rpy', [0.0, 0.0, 0.0])}
         item['transform_status'] = 'static_fallback_parent'
+        item['transform_chain'] = item.get('transform_chain') if isinstance(item.get('transform_chain'), list) else []
         item['render_skip_reason'] = ''
         item['warning'] = 'static_parent_resolved:tool0 via Scene3D UR5 primitive fallback'
         item['static_parent_resolved'] = True

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -7458,9 +7458,12 @@ void MainWindow::populate_scene_hierarchy()
           const YAML::Node visual_origin = workcell_builder::yaml_map_key(v, "visual_origin");
           const YAML::Node visual_origin_xyz = workcell_builder::yaml_map_key(visual_origin, "xyz");
           const YAML::Node visual_origin_rpy = workcell_builder::yaml_map_key(visual_origin, "rpy");
-          const QString chain_status = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "chain_status"));
-          const QString chain_base_frame = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "base_frame"));
-          if (robot_base_frame == QStringLiteral("unknown") && !chain_base_frame.trimmed().isEmpty()) robot_base_frame = chain_base_frame;
+          const QString transform_status = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "transform_status")).trimmed().toLower();
+          QString parent_link = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "parent_link")).trimmed();
+          if (parent_link.isEmpty()) {
+            parent_link = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "base_frame")).trimmed();
+          }
+          if (robot_base_frame == QStringLiteral("unknown") && !parent_link.isEmpty()) robot_base_frame = parent_link;
           const bool has_visual_metadata =
             !id.trimmed().isEmpty() &&
             !QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "link")).trimmed().isEmpty() &&
@@ -7532,10 +7535,11 @@ void MainWindow::populate_scene_hierarchy()
           p.editable = false;
           p.selectable = true;
           p.lock_reason = "generated URDF visual";
-          p.robot_base_frame = chain_base_frame.trimmed().isEmpty() ? QStringLiteral("unknown") : chain_base_frame;
+          p.robot_base_frame = parent_link.isEmpty() ? QStringLiteral("unknown") : parent_link;
           p.source_layer = QStringLiteral("generated_urdf_visual");
           const bool explicit_primitive_fallback = workcell_builder::yaml_map_key(v, "primitive_fallback").as<bool>(false) ||
-            QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "transform_status")).compare(QStringLiteral("static_fallback"), Qt::CaseInsensitive) == 0;
+            transform_status == QStringLiteral("static_fallback") ||
+            transform_status == QStringLiteral("static_fallback_parent");
           p.active_visual_source = (geometry_type == "mesh") ? QStringLiteral("mesh_preview")
                                       : (explicit_primitive_fallback ? QStringLiteral("primitive_fallback") : QStringLiteral("urdf_primitive"));
           p.linked_to_editable_layout_state = false;
@@ -7553,11 +7557,17 @@ void MainWindow::populate_scene_hierarchy()
           p.yaw = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(rpy,2).as<double>(0.0), QStringLiteral("pose.rpy[2]"), &p.warnings);
           p.chain_pose_x = p.x; p.chain_pose_y = p.y; p.chain_pose_z = p.z;
           p.chain_pose_roll = p.roll; p.chain_pose_pitch = p.pitch; p.chain_pose_yaw = p.yaw;
-          p.transform_chain_applied = chain_status.compare(QStringLiteral("ok"), Qt::CaseInsensitive) == 0 || chain_status.trimmed().isEmpty();
+          const bool transform_status_resolved =
+            transform_status == QStringLiteral("resolved") ||
+            transform_status == QStringLiteral("ok") ||
+            transform_status == QStringLiteral("static_fallback") ||
+            transform_status == QStringLiteral("static_fallback_parent");
+          p.transform_chain_applied = transform_status_resolved;
           if (p.transform_chain_applied) ++transform_chain_applied_count;
           if (!p.transform_chain_applied) {
             ++missing_chain_warning_count;
-            p.warnings << QStringLiteral("Preview warning: missing/broken URDF chain; identity fallback avoided");
+            const QString transform_status_for_warning = transform_status.isEmpty() ? QStringLiteral("missing") : transform_status;
+            p.warnings << QStringLiteral("Preview warning: missing/broken URDF chain; identity fallback avoided (transform_status=%1)").arg(transform_status_for_warning);
           }
           if (world_xyz && world_rpy && world_xyz.IsSequence() && world_rpy.IsSequence() && world_xyz.size() >= 3 && world_rpy.size() >= 3) {
             p.base_pose_x = workcell_builder::yaml_seq_index(world_xyz,0).as<double>(0.0);


### PR DESCRIPTION
### Motivation
- Normalize transform metadata between the URDF visual extractor and the Workcell Builder loader by using a single vocabulary (`transform_status`, `link_transform_status`, `transform_chain`, `parent_link`).
- Make transform resolution explicit so that missing/unknown transform status does not silently pass as success and instead surfaces warnings when appropriate.
- Preserve generated URDF preview semantics (locked, non-editable, source layer preserved) so generated-preview behavior remains unchanged.
- Keep the smoke/diagnostic script unchanged unless counter names needed alignment, after inspection no lasting change to smoke was required.

### Description
- Replaced the legacy `chain_status` and `base_frame` reads in `workcell_builder/workcell_builder/gui/mainwindow.cpp` with `transform_status` and `parent_link`, with a backward-compatible fallback to `base_frame` only when `parent_link` is empty. 
- Treated `transform_status` explicitly: `resolved`, `ok`, `static_fallback`, and `static_fallback_parent` are accepted as successful/resolved states and other/empty values now cause `transform_chain_applied` to be false and produce a preview warning that includes the `transform_status` value.
- Kept generated URDF preview item properties intact by preserving `p.locked = true`, `p.editable = false`, `p.source_layer = "generated_urdf_visual"`, and `p.linked_to_editable_layout_state = false` for generated visuals.
- Updated `scripts/extract_scene_urdf_visual_mesh_index.py` to emit canonical metadata for static fallbacks by adding `link_transform_status` and `transform_chain` for emitted bounded primitive fallbacks and normalizing `transform_chain` for `static_fallback_parent` cases.

### Testing
- Ran `git diff --check` which produced no whitespace/patch errors and passed. 
- Compiled the extractor script with `python3 -m py_compile scripts/extract_scene_urdf_visual_mesh_index.py` which passed. 
- Ran scene validation with `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` which completed successfully with `ok=true` and `readiness=task_intent_ready_offline`.
- Verified extractor help output and exercised the extractor on `scenes/ur5_2f_test` to confirm no runtime regressions and that fake-hardware defaults and guarded real-hardware behavior were not changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21f02b1adc8331b712ef8ee1885c93)