### PR TITLE
Harden xacro-lite preview health checks

### DIFF
--- a/scripts/extract_scene_urdf_visual_mesh_index.py
+++ b/scripts/extract_scene_urdf_visual_mesh_index.py
@@ -564,6 +564,23 @@ def expand_xacro(urdf_path, scene_dir=None, xacro_args=None, workspace_root=None
 
 
 
+
+
+def preview_degraded_fallback_warning(fallback_reason, extraction_mode=''):
+    text = str(fallback_reason or '')
+    if 'skipped unresolved macros' in text.lower() and _contains_unresolved_ur_robot(text):
+        return 'xacro-lite skipped robot macro ur_robot; preview uses degraded fallback geometry'
+    if str(extraction_mode or '') in {'xacro_lite_expanded', 'xacro_lite_fallback'} and _contains_unresolved_ur_robot(text):
+        return 'xacro-lite skipped robot macro ur_robot; preview uses degraded fallback geometry'
+    return ''
+
+def is_preview_fully_healthy(items, unresolved, extraction_mode, fallback_reason, renderable_mesh_count=None):
+    if renderable_mesh_count is None:
+        renderable_mesh_count = sum(1 for item in items or [] if item.get('geometry_type') == 'mesh' and item.get('render_expected', True))
+    if preview_degraded_fallback_warning(fallback_reason, extraction_mode):
+        return False
+    return bool(items) and len(unresolved or []) == 0 and extraction_mode == 'xacro_expanded' and renderable_mesh_count > 0
+
 def _contains_unresolved_ur_robot(text):
     text = text or ''
     lowered = text.lower()
@@ -647,6 +664,8 @@ def append_static_robot_primitive_fallbacks(items, urdf_text, fallback_reason, e
         or _contains_unresolved_ur_robot(source_xacro_text)
         or _contains_unresolved_ur_robot(urdf_text)
     ):
+        return 0
+    if _has_ur5_visual_mesh_uri(items):
         return 0
     existing_ids = {str(i.get('id') or '') for i in items}
     specs = UR5_STATIC_VISUAL_SPECS
@@ -856,15 +875,22 @@ def main():
             static_robot_fallback_count = append_static_robot_primitive_fallbacks(items, xml_text, fallback_reason, mode, source_xacro_text)
         static_parent_resolved_count = resolve_static_tool0_children(items)
         unresolved=[i for i in items if any(contains_placeholder(i.get(k,'')) for k in ('id','link','parent_link'))]
-        fallback_only_ur5_preview=static_robot_fallback_count > 0 and not _has_ur5_visual_mesh_uri(items)
-        safe=bool(items) and (len(unresolved)==0) and (mode in ('xacro_expanded','xacro_lite_expanded','xacro_lite_fallback'))
         mesh_format_counts=dict(collections.Counter((Path(i.get('resolved_source_path') or i.get('source_path') or '').suffix.lower() or 'unknown') for i in items if i.get('geometry_type')=='mesh'))
         transform_status_counts=dict(collections.Counter(str(i.get('transform_status') or 'unknown') for i in items))
         renderable_count=sum(1 for i in items if i.get('render_expected', True))
         renderable_mesh_count=sum(1 for i in items if i.get('geometry_type')=='mesh' and i.get('render_expected', True))
+        preview_warning=preview_degraded_fallback_warning(fallback_reason, mode)
+        preview_blockers=[]
+        preview_warnings=[]
+        if preview_warning:
+            preview_blockers.append(preview_warning)
+            preview_warnings.append(preview_warning)
+        if mode in ('xacro_lite_expanded','xacro_lite_fallback') and not preview_warning:
+            preview_warnings.append('xacro-lite preview is degraded and is not equivalent to real xacro-expanded output')
+        safe=is_preview_fully_healthy(items, unresolved, mode, fallback_reason, renderable_mesh_count)
         source_mtime=urdf_path.stat().st_mtime if urdf_path.exists() else None
         has_transform_collapse_warning=bool(items) and len({tuple((i.get('pose') or {}).get('xyz') or []) for i in items}) <= 1 and len(items) > 1
-        payload={'scene_name':scene_dir.name,'visual_count':len(items),'resolved':sum(1 for i in items if i.get('resolved')),'unresolved':sum(1 for i in items if not i.get('resolved')),'generated_at':datetime.now(timezone.utc).isoformat(),'extractor_version':EXTRACTOR_VERSION,'path_reference_root':'repository','extraction_mode':mode,'xacro_available':xacro_avail,'source_urdf_xacro_path':_repo_relative_path(urdf_path),'source_mtime':source_mtime,'source_expanded_urdf_path':_repo_relative_path(expanded_path),'fallback_reason':fallback_reason,'xacro_real_command_succeeded':real_xacro_command_succeeded,'xacro_status':xacro_diagnostics.get('xacro_status', 'not_attempted' if not xacro_avail else ('real_xacro_succeeded' if real_xacro_command_succeeded else 'real_xacro_failed')),'xacro_diagnostics':_portable_source_metadata(xacro_diagnostics),'safe_for_preview':safe,'unresolved_placeholder_count':len(unresolved),'has_transform_collapse_warning':has_transform_collapse_warning,'candidate_mesh_count':len(items),'emitted_visual_count':len(items),'transform_status_counts':transform_status_counts,'mesh_format_counts':mesh_format_counts,'renderable_mesh_count':renderable_mesh_count,'renderable_item_count':renderable_count,'static_robot_primitive_fallback_count':static_robot_fallback_count,'static_robot_mesh_visual_count':static_robot_mesh_count,'static_parent_resolved_count':static_parent_resolved_count,'stale_index':False,'stale_reasons':[],'visual_items':items,'xacro_command':_portable_source_metadata(xacro_cmd),'package_resolution_diagnostics':_portable_source_metadata(package_diagnostics)}
+        payload={'scene_name':scene_dir.name,'visual_count':len(items),'resolved':sum(1 for i in items if i.get('resolved')),'unresolved':sum(1 for i in items if not i.get('resolved')),'generated_at':datetime.now(timezone.utc).isoformat(),'extractor_version':EXTRACTOR_VERSION,'path_reference_root':'repository','extraction_mode':mode,'xacro_available':xacro_avail,'source_urdf_xacro_path':_repo_relative_path(urdf_path),'source_mtime':source_mtime,'source_expanded_urdf_path':_repo_relative_path(expanded_path),'fallback_reason':fallback_reason,'xacro_real_command_succeeded':real_xacro_command_succeeded,'xacro_status':xacro_diagnostics.get('xacro_status', 'not_attempted' if not xacro_avail else ('real_xacro_succeeded' if real_xacro_command_succeeded else 'real_xacro_failed')),'xacro_diagnostics':_portable_source_metadata(xacro_diagnostics),'safe_for_preview':safe,'unresolved_placeholder_count':len(unresolved),'has_transform_collapse_warning':has_transform_collapse_warning,'candidate_mesh_count':len(items),'emitted_visual_count':len(items),'transform_status_counts':transform_status_counts,'mesh_format_counts':mesh_format_counts,'renderable_mesh_count':renderable_mesh_count,'renderable_item_count':renderable_count,'static_robot_primitive_fallback_count':static_robot_fallback_count,'static_robot_mesh_visual_count':static_robot_mesh_count,'static_parent_resolved_count':static_parent_resolved_count,'stale_index':False,'stale_reasons':[],'blockers':preview_blockers,'warnings':preview_warnings,'visual_items':items,'xacro_command':_portable_source_metadata(xacro_cmd),'package_resolution_diagnostics':_portable_source_metadata(package_diagnostics)}
         idx_path=scene_dir/'generated/scene_visual_mesh_index.json'
         if not a.no_write:
             idx_path.parent.mkdir(parents=True,exist_ok=True)

--- a/scripts/generate_workcell_from_cell_definition.py
+++ b/scripts/generate_workcell_from_cell_definition.py
@@ -768,6 +768,18 @@ def _determine_workspace_root(
     return _workspace_root_from_path(package_dir)
 
 
+
+
+def _fallback_reason_skipped_ur_robot_macro(reason: str, mode: str = '') -> bool:
+    text = str(reason or '').lower()
+    return 'ur_robot' in text and ('skipped unresolved macros' in text or str(mode or '') in {'xacro_lite_expanded', 'xacro_lite_fallback'})
+
+
+def _preview_degraded_fallback_warning(reason: str, mode: str = '') -> str:
+    if _fallback_reason_skipped_ur_robot_macro(reason, mode):
+        return 'xacro-lite skipped robot macro ur_robot; preview uses degraded fallback geometry'
+    return ''
+
 def _fallback_scene_visual_mesh_index(
     package_name: str,
     package_dir: Path,
@@ -787,14 +799,14 @@ def _fallback_scene_visual_mesh_index(
         "extraction_mode": "fallback_empty_safe_preview",
         "source_urdf_xacro_path": "urdf/scene.urdf.xacro",
         "source_mtime": urdf_path.stat().st_mtime if urdf_path.exists() else None,
-        "safe_for_preview": True,
+        "safe_for_preview": False,
         "candidate_mesh_count": 0,
         "emitted_visual_count": 0,
         "renderable_mesh_count": 0,
         "renderable_item_count": 0,
         "visual_items": [],
         "items": [],
-        "blockers": [],
+        "blockers": [warning_text],
         "warnings": [warning_text],
         "fallback_reason": reason,
         "stale_index": False,
@@ -875,13 +887,23 @@ def _write_scene_visual_mesh_index(
             1 for item in mesh_items if item.get("render_expected", True)
         )
         renderable_item_count = sum(1 for item in items if item.get("render_expected", True))
-        safe_for_preview = len(unresolved) == 0 and mode in {"xacro_expanded", "xacro_lite_expanded"}
+        degraded_preview_warning = _preview_degraded_fallback_warning(fallback_reason, mode)
+        safe_for_preview = (
+            len(unresolved) == 0
+            and mode == "xacro_expanded"
+            and renderable_mesh_count > 0
+            and not degraded_preview_warning
+        )
         visual_readiness_reasons: list[str] = []
+        if degraded_preview_warning:
+            visual_readiness_reasons.append(degraded_preview_warning)
         if not safe_for_preview:
             visual_readiness_reasons.append(
                 "visual mesh index was not produced from a fully expanded xacro"
-                if mode not in {"xacro_expanded", "xacro_lite_expanded"}
+                if mode != "xacro_expanded"
                 else "visual mesh index contains unresolved xacro placeholders"
+                if unresolved
+                else "visual mesh index does not have renderable mesh-backed visuals"
             )
         if renderable_mesh_count <= 0:
             visual_readiness_reasons.append(
@@ -913,8 +935,8 @@ def _write_scene_visual_mesh_index(
             "renderable_item_count": renderable_item_count,
             "visual_items": _portable_source_metadata(items),
             "items": _portable_source_metadata(items),
-            "blockers": [],
-            "warnings": [fallback_reason] if fallback_reason else [],
+            "blockers": [degraded_preview_warning] if degraded_preview_warning else [],
+            "warnings": [reason for reason in (degraded_preview_warning, fallback_reason) if reason],
             "stale_index": False,
             "stale_reasons": [],
             "xacro_command": _portable_source_metadata(xacro_cmd),

--- a/tests/test_generate_workcell_from_cell_definition_contract.py
+++ b/tests/test_generate_workcell_from_cell_definition_contract.py
@@ -212,7 +212,7 @@ def _assert_generated_contract(package_dir: Path) -> None:
             encoding="utf-8"
         )
     )
-    assert mesh_index["safe_for_preview"] is True
+    assert mesh_index["safe_for_preview"] is False
     assert mesh_index["source_urdf_xacro_path"] == "urdf/scene.urdf.xacro"
 
     summary = json.loads(
@@ -357,6 +357,62 @@ def discover_xacro_command():
     assert payload["visual_readiness"]["status"] == "PASS"
     assert warnings == []
 
+
+
+def test_visual_mesh_index_marks_xacro_lite_ur_robot_macro_as_degraded(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from scripts import generate_workcell_from_cell_definition as generator
+
+    package_dir = tmp_path / "scene"
+    (package_dir / "urdf").mkdir(parents=True)
+    (package_dir / "urdf" / "scene.urdf.xacro").write_text(
+        '<robot name="demo"><link name="world"><visual><geometry>'
+        '<mesh filename="package://demo_assets/meshes/part.stl"/>'
+        "</geometry></visual></link></robot>",
+        encoding="utf-8",
+    )
+    extractor = tmp_path / "lite_extractor.py"
+    extractor.write_text(
+        """
+EXTRACTOR_VERSION = 'test'
+
+def expand_xacro(urdf_path, scene_dir=None, xacro_args=None, workspace_root=None):
+    return (open(urdf_path, encoding='utf-8').read(), True, 'skipped unresolved macros: ur_robot', ['xacro-lite', str(urdf_path)])
+
+def discover_package_map(scene_dir, workspace_root=None, package_names=None):
+    return {'demo_assets': scene_dir}, {'resolution_paths': []}
+
+def extract_referenced_package_names(text):
+    return ['demo_assets']
+
+def extract_from_urdf(xml_text, package_map):
+    return [{'id': 'mesh', 'link': 'world', 'parent_link': 'world', 'geometry_type': 'mesh', 'resolved': True, 'render_expected': True}]
+
+def contains_placeholder(text):
+    return False
+
+def discover_xacro_command():
+    return ('', False, 'xacro unavailable in test')
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(generator, "MESH_INDEX_EXTRACTOR_PATH", extractor)
+    warnings: list[str] = []
+
+    assert generator._write_scene_visual_mesh_index("demo_scene", package_dir, warnings) is None
+
+    payload = json.loads(
+        (package_dir / "generated" / "scene_visual_mesh_index.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    expected = "xacro-lite skipped robot macro ur_robot; preview uses degraded fallback geometry"
+    assert payload["extraction_mode"] == "xacro_lite_expanded"
+    assert payload["safe_for_preview"] is False
+    assert expected in payload["blockers"]
+    assert expected in payload["warnings"]
+    assert expected in payload["visual_readiness"]["reasons"]
 
 def test_visual_mesh_index_warns_when_xacro_expansion_falls_back(
     tmp_path: Path, monkeypatch

--- a/tests/test_scene_urdf_visual_mesh_index.py
+++ b/tests/test_scene_urdf_visual_mesh_index.py
@@ -441,6 +441,9 @@ def test_main_marks_xacro_lite_static_ur5_fallback_preview_unsafe(monkeypatch, t
     assert payload['xacro_real_command_succeeded'] is False
     assert payload['static_robot_primitive_fallback_count'] > 0
     assert payload['safe_for_preview'] is False
+    expected = 'xacro-lite skipped robot macro ur_robot; preview uses degraded fallback geometry'
+    assert expected in payload['blockers']
+    assert expected in payload['warnings']
 
 def test_synthetic_chain_transform_composition_and_primitives():
     import scripts.extract_scene_urdf_visual_mesh_index as mesh_index


### PR DESCRIPTION
### Motivation
- Prevent xacro-lite expansions and primitive-only fallbacks from being treated as fully healthy previews and surface clear degraded/blocked signals when robot macros like `ur_robot` are skipped.
- Keep primitive fallback available for degraded preview rendering but ensure UI/consumers can distinguish degraded previews from fully expanded, mesh-backed previews.

### Description
- Added preview health helpers `preview_degraded_fallback_warning` and `is_preview_fully_healthy` to `scripts/extract_scene_urdf_visual_mesh_index.py` and corresponding `_fallback_reason_skipped_ur_robot_macro` / `_preview_degraded_fallback_warning` helpers in `scripts/generate_workcell_from_cell_definition.py` to centralize detection of degraded xacro-lite robot macro skips.
- Changed `safe_for_preview` logic so only true `xacro_expanded` output with no unresolved placeholders and at least one renderable mesh-backed visual is considered fully healthy; `xacro_lite_expanded`/`xacro_lite_fallback` are no longer automatically equivalent.
- If `fallback_reason` indicates skipped unresolved macros (notably `ur_robot`) or xacro-lite indicated a skip, force `safe_for_preview = False` and add a blocker/warning: `xacro-lite skipped robot macro ur_robot; preview uses degraded fallback geometry`.
- Preserve primitive fallback generation but prevent emitting primitive fallbacks when resolved UR mesh visuals are already present; include preview `blockers` and `warnings` in payloads and mark fallback/empty indexes as not safe.
- Updated tests to cover the new degraded-warning and safe-for-preview contract changes (modified/added tests in `tests/test_scene_urdf_visual_mesh_index.py` and `tests/test_generate_workcell_from_cell_definition_contract.py`).

### Testing
- Compiled the modified scripts with `python3 -m py_compile scripts/extract_scene_urdf_visual_mesh_index.py scripts/generate_workcell_from_cell_definition.py` and it passed.
- Ran unit tests: `pytest -q tests/test_scene_urdf_visual_mesh_index.py tests/test_generate_workcell_from_cell_definition_contract.py` and all tests passed (19 passed).
- Performed `git diff --check` to ensure no whitespace/issues; it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a315b614f58833199520252161359a2)