### PR TITLE
Make Product View clean by default (disable diagnostic overlays)

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1393,7 +1393,7 @@ void Scene3DViewportWidget::paintGL()
     const QPointF p = project_to_screen(bounds.x + (bounds.sx * 0.5), bounds.y + (bounds.sy * 0.5), bounds.z + (bounds.sz * 0.5));
     const bool selected = (it.id == selected_id);
     const NormalizedRole role = classify_item_role(it);
-    const ScenePreviewWidget::LabelMode effective_label_mode = ScenePreviewWidget::LabelMode::Selected;
+    const ScenePreviewWidget::LabelMode effective_label_mode = label_mode;
     bool draw_label = false;
     switch (effective_label_mode) {
       case ScenePreviewWidget::LabelMode::Off: draw_label = selected; break;
@@ -1478,8 +1478,13 @@ void Scene3DViewportWidget::paintGL()
   }
   last_render_counters.labels_drawn = labels_drawn;
   last_render_counters.labels_suppressed_overlap = labels_suppressed_overlap;
-  const bool concise_warning = missing_geometry_count > 0 ||
-                               last_render_counters.visual_quality_status == QStringLiteral("FAIL");
+  const bool has_missing_or_fallback_content = missing_geometry_count > 0 ||
+                                               last_render_counters.mesh_bounds_fallback_rendered_count > 0 ||
+                                               last_render_counters.primitive_fallback_rendered_count > 0 ||
+                                               wireframe_box_count > 0 ||
+                                               placeholder_count > 0 ||
+                                               last_render_counters.visual_quality_status == QStringLiteral("FAIL");
+  const bool concise_warning = show_warnings && has_missing_or_fallback_content;
   const QRectF overlay_rect = debug_overlays_mode ? QRectF(12.0, 12.0, 520.0, 88.0)
                                                   : QRectF(12.0, 12.0, concise_warning ? 430.0 : 410.0, concise_warning ? 62.0 : 46.0);
   painter.setPen(Qt::NoPen);

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -36,9 +36,9 @@ public:
   QString selected_id;
   ScenePreviewWidget::LabelMode label_mode{ ScenePreviewWidget::LabelMode::Selected };
   bool show_warnings{ true }, show_safety{ true }, show_pick_place{ true };
-  bool show_reachability_heatmap{ true }, show_collision_warnings{ true }, show_work_envelope{ true }, show_warning_labels{ true };
-  bool show_task_route{ true }, show_approach_retreat{ true };
-  bool show_camera_fov{ true }, show_pick_coverage{ true }, show_epd_detections{ true }, show_detection_labels{ true };
+  bool show_reachability_heatmap{ false }, show_collision_warnings{ false }, show_work_envelope{ false }, show_warning_labels{ false };
+  bool show_task_route{ false }, show_approach_retreat{ false };
+  bool show_camera_fov{ false }, show_pick_coverage{ false }, show_epd_detections{ false }, show_detection_labels{ false };
   bool debug_overlays_mode{ false };
   ScenePreviewWidget::MeshPreviewMode mesh_preview_mode{ ScenePreviewWidget::MeshPreviewMode::Auto };
   bool fit_include_overlays{ false };

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -166,7 +166,33 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   mouse_help_label->setToolTip(scene_preview_mouse_help_tooltip(QString()));
   mouse_help_label->setStatusTip(QString::fromUtf8(kScenePreviewMouseHelpText));
   controls->addWidget(mouse_help_label);
-  overlays_selector_ = new QComboBox(this); overlays_selector_->addItems({"Overlays", "Diagnostics Overlay", "Reachability Heatmap", "Collision Warnings", "Safety Zones", "Work Envelope", "Warning Labels", "Labels", "Pick/Place Zones", "Task Route", "Approach/Retreat", "Camera FOV", "Pick Coverage", "EPD Detections", "Detection Labels", "Warnings", "Focus Selected", "Fit Scene", "Fit Robot", "Fit overlays", "Clear Selection"}); controls->addWidget(overlays_selector_);
+  overlays_selector_ = new QComboBox(this);
+  overlays_selector_->addItems({
+    "Overlays",
+    "Diagnostics Overlay",
+    "Reachability Heatmap",
+    "Collision Warnings",
+    "Safety Zones",
+    "Work Envelope",
+    "Warning Labels",
+    "Labels",
+    "Pick/Place Zones",
+    "Task Route",
+    "Approach/Retreat",
+    "Camera FOV",
+    "Pick Coverage",
+    "EPD Detections",
+    "Detection Labels",
+    "Warnings",
+    "Focus Selected",
+    "Fit Scene",
+    "Fit Robot",
+    "Fit overlays",
+    "Clear Selection"
+  });
+  overlays_selector_->setCurrentText("Overlays");
+  overlays_selector_->setToolTip("Product View starts clean. Use these diagnostics controls to explicitly enable helper overlays for the current preview session.");
+  controls->addWidget(overlays_selector_);
   controls->addStretch(1);
   root->addLayout(controls);
   stack_ = new QStackedWidget(this);
@@ -266,11 +292,24 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
     else if (choice == "Safety Zones") v->show_safety = !v->show_safety;
     else if (choice == "Work Envelope") v->show_work_envelope = !v->show_work_envelope;
     else if (choice == "Warning Labels") v->show_warning_labels = !v->show_warning_labels;
+    else if (choice == "Labels" && labels_selector_) labels_selector_->showPopup();
+    else if (choice == "Pick/Place Zones") v->show_pick_place = !v->show_pick_place;
+    else if (choice == "Task Route") v->show_task_route = !v->show_task_route;
+    else if (choice == "Approach/Retreat") v->show_approach_retreat = !v->show_approach_retreat;
+    else if (choice == "Camera FOV") v->show_camera_fov = !v->show_camera_fov;
+    else if (choice == "Pick Coverage") v->show_pick_coverage = !v->show_pick_coverage;
+    else if (choice == "EPD Detections") v->show_epd_detections = !v->show_epd_detections;
+    else if (choice == "Detection Labels") v->show_detection_labels = !v->show_detection_labels;
+    else if (choice == "Warnings") v->show_warnings = !v->show_warnings;
     else if (choice == "Focus Selected") on_focus_selected_clicked();
     else if (choice == "Fit Scene") on_fit_scene_clicked();
     else if (choice == "Fit Robot") on_fit_robot_clicked();
     else if (choice == "Fit overlays") on_fit_overlays_clicked();
     else if (choice == "Clear Selection") on_clear_selection_clicked();
+    if (overlays_selector_ && choice != "Overlays") {
+      const QSignalBlocker blocker(overlays_selector_);
+      overlays_selector_->setCurrentText("Overlays");
+    }
     v->update();
     refresh_info_chip();
   });


### PR DESCRIPTION
### Motivation
- Ensure the 3D Product View presents core scene/product visuals (robot/tool/environment meshes and editable layout items) without diagnostic/helper overlays enabled by default. 
- Let developers and advanced users explicitly enable diagnostics and helper overlays from the overlay controls or Debug Overlays mode. 
- Avoid persistent large warning labels when there is no missing or fallback content to report.

### Description
- Changed default overlay booleans in `Scene3DViewportWidget` so diagnostic/helper layers default to off: `show_reachability_heatmap`, `show_collision_warnings`, `show_work_envelope`, `show_warning_labels`, `show_task_route`, `show_approach_retreat`, `show_camera_fov`, `show_pick_coverage`, `show_epd_detections`, and `show_detection_labels` are now `false` in `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h`.
- Updated the overlays combo initialization in `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp` to set the default selection to `"Overlays"`, add a tooltip clarifying Product View starts clean, and make overlay entries explicit so users can re-enable them for a session.
- Enhanced overlay selection handling so choosing an overlay toggles the corresponding `Scene3DViewportWidget` flag (reachability, collision, safety, work envelope, task/perception layers, labels, warnings, etc.) and then resets the combo to the `"Overlays"` placeholder to preserve the clean default.
- Restored label rendering to honor the runtime `label_mode` (so `labels_selector_` controls now affect viewport labeling) by using `label_mode` instead of a hardcoded selected-only mode in `scene3d_viewport_widget.cpp`.
- Made the on-screen warning/status compactness conditional on `show_warnings` and on the presence of real missing/fallback content (`missing_geometry_count`, mesh/primitive fallback counts, placeholder/wireframe counts, or visual quality FAIL), preventing large persistent warning banners when there is nothing to report.
- Files changed: `scene3d_viewport_widget.h`, `scene3d_viewport_widget.cpp`, `scene_preview_widget.cpp`.

### Testing
- Ran `git diff --check` and static diff checks (passed).
- Ran `pytest tests/test_workcell_studio_camera_epd_overlay_tokens.py` (all tests passed).
- Ran `pytest tests/test_workcell_builder_canvas_navigation.py tests/test_workcell_studio_camera_epd_overlay_tokens.py`; the camera/EPD tests passed but several existing token-based checks in `test_workcell_builder_canvas_navigation.py` failed (5 failures) that are unrelated to the visible/default overlay behavior adjustments in these changeset notes.
- Reran targeted overlay/camera tests after adjustments and `tests/test_workcell_studio_camera_epd_overlay_tokens.py` continued to pass.
- Attempted `colcon build --packages-select workcell_builder` but could not run because `/opt/ros/humble/setup.bash` is not available in this environment.
- Result summary: UI defaults and overlay toggles implemented and covered by the camera/EPD unit tests; broader canvas-navigation token test failures remain and appear unrelated to the clean-Product-View defaults and should be investigated separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a314ce0e6408331bfa6dffdf72d7be7)