### PR TITLE
Prefer physical isometric fit for scene preview; add fit_product_view()

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1008,8 +1008,36 @@ void Scene3DViewportWidget::fit_scene() {
   distance_ = qBound(min_distance_, fit_distance, max_distance_);
   pitch_ = qBound(0.28, pitch_, 0.9);
   orbit_offset_.setY(orbit_offset_.y() + static_cast<float>(qMax(0.10, radius * 0.05)));
-  last_camera_fit_target_ = QStringLiteral("scene");
+  last_camera_fit_target_ = fit_include_overlays ? QStringLiteral("scene_with_overlays") : QStringLiteral("scene");
   has_robot_aabb_diag_ = false;
+  update();
+}
+
+void Scene3DViewportWidget::fit_product_view()
+{
+  const bool previous_include_overlays = fit_include_overlays;
+  fit_include_overlays = false;
+
+  QVector3D bmin, bmax;
+  if (!scene_bounds_from_visible_items(bmin, bmax, false)) {
+    fit_include_overlays = previous_include_overlays;
+    set_isometric_view();
+    return;
+  }
+
+  orbit_offset_ = (bmin + bmax) * 0.5f;
+  const QVector3D ext = bmax - bmin;
+  const double radius = qMax(0.25, 0.5 * qSqrt(ext.x() * ext.x() + ext.y() * ext.y() + ext.z() * ext.z()));
+  scene_radius_ = radius;
+  const double fov = qDegreesToRadians(50.0);
+  const double fit_distance = (radius / qTan(fov * 0.5)) * 1.05;
+  distance_ = qBound(min_distance_, fit_distance, max_distance_);
+  yaw_ = -0.78539816339;
+  pitch_ = 0.61547970867;
+  orbit_offset_.setY(orbit_offset_.y() + static_cast<float>(qMax(0.10, radius * 0.05)));
+  last_camera_fit_target_ = QStringLiteral("product_physical_isometric");
+  has_robot_aabb_diag_ = false;
+  fit_include_overlays = previous_include_overlays;
   update();
 }
 void Scene3DViewportWidget::fit_robot()

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -69,6 +69,7 @@ public:
 
   void reset_view();
   void fit_scene();
+  void fit_product_view();
   void fit_robot();
   void focus_selected();
   void set_top_view();

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -296,7 +296,7 @@ void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items)
     emit studio_log_requested(has_selected ? QString("Preview selection restored after refresh: %1").arg(selected_preview_item_id_) : QString("Preview selection retained after refresh; id is hidden by filters or absent from the visible preview payload: %1").arg(selected_preview_item_id_));
   }
   viewport->fit_include_overlays = false;
-  viewport->fit_scene();
+  viewport->fit_product_view();
   emit_scene_diagnostic_once(
     QStringLiteral("payload_commit"),
     preview_items_.size(),


### PR DESCRIPTION
### Motivation
- Make the default scene preview framing prioritize real physical geometry (robot/workcell bounds) and avoid being dominated by overlay-only helpers or warning labels, while providing a deterministic angled/isometric camera after preview payload ingestion.

### Description
- Add a new public viewport method `Scene3DViewportWidget::fit_product_view()` that computes bounds excluding overlay-only helpers, applies a product-centered isometric yaw/pitch, and preserves the previous `fit_include_overlays` flag in `scene3d_viewport_widget.cpp` and `.h`.
- Update `ScenePreviewWidget::set_preview_items()` to call `viewport->fit_product_view()` immediately after `viewport->ingest_preview_items(preview_items_)` so refreshed payloads default to product/physical framing in `scene_preview_widget.cpp`.
- Keep existing `fit_scene()` behavior available and update it to tag `last_camera_fit_target_` when overlays are included; preserve manual toolbar actions `Top`, `Front`, `Side`, `Isometric`, `Fit Scene`, `Fit Robot`, and `Fit overlays` as explicit overrides.
- Modified files: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h`, `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`, and `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`.

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch issues and it passed.
- Used `rg` searches to verify the new `fit_product_view` call and that manual view/fit actions remain connected, which succeeded.
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but the container does not have `colcon` installed, so a full build could not be executed in this environment; recommend running the normal `colcon` build and runtime/visual checks in CI or a developer environment before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a302736b9dc83318bb5989cad0ccf5e)