### PR TITLE
Restore Scene3D generated visuals and RViz-style viewport polish

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -311,6 +311,8 @@ QString canonical_skip_reason_key(const QString & reason)
   if (token == QStringLiteral("unsafe_for_preview")) return QStringLiteral("unsafe_for_preview");
   if (token == QStringLiteral("zero_triangle_mesh")) return QStringLiteral("zero_triangle_mesh");
   if (token == QStringLiteral("hidden_by_filter")) return QStringLiteral("hidden_by_filter");
+  if (token == QStringLiteral("suppressed_static_robot_fallback") ||
+      token == QStringLiteral("suppressed_static_fallback")) return QStringLiteral("suppressed_static_robot_fallback");
   if (token == QStringLiteral("invalid_pose")) return QStringLiteral("invalid_pose");
   if (token == QStringLiteral("invalid_scale")) return QStringLiteral("invalid_scale");
   if (token == QStringLiteral("duplicate_id")) return QStringLiteral("duplicate_id");
@@ -8215,12 +8217,8 @@ void MainWindow::populate_scene_hierarchy()
             add_skip_reason(QStringLiteral("zero_triangle_mesh"));
             continue;
           }
-          const QString transform_status_for_static_filter = QString::fromStdString(
-            workcell_builder::yaml_map_value_or_empty(v, "transform_status")).trimmed().toLower();
           const bool static_robot_fallback_visual =
-            id.startsWith(QStringLiteral("urdf_static_fallback_")) ||
-            transform_status_for_static_filter == QStringLiteral("static_fallback") ||
-            transform_status_for_static_filter == QStringLiteral("static_fallback_parent");
+            id.startsWith(QStringLiteral("urdf_static_fallback_"));
           const bool authoritative_expanded_mesh_payload =
             visual_index_safe_for_preview &&
             (visual_index_extraction_mode == QStringLiteral("xacro_expanded") ||

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -1023,6 +1023,29 @@ QColor explicit_material_color(const ScenePreviewWidget::PreviewItem & it)
 QColor product_view_generated_locked_material(const ScenePreviewWidget::PreviewItem & it, bool diagnostic_transparency_mode)
 {
   QColor c = it.has_material_color ? explicit_material_color(it) : generated_locked_preview_material();
+  const QString visual_identity = (it.id + " " + it.display_name + " " + it.role + " " + it.category).toLower();
+  if (!it.has_material_color) {
+    if (visual_identity.contains(QStringLiteral("robotiq")) ||
+        visual_identity.contains(QStringLiteral("gripper")) ||
+        visual_identity.contains(QStringLiteral("finger")) ||
+        visual_identity.contains(QStringLiteral("knuckle"))) {
+      c = QColor("#4b5563");
+    } else if (visual_identity.contains(QStringLiteral("camera")) ||
+               visual_identity.contains(QStringLiteral("realsense")) ||
+               visual_identity.contains(QStringLiteral("d435"))) {
+      c = QColor("#111827");
+    } else if (visual_identity.contains(QStringLiteral("table")) ||
+               visual_identity.contains(QStringLiteral("workbench"))) {
+      c = QColor("#8b8175");
+    } else if (visual_identity.contains(QStringLiteral("ur5")) ||
+               visual_identity.contains(QStringLiteral("shoulder")) ||
+               visual_identity.contains(QStringLiteral("upper_arm")) ||
+               visual_identity.contains(QStringLiteral("forearm")) ||
+               visual_identity.contains(QStringLiteral("wrist")) ||
+               visual_identity.contains(QStringLiteral("base_link"))) {
+      c = QColor("#d8dee6");
+    }
+  }
   if (!diagnostic_transparency_mode) {
     c.setAlphaF(qMax(c.alphaF(), kGeneratedLockedProductMinAlpha));
   }
@@ -1364,7 +1387,7 @@ void Scene3DViewportWidget::fit_product_view()
   const double radius = qMax(0.25, 0.5 * qSqrt(ext.x() * ext.x() + ext.y() * ext.y() + ext.z() * ext.z()));
   scene_radius_ = radius;
   const double fov = qDegreesToRadians(50.0);
-  const double fit_distance = (radius / qTan(fov * 0.5)) * 0.78;
+  const double fit_distance = (radius / qTan(fov * 0.5)) * 1.08;
   distance_ = qBound(min_distance_, fit_distance, max_distance_);
   yaw_ = -0.72;
   pitch_ = 0.54;
@@ -2879,9 +2902,17 @@ void Scene3DViewportWidget::draw_ground_grid_pass()
   glDisable(GL_CULL_FACE);
   glEnable(GL_BLEND);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  glLineWidth(debug_overlays_mode ? 1.0f : 0.75f);
+  const int grid_extent = debug_overlays_mode ? 20 : 8;
+  const QColor floor = QColor(15, 23, 42, debug_overlays_mode ? 42 : 30);
+  glColor4f(floor.redF(), floor.greenF(), floor.blueF(), floor.alphaF());
+  glBegin(GL_QUADS);
+  glVertex3f(static_cast<float>(-grid_extent), -0.002f, static_cast<float>(-grid_extent));
+  glVertex3f(static_cast<float>( grid_extent), -0.002f, static_cast<float>(-grid_extent));
+  glVertex3f(static_cast<float>( grid_extent), -0.002f, static_cast<float>( grid_extent));
+  glVertex3f(static_cast<float>(-grid_extent), -0.002f, static_cast<float>( grid_extent));
+  glEnd();
+  glLineWidth(debug_overlays_mode ? 1.0f : 0.85f);
   glBegin(GL_LINES);
-  const int grid_extent = debug_overlays_mode ? 20 : 6;
   for (int i = -grid_extent; i <= grid_extent; ++i) {
     const bool major = (i % 5 == 0);
     const QColor c = debug_overlays_mode


### PR DESCRIPTION
### Motivation
- Recent cleanup over-filtered valid generated URDF visuals by treating `static_fallback`/`static_fallback_parent` broadly as debug junk, causing most UR5/Robotiq/table/camera meshes to be dropped from Scene3D previews.
- The goal is to restore the real generated visual payload first (so mesh-backed URDF visuals are preserved) and then improve viewport presentation toward an RViz-like, engineering-clear default view.
- Preserve the prior good cleanup that suppresses true debug fallback spam without masking legitimate mesh-backed visuals or semantic primitives.

### Description
- Narrowed static-fallback suppression so only IDs starting with `urdf_static_fallback_` are treated as suppressed debug fallbacks, instead of filtering by `transform_status` values; this restores `urdf_visual_*` entries that carried `static_fallback_parent` but had real mesh/package metadata (file: `mainwindow.cpp`).
- Added a canonical skip reason token `suppressed_static_robot_fallback` so intentionally suppressed debug items do not collapse into `parse_error` counts (file: `mainwindow.cpp`).
- Restored readable default generated-material heuristics for visuals lacking explicit material colors so robot, gripper, table, and camera visuals are visually distinct and engineering-readable (file: `scene3d_viewport_widget.cpp`).
- Improved viewport fit and presentation: widened full-workcell isometric fit, subtle floor plane quad + expanded grid, and slight adjustments to grid/stroke to show full workcell clearly without flashy effects (file: `scene3d_viewport_widget.cpp`).

### Testing
- Ran unit/viewport tests: `python3 -m pytest tests/test_scene3d_generated_fallback_shapes.py tests/test_scene3d_render_pipeline_not_blank.py tests/test_scene3d_view_fit_and_scale.py -q` — all executed tests passed (10 passed).
- GUI smoke wrapper contract: `python3 -m pytest tests/test_scene3d_gui_smoke_json_output_contract.py -q` — failed in this container because the test wrapper detects ROS Humble/workspace is missing and reports `status=BLOCKED smoke_status=ROS_HUMBLE_UNAVAILABLE`; this is an environment limitation rather than a scene-rendering regression.
- Not run here due to missing ROS workspace: build and full GUI smoke acceptance; acceptance command to run in a real Humble workspace is:
  `python3 scripts/run_workcell_builder_scene3d_gui_smoke.py --repo-root "$PWD" --workspace-root /home/user/workcell_ws --scene ur5_2f_test --output "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.json" --screenshot "$PWD/scenes/ur5_2f_test/generated/scene3d_gui_smoke.png" --timeout-sec 30`
- Expected before/after impact (acceptance workspace): before regression reported `Visual mesh preview items added: 2 / 19` and `parse_error=17` with `transform_chain_applied_count=2` and `visual_origin_applied_count=2`; after this change the `urdf_visual_*` entries with usable meshes should be retained so visual preview should approach `19 / 19`, parse_error skip count should not be 17, and transform/visual_origin counts should return close to 19.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32ae98750c8331b33a6d722e49128a)