### PR TITLE
Add visual mesh URI resolver coverage and extract resolver helper

### DIFF
--- a/workcell_builder/workcell_builder/CMakeLists.txt
+++ b/workcell_builder/workcell_builder/CMakeLists.txt
@@ -186,7 +186,9 @@ add_executable(workcell_builder
     src_workspace_validation.cpp
     src_workcell_builder_command_builders.cpp
     src_rviz_preview_runner.cpp
-    include/rviz_preview_runner.hpp)
+    src_visual_mesh_source_resolver.cpp
+    include/rviz_preview_runner.hpp
+    include/visual_mesh_source_resolver.hpp)
 target_sources(workcell_builder PRIVATE src_workcell_yaml_utils.cpp)
 
 ament_target_dependencies(workcell_builder
@@ -347,6 +349,9 @@ if(BUILD_TESTING)
     gui/asset_catalog_discovery.cpp
     src_workcell_warning_once.cpp
     src_workcell_yaml_utils.cpp)
+  ament_add_gtest(workcell_visual_mesh_source_resolver_test
+    test/visual_mesh_source_resolver_test.cpp
+    src_visual_mesh_source_resolver.cpp)
   ament_add_gtest(workcell_transform_clipboard_utils_test
     test/transform_clipboard_utils_test.cpp
     gui/transform_clipboard_utils.cpp)
@@ -393,6 +398,13 @@ if(BUILD_TESTING)
     target_link_libraries(workcell_asset_catalog_discovery_test yaml-cpp ${Boost_LIBRARIES})
     target_include_directories(workcell_asset_catalog_discovery_test PRIVATE gui)
   endif()
+  if(TARGET workcell_visual_mesh_source_resolver_test)
+    target_link_libraries(workcell_visual_mesh_source_resolver_test Qt5::Core ${Boost_LIBRARIES})
+    target_include_directories(workcell_visual_mesh_source_resolver_test PRIVATE ${Boost_INCLUDE_DIRS} include)
+    target_compile_definitions(workcell_visual_mesh_source_resolver_test PRIVATE
+      WORKCELL_BUILDER_REPO_ROOT="${CMAKE_CURRENT_SOURCE_DIR}/../..")
+  endif()
+
   if(TARGET workcell_transform_clipboard_utils_test)
     target_link_libraries(workcell_transform_clipboard_utils_test Qt5::Core)
     target_include_directories(workcell_transform_clipboard_utils_test PRIVATE gui)
@@ -593,6 +605,7 @@ if(BUILD_TESTING)
     layout_serialization_contract_test.cpp
     workcell_studio_layout_editor_test.cpp
     mainwindow_rviz_preview_compile_test.cpp
+    visual_mesh_source_resolver_test.cpp
   )
 
   file(GLOB workcell_builder_discovered_cpp_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/test ${CMAKE_CURRENT_SOURCE_DIR}/test/*.cpp)

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -14,6 +14,7 @@
 
 #include "gui/mainwindow.h"
 #include "gui/scene3d_viewport_widget.h"
+#include "visual_mesh_source_resolver.hpp"
 #include <QFileDialog>
 #include <QAction>
 #include <QCoreApplication>
@@ -133,6 +134,9 @@
 #include "include/rviz_preview_runner.hpp"
 #include "gui/asset_catalog_discovery.h"
 #include "gui/transform_clipboard_utils.h"
+
+using workcell_builder::resolve_visual_mesh_source_path;
+using workcell_builder::workcell_builder_repo_root_from_source;
 
 static QStringList generation_asset_support_preflight(const fs::path & layout_path, bool * severe_failure);
 
@@ -578,143 +582,6 @@ static LayoutStateModel derive_layout_state_model(const fs::path & scene_dir, co
 }
 
 
-static fs::path workcell_builder_repo_root_from_source()
-{
-  fs::path cursor = fs::path(__FILE__).parent_path();
-  for (int depth = 0; depth < 8 && !cursor.empty(); ++depth) {
-    if (fs::exists(cursor / "assets") && fs::exists(cursor / "workcell_builder")) {
-      return cursor;
-    }
-    if (cursor == cursor.parent_path()) break;
-    cursor = cursor.parent_path();
-  }
-  return fs::path(__FILE__).parent_path().parent_path().parent_path().parent_path();
-}
-
-static bool visual_mesh_package_root_exists(const fs::path & package_root)
-{
-  return fs::exists(package_root / "package.xml") ||
-         fs::exists(package_root / "meshes") ||
-         fs::exists(package_root / "urdf") ||
-         fs::exists(package_root / "dae") ||
-         fs::exists(package_root / "stl");
-}
-
-static QMap<QString, QString> discover_visual_mesh_package_map(const fs::path & scene_dir, const QString & workspace_root)
-{
-  QMap<QString, QString> package_map;
-  auto add_package_root = [&](const QString & package_name, const fs::path & package_root) {
-    if (package_name.trimmed().isEmpty()) return;
-    if (!visual_mesh_package_root_exists(package_root)) return;
-    if (!package_map.contains(package_name)) {
-      package_map.insert(package_name, QString::fromStdString(package_root.string()));
-    }
-  };
-  auto scan_root = [&](const QString & root) {
-    if (root.trimmed().isEmpty()) return;
-    const QDir base(root);
-    if (!base.exists()) return;
-    QDirIterator it(root, QStringList() << "package.xml", QDir::Files, QDirIterator::Subdirectories);
-    while (it.hasNext()) {
-      const QString package_xml = it.next();
-      const QFileInfo info(package_xml);
-      const QString package_root = info.dir().absolutePath();
-      const QString package_name = QFileInfo(package_root).fileName();
-      if (package_name.trimmed().isEmpty()) continue;
-      if (!package_map.contains(package_name)) package_map.insert(package_name, package_root);
-    }
-  };
-
-  const fs::path repo_root = workcell_builder_repo_root_from_source();
-  add_package_root(
-    QStringLiteral("robotiq_85_description"),
-    repo_root / "assets/end_effectors/robotiq_85_gripper/robotiq_85_description");
-  add_package_root(
-    QStringLiteral("workbench_description"),
-    repo_root / "assets/environment/workbench_description");
-  add_package_root(
-    QStringLiteral("realsense2_description"),
-    repo_root / "assets/environment/realsense2_description");
-
-  const QString ws = workspace_root.trimmed();
-  scan_root(QString::fromStdString((scene_dir / "generated").string()));
-  scan_root(ws + "/install/share");
-  scan_root(ws + "/src");
-  scan_root(ws + "/src/easy_manipulation_deployment/assets");
-  scan_root(ws + "/src/assets");
-  scan_root(QString::fromStdString((repo_root / "assets").string()));
-  scan_root(QString::fromStdString((repo_root / "assets/environment").string()));
-  scan_root(QString::fromStdString((repo_root / "assets/robots").string()));
-  scan_root(QString::fromStdString((repo_root / "assets/end_effectors").string()));
-  const fs::path universal_robot_assets = repo_root / "assets/robots/universal_robot";
-  const fs::path ur_description_assets = universal_robot_assets / "ur_description";
-  if (!package_map.contains(QStringLiteral("ur_description"))) {
-    if (fs::exists(ur_description_assets / "meshes/ur5/visual")) {
-      package_map.insert(QStringLiteral("ur_description"), QString::fromStdString(ur_description_assets.string()));
-    } else if (fs::exists(universal_robot_assets / "meshes/ur5/visual")) {
-      package_map.insert(QStringLiteral("ur_description"), QString::fromStdString(universal_robot_assets.string()));
-    }
-  }
-  scan_root(QStringLiteral("/opt/ros/humble/share"));
-  return package_map;
-}
-
-static QString resolve_visual_mesh_source_path(
-  const QString & raw_path, const QString & package_uri, const fs::path & scene_dir,
-  const QString & workspace_root, QStringList * tried_candidates)
-{
-  const auto add_candidate = [&](const QString & candidate) {
-    if (tried_candidates) tried_candidates->push_back(candidate);
-    const QFileInfo info(candidate);
-    if (!info.exists() || !info.isFile()) return QString();
-    const QString canonical = info.canonicalFilePath();
-    return canonical.isEmpty() ? info.absoluteFilePath() : canonical;
-  };
-  auto as_repo_relative = [&](const QString & rel) {
-    return QString::fromStdString((workcell_builder_repo_root_from_source() / rel.toStdString()).string());
-  };
-  auto as_scene_relative = [&](const QString & rel) {
-    return QString::fromStdString((scene_dir / rel.toStdString()).string());
-  };
-
-  const QString trimmed_raw = raw_path.trimmed();
-  if (!trimmed_raw.isEmpty()) {
-    QFileInfo raw_info(trimmed_raw);
-    if (raw_info.isAbsolute()) {
-      const QString resolved = add_candidate(raw_info.absoluteFilePath());
-      if (!resolved.isEmpty()) return resolved;
-    } else {
-      const QString repo_resolved = add_candidate(as_repo_relative(trimmed_raw));
-      if (!repo_resolved.isEmpty()) return repo_resolved;
-      const QString scene_resolved = add_candidate(as_scene_relative(trimmed_raw));
-      if (!scene_resolved.isEmpty()) return scene_resolved;
-    }
-  }
-
-  const QString trimmed_uri = package_uri.trimmed();
-  if (trimmed_uri.startsWith("package://")) {
-    const QString package_tail = trimmed_uri.mid(QString("package://").size());
-    const int slash = package_tail.indexOf('/');
-    const QString package_name = (slash >= 0) ? package_tail.left(slash) : package_tail;
-    const QString package_rel = (slash >= 0) ? package_tail.mid(slash + 1) : QString();
-    static QHash<QString, QMap<QString, QString>> workspace_cache;
-    const QString cache_key = QString::fromStdString(scene_dir.string()) + "::" + workspace_root;
-    if (!workspace_cache.contains(cache_key)) workspace_cache.insert(cache_key, discover_visual_mesh_package_map(scene_dir, workspace_root));
-    const QMap<QString, QString> package_map = workspace_cache.value(cache_key);
-    const QString package_root = package_map.value(package_name);
-    if (!package_root.trimmed().isEmpty()) {
-      const QString resolved = add_candidate(QDir(package_root).filePath(package_rel));
-      if (!resolved.isEmpty()) return resolved;
-    }
-  } else if (trimmed_uri.startsWith("file://")) {
-    const QString resolved = add_candidate(trimmed_uri.mid(7));
-    if (!resolved.isEmpty()) return resolved;
-  } else if (trimmed_uri.startsWith("/")) {
-    const QString resolved = add_candidate(trimmed_uri);
-    if (!resolved.isEmpty()) return resolved;
-  }
-  return QString();
-}
 
 static SceneTaskIntentSummary load_scene_task_intent_summary(const fs::path & scene_dir)
 {
@@ -5525,6 +5392,9 @@ void MainWindow::mark_layout_dirty(const QString & reason)
     layout_state_label_->setText(QString("Unsaved Layout Edits: %1").arg(reason));
   }
 }
+
+using workcell_builder::resolve_visual_mesh_source_path;
+using workcell_builder::workcell_builder_repo_root_from_source;
 
 static QStringList generation_asset_support_preflight(const fs::path & layout_path, bool * severe_failure)
 {

--- a/workcell_builder/workcell_builder/include/visual_mesh_source_resolver.hpp
+++ b/workcell_builder/workcell_builder/include/visual_mesh_source_resolver.hpp
@@ -1,0 +1,34 @@
+// Copyright 2026 Mukaram01
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef WORKCELL_BUILDER_VISUAL_MESH_SOURCE_RESOLVER_HPP_
+#define WORKCELL_BUILDER_VISUAL_MESH_SOURCE_RESOLVER_HPP_
+
+#include <boost/filesystem.hpp>
+#include <QString>
+#include <QStringList>
+
+namespace workcell_builder
+{
+
+boost::filesystem::path workcell_builder_repo_root_from_source();
+
+QString resolve_visual_mesh_source_path(
+  const QString & raw_path, const QString & package_uri,
+  const boost::filesystem::path & scene_dir, const QString & workspace_root,
+  QStringList * tried_candidates = nullptr);
+
+}  // namespace workcell_builder
+
+#endif  // WORKCELL_BUILDER_VISUAL_MESH_SOURCE_RESOLVER_HPP_

--- a/workcell_builder/workcell_builder/src_visual_mesh_source_resolver.cpp
+++ b/workcell_builder/workcell_builder/src_visual_mesh_source_resolver.cpp
@@ -1,0 +1,167 @@
+// Copyright 2026 Mukaram01
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "visual_mesh_source_resolver.hpp"
+
+#include <QDir>
+#include <QDirIterator>
+#include <QFileInfo>
+#include <QHash>
+#include <QMap>
+#include <QStringList>
+
+namespace fs = boost::filesystem;
+
+namespace workcell_builder
+{
+
+boost::filesystem::path workcell_builder_repo_root_from_source()
+{
+  fs::path cursor = fs::path(__FILE__).parent_path();
+  for (int depth = 0; depth < 8 && !cursor.empty(); ++depth) {
+    if (fs::exists(cursor / "assets") && fs::exists(cursor / "workcell_builder")) {
+      return cursor;
+    }
+    if (cursor == cursor.parent_path()) break;
+    cursor = cursor.parent_path();
+  }
+  return fs::path(__FILE__).parent_path().parent_path().parent_path().parent_path();
+}
+
+static bool visual_mesh_package_root_exists(const fs::path & package_root)
+{
+  return fs::exists(package_root / "package.xml") ||
+         fs::exists(package_root / "meshes") ||
+         fs::exists(package_root / "urdf") ||
+         fs::exists(package_root / "dae") ||
+         fs::exists(package_root / "stl");
+}
+
+static QMap<QString, QString> discover_visual_mesh_package_map(const fs::path & scene_dir, const QString & workspace_root)
+{
+  QMap<QString, QString> package_map;
+  auto add_package_root = [&](const QString & package_name, const fs::path & package_root) {
+    if (package_name.trimmed().isEmpty()) return;
+    if (!visual_mesh_package_root_exists(package_root)) return;
+    if (!package_map.contains(package_name)) {
+      package_map.insert(package_name, QString::fromStdString(package_root.string()));
+    }
+  };
+  auto scan_root = [&](const QString & root) {
+    if (root.trimmed().isEmpty()) return;
+    const QDir base(root);
+    if (!base.exists()) return;
+    QDirIterator it(root, QStringList() << "package.xml", QDir::Files, QDirIterator::Subdirectories);
+    while (it.hasNext()) {
+      const QString package_xml = it.next();
+      const QFileInfo info(package_xml);
+      const QString package_root = info.dir().absolutePath();
+      const QString package_name = QFileInfo(package_root).fileName();
+      if (package_name.trimmed().isEmpty()) continue;
+      if (!package_map.contains(package_name)) package_map.insert(package_name, package_root);
+    }
+  };
+
+  const fs::path repo_root = workcell_builder_repo_root_from_source();
+  add_package_root(
+    QStringLiteral("robotiq_85_description"),
+    repo_root / "assets/end_effectors/robotiq_85_gripper/robotiq_85_description");
+  add_package_root(
+    QStringLiteral("workbench_description"),
+    repo_root / "assets/environment/workbench_description");
+  add_package_root(
+    QStringLiteral("realsense2_description"),
+    repo_root / "assets/environment/realsense2_description");
+
+  const QString ws = workspace_root.trimmed();
+  scan_root(QString::fromStdString((scene_dir / "generated").string()));
+  scan_root(ws + "/install/share");
+  scan_root(ws + "/src");
+  scan_root(ws + "/src/easy_manipulation_deployment/assets");
+  scan_root(ws + "/src/assets");
+  scan_root(QString::fromStdString((repo_root / "assets").string()));
+  scan_root(QString::fromStdString((repo_root / "assets/environment").string()));
+  scan_root(QString::fromStdString((repo_root / "assets/robots").string()));
+  scan_root(QString::fromStdString((repo_root / "assets/end_effectors").string()));
+  const fs::path universal_robot_assets = repo_root / "assets/robots/universal_robot";
+  const fs::path ur_description_assets = universal_robot_assets / "ur_description";
+  if (!package_map.contains(QStringLiteral("ur_description"))) {
+    if (fs::exists(ur_description_assets / "meshes/ur5/visual")) {
+      package_map.insert(QStringLiteral("ur_description"), QString::fromStdString(ur_description_assets.string()));
+    } else if (fs::exists(universal_robot_assets / "meshes/ur5/visual")) {
+      package_map.insert(QStringLiteral("ur_description"), QString::fromStdString(universal_robot_assets.string()));
+    }
+  }
+  scan_root(QStringLiteral("/opt/ros/humble/share"));
+  return package_map;
+}
+
+QString resolve_visual_mesh_source_path(
+  const QString & raw_path, const QString & package_uri, const fs::path & scene_dir,
+  const QString & workspace_root, QStringList * tried_candidates)
+{
+  const auto add_candidate = [&](const QString & candidate) {
+    if (tried_candidates) tried_candidates->push_back(candidate);
+    const QFileInfo info(candidate);
+    if (!info.exists() || !info.isFile()) return QString();
+    const QString canonical = info.canonicalFilePath();
+    return canonical.isEmpty() ? info.absoluteFilePath() : canonical;
+  };
+  auto as_repo_relative = [&](const QString & rel) {
+    return QString::fromStdString((workcell_builder_repo_root_from_source() / rel.toStdString()).string());
+  };
+  auto as_scene_relative = [&](const QString & rel) {
+    return QString::fromStdString((scene_dir / rel.toStdString()).string());
+  };
+
+  const QString trimmed_raw = raw_path.trimmed();
+  if (!trimmed_raw.isEmpty()) {
+    QFileInfo raw_info(trimmed_raw);
+    if (raw_info.isAbsolute()) {
+      const QString resolved = add_candidate(raw_info.absoluteFilePath());
+      if (!resolved.isEmpty()) return resolved;
+    } else {
+      const QString repo_resolved = add_candidate(as_repo_relative(trimmed_raw));
+      if (!repo_resolved.isEmpty()) return repo_resolved;
+      const QString scene_resolved = add_candidate(as_scene_relative(trimmed_raw));
+      if (!scene_resolved.isEmpty()) return scene_resolved;
+    }
+  }
+
+  const QString trimmed_uri = package_uri.trimmed();
+  if (trimmed_uri.startsWith("package://")) {
+    const QString package_tail = trimmed_uri.mid(QString("package://").size());
+    const int slash = package_tail.indexOf('/');
+    const QString package_name = (slash >= 0) ? package_tail.left(slash) : package_tail;
+    const QString package_rel = (slash >= 0) ? package_tail.mid(slash + 1) : QString();
+    static QHash<QString, QMap<QString, QString>> workspace_cache;
+    const QString cache_key = QString::fromStdString(scene_dir.string()) + "::" + workspace_root;
+    if (!workspace_cache.contains(cache_key)) workspace_cache.insert(cache_key, discover_visual_mesh_package_map(scene_dir, workspace_root));
+    const QMap<QString, QString> package_map = workspace_cache.value(cache_key);
+    const QString package_root = package_map.value(package_name);
+    if (!package_root.trimmed().isEmpty()) {
+      const QString resolved = add_candidate(QDir(package_root).filePath(package_rel));
+      if (!resolved.isEmpty()) return resolved;
+    }
+  } else if (trimmed_uri.startsWith("file://")) {
+    const QString resolved = add_candidate(trimmed_uri.mid(7));
+    if (!resolved.isEmpty()) return resolved;
+  } else if (trimmed_uri.startsWith("/")) {
+    const QString resolved = add_candidate(trimmed_uri);
+    if (!resolved.isEmpty()) return resolved;
+  }
+  return QString();
+}
+
+}  // namespace workcell_builder

--- a/workcell_builder/workcell_builder/test/visual_mesh_source_resolver_test.cpp
+++ b/workcell_builder/workcell_builder/test/visual_mesh_source_resolver_test.cpp
@@ -1,0 +1,83 @@
+// Copyright 2026 Mukaram01
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+#include <QFileInfo>
+#include <QString>
+#include <QStringList>
+
+#include <utility>
+#include <vector>
+
+#include "visual_mesh_source_resolver.hpp"
+
+namespace fs = boost::filesystem;
+
+#ifndef WORKCELL_BUILDER_REPO_ROOT
+#define WORKCELL_BUILDER_REPO_ROOT ""
+#endif
+
+TEST(VisualMeshSourceResolver, ResolvesKnownPackageUrisToRepoAssets)
+{
+  const fs::path repo_root(WORKCELL_BUILDER_REPO_ROOT);
+  ASSERT_FALSE(repo_root.empty());
+  ASSERT_TRUE(fs::exists(repo_root / "assets"));
+
+  const fs::path scene_dir = repo_root / "scenes" / "ur5_2f_test";
+  const QString workspace_root = QString::fromStdString(repo_root.string());
+
+  const std::vector<std::pair<QString, fs::path>> cases = {
+    {QStringLiteral("package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae"),
+      repo_root / "assets/end_effectors/robotiq_85_gripper/robotiq_85_description/meshes/visual/robotiq_85_base_link.dae"},
+    {QStringLiteral("package://workbench_description/meshes/visual/table.stl"),
+      repo_root / "assets/environment/workbench_description/meshes/visual/table.stl"},
+    {QStringLiteral("package://realsense2_description/meshes/d415.stl"),
+      repo_root / "assets/environment/realsense2_description/meshes/d415.stl"},
+  };
+
+  for (const auto & test_case : cases) {
+    SCOPED_TRACE(test_case.first.toStdString());
+    QStringList tried_candidates;
+    const QString resolved = workcell_builder::resolve_visual_mesh_source_path(
+      QString(), test_case.first, scene_dir, workspace_root, &tried_candidates);
+
+    ASSERT_FALSE(resolved.isEmpty());
+    const QFileInfo resolved_info(resolved);
+    ASSERT_TRUE(resolved_info.exists());
+    ASSERT_TRUE(resolved_info.isFile());
+    EXPECT_EQ(
+      QFileInfo(QString::fromStdString(test_case.second.string())).canonicalFilePath().toStdString(),
+      resolved_info.canonicalFilePath().toStdString());
+    EXPECT_TRUE(resolved_info.canonicalFilePath().contains(QStringLiteral("/assets/")));
+  }
+}
+
+TEST(VisualMeshSourceResolver, LeavesNonexistentPackageUriUnresolved)
+{
+  const fs::path repo_root(WORKCELL_BUILDER_REPO_ROOT);
+  const fs::path scene_dir = repo_root / "scenes" / "ur5_2f_test";
+  const QString workspace_root = QString::fromStdString(repo_root.string());
+  QStringList tried_candidates;
+
+  const QString resolved = workcell_builder::resolve_visual_mesh_source_path(
+    QString(),
+    QStringLiteral("package://missing_description/meshes/visual/missing.stl"),
+    scene_dir,
+    workspace_root,
+    &tried_candidates);
+
+  EXPECT_TRUE(resolved.isEmpty());
+}


### PR DESCRIPTION
### Motivation
- Ensure URIs like `package://...` resolve to repository asset files for accurate 3D preview and mesh lookup.
- Make the visual-mesh resolution logic testable by extracting the helper from `mainwindow.cpp` into a dedicated helper.
- Provide regression coverage so missing package URIs are not incorrectly treated as successful mesh resolutions.

### Description
- Extracted `resolve_visual_mesh_source_path(...)` and `workcell_builder_repo_root_from_source()` into `include/visual_mesh_source_resolver.hpp` and `src_visual_mesh_source_resolver.cpp` and kept the main window calls wired to the same helper.
- Added `test/visual_mesh_source_resolver_test.cpp` which asserts the following URIs resolve to repo-root `assets/...` files: `package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae`, `package://workbench_description/meshes/visual/table.stl`, and `package://realsense2_description/meshes/d415.stl`.
- Added a negative test that verifies an unknown package URI (`package://missing_description/...`) remains unresolved.
- Registered the new helper/source and gtest in `workcell_builder/CMakeLists.txt` so the test is built and included in the test discovery list.

### Testing
- Ran a local Python check that confirmed the three repository asset fixture paths exist under `assets/...`; this check passed.
- Ran `git diff --check` to ensure no whitespace/index issues; this passed.
- Attempted to run the new gtest via `colcon test` but execution is blocked in this container because `/opt/ros/humble/setup.bash` (ROS 2 Humble environment and Qt/test deps) is not present, so the gtest itself was not executed here.
- The new test is added as `workcell_visual_mesh_source_resolver_test` and will run in a ROS 2 Humble environment with the repo built (e.g. via `colcon build` + sourcing `install/setup.bash`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30185f95308331869c09bd9fb4f14a)