### PR TITLE
Improve xacro discovery: prefer PATH executable, add fallbacks and diagnostics

### DIFF
--- a/scripts/extract_scene_urdf_visual_mesh_index.py
+++ b/scripts/extract_scene_urdf_visual_mesh_index.py
@@ -329,14 +329,26 @@ def xacro_env(scene_dir, workspace_root=None):
     return env
 
 def discover_xacro_command():
-    if shutil.which('xacro'): return ['xacro'], True, ''
-    if Path('/opt/ros/humble/bin/xacro').exists(): return ['/opt/ros/humble/bin/xacro'], True, ''
+    diagnostics=[]
+
+    path_xacro = shutil.which('xacro')
+    if path_xacro:
+        return [str(Path(path_xacro).resolve())], True, ''
+    diagnostics.append('PATH xacro not found')
+
+    ros_humble_xacro = Path('/opt/ros/humble/bin/xacro')
+    if ros_humble_xacro.exists():
+        return [str(ros_humble_xacro.resolve())], True, ''
+    diagnostics.append('/opt/ros/humble/bin/xacro missing')
+
     try:
-        mod = subprocess.run(['python3', '-m', 'xacro', '--help'], capture_output=True, text=True)
-        if mod.returncode == 0: return ['python3', '-m', 'xacro'], True, ''
+        if importlib.util.find_spec('xacro') is not None:
+            return ['python3', '-m', 'xacro'], True, ''
+        diagnostics.append('python xacro module import failed: module spec not found')
     except Exception as e:
-        return None, False, f"xacro executable unavailable ({e})"
-    return None, False, "xacro executable unavailable"
+        diagnostics.append(f'python xacro module import failed: {e}')
+
+    return None, False, '; '.join(diagnostics)
 
 def _xacro_tag(e):
     name=tag_name(e)

--- a/tests/test_scene_urdf_visual_mesh_index.py
+++ b/tests/test_scene_urdf_visual_mesh_index.py
@@ -40,6 +40,25 @@ def test_xacro_env_preserves_and_extends_package_lookup(monkeypatch, tmp_path):
     assert ros_package_entries.count(str(ROOT / 'assets')) == 1
 
 
+def test_discover_xacro_command_prefers_resolved_path_executable(monkeypatch, tmp_path):
+    import scripts.extract_scene_urdf_visual_mesh_index as mesh_index
+
+    fake_bin = tmp_path / 'bin'
+    fake_bin.mkdir()
+    fake_xacro = fake_bin / 'xacro'
+    fake_xacro.write_text('#!/bin/sh\necho xacro\n', encoding='utf-8')
+    fake_xacro.chmod(0o755)
+
+    monkeypatch.setenv('PATH', str(fake_bin))
+    monkeypatch.setattr(mesh_index.shutil, 'which', lambda name: str(fake_xacro) if name == 'xacro' else None)
+
+    command, available, reason = mesh_index.discover_xacro_command()
+
+    assert available is True
+    assert command == [str(fake_xacro.resolve())]
+    assert reason == ''
+
+
 def _write_package_xml(pkg_dir: Path, name: str):
     pkg_dir.mkdir(parents=True, exist_ok=True)
     (pkg_dir / 'package.xml').write_text(


### PR DESCRIPTION
### Motivation
- Make xacro command discovery more robust and explicit by preferring a PATH-resolved executable and returning its absolute path.
- Preserve a ROS Humble binary fallback and support environments where only the Python `xacro` module is available.
- Provide precise diagnostics for each failed discovery path to make failures easier to debug and report.

### Description
- Updated `discover_xacro_command()` in `scripts/extract_scene_urdf_visual_mesh_index.py` to use `shutil.which('xacro')` and return the resolved absolute executable path when found.
- Kept `/opt/ros/humble/bin/xacro` as a second-tier fallback and return its absolute path if present.
- Added a Python-module availability check using `importlib.util.find_spec('xacro')` and return `['python3','-m','xacro']` if the module is importable but no executable is available.
- Accumulate and return precise diagnostics for each failed discovery path (for example `PATH xacro not found`, `/opt/ros/humble/bin/xacro missing`, and `python xacro module import failed: ...`).
- Added a focused unit test `test_discover_xacro_command_prefers_resolved_path_executable` that monkeypatches `PATH`/`shutil.which` and verifies the resolved xacro command is detected and returned.

### Testing
- Ran the unit test file with `pytest tests/test_scene_urdf_visual_mesh_index.py -q`, which passed: `16 passed` in ~2.7s.
- The newly added focused test that monkeypatches `PATH`/`shutil.which` passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3166fd4d0083318564244e5cfdd1bd)