### PR TITLE
Throttle Scene3D load summaries and gate debug logs

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -102,7 +102,8 @@ bool path_has_mesh_asset_extension(const QString & path)
 
 bool scene3d_debug_logs_enabled()
 {
-  return qEnvironmentVariableIsSet("WORKCELL_SCENE3D_DEBUG_LOGS");
+  const QByteArray value = qgetenv("WORKCELL_SCENE3D_DEBUG_LOGS").trimmed().toLower();
+  return value == "1" || value == "true" || value == "yes" || value == "on";
 }
 
 bool item_has_credible_mesh_handoff(const ScenePreviewWidget::PreviewItem & item)
@@ -1136,13 +1137,20 @@ void Scene3DViewportWidget::invalidate_mesh_cache()
 void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidget::PreviewItem> & preview_items)
 {
   items = preview_items;
+  const bool debug_logs = scene3d_debug_logs_enabled();
+  const QString scene_key = scene_name.trimmed().isEmpty() ? QStringLiteral("No scene") : scene_name.trimmed();
   int visible_item_count = 0;
   int skipped_item_count = 0;
   int mesh_source_count = 0;
   int urdf_primitive_source_count = 0;
   int locked_urdf_count = 0;
   int editable_layout_count = 0;
+  int missing_geometry_warning_count = 0;
+  int rejected_mesh_warning_count = 0;
+  int transform_chain_failure_warning_count = 0;
+  int fallback_item_count = 0;
   QSet<QString> unique_visible_ids;
+  QStringList scene_load_warning_tokens;
   std::vector<const ScenePreviewWidget::PreviewItem *> overlay_items;
   for (const auto & it : items) {
     const NormalizedRole role = classify_item_role(it);
@@ -1154,12 +1162,51 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
     if (!overlay_helper && item_has_credible_mesh_handoff(it)) {
       ++mesh_source_count;
       const QString mesh_source = !it.mesh_path.trimmed().isEmpty() ? it.mesh_path : it.source_path;
-      if (!mesh_source.trimmed().isEmpty()) ensure_mesh_cached(it, mesh_source);
+      if (!mesh_source.trimmed().isEmpty()) {
+        const MeshCacheEntry & entry = ensure_mesh_cached(it, mesh_source);
+        if (!entry.valid || !entry.warning.trimmed().isEmpty()) {
+          ++rejected_mesh_warning_count;
+          const QString reason = !entry.failure_reason_code.trimmed().isEmpty()
+            ? entry.failure_reason_code.trimmed()
+            : (!entry.warning.trimmed().isEmpty() ? entry.warning.trimmed() : QStringLiteral("mesh_rejected"));
+          scene_load_warning_tokens << QStringLiteral("rejected_mesh:%1:%2").arg(it.id, reason);
+        }
+      }
     }
     if (!overlay_helper && generated_urdf && item_has_valid_urdf_primitive(it)) ++urdf_primitive_source_count;
+    if (!overlay_helper && !item_has_mesh_surface_candidate(it) && !item_has_explicit_primitive_dimensions(it)) {
+      ++missing_geometry_warning_count;
+      scene_load_warning_tokens << QStringLiteral("missing_geometry:%1").arg(it.id);
+    }
+    const QString layer_token = (it.source_layer + QStringLiteral("|") + it.active_visual_source).toLower();
+    if (!overlay_helper && layer_token.contains(QStringLiteral("fallback"))) ++fallback_item_count;
+    if (!it.transform_chain_applied) {
+      const QString warning_text = (it.status + QStringLiteral("|") + it.warnings.join(QLatin1Char('|'))).toLower();
+      if (warning_text.contains(QStringLiteral("transform")) ||
+          warning_text.contains(QStringLiteral("urdf chain")) ||
+          warning_text.contains(QStringLiteral("broken chain")) ||
+          warning_text.contains(QStringLiteral("missing_chain"))) {
+        ++transform_chain_failure_warning_count;
+        scene_load_warning_tokens << QStringLiteral("transform_chain_failure:%1").arg(it.id);
+      }
+    }
+    for (const QString & warning : it.warnings) {
+      const QString trimmed = warning.trimmed();
+      if (!trimmed.isEmpty()) scene_load_warning_tokens << QStringLiteral("item_warning:%1:%2").arg(it.id, trimmed);
+    }
+    if (!it.mesh_load_warning.trimmed().isEmpty()) {
+      scene_load_warning_tokens << QStringLiteral("mesh_warning:%1:%2").arg(it.id, it.mesh_load_warning.trimmed());
+    }
+    if (!it.alignment_warning.trimmed().isEmpty()) {
+      scene_load_warning_tokens << QStringLiteral("alignment_warning:%1:%2").arg(it.id, it.alignment_warning.trimmed());
+    }
     if (generated_urdf) ++locked_urdf_count;
     if (it.linked_to_editable_layout_state) ++editable_layout_count;
     if (overlay_helper) overlay_items.push_back(&it);
+  }
+  const int physical_visible_count = qMax(0, visible_item_count - static_cast<int>(overlay_items.size()));
+  if (physical_visible_count > 0 && fallback_item_count * 2 >= physical_visible_count) {
+    scene_load_warning_tokens << QStringLiteral("fallback_dominant:%1/%2").arg(fallback_item_count).arg(physical_visible_count);
   }
   last_render_counters.preview_items_count = items.size();
   last_render_counters.total_payload_count = items.size();
@@ -1186,13 +1233,41 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
   last_render_counters.last_paint_completed = false;
   last_render_counters.smoke_fallback_render_used = false;
   finalize_visual_quality(last_render_counters);
-  qInfo() << "Scene3D scene load summary:"
-          << "received=" << last_render_counters.viewport_received_count
-          << "visible=" << last_render_counters.visible_count
-          << "mesh_sources=" << last_render_counters.mesh_source_count
-          << "urdf_primitives=" << last_render_counters.urdf_primitive_source_count
-          << "overlays=" << last_render_counters.overlay_count
-          << "mesh_cache=" << last_render_counters.render_cache_count;
+  scene_load_warning_tokens.append(last_render_counters.visual_quality_warnings);
+  scene_load_warning_tokens.removeDuplicates();
+  scene_load_warning_tokens.sort();
+  const QString warning_signature = scene_load_warning_tokens.join(QLatin1Char('|'));
+  const bool should_emit_scene_load_summary =
+    debug_logs ||
+    last_scene_load_summary_item_count_ != items.size() ||
+    last_scene_load_summary_scene_name_ != scene_key ||
+    last_scene_load_summary_warning_signature_ != warning_signature;
+  if (should_emit_scene_load_summary) {
+    last_scene_load_summary_item_count_ = items.size();
+    last_scene_load_summary_scene_name_ = scene_key;
+    last_scene_load_summary_warning_signature_ = warning_signature;
+    qInfo().noquote() << QStringLiteral(
+      "Scene3D scene load: scene=%1 received=%2 visible=%3 mesh_sources=%4 urdf_primitives=%5 overlays=%6 mesh_cache=%7 warnings=%8")
+      .arg(scene_key)
+      .arg(last_render_counters.viewport_received_count)
+      .arg(last_render_counters.visible_count)
+      .arg(last_render_counters.mesh_source_count)
+      .arg(last_render_counters.urdf_primitive_source_count)
+      .arg(last_render_counters.overlay_count)
+      .arg(last_render_counters.render_cache_count)
+      .arg(scene_load_warning_tokens.isEmpty() ? QStringLiteral("none") : scene_load_warning_tokens.join(QLatin1Char(',')));
+  }
+  if (should_emit_scene_load_summary && !scene_load_warning_tokens.isEmpty()) {
+    qWarning().noquote() << QStringLiteral(
+      "Scene3D scene-load warnings: scene=%1 missing_geometry=%2 rejected_meshes=%3 transform_chain_failures=%4 fallback_items=%5/%6 details=%7")
+      .arg(scene_key)
+      .arg(missing_geometry_warning_count)
+      .arg(rejected_mesh_warning_count)
+      .arg(transform_chain_failure_warning_count)
+      .arg(fallback_item_count)
+      .arg(physical_visible_count)
+      .arg(scene_load_warning_tokens.join(QLatin1Char(',')));
+  }
   const QString diagnostics_path = QString::fromUtf8(qgetenv("SCENE3D_MESH_DIAGNOSTICS_JSON"));
   if (!diagnostics_path.trimmed().isEmpty()) {
     QFile out_file(diagnostics_path);

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -266,6 +266,9 @@ private:
   QHash<QString, MeshCacheEntry> mesh_cache_;
   QHash<QString, QString> last_mesh_rejection_reasons_;
   QSet<QString> warned_mesh_fallbacks_;
+  int last_scene_load_summary_item_count_{ -1 };
+  QString last_scene_load_summary_scene_name_;
+  QString last_scene_load_summary_warning_signature_;
   bool try_resolve_canonical_mesh_path(const QString & path, QString & out_canonical,
                                        const ScenePreviewWidget::PreviewItem * item = nullptr,
                                        QString * out_failure_reason = nullptr) const;


### PR DESCRIPTION
### Motivation
- Reduce noisy per-paint and scene-load logging while preserving important scene-load warnings for missing geometry, rejected meshes, transform-chain failures, and fallback-dominant rendering.
- Keep verbose runtime diagnostics strictly behind an explicit debug flag so normal operation emits only concise, meaningful summaries.

### Description
- Interpret `WORKCELL_SCENE3D_DEBUG_LOGS` as an explicit truthy flag (`1/true/yes/on`) in `scene3d_debug_logs_enabled()` to avoid accidental verbose logging (file: `scene3d_viewport_widget.cpp`).
- Add three persistent summary state members (`last_scene_load_summary_item_count_`, `last_scene_load_summary_scene_name_`, `last_scene_load_summary_warning_signature_`) to the widget to track when a concise scene-load summary should be emitted (file: `scene3d_viewport_widget.h`).
- Build a deterministic, de-duplicated warning signature during `ingest_preview_items()` that collects missing-geometry tokens, rejected-mesh tokens, transform-chain failure tokens, per-item warnings, mesh/alignment warnings, and a fallback-dominance indicator, and only emit the scene-load summary when the scene name, item count, or warning signature changes or when debug logging is enabled (file: `scene3d_viewport_widget.cpp`).
- Preserve and explicitly surface warnings for missing geometry, rejected meshes, transform-chain failures, and fallback-dominant preview content rather than suppressing them, and emit a concise `qInfo()` summary plus `qWarning()` lines when appropriate (file: `scene3d_viewport_widget.cpp`).

### Testing
- Ran `python3 scripts/validate_scene3d_visual_diagnostics.py` which completed and wrote diagnostics for 8 scenes with `warnings=0` (PASS).
- Ran `python3 scripts/validate_scene3d_mesh_preview_contract.py` which failed due to an existing static/token expectation (`missing token: ensure_mesh_cached(`) (FAIL, pre-existing contract check expectation).
- Ran `python3 scripts/validate_scene_builder_ui_acceptance.py` which failed on pre-existing UI wiring pattern expectations unrelated to this change (FAIL, existing UI test gaps).
- Attempted `colcon build --packages-select workcell_builder` but could not run a ROS build in this container because `/opt/ros/humble/setup.bash` is not present (NOT RUN).
- Ran `git diff --check` style checks which passed (PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a328caf5634833180944f3a4df8f51d)