### PR TITLE
docs: clarify Scene3D mesh preview behavior

### DIFF
--- a/docs/architecture/SCENE3D_CANVAS_CONTRACT.md
+++ b/docs/architecture/SCENE3D_CANVAS_CONTRACT.md
@@ -113,3 +113,16 @@ Additional invariants:
 - Dragging provides preview movement only; authoring YAML is not written on every mouse move.
 - Drag commit writes only authoring layout XYZ transforms and preserves other transform fields.
 - Drag editing must not mutate generated artifacts (`generated/scene.urdf.xacro`, expanded URDF preview data, mesh index files, generated preview artifacts).
+
+## Mesh ingestion and preview expectations
+
+- Scene3D first attempts generated URDF visual mesh rendering from the authoritative visual mesh index, such as `generated/scene_visual_mesh_index.json`, before using lower-fidelity visuals.
+- Assimp is the preferred mesh ingestion path when it is available, and should be used for STL, DAE, and OBJ visual assets.
+- Lightweight fallback parsers are only a backup path for environments where Assimp is unavailable or cannot load an otherwise previewable asset.
+- Heavy but valid workcell assets may use simplified preview meshes or semantic visual surrogates when that keeps the canvas responsive without changing the authoritative scene model.
+- Truly unsafe assets should be rejected only after scale-, origin-, and transform-aware bounds checks show that the effective preview bounds are unsafe.
+- Scene3D is a visual preview renderer. It is not a collision model, safety certificate, validation report, or proof of real-hardware readiness.
+
+### Expected `ur5_2f_test` behavior
+
+For `ur5_2f_test`, Scene3D should render the UR5 and Robotiq visual assets as real meshes when the generated visual mesh index resolves their mesh files. The table should render as either a real or simplified workbench mesh when available, or as a semantic table surrogate when a safe mesh is not available. The D435 camera should render as a real mesh when loadable, or as a labelled RealSense visual surrogate when the mesh cannot be safely loaded.


### PR DESCRIPTION
### Motivation

- Make the Scene3D canvas contract explicit about where preview meshes should come from and how ingestion/fallbacks behave so authoring and preview are reproducible and debuggable.
- Emphasize an Assimp-first ingestion path and the intended role of lightweight fallbacks to reduce confusion when assets fail to render.
- Reiterate that Scene3D is a visual preview and not a collision/safety/certification mechanism to avoid misuse of preview output.

### Description

- Added a new "Mesh ingestion and preview expectations" section to `docs/architecture/SCENE3D_CANVAS_CONTRACT.md` outlining that Scene3D first uses the authoritative visual mesh index (for example `generated/scene_visual_mesh_index.json`).
- Documented that Assimp is the preferred loader for `STL`/`DAE`/`OBJ` assets and that lightweight parsers are a backup when Assimp is unavailable or cannot load an asset.
- Clarified that heavy-but-valid workcell assets may use simplified preview meshes or semantic visual surrogates and that truly unsafe assets are rejected only after scale/origin/transform-aware bounds checks.
- Added explicit expected `ur5_2f_test` behavior stating UR5/Robotiq should render as real meshes, the table may render as a real/simplified workbench mesh or semantic surrogate, and the D435 should render as a real mesh if loadable or as a labelled RealSense surrogate.

### Testing

- Ran repository hygiene and diff checks and they passed.
- No runtime, ROS, or launch validations were executed because this change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a328306502483319381d6d494b9030d)