### PR TITLE
Suppress false Scene3D primitive preview warnings

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -7341,6 +7341,24 @@ void MainWindow::populate_scene_hierarchy()
   QVector<ScenePreviewWidget::PreviewItem> preview_items;
   int preview_warning_count = 0;
   QStringList preview_warning_details;
+  const fs::path urdf_visual_index = d / "generated" / "scene_visual_mesh_index.json";
+
+  bool accepted_safe_visual_mesh_index_has_items = false;
+  if (fs::exists(urdf_visual_index)) {
+    try {
+      const YAML::Node existing_index = YAML::LoadFile(urdf_visual_index.string());
+      const bool safe_for_preview = workcell_builder::yaml_map_key(existing_index, "safe_for_preview").as<bool>(false);
+      const QString index_scene_name = QString::fromStdString(
+        workcell_builder::yaml_map_value_or_empty(existing_index, "scene_name")).trimmed();
+      const YAML::Node visual_items = workcell_builder::yaml_map_key(existing_index, "visual_items");
+      accepted_safe_visual_mesh_index_has_items =
+        safe_for_preview &&
+        (index_scene_name.isEmpty() || index_scene_name == QString::fromStdString(d.filename().string())) &&
+        visual_items && visual_items.IsSequence() && visual_items.size() > 0;
+    } catch (...) {
+      accepted_safe_visual_mesh_index_has_items = false;
+    }
+  }
 
   auto status_for_item = [&](const workcell_builder::WorkcellStudioCanvasItem & item) {
     const QString id = QString::fromStdString(item.id);
@@ -7517,6 +7535,11 @@ void MainWindow::populate_scene_hierarchy()
     p.origin_offset_z = item.origin_offset_z;
     p.mesh_available = item.mesh_available;
     p.mesh_load_warning = QString::fromStdString(item.mesh_load_warning);
+    if (accepted_safe_visual_mesh_index_has_items &&
+        item.provenance == workcell_builder::WorkcellStudioItemProvenance::GeneratedOrLegacyPreview &&
+        p.mesh_load_warning == QStringLiteral("mesh metadata missing or legacy; using primitive preview")) {
+      p.mesh_load_warning.clear();
+    }
     p.locked = item.locked;
     p.camera_id = QString::fromStdString(item.camera_id);
     p.frame_id = QString::fromStdString(item.frame_id);
@@ -7555,10 +7578,16 @@ void MainWindow::populate_scene_hierarchy()
     }
 
     if (!item.warnings.empty()) {
-      ++preview_warning_count;
       const QString warning_text = QString::fromStdString(item.warnings.front());
-      preview_warning_details << QString("%1 (%2): %3").arg(p.id, p.role, warning_text);
-      append_studio_log(QString("Preview warning: %1").arg(warning_text));
+      const bool suppress_legacy_primitive_warning =
+        accepted_safe_visual_mesh_index_has_items &&
+        item.provenance == workcell_builder::WorkcellStudioItemProvenance::GeneratedOrLegacyPreview &&
+        warning_text == QStringLiteral("mesh metadata missing or legacy; using primitive preview");
+      if (!suppress_legacy_primitive_warning) {
+        ++preview_warning_count;
+        preview_warning_details << QString("%1 (%2): %3").arg(p.id, p.role, warning_text);
+        append_studio_log(QString("Preview warning: %1").arg(warning_text));
+      }
     }
   }
 
@@ -7860,7 +7889,6 @@ void MainWindow::populate_scene_hierarchy()
 
   QSet<QString> preview_ids;
   for (const auto &existing : preview_items) preview_ids.insert(existing.id);
-  const fs::path urdf_visual_index = d / "generated" / "scene_visual_mesh_index.json";
   const QString scene_name = QString::fromStdString(d.filename().string());
   const QString workspace_root = detect_workspace_root();
   QString visual_index_warning_reason;

--- a/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
+++ b/workcell_builder/workcell_builder/src_workcell_studio_canvas_model.cpp
@@ -88,6 +88,48 @@ static bool yaml_node_is_defined(const YAML::Node & node)
   try { return node.IsDefined(); } catch (...) { return false; }
 }
 
+static std::string normalized_canvas_match_token(std::string value)
+{
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c){ return static_cast<char>(std::tolower(c)); });
+  for (char & c : value) {
+    if (!std::isalnum(static_cast<unsigned char>(c))) c = '_';
+  }
+  value.erase(std::unique(value.begin(), value.end(), [](char a, char b){ return a == '_' && b == '_'; }), value.end());
+  while (!value.empty() && value.front() == '_') value.erase(value.begin());
+  while (!value.empty() && value.back() == '_') value.pop_back();
+  return value;
+}
+
+static bool safe_visual_mesh_index_has_matching_visual_items(const fs::path & scene_dir)
+{
+  const fs::path index_path = scene_dir / "generated" / "scene_visual_mesh_index.json";
+  if (!fs::exists(index_path)) return false;
+  try {
+    const YAML::Node index = YAML::LoadFile(index_path.string());
+    if (!yaml_map_key(index, "safe_for_preview").as<bool>(false)) return false;
+    const std::string scene_name = yaml_map_value_or_empty(index, "scene_name");
+    if (!scene_name.empty() && scene_name != scene_dir.filename().string()) return false;
+    const YAML::Node visual_items = yaml_map_key(index, "visual_items");
+    if (!visual_items || !visual_items.IsSequence() || visual_items.size() == 0) return false;
+    for (const auto & visual : visual_items) {
+      if (!visual || !visual.IsMap()) continue;
+      const bool render_expected = yaml_map_key(visual, "render_expected").as<bool>(false);
+      const bool resolved = yaml_map_key(visual, "resolved").as<bool>(false);
+      const std::string geometry_type = normalized_canvas_match_token(yaml_map_value_or_empty(visual, "geometry_type"));
+      const std::string id = normalized_canvas_match_token(yaml_map_value_or_empty(visual, "id"));
+      const std::string link = normalized_canvas_match_token(yaml_map_value_or_empty(visual, "link"));
+      const std::string source = normalized_canvas_match_token(yaml_map_value_or_empty(visual, "source_path"));
+      if ((render_expected || resolved) &&
+          (!geometry_type.empty() || !id.empty() || !link.empty() || !source.empty())) {
+        return true;
+      }
+    }
+  } catch (...) {
+    return false;
+  }
+  return false;
+}
+
 static std::vector<std::string> gather_mesh_candidates(const YAML::Node & env, const YAML::Node & manifest, const YAML::Node & layout_items, const std::string & item_id)
 {
   std::vector<std::string> out;
@@ -703,6 +745,8 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
   std::vector<fs::path> probed_visuals;
   std::vector<fs::path> probed_collisions;
   probe_mesh_candidates(scene_dir, &probed_visuals, &probed_collisions);
+  const bool safe_generated_visual_mesh_index_available =
+    safe_visual_mesh_index_has_matching_visual_items(scene_dir);
   const auto choose_probed = [](const WorkcellStudioCanvasItem & item, const std::vector<fs::path> & pool)->fs::path {
     for (const auto & p : pool) {
       const std::string b = p.stem().string();
@@ -740,7 +784,11 @@ WorkcellStudioCanvasModel build_workcell_studio_canvas_model(const fs::path & sc
       m.warnings.push_back(item.mesh_load_warning);
     } else {
       item.mesh_load_warning = "mesh metadata missing or legacy; using primitive preview";
-      m.warnings.push_back(item.mesh_load_warning);
+      if (!(safe_generated_visual_mesh_index_available &&
+            item.provenance == WorkcellStudioItemProvenance::GeneratedOrLegacyPreview &&
+            item.locked)) {
+        m.warnings.push_back(item.mesh_load_warning);
+      }
     }
 
     if (layout_items.IsSequence()) {


### PR DESCRIPTION
### Motivation
- Scene3D was emitting a generic "mesh metadata missing or legacy; using primitive preview" warning for generated URDF visuals even when a generated `generated/scene_visual_mesh_index.json` existed and was explicitly marked `safe_for_preview` with matching `visual_items` for the scene.
- The false warning pollutes logs and confuses users/editors when authoritative xacro-expanded visual indexes are available and valid.
- Keep real warnings for missing geometry, parse failures, unsafe/unsupported meshes, or intentional primitive fallbacks while removing the repeated false legacy message.

### Description
- Added `normalized_canvas_match_token` and `safe_visual_mesh_index_has_matching_visual_items` helpers to `src_workcell_studio_canvas_model.cpp` to detect a scene-local, `safe_for_preview` visual mesh index with meaningful `visual_items` before suppressing legacy warnings.
- In `build_workcell_studio_canvas_model` the model now avoids pushing the legacy primitive-preview warning into `m.warnings` for locked generated/legacy preview items when the safe generated visual mesh index is accepted for the scene (preserves collision fallback and other warnings).
- In `gui/mainwindow.cpp` the Scene3D ingestion path now pre-checks and accepts a safe visual mesh index for the selected scene, clears the `mesh_load_warning` field for generated/legacy preview items when appropriate, and suppresses only the legacy primitive-preview log entry while leaving other preview warnings intact.
- Conservatively scoped: only suppresses the specific legacy message when `safe_for_preview` is true, the index contains `visual_items` and the index scene name (if present) matches the selected scene; everything else (unreadable index, stale/unsafe index, unresolved meshes, unsupported formats, parse failures) still produces warnings.

### Testing
- Ran `git diff --check` which passed with no whitespace/errors reported.
- Inspected sample `generated/scene_visual_mesh_index.json` files with a small Python check and confirmed `safe_for_preview: true` and non-empty `visual_items` for representative scenes, matching the acceptance logic (automated `python3` invocation printed `True` and item counts).
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but the build could not be run in this environment because `/opt/ros/humble/setup.bash` is not present, so an in-container build was not completed.
- No runtime/launch changes were made; change is logging/preview-only and preserves fake-hardware defaults and real-hardware guards.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3282f018488331af1070d9df619bb6)