### PR TITLE
Ignore fixture packages during colcon discovery

### DIFF
--- a/tests/fixtures/COLCON_IGNORE
+++ b/tests/fixtures/COLCON_IGNORE
@@ -1,0 +1,1 @@
+Test fixture data only: do not let colcon recursively discover package.xml files under tests/fixtures as buildable ROS packages.


### PR DESCRIPTION
### Motivation
- Prevent `colcon` from discovering test fixture directories (which contain `package.xml` but no `CMakeLists.txt`) as buildable ROS packages so workspace builds no longer fail with the CMake `CMakeLists.txt` error for `scene3d_visual_quality_minimal_fixture`.

### Description
- Added a top-level marker file `tests/fixtures/COLCON_IGNORE` to stop recursive `colcon` discovery of static test fixtures under `tests/fixtures` without adding fake build artifacts or changing scene generation logic.
- Did not modify any fixture contents, move/rename files, or add `CMakeLists.txt`; the commit was made on branch `codex/fix-colcon-discovery-of-test-fixtures` and affects only `tests/fixtures/COLCON_IGNORE`.

### Testing
- Ran `git status --short` to confirm the new file was staged and committed successfully and the working tree was clean after the commit. (succeeded)
- Ran `find tests/fixtures -name package.xml -print` to enumerate fixture `package.xml` files and confirmed `scene3d_visual_quality_minimal_fixture` and other scene_readiness fixture manifests were present. (observed)
- Ran `find tests/fixtures -name COLCON_IGNORE -print` to confirm both the new `tests/fixtures/COLCON_IGNORE` and the existing `tests/fixtures/scene_readiness/COLCON_IGNORE` are present. (observed)
- Created a temporary Python venv, installed `colcon` and ran `colcon list | grep scene3d_visual_quality_minimal_fixture` to verify the fixture is not listed; the check returned `OK: fixture ignored`. (succeeded)
- Attempted the requested `colcon build` invocation in this container and verified the run progressed past the previous fixture discovery/CMake error but then failed due to missing ROS Humble (`/opt/ros/humble/setup.bash`/`ament_cmake` not present) in the environment; the fixture-related blocker is resolved but the build cannot complete here for unrelated environment reasons. (fixture fix: succeeded; remaining build failure: environment/ROS not available)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a259bc9c6c08331abff527d2bf1dba2)