### PR TITLE
Count only physical 3D viewport geometry as rendered

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1017,9 +1017,10 @@ void Scene3DViewportWidget::paintGL()
       int item_urdf_primitive_count = 0;
       int item_missing_geometry_count = 0;
       int item_primitive_fallback_count = 0;
-      draw_truthful_item_geometry(*it, &item_placeholder_count, &item_mesh_backed_count, &item_wireframe_box_count,
-                                  &item_urdf_primitive_count, &item_missing_geometry_count, &item_primitive_fallback_count);
-      ++rendered_item_count;
+      const bool drew_physical_geometry =
+        draw_truthful_item_geometry(*it, &item_placeholder_count, &item_mesh_backed_count, &item_wireframe_box_count,
+                                    &item_urdf_primitive_count, &item_missing_geometry_count, &item_primitive_fallback_count);
+      if (drew_physical_geometry) ++rendered_item_count;
       if (count_in_stats) {
         placeholder_count += item_placeholder_count;
         mesh_rendered_count += item_mesh_backed_count;


### PR DESCRIPTION
### Motivation
- Make `rendered_item_count` reflect only actual physical geometry draws (meshes, URDF primitives, and intentional clean semantic primitive fallbacks) and avoid counting diagnostics-only visuals like missing-geometry markers, warning badges, suppressed raw generated bounds, or overlay helpers.

### Description
- Captured the boolean return from `draw_truthful_item_geometry` into `const bool drew_physical_geometry` and incremented `rendered_item_count` only when that value is `true` in `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`, while leaving `mesh_rendered_count`, `urdf_primitive_rendered_count`, `primitive_fallback_count`, `placeholder_count`, and `missing_geometry_count` accumulation unchanged.

### Testing
- Ran `git diff --check` and committed the change on branch `codex/count-only-physical-geometry` (commit `f76003c`) successfully; no compile/test run was possible because `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder` failed due to the container missing ROS 2 Humble (`/opt/ros/humble/setup.bash` not present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26dd3a0cf4833195d8cf7a83cb4938)