### PR TITLE
Add semantic Scene3D geometry policy for PickZone/PlaceBin/Conveyor/Object

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -131,7 +131,7 @@ void finalize_visual_quality(Scene3DViewportWidget::RenderDebugCounters & counte
   }
   if (counters.missing_geometry_count > 0) {
     if (status == QStringLiteral("PASS")) status = QStringLiteral("WARNING");
-    warnings.append(QStringLiteral("missing_geometry_rendered_as_warning_markers"));
+    warnings.append(QStringLiteral("missing_geometry_requires_diagnostics"));
   }
   if (counters.placeholder_count > 0) {
     if (status == QStringLiteral("PASS")) status = QStringLiteral("WARNING");
@@ -596,6 +596,25 @@ bool is_raw_generated_bounds_only_item(const ScenePreviewWidget::PreviewItem & i
 }
 
 
+
+bool is_clean_semantic_primitive_role(NormalizedRole role)
+{
+  switch (role) {
+    case NormalizedRole::PickZone:
+    case NormalizedRole::PlaceBin:
+    case NormalizedRole::Conveyor:
+    case NormalizedRole::Object:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool should_suppress_missing_geometry_marker_for_semantic_role(const ScenePreviewWidget::PreviewItem & it)
+{
+  return is_clean_semantic_primitive_role(classify_item_role(it)) && !item_has_explicit_primitive_dimensions(it);
+}
+
 bool is_overlay_visual_role(NormalizedRole role)
 {
   switch (role) {
@@ -983,6 +1002,9 @@ void Scene3DViewportWidget::paintGL()
         urdf_primitive_rendered_count += item_urdf_primitive_count;
         missing_geometry_count += item_missing_geometry_count;
         wireframe_box_count += item_wireframe_box_count;
+        primitive_fallback_count += item_primitive_fallback_count;
+      } else {
+        missing_geometry_count += item_missing_geometry_count;
         primitive_fallback_count += item_primitive_fallback_count;
       }
       if (it->id == selected_id) {
@@ -1436,6 +1458,22 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
     if (out_mesh_count) ++(*out_mesh_count);
     return true;
   }
+  const NormalizedRole semantic_role = classify_item_role(it);
+  if (is_clean_semantic_primitive_role(semantic_role)) {
+    if (item_has_explicit_primitive_dimensions(it)) {
+      if (draw_clean_semantic_primitive(it)) {
+        if (out_primitive_fallback_count) ++(*out_primitive_fallback_count);
+        return true;
+      }
+    } else {
+      // Semantic authoring roles without dimensions remain diagnostics-only.
+      // They are still counted as missing geometry for readiness/status, but the
+      // main 3D viewport intentionally avoids large red missing-geometry markers.
+      if (out_missing_geometry_count) ++(*out_missing_geometry_count);
+      return false;
+    }
+  }
+
   const QString missing_reason = placeholder_reason_for_item(it);
   if (!missing_reason.isEmpty()) {
     draw_missing_geometry_marker(it);
@@ -1575,6 +1613,7 @@ bool Scene3DViewportWidget::should_include_in_default_fit_for_test(const ScenePr
 bool Scene3DViewportWidget::should_draw_as_solid_for_test(const ScenePreviewWidget::PreviewItem & item,
                                                            ScenePreviewWidget::MeshPreviewMode mode)
 {
+  if (should_draw_clean_semantic_primitive_for_test(item)) return true;
   const QString role = render_role_for_test(item);
   if (role == "helper_overlay" || role == "missing_mesh_fallback") return false;
   if (mode == ScenePreviewWidget::MeshPreviewMode::Meshes && !item.mesh_available) return false;
@@ -1587,7 +1626,18 @@ bool Scene3DViewportWidget::should_draw_as_wireframe_for_test(const ScenePreview
   Q_UNUSED(mode);
   const QString role = render_role_for_test(item);
   if (item_has_valid_urdf_primitive(item)) return false;
+  if (should_suppress_missing_geometry_marker_for_semantic_role(item)) return false;
   return role == "helper_overlay" || role == "missing_mesh_fallback";
+}
+
+bool Scene3DViewportWidget::should_draw_clean_semantic_primitive_for_test(const ScenePreviewWidget::PreviewItem & item)
+{
+  return is_clean_semantic_primitive_role(classify_item_role(item)) && item_has_explicit_primitive_dimensions(item);
+}
+
+bool Scene3DViewportWidget::should_suppress_missing_geometry_marker_for_test(const ScenePreviewWidget::PreviewItem & item)
+{
+  return should_suppress_missing_geometry_marker_for_semantic_role(item);
 }
 
 bool Scene3DViewportWidget::try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical,
@@ -2007,6 +2057,56 @@ void Scene3DViewportWidget::draw_warning_badge_anchor(const ScenePreviewWidget::
 {
   const double cube = qMax(0.04, qMin(it.sx, qMin(it.sy, it.sz)));
   draw_box(it.x, it.y, it.z, cube, cube, cube, QColor("#f59e0b"));
+}
+
+bool Scene3DViewportWidget::draw_clean_semantic_primitive(const ScenePreviewWidget::PreviewItem & it)
+{
+  const NormalizedRole role = classify_item_role(it);
+  if (!is_clean_semantic_primitive_role(role) || !item_has_explicit_primitive_dimensions(it)) return false;
+
+  QColor fill = item_color(it);
+  QColor line = fill.lighter(role == NormalizedRole::Object ? 130 : 145);
+  switch (role) {
+    case NormalizedRole::PickZone:
+      fill.setAlpha(34);
+      line.setAlpha(96);
+      break;
+    case NormalizedRole::PlaceBin:
+      fill.setAlpha(38);
+      line.setAlpha(110);
+      break;
+    case NormalizedRole::Conveyor:
+      fill.setAlpha(48);
+      line.setAlpha(120);
+      break;
+    case NormalizedRole::Object:
+      fill.setAlpha(64);
+      line.setAlpha(128);
+      break;
+    default:
+      return false;
+  }
+
+  if (item_has_explicit_dimensions(it)) {
+    draw_box(it.x, it.y, it.z, it.sx, it.sy, it.sz, fill, true);
+    draw_box_outline(it.x, it.y, it.z, it.sx, it.sy, it.sz, line, role == NormalizedRole::Object ? 0.9f : 1.0f);
+    if (role == NormalizedRole::Conveyor) {
+      const double mid_y = it.y + it.sy + 0.01;
+      const double start_x = it.x + it.sx * 0.25;
+      const double end_x = it.x + it.sx * 0.75;
+      const double z = it.z + it.sz * 0.5;
+      glColor4f(line.redF(), line.greenF(), line.blueF(), 0.72f);
+      glLineWidth(1.5f);
+      glBegin(GL_LINES);
+      glVertex3f(start_x, mid_y, z); glVertex3f(end_x, mid_y, z);
+      glVertex3f(end_x, mid_y, z); glVertex3f(end_x - 0.08, mid_y, z - 0.06);
+      glVertex3f(end_x, mid_y, z); glVertex3f(end_x - 0.08, mid_y, z + 0.06);
+      glEnd();
+    }
+    return true;
+  }
+
+  return draw_urdf_primitive_geometry(it, fill);
 }
 
 void Scene3DViewportWidget::draw_box(double cx, double cy, double cz, double sx, double sy, double sz, const QColor & color, bool translucent)

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -137,6 +137,8 @@ public:
                                             ScenePreviewWidget::MeshPreviewMode mode);
   static bool should_draw_as_wireframe_for_test(const ScenePreviewWidget::PreviewItem & item,
                                                 ScenePreviewWidget::MeshPreviewMode mode);
+  static bool should_draw_clean_semantic_primitive_for_test(const ScenePreviewWidget::PreviewItem & item);
+  static bool should_suppress_missing_geometry_marker_for_test(const ScenePreviewWidget::PreviewItem & item);
 
 protected:
   void initializeGL() override;
@@ -192,6 +194,7 @@ private:
   void draw_missing_geometry_marker(const ScenePreviewWidget::PreviewItem & it);
   void draw_safety_zone(const ScenePreviewWidget::PreviewItem & it);
   void draw_warning_badge_anchor(const ScenePreviewWidget::PreviewItem & it);
+  bool draw_clean_semantic_primitive(const ScenePreviewWidget::PreviewItem & it);
   bool draw_mesh_preview_if_available(const ScenePreviewWidget::PreviewItem & it, const QColor & color, bool preview_path = true);
   void draw_unit_cube_triangles(const QColor & color);
   QPoint last_;

--- a/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
@@ -146,3 +146,32 @@ TEST(Scene3DRenderRoleClassifier, IngestCountsOnlyPhysicalMeshHandoffs)
   EXPECT_EQ(counters.mesh_rendered_count, 0);
   EXPECT_FALSE(counters.last_paint_completed);
 }
+
+TEST(Scene3DRenderRoleClassifier, SemanticRolesUseCleanPrimitiveWhenDimensionsExist)
+{
+  auto pick_zone = make_item("pick_zone");
+  pick_zone.role = "pick_zone";
+  pick_zone.mesh_available = false;
+  pick_zone.mesh_path.clear();
+  pick_zone.has_mesh_metadata = false;
+
+  EXPECT_TRUE(Scene3DViewportWidget::should_draw_clean_semantic_primitive_for_test(pick_zone));
+  EXPECT_TRUE(Scene3DViewportWidget::should_draw_as_solid_for_test(pick_zone, ScenePreviewWidget::MeshPreviewMode::Meshes));
+  EXPECT_FALSE(Scene3DViewportWidget::should_suppress_missing_geometry_marker_for_test(pick_zone));
+}
+
+TEST(Scene3DRenderRoleClassifier, SemanticRolesWithoutDimensionsSuppressMissingGeometryMarker)
+{
+  auto object = make_item("object_without_size");
+  object.role = "object";
+  object.mesh_available = false;
+  object.mesh_path.clear();
+  object.has_mesh_metadata = false;
+  object.sx = 0.0;
+  object.sy = 0.0;
+  object.sz = 0.0;
+
+  EXPECT_FALSE(Scene3DViewportWidget::should_draw_clean_semantic_primitive_for_test(object));
+  EXPECT_TRUE(Scene3DViewportWidget::should_suppress_missing_geometry_marker_for_test(object));
+  EXPECT_FALSE(Scene3DViewportWidget::should_draw_as_wireframe_for_test(object, ScenePreviewWidget::MeshPreviewMode::Auto));
+}


### PR DESCRIPTION
### Motivation

- Avoid drawing large red missing-geometry markers for common semantic authoring roles and instead render clean, low-alpha semantic primitives when explicit dimensions exist.
- Preserve honest diagnostics/readiness reporting for missing required metadata while keeping the main 3D viewport visually less noisy for authoring roles.

### Description

- Added semantic-role helpers `is_clean_semantic_primitive_role` and `should_suppress_missing_geometry_marker_for_semantic_role` and test-facing helpers `should_draw_clean_semantic_primitive_for_test` and `should_suppress_missing_geometry_marker_for_test` in `scene3d_viewport_widget`. 
- Implemented `draw_clean_semantic_primitive()` to render low-alpha, role-colored primitives/outlines for `PickZone`, `PlaceBin`, `Conveyor`, and `Object` when explicit dimensions exist, including a subtle conveyor cue. (file: `scene3d_viewport_widget.cpp` / header updated)
- Updated `draw_truthful_item_geometry()` to: prefer mesh preview, then for the listed semantic roles draw the clean primitive if dimensions exist (counting it as a primitive fallback), and if dimensions are absent suppress the big missing-geometry marker in the main viewport while still incrementing missing-geometry diagnostics counters.
- Adjusted render-stat accounting in `paintGL()` so semantic-only rendering still contributes to diagnostics counters, and renamed the visual-quality warning token to `missing_geometry_requires_diagnostics` to reflect diagnostics-only treatment.
- Added two unit-test cases to `scene3d_render_role_classifier_test.cpp` covering semantic primitive rendering when sizes exist and suppression of missing-geometry markers when sizes are absent.

### Testing

- Ran source-level checks and custom source validations (inline Python checks) which passed. (success)
- Ran `python3 -m py_compile scripts/validate_builder_generated_scene.py` which passed. (success)
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` which completed and returned scene validation output (success, noted existing optional metadata warnings only). (success)
- Attempted to build and run C++ tests with `colcon`/ROS but the container lacks `/opt/ros/humble/setup.bash` and `colcon`, so `colcon build` and `colcon test` were not run here (blocked by environment). (not run)
- Verified there are no git diff check errors and committed the change (commit `89ac130`). (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26b40d6d988331b2820c8a826cf052)