### PR TITLE
Make mesh index source paths portable

### DIFF
--- a/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
+++ b/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json
@@ -3,12 +3,13 @@
   "visual_count": 19,
   "resolved": 19,
   "unresolved": 0,
-  "generated_at": "2026-06-11T12:49:47.863659+00:00",
-  "extractor_version": "2.7",
+  "generated_at": "2026-06-12T09:24:02.047841+00:00",
+  "extractor_version": "2.8",
+  "path_reference_root": "repository",
   "extraction_mode": "xacro_lite_expanded",
   "xacro_available": false,
-  "source_urdf_xacro_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
-  "source_mtime": 1781181943.1334205,
+  "source_urdf_xacro_path": "scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+  "source_mtime": 1781251015.580105,
   "source_expanded_urdf_path": "",
   "fallback_reason": "xacro executable unavailable; used safe repo-local xacro-lite expansion; skipped unresolved macros: ur_robot",
   "xacro_real_command_succeeded": false,
@@ -76,7 +77,8 @@
       "geometry_type": "mesh",
       "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
       "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
-      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+      "resolved_source_path_is_repo_relative": true,
       "resolved": true,
       "mesh_scale": [
         1.0,
@@ -142,7 +144,8 @@
       "geometry_type": "mesh",
       "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
       "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved_source_path_is_repo_relative": true,
       "resolved": true,
       "mesh_scale": [
         1.0,
@@ -208,7 +211,8 @@
       "geometry_type": "mesh",
       "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
       "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
-      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_knuckle_link.dae",
+      "resolved_source_path_is_repo_relative": true,
       "resolved": true,
       "mesh_scale": [
         1.0,
@@ -275,7 +279,8 @@
       "geometry_type": "mesh",
       "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
       "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved_source_path_is_repo_relative": true,
       "resolved": true,
       "mesh_scale": [
         1.0,
@@ -342,7 +347,8 @@
       "geometry_type": "mesh",
       "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
       "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
-      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_link.dae",
+      "resolved_source_path_is_repo_relative": true,
       "resolved": true,
       "mesh_scale": [
         1.0,
@@ -408,7 +414,8 @@
       "geometry_type": "mesh",
       "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
       "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved_source_path_is_repo_relative": true,
       "resolved": true,
       "mesh_scale": [
         1.0,
@@ -474,7 +481,8 @@
       "geometry_type": "mesh",
       "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
       "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
-      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_inner_knuckle_link.dae",
+      "resolved_source_path_is_repo_relative": true,
       "resolved": true,
       "mesh_scale": [
         1.0,
@@ -541,7 +549,8 @@
       "geometry_type": "mesh",
       "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
       "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved_source_path_is_repo_relative": true,
       "resolved": true,
       "mesh_scale": [
         1.0,
@@ -608,7 +617,8 @@
       "geometry_type": "mesh",
       "package_uri": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
       "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
-      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved_source_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_finger_tip_link.dae",
+      "resolved_source_path_is_repo_relative": true,
       "resolved": true,
       "mesh_scale": [
         1.0,
@@ -678,7 +688,8 @@
       "geometry_type": "mesh",
       "package_uri": "package://workbench_description/meshes/visual/table.stl",
       "source_path": "package://workbench_description/meshes/visual/table.stl",
-      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/meshes/visual/table.stl",
+      "resolved_source_path": "assets/environment/workbench_description/meshes/visual/table.stl",
+      "resolved_source_path_is_repo_relative": true,
       "resolved": true,
       "mesh_scale": [
         0.001,
@@ -732,7 +743,8 @@
       "geometry_type": "mesh",
       "package_uri": "package://realsense2_description/meshes/d435.dae",
       "source_path": "package://realsense2_description/meshes/d435.dae",
-      "resolved_source_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved_source_path": "assets/environment/realsense2_description/meshes/d435.dae",
+      "resolved_source_path_is_repo_relative": true,
       "resolved": true,
       "mesh_scale": [
         1.0,
@@ -1414,302 +1426,347 @@
   ],
   "xacro_command": [
     "xacro-lite",
-    "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro"
+    "scenes/ur5_2f_test/urdf/scene.urdf.xacro"
   ],
   "package_resolution_diagnostics": {
     "resolved_packages": [
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
-      },
-      {
         "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
+        "root_path": "assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description/package.xml"
+        "package_xml": "assets/robots/fanuc/fanuc_description/package.xml"
       },
       {
         "package_name": "fanuc_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
+        "root_path": "assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config/package.xml"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description/package.xml"
-      },
-      {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config/package.xml"
-      },
-      {
-        "package_name": "ur3_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config/package.xml"
-      },
-      {
-        "package_name": "ur10_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur10_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur10_moveit_config/package.xml"
-      },
-      {
-        "package_name": "ur5_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur5_moveit_config",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur5_moveit_config/package.xml"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description/package.xml"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description/package.xml"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description/package.xml"
-      },
-      {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description/package.xml"
-      },
-      {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
-        "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description/package.xml"
+        "package_xml": "assets/robots/fanuc/fanuc_moveit_config/package.xml"
       },
       {
         "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "root_path": "assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description/package.xml"
+        "package_xml": "assets/environment/flat_plate_camera_bracket_description/package.xml"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description/package.xml"
+        "package_xml": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description/package.xml"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config/package.xml"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/overhead_camera_gantry_description/package.xml"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/robots/panda_robot/panda_description/package.xml"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "assets/robots/panda_robot/panda_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/robots/panda_robot/panda_moveit_config/package.xml"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/pipe_camera_stand_description/package.xml"
+      },
+      {
+        "package_name": "realsense2_description",
+        "root_path": "assets/environment/realsense2_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/realsense2_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/package.xml"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config/package.xml"
       },
       {
         "package_name": "simple_conveyor_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
+        "root_path": "assets/environment/simple_conveyor_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description/package.xml"
+        "package_xml": "assets/environment/simple_conveyor_description/package.xml"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/single_suction_gripper/single_suction_description/package.xml"
+      },
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config/package.xml"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "assets/environment/sorting_bin_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/sorting_bin_description/package.xml"
       },
       {
         "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
+        "root_path": "assets/environment/table_clamp_camera_mount_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description/package.xml"
+        "package_xml": "assets/environment/table_clamp_camera_mount_description/package.xml"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "assets/environment/table_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/table_description/package.xml"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/tslot_camera_frame_description/package.xml"
+      },
+      {
+        "package_name": "ur10_moveit_config",
+        "root_path": "assets/robots/universal_robot/ur10_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/robots/universal_robot/ur10_moveit_config/package.xml"
+      },
+      {
+        "package_name": "ur3_moveit_config",
+        "root_path": "assets/robots/universal_robot/ur3_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/robots/universal_robot/ur3_moveit_config/package.xml"
+      },
+      {
+        "package_name": "ur5_moveit_config",
+        "root_path": "assets/robots/universal_robot/ur5_moveit_config",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/robots/universal_robot/ur5_moveit_config/package.xml"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "assets/environment/vslot_camera_frame_description",
+        "source_tier": "repo_assets",
+        "package_xml": "assets/environment/vslot_camera_frame_description/package.xml"
       },
       {
         "package_name": "workbench_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
+        "root_path": "assets/environment/workbench_description",
         "source_tier": "repo_assets",
-        "package_xml": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description/package.xml"
+        "package_xml": "assets/environment/workbench_description/package.xml"
       }
     ],
     "shadowed_packages": [],
     "resolution_paths": [
       {
-        "package_name": "onrobot_airpick4_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "onrobot_airpick4_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
         "package_name": "fanuc_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_description",
+        "root_path": "assets/robots/fanuc/fanuc_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "fanuc_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/fanuc/fanuc_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "panda_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/panda_robot/panda_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "ur3_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur3_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "ur10_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur10_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "ur5_moveit_config",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/robots/universal_robot/ur5_moveit_config",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "pipe_camera_stand_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/pipe_camera_stand_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "table_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "vslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/vslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "overhead_camera_gantry_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/overhead_camera_gantry_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "tslot_camera_frame_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/tslot_camera_frame_description",
-        "source_tier": "repo_assets"
-      },
-      {
-        "package_name": "realsense2_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/realsense2_description",
+        "root_path": "assets/robots/fanuc/fanuc_moveit_config",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "flat_plate_camera_bracket_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/flat_plate_camera_bracket_description",
+        "root_path": "assets/environment/flat_plate_camera_bracket_description",
         "source_tier": "repo_assets"
       },
       {
-        "package_name": "sorting_bin_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/sorting_bin_description",
+        "package_name": "onrobot_airpick4_description",
+        "root_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "onrobot_airpick4_moveit_config",
+        "root_path": "assets/end_effectors/onrobot_airpick4/onrobot_airpick4_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "overhead_camera_gantry_description",
+        "root_path": "assets/environment/overhead_camera_gantry_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_description",
+        "root_path": "assets/robots/panda_robot/panda_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "panda_moveit_config",
+        "root_path": "assets/robots/panda_robot/panda_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "pipe_camera_stand_description",
+        "root_path": "assets/environment/pipe_camera_stand_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "realsense2_description",
+        "root_path": "assets/environment/realsense2_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_gripper_description",
+        "root_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_gripper_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_3f_moveit_config",
+        "root_path": "assets/end_effectors/robotiq_3f_gripper/robotiq_3f_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_description",
+        "root_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "robotiq_85_moveit_config",
+        "root_path": "assets/end_effectors/robotiq_85_gripper/robotiq_85_moveit_config",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "simple_conveyor_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/simple_conveyor_description",
+        "root_path": "assets/environment/simple_conveyor_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "single_suction_description",
+        "root_path": "assets/end_effectors/single_suction_gripper/single_suction_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "single_suction_moveit_config",
+        "root_path": "assets/end_effectors/single_suction_gripper/single_suction_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "root_path": "assets/environment/sorting_bin_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "table_clamp_camera_mount_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/table_clamp_camera_mount_description",
+        "root_path": "assets/environment/table_clamp_camera_mount_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "table_description",
+        "root_path": "assets/environment/table_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "root_path": "assets/environment/tslot_camera_frame_description",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "ur10_moveit_config",
+        "root_path": "assets/robots/universal_robot/ur10_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "ur3_moveit_config",
+        "root_path": "assets/robots/universal_robot/ur3_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "ur5_moveit_config",
+        "root_path": "assets/robots/universal_robot/ur5_moveit_config",
+        "source_tier": "repo_assets"
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
+        "root_path": "assets/environment/vslot_camera_frame_description",
         "source_tier": "repo_assets"
       },
       {
         "package_name": "workbench_description",
-        "root_path": "/workspace/Easy_Manipulator_Improved/assets/environment/workbench_description",
+        "root_path": "assets/environment/workbench_description",
         "source_tier": "repo_assets"
       }
     ],
     "ros_resolution_attempts": [
       {
+        "package_name": "fanuc_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "fanuc_moveit_config",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "flat_plate_camera_bracket_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
         "package_name": "onrobot_airpick4_description",
         "attempts": [
           {
@@ -1740,97 +1797,7 @@
         ]
       },
       {
-        "package_name": "robotiq_3f_moveit_config",
-        "attempts": [
-          {
-            "source_tier": "ament_index",
-            "status": "unavailable",
-            "error": "ament_index_python.packages import unavailable"
-          },
-          {
-            "source_tier": "ros2_pkg_prefix",
-            "status": "unavailable",
-            "error": "ros2 executable unavailable"
-          }
-        ]
-      },
-      {
-        "package_name": "robotiq_3f_gripper_description",
-        "attempts": [
-          {
-            "source_tier": "ament_index",
-            "status": "unavailable",
-            "error": "ament_index_python.packages import unavailable"
-          },
-          {
-            "source_tier": "ros2_pkg_prefix",
-            "status": "unavailable",
-            "error": "ros2 executable unavailable"
-          }
-        ]
-      },
-      {
-        "package_name": "single_suction_description",
-        "attempts": [
-          {
-            "source_tier": "ament_index",
-            "status": "unavailable",
-            "error": "ament_index_python.packages import unavailable"
-          },
-          {
-            "source_tier": "ros2_pkg_prefix",
-            "status": "unavailable",
-            "error": "ros2 executable unavailable"
-          }
-        ]
-      },
-      {
-        "package_name": "single_suction_moveit_config",
-        "attempts": [
-          {
-            "source_tier": "ament_index",
-            "status": "unavailable",
-            "error": "ament_index_python.packages import unavailable"
-          },
-          {
-            "source_tier": "ros2_pkg_prefix",
-            "status": "unavailable",
-            "error": "ros2 executable unavailable"
-          }
-        ]
-      },
-      {
-        "package_name": "robotiq_85_moveit_config",
-        "attempts": [
-          {
-            "source_tier": "ament_index",
-            "status": "unavailable",
-            "error": "ament_index_python.packages import unavailable"
-          },
-          {
-            "source_tier": "ros2_pkg_prefix",
-            "status": "unavailable",
-            "error": "ros2 executable unavailable"
-          }
-        ]
-      },
-      {
-        "package_name": "fanuc_description",
-        "attempts": [
-          {
-            "source_tier": "ament_index",
-            "status": "unavailable",
-            "error": "ament_index_python.packages import unavailable"
-          },
-          {
-            "source_tier": "ros2_pkg_prefix",
-            "status": "unavailable",
-            "error": "ros2 executable unavailable"
-          }
-        ]
-      },
-      {
-        "package_name": "fanuc_moveit_config",
+        "package_name": "overhead_camera_gantry_description",
         "attempts": [
           {
             "source_tier": "ament_index",
@@ -1875,51 +1842,6 @@
         ]
       },
       {
-        "package_name": "ur3_moveit_config",
-        "attempts": [
-          {
-            "source_tier": "ament_index",
-            "status": "unavailable",
-            "error": "ament_index_python.packages import unavailable"
-          },
-          {
-            "source_tier": "ros2_pkg_prefix",
-            "status": "unavailable",
-            "error": "ros2 executable unavailable"
-          }
-        ]
-      },
-      {
-        "package_name": "ur10_moveit_config",
-        "attempts": [
-          {
-            "source_tier": "ament_index",
-            "status": "unavailable",
-            "error": "ament_index_python.packages import unavailable"
-          },
-          {
-            "source_tier": "ros2_pkg_prefix",
-            "status": "unavailable",
-            "error": "ros2 executable unavailable"
-          }
-        ]
-      },
-      {
-        "package_name": "ur5_moveit_config",
-        "attempts": [
-          {
-            "source_tier": "ament_index",
-            "status": "unavailable",
-            "error": "ament_index_python.packages import unavailable"
-          },
-          {
-            "source_tier": "ros2_pkg_prefix",
-            "status": "unavailable",
-            "error": "ros2 executable unavailable"
-          }
-        ]
-      },
-      {
         "package_name": "pipe_camera_stand_description",
         "attempts": [
           {
@@ -1935,7 +1857,7 @@
         ]
       },
       {
-        "package_name": "table_description",
+        "package_name": "robotiq_3f_gripper_description",
         "attempts": [
           {
             "source_tier": "ament_index",
@@ -1950,7 +1872,7 @@
         ]
       },
       {
-        "package_name": "vslot_camera_frame_description",
+        "package_name": "robotiq_3f_moveit_config",
         "attempts": [
           {
             "source_tier": "ament_index",
@@ -1965,52 +1887,7 @@
         ]
       },
       {
-        "package_name": "overhead_camera_gantry_description",
-        "attempts": [
-          {
-            "source_tier": "ament_index",
-            "status": "unavailable",
-            "error": "ament_index_python.packages import unavailable"
-          },
-          {
-            "source_tier": "ros2_pkg_prefix",
-            "status": "unavailable",
-            "error": "ros2 executable unavailable"
-          }
-        ]
-      },
-      {
-        "package_name": "tslot_camera_frame_description",
-        "attempts": [
-          {
-            "source_tier": "ament_index",
-            "status": "unavailable",
-            "error": "ament_index_python.packages import unavailable"
-          },
-          {
-            "source_tier": "ros2_pkg_prefix",
-            "status": "unavailable",
-            "error": "ros2 executable unavailable"
-          }
-        ]
-      },
-      {
-        "package_name": "flat_plate_camera_bracket_description",
-        "attempts": [
-          {
-            "source_tier": "ament_index",
-            "status": "unavailable",
-            "error": "ament_index_python.packages import unavailable"
-          },
-          {
-            "source_tier": "ros2_pkg_prefix",
-            "status": "unavailable",
-            "error": "ros2 executable unavailable"
-          }
-        ]
-      },
-      {
-        "package_name": "sorting_bin_description",
+        "package_name": "robotiq_85_moveit_config",
         "attempts": [
           {
             "source_tier": "ament_index",
@@ -2040,7 +1917,142 @@
         ]
       },
       {
+        "package_name": "single_suction_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "single_suction_moveit_config",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "sorting_bin_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
         "package_name": "table_clamp_camera_mount_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "table_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "tslot_camera_frame_description",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "ur10_moveit_config",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "ur3_moveit_config",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "ur5_moveit_config",
+        "attempts": [
+          {
+            "source_tier": "ament_index",
+            "status": "unavailable",
+            "error": "ament_index_python.packages import unavailable"
+          },
+          {
+            "source_tier": "ros2_pkg_prefix",
+            "status": "unavailable",
+            "error": "ros2 executable unavailable"
+          }
+        ]
+      },
+      {
+        "package_name": "vslot_camera_frame_description",
         "attempts": [
           {
             "source_tier": "ament_index",

--- a/scripts/extract_scene_urdf_visual_mesh_index.py
+++ b/scripts/extract_scene_urdf_visual_mesh_index.py
@@ -8,7 +8,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 SCENES_ROOT = ROOT / "scenes"
-EXTRACTOR_VERSION = "2.7"
+EXTRACTOR_VERSION = "2.8"
 UR5_VISUAL_MESH_URI_PREFIX = "package://ur_description/meshes/ur5/visual/"
 PLACEHOLDER_RE = re.compile(r"(\$\{[^}]+\}|\$\(arg\s+[^)]+\)|\$\(find\s+[^)]+\))")
 REPO_LOCAL_ASSET_PRECEDENCE_PACKAGES = {
@@ -55,6 +55,41 @@ def xyz_rpy_from_tf(tf):
     if abs(cp)>1e-8: roll=math.atan2(tf[2][1],tf[2][2]); yaw=math.atan2(tf[1][0],tf[0][0])
     else: roll=math.atan2(-tf[1][2],tf[1][1]); yaw=0.0
     return {"xyz":[x,y,z],"rpy":[roll,pitch,yaw]}
+
+
+
+def _repo_relative_path(path_value):
+    """Return a repository-relative path for repo-local filesystem paths.
+
+    Generated mesh indexes are committed artifacts, so they must not embed the
+    transient checkout directory (for example /workspace/...).  Keep external
+    absolute paths untouched, but make repo-local paths portable.
+    """
+    if path_value is None:
+        return ''
+    text = str(path_value)
+    if not text:
+        return ''
+    if text.startswith(('package://', 'http://', 'https://', 'model://')):
+        return text
+    path = Path(text)
+    if not path.is_absolute():
+        return text
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except Exception:
+        return text
+
+
+def _portable_source_metadata(value):
+    """Recursively strip the repo checkout prefix from generated metadata."""
+    if isinstance(value, dict):
+        return {key: _portable_source_metadata(child) for key, child in value.items()}
+    if isinstance(value, list):
+        return [_portable_source_metadata(child) for child in value]
+    if isinstance(value, str):
+        return _repo_relative_path(value)
+    return value
 
 def contains_placeholder(v): return bool(PLACEHOLDER_RE.search(json.dumps(v) if isinstance(v,(list,tuple,dict)) else str(v)))
 def sanitize(s): return re.sub(r'[^A-Za-z0-9_]+','_',str(s or 'unnamed')).strip('_') or 'unnamed'
@@ -162,7 +197,7 @@ def _fallback_package_candidates(scene_dir, workspace_root=None):
                 candidate['name_fallback']='directory_name'
                 candidate['parse_error']=parse_error
             candidates.append(candidate)
-    return candidates
+    return sorted(candidates, key=lambda c: (str(c.get('package_name', '')), str(c.get('root_path', '')), str(c.get('source_tier', ''))))
 
 def _record_package_resolution(out, diagnostics, candidate):
     pkg_name = candidate['package_name']
@@ -541,7 +576,8 @@ def append_static_ur5_mesh_visuals(items, package_map):
             'primitive_fallback': False,
             'fallback_reason': '',
             'source_path': package_uri,
-            'resolved_source_path': resolved_path,
+            'resolved_source_path': _repo_relative_path(resolved_path),
+            'resolved_source_path_is_repo_relative': bool(resolved_path and _repo_relative_path(resolved_path) != str(resolved_path)),
             'package_uri': package_uri,
             'mesh_scale': [1.0, 1.0, 1.0],
             'material': {'name': 'scene3d_static_robot_mesh', 'color': None},
@@ -710,7 +746,7 @@ def extract_from_urdf(xml_text, package_map):
             if mesh is not None:
                 mesh_uri=mesh.attrib.get('filename',''); resolved_path, skip_reason=resolve_mesh_uri(mesh_uri, package_map)
                 scale=parse_vec(mesh.attrib.get('scale','1 1 1'),3,1.0)
-                items.append({**common,'geometry_type':'mesh','package_uri':mesh_uri if mesh_uri.startswith('package://') else '','source_path':mesh_uri,'resolved_source_path':resolved_path,'resolved':bool(resolved_path and not skip_reason),'mesh_scale':scale,'render_expected':not bool(skip_reason),'render_skip_reason':skip_reason,'warning':(skip_reason or warning or '')})
+                items.append({**common,'geometry_type':'mesh','package_uri':mesh_uri if mesh_uri.startswith('package://') else '','source_path':mesh_uri,'resolved_source_path':_repo_relative_path(resolved_path),'resolved_source_path_is_repo_relative': bool(resolved_path and _repo_relative_path(resolved_path) != str(resolved_path)),'resolved':bool(resolved_path and not skip_reason),'mesh_scale':scale,'render_expected':not bool(skip_reason),'render_skip_reason':skip_reason,'warning':(skip_reason or warning or '')})
             elif box is not None:
                 items.append({**common,'geometry_type':'box','size':parse_vec(box.attrib.get('size','0.1 0.1 0.1'),3,0.1),'resolved':True,'warning':warning or ''})
             elif cyl is not None:
@@ -782,7 +818,7 @@ def main():
         renderable_mesh_count=sum(1 for i in items if i.get('geometry_type')=='mesh' and i.get('render_expected', True))
         source_mtime=urdf_path.stat().st_mtime if urdf_path.exists() else None
         has_transform_collapse_warning=bool(items) and len({tuple((i.get('pose') or {}).get('xyz') or []) for i in items}) <= 1 and len(items) > 1
-        payload={'scene_name':scene_dir.name,'visual_count':len(items),'resolved':sum(1 for i in items if i.get('resolved')),'unresolved':sum(1 for i in items if not i.get('resolved')),'generated_at':datetime.now(timezone.utc).isoformat(),'extractor_version':EXTRACTOR_VERSION,'extraction_mode':mode,'xacro_available':xacro_avail,'source_urdf_xacro_path':str(urdf_path),'source_mtime':source_mtime,'source_expanded_urdf_path':expanded_path,'fallback_reason':fallback_reason,'xacro_real_command_succeeded':real_xacro_command_succeeded,'safe_for_preview':safe,'unresolved_placeholder_count':len(unresolved),'has_transform_collapse_warning':has_transform_collapse_warning,'candidate_mesh_count':len(items),'emitted_visual_count':len(items),'transform_status_counts':transform_status_counts,'mesh_format_counts':mesh_format_counts,'renderable_mesh_count':renderable_mesh_count,'renderable_item_count':renderable_count,'static_robot_primitive_fallback_count':static_robot_fallback_count,'static_robot_mesh_visual_count':static_robot_mesh_count,'static_parent_resolved_count':static_parent_resolved_count,'stale_index':False,'stale_reasons':[],'visual_items':items,'xacro_command':xacro_cmd,'package_resolution_diagnostics':package_diagnostics}
+        payload={'scene_name':scene_dir.name,'visual_count':len(items),'resolved':sum(1 for i in items if i.get('resolved')),'unresolved':sum(1 for i in items if not i.get('resolved')),'generated_at':datetime.now(timezone.utc).isoformat(),'extractor_version':EXTRACTOR_VERSION,'path_reference_root':'repository','extraction_mode':mode,'xacro_available':xacro_avail,'source_urdf_xacro_path':_repo_relative_path(urdf_path),'source_mtime':source_mtime,'source_expanded_urdf_path':_repo_relative_path(expanded_path),'fallback_reason':fallback_reason,'xacro_real_command_succeeded':real_xacro_command_succeeded,'safe_for_preview':safe,'unresolved_placeholder_count':len(unresolved),'has_transform_collapse_warning':has_transform_collapse_warning,'candidate_mesh_count':len(items),'emitted_visual_count':len(items),'transform_status_counts':transform_status_counts,'mesh_format_counts':mesh_format_counts,'renderable_mesh_count':renderable_mesh_count,'renderable_item_count':renderable_count,'static_robot_primitive_fallback_count':static_robot_fallback_count,'static_robot_mesh_visual_count':static_robot_mesh_count,'static_parent_resolved_count':static_parent_resolved_count,'stale_index':False,'stale_reasons':[],'visual_items':items,'xacro_command':_portable_source_metadata(xacro_cmd),'package_resolution_diagnostics':_portable_source_metadata(package_diagnostics)}
         idx_path=scene_dir/'generated/scene_visual_mesh_index.json'
         if not a.no_write:
             idx_path.parent.mkdir(parents=True,exist_ok=True)

--- a/scripts/generate_workcell_from_cell_definition.py
+++ b/scripts/generate_workcell_from_cell_definition.py
@@ -54,6 +54,34 @@ def _load_module(module_name: str, module_path: Path):
     return module
 
 
+
+
+def _repo_relative_path(path_value: Any) -> str:
+    if path_value is None:
+        return ""
+    text = str(path_value)
+    if not text:
+        return ""
+    if text.startswith(("package://", "http://", "https://", "model://")):
+        return text
+    path = Path(text)
+    if not path.is_absolute():
+        return text
+    try:
+        return path.resolve().relative_to(REPO_ROOT).as_posix()
+    except Exception:
+        return text
+
+
+def _portable_source_metadata(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _portable_source_metadata(child) for key, child in value.items()}
+    if isinstance(value, list):
+        return [_portable_source_metadata(child) for child in value]
+    if isinstance(value, str):
+        return _repo_relative_path(value)
+    return value
+
 def _yaml_text_from(scene_generator: Any, data: Any) -> str:
     return str(scene_generator._to_yaml_text(data))
 
@@ -755,6 +783,7 @@ def _fallback_scene_visual_mesh_index(
         "resolved": 0,
         "unresolved": 0,
         "extractor_version": "fallback",
+        "path_reference_root": "repository",
         "extraction_mode": "fallback_empty_safe_preview",
         "source_urdf_xacro_path": "urdf/scene.urdf.xacro",
         "source_mtime": urdf_path.stat().st_mtime if urdf_path.exists() else None,
@@ -771,7 +800,7 @@ def _fallback_scene_visual_mesh_index(
         "stale_index": False,
         "stale_reasons": [],
         "package_resolution_diagnostics": {"resolved_packages": [], "shadowed_packages": [], "resolution_paths": []},
-        "generated_package_dir": str(package_dir),
+        "generated_package_dir": _repo_relative_path(package_dir),
     }
 
 
@@ -869,6 +898,7 @@ def _write_scene_visual_mesh_index(
             "resolved": sum(1 for item in items if item.get("resolved")),
             "unresolved": sum(1 for item in items if not item.get("resolved")),
             "extractor_version": getattr(extractor, "EXTRACTOR_VERSION", "unknown"),
+            "path_reference_root": "repository",
             "extraction_mode": mode,
             "xacro_available": extractor.discover_xacro_command()[1],
             "source_urdf_xacro_path": "urdf/scene.urdf.xacro",
@@ -881,20 +911,20 @@ def _write_scene_visual_mesh_index(
             "emitted_visual_count": len(items),
             "renderable_mesh_count": renderable_mesh_count,
             "renderable_item_count": renderable_item_count,
-            "visual_items": items,
-            "items": items,
+            "visual_items": _portable_source_metadata(items),
+            "items": _portable_source_metadata(items),
             "blockers": [],
             "warnings": [fallback_reason] if fallback_reason else [],
             "stale_index": False,
             "stale_reasons": [],
-            "xacro_command": xacro_cmd,
-            "workspace_root": str(resolved_workspace_root) if resolved_workspace_root else "",
+            "xacro_command": _portable_source_metadata(xacro_cmd),
+            "workspace_root": _repo_relative_path(resolved_workspace_root) if resolved_workspace_root else "",
             "visual_readiness": {
                 "status": visual_readiness_status,
                 "reasons": visual_readiness_reasons,
             },
             "status": visual_readiness_status,
-            "package_resolution_diagnostics": package_diagnostics,
+            "package_resolution_diagnostics": _portable_source_metadata(package_diagnostics),
         }
         generated_dir.mkdir(parents=True, exist_ok=True)
         index_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Generated visual-mesh metadata embedded absolute checkout paths which polluted committed artifacts and produced noisy absolute-path warnings in readiness checks. 
- The mesh index payload must preserve `package://` URIs while making repo-local filesystem paths portable so committed JSONs do not contain `/workspace/...` checkout roots. 
- Keep fake-hardware-first safety and existing runtime launch defaults unchanged while improving artifact portability.

### Description
- Added helpers `_repo_relative_path` and `_portable_source_metadata` to `scripts/extract_scene_urdf_visual_mesh_index.py` to emit repo-relative `resolved_source_path` for repo-local assets and to preserve `package://`, `http(s)://`, and other URIs. 
- Augmented mesh item objects with a new boolean `resolved_source_path_is_repo_relative` and added top-level `path_reference_root: "repository"` and portable `source_urdf_xacro_path`/`xacro_command` normalization. 
- Applied the same portability functions in `scripts/generate_workcell_from_cell_definition.py` for fallback and generated payloads so future writes avoid checkout-root absolutes. 
- Regenerated only `scenes/ur5_2f_test/generated/scene_visual_mesh_index.json`, preserving `package_uri` values while replacing repo-local absolute `resolved_source_path` values with repository-relative paths and making xacro entries portable.

### Testing
- Compiled modified scripts with `python3 -m py_compile scripts/extract_scene_urdf_visual_mesh_index.py scripts/generate_workcell_from_cell_definition.py` and the compile step passed. 
- Ran the extractor `python3 scripts/extract_scene_urdf_visual_mesh_index.py --scene ur5_2f_test --prefer-xacro-expanded` and the command completed successfully producing a portable index. 
- Verified no occurrences of the checkout root with `rg -n "/workspace/Easy_Manipulator_Improved|/workspace/" scenes/ur5_2f_test/generated/scene_visual_mesh_index.json` (no matches). 
- Executed readiness checks: `python3 scripts/check_scene_readiness.py --scene-package scenes/ur5_2f_test --json` and `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --repo-root /workspace/Easy_Manipulator_Improved --workspace-root /workspace/Easy_Manipulator_Improved --output-dir build/workcell_studio_scene_readiness`; the mesh-index absolute-path warnings for `generated/scene_visual_mesh_index.json` dropped to zero while remaining absolute warnings in `generated/scene_package_readiness.json` persist because that artifact was not regenerated in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bcf3d06048331a97dd1965eb2b658)