### PR TITLE
Demote Scene3D fallback-dominance blockers to warnings when runtime evidence is valid

### DIFF
--- a/scripts/run_workcell_studio_scene_readiness_matrix.py
+++ b/scripts/run_workcell_studio_scene_readiness_matrix.py
@@ -446,7 +446,6 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
     )
     blockers = [str(item) for item in visual.get("blockers", [])]
     visual_blocker_reasons = [str(item) for item in visual.get("blocker_reasons", [])]
-    physical_blockers = [blocker for blocker in blockers if not blocker.startswith("screenshot_missing:") and blocker != "screenshot_missing"]
     warnings = [str(item) for item in visual.get("warnings", [])]
     visual_status = str(visual.get("visual_quality_status") or "").upper()
     runtime_blocked = smoke_evidence["smoke_status"] == BLOCKED or smoke_evidence["runtime_available"] is False
@@ -460,6 +459,8 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
     runtime_failure_reasons: list[str] = []
     if smoke_evidence["smoke_status"] != PASS:
         runtime_failure_reasons.append("smoke_status_not_pass")
+    if smoke_evidence.get("wrapper_status") not in {PASS, None}:
+        runtime_failure_reasons.append("wrapper_status_not_pass")
     if smoke_evidence["runtime_available"] is not True:
         runtime_failure_reasons.append("runtime_unavailable")
     if not screenshot_runtime_available:
@@ -481,6 +482,49 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
     if diagnostic_rendered <= 0:
         runtime_failure_reasons.append("zero_rendered_count")
     runtime_evidence_valid = not runtime_failure_reasons
+
+    runtime_valid_warning_reason_codes = {
+        "physical_fallback_dominates",
+    }
+    runtime_valid_warning_blocker_fragments = (
+        "fallback",
+        "placeholder",
+        "polish",
+        "wireframe",
+        "missing geometry",
+    )
+    visual_warning_blockers: list[str] = []
+    hard_blockers: list[str] = []
+    hard_blocker_reasons: list[str] = []
+    warning_blocker_reasons: list[str] = []
+    for idx, blocker in enumerate(blockers):
+        reason = visual_blocker_reasons[idx] if idx < len(visual_blocker_reasons) else ""
+        blocker_lc = blocker.lower()
+        reason_lc = reason.lower()
+        runtime_valid_warning = (
+            runtime_evidence_valid
+            and (
+                reason_lc in runtime_valid_warning_reason_codes
+                or any(fragment in blocker_lc for fragment in runtime_valid_warning_blocker_fragments)
+            )
+        )
+        if runtime_valid_warning:
+            if blocker not in visual_warning_blockers:
+                visual_warning_blockers.append(blocker)
+            if reason and reason not in warning_blocker_reasons:
+                warning_blocker_reasons.append(reason)
+        else:
+            hard_blockers.append(blocker)
+            if reason and reason not in hard_blocker_reasons:
+                hard_blocker_reasons.append(reason)
+    for blocker in visual_warning_blockers:
+        if blocker not in warnings:
+            warnings.append(blocker)
+    physical_blockers = [
+        blocker
+        for blocker in hard_blockers
+        if not blocker.startswith("screenshot_missing:") and blocker != "screenshot_missing"
+    ]
 
     summary_state = PASS if visual_status == PASS else FAIL
     if runtime_evidence_valid and mesh_index.is_file() and source_count > 0:
@@ -504,8 +548,10 @@ def _check_scene3d(scene_name: str, scene_dir: Path) -> tuple[dict[str, Any], di
         mesh_index_path=str(mesh_index),
         smoke_json=str(smoke_json),
         screenshot_path=str(screenshot_path) if screenshot_path is not None else None,
-        blockers=blockers,
-        blocker_reasons=visual_blocker_reasons,
+        blockers=hard_blockers,
+        blocker_reasons=hard_blocker_reasons,
+        runtime_valid_warning_blockers=visual_warning_blockers,
+        runtime_valid_warning_blocker_reasons=warning_blocker_reasons,
         warnings=warnings,
         runtime_available=runtime_available,
         runtime_evidence_valid=runtime_evidence_valid,

--- a/tests/test_workcell_studio_scene_readiness_matrix.py
+++ b/tests/test_workcell_studio_scene_readiness_matrix.py
@@ -534,6 +534,8 @@ def test_check_scene3d_downgrades_fallback_dominance_to_warning_with_valid_runti
                 "log_ready": True,
                 "selected_scene_ready": True,
                 "runtime_available": True,
+                "wrapper_status": "PASS",
+                "valid_physical_fallback_count": 7,
                 "placeholder_count": 7,
                 "rendered_count": 7,
                 "runtime_scene3d_diagnostics": "Scene3D canvas: scene=ur5_2f_test received=7 visible=7 rendered=7 mesh=0 primitive=0 fallback=7",
@@ -542,9 +544,14 @@ def test_check_scene3d_downgrades_fallback_dominance_to_warning_with_valid_runti
         encoding="utf-8",
     )
 
-    _visual_result, physical_result = matrix._check_scene3d("ur5_2f_test", scene_dir)
+    visual_result, physical_result = matrix._check_scene3d("ur5_2f_test", scene_dir)
 
-    assert physical_result["status"] == "PASS"
+    assert visual_result["runtime_evidence_valid"] is True
+    assert physical_result["runtime_evidence_valid"] is True
+    assert "physical_fallback_dominates" in visual_result["runtime_valid_warning_blocker_reasons"]
+    assert all("fallback" not in blocker for blocker in visual_result["blockers"])
+    assert physical_result["status"] != "FAIL"
+    assert visual_result["status"] not in {"BLOCKED", "FAIL"}
     assert physical_result["fallback_rendered_count"] == 7
     assert physical_result["credible_physical_rendered_count"] == 0
     assert any("fallback" in warning for warning in physical_result["warnings"])


### PR DESCRIPTION
### Motivation
- Improve Scene3D readiness reporting by not letting polish/fallback-only visual evidence (placeholders, wireframes, generated bounds) block a scene when runtime diagnostics are credible. 
- Preserve strong runtime-evidence failures as hard blockers so real runtime issues (smoke/wrapper not PASS, missing screenshot/viewport/diagnostics, scene mismatch, zero counts) still fail the evaluation.

### Description
- Add `wrapper_status` to runtime failure checks and keep the set of runtime-evidence failure reasons unchanged for hard failures. 
- Split `visual.get("blockers")` into `hard_blockers` and `runtime_valid_warning_blockers` after `runtime_evidence_valid` is computed, using explicit reason codes and blocker text fragments (e.g., `fallback`, `placeholder`, `polish`, `wireframe`, `missing geometry`) to demote fallback-style blockers when runtime evidence is valid. 
- Keep only true hard blockers in the `blockers`/`blocker_reasons` fields of the visual summary and expose downgraded issues via `runtime_valid_warning_blockers` and `runtime_valid_warning_blocker_reasons`, while also appending downgraded blockers into `warnings`. 
- Ensure `physical_blockers` for the physical result are derived from the hard blockers list so fallback-dominance no longer forces a physical FAIL when runtime evidence is valid. 
- Update the focused test `test_check_scene3d_downgrades_fallback_dominance_to_warning_with_valid_runtime` to exercise runtime-valid fallback-dominance and assert that `runtime_evidence_valid is True`, fallback dominance appears in the runtime-valid warning fields, and the visual/physical categories are not failed solely for fallback dominance.

### Testing
- Ran unit tests with `pytest -q tests/test_workcell_studio_scene_readiness_matrix.py` and all tests passed (`18 passed`).
- The modified test `test_check_scene3d_downgrades_fallback_dominance_to_warning_with_valid_runtime` was executed and validates the new classification behavior.
- No runtime commands, launches, or hardware interactions were performed during testing; behavior remains fake-hardware-first and safe.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3024721584833187c8d318a0b34b5e)