### PR TITLE
Mark ur5_2f_test supported after Scene3D smoke evidence

### DIFF
--- a/scenes/supported_scenes.yaml
+++ b/scenes/supported_scenes.yaml
@@ -96,8 +96,8 @@ scenes:
     package_name: ur5_2f_test
     scene_path: scenes/ur5_2f_test
     support_level: supported
-    status: blocked
-    known_blocker: "Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable, indicating the ROS Humble/ament workcell_builder executable is unavailable in this container."
+    status: supported
+    known_blocker: ""
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json


### PR DESCRIPTION
### Motivation
- Remove a stale Scene3D smoke blocker from the catalog entry for `ur5_2f_test` now that the generated `scene3d_gui_smoke.json` contains fresh smoke evidence and the scene passes builder validation.

### Description
- Updated only `scenes/supported_scenes.yaml` for the `ur5_2f_test` entry to set `status: supported` and `known_blocker: ""` while leaving validation/build/launch commands and other scene entries unchanged.

### Testing
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` which returned `ok: true` (warnings only) and completed successfully.
- Parsed `scenes/supported_scenes.yaml` with a small Python snippet (`yaml.safe_load(...)`) to confirm the `ur5_2f_test` entry now has `status: supported` and `known_blocker: ""`.
- Ran `git diff --check` to ensure no whitespace or patch-format issues were introduced and the catalog file change is syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25ae3d93b88331a41684208e5f374c)