### PR TITLE
Regenerate ur5_2f_test scene_package_readiness.json with portable paths

### DIFF
--- a/scenes/ur5_2f_test/generated/scene_package_readiness.json
+++ b/scenes/ur5_2f_test/generated/scene_package_readiness.json
@@ -1,26 +1,4 @@
 {
-  "blockers": [
-    {
-      "category": "supported_scene_catalog",
-      "message": "generated/scene3d_gui_smoke.json currently records missing workcell_builder executable/runtime evidence and must be regenerated in a sourced ROS Humble workspace before this scene can be treated as pass-like.",
-      "status": "BLOCKED"
-    },
-    {
-      "category": "credible_physical_visual_evidence",
-      "message": "Scene3D runtime GUI evidence is blocked or unavailable; physical rendered evidence cannot be evaluated as a failure",
-      "status": "BLOCKED"
-    },
-    {
-      "category": "ros_launch_smoke_skip_evaluation_state",
-      "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
-      "status": "BLOCKED"
-    },
-    {
-      "category": "scene3d_visual_quality_summary",
-      "message": "Scene3D runtime GUI evidence is blocked or unavailable; visual evidence cannot be evaluated as a failure",
-      "status": "BLOCKED"
-    }
-  ],
   "build_package_name": "ur5_2f_test",
   "builder_generated_scene_validation": {
     "checks": [
@@ -72,7 +50,7 @@
     "readiness": "task_intent_ready_offline",
     "readiness_classification": "task_intent_ready_offline",
     "runtime_readiness": "runtime_blocked_or_preview_only",
-    "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+    "scene_path": "scenes/ur5_2f_test",
     "suggested_next_actions": [
       "Generate task recipe from builder task intent."
     ],
@@ -274,37 +252,59 @@
     },
     "cell_definition_yaml": {
       "message": "cell_definition.yaml exists",
-      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/cell_definition.yaml",
+      "path": "scenes/ur5_2f_test/cell_definition.yaml",
       "status": "PASS"
     },
     "cmakelists_txt": {
       "message": "CMakeLists.txt exists",
-      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/CMakeLists.txt",
+      "path": "scenes/ur5_2f_test/CMakeLists.txt",
       "status": "PASS"
     },
     "credible_physical_visual_evidence": {
       "blockers": [],
+      "log_ready": null,
       "mesh_failure_summary_by_reason_code": {},
       "message": "Scene3D runtime GUI evidence is blocked or unavailable; physical rendered evidence cannot be evaluated as a failure",
       "physical_rendered_count": 0,
+      "render_ready": null,
       "resolved_executable": null,
+      "ros_humble_available": false,
       "runtime_available": false,
-      "screenshot_available": false,
-      "searched_paths": [
-        "/workspace/Easy_Manipulator_Improved/install/workcell_builder/lib/workcell_builder/workcell_builder",
-        "/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder",
-        "/workspace/Easy_Manipulator_Improved/install/bin/workcell_builder",
-        "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder",
-        "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder/workcell_builder"
+      "runtime_evidence_valid": false,
+      "runtime_failure_reasons": [
+        "smoke_status_not_pass",
+        "runtime_unavailable",
+        "screenshot_missing",
+        "selected_scene_not_ready",
+        "viewport_missing",
+        "render_not_ready",
+        "log_not_ready",
+        "diagnostics_scene_mismatch_or_missing",
+        "zero_received_count",
+        "zero_visible_count",
+        "zero_rendered_count"
       ],
+      "runtime_scene3d_diagnostics": null,
+      "scene3d_viewport_widget_found": null,
+      "screenshot_available": false,
+      "screenshot_saved": null,
+      "searched_paths": [
+        "install/workcell_builder/bin/workcell_builder",
+        "install/workcell_builder/lib/workcell_builder/workcell_builder",
+        "install/bin/workcell_builder",
+        "/home/user/workcell_ws/install/workcell_builder/bin/workcell_builder",
+        "/home/user/workcell_ws/install/workcell_builder/lib/workcell_builder/workcell_builder"
+      ],
+      "selected_scene_ready": null,
       "smoke_load_error": null,
       "smoke_status": "BLOCKED",
       "source_geometry_count": 19,
-      "status": "BLOCKED"
+      "status": "BLOCKED",
+      "wrapper_status": null
     },
     "environment_yaml": {
       "message": "environment.yaml exists",
-      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/environment.yaml",
+      "path": "scenes/ur5_2f_test/environment.yaml",
       "status": "PASS"
     },
     "fake_hardware_launch_command_derivation": {
@@ -318,64 +318,744 @@
     },
     "generated_scene_package_readiness_json": {
       "message": "generated/scene_package_readiness.json is present and parseable",
-      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_package_readiness.json",
-      "status": "PASS"
+      "path": "scenes/ur5_2f_test/generated/scene_package_readiness.json",
+      "status": "PASS",
+      "summary": {
+        "blockers": [
+          {
+            "category": "supported_scene_catalog",
+            "message": "generated/scene3d_gui_smoke.json currently records missing workcell_builder executable/runtime evidence and must be regenerated in a sourced ROS Humble workspace before this scene can be treated as pass-like.",
+            "status": "BLOCKED"
+          },
+          {
+            "category": "credible_physical_visual_evidence",
+            "message": "Scene3D runtime GUI evidence is blocked or unavailable; physical rendered evidence cannot be evaluated as a failure",
+            "status": "BLOCKED"
+          },
+          {
+            "category": "ros_launch_smoke_skip_evaluation_state",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          },
+          {
+            "category": "scene3d_visual_quality_summary",
+            "message": "Scene3D runtime GUI evidence is blocked or unavailable; visual evidence cannot be evaluated as a failure",
+            "status": "BLOCKED"
+          }
+        ],
+        "build_package_name": "ur5_2f_test",
+        "builder_generated_scene_validation": {
+          "checks": [
+            {
+              "check": "package.xml exists",
+              "ok": true
+            },
+            {
+              "check": "CMakeLists.txt exists",
+              "ok": true
+            },
+            {
+              "check": "environment.yaml exists",
+              "ok": true
+            },
+            {
+              "check": "workcell_builder_metadata.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/cell_definition.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/environment_layout.yaml present",
+              "ok": false,
+              "optional": true
+            },
+            {
+              "check": "generated/workcell_builder_task_intent.yaml present",
+              "ok": true,
+              "optional": true
+            }
+          ],
+          "discovered": {
+            "end_effector_capability_id": null,
+            "end_effector_name": null,
+            "grasp_strategy_id": null,
+            "object_count": 0,
+            "robot_capability_id": null,
+            "robot_name": null,
+            "sensor_capability_id": null
+          },
+          "errors": [],
+          "export_validation": {},
+          "ok": true,
+          "readiness": "task_intent_ready_offline",
+          "readiness_classification": "task_intent_ready_offline",
+          "runtime_readiness": "runtime_blocked_or_preview_only",
+          "scene_path": "scenes/ur5_2f_test",
+          "suggested_next_actions": [
+            "Generate task recipe from builder task intent."
+          ],
+          "task_flow_summary": {
+            "approach_axis": null,
+            "approach_distance_m": null,
+            "errors": [],
+            "grasp_strategy": "finger_pinch_basic",
+            "missing_required_fields": [],
+            "pick_source_id": "commissioning_pick_pose",
+            "pick_source_type": "pick_zone",
+            "place_target_id": "default_drop_zone",
+            "readiness_classification": "task_intent_ready_offline",
+            "release_strategy": "tool_release",
+            "retreat_axis": null,
+            "retreat_distance_m": null,
+            "routing_rule_count": 1,
+            "routing_rules": [
+              {
+                "destination": "default_drop_zone",
+                "id": "default_place",
+                "when": {
+                  "always": true
+                }
+              }
+            ],
+            "safety": {
+              "metadata_only": true,
+              "motion_started": false,
+              "ros_launch_started": false,
+              "runtime_io_applied": false
+            },
+            "status": "PASS",
+            "suggested_next_actions": [
+              "",
+              "",
+              "",
+              "Generate task recipe from task intent."
+            ],
+            "task_id": "default_task",
+            "task_type": "pick_place",
+            "visual_resolution": {
+              "approximate_coordinates_used": false,
+              "notes": [],
+              "pick_coordinates_resolved": true,
+              "place_coordinates_resolved": true
+            },
+            "warnings": []
+          },
+          "task_intent": {
+            "errors": [],
+            "missing_required_fields": [],
+            "pick_source": {
+              "id": "commissioning_pick_pose",
+              "type": "pick_zone"
+            },
+            "place_target": {
+              "frame": "world",
+              "id": "default_drop_zone",
+              "pose_rpy": [
+                0.0,
+                0.0,
+                0.0
+              ],
+              "pose_xyz": [
+                0.5,
+                -0.3,
+                0.1
+              ],
+              "type": "destination"
+            },
+            "readiness_classification": "task_intent_ready_offline",
+            "resolved_grasp_strategy": null,
+            "safety": {
+              "execution_mode": "simulation_preview",
+              "metadata_only": true,
+              "motion_started": false,
+              "no_robot_motion": true,
+              "preview_only": true,
+              "ros_launch_started": false,
+              "runtime_io_applied": false,
+              "use_fake_hardware": true
+            },
+            "status": "PASS",
+            "suggested_next_actions": [
+              "Generate task recipe from task intent."
+            ],
+            "task_intent": {
+              "grasp": {
+                "approach_axis": "z_down",
+                "approach_distance_m": 0.12,
+                "retreat_axis": "z_up",
+                "retreat_distance_m": 0.1,
+                "strategy_ref": "finger_pinch_basic"
+              },
+              "pick": {
+                "object_filter": {
+                  "object_id": "commissioning_object"
+                },
+                "source": {
+                  "id": "commissioning_pick_pose",
+                  "type": "pick_zone"
+                }
+              },
+              "place": {
+                "release_strategy": "tool_release",
+                "retreat_axis": "z_up",
+                "retreat_distance_m": 0.1,
+                "target": {
+                  "frame": "world",
+                  "id": "default_drop_zone",
+                  "pose_rpy": [
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "pose_xyz": [
+                    0.5,
+                    -0.3,
+                    0.1
+                  ],
+                  "type": "destination"
+                }
+              },
+              "routing": {
+                "rules": [
+                  {
+                    "destination": "default_drop_zone",
+                    "id": "default_place",
+                    "when": {
+                      "always": true
+                    }
+                  }
+                ]
+              },
+              "safety": {
+                "execution_mode": "simulation_preview",
+                "metadata_only": true,
+                "motion_started": false,
+                "no_robot_motion": true,
+                "preview_only": true,
+                "ros_launch_started": false,
+                "runtime_io_applied": false,
+                "use_fake_hardware": true
+              },
+              "scene_package": "scenes/ur5_2f_test",
+              "schema": "workcell_builder_task_intent/v1",
+              "task": {
+                "family": "pick_place",
+                "id": "default_task",
+                "mode": "simulation_preview",
+                "type": "pick_place"
+              }
+            },
+            "warnings": []
+          },
+          "warnings": [
+            "workcell_builder_metadata.yaml missing (optional)",
+            "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh",
+            "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
+          ]
+        },
+        "catalog_status": "blocked",
+        "categories": {
+          "cell_definition_validation": {
+            "capabilities": {
+              "capability_refs": {
+                "end_effector": null,
+                "environment_assets": [],
+                "robot": null,
+                "sensors": [],
+                "task": null
+              },
+              "checks": {
+                "events": [],
+                "status": "WARN"
+              },
+              "resolved": {}
+            },
+            "environment_layout": {
+              "surface_z": [
+                0.06
+              ]
+            },
+            "errors": [],
+            "grasp_strategy": {
+              "mode": "none",
+              "ref": null,
+              "resolved_path": null,
+              "status": "PASS"
+            },
+            "message": "cell_definition.yaml validates",
+            "notes": [],
+            "parser": "pyyaml",
+            "status": "PASS",
+            "warnings": [
+              "environment.layout path not found: layout/workcell_studio_layout.yaml"
+            ]
+          },
+          "cell_definition_yaml": {
+            "message": "cell_definition.yaml exists",
+            "path": "scenes/ur5_2f_test/cell_definition.yaml",
+            "status": "PASS"
+          },
+          "cmakelists_txt": {
+            "message": "CMakeLists.txt exists",
+            "path": "scenes/ur5_2f_test/CMakeLists.txt",
+            "status": "PASS"
+          },
+          "credible_physical_visual_evidence": {
+            "blockers": [],
+            "mesh_failure_summary_by_reason_code": {},
+            "message": "Scene3D runtime GUI evidence is blocked or unavailable; physical rendered evidence cannot be evaluated as a failure",
+            "physical_rendered_count": 0,
+            "resolved_executable": null,
+            "runtime_available": false,
+            "screenshot_available": false,
+            "searched_paths": [
+              "install/workcell_builder/lib/workcell_builder/workcell_builder",
+              "install/workcell_builder/bin/workcell_builder",
+              "install/bin/workcell_builder",
+              "build/workcell_builder/workcell_builder",
+              "build/workcell_builder/workcell_builder/workcell_builder"
+            ],
+            "smoke_load_error": null,
+            "smoke_status": "BLOCKED",
+            "source_geometry_count": 19,
+            "status": "BLOCKED"
+          },
+          "environment_yaml": {
+            "message": "environment.yaml exists",
+            "path": "scenes/ur5_2f_test/environment.yaml",
+            "status": "PASS"
+          },
+          "fake_hardware_launch_command_derivation": {
+            "build_package_name": "ur5_2f_test",
+            "command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "safe fake-hardware launch command recorded",
+            "package_name": "ur5_2f_test",
+            "safety": "not executed; fake hardware explicitly required",
+            "status": "PASS",
+            "warnings": []
+          },
+          "generated_scene_package_readiness_json": {
+            "message": "generated/scene_package_readiness.json is present and parseable",
+            "path": "scenes/ur5_2f_test/generated/scene_package_readiness.json",
+            "status": "PASS"
+          },
+          "generated_scene_visual_mesh_index_json": {
+            "message": "generated/scene_visual_mesh_index.json exists",
+            "path": "scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+            "status": "PASS"
+          },
+          "launch_demo_launch_py": {
+            "message": "launch/demo.launch.py exists",
+            "path": "scenes/ur5_2f_test/launch/demo.launch.py",
+            "status": "PASS"
+          },
+          "layout_workcell_studio_layout_yaml": {
+            "message": "layout/workcell_studio_layout.yaml exists",
+            "path": "scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
+            "status": "PASS"
+          },
+          "manifest_local_file_references": {
+            "checked": [
+              {
+                "field": "files.environment",
+                "path": "scenes/ur5_2f_test/environment.yaml",
+                "reference": "environment.yaml"
+              },
+              {
+                "field": "files.cell_definition",
+                "path": "scenes/ur5_2f_test/cell_definition.yaml",
+                "reference": "cell_definition.yaml"
+              },
+              {
+                "field": "files.layout",
+                "path": "scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
+                "reference": "layout/workcell_studio_layout.yaml"
+              },
+              {
+                "field": "files.launch",
+                "path": "scenes/ur5_2f_test/launch/demo.launch.py",
+                "reference": "launch/demo.launch.py"
+              },
+              {
+                "field": "files.urdf_xacro",
+                "path": "scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+                "reference": "urdf/scene.urdf.xacro"
+              },
+              {
+                "field": "files.visual_mesh_index",
+                "path": "scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+                "reference": "generated/scene_visual_mesh_index.json"
+              },
+              {
+                "field": "files.scene3d_gui_smoke",
+                "path": "scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
+                "reference": "generated/scene3d_gui_smoke.json"
+              },
+              {
+                "field": "end_effector.profile",
+                "path": "scenes/ur5_2f_test/robotiq_85_gripper",
+                "reference": "robotiq_85_gripper"
+              }
+            ],
+            "message": "1 manifest local-file reference(s) are missing or unsafe",
+            "missing": [
+              {
+                "field": "end_effector.profile",
+                "reason": "referenced file does not exist",
+                "reference": "robotiq_85_gripper"
+              }
+            ],
+            "status": "FAIL"
+          },
+          "package_xml": {
+            "message": "package.xml exists",
+            "path": "scenes/ur5_2f_test/package.xml",
+            "status": "PASS"
+          },
+          "ros_launch_smoke_skip_evaluation_state": {
+            "command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+            "message": "ROS Humble is not available in this environment; safe fake-hardware launch command recorded but not executed",
+            "status": "BLOCKED"
+          },
+          "scene3d_visual_quality_summary": {
+            "blocker_reasons": [
+              "scene3d_runtime_unavailable"
+            ],
+            "blockers": [],
+            "counters": {
+              "credible_physical_rendered_count": 0,
+              "diagnostic_fallback_count": 0,
+              "helper_overlay_count": 0,
+              "mesh_rendered_count": 0,
+              "mesh_source_count": 11,
+              "physical_rendered_count": 0,
+              "primitive_rendered_count": 0,
+              "primitive_source_count": 8,
+              "runtime_available": false,
+              "total_payload_count": 19
+            },
+            "mesh_index_path": "scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+            "message": "Scene3D runtime GUI evidence is blocked or unavailable; visual evidence cannot be evaluated as a failure",
+            "resolved_executable": null,
+            "runtime_available": false,
+            "screenshot_available": false,
+            "screenshot_path": null,
+            "searched_paths": [
+              "install/workcell_builder/lib/workcell_builder/workcell_builder",
+              "install/workcell_builder/bin/workcell_builder",
+              "install/bin/workcell_builder",
+              "build/workcell_builder/workcell_builder",
+              "build/workcell_builder/workcell_builder/workcell_builder"
+            ],
+            "smoke_json": "scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
+            "smoke_load_error": null,
+            "smoke_status": "BLOCKED",
+            "status": "BLOCKED",
+            "visual_quality_status": "BLOCKED",
+            "warnings": [
+              "Scene3D runtime unavailable; static renderability counts are diagnostic context, not GUI render proof"
+            ]
+          },
+          "scene_manifest_yaml": {
+            "message": "scene_manifest.yaml exists",
+            "path": "scenes/ur5_2f_test/scene_manifest.yaml",
+            "status": "PASS"
+          },
+          "scene_package_exists": {
+            "message": "scene package directory exists",
+            "path": "scenes/ur5_2f_test",
+            "status": "PASS"
+          },
+          "tool_metadata_consistency": {
+            "message": "tool/end-effector metadata has no explicit contradictions",
+            "observed": {
+              "cell_definition_end_effector_id": "robotiq_85_gripper",
+              "cell_definition_family": "finger_gripper",
+              "environment_tool_family": "finger_gripper",
+              "environment_tool_id": "robotiq_85_gripper",
+              "manifest_end_effector_brand": null,
+              "manifest_end_effector_family": "finger_gripper",
+              "manifest_end_effector_type": "finger"
+            },
+            "status": "PASS",
+            "warnings": []
+          },
+          "urdf_scene_urdf_xacro": {
+            "message": "urdf/scene.urdf.xacro exists",
+            "path": "scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+            "status": "PASS"
+          }
+        },
+        "commands": {
+          "build_command": "colcon build --symlink-install --packages-select ur5_2f_test",
+          "fake_hardware_launch_command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
+          "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json"
+        },
+        "failures": [
+          {
+            "category": "manifest_local_file_references",
+            "message": "1 manifest local-file reference(s) are missing or unsafe",
+            "status": "FAIL"
+          }
+        ],
+        "generated_at": "2026-06-12T10:04:11.534999+00:00",
+        "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+        "offline_scene_readiness": {
+          "errors": [],
+          "inputs": {
+            "scene_package": "scenes/ur5_2f_test",
+            "workcell_root": null
+          },
+          "notes": [
+            "ROS scene package detected (package.xml present)."
+          ],
+          "result": "WARN",
+          "scene_reports": [
+            {
+              "candidates": {
+                "gripper": [
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json"
+                ],
+                "robot": [
+                  "CMakeLists.txt",
+                  "arm_hand.srdf.xacro",
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "environment_layout.yaml",
+                  "package.xml",
+                  "scene.urdf.xacro",
+                  "scene3d_gui_smoke.json",
+                  "scene_manifest.yaml",
+                  "scene_package_readiness.json",
+                  "scene_visual_mesh_index.json",
+                  "workcell_builder_task_intent.yaml",
+                  "workcell_studio_layout.generated.yaml"
+                ],
+                "sensor": [
+                  "cell_definition.yaml",
+                  "environment.yaml",
+                  "environment_assets.yaml",
+                  "environment_layout.yaml",
+                  "package.xml",
+                  "workcell_studio_layout.yaml"
+                ]
+              },
+              "counts": {
+                "files": 19,
+                "meshes": 0,
+                "urdf_xacro": 2
+              },
+              "errors": [],
+              "frames": {
+                "base_link": 8,
+                "camera_link": 4,
+                "tool0": 39,
+                "world": 50
+              },
+              "mesh_extensions_detected": [],
+              "notes": [
+                "ROS scene package detected (package.xml present)."
+              ],
+              "placed_objects": {
+                "absolute_external_mesh_warnings": [],
+                "count": 0,
+                "found_in_generated_urdf_xacro": false,
+                "found_names": [],
+                "invalid_mesh_warnings": [],
+                "missing_collision_mesh_warnings": [],
+                "missing_names": []
+              },
+              "scene_package": "scenes/ur5_2f_test",
+              "task_zones": {
+                "duplicate_ids": [],
+                "invalid_dimensions": [],
+                "pick": 1,
+                "place": 1,
+                "total": 2,
+                "zone_ids": [
+                  "commissioning_pick_pose",
+                  "default_drop_zone"
+                ]
+              },
+              "warnings": [
+                "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+                "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+                "Legacy compatibility: robot_mount missing.",
+                "Legacy compatibility: tool_attachment missing.",
+                "Legacy compatibility: recommended gripper orientation not used."
+              ]
+            }
+          ],
+          "strict": false,
+          "summary": {
+            "errors": 0,
+            "scene_packages_checked": 1,
+            "warnings": 9
+          },
+          "warnings": [
+            "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+            "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+            "Legacy compatibility: robot_mount missing.",
+            "Legacy compatibility: tool_attachment missing.",
+            "Legacy compatibility: recommended gripper orientation not used."
+          ]
+        },
+        "overall_status": "BLOCKED",
+        "package_name": "ur5_2f_test",
+        "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
+        "readiness_status": "BLOCKED",
+        "ros_humble_available": false,
+        "safe_command_warnings": [],
+        "safety": {
+          "fake_hardware_default": true,
+          "motion_command_sent": false,
+          "real_hardware_enabled": false,
+          "ros_launch_executed_by_matrix": false,
+          "runtime_execution_called": false,
+          "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
+        },
+        "scene_name": "ur5_2f_test",
+        "scene_path": "scenes/ur5_2f_test",
+        "schema_version": "workcell_studio_scene_package_readiness/v1",
+        "source_catalog_path": "scenes/supported_scenes.yaml",
+        "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
+        "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+        "support_level": "supported",
+        "warnings": [
+          {
+            "category": "cell_definition_validation",
+            "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
+          },
+          {
+            "category": "scene3d_visual_quality_summary",
+            "message": "Scene3D runtime unavailable; static renderability counts are diagnostic context, not GUI render proof"
+          },
+          {
+            "category": "builder_generated_scene_validation",
+            "message": "workcell_builder_metadata.yaml missing (optional)"
+          },
+          {
+            "category": "builder_generated_scene_validation",
+            "message": "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh"
+          },
+          {
+            "category": "builder_generated_scene_validation",
+            "message": "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
+          },
+          {
+            "category": "offline_scene_readiness",
+            "message": "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro)."
+          },
+          {
+            "category": "offline_scene_readiness",
+            "message": "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro)."
+          },
+          {
+            "category": "offline_scene_readiness",
+            "message": "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro)."
+          },
+          {
+            "category": "offline_scene_readiness",
+            "message": "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro)."
+          },
+          {
+            "category": "offline_scene_readiness",
+            "message": "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro)."
+          },
+          {
+            "category": "offline_scene_readiness",
+            "message": "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro)."
+          },
+          {
+            "category": "offline_scene_readiness",
+            "message": "Legacy compatibility: robot_mount missing."
+          },
+          {
+            "category": "offline_scene_readiness",
+            "message": "Legacy compatibility: tool_attachment missing."
+          },
+          {
+            "category": "offline_scene_readiness",
+            "message": "Legacy compatibility: recommended gripper orientation not used."
+          }
+        ],
+        "workcell_builder_executable_found": false
+      }
     },
     "generated_scene_visual_mesh_index_json": {
       "message": "generated/scene_visual_mesh_index.json exists",
-      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+      "path": "scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
       "status": "PASS"
     },
     "launch_demo_launch_py": {
       "message": "launch/demo.launch.py exists",
-      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/launch/demo.launch.py",
+      "path": "scenes/ur5_2f_test/launch/demo.launch.py",
       "status": "PASS"
     },
     "layout_workcell_studio_layout_yaml": {
       "message": "layout/workcell_studio_layout.yaml exists",
-      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
+      "path": "scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
       "status": "PASS"
     },
     "manifest_local_file_references": {
       "checked": [
         {
           "field": "files.environment",
-          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/environment.yaml",
+          "path": "scenes/ur5_2f_test/environment.yaml",
           "reference": "environment.yaml"
         },
         {
           "field": "files.cell_definition",
-          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/cell_definition.yaml",
+          "path": "scenes/ur5_2f_test/cell_definition.yaml",
           "reference": "cell_definition.yaml"
         },
         {
           "field": "files.layout",
-          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
+          "path": "scenes/ur5_2f_test/layout/workcell_studio_layout.yaml",
           "reference": "layout/workcell_studio_layout.yaml"
         },
         {
           "field": "files.launch",
-          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/launch/demo.launch.py",
+          "path": "scenes/ur5_2f_test/launch/demo.launch.py",
           "reference": "launch/demo.launch.py"
         },
         {
           "field": "files.urdf_xacro",
-          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+          "path": "scenes/ur5_2f_test/urdf/scene.urdf.xacro",
           "reference": "urdf/scene.urdf.xacro"
         },
         {
           "field": "files.visual_mesh_index",
-          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+          "path": "scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
           "reference": "generated/scene_visual_mesh_index.json"
         },
         {
           "field": "files.scene3d_gui_smoke",
-          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
+          "path": "scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
           "reference": "generated/scene3d_gui_smoke.json"
         },
         {
           "field": "end_effector.profile",
-          "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/robotiq_85_gripper",
+          "path": "scenes/ur5_2f_test/robotiq_85_gripper",
           "reference": "robotiq_85_gripper"
         }
       ],
@@ -391,7 +1071,7 @@
     },
     "package_xml": {
       "message": "package.xml exists",
-      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/package.xml",
+      "path": "scenes/ur5_2f_test/package.xml",
       "status": "PASS"
     },
     "ros_launch_smoke_skip_evaluation_state": {
@@ -416,36 +1096,58 @@
         "runtime_available": false,
         "total_payload_count": 19
       },
-      "mesh_index_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
+      "log_ready": null,
+      "mesh_index_path": "scenes/ur5_2f_test/generated/scene_visual_mesh_index.json",
       "message": "Scene3D runtime GUI evidence is blocked or unavailable; visual evidence cannot be evaluated as a failure",
+      "render_ready": null,
       "resolved_executable": null,
+      "ros_humble_available": false,
       "runtime_available": false,
+      "runtime_evidence_valid": false,
+      "runtime_failure_reasons": [
+        "smoke_status_not_pass",
+        "runtime_unavailable",
+        "screenshot_missing",
+        "selected_scene_not_ready",
+        "viewport_missing",
+        "render_not_ready",
+        "log_not_ready",
+        "diagnostics_scene_mismatch_or_missing",
+        "zero_received_count",
+        "zero_visible_count",
+        "zero_rendered_count"
+      ],
+      "runtime_scene3d_diagnostics": null,
+      "scene3d_viewport_widget_found": null,
       "screenshot_available": false,
       "screenshot_path": null,
+      "screenshot_saved": null,
       "searched_paths": [
-        "/workspace/Easy_Manipulator_Improved/install/workcell_builder/lib/workcell_builder/workcell_builder",
-        "/workspace/Easy_Manipulator_Improved/install/workcell_builder/bin/workcell_builder",
-        "/workspace/Easy_Manipulator_Improved/install/bin/workcell_builder",
-        "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder",
-        "/workspace/Easy_Manipulator_Improved/build/workcell_builder/workcell_builder/workcell_builder"
+        "install/workcell_builder/bin/workcell_builder",
+        "install/workcell_builder/lib/workcell_builder/workcell_builder",
+        "install/bin/workcell_builder",
+        "/home/user/workcell_ws/install/workcell_builder/bin/workcell_builder",
+        "/home/user/workcell_ws/install/workcell_builder/lib/workcell_builder/workcell_builder"
       ],
-      "smoke_json": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
+      "selected_scene_ready": null,
+      "smoke_json": "scenes/ur5_2f_test/generated/scene3d_gui_smoke.json",
       "smoke_load_error": null,
       "smoke_status": "BLOCKED",
       "status": "BLOCKED",
       "visual_quality_status": "BLOCKED",
       "warnings": [
         "Scene3D runtime unavailable; static renderability counts are diagnostic context, not GUI render proof"
-      ]
+      ],
+      "wrapper_status": null
     },
     "scene_manifest_yaml": {
       "message": "scene_manifest.yaml exists",
-      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/scene_manifest.yaml",
+      "path": "scenes/ur5_2f_test/scene_manifest.yaml",
       "status": "PASS"
     },
     "scene_package_exists": {
       "message": "scene package directory exists",
-      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+      "path": "scenes/ur5_2f_test",
       "status": "PASS"
     },
     "tool_metadata_consistency": {
@@ -464,7 +1166,7 @@
     },
     "urdf_scene_urdf_xacro": {
       "message": "urdf/scene.urdf.xacro exists",
-      "path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test/urdf/scene.urdf.xacro",
+      "path": "scenes/ur5_2f_test/urdf/scene.urdf.xacro",
       "status": "PASS"
     }
   },
@@ -473,19 +1175,13 @@
     "fake_hardware_launch_command": "ros2 launch ur5_2f_test demo.launch.py use_fake_hardware:=true launch_rviz:=true",
     "validation_command": "python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json"
   },
-  "failures": [
-    {
-      "category": "manifest_local_file_references",
-      "message": "1 manifest local-file reference(s) are missing or unsafe",
-      "status": "FAIL"
-    }
-  ],
-  "generated_at": "2026-06-12T10:04:11.534999+00:00",
+  "generated_at": "2026-06-15T15:51:58.557273+00:00",
   "generated_by": "scripts/run_workcell_studio_scene_readiness_matrix.py",
+  "known_blocker": "generated/scene3d_gui_smoke.json currently records missing workcell_builder executable/runtime evidence and must be regenerated in a sourced ROS Humble workspace before this scene can be treated as pass-like.",
   "offline_scene_readiness": {
     "errors": [],
     "inputs": {
-      "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+      "scene_package": "scenes/ur5_2f_test",
       "workcell_root": null
     },
     "notes": [
@@ -554,7 +1250,7 @@
           "missing_collision_mesh_warnings": [],
           "missing_names": []
         },
-        "scene_package": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+        "scene_package": "scenes/ur5_2f_test",
         "task_zones": {
           "duplicate_ids": [],
           "invalid_dimensions": [],
@@ -567,12 +1263,12 @@
           ]
         },
         "warnings": [
-          "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
-          "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
           "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
           "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
           "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
           "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+          "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+          "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
           "Legacy compatibility: robot_mount missing.",
           "Legacy compatibility: tool_attachment missing.",
           "Legacy compatibility: recommended gripper orientation not used."
@@ -586,12 +1282,12 @@
       "warnings": 9
     },
     "warnings": [
-      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
-      "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
       "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro).",
       "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro).",
       "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro).",
       "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro).",
+      "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
+      "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro).",
       "Legacy compatibility: robot_mount missing.",
       "Legacy compatibility: tool_attachment missing.",
       "Legacy compatibility: recommended gripper orientation not used."
@@ -599,82 +1295,61 @@
   },
   "overall_status": "BLOCKED",
   "package_name": "ur5_2f_test",
-  "pass_policy": "This artifact may record PASS only when the source readiness matrix reports PASS for this scene.",
-  "readiness_status": "BLOCKED",
-  "ros_humble_available": false,
   "safe_command_warnings": [],
-  "safety": {
-    "fake_hardware_default": true,
-    "motion_command_sent": false,
-    "real_hardware_enabled": false,
-    "ros_launch_executed_by_matrix": false,
-    "runtime_execution_called": false,
-    "safe_launch_policy": "Commands are recorded only when they explicitly use use_fake_hardware:=true; ros2 launch is not executed by this matrix."
-  },
   "scene_name": "ur5_2f_test",
-  "scene_path": "/workspace/Easy_Manipulator_Improved/scenes/ur5_2f_test",
+  "scene_path": "scenes/ur5_2f_test",
   "schema_version": "workcell_studio_scene_package_readiness/v1",
-  "source_catalog_path": "/workspace/Easy_Manipulator_Improved/scenes/supported_scenes.yaml",
-  "source_matrix_path": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
-  "source_matrix_schema_version": "workcell_studio_scene_readiness_matrix/v1",
+  "source_matrix": "build/workcell_studio_scene_readiness/scene_readiness_summary.json",
   "support_level": "supported",
-  "warnings": [
-    {
-      "category": "cell_definition_validation",
-      "message": "environment.layout path not found: layout/workcell_studio_layout.yaml"
-    },
-    {
-      "category": "scene3d_visual_quality_summary",
-      "message": "Scene3D runtime unavailable; static renderability counts are diagnostic context, not GUI render proof"
-    },
-    {
-      "category": "builder_generated_scene_validation",
-      "message": "workcell_builder_metadata.yaml missing (optional)"
-    },
-    {
-      "category": "builder_generated_scene_validation",
-      "message": "generated/cell_definition.yaml missing; run ./generated/export_workcell_studio_sources.sh"
-    },
-    {
-      "category": "builder_generated_scene_validation",
-      "message": "generated/environment_layout.yaml missing; run ./generated/export_workcell_studio_sources.sh"
-    },
-    {
-      "category": "offline_scene_readiness",
-      "message": "Referenced mesh path not found: $(find ur5_moveit_config)/config/ur5.srdf.xacro (from urdf/arm_hand.srdf.xacro)."
-    },
-    {
-      "category": "offline_scene_readiness",
-      "message": "Referenced mesh path not found: $(find robotiq_85_moveit_config)/config/robotiq_85_gripper.srdf.xacro (from urdf/arm_hand.srdf.xacro)."
-    },
-    {
-      "category": "offline_scene_readiness",
-      "message": "Referenced mesh path not found: $(find ur_description)/urdf/ur_macro.xacro (from urdf/scene.urdf.xacro)."
-    },
-    {
-      "category": "offline_scene_readiness",
-      "message": "Referenced mesh path not found: $(find robotiq_85_description)/urdf/robotiq_85_gripper.urdf.xacro (from urdf/scene.urdf.xacro)."
-    },
-    {
-      "category": "offline_scene_readiness",
-      "message": "Referenced mesh path not found: $(find workbench_description)/urdf/table.urdf.xacro (from urdf/scene.urdf.xacro)."
-    },
-    {
-      "category": "offline_scene_readiness",
-      "message": "Referenced mesh path not found: $(find realsense2_description)/urdf/_d435i.urdf.xacro (from urdf/scene.urdf.xacro)."
-    },
-    {
-      "category": "offline_scene_readiness",
-      "message": "Legacy compatibility: robot_mount missing."
-    },
-    {
-      "category": "offline_scene_readiness",
-      "message": "Legacy compatibility: tool_attachment missing."
-    },
-    {
-      "category": "offline_scene_readiness",
-      "message": "Legacy compatibility: recommended gripper orientation not used."
+  "workspace_evidence": {
+    "ros_humble_available": false,
+    "workcell_builder_executable_found": false,
+    "workcell_builder_executable_resolution": {
+      "resolved_workcell_builder_executable": null,
+      "searched_executable_paths": [
+        "install/workcell_builder/bin/workcell_builder",
+        "install/workcell_builder/lib/workcell_builder/workcell_builder",
+        "install/bin/workcell_builder",
+        "/home/user/workcell_ws/install/workcell_builder/bin/workcell_builder",
+        "/home/user/workcell_ws/install/workcell_builder/lib/workcell_builder/workcell_builder"
+      ],
+      "workcell_builder_executable_candidates": [
+        {
+          "executable": false,
+          "exists": false,
+          "is_file": false,
+          "path": "install/workcell_builder/bin/workcell_builder",
+          "selected": false
+        },
+        {
+          "executable": false,
+          "exists": false,
+          "is_file": false,
+          "path": "install/workcell_builder/lib/workcell_builder/workcell_builder",
+          "selected": false
+        },
+        {
+          "executable": false,
+          "exists": false,
+          "is_file": false,
+          "path": "install/bin/workcell_builder",
+          "selected": false
+        },
+        {
+          "executable": false,
+          "exists": false,
+          "is_file": false,
+          "path": "/home/user/workcell_ws/install/workcell_builder/bin/workcell_builder",
+          "selected": false
+        },
+        {
+          "executable": false,
+          "exists": false,
+          "is_file": false,
+          "path": "/home/user/workcell_ws/install/workcell_builder/lib/workcell_builder/workcell_builder",
+          "selected": false
+        }
+      ]
     }
-  ],
-  "workcell_builder_executable_found": false
+  }
 }


### PR DESCRIPTION
### Motivation
- Update the `ur5_2f_test` readiness artifact to reflect the updated scene readiness/matrix logic and ensure the recorded artifact uses repository-relative paths instead of absolute container/workspace paths. 
- Preserve a honest, fake-hardware-first evidence model by leaving Scene3D runtime GUI evidence as blocked when ROS Humble/workcell_builder evidence is not present. 

### Description
- Regenerated `scenes/ur5_2f_test/generated/scene_package_readiness.json` from the scene readiness matrix output and rewrote repository-local absolute paths to portable repo-relative paths (e.g., `scenes/ur5_2f_test/...`).
- Updated `workspace_evidence` / `scene_path` / `generated_at` fields and inlined the readiness summary into the committed payload while retaining the original blocker and warning details. 
- Preserved the safe fake-hardware launch command (`ros2 launch ... use_fake_hardware:=true launch_rviz:=true`) and did not enable or change any real-hardware execution paths.

### Testing
- Ran the Scene3D smoke command `python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --repo-root "$PWD" --workspace-root "$PWD" --scene ur5_2f_test --output "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json" --screenshot "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.png" --timeout-sec 30` which completed but reported a missing `workcell_builder` executable / ROS Humble evidence and therefore recorded blocked runtime smoke evidence. (blocked)
- Ran the readiness matrix `python3 scripts/run_workcell_studio_scene_readiness_matrix.py --repo-root "$PWD" --workspace-root "$PWD" --supported-scenes scenes/supported_scenes.yaml --output-dir build/workcell_studio_scene_readiness` which completed and produced `build/workcell_studio_scene_readiness/scene_readiness_summary.json`. (passed)
- Validated the generated artifact with `python3 -m json.tool scenes/ur5_2f_test/generated/scene_package_readiness.json` which succeeded. (passed)
- Ran builder validation `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` which completed and returned a valid builder validation report. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a301f55b080833186e65ccd9dd9d678)