### PR TITLE
Complete xacro package lookup environment

### DIFF
--- a/scripts/extract_scene_urdf_visual_mesh_index.py
+++ b/scripts/extract_scene_urdf_visual_mesh_index.py
@@ -104,14 +104,37 @@ def _package_search_paths(scene_dir=None, workspace_root=None):
                 seen.add(pkg_dir); package_dirs.append(pkg_dir)
     return roots, package_dirs
 
+def _dedupe_path_entries(entries):
+    out=[]
+    seen=set()
+    for entry in entries:
+        entry=str(entry).strip() if entry else ''
+        if not entry or entry in seen:
+            continue
+        seen.add(entry)
+        out.append(entry)
+    return out
+
 def xacro_env(scene_dir, workspace_root=None):
     roots, package_dirs = _package_search_paths(scene_dir, workspace_root)
     rp=[str(p) for p in [*roots, *package_dirs, *(p.parent for p in package_dirs)] if p]
     old=os.environ.get('ROS_PACKAGE_PATH','')
-    if old: rp.extend(old.split(':'))
+    if old: rp.extend(old.split(os.pathsep))
     env=dict(os.environ)
-    env['ROS_PACKAGE_PATH']=':'.join(dict.fromkeys([p for p in rp if p]))
-    env['AMENT_PREFIX_PATH']=os.environ.get('AMENT_PREFIX_PATH','')
+    env['ROS_PACKAGE_PATH']=os.pathsep.join(_dedupe_path_entries(rp))
+
+    ament_prefix_entries=[]
+    inherited_ament=os.environ.get('AMENT_PREFIX_PATH','')
+    if inherited_ament:
+        ament_prefix_entries.extend(inherited_ament.split(os.pathsep))
+    if workspace_root:
+        workspace_install=Path(workspace_root)/'install'
+        if workspace_install.exists():
+            ament_prefix_entries.append(str(workspace_install))
+    ros_humble=Path('/opt/ros/humble')
+    if ros_humble.exists():
+        ament_prefix_entries.append(str(ros_humble))
+    env['AMENT_PREFIX_PATH']=os.pathsep.join(_dedupe_path_entries(ament_prefix_entries))
     return env
 
 def discover_xacro_command():

--- a/tests/test_scene_urdf_visual_mesh_index.py
+++ b/tests/test_scene_urdf_visual_mesh_index.py
@@ -1,10 +1,43 @@
 from pathlib import Path
 import json
+import os
 import subprocess
 
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_xacro_env_preserves_and_extends_package_lookup(monkeypatch, tmp_path):
+    import scripts.extract_scene_urdf_visual_mesh_index as mesh_index
+
+    workspace_root = tmp_path / 'workcell_ws'
+    workspace_install = workspace_root / 'install'
+    workspace_install.mkdir(parents=True)
+    inherited_prefix = os.pathsep.join(['/existing/overlay', str(workspace_install), '/existing/overlay'])
+    inherited_ros_package_path = os.pathsep.join([str(ROOT / 'assets'), '/extra/packages'])
+    monkeypatch.setenv('AMENT_PREFIX_PATH', inherited_prefix)
+    monkeypatch.setenv('ROS_PACKAGE_PATH', inherited_ros_package_path)
+
+    original_exists = mesh_index.Path.exists
+
+    def fake_exists(path):
+        if str(path) == '/opt/ros/humble':
+            return True
+        return original_exists(path)
+
+    monkeypatch.setattr(mesh_index.Path, 'exists', fake_exists)
+
+    env = mesh_index.xacro_env(ROOT / 'scenes' / 'ur5_2f_test', workspace_root=workspace_root)
+
+    ament_entries = env['AMENT_PREFIX_PATH'].split(os.pathsep)
+    assert ament_entries == ['/existing/overlay', str(workspace_install), '/opt/ros/humble']
+
+    ros_package_entries = env['ROS_PACKAGE_PATH'].split(os.pathsep)
+    assert str(ROOT / 'assets') in ros_package_entries
+    assert str(ROOT / 'workcell_builder' / 'workcell_builder' / 'assets') in ros_package_entries
+    assert '/extra/packages' in ros_package_entries
+    assert ros_package_entries.count(str(ROOT / 'assets')) == 1
 
 
 def _xyz_from_item(item: dict):


### PR DESCRIPTION
### Motivation
- Ensure full xacro expansion runs with a complete package lookup environment so xacro can resolve packages from overlays, workspace installs, and the system ROS install while preserving repo-local asset resolution.
- Preserve any inherited `AMENT_PREFIX_PATH` and avoid breaking resolution for repo-local packages like `robotiq_85_description` that rely on `assets/` discovery.
- Keep the lightweight `xacro-lite` fallback unchanged and only use it if the full `xacro` binary is unavailable or fails.

### Description
- Added a `_dedupe_path_entries` helper and switched `ROS_PACKAGE_PATH` construction to use `os.pathsep` and de-duplicated path entries while preserving order, keeping the existing repo-local package discovery roots intact.
- Updated `xacro_env(scene_dir, workspace_root=None)` to preserve inherited `AMENT_PREFIX_PATH`, append `workspace_root/install` when `workspace_root` exists, and append `/opt/ros/humble` when present, then deduplicate entries into `AMENT_PREFIX_PATH`.
- Left the `xacro-lite` expansion and failure fallback logic unchanged so the script still falls back when full `xacro` is unavailable or when expansion fails.
- Added a regression unit test `test_xacro_env_preserves_and_extends_package_lookup` to validate inherited prefix preservation, workspace install and `/opt/ros/humble` insertion, repo asset retention in `ROS_PACKAGE_PATH`, and deduplication.

### Testing
- Ran the new unit test: `python3 -m pytest tests/test_scene_urdf_visual_mesh_index.py::test_xacro_env_preserves_and_extends_package_lookup -q` which passed.
- Ran the extractor smoke: `python3 scripts/extract_scene_urdf_visual_mesh_index.py --scene ur5_2f_test --prefer-xacro --no-write` which returned successfully.
- Ran full test module: `python3 -m pytest tests/test_scene_urdf_visual_mesh_index.py -q` which completed with all tests passing.
- Verified syntax by compiling: `python3 -m py_compile scripts/extract_scene_urdf_visual_mesh_index.py tests/test_scene_urdf_visual_mesh_index.py` and ran `git diff --check` locally; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25c9924fd48331ac658a11d79becfa)