### PR TITLE
Adjust workcell_builder executable search order and add workspace fallbacks

### DIFF
--- a/scripts/workcell_studio_path_resolver.py
+++ b/scripts/workcell_studio_path_resolver.py
@@ -62,8 +62,10 @@ def workcell_builder_executable_candidates(workspace_root: Path | None) -> list[
             candidates.append(candidate_path)
 
     add_candidate(os.environ.get("WORKCELL_BUILDER_EXECUTABLE"))
+    add_candidate(shutil.which("workcell_builder"))
 
     if workspace_root:
+        add_candidate(workspace_root / "install" / "workcell_builder" / "bin" / "workcell_builder")
         add_candidate(
             workspace_root
             / "install"
@@ -72,10 +74,18 @@ def workcell_builder_executable_candidates(workspace_root: Path | None) -> list[
             / "workcell_builder"
             / "workcell_builder"
         )
-        add_candidate(workspace_root / "install" / "workcell_builder" / "bin" / "workcell_builder")
         add_candidate(workspace_root / "install" / "bin" / "workcell_builder")
 
-    add_candidate(shutil.which("workcell_builder"))
+    real_workspace = Path("/home/user/workcell_ws")
+    add_candidate(real_workspace / "install" / "workcell_builder" / "bin" / "workcell_builder")
+    add_candidate(
+        real_workspace
+        / "install"
+        / "workcell_builder"
+        / "lib"
+        / "workcell_builder"
+        / "workcell_builder"
+    )
 
     ros2 = shutil.which("ros2")
     if ros2:

--- a/tests/test_workcell_studio_path_resolver.py
+++ b/tests/test_workcell_studio_path_resolver.py
@@ -36,19 +36,29 @@ def test_invalid_explicit_executable_reports_only_explicit_path(tmp_path):
     assert resolve_workcell_builder_executable(ws, explicit_executable=not_executable) is None
     assert describe_resolution().get('searched_executable_paths') == [str(not_executable.resolve())]
 
-def test_workcell_builder_candidate_order_prefers_env_then_install_paths(tmp_path, monkeypatch):
+def test_workcell_builder_candidate_order_prefers_env_then_path_then_install_paths(tmp_path, monkeypatch):
     ws = tmp_path / 'robot_ws'
     env_exe = tmp_path / 'custom_workcell_builder'
+    path_exe = tmp_path / 'path_workcell_builder'
     monkeypatch.setenv('WORKCELL_BUILDER_EXECUTABLE', str(env_exe))
-    monkeypatch.setattr('scripts.workcell_studio_path_resolver.shutil.which', lambda name: None)
+
+    def fake_which(name):
+        if name == 'workcell_builder':
+            return str(path_exe)
+        return None
+
+    monkeypatch.setattr('scripts.workcell_studio_path_resolver.shutil.which', fake_which)
 
     candidates = workcell_builder_executable_candidates(ws)
 
-    assert candidates[:4] == [
+    assert candidates[:7] == [
         env_exe,
-        ws / 'install' / 'workcell_builder' / 'lib' / 'workcell_builder' / 'workcell_builder',
+        path_exe,
         ws / 'install' / 'workcell_builder' / 'bin' / 'workcell_builder',
+        ws / 'install' / 'workcell_builder' / 'lib' / 'workcell_builder' / 'workcell_builder',
         ws / 'install' / 'bin' / 'workcell_builder',
+        Path('/home/user/workcell_ws/install/workcell_builder/bin/workcell_builder'),
+        Path('/home/user/workcell_ws/install/workcell_builder/lib/workcell_builder/workcell_builder'),
     ]
 
 
@@ -98,4 +108,4 @@ def test_resolve_records_candidate_metadata_for_env_override(tmp_path, monkeypat
         'executable': True,
         'selected': True,
     }
-    assert len(evidence) == 4
+    assert len(evidence) == 6


### PR DESCRIPTION
### Motivation
- Ensure `WORKCELL_BUILDER_EXECUTABLE` remains the top override while preferring PATH discovery (`workcell_builder` via `shutil.which`) immediately after the environment override for more predictable CLI-installed workflows.
- Add workspace-relative install candidates and fixed real-workspace fallbacks to increase the chance of finding the Workcell Builder executable in common development layouts.
- Preserve candidate de-duplication and the existing ROS 2 package-prefix probing to avoid regressions in discovery behavior.

### Description
- Reordered candidate construction in `workcell_builder_executable_candidates` so `WORKCELL_BUILDER_EXECUTABLE` is added first and `shutil.which("workcell_builder")` is added immediately after the environment override.
- Added workspace-relative candidates after the PATH probe: ``<workspace>/install/workcell_builder/bin/workcell_builder``, ``<workspace>/install/workcell_builder/lib/workcell_builder/workcell_builder``, and the existing ``<workspace>/install/bin/workcell_builder``.
- Added fixed real-workspace fallbacks for `/home/user/workcell_ws/install/workcell_builder/bin/workcell_builder` and `/home/user/workcell_ws/install/workcell_builder/lib/workcell_builder/workcell_builder`.
- Kept the ROS 2 prefix candidates and preserved de-duplication and candidate metadata recording in `_record_executable_search`.
- Files changed: `scripts/workcell_studio_path_resolver.py` and `tests/test_workcell_studio_path_resolver.py` (test updated to assert env -> PATH -> install-path -> `/home/user/workcell_ws` ordering and adjusted candidate-metadata length).

### Testing
- Ran unit tests with `pytest -q tests/test_workcell_studio_path_resolver.py`, which passed all tests (7 passed).
- Updated `test_workcell_builder_candidate_order_prefers_env_then_path_then_install_paths` to validate the new ordering and updated candidate count assertion, and this updated test passed.
- No broader ROS/colcon builds were run because the change is limited to Python path-resolution logic covered by the unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a941e74c8833185a904690e6d8b19)