### PR TITLE
Set ScenePreviewWidget product view default to Isometric and add helper to restore it

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -156,6 +156,10 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
   controls->addWidget(view_actions_label_);
   view_actions_selector_ = new QComboBox(this);
   view_actions_selector_->addItems({"Top", "Front", "Side", "Isometric", "Fit View"});
+  {
+    const QSignalBlocker blocker(view_actions_selector_);
+    view_actions_selector_->setCurrentText("Isometric");
+  }
   controls->addWidget(view_actions_selector_);
   toolbar_status_chip_ = new QLabel(this);
   toolbar_status_chip_->setObjectName("previewToolbarChip");
@@ -348,12 +352,7 @@ void ScenePreviewWidget::set_preview_items(const QVector<PreviewItem> & items)
     emit studio_log_requested(has_selected ? QString("Preview selection restored after refresh: %1").arg(selected_preview_item_id_) : QString("Preview selection retained after refresh; id is hidden by filters or absent from the visible preview payload: %1").arg(selected_preview_item_id_));
   }
   viewport->fit_include_overlays = false;
-  // Product previews should open in the same camera path users get from the
-  // normal canvas controls: an isometric view followed by product-fit bounds
-  // that keep robot/tool/environment meshes and editable layout items legible
-  // without letting diagnostics overlays dominate the initial framing.
-  viewport->set_isometric_view();
-  viewport->fit_product_view();
+  apply_product_view_defaults();
   emit_scene_diagnostic_once(
     QStringLiteral("payload_commit"),
     preview_items_.size(),
@@ -468,9 +467,26 @@ void ScenePreviewWidget::reload_meshes()
 {
   auto * v = static_cast<Scene3DViewportWidget *>(simple_3d_view_);
   v->invalidate_mesh_cache();
-  v->update();
+  apply_product_view_defaults();
   update();
   emit studio_log_requested("Reloaded mesh preview cache (visual-only).");
+}
+void ScenePreviewWidget::apply_product_view_defaults()
+{
+  auto * v = static_cast<Scene3DViewportWidget *>(simple_3d_view_);
+  if (!v) return;
+  if (view_actions_selector_) {
+    const QSignalBlocker blocker(view_actions_selector_);
+    view_actions_selector_->setCurrentText("Isometric");
+  }
+  // Product previews should open in the same camera path users get from the
+  // normal canvas controls: an isometric view followed by product-fit bounds
+  // that keep robot/tool/environment meshes and editable layout items legible
+  // without letting diagnostics overlays dominate the initial framing.
+  v->fit_include_overlays = false;
+  v->set_isometric_view();
+  v->fit_product_view();
+  fit_fallback_scene_to_items(false);
 }
 void ScenePreviewWidget::on_reset_view_clicked(){ static_cast<Scene3DViewportWidget *>(simple_3d_view_)->reset_view(); reset_fallback_scene_view(); }
 void ScenePreviewWidget::on_fit_scene_clicked(){ auto *v = static_cast<Scene3DViewportWidget *>(simple_3d_view_); v->fit_include_overlays = false; v->fit_scene(); fit_fallback_scene_to_items(false); } // Fit Scene intentionally excludes overlay-only bounds by default.

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -193,6 +193,7 @@ public:
   const PreviewItem * preview_item_by_id(const QString & id) const;
   MeshPreviewMode mesh_preview_mode() const;
   void reload_meshes();
+  void apply_product_view_defaults();
   struct RenderDebugCounters
   {
     int preview_items_count{ 0 };

--- a/workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene_preview_widget_ui_test.cpp
@@ -77,3 +77,27 @@ TEST(ScenePreviewWidgetUi, LabelModeDefaultsToSelected)
   ASSERT_NE(label_combo, nullptr);
   EXPECT_EQ(label_combo->currentText(), QString("Selected"));
 }
+
+TEST(ScenePreviewWidgetUi, ProductViewDefaultsToIsometric)
+{
+  ASSERT_NE(ensure_app(), nullptr);
+
+  ScenePreviewWidget widget;
+  const auto combos = widget.findChildren<QComboBox *>();
+  QComboBox * view_combo = nullptr;
+  for (auto * combo : combos) {
+    if (combo && combo->findText("Top") >= 0 && combo->findText("Front") >= 0 &&
+        combo->findText("Side") >= 0 && combo->findText("Isometric") >= 0 &&
+        combo->findText("Fit View") >= 0) {
+      view_combo = combo;
+      break;
+    }
+  }
+
+  ASSERT_NE(view_combo, nullptr);
+  EXPECT_EQ(view_combo->currentText(), QString("Isometric"));
+
+  view_combo->setCurrentText("Top");
+  widget.apply_product_view_defaults();
+  EXPECT_EQ(view_combo->currentText(), QString("Isometric"));
+}


### PR DESCRIPTION
### Motivation

- Prevent startup from accidentally triggering a camera change when the view selector is populated before scene content is available by ensuring the selector is initialized without emitting signals. 
- Provide a single helper to consistently apply the desired product preview camera+fit behavior after payloads or mesh reloads. 

### Description

- Set the view selector default to `Isometric` immediately after `view_actions_selector_->addItems(...)` under a `QSignalBlocker` to avoid emitting a camera-change signal during construction. 
- Add and expose `apply_product_view_defaults()` which blocks selector signals, sets the selector to `Isometric`, calls `Scene3DViewportWidget::set_isometric_view()`, and runs a product-focused fit with overlays excluded. 
- Call `apply_product_view_defaults()` from `set_preview_items()` (payload commit path) and `reload_meshes()` (mesh index reload path) so the preview resets to the intended product view after updates. 
- Add a UI unit test `ProductViewDefaultsToIsometric` in `test/scene_preview_widget_ui_test.cpp` that asserts the selector default and that `apply_product_view_defaults()` restores `Isometric` after a change. 

### Testing

- Ran `git diff --check` which passed without whitespace or diff issues. 
- Added a GTest UI test `ProductViewDefaultsToIsometric` under `workcell_builder` to validate the selector default and helper behavior; this test is included in the repo but was not executed in this container. 
- Attempted to run a local `colcon` build for `workcell_builder` but the container lacks the ROS setup (`/opt/ros/humble/setup.bash`), so the full build/CI test run was not performed here; the new test should run in CI or a properly provisioned dev environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31718944a883319505b6d0d04fe302)