### PR TITLE
Align ur5_2f_test scene contract (robot/tool/frame/grasp)

### DIFF
--- a/scenes/ur5_2f_test/cell_definition.yaml
+++ b/scenes/ur5_2f_test/cell_definition.yaml
@@ -5,15 +5,18 @@ cell:
 robot:
   model: ur5
   planning_group: manipulator
-  base_frame: world
+  world_frame: world
+  base_frame: base_link
   tool_link: tool0
   home_named_target: home
   safe_joint_state: []
 end_effector:
-  id: robotiq_2f
+  id: robotiq_85_gripper
   type: finger
-  brand: robotiq
-  grasp_frame: tool0
+  model: robotiq_85_gripper
+  profile: robotiq_85_gripper
+  mount_link: tool0
+  grasp_frame: ee_palm
 camera:
   enabled: false
   camera_id: UNKNOWN_CAMERA

--- a/scenes/ur5_2f_test/environment.yaml
+++ b/scenes/ur5_2f_test/environment.yaml
@@ -4,14 +4,29 @@ scene:
   name: ur5_2f_test
 robot:
   id: ur5
+  model: ur5
   profile: ur5
+  world_frame: world
+  base_frame: base_link
+  planning_group: manipulator
+  tool_mount_link: tool0
 tool:
-  id: robotiq_2f
-  profile: robotiq_2f
+  id: robotiq_85_gripper
+  model: robotiq_85_gripper
+  profile: robotiq_85_gripper
+  mount_link: tool0
+  grasp_frame: ee_palm
+end_effector:
+  id: robotiq_85_gripper
+  type: finger
+  model: robotiq_85_gripper
+  profile: robotiq_85_gripper
+  mount_link: tool0
+  grasp_frame: ee_palm
 compatibility:
   status: COMPATIBLE
   robot: ur5
-  tool: robotiq_2f
+  tool: robotiq_85_gripper
 placed_objects:
 camera:
   enabled: false

--- a/scenes/ur5_2f_test/launch/demo.launch.py
+++ b/scenes/ur5_2f_test/launch/demo.launch.py
@@ -14,7 +14,13 @@ from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
 scene_pkg = "ur5_2f_test"
+robot_model = "ur5"
+planning_group = "manipulator"
+world_frame = "world"
 robot_base_link = "base_link"
+tool_mount_link = "tool0"
+gripper_profile = "robotiq_85_gripper"
+grasp_frame = "ee_palm"
 robot_moveit_pkg = "ur5_moveit_config"
 
 
@@ -162,9 +168,13 @@ def _launch_setup(context):
         scene_pkg,
         "urdf/scene.urdf.xacro",
         mappings={
-            "ur_type": "ur5",
-            "name": "ur5",
+            "ur_type": robot_model,
+            "name": robot_model,
             "tf_prefix": "",
+            "world_frame": world_frame,
+            "tool_mount_link": tool_mount_link,
+            "gripper_profile": gripper_profile,
+            "grasp_frame": grasp_frame,
             "use_fake_hardware": use_fake_hardware.perform(context),
         },
     )
@@ -289,7 +299,7 @@ def _launch_setup(context):
             "--yaw",
             "0.0",
             "--frame-id",
-            "world",
+            world_frame,
             "--child-frame-id",
             robot_base_link,
         ],

--- a/scenes/ur5_2f_test/scene_manifest.yaml
+++ b/scenes/ur5_2f_test/scene_manifest.yaml
@@ -15,14 +15,18 @@ files:
 robot:
   model: ur5
   planning_group: manipulator
+  world_frame: world
   base_frame: base_link
-  ee_link: gripper_base_link
+  tool_mount_link: tool0
+  ee_link: ee_palm
   home_named_target: home
 
 end_effector:
   type: finger
-  brand: robotiq_85_gripper
-  grasp_frame: gripper_base_link
+  model: robotiq_85_gripper
+  profile: robotiq_85_gripper
+  mount_link: tool0
+  grasp_frame: ee_palm
   allowed_touch_links:
     - gripper_base_link
     - gripper_finger1_knuckle_link

--- a/scenes/ur5_2f_test/urdf/scene.urdf.xacro
+++ b/scenes/ur5_2f_test/urdf/scene.urdf.xacro
@@ -5,16 +5,22 @@
  <xacro:arg name="ur_type" default="ur5"/>
  <xacro:arg name="name" default="$(arg ur_type)"/>
  <xacro:arg name="tf_prefix" default=""/>
+ <xacro:arg name="world_frame" default="world"/>
+ <xacro:arg name="tool_mount_link" default="tool0"/>
+ <xacro:arg name="gripper_profile" default="robotiq_85_gripper"/>
+ <xacro:arg name="grasp_frame" default="ee_palm"/>
  <xacro:arg name="use_fake_hardware" default="true"/>
 
- <link name="world"/>
+ <!-- Contract: world_frame is the scene/world frame; UR creates base_link as the robot base. -->
+ <!-- Contract: tool_mount_link is tool0; gripper_profile is robotiq_85_gripper; grasp_frame is ee_palm. -->
+ <link name="$(arg world_frame)"/>
 
 <xacro:include filename="$(find ur_description)/urdf/ur_macro.xacro"/>
 
 <xacro:ur_robot
   name="$(arg name)"
   tf_prefix="$(arg tf_prefix)"
-  parent="world"
+  parent="$(arg world_frame)"
   safety_limits="true"
   joint_limits_parameters_file="$(find ur_description)/config/$(arg ur_type)/joint_limits.yaml"
   kinematics_parameters_file="$(find ur_description)/config/$(arg ur_type)/default_kinematics.yaml"
@@ -25,7 +31,7 @@
 </xacro:ur_robot>
 
  <xacro:include filename="$(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro"/>
- <xacro:robotiq_85_gripper prefix="" parent="tool0">
+ <xacro:robotiq_85_gripper prefix="" parent="$(arg tool_mount_link)">
 	<origin xyz="0 0 0" rpy="1.5707 -1.5707 0"/>
  </xacro:robotiq_85_gripper>
 
@@ -47,7 +53,7 @@
  </xacro:if>
 
  <xacro:include filename="$(find workbench_description)/urdf/table.urdf.xacro"/>
- <xacro:table prefix="" parent="world">
+ <xacro:table prefix="" parent="$(arg world_frame)">
 	<origin xyz="0 0 0" rpy="0 0 0"/>
  </xacro:table>
  
@@ -66,10 +72,10 @@
     <origin xyz="0 0 0" rpy="1.57079506 0 1.57079506"/>
  </joint>
  
- <link name="ee_palm" />
- <joint name="base_to_palm" type="fixed">
-    <parent link="tool0"/>
-    <child link="ee_palm"/>
+ <link name="$(arg grasp_frame)" />
+ <joint name="tool0_to_grasp_frame" type="fixed">
+    <parent link="$(arg tool_mount_link)"/>
+    <child link="$(arg grasp_frame)"/>
     <origin xyz="0 0 0.14" rpy="0 0 0"/>
  </joint>
 


### PR DESCRIPTION
### Motivation
- Make scene metadata consistent and unambiguous across manifest, cell definition, environment, launch, and URDF so downstream tools and planners share a single contract for robot, frames, and end-effector.
- Ensure the scene preserves safe defaults (fake-hardware-first) while providing explicit names for world/base/tool/grasp to avoid prior ambiguity.

### Description
- Updated `scene_manifest.yaml`, `cell_definition.yaml`, and `environment.yaml` to use a single contract: robot model `ur5`, planning group `manipulator`, scene/world frame `world`, robot base frame `base_link`, and tool mount `tool0`.
- Standardized end-effector metadata to `robotiq_85_gripper` and made the grasp/EE frame `ee_palm` across manifest, cell definition, and environment, and added explicit `mount_link`/`profile`/`grasp_frame` fields.
- Passed new constants from `launch/demo.launch.py` into the xacro expansion (`robot_model`, `planning_group`, `world_frame`, `tool_mount_link`, `gripper_profile`, `grasp_frame`) and used `world_frame` for the static transform instead of a hardcoded string.
- Modified `urdf/scene.urdf.xacro` to accept `world_frame`, `tool_mount_link`, `gripper_profile`, and `grasp_frame` args, mount the Robotiq 85 gripper on `tool0`, attach the UR robot under the scene `world_frame`, and expose the fixed grasp link `ee_palm` for planning.
- Kept `use_fake_hardware` default as `true` and left `trajectory_execution`/controller management configured to avoid enabling real robot motion.

### Testing
- Ran `git diff --check` and it passed without whitespace errors.
- Validated YAML parsing for `scene_manifest.yaml`, `cell_definition.yaml`, and `environment.yaml` using `yaml.safe_load`, and all files loaded successfully.
- Compiled the launch file with `python3 -m py_compile scenes/ur5_2f_test/launch/demo.launch.py` and parsed the URDF xacro file with `xml.etree.ElementTree` successfully.
- Asserted contract consistency across manifest/cell/environment via a small Python check (robot model, planning group, world/base frames, tool mount, gripper profile, and grasp frame) and received `contract OK`.
- Ran the repository validator `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` which returned `ok: true` and `readiness: task_intent_ready_offline` while reporting existing optional warnings about missing generated export/metadata artifacts.
- Note: full ROS/xacro runtime expansion and ROS 2 Humble launch validation were not executed because this container reported `ROS_HUMBLE_MISSING` and `XACRO_MISSING`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a9b51d67c8331af7cd597ffe3dcb4)