### PR TITLE
Improve Workcell Builder executable resolution and diagnostics

### DIFF
--- a/scripts/workcell_studio_path_resolver.py
+++ b/scripts/workcell_studio_path_resolver.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -53,22 +54,48 @@ def resolve_install_setup(workspace_root: Path | None) -> Path | None:
 def workcell_builder_executable_candidates(workspace_root: Path | None) -> list[Path]:
     candidates: list[Path] = []
 
-    if workspace_root:
-        candidates.extend([
-            workspace_root / "install" / "workcell_builder" / "bin" / "workcell_builder",
-            workspace_root / "install" / "workcell_builder" / "lib" / "workcell_builder" / "workcell_builder",
-            workspace_root / "install" / "bin" / "workcell_builder",
-        ])
+    def add_candidate(candidate: Path | str | None) -> None:
+        if not candidate:
+            return
+        candidate_path = Path(candidate).expanduser()
+        if candidate_path not in candidates:
+            candidates.append(candidate_path)
 
-    path_hit = shutil.which("workcell_builder")
-    if path_hit:
-        candidates.append(Path(path_hit))
+    add_candidate(os.environ.get("WORKCELL_BUILDER_EXECUTABLE"))
 
     if workspace_root:
-        candidates.extend([
-            workspace_root / "build" / "workcell_builder" / "workcell_builder",
-            workspace_root / "build" / "workcell_builder" / "workcell_builder" / "workcell_builder",
-        ])
+        add_candidate(
+            workspace_root
+            / "install"
+            / "workcell_builder"
+            / "lib"
+            / "workcell_builder"
+            / "workcell_builder"
+        )
+        add_candidate(workspace_root / "install" / "workcell_builder" / "bin" / "workcell_builder")
+        add_candidate(workspace_root / "install" / "bin" / "workcell_builder")
+
+    add_candidate(shutil.which("workcell_builder"))
+
+    ros2 = shutil.which("ros2")
+    if ros2:
+        try:
+            result = subprocess.run(
+                [ros2, "pkg", "prefix", "workcell_builder"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            result = None
+        if result and result.returncode == 0:
+            prefix_text = result.stdout.strip().splitlines()
+            if prefix_text:
+                prefix = Path(prefix_text[0]).expanduser()
+                add_candidate(prefix / "lib" / "workcell_builder" / "workcell_builder")
+                add_candidate(prefix / "bin" / "workcell_builder")
+                add_candidate(prefix / ".." / "bin" / "workcell_builder")
 
     return candidates
 

--- a/tests/test_workcell_studio_path_resolver.py
+++ b/tests/test_workcell_studio_path_resolver.py
@@ -11,9 +11,13 @@ def test_infer_workspace_root_custom_name(tmp_path):
     ws = resolve_workspace_root(repo)
     assert ws.name == 'custom_robot_ws'
 
-def test_missing_executable_reports_searched_paths(tmp_path):
+def test_missing_executable_reports_searched_paths(tmp_path, monkeypatch):
     ws = tmp_path / 'robot_ws'; ws.mkdir()
+    monkeypatch.delenv('WORKCELL_BUILDER_EXECUTABLE', raising=False)
+    monkeypatch.setattr('scripts.workcell_studio_path_resolver.shutil.which', lambda name: None)
+
     exe = resolve_workcell_builder_executable(ws)
+
     assert exe is None
     assert describe_resolution().get('searched_executable_paths')
 
@@ -31,3 +35,67 @@ def test_invalid_explicit_executable_reports_only_explicit_path(tmp_path):
 
     assert resolve_workcell_builder_executable(ws, explicit_executable=not_executable) is None
     assert describe_resolution().get('searched_executable_paths') == [str(not_executable.resolve())]
+
+def test_workcell_builder_candidate_order_prefers_env_then_install_paths(tmp_path, monkeypatch):
+    ws = tmp_path / 'robot_ws'
+    env_exe = tmp_path / 'custom_workcell_builder'
+    monkeypatch.setenv('WORKCELL_BUILDER_EXECUTABLE', str(env_exe))
+    monkeypatch.setattr('scripts.workcell_studio_path_resolver.shutil.which', lambda name: None)
+
+    candidates = workcell_builder_executable_candidates(ws)
+
+    assert candidates[:4] == [
+        env_exe,
+        ws / 'install' / 'workcell_builder' / 'lib' / 'workcell_builder' / 'workcell_builder',
+        ws / 'install' / 'workcell_builder' / 'bin' / 'workcell_builder',
+        ws / 'install' / 'bin' / 'workcell_builder',
+    ]
+
+
+def test_workcell_builder_candidates_include_ros2_prefix_paths(tmp_path, monkeypatch):
+    ws = tmp_path / 'robot_ws'
+    prefix = tmp_path / 'install' / 'workcell_builder'
+
+    def fake_which(name):
+        if name == 'workcell_builder':
+            return None
+        if name == 'ros2':
+            return '/usr/bin/ros2'
+        return None
+
+    class Result:
+        returncode = 0
+        stdout = f'{prefix}\n'
+
+    monkeypatch.delenv('WORKCELL_BUILDER_EXECUTABLE', raising=False)
+    monkeypatch.setattr('scripts.workcell_studio_path_resolver.shutil.which', fake_which)
+    monkeypatch.setattr('scripts.workcell_studio_path_resolver.subprocess.run', lambda *args, **kwargs: Result())
+
+    candidates = workcell_builder_executable_candidates(ws)
+
+    assert candidates[-3:] == [
+        prefix / 'lib' / 'workcell_builder' / 'workcell_builder',
+        prefix / 'bin' / 'workcell_builder',
+        prefix / '..' / 'bin' / 'workcell_builder',
+    ]
+
+
+def test_resolve_records_candidate_metadata_for_env_override(tmp_path, monkeypatch):
+    ws = tmp_path / 'robot_ws'
+    env_exe = tmp_path / 'custom_workcell_builder'
+    env_exe.write_text('#!/bin/sh\nexit 0\n', encoding='utf-8')
+    env_exe.chmod(0o755)
+    monkeypatch.setenv('WORKCELL_BUILDER_EXECUTABLE', str(env_exe))
+    monkeypatch.setattr('scripts.workcell_studio_path_resolver.shutil.which', lambda name: None)
+
+    assert resolve_workcell_builder_executable(ws) == env_exe
+
+    evidence = describe_resolution().get('workcell_builder_executable_candidates')
+    assert evidence[0] == {
+        'path': str(env_exe),
+        'exists': True,
+        'is_file': True,
+        'executable': True,
+        'selected': True,
+    }
+    assert len(evidence) == 4


### PR DESCRIPTION
### Motivation
- Make executable resolution more predictable and explainable by adding an environment override, improving workspace install candidate order, optionally consulting ROS 2 package prefixes, and capturing detailed search evidence for smoke/readiness diagnostics.

### Description
- Add `WORKCELL_BUILDER_EXECUTABLE` as an environment override candidate that is considered before workspace install paths.
- Reorder workspace candidates to check `<workspace>/install/workcell_builder/lib/workcell_builder/workcell_builder` then `<workspace>/install/workcell_builder/bin/workcell_builder` then `<workspace>/install/bin/workcell_builder`, then `shutil.which("workcell_builder")`.
- Optionally run `ros2 pkg prefix workcell_builder` when `ros2` is on PATH and safely add `<prefix>/lib/workcell_builder/workcell_builder`, `<prefix>/bin/workcell_builder`, and `<prefix>/../bin/workcell_builder` as candidates, with errors/timeouts handled gracefully.
- Ensure `resolve_workcell_builder_executable()` still prefers an explicit `explicit_executable` and that `_record_executable_search()` records the full searched candidate list including existence, `is_file`, executable bit, and which candidate was selected, and add unit tests to cover ordering, ros2 fallbacks, and recorded metadata.

### Testing
- Ran `pytest tests/test_workcell_studio_path_resolver.py` and all tests passed (`7 passed`).
- Compiled the resolver and tests with `python3 -m py_compile scripts/workcell_studio_path_resolver.py tests/test_workcell_studio_path_resolver.py` with no errors.
- Ran repository checks (`git diff --check`) and found no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25ae2102648331aa4c4cd9fc93fd19)