### PR TITLE
Scene3D: fallback to active viewport render evidence for log readiness

### DIFF
--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -498,8 +498,17 @@ private:
     const bool hierarchy_ready = (tree != nullptr && hierarchy_child_rows > 0);
     const bool selected_scene_ready = !selected_scene_name.trimmed().isEmpty() && selected_scene_name != "(none)" && selected_scene_name != "none";
     const bool inspector_ready = (inspector != nullptr && !inspector_no_scene_selected && selected_scene_ready);
-    const bool log_ready = (log != nullptr && has_valid_runtime_scene3d_diagnostics(parse_latest_scene3d_diagnostics(log->toPlainText())));
+    const QJsonObject parsed_runtime_diagnostics =
+      log ? parse_latest_scene3d_diagnostics(log->toPlainText()) : QJsonObject{};
+    const bool parsed_log_ready =
+      log != nullptr && has_valid_runtime_scene3d_diagnostics(parsed_runtime_diagnostics);
     const auto rc = viewport ? viewport->render_debug_counters() : Scene3DViewportWidget::RenderDebugCounters{};
+    const bool viewport_runtime_render_evidence =
+      viewport != nullptr &&
+      rc.viewport_received_count > 0 &&
+      rc.rendered_count > 0 &&
+      rc.visible_count > 0;
+    const bool log_ready = parsed_log_ready || viewport_runtime_render_evidence;
     const bool screenshot_saved = latest_counters_.value("screenshot_saved").toBool(false);
     const bool paint_completed = paint_cycle_completed(rc, screenshot_saved);
     const bool render_ready =


### PR DESCRIPTION
### Motivation
- Ensure `readiness_markers.log_ready` is true only when runtime Scene3D diagnostics match the requested scene or when the active Scene3D viewport provides concrete render evidence, so scenes like `ur5_2f_test` are marked ready only with real Scene3D runtime evidence.

### Description
- Update `Scene3DSmokeRunner::collect_readiness_markers()` in `workcell_builder/workcell_builder/gui/main.cpp` to keep parsed `studioHomeLog` diagnostics gated through `parse_latest_scene3d_diagnostics()` and `has_valid_runtime_scene3d_diagnostics()`, and add an active-viewport fallback that uses `resolve_active_scene3d_viewport()` and `Scene3DViewportWidget::RenderDebugCounters` requiring `viewport_received_count > 0`, `rendered_count > 0`, and `visible_count > 0` before marking `log_ready`.

### Testing
- Code checks passed and the change is limited to `collect_readiness_markers()` and related runtime-visibility logic, and an attempted build with `colcon build --symlink-install --packages-select workcell_builder` could not be run because the container lacks ROS Humble (`/opt/ros/humble/setup.bash` not present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ffe3a3ac88331827dafcbffa80e58)