### PR TITLE
Constrain scene preview fit to product visuals

### DIFF
--- a/tests/test_scene3d_view_fit_and_scale.py
+++ b/tests/test_scene3d_view_fit_and_scale.py
@@ -45,8 +45,10 @@ def test_fit_bounds_include_mesh_urdf_primitive_semantic_fallback_and_layout_ite
     assert 'item_has_credible_mesh_handoff(it)' in include_fit
     assert 'item_has_explicit_primitive_dimensions(it)' in include_fit
     assert 'if (helper_overlay) return false;' in include_fit
+    assert 'if (generated_urdf_visual) return true;' in include_fit
     assert 'if (it.linked_to_editable_layout_state) return true;' in include_fit
-    assert 'return mesh_backed || explicit_primitive;' in include_fit
+    assert 'source_layer == "mesh_preview"' in include_fit
+    assert 'product_physical_role && (mesh_backed || explicit_primitive)' in include_fit
 
     assert 'include_in_fit_bounds(it, include_overlays)' in scene_bounds
     assert 'item_bounds_for_role(it)' in scene_bounds

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -785,21 +785,37 @@ bool is_overlay_only_item(const ScenePreviewWidget::PreviewItem & it);
 
 bool include_in_fit_bounds(const ScenePreviewWidget::PreviewItem & it, bool include_overlays)
 {
+  // FIT_PHYSICAL_ONLY_FILTER: default/product fits exclude overlays and helpers.
   if (include_overlays) return true;
+
   const QString source_layer = normalized_scene3d_layer_token(it.source_layer);
   const QString visual_source = normalized_scene3d_layer_token(it.active_visual_source);
   const bool helper_overlay = is_overlay_only_item(it) || source_layer == "overlay" || visual_source == "overlay";
+  if (helper_overlay) return false;
+
   const bool generated_urdf_visual = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
   const bool mesh_backed = item_has_credible_mesh_handoff(it);
   const bool explicit_primitive = item_has_explicit_primitive_dimensions(it);
   const bool missing_geometry = !mesh_backed && !explicit_primitive;
-  const bool missing_mesh_fallback = missing_geometry && !it.linked_to_editable_layout_state && !generated_urdf_visual;
-  if (helper_overlay) return false;
-  if (missing_mesh_fallback) return false;
-  if (generated_urdf_visual && mesh_backed) return true;
+  if (missing_geometry && !it.linked_to_editable_layout_state && !generated_urdf_visual) return false;
+
   if (generated_urdf_visual) return true;
   if (it.linked_to_editable_layout_state) return true;
-  return mesh_backed || explicit_primitive;
+  if (source_layer == "mesh_preview" || visual_source == "mesh_preview") return mesh_backed || explicit_primitive;
+
+  const NormalizedRole role = classify_item_role(it);
+  const QString role_text = normalized_token(it.role);
+  const QString category = normalized_token(it.category);
+  const QString id = normalized_token(it.id);
+  const QString display_name = normalized_token(it.display_name);
+  const QString mix = role_text + "|" + category + "|" + id + "|" + display_name;
+  const bool product_physical_role =
+    role == NormalizedRole::RobotBase ||
+    role == NormalizedRole::Table ||
+    role == NormalizedRole::Camera ||
+    mix.contains("gripper") || mix.contains("tool") ||
+    mix.contains("end_effector") || mix.contains("end effector");
+  return product_physical_role && (mesh_backed || explicit_primitive);
 }
 
 bool is_overlay_only_item(const ScenePreviewWidget::PreviewItem & it)
@@ -1118,19 +1134,21 @@ void Scene3DViewportWidget::fit_scene() {
   distance_ = qBound(min_distance_, fit_distance, max_distance_);
   pitch_ = qBound(0.28, pitch_, 0.9);
   orbit_offset_.setY(orbit_offset_.y() + static_cast<float>(qMax(0.10, radius * 0.05)));
-  last_camera_fit_target_ = fit_include_overlays ? QStringLiteral("scene_with_overlays") : QStringLiteral("scene");
+  if (fit_include_overlays) {
+    last_camera_fit_target_ = QStringLiteral("scene_with_overlays");
+  } else {
+    last_camera_fit_target_ = QStringLiteral("scene");
+  }
   has_robot_aabb_diag_ = false;
   update();
 }
 
 void Scene3DViewportWidget::fit_product_view()
 {
-  const bool previous_include_overlays = fit_include_overlays;
   fit_include_overlays = false;
 
   QVector3D bmin, bmax;
   if (!scene_bounds_from_visible_items(bmin, bmax, false)) {
-    fit_include_overlays = previous_include_overlays;
     set_isometric_view();
     return;
   }
@@ -1147,7 +1165,7 @@ void Scene3DViewportWidget::fit_product_view()
   orbit_offset_.setY(orbit_offset_.y() + static_cast<float>(qMax(0.04, radius * 0.025)));
   last_camera_fit_target_ = QStringLiteral("product_physical_isometric");
   has_robot_aabb_diag_ = false;
-  fit_include_overlays = previous_include_overlays;
+  fit_include_overlays = false;
   update();
 }
 void Scene3DViewportWidget::fit_robot()

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -308,7 +308,7 @@ ScenePreviewWidget::ScenePreviewWidget(QWidget * parent) : QWidget(parent)
     else if (choice == "Focus Selected") on_focus_selected_clicked();
     else if (choice == "Fit Scene") on_fit_scene_clicked();
     else if (choice == "Fit Robot") on_fit_robot_clicked();
-    else if (choice == "Fit Overlays") on_fit_overlays_clicked();
+    else if (choice == "Fit overlays") on_fit_overlays_clicked();
     else if (choice == "Clear Selection") on_clear_selection_clicked();
     if (overlays_selector_ && choice != "Overlays") {
       const QSignalBlocker blocker(overlays_selector_);
@@ -558,8 +558,33 @@ QRectF ScenePreviewWidget::rendered_items_bounds_2d(bool include_overlays) const
   auto include_in_fit_bounds = [include_overlays](const PreviewItem & it) {
     if (include_overlays) return true;
     if (preview_item_is_overlay_or_helper(it)) return false;
-    if (preview_item_is_raw_generated_bounds_only(it)) return false;
-    return true;
+
+    const QString source_layer = normalized_preview_token(it.source_layer);
+    const QString visual_source = normalized_preview_token(it.active_visual_source);
+    if (source_layer.contains("overlay") || visual_source.contains("overlay")) return false;
+
+    const bool generated_urdf = preview_item_is_generated_or_locked_urdf(it);
+    const bool mesh_backed = preview_item_has_credible_mesh_handoff(it);
+    const bool explicit_primitive = preview_item_has_valid_urdf_primitive(it) ||
+                                    (it.sx > 0.001 && it.sy > 0.001 && it.sz > 0.001);
+    if (generated_urdf) return true;
+    if (it.linked_to_editable_layout_state) return true;
+    if (source_layer == QStringLiteral("mesh_preview") || visual_source == QStringLiteral("mesh_preview")) {
+      return mesh_backed || explicit_primitive;
+    }
+
+    const QString role = normalized_preview_token(it.role);
+    const QString category = normalized_preview_token(it.category);
+    const QString id = normalized_preview_token(it.id);
+    const QString display_name = normalized_preview_token(it.display_name);
+    const QString mix = role + QStringLiteral("|") + category + QStringLiteral("|") + id + QStringLiteral("|") + display_name;
+    const bool product_physical = mix.contains("robot") || mix.contains("gripper") ||
+                                  mix.contains("tool") || mix.contains("end_effector") ||
+                                  mix.contains("table") || mix.contains("work_surface") ||
+                                  mix.contains("workbench") || mix.contains("camera") ||
+                                  mix.contains("realsense") || mix.contains("depth_camera") ||
+                                  mix.contains("rgbd");
+    return product_physical && (mesh_backed || explicit_primitive);
   };
   for (const auto & it : preview_items_) {
     if (!include_in_fit_bounds(it)) continue;

--- a/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
@@ -100,6 +100,14 @@ TEST(Scene3DRenderRoleClassifier, DefaultProductFitIncludesPhysicalItemsAndExclu
   auto bounds_box = make_item("bounds_box");
   bounds_box.category = "diagnostic_bounds_box";
   EXPECT_FALSE(Scene3DViewportWidget::should_include_in_default_fit_for_test(bounds_box));
+  auto generic_primitive = make_item("generic_box");
+  EXPECT_FALSE(Scene3DViewportWidget::should_include_in_default_fit_for_test(generic_primitive));
+
+  auto mesh_preview = make_item("mesh_preview_asset");
+  mesh_preview.source_layer = "mesh_preview";
+  mesh_preview.mesh_available = true;
+  EXPECT_TRUE(Scene3DViewportWidget::should_include_in_default_fit_for_test(mesh_preview));
+
 }
 
 TEST(Scene3DRenderRoleClassifier, MeshesModeDoesNotDrawFallbackSolid)


### PR DESCRIPTION
### Motivation
- Prevent overlay/helper bounds (camera FOV, reachability, pick/place routes, warning anchors, diagnostics) from dominating the default/product fit so physical meshes remain legible. 
- Ensure the product-view path reliably frames robot, gripper/tool, table, camera body, generated URDF visuals, mesh previews, and editable layout assets only, and keep `Fit overlays` as the explicit overlay-inclusive action.
- Apply the product-view defaults after every scene load and payload commit so the initial framing is consistent and non-diagnostic by default.

### Description
- Tightened the default fit filtering by updating `include_in_fit_bounds` to exclude overlay/helper items and to include only generated/locked URDF visuals, mesh-preview-backed items, explicit URDF primitives, and editable layout items or product-physical roles (robot, table, camera, gripper/tool/end-effector). (Modified `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`.)
- Ensured `fit_include_overlays = false` is enforced for product fits and remains false after `fit_product_view()` so overlay bounds are never implicitly included during product preview defaults. (Modified `Scene3DViewportWidget::fit_product_view` and `fit_scene` behavior in `scene3d_viewport_widget.cpp`.)
- Brought 2D fallback framing into parity by applying the same product-only filter when computing 2D bounds. (Modified `workcell_builder/workcell_builder/gui/scene_preview_widget.cpp`.)
- Preserved the explicit `Fit overlays` action as the only path that temporarily enables overlay-inclusive framing, and adjusted the overlay menu dispatch to match the selector label. (Modified `scene_preview_widget.cpp`.)
- Added/updated tests that assert the default/product-fit contract: `tests/test_scene3d_view_fit_and_scale.py` and extended the classifier test coverage in `workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp`.

### Testing
- Ran `python3 -m pytest tests/test_scene3d_view_fit_and_scale.py`, which passed (all tests in that file succeeded).
- Ran the preview contract validator `python3 scripts/validate_scene3d_mesh_preview_contract.py`, which failed due to an unrelated contract token expectation (`missing token: ensure_mesh_cached(`) inside the parsed GL paint body; this is a pre-existing/independent contract requirement not covered by these fit-focused changes.
- Could not run ROS build validation (`colcon build --packages-select workcell_builder`) in this environment because the container lacks the ROS Humble setup (`/opt/ros/humble/setup.bash`).
- No runtime, launch, controller, or hardware execution behavior was changed and fake-hardware defaults were preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3173692a2483318c1691d96b427032)