### PR TITLE
Fix Scene3D mesh cache build and warning hygiene

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -2057,6 +2057,7 @@ const Scene3DViewportWidget::MeshCacheEntry & Scene3DViewportWidget::ensure_mesh
   QString load_failure_reason;
   const bool path_resolved = try_resolve_canonical_mesh_path(path, canonical, &item, &load_failure_reason);
   if (!path_resolved) canonical = input_info.absoluteFilePath();
+  const QFileInfo canonical_info(canonical);
   auto it = mesh_cache_.find(canonical);
   if (it != mesh_cache_.end()) return it.value();
   MeshCacheEntry entry;

--- a/workcell_builder/workcell_builder/src_asset_discovery_helper.cpp
+++ b/workcell_builder/workcell_builder/src_asset_discovery_helper.cpp
@@ -11,7 +11,7 @@ namespace fs = boost::filesystem;
 namespace {
 
 const std::vector<std::string> kEnvironmentPresets = {"table", "bin", "conveyor_placeholder", "fixture", "custom_stl"};
-const char * kExternalAbsoluteStlWarning = "Absolute mesh path is outside workspace";
+[[maybe_unused]] const char * kExternalAbsoluteStlWarning = "Absolute mesh path is outside workspace";
 
 bool should_skip_path(const fs::path & p)
 {

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -145,7 +145,7 @@ static double yaml_double_or_default(const YAML::Node & node, double fallback)
   return yaml_read_double(node, &out) ? out : fallback;
 }
 
-static fs::path manifest_declared_canvas_layout_path(const fs::path & scene_dir, const YAML::Node & manifest)
+[[maybe_unused]] static fs::path manifest_declared_canvas_layout_path(const fs::path & scene_dir, const YAML::Node & manifest)
 {
   try {
     const YAML::Node files = yaml_map_key(manifest, "files");
@@ -260,7 +260,7 @@ static bool append_environment_layout_canvas_item(const YAML::Node & source, con
   return true;
 }
 
-static YAML::Node normalize_environment_layout_canvas_items(const YAML::Node & environment_layout)
+[[maybe_unused]] static YAML::Node normalize_environment_layout_canvas_items(const YAML::Node & environment_layout)
 {
   YAML::Node normalized(YAML::NodeType::Map);
   normalized["schema_version"] = "workcell_studio_layout/v1";
@@ -1260,7 +1260,7 @@ static std::string sanitize_preview_id_for_editable_layout_id(const std::string 
   return sanitized;
 }
 
-static std::string editable_layout_copy_id_from_preview_id(const std::string & preview_id)
+[[maybe_unused]] static std::string editable_layout_copy_id_from_preview_id(const std::string & preview_id)
 {
   return "editable_" + sanitize_preview_id_for_editable_layout_id(preview_id);
 }


### PR DESCRIPTION
Also marks currently-unused helper functions/constants as maybe_unused to keep the local workcell_builder build warning-cleaner without deleting future-facing helper code.

Validation:
- source /opt/ros/humble/setup.bash
- colcon build --symlink-install --packages-select workcell_builder

No generated smoke outputs, screenshots, logs, or scene generated artifacts are included."