### PR TITLE
Add structured Scene3D smoke readiness coverage

### DIFF
--- a/scripts/run_workcell_studio_scene_readiness_matrix.py
+++ b/scripts/run_workcell_studio_scene_readiness_matrix.py
@@ -322,6 +322,19 @@ def _check_cell_definition(scene_dir: Path) -> dict[str, Any]:
 
 def _parse_scene3d_diagnostics_line(value: Any) -> dict[str, Any]:
     """Parse a Scene3D runtime diagnostics line into stable readiness counters."""
+    if isinstance(value, dict):
+        parsed: dict[str, Any] = {}
+        scene = value.get("scene")
+        if scene is not None:
+            parsed["diagnostic_scene"] = str(scene)
+        counts = value.get("counts")
+        if isinstance(counts, dict):
+            for key, raw in counts.items():
+                try:
+                    parsed[f"diagnostic_{key}_count"] = int(raw)
+                except (TypeError, ValueError):
+                    parsed[f"diagnostic_{key}"] = raw
+        return parsed
     if isinstance(value, list):
         value = "\n".join(str(item) for item in value)
     if not isinstance(value, str) or not value.strip():
@@ -352,7 +365,13 @@ def _extract_scene3d_smoke_evidence(smoke_json: Path) -> dict[str, Any]:
 
     def nested_value(*keys: str) -> Any:
         sources = [payload]
-        for nested_key in ("result", "render_debug_counters", "static_scene3d_visual_evidence"):
+        for nested_key in (
+            "result",
+            "render_debug_counters",
+            "static_scene3d_visual_evidence",
+            "readiness_markers",
+            "counters",
+        ):
             nested = payload.get(nested_key)
             if isinstance(nested, dict):
                 sources.append(nested)

--- a/tests/test_workcell_studio_scene_readiness_matrix.py
+++ b/tests/test_workcell_studio_scene_readiness_matrix.py
@@ -516,6 +516,84 @@ def test_check_scene3d_accepts_valid_new_runtime_smoke_evidence(tmp_path: Path) 
     assert physical_result["runtime_evidence_valid"] is True
 
 
+def test_check_scene3d_accepts_structured_gui_smoke_readiness_fixture(tmp_path: Path) -> None:
+    scene_dir = tmp_path / "scenes" / "ur5_2f_test"
+    generated = scene_dir / "generated"
+    generated.mkdir(parents=True)
+    (generated / "scene_visual_mesh_index.json").write_text(
+        json.dumps(
+            {
+                "schema": "workcell_studio_scene_visual_mesh_index/v1",
+                "scene": "ur5_2f_test",
+                "visual_items": [
+                    {
+                        "id": f"ur5_mesh_{index:02d}",
+                        "source": "urdf/scene.urdf.xacro",
+                        "mesh": f"package://ur_description/meshes/ur5/visual/link_{index:02d}.dae",
+                        "resolved": True,
+                    }
+                    for index in range(23)
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (generated / "scene3d_gui_smoke.json").write_text(
+        json.dumps(
+            {
+                "status": "PASS",
+                "wrapper_status": "PASS",
+                "runtime_available": True,
+                "ros_humble_available": True,
+                "screenshot_available": True,
+                "screenshot_saved": True,
+                "readiness_markers": {
+                    "selected_scene_ready": True,
+                    "render_ready": True,
+                    "log_ready": True,
+                    "screenshot_ready": True,
+                    "hierarchy_ready": True,
+                    "inspector_ready": True,
+                    "paint_completed": True,
+                },
+                "scene3d_viewport_widget_found": True,
+                "runtime_scene3d_diagnostics": {
+                    "scene": "ur5_2f_test",
+                    "counts": {
+                        "received": 33,
+                        "visible": 33,
+                        "rendered": 33,
+                        "cached": 33,
+                        "mesh": 23,
+                        "fallback": 0,
+                        "locked": 23,
+                        "skipped": 0,
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    visual_result, physical_result = matrix._check_scene3d("ur5_2f_test", scene_dir)
+
+    assert visual_result["runtime_evidence_valid"] is True
+    rejected_reasons = {
+        "selected_scene_not_ready",
+        "viewport_missing",
+        "render_not_ready",
+        "log_not_ready",
+        "diagnostics_scene_mismatch_or_missing",
+        "zero_received_count",
+        "zero_visible_count",
+        "zero_rendered_count",
+    }
+    assert rejected_reasons.isdisjoint(visual_result["runtime_failure_reasons"])
+    assert physical_result["status"] in {"PASS", "WARNING"}
+    assert visual_result["status"] in {"PASS", "WARNING"}
+    assert visual_result["status"] not in {"BLOCKED", "FAIL"}
+
+
 def test_check_scene3d_downgrades_fallback_dominance_to_warning_with_valid_runtime(tmp_path: Path) -> None:
     scene_dir = tmp_path / "scenes" / "ur5_2f_test"
     generated = scene_dir / "generated"


### PR DESCRIPTION
### Motivation

- Improve Scene3D smoke-evidence parsing to accept structured runtime diagnostics and nested readiness/counter payloads so the readiness matrix can validate richer GUI smoke JSON shapes.

### Description

- Extended `_parse_scene3d_diagnostics_line` to accept a dict-shaped diagnostics payload with `scene` and `counts` and to map counts to `diagnostic_*_count` fields.
- Expanded `_extract_scene3d_smoke_evidence` nested-value lookup to include `readiness_markers` and `counters` so readiness markers and counters are discovered in nested payloads.
- Added a new test `test_check_scene3d_accepts_structured_gui_smoke_readiness_fixture` that writes `generated/scene3d_gui_smoke.json` and `generated/scene_visual_mesh_index.json`, calls `matrix._check_scene3d("ur5_2f_test", scene_dir)`, and asserts runtime evidence validity and acceptable visual/physical statuses.
- Modified files: `scripts/run_workcell_studio_scene_readiness_matrix.py` and `tests/test_workcell_studio_scene_readiness_matrix.py`.

### Testing

- Ran the Scene readiness unit tests via `pytest -q tests/test_workcell_studio_scene_readiness_matrix.py` and all tests passed (19 passed).
- The new test verifies that `visual_result["runtime_evidence_valid"] is True`, that none of the listed runtime failure reasons are present, and that `physical_result["status"]` and `visual_result["status"]` are not `BLOCKED`/`FAIL`.
- No runtime, launch, controller, or hardware configuration changes were made and fake-hardware defaults remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a302469458c8331a11bd7382a65fc41)