### PR TITLE
Make ScenePreviewWidget::total_warning_count() public to fix MainWindow compile error

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -229,6 +229,7 @@ public:
     bool smoke_fallback_render_used{ false };
   };
   RenderDebugCounters render_debug_counters() const;
+  int total_warning_count() const;
 
 signals:
   void studio_log_requested(const QString & message);
@@ -253,7 +254,6 @@ private:
   bool diagnostic_debug_logging_enabled() const;
   bool emit_scene_diagnostic_once(const QString & event, int payload_count, const QString & message);
   void emit_visual_quality_assessment_once();
-  int total_warning_count() const;
   bool task_is_ready() const;
 
   QComboBox * mode_selector_{ nullptr };


### PR DESCRIPTION
### Motivation
- Recent Scene3D UI changes caused `MainWindow` to call `scene_preview_widget_->total_warning_count()` but the accessor was declared private, producing a compile error.
- The intent is to provide a read-only status accessor for warning counts without changing behavior or rolling back UI changes.

### Description
- Moved `int total_warning_count() const;` from the private section into the public API of `ScenePreviewWidget` so callers like `MainWindow` can access it. 
- Kept the existing implementation in `scene_preview_widget.cpp` unchanged and preserved `const` and side-effect-free semantics. 
- Changed file: `workcell_builder/workcell_builder/gui/scene_preview_widget.h`.
- The change is a minimal header-only API exposure and does not touch EPD, launch files, controllers, or any real-hardware code.

### Testing
- Ran a static header check confirming `total_warning_count() const` is public and not redeclared private, and it succeeded. 
- Ran `git diff --check` and basic repo/status validations, which passed. 
- Attempted to run `colcon build --symlink-install --packages-select workcell_builder` and launch smoke tests but these were blocked in this environment because `/home/ubuntu/workcell_ws`, `/opt/ros/humble/setup.bash`, and `colcon` are not available, so full build and runtime smoke validation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a302a37d3948331ae4e6434fa81b97b)