### PR TITLE
Update URDF visual mesh package resolution

### DIFF
--- a/scripts/extract_scene_urdf_visual_mesh_index.py
+++ b/scripts/extract_scene_urdf_visual_mesh_index.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import argparse, copy, json, os, re, shutil, subprocess, math, collections
+import argparse, collections, copy, importlib, importlib.util, json, math, os, re, shutil, subprocess
 from pathlib import Path
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
@@ -10,6 +10,11 @@ ROOT = Path(__file__).resolve().parents[1]
 SCENES_ROOT = ROOT / "scenes"
 EXTRACTOR_VERSION = "2.5"
 PLACEHOLDER_RE = re.compile(r"(\$\{[^}]+\}|\$\(arg\s+[^)]+\)|\$\(find\s+[^)]+\))")
+REPO_LOCAL_ASSET_PRECEDENCE_PACKAGES = {
+    "robotiq_85_description",
+    "workbench_description",
+    "realsense2_description",
+}
 
 def read_yaml(path):
     try:return yaml.safe_load(Path(path).read_text()) if Path(path).exists() else None
@@ -43,9 +48,87 @@ def contains_placeholder(v): return bool(PLACEHOLDER_RE.search(json.dumps(v) if 
 def sanitize(s): return re.sub(r'[^A-Za-z0-9_]+','_',str(s or 'unnamed')).strip('_') or 'unnamed'
 def tag_name(e): return e.tag.split('}')[-1]
 
-def discover_package_map(scene_dir, workspace_root=None):
-    out={}
-    diagnostics={'resolved_packages':[], 'shadowed_packages':[], 'resolution_paths':[]}
+def _package_name_from_xml(pkg_xml):
+    pkg_dir = Path(pkg_xml).parent
+    pkg_name = pkg_dir.name
+    parse_error = ''
+    try:
+        xml_root = ET.parse(pkg_xml).getroot()
+        name_node = xml_root.find('name')
+        if name_node is not None and (name_node.text or '').strip():
+            pkg_name = name_node.text.strip()
+    except Exception as e:
+        parse_error = str(e)
+    return pkg_name, parse_error
+
+def _ros_resolution_env(workspace_root=None):
+    env=dict(os.environ)
+    ament_prefix_entries=[]
+    inherited_ament=os.environ.get('AMENT_PREFIX_PATH','')
+    if inherited_ament:
+        ament_prefix_entries.extend(inherited_ament.split(os.pathsep))
+    if workspace_root:
+        workspace_install=Path(workspace_root)/'install'
+        if workspace_install.exists():
+            ament_prefix_entries.append(str(workspace_install))
+    ros_humble=Path('/opt/ros/humble')
+    if ros_humble.exists():
+        ament_prefix_entries.append(str(ros_humble))
+    if ament_prefix_entries:
+        env['AMENT_PREFIX_PATH']=os.pathsep.join(_dedupe_path_entries(ament_prefix_entries))
+    return env
+
+def resolve_ros_package_share(package_name, workspace_root=None):
+    """Resolve a ROS package share directory through installed ROS mechanisms.
+
+    Returns ``(share_path, source_tier, diagnostics)``. ``share_path`` is ``None``
+    when neither ament index nor ``ros2 pkg prefix`` can resolve the package.
+    """
+    diagnostics={'package_name':package_name,'attempts':[]}
+    if not package_name:
+        diagnostics['error']='empty_package_name'
+        return None, '', diagnostics
+
+    has_ament_index = importlib.util.find_spec('ament_index_python') is not None
+    has_ament_packages = has_ament_index and importlib.util.find_spec('ament_index_python.packages') is not None
+    if has_ament_packages:
+        ament_packages = importlib.import_module('ament_index_python.packages')
+        try:
+            share = Path(ament_packages.get_package_share_directory(package_name))
+            diagnostics['attempts'].append({'source_tier':'ament_index','root_path':str(share),'status':'resolved'})
+            if share.exists():
+                return share, 'ament_index', diagnostics
+            diagnostics['attempts'][-1]['status']='missing_path'
+        except Exception as e:
+            diagnostics['attempts'].append({'source_tier':'ament_index','status':'unresolved','error':str(e)})
+    else:
+        diagnostics['attempts'].append({'source_tier':'ament_index','status':'unavailable','error':'ament_index_python.packages import unavailable'})
+
+    ros2 = shutil.which('ros2') or ('/opt/ros/humble/bin/ros2' if Path('/opt/ros/humble/bin/ros2').exists() else '')
+    if ros2:
+        try:
+            proc=subprocess.run(
+                [ros2,'pkg','prefix',package_name],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=_ros_resolution_env(workspace_root),
+            )
+            if proc.returncode == 0 and proc.stdout.strip():
+                share = Path(proc.stdout.strip())/'share'/package_name
+                diagnostics['attempts'].append({'source_tier':'ros2_pkg_prefix','prefix':proc.stdout.strip(),'root_path':str(share),'status':'resolved' if share.exists() else 'missing_path'})
+                if share.exists():
+                    return share, 'ros2_pkg_prefix', diagnostics
+            else:
+                diagnostics['attempts'].append({'source_tier':'ros2_pkg_prefix','status':'unresolved','error':(proc.stderr or proc.stdout or '').strip()})
+        except Exception as e:
+            diagnostics['attempts'].append({'source_tier':'ros2_pkg_prefix','status':'unresolved','error':str(e)})
+    else:
+        diagnostics['attempts'].append({'source_tier':'ros2_pkg_prefix','status':'unavailable','error':'ros2 executable unavailable'})
+
+    return None, '', diagnostics
+
+def _fallback_package_candidates(scene_dir, workspace_root=None):
     ws = Path(workspace_root) if workspace_root else None
     roots=[
         ('scene_generated_package', scene_dir/'generated'),
@@ -55,33 +138,74 @@ def discover_package_map(scene_dir, workspace_root=None):
         ('repo_assets', ROOT/'assets'),
         ('ros_humble_share', Path('/opt/ros/humble/share')),
     ]
+    candidates=[]
     for tier, root in roots:
         if root is None or not root.exists():
             continue
         for pkg_xml in root.rglob('package.xml'):
             pkg_dir = pkg_xml.parent
-            pkg_name = pkg_dir.name
-            parse_error = ''
-            try:
-                xml_root = ET.parse(pkg_xml).getroot()
-                name_node = xml_root.find('name')
-                if name_node is not None and (name_node.text or '').strip():
-                    pkg_name = name_node.text.strip()
-            except Exception as e:
-                parse_error = str(e)
+            pkg_name, parse_error = _package_name_from_xml(pkg_xml)
             candidate={'package_name':pkg_name,'root_path':str(pkg_dir),'source_tier':tier,'package_xml':str(pkg_xml)}
             if parse_error:
                 candidate['name_fallback']='directory_name'
                 candidate['parse_error']=parse_error
-            if pkg_name in out:
-                diagnostics['shadowed_packages'].append({
-                    **candidate,
-                    'shadowed_by':str(out[pkg_name]),
-                })
-                continue
-            out[pkg_name]=pkg_dir
-            diagnostics['resolved_packages'].append(candidate)
-            diagnostics['resolution_paths'].append({'package_name':pkg_name,'root_path':str(pkg_dir),'source_tier':tier})
+            candidates.append(candidate)
+    return candidates
+
+def _record_package_resolution(out, diagnostics, candidate):
+    pkg_name = candidate['package_name']
+    if pkg_name in out:
+        diagnostics['shadowed_packages'].append({
+            **candidate,
+            'shadowed_by':str(out[pkg_name]),
+        })
+        return False
+    out[pkg_name]=Path(candidate['root_path'])
+    diagnostics['resolved_packages'].append(candidate)
+    diagnostics['resolution_paths'].append({'package_name':pkg_name,'root_path':candidate['root_path'],'source_tier':candidate['source_tier']})
+    return True
+
+def extract_referenced_package_names(text):
+    text = text or ''
+    names=set(re.findall(r"package://([^/\s\"\']+)", text))
+    names.update(n.strip() for n in re.findall(r'\$\(find\s+([^)]+)\)', text) if n.strip())
+    return sorted(names)
+
+def discover_package_map(scene_dir, workspace_root=None, package_names=None):
+    out={}
+    diagnostics={'resolved_packages':[], 'shadowed_packages':[], 'resolution_paths':[], 'ros_resolution_attempts':[], 'unresolved_packages':[]}
+    fallback_candidates=_fallback_package_candidates(Path(scene_dir), workspace_root=workspace_root)
+    by_name=collections.OrderedDict()
+    for candidate in fallback_candidates:
+        by_name.setdefault(candidate['package_name'], []).append(candidate)
+    for pkg_name in package_names or []:
+        by_name.setdefault(pkg_name, [])
+
+    for pkg_name, candidates in by_name.items():
+        repo_local_candidates=[c for c in candidates if c['source_tier'] in {'repo_assets','workspace_src_easy_manipulation_deployment_assets','workspace_src_assets'}]
+        if pkg_name in REPO_LOCAL_ASSET_PRECEDENCE_PACKAGES and repo_local_candidates:
+            _record_package_resolution(out, diagnostics, repo_local_candidates[0])
+            for candidate in candidates:
+                if candidate is not repo_local_candidates[0]:
+                    diagnostics['shadowed_packages'].append({**candidate,'shadowed_by':str(out[pkg_name])})
+            continue
+
+        share_path, source_tier, ros_diag = resolve_ros_package_share(pkg_name, workspace_root=workspace_root)
+        diagnostics['ros_resolution_attempts'].append(ros_diag)
+        if share_path:
+            ros_candidate={'package_name':pkg_name,'root_path':str(share_path),'source_tier':source_tier,'package_xml':str(share_path/'package.xml')}
+            _record_package_resolution(out, diagnostics, ros_candidate)
+            for candidate in candidates:
+                if Path(candidate['root_path']).resolve() != share_path.resolve():
+                    diagnostics['shadowed_packages'].append({**candidate,'shadowed_by':str(out[pkg_name])})
+            continue
+
+        if not candidates:
+            diagnostics['unresolved_packages'].append({'package_name':pkg_name,'source_tier':'unresolved','reason':'not_found_by_ament_ros2_or_package_xml_scan'})
+            continue
+        _record_package_resolution(out, diagnostics, candidates[0])
+        for candidate in candidates[1:]:
+            diagnostics['shadowed_packages'].append({**candidate,'shadowed_by':str(out[pkg_name])})
     return out, diagnostics
 
 def _package_search_paths(scene_dir=None, workspace_root=None):
@@ -273,9 +397,10 @@ def _expand_lite_node(node, args, package_map, macros):
 
 def expand_xacro_lite(urdf_path, scene_dir=None, xacro_args=None, workspace_root=None):
     scene_dir = scene_dir or Path(urdf_path).parents[1]; xacro_args = dict(xacro_args or {})
-    package_map, diagnostics = discover_package_map(scene_dir, workspace_root=workspace_root)
+    source_text = Path(urdf_path).read_text(errors='ignore') if Path(urdf_path).exists() else ''
+    package_map, diagnostics = discover_package_map(scene_dir, workspace_root=workspace_root, package_names=extract_referenced_package_names(source_text))
     try:
-        root=ET.parse(urdf_path).getroot()
+        root=ET.fromstring(source_text) if source_text else ET.parse(urdf_path).getroot()
     except Exception as e:
         return None, False, f'xacro lite parse failed: {e}', None
     args=dict(xacro_args)
@@ -530,7 +655,7 @@ def main():
         if a.require_xacro and not xacro_avail:
             print('xacro executable unavailable (required)'); return 2
         if not xml_text: xml_text=(urdf_path.read_text(errors='ignore') if urdf_path.exists() else '<robot/>')
-        package_map, package_diagnostics = discover_package_map(scene_dir, workspace_root=(a.workspace_root or None))
+        package_map, package_diagnostics = discover_package_map(scene_dir, workspace_root=(a.workspace_root or None), package_names=extract_referenced_package_names(xml_text))
         try: items=extract_from_urdf(xml_text, package_map)
         except Exception: items=[]
         static_robot_fallback_count = append_static_robot_primitive_fallbacks(items, xml_text, fallback_reason)

--- a/tests/test_scene_urdf_visual_mesh_index.py
+++ b/tests/test_scene_urdf_visual_mesh_index.py
@@ -40,6 +40,112 @@ def test_xacro_env_preserves_and_extends_package_lookup(monkeypatch, tmp_path):
     assert ros_package_entries.count(str(ROOT / 'assets')) == 1
 
 
+def _write_package_xml(pkg_dir: Path, name: str):
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    (pkg_dir / 'package.xml').write_text(
+        f'<package format="3"><name>{name}</name><version>0.0.0</version><description>test</description><maintainer email="test@example.com">Test</maintainer><license>Apache-2.0</license></package>',
+        encoding='utf-8',
+    )
+
+
+def test_discover_package_map_prefers_ros_resolution_before_scan_fallback(monkeypatch, tmp_path):
+    import scripts.extract_scene_urdf_visual_mesh_index as mesh_index
+
+    scene_dir = tmp_path / 'scene'
+    fallback_pkg = scene_dir / 'generated' / 'custom_description'
+    resolved_pkg = tmp_path / 'install' / 'share' / 'custom_description'
+    _write_package_xml(fallback_pkg, 'custom_description')
+    _write_package_xml(resolved_pkg, 'custom_description')
+
+    def fake_resolve(package_name, workspace_root=None):
+        if package_name == 'custom_description':
+            return resolved_pkg, 'ament_index', {'package_name': package_name, 'attempts': [{'source_tier': 'ament_index', 'status': 'resolved'}]}
+        return None, '', {'package_name': package_name, 'attempts': []}
+
+    monkeypatch.setattr(mesh_index, 'resolve_ros_package_share', fake_resolve)
+
+    package_map, diagnostics = mesh_index.discover_package_map(scene_dir)
+
+    assert package_map['custom_description'] == resolved_pkg
+    resolved = [p for p in diagnostics['resolved_packages'] if p['package_name'] == 'custom_description']
+    assert resolved and resolved[0]['source_tier'] == 'ament_index'
+    shadowed = [p for p in diagnostics['shadowed_packages'] if p['package_name'] == 'custom_description']
+    assert shadowed and shadowed[0]['source_tier'] == 'scene_generated_package'
+
+
+def test_discover_package_map_preserves_repo_local_asset_precedence(monkeypatch, tmp_path):
+    import scripts.extract_scene_urdf_visual_mesh_index as mesh_index
+
+    installed_pkg = tmp_path / 'install' / 'share' / 'robotiq_85_description'
+    _write_package_xml(installed_pkg, 'robotiq_85_description')
+
+    def fake_resolve(package_name, workspace_root=None):
+        if package_name == 'robotiq_85_description':
+            return installed_pkg, 'ament_index', {'package_name': package_name, 'attempts': [{'source_tier': 'ament_index', 'status': 'resolved'}]}
+        return None, '', {'package_name': package_name, 'attempts': []}
+
+    monkeypatch.setattr(mesh_index, 'resolve_ros_package_share', fake_resolve)
+
+    package_map, diagnostics = mesh_index.discover_package_map(ROOT / 'scenes' / 'ur5_2f_test')
+
+    assert package_map['robotiq_85_description'] == ROOT / 'assets' / 'end_effectors' / 'robotiq_85_gripper' / 'robotiq_85_description'
+    resolved = [p for p in diagnostics['resolved_packages'] if p['package_name'] == 'robotiq_85_description']
+    assert resolved and resolved[0]['source_tier'] == 'repo_assets'
+
+
+def test_discover_package_map_resolves_referenced_packages_without_scanned_package_xml(monkeypatch, tmp_path):
+    import scripts.extract_scene_urdf_visual_mesh_index as mesh_index
+
+    scene_dir = tmp_path / 'scene'
+    scene_dir.mkdir()
+    resolved_pkg = tmp_path / 'install' / 'share' / 'uri_only_description'
+    _write_package_xml(resolved_pkg, 'uri_only_description')
+
+    def fake_resolve(package_name, workspace_root=None):
+        if package_name == 'uri_only_description':
+            return resolved_pkg, 'ros2_pkg_prefix', {'package_name': package_name, 'attempts': [{'source_tier': 'ros2_pkg_prefix', 'status': 'resolved'}]}
+        return None, '', {'package_name': package_name, 'attempts': []}
+
+    monkeypatch.setattr(mesh_index, 'resolve_ros_package_share', fake_resolve)
+
+    package_map, diagnostics = mesh_index.discover_package_map(
+        scene_dir,
+        package_names=mesh_index.extract_referenced_package_names('<mesh filename="package://uri_only_description/meshes/tool.stl"/>'),
+    )
+
+    assert package_map['uri_only_description'] == resolved_pkg
+    resolved = [p for p in diagnostics['resolved_packages'] if p['package_name'] == 'uri_only_description']
+    assert resolved and resolved[0]['source_tier'] == 'ros2_pkg_prefix'
+
+
+def test_resolve_ros_package_share_uses_ros2_pkg_prefix_when_ament_unavailable(monkeypatch, tmp_path):
+    import scripts.extract_scene_urdf_visual_mesh_index as mesh_index
+
+    prefix = tmp_path / 'ros_overlay'
+    share = prefix / 'share' / 'prefix_only_description'
+    share.mkdir(parents=True)
+
+    monkeypatch.setattr(mesh_index.importlib.util, 'find_spec', lambda name: None)
+    monkeypatch.setattr(mesh_index.shutil, 'which', lambda name: '/usr/bin/ros2' if name == 'ros2' else None)
+
+    class Result:
+        returncode = 0
+        stdout = str(prefix) + '\n'
+        stderr = ''
+
+    def fake_run(cmd, **kwargs):
+        assert cmd == ['/usr/bin/ros2', 'pkg', 'prefix', 'prefix_only_description']
+        return Result()
+
+    monkeypatch.setattr(mesh_index.subprocess, 'run', fake_run)
+
+    resolved, source_tier, diagnostics = mesh_index.resolve_ros_package_share('prefix_only_description')
+
+    assert resolved == share
+    assert source_tier == 'ros2_pkg_prefix'
+    assert diagnostics['attempts'][-1]['source_tier'] == 'ros2_pkg_prefix'
+
+
 def _xyz_from_item(item: dict):
     pose = item.get('world_pose') or item.get('computed_world_pose') or item.get('pose') or {}
     xyz = pose.get('xyz')


### PR DESCRIPTION
### Motivation
- Make package share resolution for URDF mesh lookups more robust by consulting ROS-installed package discovery before falling back to scanning repository/package.xml files. 
- Preserve repo-local asset precedence for a small set of critical local packages so authoring assets are not unexpectedly shadowed by installed packages. 
- Provide clearer diagnostics about which tier resolved each package (ament index, ros2 prefix, repo scan, etc.) to aid debugging and reproducible scene generation. 

### Description
- Added `resolve_ros_package_share(package_name, workspace_root=None)` which first tries `ament_index_python.packages.get_package_share_directory`, then `ros2 pkg prefix <pkg>` (if available), returning the share path, source tier, and diagnostics. 
- Reworked package discovery: introduced `_fallback_package_candidates()`, `extract_referenced_package_names()`, `_record_package_resolution()` and updated `discover_package_map()` to consult ROS resolution tiers before falling back to package.xml scan and to record `ros_resolution_attempts`, `unresolved_packages`, and shadowing information. 
- Preserved repo-local precedence for `robotiq_85_description`, `workbench_description`, and `realsense2_description` so local `assets/` packages remain preferred when present. 
- Wire package-name extraction into xacro-lite and main extraction paths so `package://` URIs and `$(find ...)` references can be resolved even if a package.xml scan would otherwise miss them. 
- Added unit tests exercising ament precedence, `ros2 pkg prefix` fallback, URI-only package resolution, and repo-local precedence, and extended diagnostics returned in payloads. 

### Testing
- Ran `pytest -q tests/test_scene_urdf_visual_mesh_index.py` and all tests passed (`12 passed`). 
- Ran the extractor on a real scene with `python3 scripts/extract_scene_urdf_visual_mesh_index.py --scene ur5_2f_test --prefer-xacro --no-write` which completed successfully. 
- Verified module syntax with `python3 -m py_compile scripts/extract_scene_urdf_visual_mesh_index.py tests/test_scene_urdf_visual_mesh_index.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25cac9bca083319ae1088de41770ee)