### PR TITLE
Handle nested Scene3D smoke evidence

### DIFF
--- a/scripts/run_workcell_studio_scene_readiness_matrix.py
+++ b/scripts/run_workcell_studio_scene_readiness_matrix.py
@@ -320,14 +320,36 @@ def _check_cell_definition(scene_dir: Path) -> dict[str, Any]:
     )
 
 
+def _normalize_scene3d_diagnostic_count(key: str, value: Any) -> tuple[str, Any]:
+    try:
+        return f"diagnostic_{key}_count", int(value)
+    except (TypeError, ValueError):
+        return f"diagnostic_{key}", value
+
+
 def _parse_scene3d_diagnostics_line(value: Any) -> dict[str, Any]:
-    """Parse a Scene3D runtime diagnostics line into stable readiness counters."""
+    """Parse Scene3D runtime diagnostics into stable readiness counters."""
+    if isinstance(value, dict):
+        parsed: dict[str, Any] = {}
+        scene = value.get("scene")
+        if scene is not None:
+            parsed["diagnostic_scene"] = str(scene)
+        counts = value.get("counts")
+        if isinstance(counts, dict):
+            for key, raw in counts.items():
+                if key == "scene":
+                    parsed["diagnostic_scene"] = str(raw)
+                    continue
+                normalized_key, normalized_value = _normalize_scene3d_diagnostic_count(str(key), raw)
+                parsed[normalized_key] = normalized_value
+        return parsed
+
     if isinstance(value, list):
         value = "\n".join(str(item) for item in value)
     if not isinstance(value, str) or not value.strip():
         return {}
 
-    parsed: dict[str, Any] = {}
+    parsed = {}
     for line in value.splitlines():
         if "Scene3D canvas:" not in line:
             continue
@@ -335,10 +357,8 @@ def _parse_scene3d_diagnostics_line(value: Any) -> dict[str, Any]:
             if key == "scene":
                 parsed["diagnostic_scene"] = raw
                 continue
-            try:
-                parsed[f"diagnostic_{key}_count"] = int(raw)
-            except ValueError:
-                parsed[f"diagnostic_{key}"] = raw
+            normalized_key, normalized_value = _normalize_scene3d_diagnostic_count(key, raw)
+            parsed[normalized_key] = normalized_value
     return parsed
 
 
@@ -351,11 +371,27 @@ def _extract_scene3d_smoke_evidence(smoke_json: Path) -> dict[str, Any]:
             payload = loaded
 
     def nested_value(*keys: str) -> Any:
-        sources = [payload]
+        sources: list[dict[str, Any]] = [payload]
         for nested_key in ("result", "render_debug_counters", "static_scene3d_visual_evidence"):
             nested = payload.get(nested_key)
             if isinstance(nested, dict):
                 sources.append(nested)
+        readiness_markers = payload.get("readiness_markers")
+        if isinstance(readiness_markers, dict):
+            marker_keys = {
+                "selected_scene_ready",
+                "render_ready",
+                "log_ready",
+                "screenshot_ready",
+                "hierarchy_ready",
+                "inspector_ready",
+                "paint_completed",
+            }
+            if any(key in marker_keys for key in keys):
+                sources.append(readiness_markers)
+        counters = payload.get("counters")
+        if isinstance(counters, dict) and "scene3d_viewport_widget_found" in keys:
+            sources.append(counters)
         for source in sources:
             for key in keys:
                 if key in source and source.get(key) is not None:
@@ -376,6 +412,8 @@ def _extract_scene3d_smoke_evidence(smoke_json: Path) -> dict[str, Any]:
     runtime_available = optional_bool(nested_value("runtime_available"))
     screenshot_saved = optional_bool(nested_value("screenshot_saved"))
     screenshot_available = optional_bool(nested_value("screenshot_available"))
+    if screenshot_available is None:
+        screenshot_available = optional_bool(nested_value("screenshot_ready"))
     if screenshot_available is None:
         screenshot_available = screenshot_saved
     default_status = "INVALID" if smoke_error else "MISSING" if not smoke_json.is_file() else "UNKNOWN"
@@ -403,6 +441,10 @@ def _extract_scene3d_smoke_evidence(smoke_json: Path) -> dict[str, Any]:
         "render_ready": optional_bool(nested_value("render_ready")),
         "log_ready": optional_bool(nested_value("log_ready")),
         "selected_scene_ready": optional_bool(nested_value("selected_scene_ready")),
+        "screenshot_ready": optional_bool(nested_value("screenshot_ready")),
+        "hierarchy_ready": optional_bool(nested_value("hierarchy_ready")),
+        "inspector_ready": optional_bool(nested_value("inspector_ready")),
+        "paint_completed": optional_bool(nested_value("paint_completed")),
         "ros_humble_available": optional_bool(nested_value("ros_humble_available")),
         "runtime_scene3d_diagnostics": nested_value("runtime_scene3d_diagnostics"),
         **diagnostics,

--- a/tests/test_workcell_studio_scene_readiness_matrix.py
+++ b/tests/test_workcell_studio_scene_readiness_matrix.py
@@ -479,6 +479,63 @@ def test_extract_scene3d_smoke_evidence_parses_new_runtime_diagnostics(tmp_path:
     assert evidence["diagnostic_fallback_count"] == 0
 
 
+def test_extract_scene3d_smoke_evidence_reads_markers_counters_and_mapping_diagnostics(tmp_path: Path) -> None:
+    smoke = tmp_path / "scene3d_gui_smoke.json"
+    smoke.write_text(
+        json.dumps(
+            {
+                "wrapper_status": "PASS",
+                "readiness_markers": {
+                    "selected_scene_ready": True,
+                    "render_ready": True,
+                    "log_ready": True,
+                    "screenshot_ready": True,
+                    "hierarchy_ready": True,
+                    "inspector_ready": True,
+                    "paint_completed": True,
+                },
+                "counters": {"scene3d_viewport_widget_found": True},
+                "runtime_available": True,
+                "runtime_scene3d_diagnostics": {
+                    "scene": "ur5_2f_test",
+                    "counts": {
+                        "received": 33,
+                        "visible": "32",
+                        "rendered": 31,
+                        "mesh": 23,
+                        "fallback": 1,
+                        "cached": 30,
+                        "locked": 20,
+                        "skipped": 2,
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    evidence = matrix._extract_scene3d_smoke_evidence(smoke)
+
+    assert evidence["scene3d_viewport_widget_found"] is True
+    assert evidence["selected_scene_ready"] is True
+    assert evidence["render_ready"] is True
+    assert evidence["log_ready"] is True
+    assert evidence["screenshot_ready"] is True
+    assert evidence["screenshot_available"] is True
+    assert evidence["hierarchy_ready"] is True
+    assert evidence["inspector_ready"] is True
+    assert evidence["paint_completed"] is True
+    assert evidence["diagnostic_scene"] == "ur5_2f_test"
+    assert evidence["diagnostic_received_count"] == 33
+    assert evidence["diagnostic_visible_count"] == 32
+    assert evidence["diagnostic_rendered_count"] == 31
+    assert evidence["diagnostic_mesh_count"] == 23
+    assert evidence["diagnostic_fallback_count"] == 1
+    assert evidence["diagnostic_cached_count"] == 30
+    assert evidence["diagnostic_locked_count"] == 20
+    assert evidence["diagnostic_skipped_count"] == 2
+
+
 def test_check_scene3d_accepts_valid_new_runtime_smoke_evidence(tmp_path: Path) -> None:
     scene_dir = tmp_path / "scenes" / "ur5_2f_test"
     generated = scene_dir / "generated"


### PR DESCRIPTION
### Motivation
- Scene3D smoke output can surface readiness markers and viewport counters in nested payload fields and may emit diagnostics as a mapping (`scene` + `counts`) in addition to the legacy diagnostic string, so evidence extraction must normalize both forms for reliable visual-quality checks.

### Description
- Added helper `_normalize_scene3d_diagnostic_count()` and extended `_parse_scene3d_diagnostics_line()` to accept mapping-form diagnostics with `scene` and `counts` while preserving the existing string parser.
- Extended `nested_value()` inside `_extract_scene3d_smoke_evidence()` to search `payload["readiness_markers"]` for `selected_scene_ready`, `render_ready`, `log_ready`, `screenshot_ready`, `hierarchy_ready`, `inspector_ready`, and `paint_completed`, and to search `payload["counters"]` for `scene3d_viewport_widget_found` when the top-level key is absent.
- Added `screenshot_ready` fallback into screenshot availability logic and returned the additional normalized readiness keys and diagnostic count fields (e.g. `diagnostic_received_count`, `diagnostic_visible_count`, `diagnostic_rendered_count`, `diagnostic_mesh_count`, `diagnostic_fallback_count`, and other present counts such as `cached`, `locked`, `skipped`).
- Added a regression test `test_extract_scene3d_smoke_evidence_reads_markers_counters_and_mapping_diagnostics` that exercises nested readiness markers, counters fallback, and mapping diagnostics normalization.

### Testing
- Ran `python3 -m pytest tests/test_workcell_studio_scene_readiness_matrix.py -q` and the test suite passed (`19 passed`).
- Existing legacy diagnostics parsing and existing Scene3D smoke tests were preserved and exercised by the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a302452e6488331b5726e7321999b94)