### PR TITLE
Include scene contract files in ur5_2f_test install rules

### DIFF
--- a/scenes/ur5_2f_test/CMakeLists.txt
+++ b/scenes/ur5_2f_test/CMakeLists.txt
@@ -21,7 +21,12 @@ install(DIRECTORY urdf
   DESTINATION share/${PROJECT_NAME}
 )
 
+install(DIRECTORY config generated layout
+  DESTINATION share/${PROJECT_NAME}
+)
+
 install(FILES
+  cell_definition.yaml
   environment.yaml
   scene_manifest.yaml
   DESTINATION share/${PROJECT_NAME}


### PR DESCRIPTION
### Motivation
- Ensure the installed `ur5_2f_test` package contains all files advertised by `scene_manifest.yaml` (layout, generated artifacts, and any scene-level task recipes) so downstream consumers can rely on the scene contract.

### Description
- Updated `scenes/ur5_2f_test/CMakeLists.txt` to install the `config`, `generated`, and `layout` directories and to include `cell_definition.yaml` alongside `environment.yaml` and `scene_manifest.yaml` so the package matches the scene manifest contract.

### Testing
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` which completed successfully and reported the scene as OK.
- Ran a static verification script that confirmed the expected files exist and that the `CMakeLists.txt` contains the new `install(DIRECTORY config generated layout` entry along with `cell_definition.yaml`, `environment.yaml`, and `scene_manifest.yaml` which succeeded.
- Attempted `colcon build --symlink-install --packages-select ur5_2f_test` but the container lacks `/opt/ros/humble/setup.bash`, so the build was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aa8c31c0c8331a8ea8f3d9c8965b9)