### PR TITLE
Route semantic viewport primitives before generic fallback

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -599,8 +599,6 @@ bool is_raw_generated_bounds_only_item(const ScenePreviewWidget::PreviewItem & i
 bool is_overlay_visual_role(NormalizedRole role)
 {
   switch (role) {
-    case NormalizedRole::PickZone:
-    case NormalizedRole::PlaceBin:
     case NormalizedRole::SafetyZone:
     case NormalizedRole::WarningAnchor:
       return true;
@@ -1416,6 +1414,7 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
                                                         int * out_urdf_primitive_count, int * out_missing_geometry_count,
                                                         int * out_primitive_fallback_count)
 {
+  const NormalizedRole role = classify_item_role(it);
   const QString source_layer = normalized_scene3d_layer_token(it.source_layer);
   const QString visual_source = normalized_scene3d_layer_token(it.active_visual_source);
   const bool helper_overlay = is_overlay_only_item(it) || source_layer == "overlay" || visual_source == "overlay";
@@ -1461,6 +1460,36 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
   if (item_has_explicit_dimensions(it)) {
     const bool intentional_primitive_fallback =
       source_layer == QStringLiteral("primitive_fallback") || visual_source == QStringLiteral("primitive_fallback");
+    const bool semantic_physical_primitive =
+      role == NormalizedRole::Table || role == NormalizedRole::Conveyor ||
+      role == NormalizedRole::Camera || role == NormalizedRole::PickZone ||
+      role == NormalizedRole::PlaceBin || role == NormalizedRole::Object;
+    if (semantic_physical_primitive) {
+      switch (role) {
+        case NormalizedRole::Table:
+          draw_table_slab(it);
+          break;
+        case NormalizedRole::Conveyor:
+          draw_conveyor(it);
+          break;
+        case NormalizedRole::Camera:
+          draw_camera_body_with_frustum(it);
+          break;
+        case NormalizedRole::PickZone:
+          draw_pick_zone(it);
+          break;
+        case NormalizedRole::PlaceBin:
+          draw_place_target_bin(it);
+          break;
+        case NormalizedRole::Object:
+          draw_object_cube(it);
+          break;
+        default:
+          break;
+      }
+      if (out_primitive_fallback_count) ++(*out_primitive_fallback_count);
+      return true;
+    }
     if (mesh_preview_mode == ScenePreviewWidget::MeshPreviewMode::Meshes || is_raw_generated_bounds_only_item(it)) {
       draw_missing_geometry_marker(it);
       ++last_render_counters.generated_fallback_count;
@@ -1992,7 +2021,6 @@ void Scene3DViewportWidget::draw_place_target_bin(const ScenePreviewWidget::Prev
 }
 void Scene3DViewportWidget::draw_object_cube(const ScenePreviewWidget::PreviewItem & it)
 {
-  if (draw_mesh_preview_if_available(it, item_color(it), true)) return;
   const double cube = qMax(0.05, qMin(it.sx, qMin(it.sy, it.sz)));
   draw_box(it.x, it.y, it.z, cube, cube, cube, item_color(it));
 }


### PR DESCRIPTION
### Motivation
- Improve 3D viewport fidelity by classifying preview items and rendering semantic physical primitives (tables, conveyors, cameras, pick/place zones, objects) with their role-specific renderers instead of falling back to a generic wireframe box.
- Ensure semantic primitive rendering is counted as physical/primitive rendering (not mesh rendering) and keep safety/warning overlays separate from physical objects.

### Description
- Call `classify_item_role(it)` at the start of `draw_truthful_item_geometry()` and use the result to drive rendering decisions.
- Route explicit-dimensions items with semantic roles to role-specific renderers: `Table -> draw_table_slab`, `Conveyor -> draw_conveyor`, `Camera -> draw_camera_body_with_frustum`, `PickZone -> draw_pick_zone`, `PlaceBin -> draw_place_target_bin`, and `Object -> draw_object_cube`, incrementing the primitive-fallback output counter and returning success (physical rendering) before the generic fallback.
- Remove `PickZone`/`PlaceBin` from the overlay-only set so pick/place semantic objects are treated as physical semantic objects rather than overlay helpers.
- Stop `draw_object_cube()` from re-attempting `draw_mesh_preview_if_available()` so the semantic object cube path is treated as a primitive rendering path (not a mesh render).

### Testing
- Ran `git diff --check` which reported no whitespace or simple diff issues and succeeded.
- Attempted ROS build with `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder`, but build was blocked because `/opt/ros/humble/setup.bash` is not present in this container; no compile-time validation performed.
- Attempted `colcon build --symlink-install --packages-select workcell_builder`, but `colcon` is not installed in the container, so no build completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25d6013f0c8331ae25ba1db315f623)