### PR TITLE
Harden missing workcell_builder smoke payload and add concrete guidance

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -197,11 +197,33 @@ def _subprocess_exception_to_text(exc: FileNotFoundError | PermissionError) -> s
     return f"{type(exc).__name__}: {exc}"
 
 
+WORKCELL_BUILDER_EXECUTABLE_MISSING_MESSAGE = (
+    "workcell_builder executable was not found; build workcell_builder in a ROS Humble "
+    "workspace and source install/setup.bash, or set WORKCELL_BUILDER_EXECUTABLE"
+)
+
+
 def _executable_guidance() -> list[str]:
     return [
-        "Build and source the ROS 2 workspace so workcell_builder is installed and on PATH.",
-        "Or pass --executable with the absolute path to an executable workcell_builder binary.",
+        "cd /home/user/workcell_ws",
+        "source /opt/ros/humble/setup.bash",
+        "colcon build --symlink-install --packages-select workcell_builder",
+        "source install/setup.bash",
+        "export WORKCELL_BUILDER_EXECUTABLE=/home/user/workcell_ws/install/workcell_builder/bin/workcell_builder",
     ]
+
+
+def _non_runtime_static_headless_renderability_counts(static_evidence: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "runtime_available": False,
+        "physical_mesh_items_renderable": static_evidence.get("physical_mesh_items_renderable", 0),
+        "primitive_fallback_items_renderable": static_evidence.get("primitive_fallback_items_renderable", 0),
+        "zones_overlays_renderable": static_evidence.get("zones_overlays_renderable", 0),
+        "missing_mesh_items": static_evidence.get("missing_mesh_items", 0),
+        "unresolved_transform_items": static_evidence.get("unresolved_transform_items", 0),
+        "skipped_helper_static_fallback_items": static_evidence.get("skipped_helper_static_fallback_items", 0),
+        "note": "non-runtime evidence only; static/headless renderability is not GUI runtime PASS evidence",
+    }
 
 
 def _write_blocked_executable_payload(
@@ -213,14 +235,13 @@ def _write_blocked_executable_payload(
     searched: list[str],
     blocker: str,
     exception: str | None = None,
-    status: str = "BLOCKED",
     warnings: list[str] | None = None,
 ) -> None:
     scene_dir = _resolve_single_scene_dir(repo_root, args.scene, args.scene_path)
     static_evidence = _static_scene3d_visual_evidence(scene_dir)
     payload: dict[str, Any] = {
         "schema": EXPECTED_SCHEMA,
-        "status": status,
+        "status": "BLOCKED",
         "smoke_status": "MISSING_EXECUTABLE",
         "runtime_available": False,
         "scene": args.scene or (args.scene_path.name if args.scene_path else None),
@@ -228,13 +249,15 @@ def _write_blocked_executable_payload(
         "workspace_root": _path_str(workspace_root) if workspace_root else None,
         "executable": None,
         "explicit_executable": str(args.executable) if args.executable else None,
-        "searched_paths": searched,
+        "searched_paths": list(searched),
+        "message": WORKCELL_BUILDER_EXECUTABLE_MISSING_MESSAGE,
         "blockers": [blocker],
         "guidance": _executable_guidance(),
         "warnings": _merge_unique(["runtime_gui_unavailable_static_scene3d_visual_evidence_recorded"], warnings or []),
         "screenshot_available": False,
         "scene_dir": str(scene_dir) if scene_dir else None,
         "static_scene3d_visual_evidence": static_evidence,
+        "non_runtime_static_headless_renderability_counts": _non_runtime_static_headless_renderability_counts(static_evidence),
         "render_debug_counters": {
             "runtime_available": False,
             "physical_mesh_items_rendered": 0,
@@ -400,7 +423,7 @@ def main() -> int:
     exe = resolve_workcell_builder_executable(workspace_root, args.executable)
     executable_resolution = describe_resolution()
     if exe is None and not args.all_scenes:
-        searched = list(executable_resolution.get("searched_executable_paths") or [str(p) for p in _resolve_executable_candidates(workspace_root)])
+        searched = list(executable_resolution.get("searched_executable_paths") or [])
         _write_blocked_executable_payload(
             args.output,
             repo_root=repo_root,
@@ -430,6 +453,7 @@ def main() -> int:
             "screenshot_available": False,
             "scene_dir": str(scene_dir) if scene_dir else None,
             "static_scene3d_visual_evidence": static_evidence,
+            "non_runtime_static_headless_renderability_counts": _non_runtime_static_headless_renderability_counts(static_evidence),
             "render_debug_counters": {
                 "runtime_available": False,
                 "physical_mesh_items_rendered": 0,

--- a/tests/test_scene3d_gui_smoke_json_output_contract.py
+++ b/tests/test_scene3d_gui_smoke_json_output_contract.py
@@ -82,15 +82,35 @@ def test_missing_executable_is_blocked_with_static_non_runtime_evidence(tmp_path
     ]
     env = os.environ.copy()
     env['PATH'] = str(tmp_path)
+    env.pop('WORKCELL_BUILDER_EXECUTABLE', None)
     rc = subprocess.run(cmd, text=True, capture_output=True, env=env)
     assert rc.returncode != 0
     assert 'status=BLOCKED smoke_status=MISSING_EXECUTABLE' in rc.stdout
     payload = json.loads(out.read_text(encoding='utf-8'))
     assert payload['status'] == 'BLOCKED'
     assert payload['smoke_status'] == 'MISSING_EXECUTABLE'
+    assert payload['status'] != 'PASS'
+    assert payload['smoke_status'] != 'PASS'
     assert 'workcell_builder_executable_missing' in payload['blockers']
-    assert payload['searched_paths']
-    assert 'build workcell_builder in a ROS Humble workspace' in payload['message']
+    expected_searched_paths = [
+        str(tmp_path / 'install/workcell_builder/bin/workcell_builder'),
+        str(tmp_path / 'install/workcell_builder/lib/workcell_builder/workcell_builder'),
+        str(tmp_path / 'install/bin/workcell_builder'),
+        '/home/user/workcell_ws/install/workcell_builder/bin/workcell_builder',
+        '/home/user/workcell_ws/install/workcell_builder/lib/workcell_builder/workcell_builder',
+    ]
+    assert payload['searched_paths'] == expected_searched_paths
+    assert payload['message'] == (
+        'workcell_builder executable was not found; build workcell_builder in a ROS Humble '
+        'workspace and source install/setup.bash, or set WORKCELL_BUILDER_EXECUTABLE'
+    )
+    assert payload['guidance'] == [
+        'cd /home/user/workcell_ws',
+        'source /opt/ros/humble/setup.bash',
+        'colcon build --symlink-install --packages-select workcell_builder',
+        'source install/setup.bash',
+        'export WORKCELL_BUILDER_EXECUTABLE=/home/user/workcell_ws/install/workcell_builder/bin/workcell_builder',
+    ]
     assert payload['static_scene3d_visual_evidence']['evidence_kind'] == 'non_runtime_static_headless_renderability'
     assert 'not GUI-render PASS evidence' in payload['static_scene3d_visual_evidence']['notes'][0]
     counts = payload['non_runtime_static_headless_renderability_counts']


### PR DESCRIPTION
### Motivation
- Ensure that when the `workcell_builder` executable cannot be resolved the smoke wrapper reports a clear, honest BLOCKED readiness result and does not emit PASS evidence from static renderability.
- Provide concrete, copy-paste commands users can follow to build and point to the `workcell_builder` binary to reduce confusion when the runtime is unavailable.
- Preserve static non-runtime visual evidence as separate, non-PASS counts so static renderability is not misrepresented as GUI runtime success.

### Description
- Rewrote `_executable_guidance()` to return an explicit set of ROS Humble workspace build/source commands and an `export WORKCELL_BUILDER_EXECUTABLE=...` hint.
- Added `WORKCELL_BUILDER_EXECUTABLE_MISSING_MESSAGE` and include it as `message` in the missing-executable payload.
- Modified `_write_blocked_executable_payload()` to always set `status: "BLOCKED"`, include `smoke_status: "MISSING_EXECUTABLE"`, copy the exact `searched_paths` (as supplied by `describe_resolution()`), and attach the concrete `message` and `guidance` fields while preserving the static `static_scene3d_visual_evidence` and `render_debug_counters` fields.
- Introduced helper `_non_runtime_static_headless_renderability_counts()` and added `non_runtime_static_headless_renderability_counts` to the blocked payloads so static/headless counts are explicit and clearly documented as non-runtime evidence.
- Adjusted the code path that writes the missing-executable payload to prefer the exact `searched_executable_paths` from `describe_resolution()` and not to synthesize a different fallback list.
- Updated `tests/test_scene3d_gui_smoke_json_output_contract.py` to assert that the payload is BLOCKED/MISSING_EXECUTABLE, never PASS, that `searched_paths` equals the expected candidate list, and that `message` and `guidance` contain the new concrete instructions.

### Testing
- `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py` passed successfully.
- `pytest -q tests/test_scene3d_gui_smoke_json_output_contract.py::test_missing_executable_is_blocked_with_static_non_runtime_evidence` passed after the changes and validates the concrete `message`, `guidance`, `searched_paths`, BLOCKED status, and preserved static evidence counts.
- Running the entire `tests/test_scene3d_gui_smoke_json_output_contract.py` suite inside this container produced failures earlier because ROS Humble is not available here; those failures are due to the environment (existing tests expect different behavior when ROS is present) and not due to the missing-executable payload contract changes.  The changes intentionally produce BLOCKED results when the runtime or ROS Humble is unavailable to keep safety and honesty of readiness reports.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a9736d97c8331b99dbc112bb65c03)