### PR TITLE
Gate UR static primitive fallbacks and track real xacro success

### DIFF
--- a/scripts/extract_scene_urdf_visual_mesh_index.py
+++ b/scripts/extract_scene_urdf_visual_mesh_index.py
@@ -8,7 +8,8 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 SCENES_ROOT = ROOT / "scenes"
-EXTRACTOR_VERSION = "2.5"
+EXTRACTOR_VERSION = "2.6"
+UR5_VISUAL_MESH_URI_PREFIX = "package://ur_description/meshes/ur5/visual/"
 PLACEHOLDER_RE = re.compile(r"(\$\{[^}]+\}|\$\(arg\s+[^)]+\)|\$\(find\s+[^)]+\))")
 REPO_LOCAL_ASSET_PRECEDENCE_PACKAGES = {
     "robotiq_85_description",
@@ -452,14 +453,36 @@ def expand_xacro(urdf_path, scene_dir=None, xacro_args=None, workspace_root=None
 
 
 
-def append_static_robot_primitive_fallbacks(items, urdf_text, fallback_reason):
-    """Add bounded robot primitives when xacro-lite cannot expand a known robot macro.
+def _contains_unresolved_ur_robot(text):
+    text = text or ''
+    lowered = text.lower()
+    if 'ur_robot' not in lowered:
+        return False
+    return bool(re.search(r"<\s*(?:[A-Za-z_][\w.-]*:)?ur_robot\b", text, re.IGNORECASE)) or 'ur_robot' in lowered
+
+def _has_ur5_visual_mesh_uri(items):
+    for item in items or []:
+        uri_candidates = [item.get('package_uri'), item.get('source_path')]
+        if any(str(uri or '').startswith(UR5_VISUAL_MESH_URI_PREFIX) for uri in uri_candidates):
+            return True
+    return False
+
+def append_static_robot_primitive_fallbacks(items, urdf_text, fallback_reason, extraction_mode='best_effort_recursive', source_xacro_text=''):
+    """Add bounded robot primitives when real xacro UR mesh expansion is unavailable.
 
     These entries are preview-only visual fallbacks for Scene3D. They do not alter
     launch files, controllers, or runtime robot behaviour.
     """
-    reason = (fallback_reason or '').lower()
-    if 'ur_robot' not in reason and '<xacro:ur_robot' not in (urdf_text or ''):
+    fallback_eligible_modes = {'xacro_lite_expanded', 'best_effort_recursive', 'best_effort', 'raw_fallback', 'raw'}
+    if extraction_mode not in fallback_eligible_modes:
+        return 0
+    if _has_ur5_visual_mesh_uri(items):
+        return 0
+    if not (
+        _contains_unresolved_ur_robot(fallback_reason)
+        or _contains_unresolved_ur_robot(source_xacro_text)
+        or _contains_unresolved_ur_robot(urdf_text)
+    ):
         return 0
     existing_ids = {str(i.get('id') or '') for i in items}
     specs = [
@@ -625,7 +648,7 @@ def main():
     ap=argparse.ArgumentParser(); ap.add_argument('--scene'); ap.add_argument('--all',action='store_true'); ap.add_argument('--prefer-xacro-expanded',action='store_true',default=True); ap.add_argument('--fallback-best-effort',action='store_true',default=True); ap.add_argument('--fail-on-unexpanded',action='store_true'); ap.add_argument('--xacro-arg',action='append',default=[]); ap.add_argument('--use-fake-hardware',default='true'); ap.add_argument('--robot-prefix',default=''); ap.add_argument('--tool-prefix',default=''); ap.add_argument('--no-write',action='store_true'); ap.add_argument('--prefer-xacro',action='store_true'); ap.add_argument('--require-xacro',action='store_true'); ap.add_argument('--workspace-root',default=os.environ.get('WORKSPACE_ROOT',''))
     a=ap.parse_args()
     scenes=[SCENES_ROOT/a.scene] if a.scene else sorted([p for p in SCENES_ROOT.iterdir() if p.is_dir()])
-    report={'scene_count':0,'visual_count':0,'resolved':0,'unresolved':0,'xacro_expanded_count':0,'best_effort_count':0,'scenes':[]}
+    report={'scene_count':0,'visual_count':0,'resolved':0,'unresolved':0,'xacro_expanded_count':0,'best_effort_count':0,'real_xacro_expanded_count':0,'scenes':[]}
     for scene_dir in scenes:
         manifest=read_yaml(scene_dir/'scene_manifest.yaml') or {}
         urdf_path=scene_dir/(((manifest.get('files') or {}).get('urdf_xacro')) or 'urdf/scene.urdf.xacro')
@@ -633,7 +656,7 @@ def main():
         for ent in a.xacro_arg:
             if '=' in ent:
                 k,v=ent.split('=',1); xargs[k.strip()]=v.strip()
-        mode='best_effort_recursive'; fallback_reason=''; _,xacro_avail,missing_reason=discover_xacro_command(); expanded_path=''; xacro_cmd=[]; xml_text=''
+        mode='best_effort_recursive'; fallback_reason=''; _,xacro_avail,missing_reason=discover_xacro_command(); expanded_path=''; xacro_cmd=[]; xml_text=''; real_xacro_command_succeeded=False; source_xacro_text=urdf_path.read_text(errors='ignore') if urdf_path.exists() else ''
         if (a.prefer_xacro or a.prefer_xacro_expanded or a.require_xacro):
             try:
                 expanded_result = expand_xacro(urdf_path,scene_dir,xargs,workspace_root=(a.workspace_root or None))
@@ -651,24 +674,33 @@ def main():
                 mode='xacro_lite_expanded' if xacro_cmd and xacro_cmd[0] == 'xacro-lite' else 'xacro_expanded'
                 expanded_path='' if mode == 'xacro_lite_expanded' else 'generated/expanded_scene_preview.urdf'
                 fallback_reason=err if mode == 'xacro_lite_expanded' else ''
+                real_xacro_command_succeeded=bool(mode == 'xacro_expanded' and xacro_cmd and xacro_cmd[0] != 'xacro-lite')
             else: fallback_reason=err or missing_reason
         if a.require_xacro and not xacro_avail:
             print('xacro executable unavailable (required)'); return 2
-        if not xml_text: xml_text=(urdf_path.read_text(errors='ignore') if urdf_path.exists() else '<robot/>')
+        if not xml_text: xml_text=(source_xacro_text if source_xacro_text else '<robot/>')
         package_map, package_diagnostics = discover_package_map(scene_dir, workspace_root=(a.workspace_root or None), package_names=extract_referenced_package_names(xml_text))
         try: items=extract_from_urdf(xml_text, package_map)
         except Exception: items=[]
-        static_robot_fallback_count = append_static_robot_primitive_fallbacks(items, xml_text, fallback_reason)
+        static_robot_fallback_count = 0
+        fallback_ur_robot_unresolved = (
+            _contains_unresolved_ur_robot(fallback_reason)
+            or _contains_unresolved_ur_robot(source_xacro_text)
+            or _contains_unresolved_ur_robot(xml_text)
+        )
+        if mode in {'xacro_lite_expanded', 'best_effort_recursive', 'best_effort', 'raw_fallback', 'raw'} and fallback_ur_robot_unresolved and not _has_ur5_visual_mesh_uri(items):
+            static_robot_fallback_count = append_static_robot_primitive_fallbacks(items, xml_text, fallback_reason, mode, source_xacro_text)
         static_parent_resolved_count = resolve_static_tool0_children(items)
         unresolved=[i for i in items if any(contains_placeholder(i.get(k,'')) for k in ('id','link','parent_link'))]
-        safe=bool(items) and (len(unresolved)==0) and (mode in ('xacro_expanded','xacro_lite_expanded'))
+        fallback_only_ur5_preview=static_robot_fallback_count > 0 and not _has_ur5_visual_mesh_uri(items)
+        safe=bool(items) and (len(unresolved)==0) and (mode in ('xacro_expanded','xacro_lite_expanded')) and not fallback_only_ur5_preview
         mesh_format_counts=dict(collections.Counter((Path(i.get('resolved_source_path') or i.get('source_path') or '').suffix.lower() or 'unknown') for i in items if i.get('geometry_type')=='mesh'))
         transform_status_counts=dict(collections.Counter(str(i.get('transform_status') or 'unknown') for i in items))
         renderable_count=sum(1 for i in items if i.get('render_expected', True))
         renderable_mesh_count=sum(1 for i in items if i.get('geometry_type')=='mesh' and i.get('render_expected', True))
         source_mtime=urdf_path.stat().st_mtime if urdf_path.exists() else None
         has_transform_collapse_warning=bool(items) and len({tuple((i.get('pose') or {}).get('xyz') or []) for i in items}) <= 1 and len(items) > 1
-        payload={'scene_name':scene_dir.name,'visual_count':len(items),'resolved':sum(1 for i in items if i.get('resolved')),'unresolved':sum(1 for i in items if not i.get('resolved')),'generated_at':datetime.now(timezone.utc).isoformat(),'extractor_version':EXTRACTOR_VERSION,'extraction_mode':mode,'xacro_available':xacro_avail,'source_urdf_xacro_path':str(urdf_path),'source_mtime':source_mtime,'source_expanded_urdf_path':expanded_path,'fallback_reason':fallback_reason,'safe_for_preview':safe,'unresolved_placeholder_count':len(unresolved),'has_transform_collapse_warning':has_transform_collapse_warning,'candidate_mesh_count':len(items),'emitted_visual_count':len(items),'transform_status_counts':transform_status_counts,'mesh_format_counts':mesh_format_counts,'renderable_mesh_count':renderable_mesh_count,'renderable_item_count':renderable_count,'static_robot_primitive_fallback_count':static_robot_fallback_count,'static_parent_resolved_count':static_parent_resolved_count,'stale_index':False,'stale_reasons':[],'visual_items':items,'xacro_command':xacro_cmd,'package_resolution_diagnostics':package_diagnostics}
+        payload={'scene_name':scene_dir.name,'visual_count':len(items),'resolved':sum(1 for i in items if i.get('resolved')),'unresolved':sum(1 for i in items if not i.get('resolved')),'generated_at':datetime.now(timezone.utc).isoformat(),'extractor_version':EXTRACTOR_VERSION,'extraction_mode':mode,'xacro_available':xacro_avail,'source_urdf_xacro_path':str(urdf_path),'source_mtime':source_mtime,'source_expanded_urdf_path':expanded_path,'fallback_reason':fallback_reason,'xacro_real_command_succeeded':real_xacro_command_succeeded,'safe_for_preview':safe,'unresolved_placeholder_count':len(unresolved),'has_transform_collapse_warning':has_transform_collapse_warning,'candidate_mesh_count':len(items),'emitted_visual_count':len(items),'transform_status_counts':transform_status_counts,'mesh_format_counts':mesh_format_counts,'renderable_mesh_count':renderable_mesh_count,'renderable_item_count':renderable_count,'static_robot_primitive_fallback_count':static_robot_fallback_count,'static_parent_resolved_count':static_parent_resolved_count,'stale_index':False,'stale_reasons':[],'visual_items':items,'xacro_command':xacro_cmd,'package_resolution_diagnostics':package_diagnostics}
         idx_path=scene_dir/'generated/scene_visual_mesh_index.json'
         if not a.no_write:
             idx_path.parent.mkdir(parents=True,exist_ok=True)
@@ -678,6 +710,7 @@ def main():
         report['resolved']+=sum(1 for i in items if i.get('resolved'))
         report['unresolved']+=sum(1 for i in items if not i.get('resolved'))
         report['xacro_expanded_count']+=int(mode in ('xacro_expanded','xacro_lite_expanded'))
+        report['real_xacro_expanded_count']+=int(real_xacro_command_succeeded)
         report['best_effort_count']+=int(mode not in ('xacro_expanded','xacro_lite_expanded'))
         report.setdefault('mesh_format_counts', {})
         for ext,count in mesh_format_counts.items(): report['mesh_format_counts'][ext]=report['mesh_format_counts'].get(ext,0)+count
@@ -686,7 +719,7 @@ def main():
         report['candidate_mesh_count']=report.get('candidate_mesh_count',0)+len(items)
         report['emitted_visual_count']=report.get('emitted_visual_count',0)+len(items)
         report['unresolved_placeholder_count']=report.get('unresolved_placeholder_count',0)+len(unresolved)
-        report['scenes'].append({'scene':scene_dir.name,'extraction_mode':mode,'xacro_available':payload['xacro_available'],'expanded_urdf_written':bool(expanded_path),'safe_for_preview':safe,'unresolved_placeholder_count':len(unresolved),'mesh_backed_count':sum(1 for i in items if i.get('geometry_type')=='mesh'),'skipped_count':sum(1 for i in items if i.get('render_skip_reason')),'fallback_reason':fallback_reason,'urdf_primitive_count':sum(1 for i in items if i.get('geometry_type') in ('box','cylinder','sphere','capsule')),'primitive_fallback_count':static_robot_fallback_count,'stale_index':False,'status':'PASS' if safe else 'WARN'})
+        report['scenes'].append({'scene':scene_dir.name,'extraction_mode':mode,'xacro_available':payload['xacro_available'],'xacro_real_command_succeeded':real_xacro_command_succeeded,'expanded_urdf_written':bool(expanded_path),'safe_for_preview':safe,'unresolved_placeholder_count':len(unresolved),'mesh_backed_count':sum(1 for i in items if i.get('geometry_type')=='mesh'),'skipped_count':sum(1 for i in items if i.get('render_skip_reason')),'fallback_reason':fallback_reason,'urdf_primitive_count':sum(1 for i in items if i.get('geometry_type') in ('box','cylinder','sphere','capsule')),'primitive_fallback_count':static_robot_fallback_count,'stale_index':False,'status':'PASS' if safe else 'WARN'})
         if a.require_xacro and mode not in ('xacro_expanded','xacro_lite_expanded'): return 2
     (ROOT/'build').mkdir(exist_ok=True)
     (ROOT/'build/workcell_studio_urdf_visual_mesh_index_report.json').write_text(json.dumps(report,indent=2)+'\n')

--- a/tests/test_scene_urdf_visual_mesh_index.py
+++ b/tests/test_scene_urdf_visual_mesh_index.py
@@ -365,6 +365,83 @@ def test_require_xacro_strict_nonzero_on_simulated_xacro_failure(monkeypatch):
         sys.argv = original_argv
     assert rc != 0
 
+
+def test_static_ur_robot_fallback_is_gated_by_expansion_mode_and_mesh_presence():
+    import scripts.extract_scene_urdf_visual_mesh_index as mesh_index
+
+    source_xacro = '<robot xmlns:xacro="http://ros.org/wiki/xacro"><xacro:ur_robot name="ur5"/></robot>'
+    items = []
+    assert mesh_index.append_static_robot_primitive_fallbacks(
+        items,
+        '<robot/>',
+        'skipped unresolved macros: ur_robot',
+        'xacro_expanded',
+        source_xacro,
+    ) == 0
+    assert items == []
+
+    items = [
+        {
+            'geometry_type': 'mesh',
+            'package_uri': 'package://ur_description/meshes/ur5/visual/base.dae',
+            'source_path': 'package://ur_description/meshes/ur5/visual/base.dae',
+        }
+    ]
+    assert mesh_index.append_static_robot_primitive_fallbacks(
+        items,
+        '<robot/>',
+        'skipped unresolved macros: ur_robot',
+        'xacro_lite_expanded',
+        source_xacro,
+    ) == 0
+    assert len(items) == 1
+
+    items = []
+    added = mesh_index.append_static_robot_primitive_fallbacks(
+        items,
+        '<robot/>',
+        'skipped unresolved macros: ur_robot',
+        'xacro_lite_expanded',
+        source_xacro,
+    )
+    assert added > 0
+    assert all(item.get('category') == 'robot_static_primitive_fallback' for item in items)
+
+
+def test_main_marks_xacro_lite_static_ur5_fallback_preview_unsafe(monkeypatch, tmp_path):
+    import sys
+    import scripts.extract_scene_urdf_visual_mesh_index as mesh_index
+
+    scenes_root = tmp_path / 'scenes'
+    scene = scenes_root / 'lite_scene'
+    (scene / 'urdf').mkdir(parents=True)
+    (scene / 'urdf' / 'scene.urdf.xacro').write_text(
+        '<robot xmlns:xacro="http://ros.org/wiki/xacro"><xacro:ur_robot name="ur5"/></robot>',
+        encoding='utf-8',
+    )
+    monkeypatch.setattr(mesh_index, 'SCENES_ROOT', scenes_root)
+    monkeypatch.setattr(mesh_index, 'discover_xacro_command', lambda: (None, False, 'xacro executable unavailable'))
+    monkeypatch.setattr(
+        mesh_index,
+        'expand_xacro',
+        lambda *args, **kwargs: ('<robot name="lite_scene"/>', True, 'skipped unresolved macros: ur_robot', ['xacro-lite', 'scene.urdf.xacro']),
+    )
+
+    original_argv = sys.argv
+    try:
+        sys.argv = ['extract_scene_urdf_visual_mesh_index.py', '--scene', 'lite_scene']
+        rc = mesh_index.main()
+    finally:
+        sys.argv = original_argv
+
+    assert rc == 0
+    index = scene / 'generated' / 'scene_visual_mesh_index.json'
+    payload = json.loads(index.read_text(encoding='utf-8'))
+    assert payload['extraction_mode'] == 'xacro_lite_expanded'
+    assert payload['xacro_real_command_succeeded'] is False
+    assert payload['static_robot_primitive_fallback_count'] > 0
+    assert payload['safe_for_preview'] is False
+
 def test_synthetic_chain_transform_composition_and_primitives():
     import scripts.extract_scene_urdf_visual_mesh_index as mesh_index
     xml = '''<robot name="t"><link name="root"/><link name="link1"/><link name="link2"/>


### PR DESCRIPTION
### Motivation

- Prevent spurious static UR5 primitive fallbacks from turning fallback-only previews into visual PASS and make fallback insertion conditional on real xacro failure evidence.
- Avoid adding primitives when real UR5 visual meshes are already present to preserve accurate visual readiness and avoid false positives.
- Expose whether a real `xacro` command succeeded (vs. repo-local xacro-lite) so reports can distinguish real expansion from best-effort fallbacks.

### Description

- Bumped extractor version to `2.6` and added `UR5_VISUAL_MESH_URI_PREFIX` to detect real UR5 visual mesh URIs in extracted items. (`scripts/extract_scene_urdf_visual_mesh_index.py`).
- Added helpers `_contains_unresolved_ur_robot()` and `_has_ur5_visual_mesh_uri()` and changed `append_static_robot_primitive_fallbacks()` signature to accept `extraction_mode` and `source_xacro_text` and gate fallback insertion to only run when extraction mode is a fallback/best-effort type and unresolved `ur_robot` evidence exists. (`scripts/extract_scene_urdf_visual_mesh_index.py`).
- Skip static-primitive insertion when any extracted item already references `package://ur_description/meshes/ur5/visual/` to prefer real mesh-backed previews. (`scripts/extract_scene_urdf_visual_mesh_index.py`).
- Track whether a real `xacro` command succeeded with `xacro_real_command_succeeded` and add `real_xacro_expanded_count` / `xacro_real_command_succeeded` into per-scene payload and the aggregate report to separate real expansion success from xacro-lite fallback. (`scripts/extract_scene_urdf_visual_mesh_index.py`).
- Mark previews that are only supplied by static UR5 primitives as unsafe by preventing `safe_for_preview` from becoming true when the preview is fallback-only. (`scripts/extract_scene_urdf_visual_mesh_index.py`).
- Added regression tests covering gating behavior and the preview-readiness effect: `test_static_ur_robot_fallback_is_gated_by_expansion_mode_and_mesh_presence` and `test_main_marks_xacro_lite_static_ur5_fallback_preview_unsafe`. (`tests/test_scene_urdf_visual_mesh_index.py`).

### Testing

- Ran `python3 -m py_compile scripts/extract_scene_urdf_visual_mesh_index.py` and compilation succeeded.
- Ran targeted tests: `pytest -q tests/test_scene_urdf_visual_mesh_index.py::test_static_ur_robot_fallback_is_gated_by_expansion_mode_and_mesh_presence tests/test_scene_urdf_visual_mesh_index.py::test_main_marks_xacro_lite_static_ur5_fallback_preview_unsafe` and both passed.
- Ran full relevant smoke/validation commands: `python3 scripts/extract_scene_urdf_visual_mesh_index.py --scene ur5_2f_test --prefer-xacro --no-write`, `python3 scripts/extract_scene_urdf_visual_mesh_index.py --scene suction_test --prefer-xacro --no-write`, and `python3 scripts/extract_scene_urdf_visual_mesh_index.py --scene ur3_suction_test --prefer-xacro --no-write`, and these completed successfully.
- Ran full test suite for the visual extractor tests with `pytest -q tests/test_scene_urdf_visual_mesh_index.py` and the suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25cc867a70833189c2f0d9193316af)