### PR TITLE
Make visual mesh index workspace-aware and tighten visual readiness checks

### DIFF
--- a/scripts/generate_workcell_from_cell_definition.py
+++ b/scripts/generate_workcell_from_cell_definition.py
@@ -8,6 +8,7 @@ import copy
 import importlib.util
 import json
 import math
+import os
 import shutil
 import sys
 import tempfile
@@ -703,6 +704,42 @@ def _render_scene_urdf_xacro(
     return "\n".join(lines) + "\n"
 
 
+def _workspace_root_from_path(path: Path) -> Path | None:
+    """Infer a colcon workspace root from a generated package path when possible."""
+    resolved = path.expanduser().resolve()
+    for candidate in (resolved, *resolved.parents):
+        if candidate.name == "src":
+            return candidate.parent
+        if candidate.name in {"install", "build", "log"}:
+            return candidate.parent
+    return None
+
+
+def _determine_workspace_root(
+    package_dir: Path, workspace_root: Path | str | None = None
+) -> Path | None:
+    """Resolve the workspace root used for xacro/package URI discovery.
+
+    Caller-provided roots win, then explicit environment variables, then a
+    best-effort inference from common colcon workspace layouts such as
+    <workspace>/src/.../<scene_package> or <workspace>/install/share/....
+    """
+    if workspace_root:
+        return Path(workspace_root).expanduser().resolve()
+
+    for env_name in (
+        "WORKSPACE_ROOT",
+        "COLCON_WORKSPACE_ROOT",
+        "ROS_WORKSPACE",
+        "WORKCELL_WORKSPACE_ROOT",
+    ):
+        raw = os.environ.get(env_name, "").strip()
+        if raw:
+            return Path(raw).expanduser().resolve()
+
+    return _workspace_root_from_path(package_dir)
+
+
 def _fallback_scene_visual_mesh_index(
     package_name: str,
     package_dir: Path,
@@ -738,11 +775,17 @@ def _fallback_scene_visual_mesh_index(
     }
 
 
-def _write_scene_visual_mesh_index(package_name: str, package_dir: Path, warnings: list[str]) -> str | None:
+def _write_scene_visual_mesh_index(
+    package_name: str,
+    package_dir: Path,
+    warnings: list[str],
+    workspace_root: Path | str | None = None,
+) -> str | None:
     """Best-effort visual mesh index generation with a preview-safe fallback contract."""
     generated_dir = package_dir / "generated"
     index_path = generated_dir / "scene_visual_mesh_index.json"
     urdf_path = package_dir / "urdf" / "scene.urdf.xacro"
+    resolved_workspace_root = _determine_workspace_root(package_dir, workspace_root=workspace_root)
 
     def write_fallback(reason: str) -> str:
         warning_text = f"Visual mesh extraction fallback for {index_path}: {reason}"
@@ -765,7 +808,12 @@ def _write_scene_visual_mesh_index(package_name: str, package_dir: Path, warning
         fallback_reason = ""
         xacro_cmd: list[str] = []
         try:
-            expanded_result = extractor.expand_xacro(urdf_path, package_dir, xargs)
+            expanded_result = extractor.expand_xacro(
+                urdf_path,
+                package_dir,
+                xargs,
+                workspace_root=resolved_workspace_root,
+            )
             if isinstance(expanded_result, tuple) and len(expanded_result) >= 4:
                 xml_text, _, fallback_reason, xacro_cmd = expanded_result[:4]
             elif isinstance(expanded_result, tuple) and len(expanded_result) == 3:
@@ -778,7 +826,13 @@ def _write_scene_visual_mesh_index(package_name: str, package_dir: Path, warning
             fallback_reason = f"xacro expansion skipped: {exc}"
         if not xml_text:
             xml_text = urdf_path.read_text(encoding="utf-8", errors="ignore")
-        package_map, package_diagnostics = extractor.discover_package_map(package_dir)
+        package_map, package_diagnostics = extractor.discover_package_map(
+            package_dir,
+            workspace_root=resolved_workspace_root,
+            package_names=extractor.extract_referenced_package_names(xml_text)
+            if hasattr(extractor, "extract_referenced_package_names")
+            else None,
+        )
         items = extractor.extract_from_urdf(xml_text, package_map)
         mesh_items = [item for item in items if item.get("geometry_type") == "mesh"]
         if not mesh_items:
@@ -788,7 +842,25 @@ def _write_scene_visual_mesh_index(package_name: str, package_dir: Path, warning
             for item in items
             if any(extractor.contains_placeholder(item.get(key, "")) for key in ("id", "link", "parent_link"))
         ]
-        safe_for_preview = len(unresolved) == 0 and mode in {"xacro_expanded", "xacro_lite_expanded", "best_effort_recursive"}
+        renderable_mesh_count = sum(
+            1 for item in mesh_items if item.get("render_expected", True)
+        )
+        renderable_item_count = sum(1 for item in items if item.get("render_expected", True))
+        safe_for_preview = len(unresolved) == 0 and mode in {"xacro_expanded", "xacro_lite_expanded"}
+        visual_readiness_reasons: list[str] = []
+        if not safe_for_preview:
+            visual_readiness_reasons.append(
+                "visual mesh index was not produced from a fully expanded xacro"
+                if mode not in {"xacro_expanded", "xacro_lite_expanded"}
+                else "visual mesh index contains unresolved xacro placeholders"
+            )
+        if renderable_mesh_count <= 0:
+            visual_readiness_reasons.append(
+                "no renderable mesh-backed visual was resolved; primitive fallback alone is not a PASS condition"
+            )
+        if fallback_reason:
+            visual_readiness_reasons.append(str(fallback_reason))
+        visual_readiness_status = "PASS" if not visual_readiness_reasons else "WARN"
         payload = {
             "schema_version": "scene_visual_mesh_index/v1",
             "scene_name": package_name,
@@ -807,10 +879,8 @@ def _write_scene_visual_mesh_index(package_name: str, package_dir: Path, warning
             "unresolved_placeholder_count": len(unresolved),
             "candidate_mesh_count": len(mesh_items),
             "emitted_visual_count": len(items),
-            "renderable_mesh_count": sum(
-                1 for item in mesh_items if item.get("render_expected", True)
-            ),
-            "renderable_item_count": sum(1 for item in items if item.get("render_expected", True)),
+            "renderable_mesh_count": renderable_mesh_count,
+            "renderable_item_count": renderable_item_count,
             "visual_items": items,
             "items": items,
             "blockers": [],
@@ -818,6 +888,12 @@ def _write_scene_visual_mesh_index(package_name: str, package_dir: Path, warning
             "stale_index": False,
             "stale_reasons": [],
             "xacro_command": xacro_cmd,
+            "workspace_root": str(resolved_workspace_root) if resolved_workspace_root else "",
+            "visual_readiness": {
+                "status": visual_readiness_status,
+                "reasons": visual_readiness_reasons,
+            },
+            "status": visual_readiness_status,
             "package_resolution_diagnostics": package_diagnostics,
         }
         generated_dir.mkdir(parents=True, exist_ok=True)
@@ -1139,6 +1215,7 @@ def write_scene_package_contract(
     scene_contract: Any | None = None,
     dry_result: Any | None = None,
     readiness_extra: dict[str, Any] | None = None,
+    workspace_root: Path | str | None = None,
 ) -> list[Path]:
     """Write the generated scene package contract from one authoritative helper."""
     (package_dir / "config").mkdir(parents=True, exist_ok=True)
@@ -1208,7 +1285,7 @@ def write_scene_package_contract(
         _render_scene_urdf_xacro(package_name, env_objects, cell_definition_path),
         encoding="utf-8",
     )
-    _write_scene_visual_mesh_index(package_name, package_dir, warnings)
+    _write_scene_visual_mesh_index(package_name, package_dir, warnings, workspace_root=workspace_root)
     if dry_result is not None and scene_contract is not None:
         _write_validation_report(
             package_dir / "generated" / "validation_report.md",
@@ -1288,6 +1365,7 @@ def generate_package(
     package_name: str,
     force: bool,
     dry_run: bool,
+    workspace_root: Path | str | None = None,
 ) -> int:
     if not VALIDATOR_PATH.is_file():
         print(f"FAIL: Missing required validation tool: {VALIDATOR_PATH}")
@@ -1409,6 +1487,7 @@ def generate_package(
         scene_generator=scene_generator,
         scene_contract=scene_contract,
         dry_result=dry_result,
+        workspace_root=workspace_root,
         readiness_extra={
             "dry_run_status": getattr(dry_result, "status", "UNKNOWN"),
             "source_inputs": {
@@ -1538,6 +1617,12 @@ def main() -> int:
     parser.add_argument("--package-name", type=str, required=True, help="Output ROS package name")
     parser.add_argument("--force", action="store_true", help="Overwrite existing generated package directory")
     parser.add_argument("--dry-run", action="store_true", help="Validate and preview actions without writing files")
+    parser.add_argument(
+        "--workspace-root",
+        type=Path,
+        default=None,
+        help="Optional colcon workspace root used to resolve package:// meshes during preview index generation",
+    )
     args = parser.parse_args()
 
     return generate_package(
@@ -1546,6 +1631,7 @@ def main() -> int:
         package_name=args.package_name.strip(),
         force=args.force,
         dry_run=args.dry_run,
+        workspace_root=args.workspace_root.resolve() if args.workspace_root else None,
     )
 
 

--- a/tests/test_generate_workcell_from_cell_definition_contract.py
+++ b/tests/test_generate_workcell_from_cell_definition_contract.py
@@ -293,3 +293,126 @@ def test_cli_force_in_place_regeneration_keeps_source_layout_and_environment(
     assert (package_dir / "layout" / "workcell_studio_layout.yaml").read_text(
         encoding="utf-8"
     ) == expected_workcell_layout
+
+
+def test_visual_mesh_index_passes_workspace_root_to_extractor(tmp_path: Path, monkeypatch) -> None:
+    from scripts import generate_workcell_from_cell_definition as generator
+
+    workspace_root = tmp_path / "ws"
+    package_dir = (
+        workspace_root / "src" / "easy_manipulation_deployment" / "scenes" / "demo_scene"
+    )
+    (package_dir / "urdf").mkdir(parents=True)
+    (package_dir / "urdf" / "scene.urdf.xacro").write_text(
+        '<robot name="demo"><link name="world"><visual><geometry>'
+        '<mesh filename="package://demo_assets/meshes/part.stl"/>'
+        "</geometry></visual></link></robot>",
+        encoding="utf-8",
+    )
+    extractor = tmp_path / "fake_extractor.py"
+    extractor.write_text(
+        """
+import os
+from pathlib import Path
+EXTRACTOR_VERSION = 'test'
+EXPECTED_WORKSPACE_ROOT = Path(os.environ['EXPECTED_WORKSPACE_ROOT'])
+
+def expand_xacro(urdf_path, scene_dir=None, xacro_args=None, workspace_root=None):
+    assert xacro_args == {'use_fake_hardware': 'true', 'robot_prefix': '', 'tool_prefix': ''}
+    assert Path(workspace_root) == EXPECTED_WORKSPACE_ROOT
+    return (Path(urdf_path).read_text(encoding='utf-8'), '', '', ['xacro'])
+
+def discover_package_map(scene_dir, workspace_root=None, package_names=None):
+    assert Path(workspace_root) == EXPECTED_WORKSPACE_ROOT
+    assert package_names == ['demo_assets']
+    return {'demo_assets': EXPECTED_WORKSPACE_ROOT / 'src' / 'demo_assets'}, {'resolution_paths': []}
+
+def extract_referenced_package_names(text):
+    return ['demo_assets']
+
+def extract_from_urdf(xml_text, package_map):
+    return [{'id': 'mesh', 'link': 'world', 'parent_link': 'world', 'geometry_type': 'mesh', 'resolved': True, 'render_expected': True}]
+
+def contains_placeholder(text):
+    return False
+
+def discover_xacro_command():
+    return ('xacro', True, '')
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(generator, "MESH_INDEX_EXTRACTOR_PATH", extractor)
+    monkeypatch.setenv("EXPECTED_WORKSPACE_ROOT", str(workspace_root.resolve()))
+    warnings: list[str] = []
+
+    assert generator._write_scene_visual_mesh_index("demo_scene", package_dir, warnings) is None
+
+    payload = json.loads(
+        (package_dir / "generated" / "scene_visual_mesh_index.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert payload["workspace_root"] == str(workspace_root.resolve())
+    assert payload["xacro_command"] == ["xacro"]
+    assert payload["visual_readiness"]["status"] == "PASS"
+    assert warnings == []
+
+
+def test_visual_mesh_index_warns_when_xacro_expansion_falls_back(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from scripts import generate_workcell_from_cell_definition as generator
+
+    package_dir = tmp_path / "scene"
+    (package_dir / "urdf").mkdir(parents=True)
+    (package_dir / "urdf" / "scene.urdf.xacro").write_text(
+        '<robot name="demo"><link name="world"><visual><geometry>'
+        '<mesh filename="package://missing_assets/meshes/part.stl"/>'
+        "</geometry></visual></link></robot>",
+        encoding="utf-8",
+    )
+    extractor = tmp_path / "fallback_extractor.py"
+    extractor.write_text(
+        """
+EXTRACTOR_VERSION = 'test'
+
+def expand_xacro(urdf_path, scene_dir=None, xacro_args=None, workspace_root=None):
+    return ('', 'best_effort_recursive', 'xacro unavailable in test', [])
+
+def discover_package_map(scene_dir, workspace_root=None, package_names=None):
+    return {}, {'resolution_paths': []}
+
+def extract_referenced_package_names(text):
+    return ['missing_assets']
+
+def extract_from_urdf(xml_text, package_map):
+    return [{'id': 'mesh', 'link': 'world', 'parent_link': 'world', 'geometry_type': 'mesh', 'resolved': False, 'render_expected': False}]
+
+def contains_placeholder(text):
+    return False
+
+def discover_xacro_command():
+    return ('', False, 'xacro unavailable in test')
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(generator, "MESH_INDEX_EXTRACTOR_PATH", extractor)
+    warnings: list[str] = []
+
+    assert generator._write_scene_visual_mesh_index("demo_scene", package_dir, warnings) is None
+
+    payload = json.loads(
+        (package_dir / "generated" / "scene_visual_mesh_index.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert payload["safe_for_preview"] is False
+    assert payload["visual_readiness"]["status"] == "WARN"
+    assert any(
+        "fully expanded xacro" in reason
+        for reason in payload["visual_readiness"]["reasons"]
+    )
+    assert any(
+        "primitive fallback alone" in reason
+        for reason in payload["visual_readiness"]["reasons"]
+    )


### PR DESCRIPTION
### Motivation
- Allow the visual mesh extractor to resolve `package://` URIs from the correct colcon workspace by determining a workspace root from an explicit caller value, environment variables, or by inferring common colcon layouts. 
- Preserve the existing safe fallback payload when extraction fails while preventing primitive-only fallback evidence from being treated as a visual READINESS PASS. 
- Keep fake-hardware-first behavior and the default xacro args unchanged so generated packages remain offline-safe by default. 

### Description
- Added `_determine_workspace_root()` (and helper `_workspace_root_from_path()`) to infer a workspace root from an explicit parameter, environment variables, or parent paths. 
- Updated `_write_scene_visual_mesh_index()` to accept `workspace_root` and pass it to `extractor.expand_xacro(...)` and `extractor.discover_package_map(...)`, and to include the resolved `workspace_root` in the generated payload. 
- Reworked visual-readiness calculation to report `visual_readiness` reasons and status based on xacro expansion state and whether any renderable mesh-backed visuals were resolved instead of marking PASS when only primitive fallbacks exist. 
- Threaded an optional `workspace_root` through `write_scene_package_contract()` and `generate_package()` and added a `--workspace-root` CLI option for explicit caller control, while preserving `xargs = {'use_fake_hardware': 'true', ...}` as the default passed to expansion. 

### Testing
- Compiled the modified script with `python3 -m py_compile scripts/generate_workcell_from_cell_definition.py`, which succeeded. 
- Ran `pytest -q tests/test_generate_workcell_from_cell_definition_contract.py`, including new regression tests for workspace-root propagation and fallback-readiness, and all tests passed. 
- Executed `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json`, `scenes/suction_test --json`, and `scenes/ur3_suction_test --json`, and each invocation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25cc72093083318e8aea45e14e3f04)