### PR TITLE
Adjust Scene3D physical evidence readiness

### DIFF
--- a/scripts/run_workcell_studio_scene_readiness_matrix.py
+++ b/scripts/run_workcell_studio_scene_readiness_matrix.py
@@ -456,6 +456,7 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
     diagnostic_received = int(smoke_evidence.get("diagnostic_received_count") or 0)
     diagnostic_visible = int(smoke_evidence.get("diagnostic_visible_count") or 0)
     diagnostic_rendered = int(smoke_evidence.get("diagnostic_rendered_count") or 0)
+    source_count = int(visual.get("mesh_source_count") or 0) + int(visual.get("primitive_source_count") or 0)
     runtime_failure_reasons: list[str] = []
     if smoke_evidence["smoke_status"] != PASS:
         runtime_failure_reasons.append("smoke_status_not_pass")
@@ -482,11 +483,11 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
     runtime_evidence_valid = not runtime_failure_reasons
 
     summary_state = PASS if visual_status == PASS else FAIL
-    if runtime_evidence_valid:
+    if runtime_evidence_valid and mesh_index.is_file() and source_count > 0:
         summary_state = PASS
     elif visual_status == BLOCKED or not mesh_index.is_file() or not smoke_json.is_file() or runtime_blocked or not runtime_available:
         summary_state = BLOCKED if not mesh_index.is_file() or smoke_evidence["smoke_status"] in {BLOCKED, "MISSING"} or not smoke_json.is_file() else FAIL
-    if runtime_evidence_valid:
+    if runtime_evidence_valid and summary_state == PASS:
         summary_message = "Scene3D runtime evidence passes with viewport, screenshot, readiness markers, and diagnostics"
     elif summary_state == PASS:
         summary_message = "Scene3D visual-quality evidence passes"
@@ -524,46 +525,96 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
         **smoke_context,
     )
 
-    source_count = int(visual.get("mesh_source_count") or 0) + int(visual.get("primitive_source_count") or 0)
     physical_rendered = int(visual.get("physical_rendered_count") or 0)
+    credible_physical_rendered = max(
+        int(visual.get("credible_physical_rendered_count") or 0),
+        int(smoke_evidence.get("diagnostic_mesh_count") or 0),
+        int(smoke_evidence.get("diagnostic_primitive_count") or 0),
+    )
+    fallback_rendered = max(
+        int(smoke_evidence.get("diagnostic_fallback_count") or 0),
+        int(visual.get("diagnostic_fallback_count") or 0),
+        int(visual.get("valid_physical_fallback_count") or 0),
+        int(visual.get("raw_generated_bounds_count") or 0),
+        int(visual.get("placeholder_count") or 0),
+        int(visual.get("wireframe_fallback_count") or 0),
+        int(visual.get("missing_geometry_box_count") or 0),
+    )
+    has_any_runtime_visual_evidence = any(
+        count > 0
+        for count in (
+            diagnostic_received,
+            diagnostic_visible,
+            diagnostic_rendered,
+            credible_physical_rendered,
+            physical_rendered,
+            fallback_rendered,
+        )
+    )
+    physical_warnings = list(warnings)
+    for blocker in physical_blockers:
+        if blocker not in physical_warnings:
+            physical_warnings.append(blocker)
+
     if not mesh_index.is_file():
-        physical_state = BLOCKED
+        physical_state = FAIL
         physical_message = "mesh-index evidence is missing; physical visual evidence cannot be evaluated"
     elif not smoke_json.is_file():
-        physical_state = BLOCKED
+        physical_state = FAIL
         physical_message = "Scene3D GUI smoke evidence is missing; physical rendered evidence cannot be evaluated"
-    elif runtime_evidence_valid:
-        physical_state = PASS
-        physical_message = "Scene3D runtime evidence confirms visible rendered scene geometry"
-    elif runtime_blocked:
-        physical_state = BLOCKED
-        physical_message = "Scene3D runtime GUI evidence is blocked or unavailable; physical rendered evidence cannot be evaluated as a failure"
-    elif not runtime_available:
-        physical_state = BLOCKED
-        physical_message = "Scene3D runtime is unavailable; physical rendered evidence is not evaluated from static renderability counts"
+    elif smoke_evidence["smoke_status"] != PASS:
+        physical_state = FAIL
+        physical_message = "Scene3D GUI smoke status is not PASS; physical rendered evidence cannot be trusted"
+    elif smoke_evidence["runtime_available"] is not True or runtime_blocked or not runtime_available:
+        physical_state = FAIL
+        physical_message = "Scene3D runtime is unavailable; physical rendered evidence cannot be evaluated"
+    elif not screenshot_runtime_available:
+        physical_state = FAIL
+        physical_message = "Scene3D GUI screenshot evidence is missing; physical rendered evidence cannot be evaluated"
+    elif smoke_evidence.get("scene3d_viewport_widget_found") is not True:
+        physical_state = FAIL
+        physical_message = "Scene3D viewport evidence is missing; physical rendered evidence cannot be evaluated"
+    elif smoke_evidence.get("selected_scene_ready") is not True or diagnostic_scene != scene_name:
+        physical_state = FAIL
+        physical_message = "Scene3D smoke evidence does not match the requested scene"
+    elif diagnostic_received <= 0 or diagnostic_visible <= 0 or diagnostic_rendered <= 0:
+        physical_state = FAIL
+        physical_message = "Scene3D runtime diagnostics did not report nonzero received, visible, and rendered counts"
     elif source_count <= 0:
         physical_state = FAIL
         physical_message = "mesh index does not contain credible mesh or primitive source geometry"
-    elif physical_rendered <= 0:
+    elif not has_any_runtime_visual_evidence:
         physical_state = FAIL
-        physical_message = "no credible physical mesh/primitive render evidence was recorded"
+        physical_message = "no physical, mesh, primitive, or fallback visual evidence was recorded"
+    elif credible_physical_rendered > 0 or physical_rendered > 0:
+        physical_state = PASS
+        physical_message = "credible physical mesh/primitive visual evidence is present"
+    elif fallback_rendered > 0:
+        physical_state = PASS
+        physical_message = "Scene3D runtime rendered fallback visual evidence; mesh/primitive visual polish remains a warning"
+        concern = "fallback/placeholder visual evidence dominates; improve mesh/primitive rendering quality"
+        if concern not in physical_warnings:
+            physical_warnings.append(concern)
     elif physical_blockers:
         physical_state = FAIL
         physical_message = "physical render evidence exists but physical visual-quality blockers remain"
     else:
-        physical_state = PASS
-        physical_message = "credible physical mesh/primitive visual evidence is present"
+        physical_state = FAIL
+        physical_message = "no credible physical mesh/primitive render evidence was recorded"
     physical_result = _result(
         physical_state,
         physical_message,
         source_geometry_count=source_count,
         physical_rendered_count=physical_rendered,
+        credible_physical_rendered_count=credible_physical_rendered,
+        fallback_rendered_count=fallback_rendered,
         runtime_available=runtime_available,
         runtime_evidence_valid=runtime_evidence_valid,
         runtime_failure_reasons=runtime_failure_reasons,
         mesh_failure_summary_by_reason_code=visual.get("mesh_failure_summary_by_reason_code", {}),
         **smoke_context,
         blockers=physical_blockers,
+        warnings=physical_warnings,
     )
     return visual_result, physical_result
 

--- a/tests/test_workcell_studio_scene_readiness_matrix.py
+++ b/tests/test_workcell_studio_scene_readiness_matrix.py
@@ -91,8 +91,16 @@ def _add_scene3d_pass_evidence(scene_dir: Path) -> None:
         json.dumps(
             {
                 "schema": "workcell_studio_scene3d_gui_smoke/v1",
+                "status": "PASS",
+                "scene3d_viewport_widget_found": True,
+                "screenshot_saved": True,
+                "render_ready": True,
+                "log_ready": True,
+                "selected_scene_ready": True,
+                "runtime_available": True,
                 "primitive_rendered_count": 1,
                 "rendered_count": 1,
+                "runtime_scene3d_diagnostics": f"Scene3D canvas: scene={scene_dir.name} received=1 visible=1 rendered=1 mesh=0 primitive=1 fallback=0",
             }
         ),
         encoding="utf-8",
@@ -346,7 +354,7 @@ def test_scene3d_runtime_unavailable_fails_runtime_visual_evidence(
     visual_summary = scene["categories"]["scene3d_visual_quality_summary"]
     physical_evidence = scene["categories"]["credible_physical_visual_evidence"]
     assert visual_summary["status"] == "FAIL"
-    assert physical_evidence["status"] == "BLOCKED"
+    assert physical_evidence["status"] == "FAIL"
     for category in (visual_summary, physical_evidence):
         assert category["smoke_status"] == "FAIL"
         assert category["runtime_available"] is False
@@ -507,6 +515,40 @@ def test_check_scene3d_accepts_valid_new_runtime_smoke_evidence(tmp_path: Path) 
     assert physical_result["status"] == "PASS"
     assert physical_result["runtime_evidence_valid"] is True
 
+
+def test_check_scene3d_downgrades_fallback_dominance_to_warning_with_valid_runtime(tmp_path: Path) -> None:
+    scene_dir = tmp_path / "scenes" / "ur5_2f_test"
+    generated = scene_dir / "generated"
+    generated.mkdir(parents=True)
+    (generated / "scene_visual_mesh_index.json").write_text(
+        json.dumps({"items": [{"id": "fixture_box", "primitive_type": "box"}]}),
+        encoding="utf-8",
+    )
+    (generated / "scene3d_gui_smoke.json").write_text(
+        json.dumps(
+            {
+                "status": "PASS",
+                "scene3d_viewport_widget_found": True,
+                "screenshot_saved": True,
+                "render_ready": True,
+                "log_ready": True,
+                "selected_scene_ready": True,
+                "runtime_available": True,
+                "placeholder_count": 7,
+                "rendered_count": 7,
+                "runtime_scene3d_diagnostics": "Scene3D canvas: scene=ur5_2f_test received=7 visible=7 rendered=7 mesh=0 primitive=0 fallback=7",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _visual_result, physical_result = matrix._check_scene3d("ur5_2f_test", scene_dir)
+
+    assert physical_result["status"] == "PASS"
+    assert physical_result["fallback_rendered_count"] == 7
+    assert physical_result["credible_physical_rendered_count"] == 0
+    assert any("fallback" in warning for warning in physical_result["warnings"])
+    assert any("physical" in warning for warning in physical_result["warnings"])
 
 def test_check_scene3d_rejects_new_runtime_smoke_scene_mismatch(tmp_path: Path) -> None:
     scene_dir = tmp_path / "scenes" / "ur5_2f_test"


### PR DESCRIPTION
### Motivation
- Improve the Scene3D "credible_physical_visual_evidence" decision logic so valid runtime diagnostics can allow a scene to pass while preserving hard failures for missing or invalid artifacts.
- Avoid blocking supported scenes (e.g., `ur5_2f_test`) when runtime diagnostics show nonzero rendered evidence but the render is dominated by fallback/placeholder visuals, while keeping visual-polish concerns visible.

### Description
- Require runtime diagnostics plus a nonzero mesh/primitive source count before treating runtime evidence as an automatic `PASS` for the Scene3D visual summary and adjust summary messaging accordingly in `_check_scene3d()`.
- Preserve `FAIL` for missing mesh index, missing smoke JSON, smoke status not `PASS`, runtime unavailable, missing screenshot, missing viewport, selected scene mismatch, zero received/visible/rendered counts, `source_count <= 0`, or no physical/mesh/primitive/fallback evidence at all.
- When smoke status is `PASS` and the diagnostics report nonzero rendered evidence, treat fallback/placeholder dominance as non-blocking by setting the physical category to `PASS` if credible mesh/primitive evidence exists, and otherwise pass the category while adding warnings describing fallback-dominance and physical-blocker text is preserved in `warnings` so polish issues remain visible.
- Carry physical blocker messages into the `warnings` list for the `credible_physical_visual_evidence` category and add coverage for fallback-dominance downgrade behavior in the tests.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_scene_readiness_matrix.py -q` and all tests passed (`18 passed`).
- Verified `python3 -m py_compile scripts/run_workcell_studio_scene_readiness_matrix.py` succeeded with no syntax errors.
- Modified files exercised by tests include `scripts/run_workcell_studio_scene_readiness_matrix.py` and `tests/test_workcell_studio_scene_readiness_matrix.py` and the new/updated tests validate the fallback-dominance downgrade and valid runtime-diagnostics acceptance behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a301f5d39048331879142fd1febfa20)