### PR TITLE
Improve Scene3D real mesh import for RViz-style previews

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -8588,7 +8588,8 @@ void MainWindow::populate_scene_hierarchy()
                                  skip_reason_counts.value(QStringLiteral("zero_triangle_mesh"), 0);
   const int unsupported_extension_count = skip_reason_counts.value(QStringLiteral("unsupported_format"), 0);
   const bool authoritative_mesh_index_healthy =
-    visual_index_extraction_mode.trimmed().compare(QStringLiteral("xacro_expanded"), Qt::CaseInsensitive) == 0 &&
+    (visual_index_extraction_mode.trimmed().compare(QStringLiteral("xacro_expanded"), Qt::CaseInsensitive) == 0 ||
+     visual_index_extraction_mode.trimmed().compare(QStringLiteral("xacro_lite_expanded"), Qt::CaseInsensitive) == 0) &&
     visual_index_safe_for_preview &&
     mesh_item_count > 0 &&
     primitive_item_count == 0 &&
@@ -8639,12 +8640,12 @@ void MainWindow::populate_scene_hierarchy()
     if (!matched_equivalence_key.isEmpty() || suppress_because_mesh_index_is_healthy) {
       ++suppressed_preview_placeholder_count;
       const QString reason = suppress_because_mesh_index_is_healthy
-        ? QStringLiteral("healthy_xacro_expanded_mesh_index_omits_legacy_placeholder")
+        ? QStringLiteral("healthy_xacro_mesh_index_omits_legacy_placeholder")
         : suppression_reason_for_equivalence_key(matched_equivalence_key);
       placeholder_suppression_reason_counts[reason] += 1;
       if (placeholder_suppression_diagnostics.size() < 12) {
         const QString matched_ids = suppress_because_mesh_index_is_healthy
-          ? QStringLiteral("authoritative_xacro_expanded_mesh_index")
+          ? QStringLiteral("authoritative_xacro_mesh_index")
           : authoritative_visual_equivalence_map.value(matched_equivalence_key).join(QLatin1Char('|'));
         placeholder_suppression_diagnostics << QStringLiteral("%1=>%2 via %3")
           .arg(item.id, matched_ids, reason);
@@ -8666,7 +8667,7 @@ void MainWindow::populate_scene_hierarchy()
       .arg(preserved_editable_source_count)
       .arg(authoritative_mesh_index_healthy ? QStringLiteral("true") : QStringLiteral("false")));
     if (authoritative_mesh_index_healthy) {
-      append_studio_log(QString("Preview placeholder suppression: omitted %1 legacy placeholders because authoritative xacro-expanded mesh index is healthy")
+      append_studio_log(QString("Preview placeholder suppression: omitted %1 legacy placeholders because authoritative xacro/xacro-lite mesh index is healthy")
         .arg(suppressed_preview_placeholder_count));
     }
   } else if (!authoritative_visual_equivalence_map.isEmpty()) {

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -34,7 +34,7 @@
 #endif
 
 namespace {
-constexpr int kMeshTriangleLimit = 100000;
+constexpr int kMeshTriangleLimit = 1000000;
 constexpr double kWorkspaceLimitMeters = 1000.0;
 
 [[maybe_unused]] QString snap_mode_label(Scene3DViewportWidget::SnapMode mode)
@@ -535,13 +535,23 @@ bool parse_collada_bytes(const QByteArray & bytes, Scene3DViewportWidget::Intern
         }
       }
     }
-    if (xml.isStartElement() && xml.name() == QStringLiteral("geometry")) in_geometry = true;
+    if (xml.isStartElement() && xml.name() == QStringLiteral("geometry")) {
+      in_geometry = true;
+      positions.clear();
+    }
+    if (xml.isEndElement() && xml.name() == QStringLiteral("geometry")) {
+      in_geometry = false;
+      positions.clear();
+      continue;
+    }
     if (!in_geometry || !xml.isStartElement()) continue;
-    if (xml.name() == QStringLiteral("float_array")) {
-      const QString id = xml.attributes().value(QStringLiteral("id")).toString().toLower();
-      if (id.contains("position")) {
-        const QStringList vals = xml.readElementText().split(QRegExp("\\s+"), Qt::SkipEmptyParts);
-        positions.clear();
+    if (xml.name() == QStringLiteral("float_array") && positions.isEmpty()) {
+      // RViz/Assimp-style tolerance: many ROS Collada exports use opaque IDs
+      // (for example ID5) rather than names containing "position".  The first
+      // mesh float array in these assets is the vertex position stream; later
+      // arrays are normals/UVs/material data and are ignored by this fallback.
+      const QStringList vals = xml.readElementText().split(QRegExp("\\s+"), Qt::SkipEmptyParts);
+      if (vals.size() >= 9 && vals.size() % 3 == 0) {
         positions.reserve(vals.size());
         for (const auto & v : vals) positions.push_back(v.toFloat());
       }


### PR DESCRIPTION
### Motivation
- Scene3D was treating valid STL/DAE/OBJ assets as preview fallbacks (zero-triangle, triangle-budget rejections, stale static placeholders) instead of rendering real mesh geometry like RViz, producing poor product visuals.
- The goal is to make the viewport attempt real mesh imports first (Assimp when available), apply URDF/visual transforms before rejection, and suppress legacy static fallback placeholders when a healthy generated mesh index exists.

### Description
- Increased the Scene3D triangle budget from `100000` to `1000000` to allow high-detail local assets (e.g., `assets/.../table.stl`) to be parsed and rendered rather than immediately replaced by preview surrogates, change in `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`.
- Hardened the built-in Collada (DAE) fallback parser to reset per-`<geometry>` state and to accept ROS/Collada exports that use opaque `float_array` IDs (for example `ID5`) by treating the first suitable float array as the vertex stream, improving triangulation of `d435.dae` when Assimp is not available, change in `scene3d_viewport_widget.cpp`.
- Kept the existing Assimp-first loader path (`WORKCELL_BUILDER_HAS_ASSIMP`); the code still uses Assimp when CMake discovers it, and otherwise falls back to the improved internal parsers, so no new system dependency was added (loader code located in `scene3d_viewport_widget.cpp` and `src_scene3d_visual_backend.cpp`).
- Broadened authoritative visual-index recognition so both `xacro_expanded` and `xacro_lite_expanded` extraction modes count as authoritative safe mesh indexes and will suppress legacy `urdf_static_fallback_*` placeholders from normal product-visible preview payloads, change in `workcell_builder/workcell_builder/gui/mainwindow.cpp`.
- Preserved package:// resolution and existing mesh-cache/path resolution logging behaviour; no changes to runtime launch, controllers, or hardware execution paths were made.

### Testing
- `git diff --check` completed with no whitespace errors and the changes were committed locally (sanity check passed).
- `python3 -m py_compile scripts/run_workcell_builder_scene3d_gui_smoke.py` passed to verify smoke runner syntax.
- Verified local assets: `assets/.../table.stl` (~5 MB) and `assets/.../d435.dae` (~16 MB) are present and readable in the repo; `pkg-config/ldconfig` indicated Assimp was not discoverable in this container so fallback loaders are important.
- Attempted the requested smoke command `python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --repo-root "$PWD" --workspace-root /workspace --scene ur5_2f_test --output "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json" --screenshot "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.png" --timeout-sec 30` but it was blocked with `MISSING_EXECUTABLE` because the built `workcell_builder` executable is not present in this environment; `colcon build` could not be run because `/opt/ros/humble/setup.bash` is not available in this container.
- Remaining limitations: Assimp remains preferred for robust DAE/STL/OBJ handling and will be used when found by CMake; the fallback Collada parser is more tolerant but still lightweight compared to Assimp and may not triangulate every exotic DAE variant (further mapping of non-position float arrays would be a follow-up if needed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a329a715ab8833195fe4a93dc89c149)