### PR TITLE
Expose Scene3D transform runtime counters

### DIFF
--- a/scripts/run_workcell_builder_scene3d_gui_smoke.py
+++ b/scripts/run_workcell_builder_scene3d_gui_smoke.py
@@ -291,6 +291,50 @@ def _runtime_render_class_counts(payload: dict[str, Any]) -> dict[str, int]:
     }
 
 
+def _runtime_gui_diagnostics_available(payload: dict[str, Any]) -> bool:
+    if not bool(payload.get("runtime_available")):
+        return False
+    if isinstance(payload.get("counters"), dict) or isinstance(payload.get("render_debug_counters"), dict):
+        return True
+    return _counter(payload, "viewport_received_count", "rendered_count", "visible_count") > 0
+
+
+def _apply_runtime_transform_counter_mapping(payload: dict[str, Any]) -> None:
+    if not _runtime_gui_diagnostics_available(payload):
+        return
+    counters = _first_present_mapping(payload, "counters")
+    render_debug = _first_present_mapping(payload, "render_debug_counters")
+
+    def runtime_counter(*keys: str) -> int:
+        for source in (render_debug, counters):
+            if not isinstance(source, dict):
+                continue
+            for key in keys:
+                if key in source:
+                    return _as_int(source.get(key))
+        return _counter_from_sources(payload, keys)
+
+    transform_chain_applied_count = runtime_counter("transform_chain_applied_count")
+    visual_origin_applied_count = runtime_counter("visual_origin_applied_count")
+    generated_visual_count = runtime_counter(
+        "locked_generated_urdf_visual_count",
+        "generated_visual_count",
+        "generated_urdf_visual_count",
+    )
+    payload["transform_chain_applied_count"] = transform_chain_applied_count
+    payload["visual_origin_applied_count"] = visual_origin_applied_count
+    payload["locked_generated_urdf_visual_count"] = generated_visual_count
+
+    warnings = payload.get("warnings")
+    if not isinstance(warnings, list):
+        warnings = []
+    if generated_visual_count > 0 and transform_chain_applied_count <= 0:
+        _append_unique(warnings, "runtime_transform_chain_applied_count_zero_with_generated_visuals")
+    if generated_visual_count > 0 and visual_origin_applied_count <= 0:
+        _append_unique(warnings, "runtime_visual_origin_applied_count_zero_with_generated_visuals")
+    payload["warnings"] = warnings
+
+
 def _add_smoke_report_supplemental_evidence(payload: dict[str, Any], *, screenshot_path: str | None, screenshot_available: bool | None) -> dict[str, Any]:
     runtime_available = bool(payload.get("runtime_available"))
     if runtime_available:
@@ -298,6 +342,7 @@ def _add_smoke_report_supplemental_evidence(payload: dict[str, Any], *, screensh
         payload["runtime_render_class_counts"] = render_class_counts
         for key, value in render_class_counts.items():
             payload.setdefault(key, value)
+        _apply_runtime_transform_counter_mapping(payload)
     payload.setdefault("visible_item_labels", _visible_item_labels_from_payload(payload) if runtime_available else [])
     payload.setdefault("viewport_size", _viewport_size_from_payload(payload))
     payload.setdefault("camera_fit_target", _camera_fit_target_from_payload(payload))

--- a/workcell_builder/workcell_builder/gui/main.cpp
+++ b/workcell_builder/workcell_builder/gui/main.cpp
@@ -702,6 +702,9 @@ private:
       candidate_json["primitive_fallback_rendered_count"] = candidate.counters.primitive_fallback_rendered_count;
       candidate_json["valid_physical_fallback_count"] = candidate.counters.valid_physical_fallback_count;
       candidate_json["overlay_rendered_count"] = candidate.counters.overlay_rendered_count;
+      candidate_json["locked_generated_urdf_visual_count"] = candidate.counters.locked_generated_urdf_visual_count;
+      candidate_json["transform_chain_applied_count"] = candidate.counters.transform_chain_applied_count;
+      candidate_json["visual_origin_applied_count"] = candidate.counters.visual_origin_applied_count;
       candidate_json["placeholder_count"] = candidate.counters.placeholder_count;
       candidate_json["missing_geometry_count"] = candidate.counters.missing_geometry_count;
       candidate_json["wireframe_fallback_count"] = candidate.counters.wireframe_fallback_count;
@@ -803,6 +806,8 @@ private:
       counters["valid_physical_fallback_count"] = rc.valid_physical_fallback_count;
       counters["overlay_rendered_count"] = rc.overlay_rendered_count;
       counters["locked_generated_urdf_visual_count"] = rc.locked_generated_urdf_visual_count;
+      counters["transform_chain_applied_count"] = rc.transform_chain_applied_count;
+      counters["visual_origin_applied_count"] = rc.visual_origin_applied_count;
       counters["overlay_count"] = rc.overlay_count;
       counters["selectable_count"] = qMax(0, rc.visible_count - rc.overlay_count);
       counters["hierarchy_rows_count"] = rc.hierarchy_child_row_count;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -913,6 +913,22 @@ bool is_locked_urdf_item(const ScenePreviewWidget::PreviewItem & it)
          lock_reason.contains("robotmodel") || lock_reason.contains("urdf visual");
 }
 
+void populate_runtime_transform_counters(
+  Scene3DViewportWidget::RenderDebugCounters & counters,
+  const QVector<ScenePreviewWidget::PreviewItem> & items)
+{
+  int transform_chain_applied_count = 0;
+  int visual_origin_applied_count = 0;
+  for (const auto & item : items) {
+    const bool generated_or_locked_visual = is_generated_urdf_visual_item(item) || is_locked_urdf_item(item);
+    if (!generated_or_locked_visual) continue;
+    if (item.transform_chain_applied) ++transform_chain_applied_count;
+    if (item.visual_origin_applied) ++visual_origin_applied_count;
+  }
+  counters.transform_chain_applied_count = transform_chain_applied_count;
+  counters.visual_origin_applied_count = visual_origin_applied_count;
+}
+
 bool is_raw_generated_bounds_only_item(const ScenePreviewWidget::PreviewItem & it)
 {
   const QString visual_source = normalized_scene3d_layer_token(it.active_visual_source);
@@ -1181,6 +1197,7 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
   last_render_counters.overlay_helper_count = static_cast<int>(overlay_items.size());
   last_render_counters.overlay_count = static_cast<int>(overlay_items.size());
   last_render_counters.locked_generated_urdf_visual_count = locked_urdf_count;
+  populate_runtime_transform_counters(last_render_counters, items);
   last_render_counters.editable_layout_count = editable_layout_count;
   last_render_counters.hierarchy_child_row_count = visible_item_count;
   last_render_counters.last_paint_completed = false;
@@ -1204,6 +1221,12 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
         root["robot_aabb_max"] = QJsonArray{last_robot_aabb_max_.x(), last_robot_aabb_max_.y(), last_robot_aabb_max_.z()};
       }
       root["mesh_diagnostics"] = mesh_diagnostics_export();
+      QJsonObject render_debug;
+      const auto counters = render_debug_counters();
+      render_debug["locked_generated_urdf_visual_count"] = counters.locked_generated_urdf_visual_count;
+      render_debug["transform_chain_applied_count"] = counters.transform_chain_applied_count;
+      render_debug["visual_origin_applied_count"] = counters.visual_origin_applied_count;
+      root["render_debug_counters"] = render_debug;
       out_file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
       out_file.close();
     }
@@ -1373,6 +1396,7 @@ void Scene3DViewportWidget::paintGL()
   last_render_counters.overlay_helper_count = overlay_count;
   last_render_counters.overlay_count = overlay_count;
   last_render_counters.locked_generated_urdf_visual_count = locked_urdf_count;
+  populate_runtime_transform_counters(last_render_counters, items);
   last_render_counters.editable_layout_count = editable_layout_count;
   int visible_hierarchy_items = 0;
   for (const auto * it : draw_items) {
@@ -1664,6 +1688,7 @@ void Scene3DViewportWidget::paintGL()
 Scene3DViewportWidget::RenderDebugCounters Scene3DViewportWidget::render_debug_counters() const
 {
   RenderDebugCounters counters = last_render_counters;
+  populate_runtime_transform_counters(counters, items);
   finalize_visual_quality(counters);
   return counters;
 }
@@ -1827,6 +1852,7 @@ bool Scene3DViewportWidget::render_smoke_fallback_frame(QImage * out_image)
   last_render_counters.overlay_helper_count = overlay_count;
   last_render_counters.overlay_count = overlay_count;
   last_render_counters.locked_generated_urdf_visual_count = locked_urdf_count;
+  populate_runtime_transform_counters(last_render_counters, items);
   last_render_counters.editable_layout_count = editable_layout_count;
   last_render_counters.hierarchy_child_row_count = visible_item_count;
   last_render_counters.last_paint_completed = rendered_item_count > 0;

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -115,6 +115,8 @@ public:
     int valid_physical_fallback_count{ 0 };
     int overlay_rendered_count{ 0 };
     int locked_generated_urdf_visual_count{ 0 };
+    int transform_chain_applied_count{ 0 };
+    int visual_origin_applied_count{ 0 };
     int overlay_count{ 0 };
     QString visual_quality_status{ QStringLiteral("UNAVAILABLE") };
     QStringList visual_quality_warnings;

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -691,6 +691,8 @@ ScenePreviewWidget::RenderDebugCounters ScenePreviewWidget::render_debug_counter
   out.valid_physical_fallback_count = counters.valid_physical_fallback_count;
   out.overlay_rendered_count = counters.overlay_rendered_count;
   out.locked_generated_urdf_visual_count = counters.locked_generated_urdf_visual_count;
+  out.transform_chain_applied_count = counters.transform_chain_applied_count;
+  out.visual_origin_applied_count = counters.visual_origin_applied_count;
   out.visual_quality_status = counters.visual_quality_status;
   out.visual_quality_warnings = counters.visual_quality_warnings;
   out.labels_drawn = counters.labels_drawn;

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -228,6 +228,8 @@ public:
     int valid_physical_fallback_count{ 0 };
     int overlay_rendered_count{ 0 };
     int locked_generated_urdf_visual_count{ 0 };
+    int transform_chain_applied_count{ 0 };
+    int visual_origin_applied_count{ 0 };
     QString visual_quality_status{ QStringLiteral("UNAVAILABLE") };
     QStringList visual_quality_warnings;
     int labels_drawn{ 0 };


### PR DESCRIPTION
### Motivation

- Improve Scene3D runtime diagnostics so the smoke test can prefer GUI-collected evidence for transform application rather than relying solely on static/generated indices.

### Description

- Add two runtime counters to `Scene3DViewportWidget::RenderDebugCounters`: `transform_chain_applied_count` and `visual_origin_applied_count` and populate them from the viewport `items` vector for generated/locked URDF visuals in `scene3d_viewport_widget.cpp`.
- Populate these counters during `ingest_preview_items()`, `paintGL()`, and the smoke fallback render path, and ensure `render_debug_counters()` returns the updated values.
- Export the counters into the mesh diagnostics JSON and the viewport/candidate JSON payloads produced by the GUI so child smoke processes can read them (updates in `mesh_diagnostics_export()` and `main.cpp`).
- Surface the counters through `ScenePreviewWidget` APIs so preview widgets and other consumers can access them (`scene_preview_widget.h/.cpp`).
- Update the smoke wrapper `scripts/run_workcell_builder_scene3d_gui_smoke.py` to prefer runtime GUI transform counters when available and add warnings if generated visuals exist while the runtime transform/visual-origin counts are zero.

### Testing

- Compiled the modified smoke wrapper with `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py` and it passed.
- Performed static repository checks (`git diff --check`) with no issues reported.
- No full ROS/GUI colcon build or runtime GUI smoke runs were executed in this environment; changes were validated with static code checks and script compilation only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a328ca76e6c83318d7dba62cd9f3c92)