### PR TITLE
Polish Scene3D preview status summary

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -156,6 +156,27 @@ namespace {
   "Task intent: task_intent grasp_strategy top_grasp_2f suction_top approach_distance retract_distance | "
   "Generate/Validate/Plan: generated_package_path validation_output plan_simulate_handoff fake_hardware_first";
 
+static QString scene3d_user_preview_status_summary(
+  const ScenePreviewWidget::RenderDebugCounters & counters,
+  int warning_count)
+{
+  const QString quality = counters.visual_quality_status.trimmed().toUpper();
+  const int rendered_count = qMax(counters.rendered_count, counters.visible_count);
+  const int mesh_count = qMax(counters.mesh_rendered_count, counters.mesh_backed_count);
+  const bool unusable =
+    quality == QStringLiteral("FAIL") ||
+    (counters.viewport_received_count <= 0 && counters.visible_count <= 0 && counters.rendered_count <= 0);
+  const bool has_warnings = warning_count > 0 || quality == QStringLiteral("WARNING") || !counters.visual_quality_warnings.isEmpty();
+  const QString title = unusable
+    ? QStringLiteral("3D Preview Unavailable")
+    : (has_warnings ? QStringLiteral("3D Preview Warnings") : QStringLiteral("3D Preview Ready"));
+  const QString details = QString("Rendered %1 items · Mesh %2 · Warnings %3")
+    .arg(rendered_count)
+    .arg(mesh_count)
+    .arg(qMax(0, warning_count));
+  return QString("%1\n%2").arg(title, details);
+}
+
 
 
 struct Scene3DDetectionSnapshotLoadResult {
@@ -6971,6 +6992,10 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
     append_studio_log("Scene3D blocker: current layer filters hide all items. Re-enable editable layout, mesh preview, primitive fallback, or locked generated URDF visuals.");
   }
   scene_preview_widget_->set_preview_items(filtered_items);
+  scene_preview_widget_->set_preview_status_summary(
+    scene3d_user_preview_status_summary(
+      scene_preview_widget_->render_debug_counters(),
+      scene_preview_widget_->total_warning_count()));
   if (scene3d_debug_logging_enabled()) {
     append_studio_log(
       QString("Scene3D diagnostics {model_items_count=%1, filtered_visible_count=%2}")
@@ -8489,10 +8514,13 @@ void MainWindow::populate_scene_hierarchy()
   if (scene_preview_widget_) {
     scene_preview_widget_->set_scene_selected(true);
     scene_preview_widget_->set_preview_scene_name(selected_scene_state_.name);
-    scene_preview_widget_->set_preview_status_summary(preview_provenance_summary_);
     apply_scene3d_preview_layer_filters(false);
 
     const auto scene3d_full_payload_counters = scene_preview_widget_->render_debug_counters();
+    scene_preview_widget_->set_preview_status_summary(
+      scene3d_user_preview_status_summary(
+        scene3d_full_payload_counters,
+        scene_preview_widget_->total_warning_count()));
     ++scene_diagnostic_payload_revision_;
     append_scene_diagnostic_log_once(
       QStringLiteral("full_payload_commit"),


### PR DESCRIPTION
### Motivation
- Provide a concise, user-facing Scene3D preview chip that summarizes runtime render counters without surfacing scary or verbose provenance/diagnostic text.
- Keep detailed `preview_provenance_summary_`, `scene3d_diagnostics_line`, and `scene3d_warning_buckets` confined to logs and developer diagnostics.

### Description
- Added `scene3d_user_preview_status_summary(const ScenePreviewWidget::RenderDebugCounters &, int)` to build a short two-line status with a title (`3D Preview Ready`, `3D Preview Warnings`, or `3D Preview Unavailable`) and a compact details line like `Rendered 33 items · Mesh 23 · Warnings 2` in `mainwindow.cpp`.
- Replaced the direct use of `preview_provenance_summary_` for the preview chip with the new summary after preview items are applied and after preview payload commit by calling `scene_preview_widget_->set_preview_status_summary(...)` with the new summary.
- Preserved existing verbose provenance, diagnostics, and warning-bucket logging; those remain in logs/dev-diagnostics only and are not shown in the main status chip.

### Testing
- Ran `git diff --check` which passed without errors.
- Confirmed code references and replacements via local source inspection of `workcell_builder/workcell_builder/gui/mainwindow.cpp`.
- Did not run `colcon build --symlink-install --packages-select workcell_builder` because the container lacks the ROS Humble environment (`/opt/ros/humble/setup.bash` not present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30273147048331a47b287865cacdd9)