### PR TITLE
Align ur5_2f_test task metadata contract

### DIFF
--- a/scenes/ur5_2f_test/cell_definition.yaml
+++ b/scenes/ur5_2f_test/cell_definition.yaml
@@ -22,25 +22,40 @@ environment:
   frame: world
   layout: layout/workcell_studio_layout.yaml
 objects:
-  - id: commissioning_object
-    frame: world
-    pose_xyz: [0.45, 0.25, 0.1]
-    pose_rpy: [0.0, 0.0, 0.0]
-    dimensions: [0.05, 0.05, 0.05]
+- id: commissioning_object
+  frame: world
+  pose_xyz:
+  - 0.45
+  - 0.25
+  - 0.1
+  pose_rpy:
+  - 0.0
+  - 0.0
+  - 0.0
+  dimensions:
+  - 0.05
+  - 0.05
+  - 0.05
 task:
   id: default_task
   type: pick_place
   source_object: commissioning_object
   destinations:
-    - id: default_drop_zone
-      frame: world
-      pose_xyz: [0.5, -0.3, 0.1]
-      pose_rpy: [0.0, 0.0, 0.0]
+  - id: default_drop_zone
+    frame: world
+    pose_xyz:
+    - 0.5
+    - -0.3
+    - 0.1
+    pose_rpy:
+    - 0.0
+    - 0.0
+    - 0.0
   rules:
-    - id: default_place
-      when:
-        always: true
-      destination: default_drop_zone
+  - id: default_place
+    when:
+      always: true
+    destination: default_drop_zone
 commissioning:
   self_test_enabled: true
   export_bundle: false

--- a/scenes/ur5_2f_test/config/task_recipe.yaml
+++ b/scenes/ur5_2f_test/config/task_recipe.yaml
@@ -2,6 +2,7 @@ schema_version: task_recipe/v1
 task:
   id: default_task
   type: pick_place
+  mode: simulation_preview
   source_object: commissioning_object
   destinations:
   - id: default_drop_zone
@@ -19,8 +20,9 @@ task:
     when:
       always: true
     destination: default_drop_zone
-  notes: Generated from existing scene metadata. Preview-safe.
+  notes: Commissioning canary pick/place task for offline validation. Preview-safe.
 provenance:
   mode: generated_readiness_metadata
   sources:
   - cell_definition.yaml
+  - environment.yaml

--- a/scenes/ur5_2f_test/config/workcell_builder_task_intent.yaml
+++ b/scenes/ur5_2f_test/config/workcell_builder_task_intent.yaml
@@ -1,25 +1,38 @@
 schema: workcell_builder_task_intent/v1
 scene_package: scenes/ur5_2f_test
 task:
-  id: ur5_2f_test_preview_task
+  id: default_task
   type: pick_place
   family: pick_place
   mode: simulation_preview
 pick:
   source:
-    type: zone
-    id: pick_zone_main
+    type: pick_zone
+    id: commissioning_pick_pose
+  object_filter:
+    object_id: commissioning_object
 place:
   target:
     type: destination
-    id: bin_red
+    id: default_drop_zone
+    frame: world
+    pose_xyz:
+    - 0.5
+    - -0.3
+    - 0.1
+    pose_rpy:
+    - 0.0
+    - 0.0
+    - 0.0
   release_strategy: tool_release
+  retreat_axis: z_up
+  retreat_distance_m: 0.1
 grasp:
   strategy_ref: finger_pinch_basic
   approach_axis: z_down
   approach_distance_m: 0.12
   retreat_axis: z_up
-  retreat_distance_m: 0.10
+  retreat_distance_m: 0.1
 safety:
   preview_only: true
   use_fake_hardware: true
@@ -33,3 +46,9 @@ provenance:
   mode: generated_readiness_metadata
   sources:
   - environment.yaml
+routing:
+  rules:
+  - id: default_place
+    when:
+      always: true
+    destination: default_drop_zone

--- a/scenes/ur5_2f_test/environment.yaml
+++ b/scenes/ur5_2f_test/environment.yaml
@@ -12,28 +12,50 @@ compatibility:
   status: COMPATIBLE
   robot: ur5
   tool: robotiq_2f
-placed_objects:
+placed_objects: null
 camera:
   enabled: false
   camera_id: UNKNOWN_CAMERA
   frame_id: UNKNOWN_FRAME
   pose:
-    - -0.55
-    - 0.55
-    - 0.4
-    - 0.0
-    - 0.0
-    - 0.0
-  rgb_topic: 
-  depth_topic: 
-  pointcloud_topic: 
+  - -0.55
+  - 0.55
+  - 0.4
+  - 0.0
+  - 0.0
+  - 0.0
+  rgb_topic: null
+  depth_topic: null
+  pointcloud_topic: null
 task:
+  id: default_task
   template: pick_place
+  type: pick_place
+  mode: simulation_preview
+  source_object: commissioning_object
   pick:
-    source_ref: pick_zone_main
-    object_ref: red_box_001
+    source_ref: commissioning_pick_pose
+    object_ref: commissioning_object
+    object_source: commissioning_object
   place:
-    target_ref: bin_red
+    target_ref: default_drop_zone
+    release_strategy: tool_release
+  destinations:
+  - id: default_drop_zone
+    frame: world
+    pose_xyz:
+    - 0.5
+    - -0.3
+    - 0.1
+    pose_rpy:
+    - 0.0
+    - 0.0
+    - 0.0
+  rules:
+  - id: default_place
+    when:
+      always: true
+    destination: default_drop_zone
   grasp:
     strategy: finger_pinch_basic
     approach_axis: z_down
@@ -41,20 +63,20 @@ task:
     approach_distance_m: 0.12
     retreat_distance_m: 0.1
     allowed_roll_angles_deg:
-      - 0.0
+    - 0.0
     allowed_yaw_angles_deg:
-      - 0.0
-      - 90.0
-      - 180.0
-      - 270.0
+    - 0.0
+    - 90.0
+    - 180.0
+    - 270.0
     tool_offset_xyz:
-      - 0.0
-      - 0.0
-      - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
     tool_offset_rpy:
-      - 0.0
-      - 0.0
-      - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
     suction_cups: null
 workspace:
   bounds:
@@ -65,10 +87,9 @@ workspace:
     z_min: 0.0
     z_max: 1.8
   zones:
-    -
-      id: robot_base_exclusion
-      type: exclusion
-      shape: circle
+  - id: robot_base_exclusion
+    type: exclusion
+    shape: circle
 safety:
   fake_hardware_first: true
   real_hardware_enabled: false
@@ -78,5 +99,39 @@ metadata:
   generated_by: workcell_builder
   scene_schema_version: workcell_scene/v1
   scene_schema_warnings:
-    - camera disabled: no camera selection
+  - camera disabled: no camera selection
   scene_schema_blockers: []
+task_zones:
+- id: commissioning_pick_pose
+  type: pick_zone
+  frame: world
+  shape: box
+  pose_xyz:
+  - 0.45
+  - 0.25
+  - 0.1
+  pose_rpy:
+  - 0.0
+  - 0.0
+  - 0.0
+  dimensions:
+  - 0.2
+  - 0.2
+  - 0.1
+  object_ref: commissioning_object
+- id: default_drop_zone
+  type: place_target
+  frame: world
+  shape: box
+  pose_xyz:
+  - 0.5
+  - -0.3
+  - 0.1
+  pose_rpy:
+  - 0.0
+  - 0.0
+  - 0.0
+  dimensions:
+  - 0.2
+  - 0.2
+  - 0.1

--- a/scenes/ur5_2f_test/environment_layout.yaml
+++ b/scenes/ur5_2f_test/environment_layout.yaml
@@ -3,31 +3,31 @@ layout_id: ur5_2f_test_layout
 name: UR5 2F Builder Authored Layout
 frame: world
 zones:
-  - id: pick_zone_main
+  - id: commissioning_pick_pose
     type: pick_zone
-    label: Main Pick Zone
+    label: Commissioning Pick Pose
     frame: world
     pose:
-      xyz: [0.45, 0.0, 0.09]
+      xyz: [0.45, 0.25, 0.1]
       rpy: [0.0, 0.0, 0.0]
     dimensions: [0.30, 0.20, 0.08]
 targets:
-  - id: bin_red
+  - id: default_drop_zone
     type: place_target
-    label: Red Bin
+    label: Default Drop Zone
     frame: world
     pose:
-      xyz: [0.35, 0.35, 0.10]
+      xyz: [0.5, -0.3, 0.1]
       rpy: [0.0, 0.0, 0.0]
     dimensions: [0.22, 0.22, 0.14]
 objects:
-  - id: red_box_001
+  - id: commissioning_object
     class: box
-    label: Red Box
+    label: Commissioning Object
     color: red
     frame: world
     pose:
-      xyz: [0.45, 0.0, 0.12]
+      xyz: [0.45, 0.25, 0.1]
       rpy: [0.0, 0.0, 0.0]
     dimensions: [0.05, 0.05, 0.05]
   - id: table_surface

--- a/scenes/ur5_2f_test/generated/scene_package_readiness.json
+++ b/scenes/ur5_2f_test/generated/scene_package_readiness.json
@@ -62,7 +62,7 @@
     "readiness": "task_intent_ready_offline",
     "readiness_classification": "task_intent_ready_offline",
     "runtime_readiness": "runtime_blocked_or_preview_only",
-    "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+    "scene_path": "scenes/ur5_2f_test",
     "suggested_next_actions": [
       "Generate task recipe from builder task intent."
     ],
@@ -72,9 +72,9 @@
       "errors": [],
       "grasp_strategy": "finger_pinch_basic",
       "missing_required_fields": [],
-      "pick_source_id": "pick_zone_main",
-      "pick_source_type": "zone",
-      "place_target_id": "bin_red",
+      "pick_source_id": "commissioning_pick_pose",
+      "pick_source_type": "pick_zone",
+      "place_target_id": "default_drop_zone",
       "readiness_classification": "task_intent_ready_offline",
       "release_strategy": "tool_release",
       "retreat_axis": null,
@@ -82,11 +82,10 @@
       "routing_rule_count": 1,
       "routing_rules": [
         {
-          "destination": "bin_red",
-          "id": "route_red_box_to_bin_red",
+          "destination": "default_drop_zone",
+          "id": "default_place",
           "when": {
-            "object_class": "box",
-            "object_color": "red"
+            "always": true
           }
         }
       ],
@@ -103,7 +102,7 @@
         "",
         "Generate task recipe from task intent."
       ],
-      "task_id": "sorting_task_001",
+      "task_id": "default_task",
       "task_type": "pick_place",
       "visual_resolution": {
         "approximate_coordinates_used": false,
@@ -117,20 +116,35 @@
       "errors": [],
       "missing_required_fields": [],
       "pick_source": {
-        "id": "pick_zone_main",
-        "type": "zone"
+        "id": "commissioning_pick_pose",
+        "type": "pick_zone"
       },
       "place_target": {
-        "id": "bin_red",
+        "frame": "world",
+        "id": "default_drop_zone",
+        "pose_rpy": [
+          0.0,
+          0.0,
+          0.0
+        ],
+        "pose_xyz": [
+          0.5,
+          -0.3,
+          0.1
+        ],
         "type": "destination"
       },
       "readiness_classification": "task_intent_ready_offline",
       "resolved_grasp_strategy": null,
       "safety": {
+        "execution_mode": "simulation_preview",
         "metadata_only": true,
         "motion_started": false,
+        "no_robot_motion": true,
+        "preview_only": true,
         "ros_launch_started": false,
-        "runtime_io_applied": false
+        "runtime_io_applied": false,
+        "use_fake_hardware": true
       },
       "status": "PASS",
       "suggested_next_actions": [
@@ -146,12 +160,11 @@
         },
         "pick": {
           "object_filter": {
-            "class_id": "box",
-            "color": "red"
+            "object_id": "commissioning_object"
           },
           "source": {
-            "id": "pick_zone_main",
-            "type": "zone"
+            "id": "commissioning_pick_pose",
+            "type": "pick_zone"
           }
         },
         "place": {
@@ -159,33 +172,48 @@
           "retreat_axis": "z_up",
           "retreat_distance_m": 0.1,
           "target": {
-            "id": "bin_red",
+            "frame": "world",
+            "id": "default_drop_zone",
+            "pose_rpy": [
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pose_xyz": [
+              0.5,
+              -0.3,
+              0.1
+            ],
             "type": "destination"
           }
         },
         "routing": {
           "rules": [
             {
-              "destination": "bin_red",
-              "id": "route_red_box_to_bin_red",
+              "destination": "default_drop_zone",
+              "id": "default_place",
               "when": {
-                "object_class": "box",
-                "object_color": "red"
+                "always": true
               }
             }
           ]
         },
         "safety": {
+          "execution_mode": "simulation_preview",
           "metadata_only": true,
           "motion_started": false,
+          "no_robot_motion": true,
+          "preview_only": true,
           "ros_launch_started": false,
-          "runtime_io_applied": false
+          "runtime_io_applied": false,
+          "use_fake_hardware": true
         },
         "scene_package": "scenes/ur5_2f_test",
         "schema": "workcell_builder_task_intent/v1",
         "task": {
-          "id": "sorting_task_001",
-          "mode": "offline_preview",
+          "family": "pick_place",
+          "id": "default_task",
+          "mode": "simulation_preview",
           "type": "pick_place"
         }
       },
@@ -264,1192 +292,8 @@
     },
     "generated_scene_package_readiness_json": {
       "message": "generated/scene_package_readiness.json is present and parseable",
-      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_package_readiness.json",
-      "status": "PASS",
-      "summary": {
-        "blockers": [
-          {
-            "category": "supported_scene_catalog",
-            "message": "Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable, indicating the ROS Humble/ament workcell_builder executable is unavailable in this container.",
-            "status": "BLOCKED"
-          },
-          {
-            "category": "ros_launch_smoke_skip_evaluation_state",
-            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
-            "status": "BLOCKED"
-          }
-        ],
-        "build_package_name": "ur5_2f_test",
-        "builder_generated_scene_validation": {
-          "checks": [
-            {
-              "check": "package.xml exists",
-              "ok": true
-            },
-            {
-              "check": "CMakeLists.txt exists",
-              "ok": true
-            },
-            {
-              "check": "environment.yaml exists",
-              "ok": true
-            },
-            {
-              "check": "workcell_builder_metadata.yaml present",
-              "ok": false,
-              "optional": true
-            },
-            {
-              "check": "generated/cell_definition.yaml present",
-              "ok": false,
-              "optional": true
-            },
-            {
-              "check": "generated/environment_layout.yaml present",
-              "ok": false,
-              "optional": true
-            },
-            {
-              "check": "generated/workcell_builder_task_intent.yaml present",
-              "ok": true,
-              "optional": true
-            }
-          ],
-          "discovered": {
-            "end_effector_capability_id": null,
-            "end_effector_name": null,
-            "grasp_strategy_id": null,
-            "object_count": 0,
-            "robot_capability_id": null,
-            "robot_name": null,
-            "sensor_capability_id": null
-          },
-          "errors": [],
-          "export_validation": {},
-          "ok": true,
-          "readiness": "task_intent_ready_offline",
-          "readiness_classification": "task_intent_ready_offline",
-          "runtime_readiness": "runtime_blocked_or_preview_only",
-          "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
-          "suggested_next_actions": [
-            "Generate task recipe from builder task intent."
-          ],
-          "task_flow_summary": {
-            "approach_axis": null,
-            "approach_distance_m": null,
-            "errors": [],
-            "grasp_strategy": "finger_pinch_basic",
-            "missing_required_fields": [],
-            "pick_source_id": "pick_zone_main",
-            "pick_source_type": "zone",
-            "place_target_id": "bin_red",
-            "readiness_classification": "task_intent_ready_offline",
-            "release_strategy": "tool_release",
-            "retreat_axis": null,
-            "retreat_distance_m": null,
-            "routing_rule_count": 1,
-            "routing_rules": [
-              {
-                "destination": "bin_red",
-                "id": "route_red_box_to_bin_red",
-                "when": {
-                  "object_class": "box",
-                  "object_color": "red"
-                }
-              }
-            ],
-            "safety": {
-              "metadata_only": true,
-              "motion_started": false,
-              "ros_launch_started": false,
-              "runtime_io_applied": false
-            },
-            "status": "PASS",
-            "suggested_next_actions": [
-              "",
-              "",
-              "",
-              "Generate task recipe from task intent."
-            ],
-            "task_id": "sorting_task_001",
-            "task_type": "pick_place",
-            "visual_resolution": {
-              "approximate_coordinates_used": false,
-              "notes": [],
-              "pick_coordinates_resolved": true,
-              "place_coordinates_resolved": true
-            },
-            "warnings": []
-          },
-          "task_intent": {
-            "errors": [],
-            "missing_required_fields": [],
-            "pick_source": {
-              "id": "pick_zone_main",
-              "type": "zone"
-            },
-            "place_target": {
-              "id": "bin_red",
-              "type": "destination"
-            },
-            "readiness_classification": "task_intent_ready_offline",
-            "resolved_grasp_strategy": null,
-            "safety": {
-              "metadata_only": true,
-              "motion_started": false,
-              "ros_launch_started": false,
-              "runtime_io_applied": false
-            },
-            "status": "PASS",
-            "suggested_next_actions": [
-              "Generate task recipe from task intent."
-            ],
-            "task_intent": {
-              "grasp": {
-                "approach_axis": "z_down",
-                "approach_distance_m": 0.12,
-                "retreat_axis": "z_up",
-                "retreat_distance_m": 0.1,
-                "strategy_ref": "finger_pinch_basic"
-              },
-              "pick": {
-                "object_filter": {
-                  "class_id": "box",
-                  "color": "red"
-                },
-                "source": {
-                  "id": "pick_zone_main",
-                  "type": "zone"
-                }
-              },
-              "place": {
-                "release_strategy": "tool_release",
-                "retreat_axis": "z_up",
-                "retreat_distance_m": 0.1,
-                "target": {
-                  "id": "bin_red",
-                  "type": "destination"
-                }
-              },
-              "routing": {
-                "rules": [
-                  {
-                    "destination": "bin_red",
-                    "id": "route_red_box_to_bin_red",
-                    "when": {
-                      "object_class": "box",
-                      "object_color": "red"
-                    }
-                  }
-                ]
-              },
-              "safety": {
-                "metadata_only": true,
-                "motion_started": false,
-                "ros_launch_started": false,
-                "runtime_io_applied": false
-              },
-              "scene_package": "scenes/ur5_2f_test",
-              "schema": "workcell_builder_task_intent/v1",
-              "task": {
-                "id": "sorting_task_001",
-                "mode": "offline_preview",
-                "type": "pick_place"
-              }
-            },
-            "warnings": []
-          },
-          "warnings": [
-            "workcell_builder_metadata.yaml missing (optional)",
-            "End-effector metadata not present in environment.yaml",
-            "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
-            "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
-          ]
-        },
-        "catalog_status": "blocked",
-        "categories": {
-          "cell_definition_validation": {
-            "capabilities": {
-              "capability_refs": {
-                "end_effector": null,
-                "environment_assets": [],
-                "robot": null,
-                "sensors": [],
-                "task": null
-              },
-              "checks": {
-                "events": [],
-                "status": "WARN"
-              },
-              "resolved": {}
-            },
-            "environment_layout": {},
-            "errors": [],
-            "grasp_strategy": {
-              "mode": "none",
-              "ref": null,
-              "resolved_path": null,
-              "status": "PASS"
-            },
-            "message": "cell_definition.yaml validates",
-            "notes": [],
-            "parser": "pyyaml",
-            "status": "PASS",
-            "warnings": [
-              "environment.layout path not found: layout/workcell_studio_layout.yaml"
-            ]
-          },
-          "cell_definition_yaml": {
-            "message": "cell_definition.yaml exists",
-            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/cell_definition.yaml",
-            "status": "PASS"
-          },
-          "cmakelists_txt": {
-            "message": "CMakeLists.txt exists",
-            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/CMakeLists.txt",
-            "status": "PASS"
-          },
-          "credible_physical_visual_evidence": {
-            "mesh_failure_summary_by_reason_code": {},
-            "message": "no credible physical mesh/primitive render evidence was recorded",
-            "physical_rendered_count": 0,
-            "source_geometry_count": 11,
-            "status": "FAIL"
-          },
-          "environment_yaml": {
-            "message": "environment.yaml exists",
-            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/environment.yaml",
-            "status": "PASS"
-          },
-          "fake_hardware_launch_command_derivation": {
-            "build_package_name": "ur5_2f_test",
-            "command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
-            "message": "safe fake-hardware launch command recorded",
-            "package_name": "ur5_2f_test",
-            "safety": "not executed; fake hardware explicitly required",
-            "status": "PASS",
-            "warnings": []
-          },
-          "generated_scene_package_readiness_json": {
-            "message": "generated/scene_package_readiness.json is present and parseable",
-            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_package_readiness.json",
-            "status": "PASS",
-            "summary": {
-              "blockers": [
-                {
-                  "category": "supported_scene_catalog",
-                  "message": "Scene3D runtime smoke evidence remains blocked because generated/scene3d_gui_smoke.json records unable_to_resolve_workcell_builder_executable, indicating the ROS Humble/ament workcell_builder executable is unavailable in this container.",
-                  "status": "BLOCKED"
-                },
-                {
-                  "category": "ros_launch_smoke_skip_evaluation_state",
-                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
-                  "status": "BLOCKED"
-                }
-              ],
-              "build_package_name": "ur5_2f_test",
-              "builder_generated_scene_validation": {
-                "checks": [
-                  {
-                    "check": "package.xml exists",
-                    "ok": true
-                  },
-                  {
-                    "check": "CMakeLists.txt exists",
-                    "ok": true
-                  },
-                  {
-                    "check": "environment.yaml exists",
-                    "ok": true
-                  },
-                  {
-                    "check": "workcell_builder_metadata.yaml present",
-                    "ok": false,
-                    "optional": true
-                  },
-                  {
-                    "check": "generated/cell_definition.yaml present",
-                    "ok": false,
-                    "optional": true
-                  },
-                  {
-                    "check": "generated/environment_layout.yaml present",
-                    "ok": false,
-                    "optional": true
-                  },
-                  {
-                    "check": "generated/workcell_builder_task_intent.yaml present",
-                    "ok": true,
-                    "optional": true
-                  }
-                ],
-                "discovered": {
-                  "end_effector_capability_id": null,
-                  "end_effector_name": null,
-                  "grasp_strategy_id": null,
-                  "object_count": 0,
-                  "robot_capability_id": null,
-                  "robot_name": null,
-                  "sensor_capability_id": null
-                },
-                "errors": [],
-                "export_validation": {},
-                "ok": true,
-                "readiness": "task_intent_ready_offline",
-                "readiness_classification": "task_intent_ready_offline",
-                "runtime_readiness": "runtime_blocked_or_preview_only",
-                "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
-                "suggested_next_actions": [
-                  "Generate task recipe from builder task intent."
-                ],
-                "task_flow_summary": {
-                  "approach_axis": null,
-                  "approach_distance_m": null,
-                  "errors": [],
-                  "grasp_strategy": "finger_pinch_basic",
-                  "missing_required_fields": [],
-                  "pick_source_id": "pick_zone_main",
-                  "pick_source_type": "zone",
-                  "place_target_id": "bin_red",
-                  "readiness_classification": "task_intent_ready_offline",
-                  "release_strategy": "tool_release",
-                  "retreat_axis": null,
-                  "retreat_distance_m": null,
-                  "routing_rule_count": 1,
-                  "routing_rules": [
-                    {
-                      "destination": "bin_red",
-                      "id": "route_red_box_to_bin_red",
-                      "when": {
-                        "object_class": "box",
-                        "object_color": "red"
-                      }
-                    }
-                  ],
-                  "safety": {
-                    "metadata_only": true,
-                    "motion_started": false,
-                    "ros_launch_started": false,
-                    "runtime_io_applied": false
-                  },
-                  "status": "PASS",
-                  "suggested_next_actions": [
-                    "",
-                    "",
-                    "",
-                    "Generate task recipe from task intent."
-                  ],
-                  "task_id": "sorting_task_001",
-                  "task_type": "pick_place",
-                  "visual_resolution": {
-                    "approximate_coordinates_used": false,
-                    "notes": [],
-                    "pick_coordinates_resolved": true,
-                    "place_coordinates_resolved": true
-                  },
-                  "warnings": []
-                },
-                "task_intent": {
-                  "errors": [],
-                  "missing_required_fields": [],
-                  "pick_source": {
-                    "id": "pick_zone_main",
-                    "type": "zone"
-                  },
-                  "place_target": {
-                    "id": "bin_red",
-                    "type": "destination"
-                  },
-                  "readiness_classification": "task_intent_ready_offline",
-                  "resolved_grasp_strategy": null,
-                  "safety": {
-                    "metadata_only": true,
-                    "motion_started": false,
-                    "ros_launch_started": false,
-                    "runtime_io_applied": false
-                  },
-                  "status": "PASS",
-                  "suggested_next_actions": [
-                    "Generate task recipe from task intent."
-                  ],
-                  "task_intent": {
-                    "grasp": {
-                      "approach_axis": "z_down",
-                      "approach_distance_m": 0.12,
-                      "retreat_axis": "z_up",
-                      "retreat_distance_m": 0.1,
-                      "strategy_ref": "finger_pinch_basic"
-                    },
-                    "pick": {
-                      "object_filter": {
-                        "class_id": "box",
-                        "color": "red"
-                      },
-                      "source": {
-                        "id": "pick_zone_main",
-                        "type": "zone"
-                      }
-                    },
-                    "place": {
-                      "release_strategy": "tool_release",
-                      "retreat_axis": "z_up",
-                      "retreat_distance_m": 0.1,
-                      "target": {
-                        "id": "bin_red",
-                        "type": "destination"
-                      }
-                    },
-                    "routing": {
-                      "rules": [
-                        {
-                          "destination": "bin_red",
-                          "id": "route_red_box_to_bin_red",
-                          "when": {
-                            "object_class": "box",
-                            "object_color": "red"
-                          }
-                        }
-                      ]
-                    },
-                    "safety": {
-                      "metadata_only": true,
-                      "motion_started": false,
-                      "ros_launch_started": false,
-                      "runtime_io_applied": false
-                    },
-                    "scene_package": "scenes/ur5_2f_test",
-                    "schema": "workcell_builder_task_intent/v1",
-                    "task": {
-                      "id": "sorting_task_001",
-                      "mode": "offline_preview",
-                      "type": "pick_place"
-                    }
-                  },
-                  "warnings": []
-                },
-                "warnings": [
-                  "workcell_builder_metadata.yaml missing (optional)",
-                  "End-effector metadata not present in environment.yaml",
-                  "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
-                  "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
-                ]
-              },
-              "catalog_status": "blocked",
-              "categories": {
-                "cell_definition_validation": {
-                  "capabilities": {
-                    "capability_refs": {
-                      "end_effector": null,
-                      "environment_assets": [],
-                      "robot": null,
-                      "sensors": [],
-                      "task": null
-                    },
-                    "checks": {
-                      "events": [],
-                      "status": "WARN"
-                    },
-                    "resolved": {}
-                  },
-                  "environment_layout": {},
-                  "errors": [],
-                  "grasp_strategy": {
-                    "mode": "none",
-                    "ref": null,
-                    "resolved_path": null,
-                    "status": "PASS"
-                  },
-                  "message": "cell_definition.yaml validates",
-                  "notes": [],
-                  "parser": "pyyaml",
-                  "status": "PASS",
-                  "warnings": [
-                    "environment.layout path not found: layout/workcell_studio_layout.yaml"
-                  ]
-                },
-                "cell_definition_yaml": {
-                  "message": "cell_definition.yaml exists",
-                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/cell_definition.yaml",
-                  "status": "PASS"
-                },
-                "cmakelists_txt": {
-                  "message": "CMakeLists.txt exists",
-                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/CMakeLists.txt",
-                  "status": "PASS"
-                },
-                "credible_physical_visual_evidence": {
-                  "mesh_failure_summary_by_reason_code": {},
-                  "message": "no credible physical mesh/primitive render evidence was recorded",
-                  "physical_rendered_count": 0,
-                  "source_geometry_count": 11,
-                  "status": "FAIL"
-                },
-                "environment_yaml": {
-                  "message": "environment.yaml exists",
-                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/environment.yaml",
-                  "status": "PASS"
-                },
-                "fake_hardware_launch_command_derivation": {
-                  "build_package_name": "ur5_2f_test",
-                  "command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
-                  "message": "safe fake-hardware launch command recorded",
-                  "package_name": "ur5_2f_test",
-                  "safety": "not executed; fake hardware explicitly required",
-                  "status": "PASS",
-                  "warnings": []
-                },
-                "generated_scene_package_readiness_json": {
-                  "message": "optional/generated-if-present readiness JSON is not present",
-                  "optional": true,
-                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_package_readiness.json",
-                  "status": "PASS"
-                },
-                "generated_scene_visual_mesh_index_json": {
-                  "message": "generated/scene_visual_mesh_index.json exists",
-                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
-                  "status": "PASS"
-                },
-                "launch_demo_launch_py": {
-                  "message": "launch/demo.launch.py exists",
-                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/launch/demo.launch.py",
-                  "status": "PASS"
-                },
-                "layout_workcell_studio_layout_yaml": {
-                  "message": "layout/workcell_studio_layout.yaml exists",
-                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
-                  "status": "PASS"
-                },
-                "manifest_local_file_references": {
-                  "checked": [
-                    {
-                      "field": "files.environment",
-                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/environment.yaml",
-                      "reference": "environment.yaml"
-                    },
-                    {
-                      "field": "files.cell_definition",
-                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/cell_definition.yaml",
-                      "reference": "cell_definition.yaml"
-                    },
-                    {
-                      "field": "files.layout",
-                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
-                      "reference": "layout/workcell_studio_layout.yaml"
-                    },
-                    {
-                      "field": "files.launch",
-                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/launch/demo.launch.py",
-                      "reference": "launch/demo.launch.py"
-                    },
-                    {
-                      "field": "files.urdf_xacro",
-                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
-                      "reference": "urdf/scene.urdf.xacro"
-                    },
-                    {
-                      "field": "files.visual_mesh_index",
-                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
-                      "reference": "generated/scene_visual_mesh_index.json"
-                    },
-                    {
-                      "field": "files.scene3d_gui_smoke",
-                      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
-                      "reference": "generated/scene3d_gui_smoke.json"
-                    }
-                  ],
-                  "message": "manifest local-file references resolved (7 checked)",
-                  "status": "PASS"
-                },
-                "package_xml": {
-                  "message": "package.xml exists",
-                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/package.xml",
-                  "status": "PASS"
-                },
-                "ros_launch_smoke_skip_evaluation_state": {
-                  "command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
-                  "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
-                  "status": "BLOCKED"
-                },
-                "scene3d_visual_quality_summary": {
-                  "blockers": [
-                    "mesh_source_count > 0 requires mesh_rendered_count > 0"
-                  ],
-                  "counters": {
-                    "credible_physical_rendered_count": 0,
-                    "diagnostic_fallback_count": 0,
-                    "helper_overlay_count": 0,
-                    "mesh_rendered_count": 0,
-                    "mesh_source_count": 11,
-                    "physical_rendered_count": 0,
-                    "primitive_rendered_count": 0,
-                    "primitive_source_count": 0,
-                    "total_payload_count": 11
-                  },
-                  "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
-                  "message": "Scene3D visual-quality evidence is blocked or failing",
-                  "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
-                  "status": "FAIL",
-                  "visual_quality_status": "FAIL",
-                  "warnings": []
-                },
-                "scene_manifest_yaml": {
-                  "message": "scene_manifest.yaml exists",
-                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/scene_manifest.yaml",
-                  "status": "PASS"
-                },
-                "scene_package_exists": {
-                  "message": "scene package directory exists",
-                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
-                  "status": "PASS"
-                },
-                "tool_metadata_consistency": {
-                  "message": "tool/end-effector metadata has no explicit contradictions",
-                  "observed": {
-                    "cell_definition_end_effector_id": "robotiq_2f",
-                    "environment_tool_id": "robotiq_2f",
-                    "manifest_end_effector_brand": "robotiq_85_gripper",
-                    "manifest_end_effector_type": "finger"
-                  },
-                  "status": "PASS"
-                },
-                "urdf_scene_urdf_xacro": {
-                  "message": "urdf/scene.urdf.xacro exists",
-                  "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
-                  "status": "PASS"
-                }
-              },
-              "commands": {
-                "build_command": "colcon build --symlink-install --packages-select ur5_2f_test",
-                "fake_hardware_launch_command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
-                "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json"
-              },
-              "failures": [
-                {
-                  "category": "credible_physical_visual_evidence",
-                  "message": "no credible physical mesh/primitive render evidence was recorded",
-                  "status": "FAIL"
-                },
-                {
-                  "category": "scene3d_visual_quality_summary",
-                  "message": "Scene3D visual-quality evidence is blocked or failing",
-                  "status": "FAIL"
-                }
-              ],
-              "generated_at": "2026-06-04T16:21:59.245618+00:00",
-              "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
-              "offline_scene_readiness": {
-                "errors": [],
-                "inputs": {
-                  "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
-                  "workcell_root": null
-                },
-                "notes": [
-                  "ROS scene package detected (package.xml present)."
-                ],
-                "result": "WARN",
-                "scene_reports": [
-                  {
-                    "candidates": {
-                      "gripper": [
-                        "arm_hand.srdf.xacro",
-                        "cell_definition.yaml",
-                        "environment.yaml",
-                        "package.xml",
-                        "scene.urdf.xacro",
-                        "scene_manifest.yaml",
-                        "scene_visual_mesh_index.json"
-                      ],
-                      "robot": [
-                        "CMakeLists.txt",
-                        "arm_hand.srdf.xacro",
-                        "cell_definition.yaml",
-                        "environment.yaml",
-                        "environment_layout.yaml",
-                        "package.xml",
-                        "scene.urdf.xacro",
-                        "scene3d_gui_smoke.json",
-                        "scene_manifest.yaml",
-                        "scene_visual_mesh_index.json",
-                        "workcell_builder_task_intent.yaml",
-                        "workcell_studio_layout.generated.yaml",
-                        "workcell_studio_layout.yaml"
-                      ],
-                      "sensor": [
-                        "cell_definition.yaml",
-                        "environment.yaml",
-                        "environment_assets.yaml",
-                        "environment_layout.yaml",
-                        "package.xml",
-                        "scene.urdf.xacro"
-                      ]
-                    },
-                    "counts": {
-                      "files": 18,
-                      "meshes": 0,
-                      "urdf_xacro": 2
-                    },
-                    "errors": [],
-                    "frames": {
-                      "base_link": 3,
-                      "camera_link": 3,
-                      "tool0": 32,
-                      "world": 23
-                    },
-                    "mesh_extensions_detected": [],
-                    "notes": [
-                      "ROS scene package detected (package.xml present)."
-                    ],
-                    "placed_objects": {
-                      "absolute_external_mesh_warnings": [],
-                      "count": 0,
-                      "found_in_generated_urdf_xacro": false,
-                      "found_names": [],
-                      "invalid_mesh_warnings": [],
-                      "missing_collision_mesh_warnings": [],
-                      "missing_names": []
-                    },
-                    "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
-                    "task_zones": {
-                      "duplicate_ids": [],
-                      "invalid_dimensions": [],
-                      "pick": 0,
-                      "place": 0,
-                      "total": 0,
-                      "zone_ids": []
-                    },
-                    "warnings": [
-                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
-                      "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
-                      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
-                      "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
-                      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
-                      "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
-                      "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
-                      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
-                      "Task intent pick.source.id not found in task_zones: pick_zone_main",
-                      "Task intent place.target.id not found in task_zones: bin_red",
-                      "Legacy compatibility: robot_mount missing.",
-                      "Legacy compatibility: tool_attachment missing.",
-                      "Legacy compatibility: recommended gripper orientation not used."
-                    ]
-                  }
-                ],
-                "strict": false,
-                "summary": {
-                  "errors": 0,
-                  "scene_packages_checked": 1,
-                  "warnings": 22
-                },
-                "warnings": [
-                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
-                  "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
-                  "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
-                  "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
-                  "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
-                  "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
-                  "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
-                  "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
-                  "Task intent pick.source.id not found in task_zones: pick_zone_main",
-                  "Task intent place.target.id not found in task_zones: bin_red",
-                  "Legacy compatibility: robot_mount missing.",
-                  "Legacy compatibility: tool_attachment missing.",
-                  "Legacy compatibility: recommended gripper orientation not used."
-                ]
-              },
-              "overall_status": "BLOCKED",
-              "package_name": "ur5_2f_test",
-              "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
-              "readiness_status": "BLOCKED",
-              "ros_humble_available": false,
-              "safe_command_warnings": [],
-              "safety": {
-                "fake_hardware_default": true,
-                "motion_command_sent": false,
-                "real_hardware_enabled": false,
-                "ros_launch_executed_by_matrix": false,
-                "runtime_execution_called": false,
-                "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
-              },
-              "scene_name": "ur5_2f_test",
-              "scene_path": "scenes/ur5_2f_test",
-              "schema_version": "workcell_studio_scene_package_readiness/v1",
-              "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
-              "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
-              "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
-              "support_level": "supported",
-              "warnings": [
-                {
-                  "category": "cell_definition_validation",
-                  "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
-                }
-              ],
-              "workcell_builder_executable_found": false
-            }
-          },
-          "generated_scene_visual_mesh_index_json": {
-            "message": "generated/scene_visual_mesh_index.json exists",
-            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
-            "status": "PASS"
-          },
-          "launch_demo_launch_py": {
-            "message": "launch/demo.launch.py exists",
-            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/launch/demo.launch.py",
-            "status": "PASS"
-          },
-          "layout_workcell_studio_layout_yaml": {
-            "message": "layout/workcell_studio_layout.yaml exists",
-            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
-            "status": "PASS"
-          },
-          "manifest_local_file_references": {
-            "checked": [
-              {
-                "field": "files.environment",
-                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/environment.yaml",
-                "reference": "environment.yaml"
-              },
-              {
-                "field": "files.cell_definition",
-                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/cell_definition.yaml",
-                "reference": "cell_definition.yaml"
-              },
-              {
-                "field": "files.layout",
-                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
-                "reference": "layout/workcell_studio_layout.yaml"
-              },
-              {
-                "field": "files.launch",
-                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/launch/demo.launch.py",
-                "reference": "launch/demo.launch.py"
-              },
-              {
-                "field": "files.urdf_xacro",
-                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
-                "reference": "urdf/scene.urdf.xacro"
-              },
-              {
-                "field": "files.visual_mesh_index",
-                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
-                "reference": "generated/scene_visual_mesh_index.json"
-              },
-              {
-                "field": "files.scene3d_gui_smoke",
-                "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
-                "reference": "generated/scene3d_gui_smoke.json"
-              }
-            ],
-            "message": "manifest local-file references resolved (7 checked)",
-            "status": "PASS"
-          },
-          "package_xml": {
-            "message": "package.xml exists",
-            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/package.xml",
-            "status": "PASS"
-          },
-          "ros_launch_smoke_skip_evaluation_state": {
-            "command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
-            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
-            "status": "BLOCKED"
-          },
-          "scene3d_visual_quality_summary": {
-            "blockers": [
-              "mesh_source_count > 0 requires mesh_rendered_count > 0"
-            ],
-            "counters": {
-              "credible_physical_rendered_count": 0,
-              "diagnostic_fallback_count": 0,
-              "helper_overlay_count": 0,
-              "mesh_rendered_count": 0,
-              "mesh_source_count": 11,
-              "physical_rendered_count": 0,
-              "primitive_rendered_count": 0,
-              "primitive_source_count": 0,
-              "total_payload_count": 11
-            },
-            "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
-            "message": "Scene3D visual-quality evidence is blocked or failing",
-            "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
-            "status": "FAIL",
-            "visual_quality_status": "FAIL",
-            "warnings": []
-          },
-          "scene_manifest_yaml": {
-            "message": "scene_manifest.yaml exists",
-            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/scene_manifest.yaml",
-            "status": "PASS"
-          },
-          "scene_package_exists": {
-            "message": "scene package directory exists",
-            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
-            "status": "PASS"
-          },
-          "tool_metadata_consistency": {
-            "message": "tool/end-effector metadata has no explicit contradictions",
-            "observed": {
-              "cell_definition_end_effector_id": "robotiq_2f",
-              "environment_tool_id": "robotiq_2f",
-              "manifest_end_effector_brand": "robotiq_85_gripper",
-              "manifest_end_effector_type": "finger"
-            },
-            "status": "PASS"
-          },
-          "urdf_scene_urdf_xacro": {
-            "message": "urdf/scene.urdf.xacro exists",
-            "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
-            "status": "PASS"
-          }
-        },
-        "commands": {
-          "build_command": "colcon build --symlink-install --packages-select ur5_2f_test",
-          "fake_hardware_launch_command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
-          "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json"
-        },
-        "failures": [
-          {
-            "category": "credible_physical_visual_evidence",
-            "message": "no credible physical mesh/primitive render evidence was recorded",
-            "status": "FAIL"
-          },
-          {
-            "category": "scene3d_visual_quality_summary",
-            "message": "Scene3D visual-quality evidence is blocked or failing",
-            "status": "FAIL"
-          }
-        ],
-        "generated_at": "2026-06-04T16:23:19.093332+00:00",
-        "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
-        "offline_scene_readiness": {
-          "errors": [],
-          "inputs": {
-            "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
-            "workcell_root": null
-          },
-          "notes": [
-            "ROS scene package detected (package.xml present)."
-          ],
-          "result": "WARN",
-          "scene_reports": [
-            {
-              "candidates": {
-                "gripper": [
-                  "arm_hand.srdf.xacro",
-                  "cell_definition.yaml",
-                  "environment.yaml",
-                  "package.xml",
-                  "scene.urdf.xacro",
-                  "scene_manifest.yaml",
-                  "scene_package_readiness.json",
-                  "scene_visual_mesh_index.json"
-                ],
-                "robot": [
-                  "CMakeLists.txt",
-                  "arm_hand.srdf.xacro",
-                  "cell_definition.yaml",
-                  "environment.yaml",
-                  "environment_layout.yaml",
-                  "package.xml",
-                  "scene.urdf.xacro",
-                  "scene3d_gui_smoke.json",
-                  "scene_manifest.yaml",
-                  "scene_package_readiness.json",
-                  "scene_visual_mesh_index.json",
-                  "workcell_builder_task_intent.yaml",
-                  "workcell_studio_layout.generated.yaml",
-                  "workcell_studio_layout.yaml"
-                ],
-                "sensor": [
-                  "cell_definition.yaml",
-                  "environment.yaml",
-                  "environment_assets.yaml",
-                  "environment_layout.yaml",
-                  "package.xml",
-                  "scene.urdf.xacro",
-                  "scene_package_readiness.json"
-                ]
-              },
-              "counts": {
-                "files": 19,
-                "meshes": 0,
-                "urdf_xacro": 2
-              },
-              "errors": [],
-              "frames": {
-                "base_link": 4,
-                "camera_link": 4,
-                "tool0": 33,
-                "world": 24
-              },
-              "mesh_extensions_detected": [],
-              "notes": [
-                "ROS scene package detected (package.xml present)."
-              ],
-              "placed_objects": {
-                "absolute_external_mesh_warnings": [],
-                "count": 0,
-                "found_in_generated_urdf_xacro": false,
-                "found_names": [],
-                "invalid_mesh_warnings": [],
-                "missing_collision_mesh_warnings": [],
-                "missing_names": []
-              },
-              "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
-              "task_zones": {
-                "duplicate_ids": [],
-                "invalid_dimensions": [],
-                "pick": 0,
-                "place": 0,
-                "total": 0,
-                "zone_ids": []
-              },
-              "warnings": [
-                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
-                "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
-                "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
-                "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
-                "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
-                "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
-                "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
-                "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
-                "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
-                "Task intent pick.source.id not found in task_zones: pick_zone_main",
-                "Task intent place.target.id not found in task_zones: bin_red",
-                "Legacy compatibility: robot_mount missing.",
-                "Legacy compatibility: tool_attachment missing.",
-                "Legacy compatibility: recommended gripper orientation not used."
-              ]
-            }
-          ],
-          "strict": false,
-          "summary": {
-            "errors": 0,
-            "scene_packages_checked": 1,
-            "warnings": 44
-          },
-          "warnings": [
-            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
-            "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
-            "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
-            "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
-            "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
-            "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
-            "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
-            "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
-            "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
-            "Task intent pick.source.id not found in task_zones: pick_zone_main",
-            "Task intent place.target.id not found in task_zones: bin_red",
-            "Legacy compatibility: robot_mount missing.",
-            "Legacy compatibility: tool_attachment missing.",
-            "Legacy compatibility: recommended gripper orientation not used."
-          ]
-        },
-        "overall_status": "BLOCKED",
-        "package_name": "ur5_2f_test",
-        "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
-        "readiness_status": "BLOCKED",
-        "ros_humble_available": false,
-        "safe_command_warnings": [],
-        "safety": {
-          "fake_hardware_default": true,
-          "motion_command_sent": false,
-          "real_hardware_enabled": false,
-          "ros_launch_executed_by_matrix": false,
-          "runtime_execution_called": false,
-          "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
-        },
-        "scene_name": "ur5_2f_test",
-        "scene_path": "scenes/ur5_2f_test",
-        "schema_version": "workcell_studio_scene_package_readiness/v1",
-        "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
-        "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
-        "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
-        "support_level": "supported",
-        "warnings": [
-          {
-            "category": "cell_definition_validation",
-            "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
-          }
-        ],
-        "workcell_builder_executable_found": false
-      }
+      "path": "scenes/ur5_2f_test/generated/scene_package_readiness.json",
+      "status": "PASS"
     },
     "generated_scene_visual_mesh_index_json": {
       "message": "generated/scene_visual_mesh_index.json exists",
@@ -1591,7 +435,7 @@
   "offline_scene_readiness": {
     "errors": [],
     "inputs": {
-      "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+      "scene_package": "scenes/ur5_2f_test",
       "workcell_root": null
     },
     "notes": [
@@ -1645,9 +489,9 @@
         "errors": [],
         "frames": {
           "base_link": 5,
-          "camera_link": 5,
+          "camera_link": 4,
           "tool0": 34,
-          "world": 25
+          "world": 36
         },
         "mesh_extensions_detected": [],
         "notes": [
@@ -1662,16 +506,25 @@
           "missing_collision_mesh_warnings": [],
           "missing_names": []
         },
-        "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+        "scene_package": "scenes/ur5_2f_test",
         "task_zones": {
           "duplicate_ids": [],
           "invalid_dimensions": [],
-          "pick": 0,
-          "place": 0,
-          "total": 0,
-          "zone_ids": []
+          "pick": 1,
+          "place": 1,
+          "total": 2,
+          "zone_ids": [
+            "commissioning_pick_pose",
+            "default_drop_zone"
+          ]
         },
         "warnings": [
+          "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
           "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
           "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
           "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
@@ -1771,14 +624,512 @@
           "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
           "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
           "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
-          "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
-          "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
-          "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
-          "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
-          "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
-          "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
-          "Task intent pick.source.id not found in task_zones: pick_zone_main",
-          "Task intent place.target.id not found in task_zones: bin_red",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+          "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
           "Legacy compatibility: robot_mount missing.",
           "Legacy compatibility: tool_attachment missing.",
           "Legacy compatibility: recommended gripper orientation not used."
@@ -1789,9 +1140,15 @@
     "summary": {
       "errors": 0,
       "scene_packages_checked": 1,
-      "warnings": 110
+      "warnings": 614
     },
     "warnings": [
+      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
       "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
       "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
       "Absolute mesh path found in generated/scene_visual_mesh_index.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
@@ -1891,14 +1248,512 @@
       "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
       "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
       "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
-      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
-      "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
-      "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
-      "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
-      "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
-      "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
-      "Task intent pick.source.id not found in task_zones: pick_zone_main",
-      "Task intent place.target.id not found in task_zones: bin_red",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "Absolute mesh path found in generated/scene_package_readiness.json: /workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
       "Legacy compatibility: robot_mount missing.",
       "Legacy compatibility: tool_attachment missing.",
       "Legacy compatibility: recommended gripper orientation not used."

--- a/scenes/ur5_2f_test/scene_manifest.yaml
+++ b/scenes/ur5_2f_test/scene_manifest.yaml
@@ -2,7 +2,6 @@ scene:
   name: ur5_2f_test
   folder: scenes/ur5_2f_test
   package: ur5_2f_test
-
 files:
   environment: environment.yaml
   cell_definition: cell_definition.yaml
@@ -11,102 +10,86 @@ files:
   urdf_xacro: urdf/scene.urdf.xacro
   visual_mesh_index: generated/scene_visual_mesh_index.json
   scene3d_gui_smoke: generated/scene3d_gui_smoke.json
-
 robot:
   model: ur5
   planning_group: manipulator
   base_frame: base_link
   ee_link: gripper_base_link
   home_named_target: home
-
 end_effector:
   type: finger
   brand: robotiq_85_gripper
   grasp_frame: gripper_base_link
   allowed_touch_links:
-    - gripper_base_link
-    - gripper_finger1_knuckle_link
-    - gripper_finger2_knuckle_link
-    - gripper_finger1_finger_link
-    - gripper_finger2_finger_link
-    - gripper_finger1_inner_knuckle_link
-    - gripper_finger2_inner_knuckle_link
-    - gripper_finger1_finger_tip_link
-    - gripper_finger2_finger_tip_link
-
+  - gripper_base_link
+  - gripper_finger1_knuckle_link
+  - gripper_finger2_knuckle_link
+  - gripper_finger1_finger_link
+  - gripper_finger2_finger_link
+  - gripper_finger1_inner_knuckle_link
+  - gripper_finger2_inner_knuckle_link
+  - gripper_finger1_finger_tip_link
+  - gripper_finger2_finger_tip_link
 environment:
   support_surface_link: table
-
 perception:
   input_frame_options:
-    - world
-    - base_link
-
+  - world
+  - base_link
 self_test:
-  # Commissioning defaults for deterministic offline checks.
-  # Tune these values for each physical workcell before production.
   enabled: true
   object:
-    id: commissioning_box
+    id: commissioning_object
     shape: box
-    dimensions: [0.05, 0.05, 0.05]
+    dimensions:
+    - 0.05
+    - 0.05
+    - 0.05
     frame_id: world
-    pose_xyz: [0.45, 0.0, 0.08]
-    pose_rpy: [0.0, 0.0, 0.0]
+    pose_xyz:
+    - 0.45
+    - 0.25
+    - 0.1
+    pose_rpy:
+    - 0.0
+    - 0.0
+    - 0.0
     attributes:
-      class: "part"
-      colour: "red"
-      shape: "box"
-      material: "plastic"
+      class: part
+      colour: red
+      shape: box
+      material: plastic
   expected:
     min_grasp_candidates: 1
     allow_simulated_execution: true
-
 task_recipe:
-  # Future runtime/UI contract example plus commissioning defaults.
-  # Metadata-only in this release: validation/reporting only.
-  id: colour_sort_demo
-  name: Colour Sort Demo
-  type: sort
+  id: default_task
+  name: Commissioning Pick Place
+  type: pick_place
   enabled: true
-  inputs:
-    perception_source: epd
-    required_attributes: [class, colour, shape]
+  mode: simulation_preview
+  source_object: commissioning_object
   pick:
-    object_source: perception
-    grasp_strategy: auto
-    allowed_grasp_methods: [finger]
+    object_source: commissioning_object
+    grasp_strategy: finger_pinch_basic
+    allowed_grasp_methods:
+    - finger
   decision_rules:
-    - id: red_to_bin_a
-      when:
-        attribute: colour
-        equals: red
-      destination: bin_a
-    - id: blue_to_bin_b
-      when:
-        attribute: colour
-        equals: blue
-      destination: bin_b
-    - id: default_reject
-      when:
-        default: true
-      destination: reject_bin
+  - id: default_place
+    when:
+      always: true
+    destination: default_drop_zone
   destinations:
-    - id: bin_a
-      frame_id: world
-      pose_xyz: [0.35, -0.35, 0.12]
-      pose_rpy: [0.0, 0.0, 0.0]
-      action: place
-    - id: bin_b
-      frame_id: world
-      pose_xyz: [0.35, 0.35, 0.12]
-      pose_rpy: [0.0, 0.0, 0.0]
-      action: place
-    - id: reject_bin
-      frame_id: world
-      pose_xyz: [0.20, 0.0, 0.12]
-      pose_rpy: [0.0, 0.0, 0.0]
-      action: reject
+  - id: default_drop_zone
+    frame: world
+    pose_xyz:
+    - 0.5
+    - -0.3
+    - 0.1
+    pose_rpy:
+    - 0.0
+    - 0.0
+    - 0.0
   expected:
     allow_offline_validation: true
     min_valid_destinations: 1

--- a/scenes/ur5_2f_test/workcell_builder_task_intent.yaml
+++ b/scenes/ur5_2f_test/workcell_builder_task_intent.yaml
@@ -1,38 +1,50 @@
 schema: workcell_builder_task_intent/v1
 scene_package: scenes/ur5_2f_test
 task:
-  id: sorting_task_001
+  id: default_task
   type: pick_place
-  mode: offline_preview
+  family: pick_place
+  mode: simulation_preview
 pick:
   source:
-    type: zone
-    id: pick_zone_main
+    type: pick_zone
+    id: commissioning_pick_pose
   object_filter:
-    class_id: box
-    color: red
+    object_id: commissioning_object
 grasp:
   strategy_ref: finger_pinch_basic
   approach_axis: z_down
   approach_distance_m: 0.12
   retreat_axis: z_up
-  retreat_distance_m: 0.10
+  retreat_distance_m: 0.1
 place:
   target:
     type: destination
-    id: bin_red
+    id: default_drop_zone
+    frame: world
+    pose_xyz:
+    - 0.5
+    - -0.3
+    - 0.1
+    pose_rpy:
+    - 0.0
+    - 0.0
+    - 0.0
   release_strategy: tool_release
   retreat_axis: z_up
-  retreat_distance_m: 0.10
+  retreat_distance_m: 0.1
 routing:
   rules:
-    - id: route_red_box_to_bin_red
-      when:
-        object_class: box
-        object_color: red
-      destination: bin_red
+  - id: default_place
+    when:
+      always: true
+    destination: default_drop_zone
 safety:
   metadata_only: true
   runtime_io_applied: false
   motion_started: false
   ros_launch_started: false
+  preview_only: true
+  use_fake_hardware: true
+  execution_mode: simulation_preview
+  no_robot_motion: true


### PR DESCRIPTION
### Motivation

- Make `scenes/ur5_2f_test` use a single commissioning pick/place canary task so task intent, recipe, and cell metadata agree and validators can resolve coordinates. 
- Remove stale sorting references (`red_box_001`, `bin_red`, `pick_zone_main`, etc.) that caused task-zone resolution errors. 
- Ensure every task destination has an explicit frame and `pose_xyz`/`pose_rpy` to support deterministic preview and offline validation. 

### Description

- Standardized the scene on a single commissioning pick/place task `default_task` and canonical IDs: `commissioning_object`, `commissioning_pick_pose`, and `default_drop_zone`. 
- Updated `environment.yaml` task section to use `commissioning_object`/`commissioning_pick_pose` and explicit `destinations` with `frame`, `pose_xyz`, and `pose_rpy`. 
- Aligned `cell_definition.yaml` `objects` and `task` entries, `config/task_recipe.yaml`, and embedded `task_recipe` in `scene_manifest.yaml` to the same pick/place contract. 
- Reworked builder task intent files (`workcell_builder_task_intent.yaml` and `config/workcell_builder_task_intent.yaml`) and `environment_layout.yaml` to provide resolved pick/place zones and preserve preview/fake-hardware safety flags. 
- Replaced stale sorting/red-bin references and refreshed `generated/scene_package_readiness.json` so readiness tooling now resolves pick/place coordinates. 

### Testing

- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` which returned `ok: true` and task-flow `PASS` (readiness `task_intent_ready_offline`).
- Performed YAML/JSON parse checks on modified files with `yaml.safe_load` and JSON loads on readiness artifacts, which succeeded. 
- Verified no stale identifiers remain with `rg -n "red_box_001|bin_red|pick_zone_main|colour_sort_demo|bin_a|bin_b|reject_bin|route_red_box_to_bin_red|sorting_task_001" scenes/ur5_2f_test` which returned no hits. 
- Ran `git diff --check` to ensure no whitespace/merge artifacts; it passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a9b67ee508331b57805e2bc02802e)