### PR TITLE
Suppress stale URDF static fallback visuals and treat semantic primitives as non-failures in Scene3D

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -8215,6 +8215,20 @@ void MainWindow::populate_scene_hierarchy()
             add_skip_reason(QStringLiteral("zero_triangle_mesh"));
             continue;
           }
+          const QString transform_status_for_static_filter = QString::fromStdString(
+            workcell_builder::yaml_map_value_or_empty(v, "transform_status")).trimmed().toLower();
+          const bool static_robot_fallback_visual =
+            id.startsWith(QStringLiteral("urdf_static_fallback_")) ||
+            transform_status_for_static_filter == QStringLiteral("static_fallback") ||
+            transform_status_for_static_filter == QStringLiteral("static_fallback_parent");
+          const bool authoritative_expanded_mesh_payload =
+            visual_index_safe_for_preview &&
+            (visual_index_extraction_mode == QStringLiteral("xacro_expanded") ||
+             visual_index_extraction_mode == QStringLiteral("xacro_lite_expanded"));
+          if (authoritative_expanded_mesh_payload && static_robot_fallback_visual) {
+            add_skip_reason(QStringLiteral("suppressed_static_robot_fallback"));
+            continue;
+          }
           ScenePreviewWidget::PreviewItem p;
           p.id = id;
           p.display_name = QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "link"));

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -265,11 +265,13 @@ void finalize_visual_quality(Scene3DViewportWidget::RenderDebugCounters & counte
     status = QStringLiteral("UNAVAILABLE");
     warnings.append(QStringLiteral("no_preview_payload"));
   }
-  if (counters.mesh_source_count > 0 && counters.mesh_rendered_count <= 0) {
+  const int rendered_mesh_success_count = qMax(counters.mesh_rendered_count, counters.mesh_surface_rendered_count);
+  const int rendered_primitive_success_count = qMax(counters.urdf_primitive_rendered_count, counters.editable_primitive_rendered_count);
+  if (counters.mesh_source_count > 0 && rendered_mesh_success_count <= 0) {
     status = QStringLiteral("FAIL");
     warnings.append(QStringLiteral("mesh_sources_present_but_none_rendered"));
   }
-  if (counters.urdf_primitive_source_count > 0 && counters.urdf_primitive_rendered_count <= 0) {
+  if (counters.urdf_primitive_source_count > 0 && rendered_primitive_success_count <= 0) {
     status = QStringLiteral("FAIL");
     warnings.append(QStringLiteral("urdf_primitive_sources_present_but_none_rendered"));
   }
@@ -2086,10 +2088,23 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
     }
     return false;
   }
-  // Always try mesh-backed draw first for physical items.
+  // Semantic/layout primitives are intentional product overlays, not failed mesh
+  // assets.  Only physical mesh candidates proceed through mesh rejection;
+  // semantic items without mesh handoff render through the semantic primitive
+  // path so they do not emit REJECT_MESH_METADATA_MISSING or increment missing
+  // geometry/fallback counters.
   QColor visual_color = item_color(it, diagnostic_transparency_mode);
   const bool generated_or_locked_preview = is_generated_urdf_visual_item(it) || is_locked_urdf_item(it);
   const bool editable_layout_preview = it.linked_to_editable_layout_state || item_is_editable_for_gizmo(it);
+  const bool semantic_without_mesh_handoff =
+    !generated_or_locked_preview &&
+    is_clean_semantic_primitive_role(semantic_role) &&
+    !item_has_credible_mesh_handoff(it);
+  if (semantic_without_mesh_handoff && draw_clean_semantic_primitive(it)) {
+    if (out_editable_primitive_count) ++(*out_editable_primitive_count);
+    return true;
+  }
+  // Always try mesh-backed draw first for physical items.
   if (draw_mesh_preview_if_available(it, visual_color, true)) {
     if (out_mesh_count) ++(*out_mesh_count);
     ItemBounds mesh_bounds{};


### PR DESCRIPTION
### Motivation
- Remove stale/debug URDF static fallback robot primitives from the normal product Scene3D payload when an authoritative generated visual mesh index exists and is safe for preview.
- Prevent semantic/layout primitives (zones, reach/safety overlays, place/pick targets, support surfaces, home markers) from being treated as missing mesh failures and inflating missing/fallback counters.
- Fix misleading scene-load warning aggregation so real mesh/primitive render success suppresses false "none rendered" warnings.

### Description
- Skip stale static robot fallback visuals when ingesting `generated/scene_visual_mesh_index.json` by detecting `urdf_static_fallback_*` IDs and/or `transform_status` values and not forwarding those entries into the product preview if `safe_for_preview=true` and `extraction_mode` is `xacro_expanded` or `xacro_lite_expanded`; this prevents those debug fallbacks from entering product counters or warnings (changes in `mainwindow.cpp`).
- Render semantic/layout primitives via the semantic primitive renderer before mesh rejection so items like `safety_zone_keepout`, `robot_reach`, pick/place zones, target bins, support surfaces, home pose markers, task overlays, and editable primitives do not emit `REJECT_MESH_METADATA_MISSING` or count as missing/fallback geometry (changes in `scene3d_viewport_widget.cpp`).
- Tighten visual-quality aggregation to consider actual mesh-surface render success and editable/semantic primitive render success when deciding "none rendered" warnings, using `mesh_surface_rendered_count` and `editable_primitive_rendered_count` to avoid false `mesh_sources_present_but_none_rendered` and `urdf_primitive_sources_present_but_none_rendered` warnings (changes in `scene3d_viewport_widget.cpp`).
- Files modified: `workcell_builder/workcell_builder/gui/mainwindow.cpp` and `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`.
- Added a suppressed skip reason (`suppressed_static_robot_fallback`) so suppressed debug fallbacks are traceable in logs only in diagnostic/degraded modes.
- Before/after counters (intent / expected):
  - Before (observed on ROS Humble `ur5_2f_test`): `fallback=8`, `fallback_items=8/30`, `placeholder_count=1`, `robot_mesh_missing_count=11`, `mesh_rendered_count=11`, `mesh_source_count=11`, `rejected_meshes=0`, with `urdf_static_fallback_ur5_static_*` logged as `REJECT_MESH_METADATA_MISSING`.
  - After: stale `urdf_static_fallback_*` entries are not forwarded into product preview when the generated visual mesh index is authoritative; semantic primitives are rendered without raising mesh-metadata rejections; this should drop `fallback`/`fallback_items` significantly, set `placeholder_count=0` for product-visible geometry, and eliminate `REJECT_MESH_METADATA_MISSING` for semantic primitives (exact post-change counters must be collected in a real ROS Humble workspace using the smoke command below).

### Testing
- Ran static checks: code diff/check successful (`diff --check` style verification passed in this environment).
- Attempted build: `colcon build --symlink-install --packages-select workcell_builder` was attempted but blocked in this container because `/opt/ros/humble/setup.bash` is not available, so no local binary smoke run or Scene3D GUI smoke was executed here.
- Recommended acceptance smoke (run in a real ROS Humble workspace):
  ```bash
  cd /home/user/workcell_ws/src/easy_manipulation_deployment
  python3 scripts/run_workcell_builder_scene3d_gui_smoke.py \
    --repo-root "$PWD" \
    --workspace-root /home/user/workcell_ws \
    --scene ur5_2f_test \
    --output "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json" \
    --screenshot "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.png" \
    --timeout-sec 30
  ```
- Inspect outputs after running the smoke to validate expected results: examine `scene3d_gui_smoke.json` for `camera_fit_target`, `transform_chain_applied_count`, `visual_origin_applied_count`, `mesh_rendered_count==mesh_source_count`, `missing_geometry_count==0`, `placeholder_count==0`, and that no `urdf_static_fallback_ur5_static_*` or `REJECT_MESH_METADATA_MISSING` appear in logs.
- Screenshot path for verification: `scenes/ur5_2f_test/generated/scene3d_gui_smoke.png`.
- Remaining fallback items: none of the stale `urdf_static_fallback_*` items should be product-visible when the generated visual mesh index is safe and expanded; any remaining fallback counts after a real-world smoke run indicate real mesh failures or intentional semantic fallbacks and should be investigated with the preserved warning details (suppressed static fallback entries are still traceable in degraded/debug modes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32abaceb7c83319671d032bb97b559)