### PR TITLE
Mirror UR5 2F support surface in cell definition

### DIFF
--- a/scenes/ur5_2f_test/cell_definition.yaml
+++ b/scenes/ur5_2f_test/cell_definition.yaml
@@ -24,6 +24,22 @@ camera:
 environment:
   frame: world
   layout: layout/workcell_studio_layout.yaml
+  support_surfaces:
+  - id: support_surface_table
+    type: table
+    frame: world
+    pose_xyz:
+    - 0.55
+    - 0.0
+    - 0.06
+    pose_rpy:
+    - 0.0
+    - 0.0
+    - 0.0
+    dimensions:
+    - 1.2
+    - 0.8
+    - 0.08
 objects:
 - id: commissioning_object
   frame: world


### PR DESCRIPTION
### Motivation
- Keep `cell_definition.yaml` consistent with the authored layout by mirroring the table support-surface so downstream validators/generators can find the canonical support surface referenced by the Workcell Studio layout.

### Description
- Added an `environment.support_surfaces` entry with id `support_surface_table` (type `table`, frame, `pose_xyz`/`pose_rpy`, and `dimensions`) to `scenes/ur5_2f_test/cell_definition.yaml` and left all other fields untouched.
- Preserved required invariants: `schema_version: cell_definition/v1`, `cell.id: ur5_2f_test`, `robot.model/planning_group/tool_link`, `end_effector.profile: robotiq_85_gripper`, `environment.layout: layout/workcell_studio_layout.yaml`, and `commissioning.self_test_enabled: true`.
- Did not introduce new unsupported schema fields for zones/assets; change is scoped to the single support-surface metadata only.

### Testing
- Ran `git diff --check` which passed with no whitespace errors.
- Ran `python3 scripts/validate_cell_definition.py scenes/ur5_2f_test/cell_definition.yaml --json` which returned no errors (existing warning about resolving `environment.layout` remains).
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` which completed with `ok: true` and only the expected optional warnings about generated artifacts.
- Executed a custom Python invariant check asserting preserved schema/robot/end-effector/layout/commissioning/task/object references and the presence of `support_surface_table`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ada1f71988331a11cc71453e3c61a)