### PR TITLE
Count physical mesh-backed items in Scene3D smoke fallback and track generated fallback separately

### DIFF
--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -117,6 +117,11 @@ def test_smoke_fallback_render_preserves_counter_gate():
     assert 'rc_after_paint.visible_count > 0' in main_cpp
     assert 'rc_after_paint.rendered_count <= 0' in main_cpp
     assert 'last_render_counters.rendered_count = rendered_item_count' in viewport_cpp
+    assert 'const bool physical_mesh_source = !overlay_helper && item_has_credible_mesh_handoff(it);' in viewport_cpp
+    assert 'if (physical_mesh_source) ++mesh_rendered_count;' in viewport_cpp
+    assert 'last_render_counters.mesh_rendered_count = mesh_rendered_count;' in viewport_cpp
+    assert '++generated_fallback_count;' in viewport_cpp
+    assert 'last_render_counters.generated_fallback_count = generated_fallback_count;' in viewport_cpp
     assert 'return rendered_item_count > 0' in viewport_cpp
 
 

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1244,11 +1244,13 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
   int skipped_item_count = 0;
   int rendered_item_count = 0;
   int mesh_source_count = 0;
+  int mesh_rendered_count = 0;
   int urdf_primitive_source_count = 0;
   int urdf_primitive_rendered_count = 0;
   int primitive_fallback_count = 0;
   int placeholder_count = 0;
   int missing_geometry_count = 0;
+  int generated_fallback_count = 0;
   int wireframe_fallback_count = 0;
   int overlay_count = 0;
   int locked_urdf_count = 0;
@@ -1294,7 +1296,8 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
     const QString source_layer = normalized_scene3d_layer_token(it.source_layer);
     const QString visual_source = normalized_scene3d_layer_token(it.active_visual_source);
     const bool intentional_primitive_fallback = source_layer == QStringLiteral("primitive_fallback") || visual_source == QStringLiteral("primitive_fallback");
-    if (!overlay_helper && item_has_credible_mesh_handoff(it)) {
+    const bool physical_mesh_source = !overlay_helper && item_has_credible_mesh_handoff(it);
+    if (physical_mesh_source) {
       ++mesh_source_count;
       if (intentional_primitive_fallback && item_has_explicit_dimensions(it)) ++primitive_fallback_count;
     } else if (!overlay_helper && generated_urdf && item_has_explicit_dimensions(it)) {
@@ -1305,6 +1308,7 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
     } else if (!overlay_helper && !item_has_explicit_dimensions(it)) {
       ++placeholder_count;
       ++missing_geometry_count;
+      ++generated_fallback_count;
     } else if (!overlay_helper) {
       ++wireframe_fallback_count;
     }
@@ -1322,6 +1326,7 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
     painter.setPen(QPen(item_color(it).lighter(135), it.id == selected_id ? 3.0 : 1.5));
     painter.drawRect(rect);
     ++rendered_item_count;
+    if (physical_mesh_source) ++mesh_rendered_count;
   }
 
   painter.setPen(QColor("#e2e8f0"));
@@ -1340,11 +1345,12 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
   last_render_counters.unique_visible_item_count = unique_visible_ids.size();
   last_render_counters.mesh_source_count = mesh_source_count;
   last_render_counters.mesh_backed_count = mesh_source_count;
-  last_render_counters.mesh_rendered_count = 0;
+  last_render_counters.mesh_rendered_count = mesh_rendered_count;
   last_render_counters.urdf_primitive_source_count = urdf_primitive_source_count;
   last_render_counters.urdf_primitive_rendered_count = urdf_primitive_rendered_count;
   last_render_counters.placeholder_count = placeholder_count;
   last_render_counters.missing_geometry_count = missing_geometry_count;
+  last_render_counters.generated_fallback_count = generated_fallback_count;
   last_render_counters.wireframe_fallback_count = wireframe_fallback_count;
   last_render_counters.primitive_fallback_rendered_count = primitive_fallback_count;
   last_render_counters.primitive_fallback_count = primitive_fallback_count;


### PR DESCRIPTION
### Motivation
- The smoke fallback image path currently did not credit visible physical mesh-backed items as `mesh_rendered_count`, causing the readiness gate to report missing mesh render evidence when OpenGL rendering is unavailable.  
- Placeholders and missing-geometry markers must not be counted as physical rendered geometry so readiness checks remain strict and honest.  

### Description
- In `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp` updated the smoke fallback rendering accounting to: compute `physical_mesh_source` per item, increment `mesh_rendered_count` when a physical mesh-backed item is drawn by the QPainter fallback, and preserve `mesh_source_count`/`mesh_backed_count` semantics.  
- Added `generated_fallback_count` (tracked separately) for items that are missing geometry and are drawn as deterministic fallback bounds so placeholders do not count as physical rendered evidence.  
- Persisted the computed `mesh_rendered_count` and `generated_fallback_count` into `last_render_counters` before `finalize_visual_quality()` runs so diagnostics and readiness logic see the updated counts.  
- Updated a smoke contract test assertion in `tests/test_scene3d_gui_smoke_json_output_contract.py` to verify the new counter tokens are present in the source (ensures the counter handoff remains covered).  

Files changed:
- `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp` (fallback render accounting: `mesh_rendered_count`, `generated_fallback_count`)  
- `tests/test_scene3d_gui_smoke_json_output_contract.py` (assertions added)

### Testing
- Ran targeted unit/contract tests: `pytest -q tests/test_scene3d_gui_smoke_json_output_contract.py::test_smoke_fallback_render_preserves_counter_gate tests/test_scene3d_mesh_loader_runtime.py::test_mesh_loader_fallback_is_per_item_not_global_collapsed_box tests/test_scene3d_generated_fallback_shapes.py` — these passed.  
- Running the broader smoke wrapper and full scene smoke in this container was blocked because ROS Humble and a built `workcell_builder` executable are not available here, so the wrapper returned `BLOCKED` (no runtime GUI run performed) and I could not confirm runtime `ur5_2f_test` thresholds; no JSON/PNG/log artifacts were committed to the repo.  
- Verified `git diff --check` and repo state show only the intended source and test edits and no generated artifacts were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26e0ab516883318a4442a7e17da6c2)