### PR TITLE
Align supported scene CMake install contracts

### DIFF
--- a/scenes/suction_test/CMakeLists.txt
+++ b/scenes/suction_test/CMakeLists.txt
@@ -13,6 +13,14 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 
+function(install_scene_directory_if_present directory_name)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${directory_name}")
+    install(DIRECTORY ${directory_name}
+      DESTINATION share/${PROJECT_NAME}
+    )
+  endif()
+endfunction()
+
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
@@ -21,7 +29,18 @@ install(DIRECTORY urdf
   DESTINATION share/${PROJECT_NAME}
 )
 
+install_scene_directory_if_present(config)
+
+install(DIRECTORY generated
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(DIRECTORY layout
+  DESTINATION share/${PROJECT_NAME}
+)
+
 install(FILES
+  cell_definition.yaml
   environment.yaml
   scene_manifest.yaml
   DESTINATION share/${PROJECT_NAME}

--- a/scenes/ur10_2f_test/CMakeLists.txt
+++ b/scenes/ur10_2f_test/CMakeLists.txt
@@ -13,6 +13,14 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 
+function(install_scene_directory_if_present directory_name)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${directory_name}")
+    install(DIRECTORY ${directory_name}
+      DESTINATION share/${PROJECT_NAME}
+    )
+  endif()
+endfunction()
+
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
@@ -21,7 +29,20 @@ install(DIRECTORY urdf
   DESTINATION share/${PROJECT_NAME}
 )
 
-install(FILES environment.yaml
+install_scene_directory_if_present(config)
+
+install(DIRECTORY generated
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(DIRECTORY layout
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(FILES
+  cell_definition.yaml
+  environment.yaml
+  scene_manifest.yaml
   DESTINATION share/${PROJECT_NAME}
 )
 ament_package()

--- a/scenes/ur3_suction_test/CMakeLists.txt
+++ b/scenes/ur3_suction_test/CMakeLists.txt
@@ -13,6 +13,14 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 
+function(install_scene_directory_if_present directory_name)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${directory_name}")
+    install(DIRECTORY ${directory_name}
+      DESTINATION share/${PROJECT_NAME}
+    )
+  endif()
+endfunction()
+
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
@@ -21,7 +29,20 @@ install(DIRECTORY urdf
   DESTINATION share/${PROJECT_NAME}
 )
 
-install(FILES environment.yaml
+install_scene_directory_if_present(config)
+
+install(DIRECTORY generated
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(DIRECTORY layout
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(FILES
+  cell_definition.yaml
+  environment.yaml
+  scene_manifest.yaml
   DESTINATION share/${PROJECT_NAME}
 )
 ament_package()

--- a/scenes/ur5_2f_builder_pick_place_demo/CMakeLists.txt
+++ b/scenes/ur5_2f_builder_pick_place_demo/CMakeLists.txt
@@ -13,6 +13,14 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 
+function(install_scene_directory_if_present directory_name)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${directory_name}")
+    install(DIRECTORY ${directory_name}
+      DESTINATION share/${PROJECT_NAME}
+    )
+  endif()
+endfunction()
+
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
@@ -21,7 +29,18 @@ install(DIRECTORY urdf
   DESTINATION share/${PROJECT_NAME}
 )
 
+install_scene_directory_if_present(config)
+
+install(DIRECTORY generated
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(DIRECTORY layout
+  DESTINATION share/${PROJECT_NAME}
+)
+
 install(FILES
+  cell_definition.yaml
   environment.yaml
   scene_manifest.yaml
   DESTINATION share/${PROJECT_NAME}

--- a/scenes/ur5_2f_sorting_test/CMakeLists.txt
+++ b/scenes/ur5_2f_sorting_test/CMakeLists.txt
@@ -14,6 +14,14 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
+function(install_scene_directory_if_present directory_name)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${directory_name}")
+    install(DIRECTORY ${directory_name}
+      DESTINATION share/${PROJECT_NAME}
+    )
+  endif()
+endfunction()
+
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
@@ -22,7 +30,18 @@ install(DIRECTORY urdf
   DESTINATION share/${PROJECT_NAME}
 )
 
+install_scene_directory_if_present(config)
+
+install(DIRECTORY generated
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(DIRECTORY layout
+  DESTINATION share/${PROJECT_NAME}
+)
+
 install(FILES
+  cell_definition.yaml
   environment.yaml
   scene_manifest.yaml
   sorting_manifest.yaml

--- a/scenes/ur5_3f_test/CMakeLists.txt
+++ b/scenes/ur5_3f_test/CMakeLists.txt
@@ -13,6 +13,14 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 
+function(install_scene_directory_if_present directory_name)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${directory_name}")
+    install(DIRECTORY ${directory_name}
+      DESTINATION share/${PROJECT_NAME}
+    )
+  endif()
+endfunction()
+
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
@@ -21,7 +29,18 @@ install(DIRECTORY urdf
   DESTINATION share/${PROJECT_NAME}
 )
 
+install_scene_directory_if_present(config)
+
+install(DIRECTORY generated
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(DIRECTORY layout
+  DESTINATION share/${PROJECT_NAME}
+)
+
 install(FILES
+  cell_definition.yaml
   environment.yaml
   scene_manifest.yaml
   DESTINATION share/${PROJECT_NAME}

--- a/scenes/ur5_airpick4_test/CMakeLists.txt
+++ b/scenes/ur5_airpick4_test/CMakeLists.txt
@@ -13,6 +13,14 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 
+function(install_scene_directory_if_present directory_name)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${directory_name}")
+    install(DIRECTORY ${directory_name}
+      DESTINATION share/${PROJECT_NAME}
+    )
+  endif()
+endfunction()
+
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
@@ -21,7 +29,18 @@ install(DIRECTORY urdf
   DESTINATION share/${PROJECT_NAME}
 )
 
+install_scene_directory_if_present(config)
+
+install(DIRECTORY generated
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(DIRECTORY layout
+  DESTINATION share/${PROJECT_NAME}
+)
+
 install(FILES
+  cell_definition.yaml
   environment.yaml
   scene_manifest.yaml
   DESTINATION share/${PROJECT_NAME}


### PR DESCRIPTION
### Motivation
- Ensure all supported scene packages listed in `scenes/supported_scenes.yaml` expose a consistent install contract so generated scene artifacts are discoverable by downstream tools. 
- Preserve existing scene-specific installs (notably sorting artifacts) while making the install layout reproducible and robust across supported scenes.

### Description
- Added a small CMake helper `install_scene_directory_if_present` to each touched `CMakeLists.txt` and used it to optionally install `config/` only if present. 
- Brought the following install contracts in line with `scenes/ur5_2f_test/CMakeLists.txt`: always install `launch/` and `urdf/`, install `generated/` and `layout/`, and install `cell_definition.yaml`, `environment.yaml`, and `scene_manifest.yaml` as package files. 
- Applied the contract to `suction_test`, `ur10_2f_test`, `ur3_suction_test`, `ur5_2f_builder_pick_place_demo`, `ur5_2f_sorting_test`, `ur5_3f_test`, and `ur5_airpick4_test`, while preserving all existing sorting-specific installs, scripts, docs, fixtures, and test registrations in `ur5_2f_sorting_test`. 
- Left `scenes/ur5_2f_test/CMakeLists.txt` behavior unchanged as the baseline contract.

### Testing
- Ran a catalog/static contract check with a small Python validator that verifies expected CMake tokens and required paths; it reported success for all 7 modified scenes. 
- Executed the scene validator `python3 scripts/validate_builder_generated_scene.py scenes/<scene> --json` for each touched scene and received `ok: true` with only pre-existing warnings about generated exports where applicable. 
- Ran sorting package unit checks `python3 scenes/ur5_2f_sorting_test/test/test_sorting_manifest.py` and `python3 scenes/ur5_2f_sorting_test/test/test_validate_static_sorting_scene_contract.py`, both of which passed. 
- Ran `git diff --check` with no whitespace/patch issues. 
- Attempted `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select <scenes>` but the build step was blocked because `/opt/ros/humble/setup.bash` is not available in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aab4f49888331808ab32d9ed2aff9)