### PR TITLE
Fix Scene3D URDF RPY transform order

### DIFF
--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -118,6 +118,36 @@ bool scene3d_debug_fallback_boxes_enabled()
   return scene3d_env_flag_enabled("WORKCELL_SCENE3D_DEBUG_FALLBACK_BOXES");
 }
 
+
+void apply_urdf_rpy_gl(double roll, double pitch, double yaw)
+{
+  // URDF RPY is fixed-axis roll/pitch/yaw: R = Rz(yaw) * Ry(pitch) * Rx(roll).
+  // OpenGL post-multiplies the current matrix, so issue rotations in Z/Y/X order.
+  glRotated(qRadiansToDegrees(yaw), 0.0, 0.0, 1.0);
+  glRotated(qRadiansToDegrees(pitch), 0.0, 1.0, 0.0);
+  glRotated(qRadiansToDegrees(roll), 1.0, 0.0, 0.0);
+}
+
+void apply_urdf_pose_gl(double x, double y, double z, double roll, double pitch, double yaw)
+{
+  glTranslated(x, y, z);
+  apply_urdf_rpy_gl(roll, pitch, yaw);
+}
+
+void apply_urdf_rpy_matrix(QMatrix4x4 & transform, double roll, double pitch, double yaw)
+{
+  // Keep Scene3D's CPU bounds path in the same URDF/RViz transform convention as rendering.
+  transform.rotate(static_cast<float>(qRadiansToDegrees(yaw)), 0.0f, 0.0f, 1.0f);
+  transform.rotate(static_cast<float>(qRadiansToDegrees(pitch)), 0.0f, 1.0f, 0.0f);
+  transform.rotate(static_cast<float>(qRadiansToDegrees(roll)), 1.0f, 0.0f, 0.0f);
+}
+
+void apply_urdf_pose_matrix(QMatrix4x4 & transform, double x, double y, double z, double roll, double pitch, double yaw)
+{
+  transform.translate(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z));
+  apply_urdf_rpy_matrix(transform, roll, pitch, yaw);
+}
+
 bool item_has_credible_mesh_handoff(const ScenePreviewWidget::PreviewItem & item)
 {
   const QString mesh_path = item.mesh_path.trimmed();
@@ -220,15 +250,9 @@ bool primitive_world_bounds_for_item(const ScenePreviewWidget::PreviewItem & ite
   }
 
   QMatrix4x4 transform;
-  transform.translate(item.x, item.y, item.z);
-  transform.rotate(qRadiansToDegrees(item.roll), 1.0f, 0.0f, 0.0f);
-  transform.rotate(qRadiansToDegrees(item.pitch), 0.0f, 1.0f, 0.0f);
-  transform.rotate(qRadiansToDegrees(item.yaw), 0.0f, 0.0f, 1.0f);
+  apply_urdf_pose_matrix(transform, item.x, item.y, item.z, item.roll, item.pitch, item.yaw);
   if (item.visual_origin_applied) {
-    transform.translate(item.visual_origin_x, item.visual_origin_y, item.visual_origin_z);
-    transform.rotate(qRadiansToDegrees(item.visual_origin_roll), 1.0f, 0.0f, 0.0f);
-    transform.rotate(qRadiansToDegrees(item.visual_origin_pitch), 0.0f, 1.0f, 0.0f);
-    transform.rotate(qRadiansToDegrees(item.visual_origin_yaw), 0.0f, 0.0f, 1.0f);
+    apply_urdf_pose_matrix(transform, item.visual_origin_x, item.visual_origin_y, item.visual_origin_z, item.visual_origin_roll, item.visual_origin_pitch, item.visual_origin_yaw);
   }
   transform.scale(item.mesh_scale_x, item.mesh_scale_y, item.mesh_scale_z);
 
@@ -2218,15 +2242,9 @@ bool Scene3DViewportWidget::draw_urdf_primitive_geometry(const ScenePreviewWidge
   if (!item_has_valid_urdf_primitive(it)) return false;
 
   glPushMatrix();
-  glTranslated(it.x, it.y, it.z);
-  glRotated(qRadiansToDegrees(it.roll), 1.0, 0.0, 0.0);
-  glRotated(qRadiansToDegrees(it.pitch), 0.0, 1.0, 0.0);
-  glRotated(qRadiansToDegrees(it.yaw), 0.0, 0.0, 1.0);
+  apply_urdf_pose_gl(it.x, it.y, it.z, it.roll, it.pitch, it.yaw);
   if (it.visual_origin_applied) {
-    glTranslated(it.visual_origin_x, it.visual_origin_y, it.visual_origin_z);
-    glRotated(qRadiansToDegrees(it.visual_origin_roll), 1.0, 0.0, 0.0);
-    glRotated(qRadiansToDegrees(it.visual_origin_pitch), 0.0, 1.0, 0.0);
-    glRotated(qRadiansToDegrees(it.visual_origin_yaw), 0.0, 0.0, 1.0);
+    apply_urdf_pose_gl(it.visual_origin_x, it.visual_origin_y, it.visual_origin_z, it.visual_origin_roll, it.visual_origin_pitch, it.visual_origin_yaw);
   }
   glScaled(it.mesh_scale_x, it.mesh_scale_y, it.mesh_scale_z);
 
@@ -2816,19 +2834,11 @@ bool Scene3DViewportWidget::validate_mesh_final_span(const ScenePreviewWidget::P
   const QVector3D raw_span = entry.local_span;
 
   QMatrix4x4 final_transform;
-  final_transform.translate(static_cast<float>(it.x), static_cast<float>(it.y), static_cast<float>(it.z));
-  final_transform.rotate(static_cast<float>(qRadiansToDegrees(it.roll)), 1.0f, 0.0f, 0.0f);
-  final_transform.rotate(static_cast<float>(qRadiansToDegrees(it.pitch)), 0.0f, 1.0f, 0.0f);
-  final_transform.rotate(static_cast<float>(qRadiansToDegrees(it.yaw)), 0.0f, 0.0f, 1.0f);
+  apply_urdf_pose_matrix(final_transform, it.x, it.y, it.z, it.roll, it.pitch, it.yaw);
   if (it.visual_origin_applied) {
-    final_transform.translate(static_cast<float>(it.visual_origin_x), static_cast<float>(it.visual_origin_y), static_cast<float>(it.visual_origin_z));
-    final_transform.rotate(static_cast<float>(qRadiansToDegrees(it.visual_origin_roll)), 1.0f, 0.0f, 0.0f);
-    final_transform.rotate(static_cast<float>(qRadiansToDegrees(it.visual_origin_pitch)), 0.0f, 1.0f, 0.0f);
-    final_transform.rotate(static_cast<float>(qRadiansToDegrees(it.visual_origin_yaw)), 0.0f, 0.0f, 1.0f);
+    apply_urdf_pose_matrix(final_transform, it.visual_origin_x, it.visual_origin_y, it.visual_origin_z, it.visual_origin_roll, it.visual_origin_pitch, it.visual_origin_yaw);
   }
-  final_transform.rotate(static_cast<float>(qRadiansToDegrees(it.mesh_r)), 1.0f, 0.0f, 0.0f);
-  final_transform.rotate(static_cast<float>(qRadiansToDegrees(it.mesh_p)), 0.0f, 1.0f, 0.0f);
-  final_transform.rotate(static_cast<float>(qRadiansToDegrees(it.mesh_y)), 0.0f, 0.0f, 1.0f);
+  apply_urdf_rpy_matrix(final_transform, it.mesh_r, it.mesh_p, it.mesh_y);
   if (it.has_origin_offset) {
     final_transform.translate(static_cast<float>(it.origin_offset_x), static_cast<float>(it.origin_offset_y), static_cast<float>(it.origin_offset_z));
   }
@@ -3010,19 +3020,11 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
   }
 
   glPushMatrix();
-  glTranslated(it.x, it.y, it.z);
-  glRotated(qRadiansToDegrees(it.roll), 1.0, 0.0, 0.0);
-  glRotated(qRadiansToDegrees(it.pitch), 0.0, 1.0, 0.0);
-  glRotated(qRadiansToDegrees(it.yaw), 0.0, 0.0, 1.0);
+  apply_urdf_pose_gl(it.x, it.y, it.z, it.roll, it.pitch, it.yaw);
   if (it.visual_origin_applied) {
-    glTranslated(it.visual_origin_x, it.visual_origin_y, it.visual_origin_z);
-    glRotated(qRadiansToDegrees(it.visual_origin_roll), 1.0, 0.0, 0.0);
-    glRotated(qRadiansToDegrees(it.visual_origin_pitch), 0.0, 1.0, 0.0);
-    glRotated(qRadiansToDegrees(it.visual_origin_yaw), 0.0, 0.0, 1.0);
+    apply_urdf_pose_gl(it.visual_origin_x, it.visual_origin_y, it.visual_origin_z, it.visual_origin_roll, it.visual_origin_pitch, it.visual_origin_yaw);
   }
-  glRotated(qRadiansToDegrees(it.mesh_r), 1.0, 0.0, 0.0);
-  glRotated(qRadiansToDegrees(it.mesh_p), 0.0, 1.0, 0.0);
-  glRotated(qRadiansToDegrees(it.mesh_y), 0.0, 0.0, 1.0);
+  apply_urdf_rpy_gl(it.mesh_r, it.mesh_p, it.mesh_y);
   if (preview_path && it.has_origin_offset) glTranslated(it.origin_offset_x, it.origin_offset_y, it.origin_offset_z);
   glScaled(it.mesh_scale_x, it.mesh_scale_y, it.mesh_scale_z);
 
@@ -3207,19 +3209,11 @@ void Scene3DViewportWidget::draw_realsense_d435_visual_surrogate(const ScenePrev
   // Preview-safe visual_surrogate for RealSense D435/D435i meshes whose DAE cannot be triangulated.
   // It uses the same pose, visual-origin, mesh RPY, mesh scale, and origin-offset placement path as real meshes.
   glPushMatrix();
-  glTranslated(it.x, it.y, it.z);
-  glRotated(qRadiansToDegrees(it.roll), 1.0, 0.0, 0.0);
-  glRotated(qRadiansToDegrees(it.pitch), 0.0, 1.0, 0.0);
-  glRotated(qRadiansToDegrees(it.yaw), 0.0, 0.0, 1.0);
+  apply_urdf_pose_gl(it.x, it.y, it.z, it.roll, it.pitch, it.yaw);
   if (it.visual_origin_applied) {
-    glTranslated(it.visual_origin_x, it.visual_origin_y, it.visual_origin_z);
-    glRotated(qRadiansToDegrees(it.visual_origin_roll), 1.0, 0.0, 0.0);
-    glRotated(qRadiansToDegrees(it.visual_origin_pitch), 0.0, 1.0, 0.0);
-    glRotated(qRadiansToDegrees(it.visual_origin_yaw), 0.0, 0.0, 1.0);
+    apply_urdf_pose_gl(it.visual_origin_x, it.visual_origin_y, it.visual_origin_z, it.visual_origin_roll, it.visual_origin_pitch, it.visual_origin_yaw);
   }
-  glRotated(qRadiansToDegrees(it.mesh_r), 1.0, 0.0, 0.0);
-  glRotated(qRadiansToDegrees(it.mesh_p), 0.0, 1.0, 0.0);
-  glRotated(qRadiansToDegrees(it.mesh_y), 0.0, 0.0, 1.0);
+  apply_urdf_rpy_gl(it.mesh_r, it.mesh_p, it.mesh_y);
   if (it.has_origin_offset) glTranslated(it.origin_offset_x, it.origin_offset_y, it.origin_offset_z);
   glScaled(it.mesh_scale_x, it.mesh_scale_y, it.mesh_scale_z);
 
@@ -3662,19 +3656,11 @@ bool Scene3DViewportWidget::mesh_world_bounds_for_item(const ScenePreviewWidget:
   if (!cache.loaded || !cache.valid || !cache.has_bounds) return false;
 
   QMatrix4x4 transform;
-  transform.translate(item.x, item.y, item.z);
-  transform.rotate(qRadiansToDegrees(item.roll), 1.0f, 0.0f, 0.0f);
-  transform.rotate(qRadiansToDegrees(item.pitch), 0.0f, 1.0f, 0.0f);
-  transform.rotate(qRadiansToDegrees(item.yaw), 0.0f, 0.0f, 1.0f);
+  apply_urdf_pose_matrix(transform, item.x, item.y, item.z, item.roll, item.pitch, item.yaw);
   if (item.visual_origin_applied) {
-    transform.translate(item.visual_origin_x, item.visual_origin_y, item.visual_origin_z);
-    transform.rotate(qRadiansToDegrees(item.visual_origin_roll), 1.0f, 0.0f, 0.0f);
-    transform.rotate(qRadiansToDegrees(item.visual_origin_pitch), 0.0f, 1.0f, 0.0f);
-    transform.rotate(qRadiansToDegrees(item.visual_origin_yaw), 0.0f, 0.0f, 1.0f);
+    apply_urdf_pose_matrix(transform, item.visual_origin_x, item.visual_origin_y, item.visual_origin_z, item.visual_origin_roll, item.visual_origin_pitch, item.visual_origin_yaw);
   }
-  transform.rotate(qRadiansToDegrees(item.mesh_r), 1.0f, 0.0f, 0.0f);
-  transform.rotate(qRadiansToDegrees(item.mesh_p), 0.0f, 1.0f, 0.0f);
-  transform.rotate(qRadiansToDegrees(item.mesh_y), 0.0f, 0.0f, 1.0f);
+  apply_urdf_rpy_matrix(transform, item.mesh_r, item.mesh_p, item.mesh_y);
   if (item.has_origin_offset) transform.translate(item.origin_offset_x, item.origin_offset_y, item.origin_offset_z);
   transform.scale(item.mesh_scale_x, item.mesh_scale_y, item.mesh_scale_z);
 

--- a/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
+++ b/workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp
@@ -91,11 +91,34 @@ TEST(Scene3DMeshPreviewRegression, RealSenseCameraPrimitiveUsesMeshAlignedSurrog
   const auto generic = src.find("void Scene3DViewportWidget::draw_camera_body_with_frustum", surrogate);
   ASSERT_NE(generic, std::string::npos);
   const std::string body = src.substr(surrogate, generic - surrogate);
-  EXPECT_NE(body.find("glTranslated(it.x, it.y, it.z)"), std::string::npos);
+  EXPECT_NE(body.find("apply_urdf_pose_gl(it.x, it.y, it.z, it.roll, it.pitch, it.yaw)"), std::string::npos);
   EXPECT_NE(body.find("if (it.visual_origin_applied)"), std::string::npos);
-  EXPECT_NE(body.find("glRotated(qRadiansToDegrees(it.mesh_r)"), std::string::npos);
+  EXPECT_NE(body.find("apply_urdf_rpy_gl(it.mesh_r, it.mesh_p, it.mesh_y)"), std::string::npos);
   EXPECT_NE(body.find("if (it.has_origin_offset) glTranslated(it.origin_offset_x"), std::string::npos);
   EXPECT_NE(body.find("glScaled(it.mesh_scale_x, it.mesh_scale_y, it.mesh_scale_z)"), std::string::npos);
+}
+
+TEST(Scene3DMeshPreviewRegression, UsesUrdfRvizRpyOrderForGeneratedVisuals)
+{
+  const std::string src = load_file(std::string(WORKCELL_BUILDER_SOURCE_DIR) + "/gui/scene3d_viewport_widget.cpp");
+  ASSERT_FALSE(src.empty());
+
+  const auto helper = src.find("void apply_urdf_rpy_gl(double roll, double pitch, double yaw)");
+  ASSERT_NE(helper, std::string::npos);
+  const auto helper_end = src.find("void apply_urdf_pose_gl", helper);
+  ASSERT_NE(helper_end, std::string::npos);
+  const std::string helper_body = src.substr(helper, helper_end - helper);
+  const auto yaw = helper_body.find("glRotated(qRadiansToDegrees(yaw)");
+  const auto pitch = helper_body.find("glRotated(qRadiansToDegrees(pitch)");
+  const auto roll = helper_body.find("glRotated(qRadiansToDegrees(roll)");
+  ASSERT_NE(yaw, std::string::npos);
+  ASSERT_NE(pitch, std::string::npos);
+  ASSERT_NE(roll, std::string::npos);
+  EXPECT_LT(yaw, pitch);
+  EXPECT_LT(pitch, roll);
+
+  EXPECT_NE(src.find("apply_urdf_pose_matrix(final_transform, it.x, it.y, it.z, it.roll, it.pitch, it.yaw)"), std::string::npos);
+  EXPECT_NE(src.find("apply_urdf_pose_gl(it.x, it.y, it.z, it.roll, it.pitch, it.yaw)"), std::string::npos);
 }
 
 TEST(Scene3DMeshPreviewRegression, KeepsScene3DDiagnosticsSummaryLine)


### PR DESCRIPTION
### Motivation
- Scene3D showed UR5 visuals as disconnected/exploded despite meshes resolving (`missing_mesh=0` and transform diagnostics present), indicating a transform composition parity problem with RViz/`robot_state_publisher` rather than asset resolution.
- The root cause was that Scene3D applied roll/pitch/yaw in X/Y/Z order, whereas URDF/RViz uses fixed-axis RPY composed as `Rz(yaw) * Ry(pitch) * Rx(roll)`, causing incorrect visual poses when composing joint origins + visual origins.

### Description
- Added URDF-parity transform helpers in `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`: `apply_urdf_rpy_gl`, `apply_urdf_pose_gl`, `apply_urdf_rpy_matrix`, and `apply_urdf_pose_matrix` to centralize Z/Y/X fixed-axis RPY composition for both GL rendering and `QMatrix4x4` CPU paths.
- Replaced ad-hoc `glTranslated`/`glRotated` and `QMatrix4x4::rotate` sequences with the new helpers in rendering and bounds/validation code paths including primitive rendering, mesh preview drawing, final-span validation, mesh world-bounds computation, and RealSense surrogate rendering so CPU diagnostics and GL rendering share the same convention.
- Updated the focused regression test `workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp` to assert the presence of the helpers and the Z/Y/X URDF rotation order and to verify the shared helper usage in the relevant rendering paths.
- Files changed: `workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp`, `workcell_builder/workcell_builder/test/scene3d_mesh_preview_regression_test.cpp` (commit on branch `codex/fix-scene3d-ur5-rviz-transform-parity`).

### Testing
- Ran `python3 scripts/extract_scene_urdf_visual_mesh_index.py --scene ur5_2f_test --workspace-root /workspace --no-write` which completed and reported 7 UR5 visual mesh items generated (mesh resolution succeeded) indicating the extractor still resolves assets correctly (PASS).
- Ran `git diff --check` to verify no whitespace or diff-check issues (PASS).
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but the build was blocked because `/opt/ros/humble/setup.bash` is not present in this container (BLOCKED).
- Attempted the Scene3D GUI smoke runner `python3 scripts/run_workcell_builder_scene3d_gui_smoke.py ...` but it was blocked because the expected workspace/install tree and `workcell_builder` executable were not available in this environment (BLOCKED), so automated GUI screenshot/manual visual check was not performed.
- No changes touch launch files, controllers, runtime services, or hardware motion and no real hardware motion was used.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33afd9b974833186f6ad6d1aef84ca)