### PR TITLE
Scene3D: default fit includes mesh, URDF primitives, semantic fallbacks and layout items

### DIFF
--- a/tests/test_scene3d_view_fit_and_scale.py
+++ b/tests/test_scene3d_view_fit_and_scale.py
@@ -2,7 +2,57 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 VIEW_CPP = (ROOT/'workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp').read_text(encoding='utf-8')
 
+
+def _function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    brace = source.index('{', start)
+    depth = 0
+    for idx in range(brace, len(source)):
+        if source[idx] == '{':
+            depth += 1
+        elif source[idx] == '}':
+            depth -= 1
+            if depth == 0:
+                return source[brace + 1:idx]
+    raise AssertionError(f'could not parse function body for {signature}')
+
+
 def test_scene_fit_uses_visible_items_bounds_and_has_diagnostics():
     assert 'scene_bounds_from_visible_items' in VIEW_CPP
     assert 'include_overlays' in VIEW_CPP
     assert 'Scene3D diagnostics {viewport_received_count=' in VIEW_CPP
+
+
+def test_default_scene_fit_uses_mixed_physical_scene_bounds_not_generated_mesh_focus():
+    fit_scene = _function_body(VIEW_CPP, 'void Scene3DViewportWidget::fit_scene()')
+
+    assert 'scene_bounds_from_visible_items(bmin, bmax, fit_include_overlays)' in fit_scene
+    assert 'has_generated_mesh_focus' not in fit_scene
+    assert 'last_camera_fit_target_ = QStringLiteral("scene")' in fit_scene
+
+    fit_robot = _function_body(VIEW_CPP, 'void Scene3DViewportWidget::fit_robot()')
+    assert 'robot_bounds_from_rendered_visuals(bmin, bmax)' in fit_robot
+    assert 'last_camera_fit_target_ = QStringLiteral("robot")' in fit_robot
+
+
+def test_fit_bounds_include_mesh_urdf_primitive_semantic_fallback_and_layout_items():
+    include_fit = _function_body(VIEW_CPP, 'bool include_in_fit_bounds')
+    scene_bounds = _function_body(VIEW_CPP, 'bool Scene3DViewportWidget::scene_bounds_from_visible_items')
+    item_bounds = _function_body(VIEW_CPP, 'Scene3DViewportWidget::ItemBounds Scene3DViewportWidget::item_bounds_for_role')
+    primitive_local = _function_body(VIEW_CPP, 'bool primitive_local_bounds_for_item')
+    primitive_world = _function_body(VIEW_CPP, 'bool primitive_world_bounds_for_item')
+
+    assert 'item_has_credible_mesh_handoff(it)' in include_fit
+    assert 'item_has_explicit_primitive_dimensions(it)' in include_fit
+    assert 'if (helper_overlay) return false;' in include_fit
+    assert 'if (it.linked_to_editable_layout_state) return true;' in include_fit
+    assert 'return mesh_backed || explicit_primitive;' in include_fit
+
+    assert 'include_in_fit_bounds(it, include_overlays)' in scene_bounds
+    assert 'item_bounds_for_role(it)' in scene_bounds
+    assert 'mesh_world_bounds_for_item(item, mesh_bounds)' in item_bounds
+    assert 'primitive_world_bounds_for_item(item, primitive_bounds)' in item_bounds
+
+    assert 'primitive_radius' in primitive_local
+    assert 'primitive_length' in primitive_local
+    assert 'Semantic fallback/editable boxes are rendered as axis-aligned min-corner boxes.' in primitive_local

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -121,6 +121,107 @@ bool item_has_explicit_primitive_dimensions(const ScenePreviewWidget::PreviewIte
   return item_has_valid_urdf_primitive(item) || (item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001);
 }
 
+bool primitive_local_bounds_for_item(const ScenePreviewWidget::PreviewItem & item, QVector3D & out_min, QVector3D & out_max)
+{
+  const QString type = item.primitive_geometry_type.trimmed().toLower().replace(QLatin1Char('-'), QLatin1Char('_')).replace(QLatin1Char(' '), QLatin1Char('_'));
+  if (type == QStringLiteral("cylinder")) {
+    if (item.primitive_radius <= 0.001 || item.primitive_length <= 0.001) return false;
+    const float r = static_cast<float>(item.primitive_radius);
+    const float h = static_cast<float>(item.primitive_length);
+    // draw_urdf_primitive_geometry renders cylinders along the local Y axis.
+    out_min = QVector3D(-r, -h * 0.5f, -r);
+    out_max = QVector3D(r, h * 0.5f, r);
+    return true;
+  }
+  if (type == QStringLiteral("sphere")) {
+    if (item.primitive_radius <= 0.001) return false;
+    const float r = static_cast<float>(item.primitive_radius);
+    out_min = QVector3D(-r, -r, -r);
+    out_max = QVector3D(r, r, r);
+    return true;
+  }
+  if (type == QStringLiteral("capsule")) {
+    if (item.primitive_radius <= 0.001 || item.primitive_length <= 0.001) return false;
+    const float r = static_cast<float>(item.primitive_radius);
+    const float h = static_cast<float>(item.primitive_length);
+    // Capsule is drawn as a local-Y cylinder plus radius-sized end spheres.
+    out_min = QVector3D(-r, -h * 0.5f - r, -r);
+    out_max = QVector3D(r, h * 0.5f + r, r);
+    return true;
+  }
+  if (type == QStringLiteral("box") &&
+      item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001) {
+    out_min = QVector3D(static_cast<float>(-item.sx * 0.5),
+                        static_cast<float>(-item.sy * 0.5),
+                        static_cast<float>(-item.sz * 0.5));
+    out_max = QVector3D(static_cast<float>(item.sx * 0.5),
+                        static_cast<float>(item.sy * 0.5),
+                        static_cast<float>(item.sz * 0.5));
+    return true;
+  }
+  if (type.isEmpty() && item.sx > 0.001 && item.sy > 0.001 && item.sz > 0.001) {
+    // Semantic fallback/editable boxes are rendered as axis-aligned min-corner boxes.
+    out_min = QVector3D(0.0f, 0.0f, 0.0f);
+    out_max = QVector3D(static_cast<float>(item.sx), static_cast<float>(item.sy), static_cast<float>(item.sz));
+    return true;
+  }
+  return false;
+}
+
+struct PrimitiveWorldBounds { double x, y, z, sx, sy, sz; };
+
+bool primitive_world_bounds_for_item(const ScenePreviewWidget::PreviewItem & item, PrimitiveWorldBounds & out_bounds)
+{
+  QVector3D lmin, lmax;
+  if (!primitive_local_bounds_for_item(item, lmin, lmax)) return false;
+
+  const QString type = item.primitive_geometry_type.trimmed().toLower().replace(QLatin1Char('-'), QLatin1Char('_')).replace(QLatin1Char(' '), QLatin1Char('_'));
+  const bool axis_aligned_scene_box = (type.isEmpty() || type == QStringLiteral("box")) &&
+                                      !item_has_valid_urdf_primitive(item);
+  if (axis_aligned_scene_box) {
+    out_bounds = { item.x, item.y, item.z, item.sx, item.sy, item.sz };
+    return true;
+  }
+
+  QMatrix4x4 transform;
+  transform.translate(item.x, item.y, item.z);
+  transform.rotate(qRadiansToDegrees(item.roll), 1.0f, 0.0f, 0.0f);
+  transform.rotate(qRadiansToDegrees(item.pitch), 0.0f, 1.0f, 0.0f);
+  transform.rotate(qRadiansToDegrees(item.yaw), 0.0f, 0.0f, 1.0f);
+  if (item.visual_origin_applied) {
+    transform.translate(item.visual_origin_x, item.visual_origin_y, item.visual_origin_z);
+    transform.rotate(qRadiansToDegrees(item.visual_origin_roll), 1.0f, 0.0f, 0.0f);
+    transform.rotate(qRadiansToDegrees(item.visual_origin_pitch), 0.0f, 1.0f, 0.0f);
+    transform.rotate(qRadiansToDegrees(item.visual_origin_yaw), 0.0f, 0.0f, 1.0f);
+  }
+  transform.scale(item.mesh_scale_x, item.mesh_scale_y, item.mesh_scale_z);
+
+  QVector3D wmin(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
+  QVector3D wmax(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
+  for (int xi = 0; xi < 2; ++xi) {
+    for (int yi = 0; yi < 2; ++yi) {
+      for (int zi = 0; zi < 2; ++zi) {
+        const QVector3D local_corner(
+          xi == 0 ? lmin.x() : lmax.x(),
+          yi == 0 ? lmin.y() : lmax.y(),
+          zi == 0 ? lmin.z() : lmax.z());
+        const QVector3D world_corner = transform * local_corner;
+        wmin.setX(qMin(wmin.x(), world_corner.x()));
+        wmin.setY(qMin(wmin.y(), world_corner.y()));
+        wmin.setZ(qMin(wmin.z(), world_corner.z()));
+        wmax.setX(qMax(wmax.x(), world_corner.x()));
+        wmax.setY(qMax(wmax.y(), world_corner.y()));
+        wmax.setZ(qMax(wmax.z(), world_corner.z()));
+      }
+    }
+  }
+  out_bounds = { wmin.x(), wmin.y(), wmin.z(),
+                 qMax(0.0f, wmax.x() - wmin.x()),
+                 qMax(0.0f, wmax.y() - wmin.y()),
+                 qMax(0.0f, wmax.z() - wmin.z()) };
+  return true;
+}
+
 void finalize_visual_quality(Scene3DViewportWidget::RenderDebugCounters & counters)
 {
   counters.total_payload_count = counters.preview_items_count;
@@ -576,7 +677,7 @@ bool include_in_fit_bounds(const ScenePreviewWidget::PreviewItem & it, bool incl
   const bool helper_overlay = is_overlay_only_item(it) || source_layer == "overlay" || visual_source == "overlay";
   const bool generated_urdf_visual = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
   const bool mesh_backed = item_has_credible_mesh_handoff(it);
-  const bool explicit_primitive = it.sx > 0.001 && it.sy > 0.001 && it.sz > 0.001;
+  const bool explicit_primitive = item_has_explicit_primitive_dimensions(it);
   const bool missing_geometry = !mesh_backed && !explicit_primitive;
   const bool missing_mesh_fallback = missing_geometry && !it.linked_to_editable_layout_state && !generated_urdf_visual;
   if (helper_overlay) return false;
@@ -852,27 +953,7 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
 }
 void Scene3DViewportWidget::fit_scene() {
   QVector3D bmin, bmax;
-  bool has_generated_mesh_focus = false;
-  QVector3D mesh_min(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
-  QVector3D mesh_max(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest());
-  for (const auto & it : items) {
-    if (!include_in_fit_bounds(it, false)) continue;
-    const bool generated_urdf = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
-    const bool mesh_backed = item_has_credible_mesh_handoff(it);
-    if (!generated_urdf || !mesh_backed) continue;
-    const ItemBounds bounds = item_bounds_for_role(it);
-    mesh_min.setX(std::min(mesh_min.x(), static_cast<float>(bounds.x)));
-    mesh_min.setY(std::min(mesh_min.y(), static_cast<float>(bounds.y)));
-    mesh_min.setZ(std::min(mesh_min.z(), static_cast<float>(bounds.z)));
-    mesh_max.setX(std::max(mesh_max.x(), static_cast<float>(bounds.x + bounds.sx)));
-    mesh_max.setY(std::max(mesh_max.y(), static_cast<float>(bounds.y + bounds.sy)));
-    mesh_max.setZ(std::max(mesh_max.z(), static_cast<float>(bounds.z + bounds.sz)));
-    has_generated_mesh_focus = true;
-  }
-  if (has_generated_mesh_focus) {
-    bmin = mesh_min;
-    bmax = mesh_max;
-  } else if (!scene_bounds_from_visible_items(bmin, bmax, fit_include_overlays)) {
+  if (!scene_bounds_from_visible_items(bmin, bmax, fit_include_overlays)) {
     set_isometric_view();
     return;
   }
@@ -2319,6 +2400,11 @@ Scene3DViewportWidget::ItemBounds Scene3DViewportWidget::item_bounds_for_role(co
 {
   ItemBounds mesh_bounds{};
   if (mesh_world_bounds_for_item(item, mesh_bounds)) return mesh_bounds;
+  PrimitiveWorldBounds primitive_bounds{};
+  if (primitive_world_bounds_for_item(item, primitive_bounds)) {
+    return { primitive_bounds.x, primitive_bounds.y, primitive_bounds.z,
+             primitive_bounds.sx, primitive_bounds.sy, primitive_bounds.sz };
+  }
 
   const NormalizedRole role = classify_item_role(item);
   if (role == NormalizedRole::Object || role == NormalizedRole::WarningAnchor) {


### PR DESCRIPTION
### Motivation
- Make the default Scene3D camera fit use all credible physical scene content instead of preferring only generated mesh-backed URDF visuals. 
- Ensure semantic primitive fallbacks and editable layout items with valid dimensions contribute to camera framing so mixed mesh+primitive scenes are framed sensibly. 
- Preserve helper/overlay exclusion by default and keep the explicit robot-focused `fit_robot()` path unchanged.

### Description
- Changed default `fit_scene()` to use `scene_bounds_from_visible_items(..., fit_include_overlays)` as the primary fit target so the scene fit considers all visible, credible physical items instead of only generated mesh-backed URDF visuals.
- Added `primitive_local_bounds_for_item(...)` and `primitive_world_bounds_for_item(...)` helpers to compute primitive geometry bounds (cylinder, sphere, capsule, box and semantic fallback boxes) and return transformed world AABBs when applicable.
- Updated `item_bounds_for_role(...)` to prefer mesh world bounds, then primitive world bounds, then legacy role-based fallbacks so mixed mesh + primitive items are included correctly.
- Made `include_in_fit_bounds(...)` use `item_has_explicit_primitive_dimensions(...)` and continue to exclude overlay/helper-only items unless `fit_include_overlays` is enabled.
- Kept `fit_robot()` unchanged as the explicit robot-centric fit path; `fit_scene()` remains the default scene-fit behavior.
- Tests: extended `tests/test_scene3d_view_fit_and_scale.py` to assert the new fit behavior and presence of the new primitive-bounds helpers and checks for overlay exclusion.
- Files changed: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp` and `tests/test_scene3d_view_fit_and_scale.py`.

### Testing
- Ran the updated unit test file with `pytest -q tests/test_scene3d_view_fit_and_scale.py` and received all tests passing (3 passed).
- Ran source-level checks (`git diff --check`) and static/parse-based tests used by the repository smoke tests; no issues were detected in this change set.
- Attempted full package build (`colcon build --packages-select workcell_builder`) but this was not executed in the container because `/opt/ros/humble/setup.bash` was not available in the environment; the change is limited to viewport logic and unit tests, and does not modify launch/runtime/hardware paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aae7228348331adc528dbebfa4ab8)