### PR TITLE
Report per-item mesh rejection reasons and distinguish mesh-surface candidates from raw bounds

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -112,6 +112,18 @@ bool item_has_credible_mesh_handoff(const ScenePreviewWidget::PreviewItem & item
          (!source_path.isEmpty() && path_has_mesh_asset_extension(source_path));
 }
 
+bool item_has_mesh_surface_candidate(const ScenePreviewWidget::PreviewItem & item)
+{
+  const QString mesh_path = item.mesh_path.trimmed();
+  const QString package_uri = item.package_uri.trimmed();
+  const QString source_path = item.source_path.trimmed();
+  return item.mesh_available ||
+         item.has_mesh_metadata ||
+         (!mesh_path.isEmpty() && path_has_mesh_asset_extension(mesh_path)) ||
+         (!package_uri.isEmpty() && path_has_mesh_asset_extension(package_uri)) ||
+         (!source_path.isEmpty() && path_has_mesh_asset_extension(source_path));
+}
+
 bool item_has_valid_urdf_primitive(const ScenePreviewWidget::PreviewItem & item)
 {
   const QString type = item.primitive_geometry_type.trimmed().toLower().replace(QLatin1Char('-'), QLatin1Char('_')).replace(QLatin1Char(' '), QLatin1Char('_'));
@@ -853,7 +865,7 @@ bool is_raw_generated_bounds_only_item(const ScenePreviewWidget::PreviewItem & i
   }
   const bool generated_or_locked = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
   if (!generated_or_locked || !item_has_explicit_primitive_dimensions(it)) return false;
-  return item_has_credible_mesh_handoff(it) || item_has_valid_urdf_primitive(it);
+  return item_has_mesh_surface_candidate(it) || item_has_valid_urdf_primitive(it);
 }
 
 
@@ -1038,6 +1050,7 @@ void Scene3DViewportWidget::set_side_view() { yaw_ = -M_PI_2; pitch_ = 0.0; upda
 void Scene3DViewportWidget::invalidate_mesh_cache()
 {
   mesh_cache_.clear();
+  last_mesh_rejection_reasons_.clear();
   warned_mesh_fallbacks_.clear();
   for (const auto & it : items) {
     const NormalizedRole role = classify_item_role(it);
@@ -1917,7 +1930,16 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
     const bool raw_generated_bounds_only = is_raw_generated_bounds_only_item(it);
     if (mesh_preview_mode == ScenePreviewWidget::MeshPreviewMode::Meshes || raw_generated_bounds_only) {
       if (raw_generated_bounds_only) {
-        warn_mesh_fallback_once(it.id, QStringLiteral("REJECT_RAW_GENERATED_BOUNDS_SUPPRESSED: mesh or URDF primitive source should provide geometry"), it.source_path);
+        const QString mesh_source = !it.mesh_path.trimmed().isEmpty() ? it.mesh_path : it.source_path;
+        const bool mesh_candidate = item_has_mesh_surface_candidate(it);
+        const QString stored_reason = last_mesh_rejection_reason_for_item(it.id);
+        if (mesh_candidate && !stored_reason.trimmed().isEmpty()) {
+          warn_mesh_fallback_once(it.id, stored_reason, mesh_source);
+        } else if (mesh_candidate) {
+          warn_mesh_fallback_once(it.id, QStringLiteral("REJECT_MESH_CANDIDATE_SUPPRESSED: mesh surface candidate could not be rendered"), mesh_source);
+        } else {
+          warn_mesh_fallback_once(it.id, QStringLiteral("REJECT_RAW_GENERATED_BOUNDS_SUPPRESSED: raw generated bounds placeholder has no valid mesh source candidate"), it.source_path);
+        }
         return false;
       }
       // Semantic primitive geometry exists but is intentionally hidden by Meshes-only mode; do not show a warning marker
@@ -2073,6 +2095,16 @@ bool Scene3DViewportWidget::should_suppress_missing_geometry_marker_for_test(con
   return should_suppress_missing_geometry_marker_for_semantic_role(item);
 }
 
+bool Scene3DViewportWidget::has_mesh_surface_candidate_for_test(const ScenePreviewWidget::PreviewItem & item)
+{
+  return item_has_mesh_surface_candidate(item);
+}
+
+bool Scene3DViewportWidget::is_raw_generated_bounds_only_for_test(const ScenePreviewWidget::PreviewItem & item)
+{
+  return is_raw_generated_bounds_only_item(item);
+}
+
 bool Scene3DViewportWidget::try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical,
                                                                const ScenePreviewWidget::PreviewItem * item,
                                                                QString * out_failure_reason) const
@@ -2087,6 +2119,18 @@ bool Scene3DViewportWidget::try_resolve_canonical_mesh_path(const QString & path
   if (out_canonical.isEmpty()) out_canonical = info.absoluteFilePath();
   if (out_canonical.isEmpty() && out_failure_reason) *out_failure_reason = mesh_load_failure_reason_for_item(path, item);
   return !out_canonical.isEmpty();
+}
+
+void Scene3DViewportWidget::remember_mesh_rejection_reason(const QString & item_id, const QString & reason)
+{
+  const QString key = item_id.trimmed().isEmpty() ? QStringLiteral("<unknown>") : item_id.trimmed();
+  last_mesh_rejection_reasons_.insert(key, reason.trimmed().isEmpty() ? QStringLiteral("REJECT_UNKNOWN") : reason);
+}
+
+QString Scene3DViewportWidget::last_mesh_rejection_reason_for_item(const QString & item_id) const
+{
+  const QString key = item_id.trimmed().isEmpty() ? QStringLiteral("<unknown>") : item_id.trimmed();
+  return last_mesh_rejection_reasons_.value(key);
 }
 
 bool Scene3DViewportWidget::warn_mesh_fallback_once(const QString & item_id, const QString & reason, const QString & path)
@@ -2336,6 +2380,7 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
     // explicit branch kept for static mesh-preview contract checks
   }
   const auto warn_for_mode = [&](const QString & reason, const QString & path) {
+    remember_mesh_rejection_reason(it.id, reason);
     if (meshes_only_mode || qEnvironmentVariableIsSet("WORKCELL_SCENE3D_DEBUG_LOGS")) warn_mesh_fallback_once(it.id, reason, path);
   };
 
@@ -2355,10 +2400,9 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
   }
   const auto cache_it = mesh_cache_.constFind(canonical_mesh_source);
   if (cache_it == mesh_cache_.constEnd()) {
-    warn_mesh_fallback_once(
-      it.id,
-      QStringLiteral("REJECT_MESH_CACHE_MISS: mesh cache entry missing; waiting for controlled preview ingest/reload"),
-      mesh_source);
+    const QString reason = QStringLiteral("REJECT_MESH_CACHE_MISS: mesh cache entry missing; waiting for controlled preview ingest/reload");
+    remember_mesh_rejection_reason(it.id, reason);
+    warn_mesh_fallback_once(it.id, reason, mesh_source);
     return false;
   }
   const MeshCacheEntry & entry = cache_it.value();
@@ -2367,10 +2411,10 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
     warn_for_mode(reason, mesh_source);
     return false;
   };
-  if (!entry.loaded || !entry.valid || entry.oversized || entry.mesh.triangles.isEmpty()) {
+  if (!entry.loaded || entry.oversized || !entry.valid || entry.mesh.triangles.isEmpty()) {
     if (!entry.loaded) return reject(QStringLiteral("parse_failed"));
-    if (!entry.valid) return reject(entry.failure_reason_code.trimmed().isEmpty() ? QStringLiteral("parse_failed") : entry.failure_reason_code, entry.warning);
     if (entry.oversized) return reject(QStringLiteral("unreasonable_bounds"), entry.warning);
+    if (!entry.valid) return reject(entry.failure_reason_code.trimmed().isEmpty() ? QStringLiteral("parse_failed") : entry.failure_reason_code, entry.warning);
     return reject(QStringLiteral("zero_triangle_mesh"), entry.warning);
   }
   QString final_span_reason;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -146,6 +146,8 @@ public:
                                                 ScenePreviewWidget::MeshPreviewMode mode);
   static bool should_draw_clean_semantic_primitive_for_test(const ScenePreviewWidget::PreviewItem & item);
   static bool should_suppress_missing_geometry_marker_for_test(const ScenePreviewWidget::PreviewItem & item);
+  static bool has_mesh_surface_candidate_for_test(const ScenePreviewWidget::PreviewItem & item);
+  static bool is_raw_generated_bounds_only_for_test(const ScenePreviewWidget::PreviewItem & item);
 
 protected:
   void initializeGL() override;
@@ -253,11 +255,14 @@ private:
     QVector3D dae_pre_unit_span;
   };
   QHash<QString, MeshCacheEntry> mesh_cache_;
+  QHash<QString, QString> last_mesh_rejection_reasons_;
   QSet<QString> warned_mesh_fallbacks_;
   bool try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical,
                                        const ScenePreviewWidget::PreviewItem * item = nullptr,
                                        QString * out_failure_reason = nullptr) const;
   bool warn_mesh_fallback_once(const QString & item_id, const QString & reason, const QString & path);
+  void remember_mesh_rejection_reason(const QString & item_id, const QString & reason);
+  QString last_mesh_rejection_reason_for_item(const QString & item_id) const;
   const MeshCacheEntry & ensure_mesh_cached(const ScenePreviewWidget::PreviewItem & item, const QString & path);
   bool validate_mesh_final_span(const ScenePreviewWidget::PreviewItem & it,
                                 const MeshCacheEntry & entry,

--- a/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
@@ -263,3 +263,33 @@ TEST(Scene3DRenderRoleClassifier, EditableLayoutPrimitivesDoNotCountAsGeneratedF
   EXPECT_EQ(counters.valid_physical_fallback_count, 0);
   EXPECT_EQ(counters.editable_primitive_rendered_count, 1);
 }
+
+TEST(Scene3DRenderRoleClassifier, ValidStlAndDaePreviewItemsAreMeshSurfaceCandidates)
+{
+  auto stl = make_item("valid_stl_preview");
+  stl.locked = true;
+  stl.editable = false;
+  stl.lock_reason = "Generated URDF visual";
+  stl.source_layer = "generated_urdf_visual";
+  stl.active_visual_source = "generated_urdf_visual";
+  stl.has_mesh_metadata = true;
+  stl.mesh_available = true;
+  stl.mesh_path = "meshes/valid_part.stl";
+
+  auto dae = make_item("valid_dae_preview");
+  dae.locked = true;
+  dae.editable = false;
+  dae.lock_reason = "Generated URDF visual";
+  dae.source_layer = "generated_urdf_visual";
+  dae.active_visual_source = "generated_urdf_visual";
+  dae.has_mesh_metadata = true;
+  dae.mesh_available = true;
+  dae.mesh_path = "package://demo_cell/meshes/valid_part.dae";
+
+  EXPECT_TRUE(Scene3DViewportWidget::has_mesh_surface_candidate_for_test(stl));
+  EXPECT_TRUE(Scene3DViewportWidget::has_mesh_surface_candidate_for_test(dae));
+  EXPECT_FALSE(Scene3DViewportWidget::should_draw_as_wireframe_for_test(stl, ScenePreviewWidget::MeshPreviewMode::Auto));
+  EXPECT_FALSE(Scene3DViewportWidget::should_draw_as_wireframe_for_test(dae, ScenePreviewWidget::MeshPreviewMode::Auto));
+  EXPECT_EQ(Scene3DViewportWidget::render_role_for_test(stl), "generated_urdf_mesh");
+  EXPECT_EQ(Scene3DViewportWidget::render_role_for_test(dae), "generated_urdf_mesh");
+}


### PR DESCRIPTION
### Motivation
- Improve Scene3D diagnostics so generated raw-bounds placeholders report the exact mesh rejection reason when a mesh-like source exists instead of a generic suppression message.
- Make the viewport differentiate true raw generated-bounds placeholders from items that have mesh-surface candidates (e.g. `.stl`, `.dae`, `.obj`, `.glb`, `.gltf`) so warnings are informative.

### Description
- Added per-item storage `last_mesh_rejection_reasons_` and helper methods `remember_mesh_rejection_reason()` and `last_mesh_rejection_reason_for_item()` to track the last mesh rejection reason observed for each preview item.
- Introduced `item_has_mesh_surface_candidate()` and exposed `has_mesh_surface_candidate_for_test()` to detect mesh-like source candidates using metadata and mesh-like path extensions.
- Changed `is_raw_generated_bounds_only_item()` to use mesh-surface candidate detection so true raw placeholders are distinguished from mesh candidates.
- Updated `draw_truthful_item_geometry()` to, when `raw_generated_bounds_only` is true, log the stored per-item mesh rejection reason if a mesh-like candidate exists; reserve `REJECT_RAW_GENERATED_BOUNDS_SUPPRESSED` for placeholders with no mesh candidate.
- Modified `draw_mesh_preview_if_available()` to call `remember_mesh_rejection_reason()` at failure points (e.g. missing metadata, cache miss) so the rejection reason is available later.
- Cleared the stored rejection map on `invalidate_mesh_cache()` and added focused test helpers `is_raw_generated_bounds_only_for_test()`.
- Added tests `ValidStlAndDaePreviewItemsAreMeshSurfaceCandidates` in `scene3d_render_role_classifier_test.cpp` to verify `.stl` and `.dae` generated preview items classify as mesh-surface candidates and are treated as generated URDF meshes rather than wireframe/raw fallbacks.

### Testing
- Ran repository static checks: `git diff --check` passed.
- Attempted to run unit test collection via `python3 -m pytest workcell_builder/workcell_builder/test`; collection failed due to an unrelated test import resolution error (`ModuleNotFoundError: No module named 'test_ur5_2f_demo_launch'`) so full test suite was not executed in this environment.
- Attempted `colcon build` for `workcell_builder` but build could not be run because the container lacks the ROS 2 Humble environment (`/opt/ros/humble/setup.bash` missing).
- No runtime, launch, hardware, or real-robot defaults were changed by this patch; change is diagnostic/classification-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a326e5630e0833188c83dc1ed8128a7)