### PR TITLE
Use product-view camera fit for Scene3D preview

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -810,7 +810,13 @@ bool is_overlay_only_item(const ScenePreviewWidget::PreviewItem & it)
   const QString category = it.category.trimmed().toLower();
   const QString lock_reason = it.lock_reason.trimmed().toLower();
   return role_text.contains("overlay") || role_text.contains("helper") || role_text.contains("guide") ||
-         category.contains("overlay") || lock_reason.contains("overlay");
+         role_text.contains("fov") || role_text.contains("reachability") || role_text.contains("route") ||
+         role_text.contains("warning_anchor") || role_text.contains("warning_badge") ||
+         role_text.contains("bounds_box") || role_text.contains("bounding_box") ||
+         category.contains("overlay") || category.contains("helper") || category.contains("diagnostic") ||
+         category.contains("fov") || category.contains("reachability") || category.contains("route") ||
+         category.contains("bounds_box") || category.contains("bounding_box") ||
+         lock_reason.contains("overlay") || lock_reason.contains("helper") || lock_reason.contains("diagnostic");
 }
 
 bool is_locked_urdf_item(const ScenePreviewWidget::PreviewItem & it)

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -309,6 +309,11 @@ void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items)
     emit studio_log_requested(has_selected ? QString("Preview selection restored after refresh: %1").arg(selected_preview_item_id_) : QString("Preview selection retained after refresh; id is hidden by filters or absent from the visible preview payload: %1").arg(selected_preview_item_id_));
   }
   viewport->fit_include_overlays = false;
+  // Product previews should open in the same camera path users get from the
+  // normal canvas controls: an isometric view followed by product-fit bounds
+  // that keep robot/tool/environment meshes and editable layout items legible
+  // without letting diagnostics overlays dominate the initial framing.
+  viewport->set_isometric_view();
   viewport->fit_product_view();
   emit_scene_diagnostic_once(
     QStringLiteral("payload_commit"),

--- a/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
@@ -63,6 +63,45 @@ TEST(Scene3DRenderRoleClassifier, FitExcludesHelpersIncludesGenerated)
   EXPECT_FALSE(Scene3DViewportWidget::should_include_in_default_fit_for_test(helper));
 }
 
+
+TEST(Scene3DRenderRoleClassifier, DefaultProductFitIncludesPhysicalItemsAndExcludesDiagnostics)
+{
+  auto robot_mesh = make_item("robot_tool_mesh");
+  robot_mesh.locked = true;
+  robot_mesh.editable = false;
+  robot_mesh.lock_reason = "Generated URDF visual";
+  robot_mesh.source_layer = "generated_urdf_visual";
+  robot_mesh.mesh_available = true;
+  EXPECT_TRUE(Scene3DViewportWidget::should_include_in_default_fit_for_test(robot_mesh));
+
+  auto editable_layout = make_item("editable_table");
+  editable_layout.source_layer = "editable_layout";
+  editable_layout.linked_to_editable_layout_state = true;
+  editable_layout.editable = true;
+  EXPECT_TRUE(Scene3DViewportWidget::should_include_in_default_fit_for_test(editable_layout));
+
+  auto camera_fov = make_item("camera_fov");
+  camera_fov.role = "camera_fov_cone";
+  camera_fov.category = "diagnostic_overlay";
+  EXPECT_FALSE(Scene3DViewportWidget::should_include_in_default_fit_for_test(camera_fov));
+
+  auto reachability = make_item("reachability");
+  reachability.role = "reachability_heatmap";
+  EXPECT_FALSE(Scene3DViewportWidget::should_include_in_default_fit_for_test(reachability));
+
+  auto route_helper = make_item("task_route");
+  route_helper.role = "task_route_helper";
+  EXPECT_FALSE(Scene3DViewportWidget::should_include_in_default_fit_for_test(route_helper));
+
+  auto warning_anchor = make_item("warning_anchor");
+  warning_anchor.role = "warning_anchor";
+  EXPECT_FALSE(Scene3DViewportWidget::should_include_in_default_fit_for_test(warning_anchor));
+
+  auto bounds_box = make_item("bounds_box");
+  bounds_box.category = "diagnostic_bounds_box";
+  EXPECT_FALSE(Scene3DViewportWidget::should_include_in_default_fit_for_test(bounds_box));
+}
+
 TEST(Scene3DRenderRoleClassifier, MeshesModeDoesNotDrawFallbackSolid)
 {
   auto missing = make_item("missing2");


### PR DESCRIPTION
### Motivation
- Ensure scene preview opens with the same product-focused camera path as the main canvas so robot/tool/environment visuals and editable layout items are legible by default.
- Prevent diagnostic overlays (FOV cones, reachability heatmaps, route helpers, warning anchors, bounds boxes, etc.) from dominating the default product framing.

### Description
- When preview items are committed, explicitly set the viewport to isometric and then call the product fit path via `Scene3DViewportWidget::set_isometric_view()` followed by `Scene3DViewportWidget::fit_product_view()` so initial camera framing matches the product view. (file: `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`)
- Tightened the default-fit classification by expanding overlay/helper detection to exclude diagnostic-like roles/categories such as `fov`, `reachability`, `route`, `warning_anchor`/`warning_badge`, `bounds_box`/`bounding_box`, and `diagnostic` so `include_in_fit_bounds()` now ignores those when `include_overlays` is false. (file: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`)
- Kept explicit user actions unchanged for `Fit Scene`, `Fit Robot`, and `Fit overlays` so users can still choose full-scene, robot-focused, or overlay-inclusive framing. (file: `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`)
- Added a focused unit test that verifies default product-fit inclusion for generated robot/tool visuals and editable layout items and exclusion for diagnostics/overlay helpers. (file: `workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp`)

### Testing
- Ran static checks that asserted the new `set_isometric_view()` + `fit_product_view()` sequence and the diagnostic exclusion tokens are present; these checks passed.
- Ran the viewport contract tests via `pytest -q tests/test_scene3d_true_viewport_contract.py`; outcome: 5 tests passed and 1 pre-existing contract token assertion failed due to an unrelated missing malformed-metadata warning string in current source.
- Attempted to run `colcon`-based CTest for the viewport gtest but the container lacks a local ROS Humble environment (`/opt/ros/humble/setup.bash`), so `colcon test` could not be executed here.
- `git diff --check` and basic repository static validations were run and passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a314cfb93e48331ae6ef45870a5a843)