### PR TITLE
Productize Scene3D default viewport and concise overlay (Diagnostics toggle)

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1030,11 +1030,11 @@ void Scene3DViewportWidget::fit_product_view()
   const double radius = qMax(0.25, 0.5 * qSqrt(ext.x() * ext.x() + ext.y() * ext.y() + ext.z() * ext.z()));
   scene_radius_ = radius;
   const double fov = qDegreesToRadians(50.0);
-  const double fit_distance = (radius / qTan(fov * 0.5)) * 1.05;
+  const double fit_distance = (radius / qTan(fov * 0.5)) * 0.78;
   distance_ = qBound(min_distance_, fit_distance, max_distance_);
-  yaw_ = -0.78539816339;
-  pitch_ = 0.61547970867;
-  orbit_offset_.setY(orbit_offset_.y() + static_cast<float>(qMax(0.10, radius * 0.05)));
+  yaw_ = -0.72;
+  pitch_ = 0.54;
+  orbit_offset_.setY(orbit_offset_.y() + static_cast<float>(qMax(0.04, radius * 0.025)));
   last_camera_fit_target_ = QStringLiteral("product_physical_isometric");
   has_robot_aabb_diag_ = false;
   fit_include_overlays = previous_include_overlays;
@@ -1355,21 +1355,39 @@ void Scene3DViewportWidget::paintGL()
   }
   last_render_counters.labels_drawn = labels_drawn;
   last_render_counters.labels_suppressed_overlap = labels_suppressed_overlap;
+  const bool concise_warning = missing_geometry_count > 0 ||
+                               last_render_counters.visual_quality_status == QStringLiteral("FAIL");
+  const QRectF overlay_rect = debug_overlays_mode ? QRectF(12.0, 12.0, 430.0, 88.0)
+                                                  : QRectF(12.0, 12.0, concise_warning ? 300.0 : 270.0, concise_warning ? 62.0 : 46.0);
   painter.setPen(Qt::NoPen);
-  painter.setBrush(QColor(15, 23, 42, 190));
-  painter.drawRoundedRect(QRectF(12.0, 12.0, 360.0, 74.0), 6.0, 6.0);
+  painter.setBrush(QColor(15, 23, 42, debug_overlays_mode ? 205 : 165));
+  painter.drawRoundedRect(overlay_rect, 8.0, 8.0);
   painter.setPen(QColor("#e2e8f0"));
-  painter.drawText(QRectF(20.0, 18.0, 344.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter, "View: 3D");
-  painter.drawText(QRectF(20.0, 34.0, 344.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
-                   QString("Scene: %1").arg(scene_name));
-  painter.drawText(QRectF(20.0, 50.0, 460.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
-                   QString("Generated mesh %1/%2 • URDF primitives %3/%4 • Helpers %5 • Missing geometry %6")
-                     .arg(mesh_rendered_count).arg(mesh_source_count)
-                     .arg(urdf_primitive_rendered_count).arg(urdf_primitive_source_count)
-                     .arg(overlay_count).arg(missing_geometry_count));
-  painter.drawText(QRectF(20.0, 66.0, 344.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
-                   QString("Physical %1 • Locked URDF %2 • Fit: %3")
-                     .arg(physical_item_count).arg(locked_urdf_count).arg(fit_include_overlays ? "all_items" : "generated_visuals"));
+  if (debug_overlays_mode) {
+    painter.drawText(QRectF(20.0, 18.0, 410.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter, "View: 3D diagnostics");
+    painter.drawText(QRectF(20.0, 34.0, 410.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
+                     QString("Scene: %1").arg(scene_name));
+    painter.drawText(QRectF(20.0, 50.0, 410.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
+                     QString("Generated mesh %1/%2 • URDF primitives %3/%4 • Helpers %5 • Missing geometry %6")
+                       .arg(mesh_rendered_count).arg(mesh_source_count)
+                       .arg(urdf_primitive_rendered_count).arg(urdf_primitive_source_count)
+                       .arg(overlay_count).arg(missing_geometry_count));
+    painter.drawText(QRectF(20.0, 66.0, 410.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
+                     QString("Physical %1 • Locked URDF %2 • Fit: %3")
+                       .arg(physical_item_count).arg(locked_urdf_count).arg(fit_include_overlays ? "all_items" : "generated_visuals"));
+  } else {
+    painter.drawText(QRectF(20.0, 18.0, 260.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
+                     concise_warning ? QStringLiteral("3D Preview Ready · Warnings") : QStringLiteral("3D Preview Ready"));
+    painter.setPen(concise_warning ? QColor("#fde68a") : QColor("#cbd5e1"));
+    painter.drawText(QRectF(20.0, 36.0, 280.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
+                     QString("%1 items · %2 meshes · %3 missing")
+                       .arg(visible_item_count).arg(mesh_rendered_count).arg(missing_geometry_count));
+    if (concise_warning) {
+      painter.setPen(QColor("#fbbf24"));
+      painter.drawText(QRectF(20.0, 52.0, 280.0, 16.0), Qt::AlignLeft | Qt::AlignVCenter,
+                       QStringLiteral("Use Overlays → Diagnostics for details."));
+    }
+  }
   if (drag_asset_preview_visible_) {
     const double x = (drag_asset_screen_pos_.x() - width() * 0.5) / 50.0;
     const double y = (height() * 0.6 - drag_asset_screen_pos_.y()) / 50.0;
@@ -2168,16 +2186,22 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
 void Scene3DViewportWidget::draw_ground_grid_pass()
 {
   glDisable(GL_CULL_FACE);
-  glLineWidth(1.0f);
+  glEnable(GL_BLEND);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  glLineWidth(debug_overlays_mode ? 1.0f : 0.75f);
   glBegin(GL_LINES);
-  for (int i = -20; i <= 20; ++i) {
+  const int grid_extent = debug_overlays_mode ? 20 : 6;
+  for (int i = -grid_extent; i <= grid_extent; ++i) {
     const bool major = (i % 5 == 0);
-    const QColor c = major ? QColor(100, 116, 139, 140) : QColor(71, 85, 105, 80);
+    const QColor c = debug_overlays_mode
+      ? (major ? QColor(100, 116, 139, 140) : QColor(71, 85, 105, 80))
+      : (major ? QColor(100, 116, 139, 54) : QColor(71, 85, 105, 24));
     glColor4f(c.redF(), c.greenF(), c.blueF(), c.alphaF());
-    glVertex3f(static_cast<float>(i), 0.0f, -20.0f); glVertex3f(static_cast<float>(i), 0.0f, 20.0f);
-    glVertex3f(-20.0f, 0.0f, static_cast<float>(i)); glVertex3f(20.0f, 0.0f, static_cast<float>(i));
+    glVertex3f(static_cast<float>(i), 0.0f, static_cast<float>(-grid_extent)); glVertex3f(static_cast<float>(i), 0.0f, static_cast<float>(grid_extent));
+    glVertex3f(static_cast<float>(-grid_extent), 0.0f, static_cast<float>(i)); glVertex3f(static_cast<float>(grid_extent), 0.0f, static_cast<float>(i));
   }
   glEnd();
+  glDisable(GL_BLEND);
   glEnable(GL_CULL_FACE);
 }
 
@@ -2194,7 +2218,7 @@ void Scene3DViewportWidget::draw_world_axes_pass()
   painter.drawText(project_to_screen(0.50, 0.0, 0.0), "X");
   painter.drawText(project_to_screen(0.0, 0.50, 0.0), "Y");
   painter.drawText(project_to_screen(0.0, 0.0, 0.50), "Z");
-  painter.drawText(QPointF(10.0, height() - 14.0), "Scale: major grid 5 m");
+  if (debug_overlays_mode) painter.drawText(QPointF(10.0, height() - 14.0), "Scale: major grid 5 m");
 }
 
 void Scene3DViewportWidget::draw_unit_cube_triangles(const QColor & color)

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -166,7 +166,7 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   mouse_help_label->setToolTip(scene_preview_mouse_help_tooltip(QString()));
   mouse_help_label->setStatusTip(QString::fromUtf8(kScenePreviewMouseHelpText));
   controls->addWidget(mouse_help_label);
-  overlays_selector_ = new QComboBox(this); overlays_selector_->addItems({"Overlays", "Reachability Heatmap", "Collision Warnings", "Safety Zones", "Work Envelope", "Warning Labels", "Labels", "Pick/Place Zones", "Task Route", "Approach/Retreat", "Camera FOV", "Pick Coverage", "EPD Detections", "Detection Labels", "Warnings", "Focus Selected", "Fit Scene", "Fit Robot", "Fit overlays", "Clear Selection"}); controls->addWidget(overlays_selector_);
+  overlays_selector_ = new QComboBox(this); overlays_selector_->addItems({"Overlays", "Diagnostics Overlay", "Reachability Heatmap", "Collision Warnings", "Safety Zones", "Work Envelope", "Warning Labels", "Labels", "Pick/Place Zones", "Task Route", "Approach/Retreat", "Camera FOV", "Pick Coverage", "EPD Detections", "Detection Labels", "Warnings", "Focus Selected", "Fit Scene", "Fit Robot", "Fit overlays", "Clear Selection"}); controls->addWidget(overlays_selector_);
   controls->addStretch(1);
   root->addLayout(controls);
   stack_ = new QStackedWidget(this);
@@ -256,7 +256,12 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   connect(overlays_selector_, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int){
     auto *v = static_cast<Scene3DViewportWidget *>(simple_3d_view_);
     const QString choice = overlays_selector_->currentText();
-    if (choice == "Reachability Heatmap") v->show_reachability_heatmap = !v->show_reachability_heatmap;
+    if (choice == "Diagnostics Overlay") {
+      v->debug_overlays_mode = !v->debug_overlays_mode;
+      emit studio_log_requested(QString("Scene3D diagnostics overlay %1. Detailed render diagnostics remain available in logs.")
+                                  .arg(v->debug_overlays_mode ? "enabled" : "disabled"));
+    }
+    else if (choice == "Reachability Heatmap") v->show_reachability_heatmap = !v->show_reachability_heatmap;
     else if (choice == "Collision Warnings") v->show_collision_warnings = !v->show_collision_warnings;
     else if (choice == "Safety Zones") v->show_safety = !v->show_safety;
     else if (choice == "Work Envelope") v->show_work_envelope = !v->show_work_envelope;


### PR DESCRIPTION
### Motivation
- Make the Scene3D viewport the default product/demo-friendly presentation by reducing debug noise and emphasizing the workcell visuals. 
- Provide a concise normal overlay while keeping detailed render diagnostics available behind an explicit developer toggle. 
- Reduce grid dominance and improve default camera framing so scenes load larger and clearer by default.

### Description
- Tightened the product camera fit in `Scene3DViewportWidget::fit_product_view()` by reducing computed fit distance and adjusting `yaw`, `pitch`, and `orbit_offset` so the workcell appears larger and in a clearer angled isometric view. (file: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`)
- Replaced the dense debug overlay block with a concise normal-mode info chip that shows a friendly status (`3D Preview Ready`) and compact counts (`items · meshes · missing`), and added a `Diagnostics Overlay` mode that restores full detailed diagnostics for developers. (file: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`)
- Added a `Diagnostics Overlay` option to the Overlays menu that toggles `debug_overlays_mode` and emits a log message that detailed diagnostics remain available in logs. (file: `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`)
- Reduced grid dominance by shrinking default grid extent and opacity, enabling alpha blending for the ground grid, and making the grid scale note visible only in diagnostics mode, so the workcell is the visual focus by default. (file: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`)
- Preserved all diagnostics, mesh/mesh-cache exports, and smoke evidence paths; detailed render counts still emit to logs and are available when diagnostics are enabled or via existing diagnostic export hooks. (no EPD/launch/runtime changes)

### Testing
- `git diff --check` passed with no whitespace or immediate diff errors. (succeeded)
- `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py` ran successfully to verify the smoke helper script compiles. (succeeded)
- Attempt to run a full ROS build (`colcon build --packages-select workcell_builder`) was not executed in this environment because the expected workspace and ROS Humble environment were not present in the container; therefore binary `workcell_builder` was not available here. (not run / environment blocked)
- The Scene3D GUI smoke runner invocation was attempted but reported `MISSING_EXECUTABLE` because the installed `workcell_builder` binary paths under the requested workspace are absent in this headless container; manual GUI verification and screenshots must be performed on a machine with the ROS workspace and GUI available. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3028d94a0483319762b17635293d6c)