### PR TITLE
Suppress mesh-only primitive fallback diagnostics

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1888,12 +1888,14 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
   }
   if (item_has_valid_urdf_primitive(it)) {
     if (mesh_preview_mode == ScenePreviewWidget::MeshPreviewMode::Meshes) {
-      // Primitive geometry exists but is intentionally hidden by Meshes-only mode; do not show a red missing-geometry marker.
+      // Primitive geometry exists but is intentionally hidden by Meshes-only mode; do not show a red missing-geometry marker
+      // or count an expected suppression as a generated fallback during normal product rendering.
       if (debug_overlays_mode && item_has_explicit_dimensions(it)) {
         draw_box_outline(it.x, it.y, it.z, it.sx, it.sy, it.sz, generated_primitive_fallback_outline(), 0.6f);
       }
-      ++last_render_counters.generated_fallback_count;
-      warn_mesh_fallback_once(it.id, QStringLiteral("REJECT_PRIMITIVE_SUPPRESSED_BY_MESH_ONLY_MODE: URDF primitive available but disabled"), it.source_path);
+      if (debug_overlays_mode || qEnvironmentVariableIsSet("WORKCELL_SCENE3D_DEBUG_LOGS")) {
+        warn_mesh_fallback_once(it.id, QStringLiteral("REJECT_PRIMITIVE_SUPPRESSED_BY_MESH_ONLY_MODE: URDF primitive available but disabled"), it.source_path);
+      }
       return false;
     }
     const QColor primitive_fill = generated_or_locked_preview ? generated_primitive_fallback_fill() : visual_color;
@@ -1918,12 +1920,14 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
         warn_mesh_fallback_once(it.id, QStringLiteral("REJECT_RAW_GENERATED_BOUNDS_SUPPRESSED: mesh or URDF primitive source should provide geometry"), it.source_path);
         return false;
       }
-      // Semantic primitive geometry exists but is intentionally hidden by Meshes-only mode; do not show a warning marker.
+      // Semantic primitive geometry exists but is intentionally hidden by Meshes-only mode; do not show a warning marker
+      // or count an expected suppression as a generated fallback during normal product rendering.
       if (debug_overlays_mode) {
         draw_box_outline(it.x, it.y, it.z, it.sx, it.sy, it.sz, generated_primitive_fallback_outline(), 0.6f);
       }
-      ++last_render_counters.generated_fallback_count;
-      warn_mesh_fallback_once(it.id, QStringLiteral("REJECT_PRIMITIVE_SUPPRESSED_BY_MESH_ONLY_MODE: semantic primitive dimensions available but disabled"), it.source_path);
+      if (debug_overlays_mode || qEnvironmentVariableIsSet("WORKCELL_SCENE3D_DEBUG_LOGS")) {
+        warn_mesh_fallback_once(it.id, QStringLiteral("REJECT_PRIMITIVE_SUPPRESSED_BY_MESH_ONLY_MODE: semantic primitive dimensions available but disabled"), it.source_path);
+      }
       return false;
     }
     const QColor fallback_fill = generated_or_locked_preview ? generated_primitive_fallback_fill()


### PR DESCRIPTION
### Motivation
- Avoid counting expected Meshes-only suppressions as `generated_fallback_count` so diagnostics reflect only real missing geometry in normal product rendering.
- Prevent noisy fallback warnings during normal product render by only emitting `REJECT_PRIMITIVE_SUPPRESSED_BY_MESH_ONLY_MODE` diagnostics when debug overlays or explicit debug logging are enabled.

### Description
- Changed `Scene3DViewportWidget::draw_truthful_item_geometry()` to stop incrementing `last_render_counters.generated_fallback_count` in the Meshes-only suppression paths for URDF primitives and semantic primitive dimensions.
- Gated calls to `warn_mesh_fallback_once(... "REJECT_PRIMITIVE_SUPPRESSED_BY_MESH_ONLY_MODE" ...)` behind `debug_overlays_mode || qEnvironmentVariableIsSet("WORKCELL_SCENE3D_DEBUG_LOGS")` so suppressed diagnostics only appear when overlays/logging are explicitly enabled.
- Applied identical treatment to the `item_has_valid_urdf_primitive(it)` branch and the `item_has_explicit_dimensions(it)` branch that handle Meshes-only hiding of primitives.
- Left other missing-geometry and placeholder paths unchanged so true missing geometry still increments `generated_fallback_count` and warns as before.

### Testing
- Ran a small Python static check that scanned the modified source to confirm the suppressed Meshes-only branches no longer increment `generated_fallback_count` and that the warning calls are debug/log guarded, which succeeded.
- Ran `git diff --check` which produced no whitespace or patch issues.
- Attempted `colcon build --packages-select workcell_builder` but `colcon` is not available in this container so an in-container build was not executed; no runtime or launch behavior was modified by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a326c4bb1308331a8d1dc40832a2716)