### PR TITLE
Attempt package:// resolution for stale resolved_source_path and record diagnostics

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -8271,8 +8271,32 @@ void MainWindow::populate_scene_hierarchy()
           if (geometry_type == "mesh") {
             if (p.mesh_path.trimmed().isEmpty()) {
               QStringList tried_candidates;
-              const QString resolved_mesh_path = resolve_visual_mesh_source_path(
-                p.source_path, package_uri, d, detect_workspace_root(), &tried_candidates);
+              const QString workspace_root = detect_workspace_root();
+              QString resolved_mesh_path;
+              const bool should_try_package_uri_after_stale_resolved_source_path =
+                p.resolved_source_path_stale && package_uri.trimmed().startsWith(QStringLiteral("package://"));
+              if (should_try_package_uri_after_stale_resolved_source_path) {
+                resolved_mesh_path = resolve_visual_mesh_source_path(
+                  QString(), package_uri, d, workspace_root, &tried_candidates);
+                if (!resolved_mesh_path.trimmed().isEmpty()) {
+                  const QFileInfo resolved_mesh_info(resolved_mesh_path);
+                  if (resolved_mesh_info.exists() && resolved_mesh_info.isFile()) {
+                    p.source_path_resolution_outcome =
+                      QStringLiteral("resolved_via_package_uri_after_stale_resolved_source_path");
+                    ++package_uri_resolved_by_loader;
+                    ++package_uri_resolved_after_stale_resolved_source_path;
+                    append_studio_log(QString(
+                      "URDF visual resolution outcome for %1: resolved_source_path=%2 package_uri=%3 outcome=%4 source_path=%5")
+                      .arg(p.id, resolved_source_path, package_uri, p.source_path_resolution_outcome, resolved_mesh_path));
+                  } else {
+                    resolved_mesh_path.clear();
+                  }
+                }
+              }
+              if (resolved_mesh_path.trimmed().isEmpty()) {
+                resolved_mesh_path = resolve_visual_mesh_source_path(
+                  p.source_path, package_uri, d, workspace_root, &tried_candidates);
+              }
               if (unsupported_format) {
                 mesh_fallback = true;
               } else if (resolved_mesh_path.trimmed().isEmpty()) {

--- a/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
@@ -89,6 +89,17 @@ TEST(Scene3DMeshPreviewRegression, KeepsMeshLoadFailureReasonDiagnostics)
   EXPECT_NE(src.find("ensure_mesh_cached(item, mesh_source)"), std::string::npos);
 }
 
+TEST(Scene3DMeshPreviewRegression, KeepsStaleResolvedSourcePathPackageUriDiagnostics)
+{
+  const std::string src = load_file(std::string(WORKCELL_BUILDER_SOURCE_DIR) + "/gui/mainwindow.cpp");
+  ASSERT_FALSE(src.empty());
+  EXPECT_NE(src.find("should_try_package_uri_after_stale_resolved_source_path"), std::string::npos);
+  EXPECT_NE(src.find("resolved_via_package_uri_after_stale_resolved_source_path"), std::string::npos);
+  EXPECT_NE(src.find("package_uri_resolved_by_loader"), std::string::npos);
+  EXPECT_NE(src.find("package_uri_resolved_after_stale_resolved_source_path"), std::string::npos);
+  EXPECT_NE(src.find("stale_resolved_source_path_unresolved_after_package_uri_attempt"), std::string::npos);
+}
+
 TEST(Scene3DMeshPreviewRegression, KeepsSceneAuthoringSemanticPrimitiveAssembly)
 {
   const std::string src = load_file(std::string(WORKCELL_BUILDER_SOURCE_DIR) + "/gui/mainwindow.cpp");


### PR DESCRIPTION
### Motivation
- Preserve the `resolved_source_path` stale marker when the original file is missing and allow a subsequent `package://` lookup to succeed for the same item instead of masking the stale state. 
- Ensure we only treat a `package://` resolution as successful when the resolved mesh file actually exists on disk so genuinely-missing Robotiq/other meshes still warn and fall back to primitives.

### Description
- When `p.resolved_source_path_stale` is true and `p.package_uri` begins with `package://`, attempt an early package lookup using `resolve_visual_mesh_source_path` and the workspace cache before the regular mesh-source resolution path. 
- If that package lookup returns an existing file, set `p.source_path_resolution_outcome = "resolved_via_package_uri_after_stale_resolved_source_path"`, increment `package_uri_resolved_by_loader` and `package_uri_resolved_after_stale_resolved_source_path`, and append the diagnostic log entry. 
- Only apply the package-based success path after verifying the resolved mesh file exists; otherwise continue the normal resolution/fallback logic so missing Robotiq meshes still produce warnings and use primitive fallback. 
- Added a small regression guard test `KeepsStaleResolvedSourcePathPackageUriDiagnostics` to ensure the new diagnostic tokens and counters remain present in the source.

### Testing
- Ran a source-token check that validated the new diagnostic tokens and counter increments are present in `gui/mainwindow.cpp`, which passed. 
- Ran `git diff --check` and commit checks, which passed. 
- Attempted `colcon build` for `workcell_builder` but could not run because `/opt/ros/humble/setup.bash` is not available in this container, so full build/tests were not executed here. 
- No runtime or hardware-related files were changed and fake-hardware defaults remain unmodified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3017a9f3b8833190785733a157ff93)