### PR TITLE
Clamp generated URDF preview opacity and enforce solid shaded mesh rendering

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -756,6 +756,8 @@ QString item_visual_ownership_label(const ScenePreviewWidget::PreviewItem & it)
   return QStringLiteral("Reference preview");
 }
 
+constexpr double kGeneratedLockedProductMinAlpha = 0.92;
+
 QColor generated_locked_preview_material() { return QColor("#cfd4da"); }
 QColor generated_locked_preview_outline() { return QColor(125, 211, 252, 92); }
 QColor generated_primitive_fallback_fill() { return QColor(96, 165, 250, 52); }
@@ -921,16 +923,30 @@ bool is_critical_label_role(NormalizedRole role)
       return false;
   }
 }
-QColor item_color(const ScenePreviewWidget::PreviewItem & it)
+QColor explicit_material_color(const ScenePreviewWidget::PreviewItem & it)
+{
+  QColor c;
+  c.setRgbF(qBound(0.0, it.material_r, 1.0), qBound(0.0, it.material_g, 1.0),
+            qBound(0.0, it.material_b, 1.0), qBound(0.0, it.material_a, 1.0));
+  return c;
+}
+
+QColor product_view_generated_locked_material(const ScenePreviewWidget::PreviewItem & it, bool diagnostic_transparency_mode)
+{
+  QColor c = it.has_material_color ? explicit_material_color(it) : generated_locked_preview_material();
+  if (!diagnostic_transparency_mode) {
+    c.setAlphaF(qMax(c.alphaF(), kGeneratedLockedProductMinAlpha));
+  }
+  return c;
+}
+
+QColor item_color(const ScenePreviewWidget::PreviewItem & it, bool diagnostic_transparency_mode = false)
 {
   if (is_generated_urdf_visual_item(it) || is_locked_urdf_item(it)) {
-    return generated_locked_preview_material();
+    return product_view_generated_locked_material(it, diagnostic_transparency_mode);
   }
   if (it.has_material_color) {
-    QColor c;
-    c.setRgbF(qBound(0.0, it.material_r, 1.0), qBound(0.0, it.material_g, 1.0),
-              qBound(0.0, it.material_b, 1.0), qBound(0.0, it.material_a, 1.0));
-    return c;
+    return explicit_material_color(it);
   }
   if (it.linked_to_editable_layout_state || item_is_editable_for_gizmo(it)) {
     return QColor("#67e8f9");
@@ -1861,7 +1877,7 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
     return false;
   }
   // Always try mesh-backed draw first for physical items.
-  QColor visual_color = item_color(it);
+  QColor visual_color = item_color(it, diagnostic_transparency_mode);
   const bool generated_or_locked_preview = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
   const bool editable_layout_preview = it.linked_to_editable_layout_state || item_is_editable_for_gizmo(it);
   if (draw_mesh_preview_if_available(it, visual_color, true)) {
@@ -1911,7 +1927,7 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
       }
       return false;
     }
-    const QColor primitive_fill = generated_or_locked_preview ? generated_primitive_fallback_fill() : visual_color;
+    const QColor primitive_fill = generated_or_locked_preview ? product_view_generated_locked_material(it, diagnostic_transparency_mode) : visual_color;
     if (draw_urdf_primitive_geometry(it, primitive_fill)) {
       if (debug_overlays_mode && generated_or_locked_preview && item_has_explicit_dimensions(it)) {
         draw_box_outline(it.x, it.y, it.z, it.sx, it.sy, it.sz, generated_primitive_fallback_outline(), 0.7f);
@@ -2098,6 +2114,11 @@ bool Scene3DViewportWidget::should_suppress_missing_geometry_marker_for_test(con
 bool Scene3DViewportWidget::has_mesh_surface_candidate_for_test(const ScenePreviewWidget::PreviewItem & item)
 {
   return item_has_mesh_surface_candidate(item);
+}
+
+QColor Scene3DViewportWidget::material_color_for_test(const ScenePreviewWidget::PreviewItem & item, bool diagnostic_transparency_mode)
+{
+  return item_color(item, diagnostic_transparency_mode);
 }
 
 bool Scene3DViewportWidget::is_raw_generated_bounds_only_for_test(const ScenePreviewWidget::PreviewItem & item)
@@ -2475,7 +2496,7 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
     const float red = qMin(1.0f, static_cast<float>(color.redF()) * shade + edge_boost);
     const float green = qMin(1.0f, static_cast<float>(color.greenF()) * shade + edge_boost);
     const float blue = qMin(1.0f, static_cast<float>(color.blueF()) * shade + edge_boost);
-    glColor4f(red, green, blue, 1.0f);
+    glColor4f(red, green, blue, color.alphaF());
     glVertex3f(tri.vertices[0].x(), tri.vertices[0].y(), tri.vertices[0].z());
     glVertex3f(tri.vertices[1].x(), tri.vertices[1].y(), tri.vertices[1].z());
     glVertex3f(tri.vertices[2].x(), tri.vertices[2].y(), tri.vertices[2].z());

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -4,6 +4,7 @@
 
 #include <QOpenGLFunctions>
 #include <QOpenGLWidget>
+#include <QColor>
 #include <QHash>
 #include <QSet>
 #include <QVector3D>
@@ -40,6 +41,7 @@ public:
   bool show_task_route{ false }, show_approach_retreat{ false };
   bool show_camera_fov{ false }, show_pick_coverage{ false }, show_epd_detections{ false }, show_detection_labels{ false };
   bool debug_overlays_mode{ false };
+  bool diagnostic_transparency_mode{ false };
   ScenePreviewWidget::MeshPreviewMode mesh_preview_mode{ ScenePreviewWidget::MeshPreviewMode::Auto };
   bool fit_include_overlays{ false };
   ScenePreviewWidget::TaskOverlayModel task_overlay;
@@ -147,6 +149,7 @@ public:
   static bool should_draw_clean_semantic_primitive_for_test(const ScenePreviewWidget::PreviewItem & item);
   static bool should_suppress_missing_geometry_marker_for_test(const ScenePreviewWidget::PreviewItem & item);
   static bool has_mesh_surface_candidate_for_test(const ScenePreviewWidget::PreviewItem & item);
+  static QColor material_color_for_test(const ScenePreviewWidget::PreviewItem & item, bool diagnostic_transparency_mode = false);
   static bool is_raw_generated_bounds_only_for_test(const ScenePreviewWidget::PreviewItem & item);
 
 protected:

--- a/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
@@ -110,6 +110,30 @@ TEST(Scene3DRenderRoleClassifier, DefaultProductFitIncludesPhysicalItemsAndExclu
 
 }
 
+
+TEST(Scene3DRenderRoleClassifier, GeneratedUrdfMeshPreviewMaterialIsOpaqueInProductView)
+{
+  auto generated = make_item("generated_transparent_robot_mesh");
+  generated.locked = true;
+  generated.editable = false;
+  generated.lock_reason = "Generated URDF visual";
+  generated.source_layer = "generated_urdf_visual";
+  generated.active_visual_source = "generated_urdf_visual";
+  generated.mesh_available = true;
+  generated.has_mesh_metadata = true;
+  generated.has_material_color = true;
+  generated.material_r = 0.4;
+  generated.material_g = 0.5;
+  generated.material_b = 0.6;
+  generated.material_a = 0.18;
+
+  const QColor product_color = Scene3DViewportWidget::material_color_for_test(generated, false);
+  EXPECT_GE(product_color.alphaF(), 0.92);
+
+  const QColor diagnostic_color = Scene3DViewportWidget::material_color_for_test(generated, true);
+  EXPECT_LT(diagnostic_color.alphaF(), 0.25);
+}
+
 TEST(Scene3DRenderRoleClassifier, MeshesModeDoesNotDrawFallbackSolid)
 {
   auto missing = make_item("missing2");


### PR DESCRIPTION
### Motivation
- Generated/locked URDF visuals were rendering with low alpha or diagnostic outlines by default, reducing product-quality visuals for robots, tools, tables and cameras.
- Bounds outlines and wireframe fallbacks should remain diagnostic-only and not appear in normal product view unless a debug mode is explicitly enabled.
- Add a small programmatic hook so tests can assert the effective material alpha used for generated URDF preview items.

### Description
- Clamp generated/locked URDF preview material alpha to a near-opaque minimum (`kGeneratedLockedProductMinAlpha = 0.92`) for normal product rendering while preserving explicit low-alpha only when `diagnostic_transparency_mode` is enabled by the caller.
- Add `diagnostic_transparency_mode` flag to the viewport and new helpers: `explicit_material_color`, `product_view_generated_locked_material`, and `material_color_for_test` to centralize material handling for generated/locked previews.
- Keep bounds outlines and wireframe diagnostics gated by `debug_overlays_mode` (no outlines/wireframes in normal product view), and ensure mesh previews render as shaded, filled triangles by default by applying the chosen material alpha to triangle shading.
- Add focused regression test `GeneratedUrdfMeshPreviewMaterialIsOpaqueInProductView` (in `scene3d_render_role_classifier_test.cpp`) which inspects the chosen material alpha in product vs diagnostic modes.

### Testing
- Ran static source assertions to verify new symbols/logic and triangle-color alpha usage; assertions passed.
- Added unit test `GeneratedUrdfMeshPreviewMaterialIsOpaqueInProductView` to `workcell_builder` test suite (GTest source updated); this test verifies the alpha clamp in product view and the preservation of low alpha in diagnostic mode.
- Attempted to run a `colcon build` for `workcell_builder` but the container lacked the ROS 2 Humble environment (`/opt/ros/humble/setup.bash`), so an actual build/run of the gtests was not executed in this environment. Continuous integration should run the new test normally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32722f5a1083318d7575d07251e1a6)