### PR TITLE
Mark ur5_2f_test supported scene as blocked

### DIFF
--- a/scenes/supported_scenes.yaml
+++ b/scenes/supported_scenes.yaml
@@ -96,8 +96,8 @@ scenes:
     package_name: ur5_2f_test
     scene_path: scenes/ur5_2f_test
     support_level: supported
-    status: supported
-    known_blocker: ""
+    status: blocked
+    known_blocker: "generated/scene3d_gui_smoke.json currently records missing workcell_builder executable/runtime evidence and must be regenerated in a sourced ROS Humble workspace before this scene can be treated as pass-like."
     authoring_files: *common_authoring_files
     generated_files: *common_generated_files
     validation_command: python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json


### PR DESCRIPTION
### Motivation
- Update the supported scene catalog to reflect that `ur5_2f_test` is not currently pass-like because `generated/scene3d_gui_smoke.json` records missing `workcell_builder` executable/runtime evidence and the smoke file must be regenerated in a sourced ROS Humble workspace before treating the scene as PASS-like.

### Description
- Change `scenes/supported_scenes.yaml` for `scene_name: ur5_2f_test` to set `status: blocked` and populate `known_blocker` with a concise explanation while preserving `support_level: supported`.

### Testing
- Ran an automated YAML assertion that confirmed the `ur5_2f_test` entry remains present, retains `support_level: supported`, reports `status: blocked`, and references `generated/scene3d_gui_smoke.json` and `workcell_builder`, and also ran `git diff --check`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a9b73fad083319e12ad3d808fae4d)