### PR TITLE
Suppress generic canvas placeholders when canonical layout provides semantic items

### DIFF
--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cctype>
 #include <fstream>
+#include <initializer_list>
 #include <set>
 #include <vector>
 #include <yaml-cpp/yaml.h>
@@ -370,12 +371,48 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   m.place_target = task_ok ? read_string_or_warn(yaml_map_key(task, "place_target"), "task_recipe.place_target", "Task intent missing") : "Task intent missing";
   m.release_strategy = task_ok ? read_string_or_warn(yaml_map_key(task, "release_strategy"), "task_recipe.release_strategy", "Generate task recipe to populate this panel") : "Generate task recipe to populate this panel";
 
-  const auto push_default_item = [&m](const std::string & id, const std::string & type, const std::string & role,
+  const std::string canonical_schema_version = canonical_layout_status.loaded ?
+    read_string_or_warn(yaml_map_key(layout, "schema_version"), "schema_version", "") : "";
+  const YAML::Node canonical_layout_items = canonical_layout_status.loaded ? yaml_map_key(layout, "items") : YAML::Node();
+  const bool canonical_schema_current = (canonical_schema_version == "workcell_studio_layout/v1");
+  const bool canonical_schema_legacy = canonical_schema_version.empty() && canonical_layout_items.IsSequence();
+  const bool canonical_layout_usable = canonical_layout_status.loaded && (canonical_schema_current || canonical_schema_legacy);
+  const bool canonical_layout_has_items = canonical_layout_usable && canonical_layout_items.IsSequence() && canonical_layout_items.size() > 0;
+
+  const auto canonical_layout_has_semantic = [&](std::initializer_list<const char *> semantic_tokens) {
+    if (!canonical_layout_has_items) return false;
+    for (const auto & node : canonical_layout_items) {
+      if (!node || !node.IsMap()) continue;
+      for (const char * key : {"id", "type", "role", "category"}) {
+        std::string value = yaml_map_value_or_empty(node, key);
+        std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c){ return static_cast<char>(std::tolower(c)); });
+        for (const char * raw_token : semantic_tokens) {
+          const std::string token(raw_token == nullptr ? "" : raw_token);
+          if (!token.empty() && (value == token || value.find(token) != std::string::npos)) return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  const auto should_add_default_preview_item = [&](const std::string & id) {
+    if (!canonical_layout_has_items) return true;
+    if (id == "table") return !canonical_layout_has_semantic({"table", "support_surface", "work_surface"});
+    if (id == "pick_zone") return !canonical_layout_has_semantic({"pick_zone"});
+    if (id == "place_zone") return !canonical_layout_has_semantic({"place_zone"});
+    if (id == "bin_a") return !canonical_layout_has_semantic({"bin", "target_bin"});
+    if (id == "camera") return !canonical_layout_has_semantic({"camera", "realsense"});
+    if (id == "home_pose") return !canonical_layout_has_semantic({"home_pose", "safety/home"});
+    return true;
+  };
+
+  const auto push_default_item = [&m, &should_add_default_preview_item](const std::string & id, const std::string & type, const std::string & role,
                                        const std::string & label, const std::string & source_file,
                                        double x, double y, double z,
                                        double roll, double pitch, double yaw,
                                        double width, double depth, double height,
                                        double radius, bool locked) {
+    if (!should_add_default_preview_item(id)) return;
     WorkcellStudioCanvasItem item;
     item.id = id;
     item.type = type;
@@ -455,13 +492,6 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
     const YAML::Node camera = yaml_map_key(root, "camera");
     if (camera && camera.IsMap()) items->push_back(YAML::Clone(camera));
   };
-
-  const std::string canonical_schema_version = canonical_layout_status.loaded ?
-    read_string_or_warn(yaml_map_key(layout, "schema_version"), "schema_version", "") : "";
-  const YAML::Node canonical_layout_items = canonical_layout_status.loaded ? yaml_map_key(layout, "items") : YAML::Node();
-  const bool canonical_schema_current = (canonical_schema_version == "workcell_studio_layout/v1");
-  const bool canonical_schema_legacy = canonical_schema_version.empty() && canonical_layout_items.IsSequence();
-  const bool canonical_layout_usable = canonical_layout_status.loaded && (canonical_schema_current || canonical_schema_legacy);
 
   YAML::Node effective_layout;
   bool layout_source_is_environment_layout = false;

--- a/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
+++ b/workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp
@@ -2,6 +2,7 @@
 #include <boost/filesystem.hpp>
 #include <algorithm>
 #include <fstream>
+#include <map>
 #include <set>
 
 #include "workcell_studio_canvas_model.hpp"
@@ -872,6 +873,59 @@ TEST(WorkcellStudioCanvasMesh, PreviewStarterLayoutCopiesLockedGeneratedPhysical
   EXPECT_FALSE(found_original_locked_preview) << "the copied layout item must not masquerade as the original generated preview id";
 
   fs::remove_all(root);
+}
+
+
+TEST(WorkcellStudioCanvasMesh, Ur5CanonicalLayoutSuppressesGenericSemanticPlaceholders)
+{
+#ifndef WORKCELL_BUILDER_REPO_ROOT
+  GTEST_SKIP() << "WORKCELL_BUILDER_REPO_ROOT is not configured for ur5_2f_test layout coverage";
+#else
+  const fs::path repo_root = fs::path(WORKCELL_BUILDER_REPO_ROOT);
+  const fs::path source_scene = repo_root / "scenes" / "ur5_2f_test";
+  ASSERT_TRUE(fs::exists(source_scene)) << "expected ur5_2f_test scene fixture";
+
+  const fs::path editable_layout_path = source_scene / "layout" / "workcell_studio_layout.yaml";
+  ASSERT_TRUE(fs::exists(editable_layout_path));
+  const YAML::Node layout = load_yaml_file(editable_layout_path);
+  ASSERT_TRUE(layout && layout.IsMap());
+  ASSERT_EQ(layout["schema_version"].as<std::string>(), "workcell_studio_layout/v1");
+  ASSERT_TRUE(layout["items"] && layout["items"].IsSequence());
+  ASSERT_GT(layout["items"].size(), 0u);
+
+  std::set<std::string> expected_editable_ids;
+  for (const auto & item : layout["items"]) {
+    ASSERT_TRUE(item && item.IsMap());
+    ASSERT_TRUE(item["id"]);
+    expected_editable_ids.insert(item["id"].as<std::string>());
+  }
+  ASSERT_EQ(expected_editable_ids.count("support_surface_table"), 1u);
+  ASSERT_EQ(expected_editable_ids.count("pick_zone_commissioning"), 1u);
+  ASSERT_EQ(expected_editable_ids.count("place_zone_default"), 1u);
+  ASSERT_EQ(expected_editable_ids.count("target_bin_default"), 1u);
+  ASSERT_EQ(expected_editable_ids.count("realsense_overhead"), 1u);
+  ASSERT_EQ(expected_editable_ids.count("home_pose_safe"), 1u);
+
+  const auto model = workcell_builder::build_workcell_studio_canvas_model(source_scene, "ur5_2f_test");
+  std::map<std::string, int> id_counts;
+  for (const auto & item : model.items) {
+    ++id_counts[item.id];
+  }
+
+  for (const auto & id : expected_editable_ids) {
+    EXPECT_EQ(id_counts[id], 1) << "canonical editable layout id should appear exactly once: " << id;
+  }
+
+  const std::set<std::string> suppressed_generic_placeholder_ids = {
+    "table", "pick_zone", "place_zone", "bin_a", "camera", "home_pose"
+  };
+  for (const auto & id : suppressed_generic_placeholder_ids) {
+    EXPECT_EQ(id_counts[id], 0) << "canonical semantic layout should suppress generic placeholder id: " << id;
+  }
+
+  EXPECT_EQ(id_counts["robot_base"], 1) << "locked robot preview should remain separate from editable layout items";
+  EXPECT_EQ(id_counts["robot_reach"], 1) << "locked reach preview should remain separate from editable layout items";
+#endif
 }
 
 TEST(WorkcellStudioCanvasMesh, StarterLayoutAcceptanceCopiesSceneAndFiltersUnsafePreviewItems)


### PR DESCRIPTION
### Motivation

- Avoid duplicating semantic preview placeholders when a canonical `layout/workcell_studio_layout.yaml` already contains authored editable items for the same semantic roles.  
- Keep generated/locked URDF or mesh preview rows separate from editable layout rows and ensure the editor shows canonical IDs exactly once.

### Description

- Detect whether the canonical `layout/workcell_studio_layout.yaml` is usable and has one or more `items` before seeding default preview rows in `build_workcell_studio_canvas_model()` by checking schema and item presence.  
- Add semantic checks that suppress adding generic default preview items for roles when the canonical layout already contains matching semantic items, specifically suppressing `table`, `pick_zone`, `place_zone`, `bin_a`, `camera`, and `home_pose` placeholders.  
- Preserve locked/generated preview helpers (e.g., `robot_base`, `robot_reach`) separately so URDF/mesh preview items remain distinct and locked.  
- Add a Scene3D/layout test `Ur5CanonicalLayoutSuppressesGenericSemanticPlaceholders` (using `scenes/ur5_2f_test`) that asserts canonical editable layout IDs are present exactly once and that generic placeholder IDs are not introduced as replacements.  
- Files changed: `workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp` and `workcell_builder/workcell_builder/test/workcell_studio_canvas_model_mesh_test.cpp`.

### Testing

- Ran the added unit test and related canvas-model tests by compiling and executing the `workcell_studio_canvas_model_mesh_test` binary; the new `Ur5CanonicalLayoutSuppressesGenericSemanticPlaceholders` test passed.  
- Ran a selection of canvas-model tests via the built test binary (filters used in the rollout); those filtered runs passed.  
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` to validate the scene; it reported the scene as OK for the intended checks.  
- Attempted `colcon build` workspace validation but `source /opt/ros/humble/setup.bash` is not present in this container so the `colcon` build step was not executed here.  
- Note: when running the entire canvas-model test suite during iterative development two unrelated existing tests (`UsesEnvironmentLayoutAsEditableFallback` and `UsesSafeManifestLayoutOnlyAfterCanonicalAndLegacyMissing`) were observed to fail in a manually-linked run; these appear to be pre-existing or environment-dependent and are not related to the new suppression logic or the new canonical-layout assertion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bb9874a148331a31fe7d5c6aba7f5)