### PR TITLE
Fix Scene3D build by forward-declaring `is_locked_urdf_item`

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -582,6 +582,8 @@ bool is_generated_urdf_visual_item(const ScenePreviewWidget::PreviewItem & it)
   return false;
 }
 
+bool is_locked_urdf_item(const ScenePreviewWidget::PreviewItem & it);
+
 QString clean_label_from_item(const ScenePreviewWidget::PreviewItem & it)
 {
   QString label = it.display_name.trimmed();
@@ -692,7 +694,6 @@ NormalizedRole classify_item_role(const ScenePreviewWidget::PreviewItem & it)
 
 
 bool is_overlay_only_item(const ScenePreviewWidget::PreviewItem & it);
-bool is_locked_urdf_item(const ScenePreviewWidget::PreviewItem & it);
 
 
 bool include_in_fit_bounds(const ScenePreviewWidget::PreviewItem & it, bool include_overlays)


### PR DESCRIPTION
### Motivation
- A real ROS Humble build failed because `item_visual_ownership_label` referenced `is_locked_urdf_item` before that predicate was visible in the translation unit, causing a compilation error that blocks `workcell_builder` readiness work.  The change restores correct declaration ordering so existing ownership labeling logic can be reused.  

### Description
- Added a forward declaration `bool is_locked_urdf_item(const ScenePreviewWidget::PreviewItem & it);` before the ownership/labeling helpers in `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp` so `item_visual_ownership_label` can reuse the existing `is_locked_urdf_item` predicate without modifying its implementation or behavior.  

### Testing
- Ran `rg -n "is_locked_urdf_item|is_generated_urdf_visual_item|item_visual_ownership_label|item_is_editable_for_gizmo"` and a Python check that confirmed the forward declaration now precedes the ownership label use and that the label strings (`"Generated / locked preview"`, `"Editable layout"`) remain present, and these static checks passed; attempted `colcon build`/`colcon test` but they could not be executed in this container because `ROS Humble` and `colcon` are not available, so runtime build/test were not run here; no readiness artifacts were regenerated and no runtime/hardware or launch behavior was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bee559ae08331ae7bc4a4e7a9a7ed)