### PR TITLE
Update ur5_2f_test editable layout entries

### DIFF
--- a/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml
+++ b/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml
@@ -1,12 +1,121 @@
 schema_version: workcell_studio_layout/v1
 items:
-  - id: robot_base
-    type: robot
+  - id: support_surface_table
+    type: support_surface
+    role: support_surface
+    category: work_surface
+    display_name: Commissioning Work Surface
+    editable: true
+    locked: false
+    source_layer: editable_layout
+    source: layout/workcell_studio_layout.yaml
     pose:
-      xyz: [0.0, 0.0, 0.0]
+      xyz: [0.55, 0.0, 0.06]
       rpy: [0.0, 0.0, 0.0]
-  - id: table_main
-    type: table
+    dimensions: [1.2, 0.8, 0.08]
+    geometry_type: box
+    primitive_geometry_type: box
+    material:
+      color: [0.55, 0.58, 0.62, 1.0]
+  - id: pick_zone_commissioning
+    type: pick_zone
+    role: pick_zone
+    category: work_surface
+    display_name: Commissioning Pick Zone
+    editable: true
+    locked: false
+    source_layer: editable_layout
+    source: layout/workcell_studio_layout.yaml
     pose:
-      xyz: [0.5, 0.0, 0.0]
+      xyz: [0.45, 0.25, 0.105]
       rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.35, 0.30, 0.01]
+    geometry_type: box
+    primitive_geometry_type: box
+    material:
+      color: [0.12, 0.55, 1.0, 0.45]
+  - id: place_zone_default
+    type: place_zone
+    role: place_zone
+    category: work_surface
+    display_name: Default Place Zone
+    editable: true
+    locked: false
+    source_layer: editable_layout
+    source: layout/workcell_studio_layout.yaml
+    pose:
+      xyz: [0.55, -0.28, 0.105]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.35, 0.30, 0.01]
+    geometry_type: box
+    primitive_geometry_type: box
+    material:
+      color: [0.10, 0.75, 0.35, 0.45]
+  - id: target_bin_default
+    type: target_bin
+    role: target_bin
+    category: place_zone
+    display_name: Default Target Bin
+    editable: true
+    locked: false
+    source_layer: editable_layout
+    source: layout/workcell_studio_layout.yaml
+    pose:
+      xyz: [0.55, -0.28, 0.19]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.35, 0.25, 0.18]
+    geometry_type: box
+    primitive_geometry_type: box
+    material:
+      color: [0.95, 0.68, 0.20, 0.65]
+  - id: realsense_overhead
+    type: realsense
+    role: camera
+    category: camera
+    display_name: Overhead RealSense Camera
+    editable: true
+    locked: false
+    source_layer: editable_layout
+    source: layout/workcell_studio_layout.yaml
+    pose:
+      xyz: [0.35, 0.0, 0.85]
+      rpy: [0.0, 1.5708, 0.0]
+    dimensions: [0.08, 0.08, 0.06]
+    geometry_type: box
+    primitive_geometry_type: box
+    material:
+      color: [0.08, 0.09, 0.10, 1.0]
+  - id: safety_zone_keepout
+    type: safety_zone
+    role: keepout
+    category: safety_zone
+    display_name: Robot/Table Keepout Boundary
+    editable: true
+    locked: false
+    source_layer: editable_layout
+    source: layout/workcell_studio_layout.yaml
+    pose:
+      xyz: [0.35, 0.0, 0.102]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [2.0, 1.6, 0.01]
+    geometry_type: box
+    primitive_geometry_type: box
+    material:
+      color: [1.0, 0.15, 0.12, 0.18]
+  - id: home_pose_safe
+    type: home_pose
+    role: home_pose
+    category: safety_zone
+    display_name: Safe Home Pose Marker
+    editable: true
+    locked: false
+    source_layer: editable_layout
+    source: layout/workcell_studio_layout.yaml
+    pose:
+      xyz: [0.25, 0.0, 0.45]
+      rpy: [0.0, 0.0, 0.0]
+    dimensions: [0.08, 0.08, 0.08]
+    geometry_type: sphere
+    primitive_geometry_type: sphere
+    material:
+      color: [0.55, 0.25, 1.0, 0.85]


### PR DESCRIPTION
### Motivation
- Provide a stable, editor-friendly `workcell_studio_layout/v1` saved layout for `ur5_2f_test` so the Workcell Studio 3D canvas and builder workflows have deterministic editable preview items and clearer task bindings.
- Replace the prior minimal two-item layout with explicit editable records for common semantic tokens (support surface, pick/place zones, bin, camera, safety, home) to improve scene authoring and downstream generation.

### Description
- Replaced `scenes/ur5_2f_test/layout/workcell_studio_layout.yaml` items with seven editable entries (`support_surface_table`, `pick_zone_commissioning`, `place_zone_default`, `target_bin_default`, `realsense_overhead`, `safety_zone_keepout`, `home_pose_safe`) each including `id`, `type`, `role`, `category`, `display_name`, `editable: true`, `locked: false`, `source_layer: editable_layout`, `pose.xyz`, `pose.rpy`, and `dimensions`/`geometry` hints.
- Added renderer-friendly tokens and primitive hints such as `primitive_geometry_type` / `geometry_type` and `material.color` to improve 3D preview visuals and make items usable as editable layout overlays rather than generated URDF previews.
- Kept `schema_version: workcell_studio_layout/v1` and ensured the new records are primitive/preview-only (no mesh/URDF changes), preserving the separation between editable layout and generated URDF visuals.

### Testing
- Ran a local Python assertion that loaded `layout/workcell_studio_layout.yaml` and validated `schema_version`, presence of required fields (`id`, `type`, `role`, `category`, `display_name`, `editable`, `locked`, `source_layer`, `pose`, `dimensions`), vector lengths, and `editable`/`locked`/`source_layer` flags; the check passed for all 7 items.
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` and confirmed `ok: true` with readiness `task_intent_ready_offline`, indicating the scene validator accepted the saved editable layout.
- Ran the layout merge via `python3 scripts/workcell_studio_layout_merge.py scenes/ur5_2f_test --json` and observed a successful merge report with no blockers (only expected PREVIEW_ONLY warnings for missing mesh/URDF paths).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ad941ff04833190fad00476494117)