### PR TITLE
Scene3D: treat robot_reach as semantic/editor primitive (avoid missing-mesh fallback)

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -823,7 +823,11 @@ NormalizedRole classify_item_role(const ScenePreviewWidget::PreviewItem & it)
 {
   const QString role = normalized_token(it.role);
   const QString category = normalized_token(it.category);
-  const QString mix = role + "|" + category;
+  const QString id = normalized_token(it.id);
+  const QString display_name = normalized_token(it.display_name);
+  const QString metadata = normalized_token(it.metadata_tags + QStringLiteral("|") + it.mesh_type + QStringLiteral("|") +
+                                           it.material_name + QStringLiteral("|") + it.status);
+  const QString mix = role + "|" + category + "|" + id + "|" + display_name + "|" + metadata;
 
   if (mix.contains("robot_reach") || mix.contains("reachability") || mix.contains("reach_envelope") ||
       mix.contains("reach_zone") || mix.contains("workspace_reach")) return NormalizedRole::RobotReach;
@@ -2169,7 +2173,6 @@ bool Scene3DViewportWidget::draw_truthful_item_geometry(const ScenePreviewWidget
     return true;
   }
   const bool semantic_without_mesh_handoff =
-    !generated_or_locked_preview &&
     is_clean_semantic_primitive_role(semantic_role) &&
     !item_has_credible_mesh_handoff(it);
   if (semantic_without_mesh_handoff && draw_clean_semantic_primitive(it)) {

--- a/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_render_role_classifier_test.cpp
@@ -262,6 +262,38 @@ TEST(Scene3DRenderRoleClassifier, SemanticRolesWithoutDimensionsSuppressMissingG
   EXPECT_FALSE(Scene3DViewportWidget::should_draw_as_wireframe_for_test(object, ScenePreviewWidget::MeshPreviewMode::Auto));
 }
 
+
+TEST(Scene3DRenderRoleClassifier, RobotReachIdIsSemanticEvenWhenLockedWithoutMeshMetadata)
+{
+  ASSERT_NE(ensure_app(), nullptr);
+
+  auto robot_reach = make_item("robot_reach");
+  robot_reach.role = "reach";
+  robot_reach.category = "reach";
+  robot_reach.source_layer = "environment_yaml";
+  robot_reach.active_visual_source = "environment_yaml";
+  robot_reach.locked = true;
+  robot_reach.editable = false;
+  robot_reach.lock_reason = "generated environment preview";
+  robot_reach.mesh_available = false;
+  robot_reach.has_mesh_metadata = false;
+  robot_reach.mesh_path.clear();
+
+  EXPECT_TRUE(Scene3DViewportWidget::should_draw_clean_semantic_primitive_for_test(robot_reach));
+  EXPECT_TRUE(Scene3DViewportWidget::should_draw_as_solid_for_test(robot_reach, ScenePreviewWidget::MeshPreviewMode::Meshes));
+  EXPECT_FALSE(Scene3DViewportWidget::should_draw_as_wireframe_for_test(robot_reach, ScenePreviewWidget::MeshPreviewMode::Auto));
+  EXPECT_FALSE(Scene3DViewportWidget::should_suppress_missing_geometry_marker_for_test(robot_reach));
+
+  Scene3DViewportWidget viewport;
+  viewport.ingest_preview_items(QVector<ScenePreviewWidget::PreviewItem>{ robot_reach });
+  ASSERT_TRUE(viewport.render_smoke_fallback_frame(nullptr));
+
+  const auto counters = viewport.render_debug_counters();
+  EXPECT_EQ(counters.missing_geometry_count, 0);
+  EXPECT_EQ(counters.primitive_fallback_count, 0);
+  EXPECT_EQ(counters.editable_primitive_rendered_count, 1);
+}
+
 TEST(Scene3DRenderRoleClassifier, EditableLayoutPrimitivesDoNotCountAsGeneratedFallbacks)
 {
   ASSERT_NE(ensure_app(), nullptr);


### PR DESCRIPTION
### Motivation

- Fix a false Scene3D warning where `robot_reach` was classified as missing mesh and emitted `REJECT_MESH_METADATA_MISSING` and `missing_geometry` diagnostics.
- Ensure semantic/editor roles (e.g., `robot_reach`, `robot_base`, zones, markers) win over mesh/locked checks when no credible mesh handoff exists so editor primitives render correctly.

### Description

- Broadened role classification to include `id`, `display_name`, and key metadata tokens in addition to `role`/`category` so `robot_reach` is recognized as `RobotReach` even when authored from environment/editor sources. (scene3d role classifier change)
- Adjusted routing so semantic primitive rendering is considered before mesh rejection for recognized semantic roles, allowing semantic/editor primitives to render (transparent outline/primitive) instead of taking the mesh-rejection path. (semantic routing change)
- Added a regression test `RobotReachIdIsSemanticEvenWhenLockedWithoutMeshMetadata` to assert that a locked `robot_reach` with no mesh metadata renders as a semantic primitive and does not increment `missing_geometry` or primitive-fallback counters. (unit test added)
- No renderer engine rewrite, no launch or hardware changes; change is limited to Scene3D classification/render-routing logic and test coverage.

### Testing

- Ran code diagnostic check (`diff --check` style) — passed locally.
- Attempted to build `workcell_builder` with the normal Humble/`colcon` workflow but the container lacked ROS Humble and `colcon`, so the build was not executed in this environment (blocked by missing tools). (environment limitation)
- Ran the Scene3D smoke script `python3 scripts/run_workcell_builder_scene3d_gui_smoke.py` but it was blocked with `MISSING_EXECUTABLE` because the `workcell_builder` binary was not built/installed in this container; smoke-run logs were therefore not produced here. (environment limitation)
- Added the targeted unit test; it is included in the test set and expected to be exercised by CI or a local `colcon` build of `workcell_builder` where ROS/colcon are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32b85266108331b27acde3073dd308)