### PR TITLE
Forward workspace root through visual mesh index regeneration

### DIFF
--- a/scripts/regenerate_scene_visual_mesh_indexes.py
+++ b/scripts/regenerate_scene_visual_mesh_indexes.py
@@ -9,6 +9,8 @@ SUPPORTED_SCENES = ["ur5_2f_test","ur5_3f_test","ur10_2f_test","ur3_suction_test
 
 def parse():
     p=argparse.ArgumentParser()
+    p.add_argument('--repo-root', type=Path, default=ROOT, help='Repository root that contains scripts/ and scenes/.')
+    p.add_argument('--workspace-root', type=Path, help='Optional ROS workspace root forwarded to the extractor.')
     g=p.add_mutually_exclusive_group(required=True); g.add_argument('--all',action='store_true'); g.add_argument('--scene')
     p.add_argument('--portable',action='store_true')
     p.add_argument('--prefer-xacro-expanded',action='store_true',default=True)
@@ -19,11 +21,12 @@ def parse():
     return p.parse_args()
 
 def scene_list(a):
+    scenes_root = a.repo_root / 'scenes'
     if a.scene:
-        return [SCENES/a.scene]
-    return [SCENES/s for s in SUPPORTED_SCENES if (SCENES/s).exists()]
+        return [scenes_root/a.scene]
+    return [scenes_root/s for s in SUPPORTED_SCENES if (scenes_root/s).exists()]
 
-def summarize(scene):
+def summarize(scene, repo_root=ROOT):
     idx=scene/'generated/scene_visual_mesh_index.json'; data=json.loads(idx.read_text()) if idx.exists() else {}
     items=data.get('visual_items',[])
     mesh_backed=sum(1 for i in items if i.get('geometry_type')=='mesh')
@@ -40,19 +43,23 @@ def summarize(scene):
     safe=data.get('safe_for_preview',False)
     status='PASS' if safe else ('FAIL' if not items else 'WARN')
     stale_unsafe = int(bool(data.get('stale_index'))) + (1 if not safe else 0)
-    return {'scene':scene.name,'extraction_mode':data.get('extraction_mode','unknown'),'xacro_available':data.get('xacro_available',False),'expanded_urdf_written':bool(data.get('source_expanded_urdf_path')),'safe_for_preview':safe,'fallback_reason':data.get('fallback_reason',''),'unresolved_placeholder_count':unresolved,'mesh_backed_count':mesh_backed,'skipped_count':sum(1 for i in items if i.get('render_skip_reason')),'primitive_fallback_count':primitive,'stale_index':data.get('stale_index',False),'status':status,'visual_item_count':len(items),'unresolved_count':unresolved,'stale_or_unsafe_count':stale_unsafe,'generated_index_path':str(idx.relative_to(ROOT)),'distinct_pose_count':distinct_pose_count,'bounding_box_min':mins,'bounding_box_max':maxs,'collapsed_pose_warning':collapsed_pose_warning}
+    return {'scene':scene.name,'extraction_mode':data.get('extraction_mode','unknown'),'xacro_available':data.get('xacro_available',False),'expanded_urdf_written':bool(data.get('source_expanded_urdf_path')),'safe_for_preview':safe,'fallback_reason':data.get('fallback_reason',''),'unresolved_placeholder_count':unresolved,'mesh_backed_count':mesh_backed,'skipped_count':sum(1 for i in items if i.get('render_skip_reason')),'primitive_fallback_count':primitive,'stale_index':data.get('stale_index',False),'status':status,'visual_item_count':len(items),'unresolved_count':unresolved,'stale_or_unsafe_count':stale_unsafe,'generated_index_path':str(idx.relative_to(repo_root)),'distinct_pose_count':distinct_pose_count,'bounding_box_min':mins,'bounding_box_max':maxs,'collapsed_pose_warning':collapsed_pose_warning}
 
 def main():
     a=parse(); rows=[]
+    a.repo_root = a.repo_root.resolve()
+    out = a.repo_root / 'build/workcell_studio/visual_mesh_index_regeneration_report.json'
+    extractor = a.repo_root / 'scripts/extract_scene_urdf_visual_mesh_index.py'
     for s in scene_list(a):
-        cmd=['python3',str(ROOT/'scripts/extract_scene_urdf_visual_mesh_index.py'),'--scene',s.name,'--prefer-xacro-expanded']
+        cmd=['python3',str(extractor),'--scene',s.name,'--prefer-xacro-expanded']
+        if a.workspace_root is not None: cmd += ['--workspace-root', str(a.workspace_root)]
         for xa in a.xacro_arg: cmd += ['--xacro-arg', xa]
         if a.fail_on_unexpanded: cmd.append('--fail-on-unexpanded')
         subprocess.run(cmd,check=False)
-        row=summarize(s); rows.append(row)
+        row=summarize(s, a.repo_root); rows.append(row)
         print(f"{row['scene']}: visual_items={row['visual_item_count']} mesh={row['mesh_backed_count']} primitive={row['primitive_fallback_count']} distinct_pose_count={row['distinct_pose_count']} bbox_min={row['bounding_box_min']} bbox_max={row['bounding_box_max']} collapsed_pose_warning={row['collapsed_pose_warning']} skipped={row['skipped_count']} safe={row['safe_for_preview']} fallback_reason={row['fallback_reason']}")
     payload={'schema':'workcell_studio_visual_mesh_index_regeneration/v2','scenes':rows,'summary':{'scene_count':len(rows)}}
-    OUT.parent.mkdir(parents=True,exist_ok=True); OUT.write_text(json.dumps(payload,indent=2)+'\n'); print(OUT)
+    out.parent.mkdir(parents=True,exist_ok=True); out.write_text(json.dumps(payload,indent=2)+'\n'); print(out)
     if a.fail_on_unsafe and any(r['status']!='PASS' for r in rows): return 1
     if a.fail_on_unexpanded and any(r['extraction_mode']!='xacro_expanded' for r in rows): return 3
     return 0

--- a/tests/test_scene_urdf_visual_mesh_index.py
+++ b/tests/test_scene_urdf_visual_mesh_index.py
@@ -463,3 +463,67 @@ def test_synthetic_chain_transform_composition_and_primitives():
     assert item['size'] == [1.0, 2.0, 3.0]
     assert item['transform_status'] == 'resolved'
     assert len(item['transform_chain']) == 2
+
+
+def test_regenerate_visual_mesh_indexes_forwards_workspace_root(monkeypatch, tmp_path):
+    import sys
+    import scripts.regenerate_scene_visual_mesh_indexes as regenerate
+
+    repo_root = tmp_path / 'repo'
+    scene = repo_root / 'scenes' / 'demo_scene'
+    (scene / 'generated').mkdir(parents=True)
+    (repo_root / 'scripts').mkdir(parents=True)
+    (scene / 'generated' / 'scene_visual_mesh_index.json').write_text(
+        json.dumps(
+            {
+                'extraction_mode': 'xacro_expanded',
+                'xacro_available': True,
+                'safe_for_preview': True,
+                'visual_items': [
+                    {
+                        'geometry_type': 'mesh',
+                        'pose': {'xyz': [0.1, 0.2, 0.3]},
+                    }
+                ],
+            }
+        ),
+        encoding='utf-8',
+    )
+    workspace_root = tmp_path / 'workcell_ws'
+    calls = []
+
+    def fake_run(cmd, check=False):
+        calls.append((cmd, check))
+
+    monkeypatch.setattr(regenerate.subprocess, 'run', fake_run)
+    original_argv = sys.argv
+    try:
+        sys.argv = [
+            'regenerate_scene_visual_mesh_indexes.py',
+            '--repo-root',
+            str(repo_root),
+            '--workspace-root',
+            str(workspace_root),
+            '--scene',
+            'demo_scene',
+            '--fail-on-unexpanded',
+            '--xacro-arg',
+            'use_fake_hardware:=true',
+        ]
+        rc = regenerate.main()
+    finally:
+        sys.argv = original_argv
+
+    assert rc == 0
+    assert len(calls) == 1
+    cmd, check = calls[0]
+    assert check is False
+    assert cmd[:4] == [
+        'python3',
+        str(repo_root.resolve() / 'scripts' / 'extract_scene_urdf_visual_mesh_index.py'),
+        '--scene',
+        'demo_scene',
+    ]
+    assert cmd[cmd.index('--workspace-root') + 1] == str(workspace_root)
+    assert cmd[cmd.index('--xacro-arg') + 1] == 'use_fake_hardware:=true'
+    assert '--fail-on-unexpanded' in cmd


### PR DESCRIPTION
### Motivation
- Allow callers of the regeneration wrapper to specify an alternate repository root and to forward a workspace root into the underlying extractor so tests and external workflows can control package lookup and overlays.
- Preserve existing behavior by defaulting `--repo-root` to the current repository root so existing automation is unaffected.

### Description
- Added CLI options `--repo-root` and `--workspace-root` to `scripts/regenerate_scene_visual_mesh_indexes.py` and updated parsing to accept these arguments.
- Defaulted `repo_root` to the script `ROOT` to maintain current behavior while using the provided `--repo-root` for scene discovery and report path resolution.
- Forward `--workspace-root <value>` to the invoked `scripts/extract_scene_urdf_visual_mesh_index.py` when present and preserved existing wrapper flags `--scene`, `--all`, `--fail-on-unexpanded`, and `--xacro-arg`.
- Updated `summarize()` and the generated report output path to be computed relative to the selected repo root and added a focused pytest `test_regenerate_visual_mesh_indexes_forwards_workspace_root` that asserts the extractor command includes the forwarded `--workspace-root` and existing flags.

### Testing
- Ran the new focused test with `pytest -q tests/test_scene_urdf_visual_mesh_index.py::test_regenerate_visual_mesh_indexes_forwards_workspace_root` and it passed.
- Verified `python3 scripts/regenerate_scene_visual_mesh_indexes.py --help` shows the new options and `python3 -m py_compile` succeeded for the modified files.
- Confirmed the wrapper still constructs calls that include `--scene`, `--xacro-arg`, and `--fail-on-unexpanded` when provided, as asserted by the added test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31666c67088331a4aebbb612e47fda)