### PR TITLE
Separate product vs debug Scene3D warning logic; exclude editable/overlay diagnostics from product warnings

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -298,6 +298,28 @@ void finalize_visual_quality(Scene3DViewportWidget::RenderDebugCounters & counte
 }
 
 
+bool product_view_has_generated_mesh_warning_content(const Scene3DViewportWidget::RenderDebugCounters & counters)
+{
+  // Product view warnings are reserved for generated/locked URDF preview quality problems.
+  // Editable layout primitives, helper overlays, FOV/reach aids, debug bounds, and generic
+  // wireframe diagnostics remain visible diagnostics only; they must not look like generated
+  // mesh fallback failures in the normal Workcell Studio product view.
+  return counters.generated_mesh_bounds_fallback_rendered_count > 0 ||
+         counters.generated_missing_geometry_count > 0 ||
+         counters.generated_fallback_count > 0;
+}
+
+bool debug_view_has_full_diagnostic_warning_content(const Scene3DViewportWidget::RenderDebugCounters & counters)
+{
+  return counters.missing_geometry_count > 0 ||
+         counters.mesh_bounds_fallback_rendered_count > 0 ||
+         counters.primitive_fallback_rendered_count > 0 ||
+         counters.wireframe_fallback_count > 0 ||
+         counters.placeholder_count > 0 ||
+         counters.overlay_helper_count > 0 ||
+         counters.visual_quality_status == QStringLiteral("FAIL");
+}
+
 QString mesh_load_failure_reason_for_item(const QString & path, const ScenePreviewWidget::PreviewItem * item)
 {
   const QString trimmed_path = path.trimmed();
@@ -1254,7 +1276,9 @@ void Scene3DViewportWidget::paintGL()
   int editable_primitive_count = 0;
   int placeholder_count = 0;
   int missing_geometry_count = 0;
+  int generated_missing_geometry_count = 0;
   int wireframe_box_count = 0;
+  int generated_mesh_bounds_fallback_count = 0;
   int overlay_count = 0;
   int locked_urdf_count = 0;
   int physical_item_count = 0;
@@ -1326,6 +1350,11 @@ void Scene3DViewportWidget::paintGL()
         wireframe_box_count += item_wireframe_box_count;
         primitive_fallback_count += item_primitive_fallback_count;
         editable_primitive_count += item_editable_primitive_count;
+        const bool item_generated_or_locked = is_generated_urdf_visual_item(*it) || is_locked_urdf_item(*it);
+        if (item_generated_or_locked && item_has_credible_mesh_handoff(*it) && item_mesh_backed_count <= 0) {
+          ++generated_mesh_bounds_fallback_count;
+        }
+        if (item_generated_or_locked) generated_missing_geometry_count += item_missing_geometry_count;
       } else {
         missing_geometry_count += item_missing_geometry_count;
         primitive_fallback_count += item_primitive_fallback_count;
@@ -1349,6 +1378,7 @@ void Scene3DViewportWidget::paintGL()
   last_render_counters.mesh_rendered_count = mesh_rendered_count;
   last_render_counters.mesh_surface_rendered_count = mesh_surface_rendered_count;
   last_render_counters.mesh_bounds_fallback_rendered_count = qMax(0, mesh_source_count - mesh_surface_rendered_count);
+  last_render_counters.generated_mesh_bounds_fallback_rendered_count = generated_mesh_bounds_fallback_count;
   last_render_counters.mesh_path_resolved_count = 0;
   last_render_counters.mesh_file_loaded_count = 0;
   last_render_counters.mesh_triangles_loaded_count = 0;
@@ -1364,6 +1394,7 @@ void Scene3DViewportWidget::paintGL()
   last_render_counters.urdf_primitive_rendered_count = urdf_primitive_rendered_count;
   last_render_counters.placeholder_count = placeholder_count;
   last_render_counters.missing_geometry_count = missing_geometry_count;
+  last_render_counters.generated_missing_geometry_count = generated_missing_geometry_count;
   last_render_counters.wireframe_fallback_count = wireframe_box_count;
   last_render_counters.primitive_fallback_rendered_count = primitive_fallback_count;
   last_render_counters.primitive_fallback_count = primitive_fallback_count;
@@ -1528,12 +1559,9 @@ void Scene3DViewportWidget::paintGL()
   }
   last_render_counters.labels_drawn = labels_drawn;
   last_render_counters.labels_suppressed_overlap = labels_suppressed_overlap;
-  const bool has_missing_or_fallback_content = missing_geometry_count > 0 ||
-                                               last_render_counters.mesh_bounds_fallback_rendered_count > 0 ||
-                                               last_render_counters.primitive_fallback_rendered_count > 0 ||
-                                               wireframe_box_count > 0 ||
-                                               placeholder_count > 0 ||
-                                               last_render_counters.visual_quality_status == QStringLiteral("FAIL");
+  const bool has_missing_or_fallback_content = debug_overlays_mode
+    ? debug_view_has_full_diagnostic_warning_content(last_render_counters)
+    : product_view_has_generated_mesh_warning_content(last_render_counters);
   const bool concise_warning = show_warnings && has_missing_or_fallback_content;
   const QRectF overlay_rect = debug_overlays_mode ? QRectF(12.0, 12.0, 520.0, 88.0)
                                                   : QRectF(12.0, 12.0, concise_warning ? 310.0 : 250.0, concise_warning ? 46.0 : 30.0);
@@ -1604,8 +1632,10 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
   int editable_primitive_count = 0;
   int placeholder_count = 0;
   int missing_geometry_count = 0;
+  int generated_missing_geometry_count = 0;
   int generated_fallback_count = 0;
   int wireframe_fallback_count = 0;
+  int generated_mesh_bounds_fallback_count = 0;
   int overlay_count = 0;
   int locked_urdf_count = 0;
   int editable_layout_count = 0;
@@ -1656,6 +1686,7 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
     const bool physical_mesh_source = !overlay_helper && item_has_credible_mesh_handoff(it);
     if (physical_mesh_source) {
       ++mesh_source_count;
+      if (generated_urdf && mesh_preview_mode == ScenePreviewWidget::MeshPreviewMode::Meshes) ++generated_mesh_bounds_fallback_count;
       if (intentional_primitive_fallback || generated_mesh_to_primitive_fallback) ++primitive_fallback_count;
       else if (editable_or_semantic_primitive && item_has_explicit_dimensions(it)) ++editable_primitive_count;
     } else if (!overlay_helper && generated_urdf && item_has_explicit_dimensions(it)) {
@@ -1667,7 +1698,10 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
     } else if (!overlay_helper && !item_has_explicit_dimensions(it)) {
       ++placeholder_count;
       ++missing_geometry_count;
-      ++generated_fallback_count;
+      if (generated_urdf) {
+        ++generated_missing_geometry_count;
+        ++generated_fallback_count;
+      }
     } else if (!overlay_helper) {
       if (editable_or_semantic_primitive) ++editable_primitive_count;
       else ++wireframe_fallback_count;
@@ -1708,6 +1742,7 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
   last_render_counters.mesh_rendered_count = mesh_rendered_count;
   last_render_counters.mesh_surface_rendered_count = mesh_surface_rendered_count;
   last_render_counters.mesh_bounds_fallback_rendered_count = qMax(0, mesh_source_count - mesh_surface_rendered_count);
+  last_render_counters.generated_mesh_bounds_fallback_rendered_count = generated_mesh_bounds_fallback_count;
   last_render_counters.mesh_path_resolved_count = 0;
   last_render_counters.mesh_file_loaded_count = 0;
   last_render_counters.mesh_triangles_loaded_count = 0;
@@ -1723,6 +1758,7 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
   last_render_counters.urdf_primitive_rendered_count = urdf_primitive_rendered_count;
   last_render_counters.placeholder_count = placeholder_count;
   last_render_counters.missing_geometry_count = missing_geometry_count;
+  last_render_counters.generated_missing_geometry_count = generated_missing_geometry_count;
   last_render_counters.generated_fallback_count = generated_fallback_count;
   last_render_counters.wireframe_fallback_count = wireframe_fallback_count;
   last_render_counters.primitive_fallback_rendered_count = primitive_fallback_count;
@@ -1895,7 +1931,7 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
     draw_missing_geometry_marker(it);
     if (out_placeholder_count) ++(*out_placeholder_count);
     if (out_missing_geometry_count) ++(*out_missing_geometry_count);
-    ++last_render_counters.generated_fallback_count;
+    if (generated_or_locked_preview) ++last_render_counters.generated_fallback_count;
     if (show_warning_labels) warn_mesh_fallback_once(it.id, QStringLiteral("REJECT_MISSING_GEOMETRY: no mesh metadata or explicit primitive dimensions"), it.source_path);
     return false;
   }
@@ -1976,7 +2012,7 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
   draw_missing_geometry_marker(it);
   if (out_placeholder_count) ++(*out_placeholder_count);
   if (out_missing_geometry_count) ++(*out_missing_geometry_count);
-  ++last_render_counters.generated_fallback_count;
+  if (generated_or_locked_preview) ++last_render_counters.generated_fallback_count;
   return false;
 }
 

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -97,10 +97,12 @@ public:
     int mesh_rendered_count{ 0 };
     int mesh_surface_rendered_count{ 0 };
     int mesh_bounds_fallback_rendered_count{ 0 };
+    int generated_mesh_bounds_fallback_rendered_count{ 0 };
     int urdf_primitive_source_count{ 0 };
     int urdf_primitive_rendered_count{ 0 };
     int placeholder_count{ 0 };
     int missing_geometry_count{ 0 };
+    int generated_missing_geometry_count{ 0 };
     int wireframe_fallback_count{ 0 };
     int overlay_helper_count{ 0 };
     int generated_fallback_count{ 0 };

--- a/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
@@ -112,3 +112,28 @@ TEST(Scene3DMeshPreviewRegression, KeepsSceneAuthoringSemanticPrimitiveAssembly)
   EXPECT_NE(src.find("semantic_primitive"), std::string::npos);
   EXPECT_NE(src.find("editable_semantic_keys.contains(semantic_key)"), std::string::npos);
 }
+
+TEST(Scene3DMeshPreviewRegression, ProductWarningStateExcludesEditableAndOverlayDiagnostics)
+{
+  const std::string src = load_file(std::string(WORKCELL_BUILDER_SOURCE_DIR) + "/gui/scene3d_viewport_widget.cpp");
+  ASSERT_FALSE(src.empty());
+
+  const auto product = src.find("bool product_view_has_generated_mesh_warning_content");
+  const auto debug = src.find("bool debug_view_has_full_diagnostic_warning_content");
+  ASSERT_NE(product, std::string::npos);
+  ASSERT_NE(debug, std::string::npos);
+  ASSERT_LT(product, debug);
+
+  const std::string product_body = src.substr(product, debug - product);
+  EXPECT_NE(product_body.find("generated_mesh_bounds_fallback_rendered_count"), std::string::npos);
+  EXPECT_NE(product_body.find("generated_missing_geometry_count"), std::string::npos);
+  EXPECT_NE(product_body.find("generated_fallback_count"), std::string::npos);
+  EXPECT_EQ(product_body.find("wireframe_fallback_count"), std::string::npos);
+  EXPECT_EQ(product_body.find("overlay_helper_count"), std::string::npos);
+  EXPECT_EQ(product_body.find("editable_primitive_rendered_count"), std::string::npos);
+  EXPECT_EQ(product_body.find("primitive_fallback_rendered_count"), std::string::npos);
+  EXPECT_EQ(product_body.find("visual_quality_status"), std::string::npos);
+
+  const auto warning_selector = src.find("debug_overlays_mode\n    ? debug_view_has_full_diagnostic_warning_content(last_render_counters)\n    : product_view_has_generated_mesh_warning_content(last_render_counters)");
+  EXPECT_NE(warning_selector, std::string::npos);
+}


### PR DESCRIPTION
### Motivation
- Reduce noise for normal product users by limiting Scene3D "warning" state to real generated/locked URDF preview problems while keeping verbose diagnostics available in debug overlay mode. 
- Prevent editable primitives, helper overlays, FOV/reach helpers, wireframe diagnostics, and debug bounds from surfacing as product-level generated-mesh fallback warnings.

### Description
- Added two helper predicates: `product_view_has_generated_mesh_warning_content` and `debug_view_has_full_diagnostic_warning_content` to split the warning-state logic between product and debug views.
- Restrict product-view warnings to generated/locked URDF-related counters (`generated_mesh_bounds_fallback_rendered_count`, `generated_missing_geometry_count`, `generated_fallback_count`) and keep full diagnostics in debug view. 
- Introduced per-render generated counters and adjusted counting logic so editable primitives, overlays, wireframes, FOV/reach helpers, and debug bounds do not influence the product warning state; also only increment `generated_fallback_count` for generated/locked previews. 
- Added a source-level regression test `ProductWarningStateExcludesEditableAndOverlayDiagnostics` to assert the product-warning helper includes generated counters and excludes editable/overlay/wireframe/visual-quality tokens.
- Files changed: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`, `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h`, `workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp`.

### Testing
- Ran static source assertions via a Python check against `gui/scene3d_viewport_widget.cpp` to validate the product/debug helper split and the presence/absence of specific tokens; this check passed. 
- Added a source-text regression test in `scene3d_mesh_preview_regression_test.cpp` to guard the new helper functions and selection expression; the test is present but full CTest execution was not run here because `/opt/ros/humble/setup.bash` is missing in this environment. 
- `git diff --check` / local sanity checks were performed before committing the change (no code-style failures reported). 

Safety: UI-only change that affects warning presentation only; no launch files, controllers, runtime services, or hardware parameters were modified and fake-hardware defaults remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32722ddd608331bf84ea9a4b275150)