### PR TITLE
Prefer local ROS-style asset workspace for Scene3D mesh resolution

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -8146,6 +8146,30 @@ void MainWindow::populate_scene_hierarchy()
   int transform_chain_applied_count = 0;
   int visual_origin_applied_count = 0;
   int missing_chain_warning_count = 0;
+  {
+    QStringList detected_asset_roots;
+    const QMap<QString, QString> local_package_map = workcell_builder::discover_visual_mesh_package_map(
+      d, workspace_root, &detected_asset_roots);
+    detected_asset_roots.removeDuplicates();
+    if (detected_asset_roots.isEmpty()) {
+      append_studio_log(QStringLiteral("Asset workspace: none detected (checked <workspace>/src/assets and <repo>/assets)"));
+    } else {
+      append_studio_log(QStringLiteral("Asset workspace: %1").arg(detected_asset_roots.join(QStringLiteral(", "))));
+    }
+    append_studio_log(QStringLiteral("Discovered packages: %1").arg(local_package_map.keys().join(QStringLiteral(", "))));
+    const QStringList expected_visual_packages = {
+      QStringLiteral("ur_description"),
+      QStringLiteral("robotiq_85_description"),
+      QStringLiteral("workbench_description"),
+      QStringLiteral("realsense2_description")
+    };
+    QStringList missing_asset_packages;
+    for (const QString & pkg : expected_visual_packages) {
+      if (!local_package_map.contains(pkg)) missing_asset_packages << pkg;
+    }
+    append_studio_log(QStringLiteral("Missing asset packages: %1").arg(
+      missing_asset_packages.isEmpty() ? QStringLiteral("none") : missing_asset_packages.join(QStringLiteral(", "))));
+  }
   QString robot_base_frame = QStringLiteral("unknown");
   QString robot_world_pose = QStringLiteral("unknown");
   int mesh_item_count = 0;
@@ -8278,7 +8302,7 @@ void MainWindow::populate_scene_hierarchy()
               }
             }
           }
-          if (!resolved_source_path_candidate.isEmpty()) {
+          if (!resolved_source_path_candidate.isEmpty() && !package_uri.trimmed().startsWith(QStringLiteral("package://"))) {
             p.source_path = resolved_source_path_candidate;
             p.mesh_path = resolved_source_path_candidate;
             p.mesh_available = true;
@@ -8481,6 +8505,14 @@ void MainWindow::populate_scene_hierarchy()
                 p.source_path = resolved_mesh_path;
                 if (p.source_path_resolution_outcome.trimmed().isEmpty()) {
                   p.source_path_resolution_outcome = QStringLiteral("resolved_via_mesh_source_resolution");
+                }
+                if (package_uri.startsWith(QStringLiteral("package://"))) {
+                  const QString src = resolved_mesh_path.contains(QStringLiteral("/src/assets/"))
+                    ? QStringLiteral("local asset workspace")
+                    : (resolved_mesh_path.contains(QStringLiteral("/assets/"))
+                        ? QStringLiteral("repo assets")
+                        : QStringLiteral("ROS/ament or filesystem index"));
+                  append_studio_log(QStringLiteral("Resolved %1 from %2: %3").arg(package_uri, src, resolved_mesh_path));
                 }
               }
               if (mesh_fallback && !tried_candidates.isEmpty()) {

--- a/workcell_builder/workcell_builder/include/visual_mesh_source_resolver.hpp
+++ b/workcell_builder/workcell_builder/include/visual_mesh_source_resolver.hpp
@@ -18,11 +18,16 @@
 #include <boost/filesystem.hpp>
 #include <QString>
 #include <QStringList>
+#include <QMap>
 
 namespace workcell_builder
 {
 
 boost::filesystem::path workcell_builder_repo_root_from_source();
+
+QMap<QString, QString> discover_visual_mesh_package_map(
+  const boost::filesystem::path & scene_dir, const QString & workspace_root,
+  QStringList * detected_asset_roots = nullptr);
 
 QString resolve_visual_mesh_source_path(
   const QString & raw_path, const QString & package_uri,

--- a/workcell_builder/workcell_builder/src_visual_mesh_source_resolver.cpp
+++ b/workcell_builder/workcell_builder/src_visual_mesh_source_resolver.cpp
@@ -48,7 +48,7 @@ static bool visual_mesh_package_root_exists(const fs::path & package_root)
          fs::exists(package_root / "stl");
 }
 
-static QMap<QString, QString> discover_visual_mesh_package_map(const fs::path & scene_dir, const QString & workspace_root)
+QMap<QString, QString> discover_visual_mesh_package_map(const fs::path & scene_dir, const QString & workspace_root, QStringList * detected_asset_roots)
 {
   QMap<QString, QString> package_map;
   auto add_package_root = [&](const QString & package_name, const fs::path & package_root) {
@@ -58,10 +58,14 @@ static QMap<QString, QString> discover_visual_mesh_package_map(const fs::path & 
       package_map.insert(package_name, QString::fromStdString(package_root.string()));
     }
   };
-  auto scan_root = [&](const QString & root) {
+  auto scan_root = [&](const QString & root, bool report_asset_root = false) {
     if (root.trimmed().isEmpty()) return;
     const QDir base(root);
     if (!base.exists()) return;
+    if (report_asset_root && detected_asset_roots) {
+      const QString canonical = QFileInfo(root).canonicalFilePath();
+      detected_asset_roots->push_back(canonical.isEmpty() ? base.absolutePath() : canonical);
+    }
     QDirIterator it(root, QStringList() << "package.xml", QDir::Files, QDirIterator::Subdirectories);
     while (it.hasNext()) {
       const QString package_xml = it.next();
@@ -74,6 +78,18 @@ static QMap<QString, QString> discover_visual_mesh_package_map(const fs::path & 
   };
 
   const fs::path repo_root = workcell_builder_repo_root_from_source();
+  const QString ws = workspace_root.trimmed();
+  // Product preview priority: local ROS-style asset workspace first, repo assets second,
+  // then generated/workspace/ament fallbacks for legacy scenes.
+  scan_root(ws + "/src/assets", true);
+  scan_root(QString::fromStdString((repo_root / "assets").string()), true);
+  scan_root(QString::fromStdString((scene_dir / "generated").string()));
+  scan_root(ws + "/install/share");
+  scan_root(ws + "/src/easy_manipulation_deployment/assets");
+  scan_root(ws + "/src");
+  scan_root(QString::fromStdString((repo_root / "assets/environment").string()));
+  scan_root(QString::fromStdString((repo_root / "assets/robots").string()));
+  scan_root(QString::fromStdString((repo_root / "assets/end_effectors").string()));
   add_package_root(
     QStringLiteral("robotiq_85_description"),
     repo_root / "assets/end_effectors/robotiq_85_gripper/robotiq_85_description");
@@ -83,17 +99,6 @@ static QMap<QString, QString> discover_visual_mesh_package_map(const fs::path & 
   add_package_root(
     QStringLiteral("realsense2_description"),
     repo_root / "assets/environment/realsense2_description");
-
-  const QString ws = workspace_root.trimmed();
-  scan_root(QString::fromStdString((scene_dir / "generated").string()));
-  scan_root(ws + "/install/share");
-  scan_root(ws + "/src");
-  scan_root(ws + "/src/easy_manipulation_deployment/assets");
-  scan_root(ws + "/src/assets");
-  scan_root(QString::fromStdString((repo_root / "assets").string()));
-  scan_root(QString::fromStdString((repo_root / "assets/environment").string()));
-  scan_root(QString::fromStdString((repo_root / "assets/robots").string()));
-  scan_root(QString::fromStdString((repo_root / "assets/end_effectors").string()));
   const fs::path universal_robot_assets = repo_root / "assets/robots/universal_robot";
   const fs::path ur_description_assets = universal_robot_assets / "ur_description";
   if (!package_map.contains(QStringLiteral("ur_description"))) {
@@ -125,6 +130,23 @@ QString resolve_visual_mesh_source_path(
     return QString::fromStdString((scene_dir / rel.toStdString()).string());
   };
 
+  const QString trimmed_uri = package_uri.trimmed();
+  if (trimmed_uri.startsWith("package://")) {
+    const QString package_tail = trimmed_uri.mid(QString("package://").size());
+    const int slash = package_tail.indexOf('/');
+    const QString package_name = (slash >= 0) ? package_tail.left(slash) : package_tail;
+    const QString package_rel = (slash >= 0) ? package_tail.mid(slash + 1) : QString();
+    static QHash<QString, QMap<QString, QString>> workspace_cache;
+    const QString cache_key = QString::fromStdString(scene_dir.string()) + "::" + workspace_root;
+    if (!workspace_cache.contains(cache_key)) workspace_cache.insert(cache_key, discover_visual_mesh_package_map(scene_dir, workspace_root, nullptr));
+    const QMap<QString, QString> package_map = workspace_cache.value(cache_key);
+    const QString package_root = package_map.value(package_name);
+    if (!package_root.trimmed().isEmpty()) {
+      const QString resolved = add_candidate(QDir(package_root).filePath(package_rel));
+      if (!resolved.isEmpty()) return resolved;
+    }
+  }
+
   const QString trimmed_raw = raw_path.trimmed();
   if (!trimmed_raw.isEmpty()) {
     QFileInfo raw_info(trimmed_raw);
@@ -139,22 +161,7 @@ QString resolve_visual_mesh_source_path(
     }
   }
 
-  const QString trimmed_uri = package_uri.trimmed();
-  if (trimmed_uri.startsWith("package://")) {
-    const QString package_tail = trimmed_uri.mid(QString("package://").size());
-    const int slash = package_tail.indexOf('/');
-    const QString package_name = (slash >= 0) ? package_tail.left(slash) : package_tail;
-    const QString package_rel = (slash >= 0) ? package_tail.mid(slash + 1) : QString();
-    static QHash<QString, QMap<QString, QString>> workspace_cache;
-    const QString cache_key = QString::fromStdString(scene_dir.string()) + "::" + workspace_root;
-    if (!workspace_cache.contains(cache_key)) workspace_cache.insert(cache_key, discover_visual_mesh_package_map(scene_dir, workspace_root));
-    const QMap<QString, QString> package_map = workspace_cache.value(cache_key);
-    const QString package_root = package_map.value(package_name);
-    if (!package_root.trimmed().isEmpty()) {
-      const QString resolved = add_candidate(QDir(package_root).filePath(package_rel));
-      if (!resolved.isEmpty()) return resolved;
-    }
-  } else if (trimmed_uri.startsWith("file://")) {
+  if (trimmed_uri.startsWith("file://")) {
     const QString resolved = add_candidate(trimmed_uri.mid(7));
     if (!resolved.isEmpty()) return resolved;
   } else if (trimmed_uri.startsWith("/")) {

--- a/workcell_builder/workcell_builder/test/visual_mesh_source_resolver_test.cpp
+++ b/workcell_builder/workcell_builder/test/visual_mesh_source_resolver_test.cpp
@@ -18,6 +18,8 @@
 #include <QFileInfo>
 #include <QString>
 #include <QStringList>
+#include <QMap>
+#include <fstream>
 
 #include <utility>
 #include <vector>
@@ -80,4 +82,45 @@ TEST(VisualMeshSourceResolver, LeavesNonexistentPackageUriUnresolved)
     &tried_candidates);
 
   EXPECT_TRUE(resolved.isEmpty());
+}
+
+TEST(VisualMeshSourceResolver, PrefersWorkspaceSrcAssetsPackagesOverRepoAssets)
+{
+  const fs::path repo_root(WORKCELL_BUILDER_REPO_ROOT);
+  ASSERT_FALSE(repo_root.empty());
+
+  const fs::path tmp = fs::temp_directory_path() / fs::unique_path("workcell_assets_test_%%%%-%%%%-%%%%");
+  const fs::path ws = tmp / "workcell_ws";
+  const fs::path local_pkg = ws / "src/assets/robots/universal_robot/ur_description";
+  const fs::path local_mesh = local_pkg / "meshes/ur5/visual/base.dae";
+  fs::create_directories(local_mesh.parent_path());
+  {
+    std::ofstream pkg((local_pkg / "package.xml").string());
+    pkg << "<package format=\"3\"><name>ur_description</name><version>0.0.0</version><description>test</description><maintainer email=\"a@b.c\">t</maintainer><license>Apache-2.0</license></package>";
+  }
+  {
+    std::ofstream mesh(local_mesh.string());
+    mesh << "local asset mesh";
+  }
+
+  QStringList detected_roots;
+  const QMap<QString, QString> package_map = workcell_builder::discover_visual_mesh_package_map(
+    repo_root / "scenes" / "ur5_2f_test", QString::fromStdString(ws.string()), &detected_roots);
+  ASSERT_TRUE(package_map.contains(QStringLiteral("ur_description")));
+  EXPECT_EQ(
+    QFileInfo(QString::fromStdString(local_pkg.string())).canonicalFilePath(),
+    QFileInfo(package_map.value(QStringLiteral("ur_description"))).canonicalFilePath());
+
+  QStringList tried_candidates;
+  const QString resolved = workcell_builder::resolve_visual_mesh_source_path(
+    QString(),
+    QStringLiteral("package://ur_description/meshes/ur5/visual/base.dae"),
+    repo_root / "scenes" / "ur5_2f_test",
+    QString::fromStdString(ws.string()),
+    &tried_candidates);
+  EXPECT_EQ(
+    QFileInfo(QString::fromStdString(local_mesh.string())).canonicalFilePath(),
+    QFileInfo(resolved).canonicalFilePath());
+
+  fs::remove_all(tmp);
 }


### PR DESCRIPTION
### Motivation

- Make Workcell Builder Scene3D preview reliably use a local ROS-style asset workspace (`<workspace>/src/assets`) instead of fragile `package://` fallbacks and stale generated paths.
- Ensure robot visuals come from `ur_description` and MoveIt config remains separate (`ur5_moveit_config`), reducing placeholder fallbacks in the product preview.
- Provide clear runtime diagnostics so users know which asset root and package map were used when building previews.

### Description

- Added `discover_visual_mesh_package_map(scene_dir, workspace_root, detected_asset_roots)` to recursively scan for ROS-style packages and return a package_name -> absolute path map, reporting detected asset roots. (header: `include/visual_mesh_source_resolver.hpp`, impl: `src_visual_mesh_source_resolver.cpp`).
- Prioritized package resolution order for product preview as: workspace `src/assets` first, repo `assets` second, then generated/install/share/ROS (`/opt/ros/humble/share`) fallbacks; the resolver now caches the discovered package map and resolves `package://` URIs from the local package map first. (`src_visual_mesh_source_resolver.cpp`).
- Updated Scene3D loader to prefer package resolution from local workspace packages and to avoid letting stale `resolved_source_path` silently override local `package://` resolution for package URIs, and to log resolution provenance when a `package://` is resolved (local asset workspace / repo assets / ROS index). (`gui/mainwindow.cpp`).
- Added scene-load logging that reports `Asset workspace: <roots>`, `Discovered packages: <list>`, and `Missing asset packages: <list>` to aid diagnostics. (`gui/mainwindow.cpp`).
- Added a unit test `PrefersWorkspaceSrcAssetsPackagesOverRepoAssets` that creates a temporary `<tmp>/workcell_ws/src/assets/.../ur_description` package and asserts the resolver prefers it over repo assets. (`test/visual_mesh_source_resolver_test.cpp`).

### Testing

- Ran static/diff checks: `git diff --check` passed in this environment.
- Added a unit test (`PrefersWorkspaceSrcAssetsPackagesOverRepoAssets`) but full unit test execution / `colcon` build was not run in this container because `/opt/ros/humble/setup.bash` and the expected `/home/user/workcell_ws` workspace are not available here, so build and Scene3D GUI smoke were not executed.
- Validation instructions are included for local verification: run `colcon build --symlink-install --packages-select workcell_builder` in your ROS Humble workspace and then the Scene3D smoke driver script `scripts/run_workcell_builder_scene3d_gui_smoke.py` with `--workspace-root /home/user/workcell_ws` to confirm preview behavior and logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32c0330ce88331a39cb66ce8c133f7)