### PR TITLE
Use baked world visual transforms for generated URDF visuals in Scene3D

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -7212,6 +7212,8 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
   int robot_mesh_missing_count = 0;
   int transform_chain_applied_count = 0;
   int visual_origin_applied_count = 0;
+  int baked_world_visual_transform_count = 0;
+  int legacy_viewport_transform_count = 0;
   bool robot_bounds_initialized = false;
   QVector3D robot_aabb_min;
   QVector3D robot_aabb_max;
@@ -7230,6 +7232,11 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
     }
     if (p.has_origin_offset || qAbs(p.mesh_r) > 1e-9 || qAbs(p.mesh_p) > 1e-9 || qAbs(p.mesh_y) > 1e-9) {
       ++transform_chain_applied_count;
+    }
+    if (p.has_baked_world_visual_transform) {
+      ++baked_world_visual_transform_count;
+    } else {
+      ++legacy_viewport_transform_count;
     }
     const QVector3D half_span(qMax(0.0, p.sx) * 0.5f, qMax(0.0, p.sy) * 0.5f, qMax(0.0, p.sz) * 0.5f);
     const QVector3D item_min(p.x - half_span.x(), p.y - half_span.y(), p.z - half_span.z());
@@ -7261,6 +7268,8 @@ void MainWindow::apply_scene3d_preview_layer_filters(bool log_change)
   diagnostics["robot_mesh_missing_count"] = robot_mesh_missing_count;
   diagnostics["transform_chain_applied_count"] = transform_chain_applied_count;
   diagnostics["visual_origin_applied_count"] = visual_origin_applied_count;
+  diagnostics["baked_world_visual_transform_count"] = baked_world_visual_transform_count;
+  diagnostics["legacy_viewport_transform_count"] = legacy_viewport_transform_count;
   diagnostics["camera_fit_target"] = QString("product_full_workcell_isometric");
   diagnostics["robot_pose_source"] = robot_pose_source;
   diagnostics["robot_base_frame"] = robot_base_frame;
@@ -8219,6 +8228,8 @@ void MainWindow::populate_scene_hierarchy()
   int stale_or_absolute_only_mesh_index_count = 0;
   int transform_chain_applied_count = 0;
   int visual_origin_applied_count = 0;
+  int baked_world_visual_transform_count = 0;
+  int legacy_viewport_transform_count = 0;
   int missing_chain_warning_count = 0;
   {
     QStringList detected_asset_roots;
@@ -8306,6 +8317,10 @@ void MainWindow::populate_scene_hierarchy()
           const YAML::Node world_pose = workcell_builder::yaml_map_key(v, "world_pose");
           const YAML::Node world_xyz = workcell_builder::yaml_map_key(world_pose, "xyz");
           const YAML::Node world_rpy = workcell_builder::yaml_map_key(world_pose, "rpy");
+          const YAML::Node baked_world_visual_pose = workcell_builder::yaml_map_key(v, "baked_world_visual_pose");
+          const YAML::Node baked_world_visual_pose_xyz = workcell_builder::yaml_map_key(baked_world_visual_pose, "xyz");
+          const YAML::Node baked_world_visual_pose_rpy = workcell_builder::yaml_map_key(baked_world_visual_pose, "rpy");
+          const YAML::Node baked_world_visual_matrix = workcell_builder::yaml_map_key(v, "baked_world_visual_matrix");
           const YAML::Node visual_origin = workcell_builder::yaml_map_key(v, "visual_origin");
           const YAML::Node visual_origin_xyz = workcell_builder::yaml_map_key(visual_origin, "xyz");
           const YAML::Node visual_origin_rpy = workcell_builder::yaml_map_key(visual_origin, "rpy");
@@ -8449,15 +8464,63 @@ void MainWindow::populate_scene_hierarchy()
           p.yaw = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(rpy,2).as<double>(0.0), QStringLiteral("pose.rpy[2]"), &p.warnings);
           p.chain_pose_x = p.x; p.chain_pose_y = p.y; p.chain_pose_z = p.z;
           p.chain_pose_roll = p.roll; p.chain_pose_pitch = p.pitch; p.chain_pose_yaw = p.yaw;
+          if (baked_world_visual_pose_xyz && baked_world_visual_pose_rpy &&
+              baked_world_visual_pose_xyz.IsSequence() && baked_world_visual_pose_rpy.IsSequence() &&
+              baked_world_visual_pose_xyz.size() >= 3 && baked_world_visual_pose_rpy.size() >= 3) {
+            p.x = workcell_builder::yaml_seq_index(baked_world_visual_pose_xyz,0).as<double>(0.0);
+            p.y = workcell_builder::yaml_seq_index(baked_world_visual_pose_xyz,1).as<double>(0.0);
+            p.z = workcell_builder::yaml_seq_index(baked_world_visual_pose_xyz,2).as<double>(0.0);
+            p.roll = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(baked_world_visual_pose_rpy,0).as<double>(0.0), QStringLiteral("baked_world_visual_pose.rpy[0]"), &p.warnings);
+            p.pitch = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(baked_world_visual_pose_rpy,1).as<double>(0.0), QStringLiteral("baked_world_visual_pose.rpy[1]"), &p.warnings);
+            p.yaw = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(baked_world_visual_pose_rpy,2).as<double>(0.0), QStringLiteral("baked_world_visual_pose.rpy[2]"), &p.warnings);
+            p.has_baked_world_visual_transform = true;
+            p.baked_world_visual_transform_source = QStringLiteral("generated/scene_visual_mesh_index.json:baked_world_visual_pose");
+            p.transform_chain_applied = false;
+            p.visual_origin_applied = false;
+          }
+          if (baked_world_visual_matrix && baked_world_visual_matrix.IsSequence() &&
+              (baked_world_visual_matrix.size() == 16 || baked_world_visual_matrix.size() == 4)) {
+            bool matrix_loaded = false;
+            if (baked_world_visual_matrix.size() == 16) {
+              for (std::size_t i = 0; i < 16; ++i) {
+                p.baked_world_visual_matrix[i] = workcell_builder::yaml_seq_index(baked_world_visual_matrix, i).as<double>(i % 5 == 0 ? 1.0 : 0.0);
+              }
+              matrix_loaded = true;
+            } else {
+              matrix_loaded = true;
+              for (std::size_t row = 0; row < 4; ++row) {
+                const YAML::Node row_node = workcell_builder::yaml_seq_index(baked_world_visual_matrix, row);
+                if (!row_node || !row_node.IsSequence() || row_node.size() < 4) {
+                  matrix_loaded = false;
+                  break;
+                }
+                for (std::size_t col = 0; col < 4; ++col) {
+                  p.baked_world_visual_matrix[row * 4 + col] = workcell_builder::yaml_seq_index(row_node, col).as<double>(row == col ? 1.0 : 0.0);
+                }
+              }
+            }
+            if (matrix_loaded) {
+              p.has_baked_world_visual_transform = true;
+              p.has_baked_world_visual_matrix = true;
+              p.baked_world_visual_transform_source = QStringLiteral("generated/scene_visual_mesh_index.json:baked_world_visual_matrix");
+              p.transform_chain_applied = false;
+              p.visual_origin_applied = false;
+            }
+          }
           const bool transform_status_resolved =
             transform_status == QStringLiteral("resolved") ||
             transform_status == QStringLiteral("ok") ||
             transform_status == QStringLiteral("static_fallback") ||
             transform_status == QStringLiteral("static_fallback_parent") ||
             transform_status == QStringLiteral("static_mesh_resolved");
-          p.transform_chain_applied = transform_status_resolved;
+          p.transform_chain_applied = p.has_baked_world_visual_transform ? false : transform_status_resolved;
           if (p.transform_chain_applied) ++transform_chain_applied_count;
-          if (!p.transform_chain_applied) {
+          if (p.has_baked_world_visual_transform) {
+            ++baked_world_visual_transform_count;
+          } else {
+            ++legacy_viewport_transform_count;
+          }
+          if (!p.has_baked_world_visual_transform && !p.transform_chain_applied) {
             ++missing_chain_warning_count;
             const QString transform_status_for_warning = transform_status.isEmpty() ? QStringLiteral("missing") : transform_status;
             p.warnings << QStringLiteral("Preview warning: missing/broken URDF chain; identity fallback avoided (transform_status=%1)").arg(transform_status_for_warning);
@@ -8480,7 +8543,8 @@ void MainWindow::populate_scene_hierarchy()
           if (visual_origin_xyz && visual_origin_rpy &&
               visual_origin_xyz.IsSequence() && visual_origin_rpy.IsSequence() &&
               visual_origin_xyz.size() >= 3 && visual_origin_rpy.size() >= 3 &&
-              !visual_origin_already_in_pose) {
+              !visual_origin_already_in_pose &&
+              !p.has_baked_world_visual_transform) {
             p.visual_origin_x = workcell_builder::yaml_seq_index(visual_origin_xyz,0).as<double>(0.0);
             p.visual_origin_y = workcell_builder::yaml_seq_index(visual_origin_xyz,1).as<double>(0.0);
             p.visual_origin_z = workcell_builder::yaml_seq_index(visual_origin_xyz,2).as<double>(0.0);
@@ -8680,9 +8744,11 @@ void MainWindow::populate_scene_hierarchy()
       append_studio_log(QString("Resolved source path diagnostics: stale_resolved_source_path=%1 package_uri_resolved_after_stale=%2")
         .arg(stale_resolved_source_path_count)
         .arg(package_uri_resolved_after_stale_resolved_source_path));
-      append_studio_log(QString("Transform diagnostics: transform_chain_applied_count=%1 visual_origin_applied_count=%2 robot_base_frame=%3 robot_world_pose=%4 missing_chain_warnings=%5")
+      append_studio_log(QString("Transform diagnostics: transform_chain_applied_count=%1 visual_origin_applied_count=%2 baked_world_visual_transform_count=%3 legacy_viewport_transform_count=%4 robot_base_frame=%5 robot_world_pose=%6 missing_chain_warnings=%7")
         .arg(transform_chain_applied_count)
         .arg(visual_origin_applied_count)
+        .arg(baked_world_visual_transform_count)
+        .arg(legacy_viewport_transform_count)
         .arg(robot_base_frame)
         .arg(robot_world_pose)
         .arg(missing_chain_warning_count));

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.cpp
@@ -148,6 +148,35 @@ void apply_urdf_pose_matrix(QMatrix4x4 & transform, double x, double y, double z
   apply_urdf_rpy_matrix(transform, roll, pitch, yaw);
 }
 
+QMatrix4x4 authoritative_world_visual_transform(const ScenePreviewWidget::PreviewItem & item)
+{
+  QMatrix4x4 transform;
+  if (item.has_baked_world_visual_transform) {
+    if (item.has_baked_world_visual_matrix) {
+      for (int row = 0; row < 4; ++row) {
+        for (int col = 0; col < 4; ++col) {
+          transform(row, col) = static_cast<float>(item.baked_world_visual_matrix[row * 4 + col]);
+        }
+      }
+    } else {
+      apply_urdf_pose_matrix(transform, item.x, item.y, item.z, item.roll, item.pitch, item.yaw);
+    }
+    return transform;
+  }
+  apply_urdf_pose_matrix(transform, item.x, item.y, item.z, item.roll, item.pitch, item.yaw);
+  if (item.visual_origin_applied) {
+    apply_urdf_pose_matrix(transform, item.visual_origin_x, item.visual_origin_y, item.visual_origin_z,
+                           item.visual_origin_roll, item.visual_origin_pitch, item.visual_origin_yaw);
+  }
+  return transform;
+}
+
+void apply_authoritative_world_visual_transform_gl(const ScenePreviewWidget::PreviewItem & item)
+{
+  const QMatrix4x4 transform = authoritative_world_visual_transform(item);
+  glMultMatrixf(transform.constData());
+}
+
 bool item_has_credible_mesh_handoff(const ScenePreviewWidget::PreviewItem & item)
 {
   const QString mesh_path = item.mesh_path.trimmed();
@@ -249,11 +278,7 @@ bool primitive_world_bounds_for_item(const ScenePreviewWidget::PreviewItem & ite
     return true;
   }
 
-  QMatrix4x4 transform;
-  apply_urdf_pose_matrix(transform, item.x, item.y, item.z, item.roll, item.pitch, item.yaw);
-  if (item.visual_origin_applied) {
-    apply_urdf_pose_matrix(transform, item.visual_origin_x, item.visual_origin_y, item.visual_origin_z, item.visual_origin_roll, item.visual_origin_pitch, item.visual_origin_yaw);
-  }
+  QMatrix4x4 transform = authoritative_world_visual_transform(item);
   transform.scale(item.mesh_scale_x, item.mesh_scale_y, item.mesh_scale_z);
 
   QVector3D wmin(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
@@ -982,14 +1007,23 @@ void populate_runtime_transform_counters(
 {
   int transform_chain_applied_count = 0;
   int visual_origin_applied_count = 0;
+  int baked_world_visual_transform_count = 0;
+  int legacy_viewport_transform_count = 0;
   for (const auto & item : items) {
     const bool generated_or_locked_visual = is_generated_urdf_visual_item(item) || is_locked_urdf_item(item);
     if (!generated_or_locked_visual) continue;
+    if (item.has_baked_world_visual_transform) {
+      ++baked_world_visual_transform_count;
+      continue;
+    }
+    ++legacy_viewport_transform_count;
     if (item.transform_chain_applied) ++transform_chain_applied_count;
     if (item.visual_origin_applied) ++visual_origin_applied_count;
   }
   counters.transform_chain_applied_count = transform_chain_applied_count;
   counters.visual_origin_applied_count = visual_origin_applied_count;
+  counters.baked_world_visual_transform_count = baked_world_visual_transform_count;
+  counters.legacy_viewport_transform_count = legacy_viewport_transform_count;
 }
 
 bool is_raw_generated_bounds_only_item(const ScenePreviewWidget::PreviewItem & it)
@@ -1383,7 +1417,7 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
     last_scene_load_summary_scene_name_ = scene_key;
     last_scene_load_summary_warning_signature_ = warning_signature;
     qInfo().noquote() << QStringLiteral(
-      "Scene3D scene load: scene=%1 received=%2 visible=%3 mesh_sources=%4 urdf_primitives=%5 overlays=%6 mesh_cache=%7 warnings=%8")
+      "Scene3D scene load: scene=%1 received=%2 visible=%3 mesh_sources=%4 urdf_primitives=%5 overlays=%6 mesh_cache=%7 baked_world_visual_transform_count=%8 legacy_viewport_transform_count=%9 warnings=%10")
       .arg(scene_key)
       .arg(last_render_counters.viewport_received_count)
       .arg(last_render_counters.visible_count)
@@ -1391,6 +1425,8 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
       .arg(last_render_counters.urdf_primitive_source_count)
       .arg(last_render_counters.overlay_count)
       .arg(last_render_counters.render_cache_count)
+      .arg(last_render_counters.baked_world_visual_transform_count)
+      .arg(last_render_counters.legacy_viewport_transform_count)
       .arg(scene_load_warning_tokens.isEmpty() ? QStringLiteral("none") : scene_load_warning_tokens.join(QLatin1Char(',')));
   }
   if (should_emit_scene_load_summary && !scene_load_warning_tokens.isEmpty()) {
@@ -1420,6 +1456,8 @@ void Scene3DViewportWidget::ingest_preview_items(const QVector<ScenePreviewWidge
       render_debug["locked_generated_urdf_visual_count"] = counters.locked_generated_urdf_visual_count;
       render_debug["transform_chain_applied_count"] = counters.transform_chain_applied_count;
       render_debug["visual_origin_applied_count"] = counters.visual_origin_applied_count;
+      render_debug["baked_world_visual_transform_count"] = counters.baked_world_visual_transform_count;
+      render_debug["legacy_viewport_transform_count"] = counters.legacy_viewport_transform_count;
       root["render_debug_counters"] = render_debug;
       out_file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
       out_file.close();
@@ -2242,10 +2280,7 @@ bool Scene3DViewportWidget::draw_urdf_primitive_geometry(const ScenePreviewWidge
   if (!item_has_valid_urdf_primitive(it)) return false;
 
   glPushMatrix();
-  apply_urdf_pose_gl(it.x, it.y, it.z, it.roll, it.pitch, it.yaw);
-  if (it.visual_origin_applied) {
-    apply_urdf_pose_gl(it.visual_origin_x, it.visual_origin_y, it.visual_origin_z, it.visual_origin_roll, it.visual_origin_pitch, it.visual_origin_yaw);
-  }
+  apply_authoritative_world_visual_transform_gl(it);
   glScaled(it.mesh_scale_x, it.mesh_scale_y, it.mesh_scale_z);
 
   if (type == QStringLiteral("box")) {
@@ -2833,11 +2868,7 @@ bool Scene3DViewportWidget::validate_mesh_final_span(const ScenePreviewWidget::P
   constexpr double kFinalSpanThresholdMeters = 50.0;
   const QVector3D raw_span = entry.local_span;
 
-  QMatrix4x4 final_transform;
-  apply_urdf_pose_matrix(final_transform, it.x, it.y, it.z, it.roll, it.pitch, it.yaw);
-  if (it.visual_origin_applied) {
-    apply_urdf_pose_matrix(final_transform, it.visual_origin_x, it.visual_origin_y, it.visual_origin_z, it.visual_origin_roll, it.visual_origin_pitch, it.visual_origin_yaw);
-  }
+  QMatrix4x4 final_transform = authoritative_world_visual_transform(it);
   apply_urdf_rpy_matrix(final_transform, it.mesh_r, it.mesh_p, it.mesh_y);
   if (it.has_origin_offset) {
     final_transform.translate(static_cast<float>(it.origin_offset_x), static_cast<float>(it.origin_offset_y), static_cast<float>(it.origin_offset_z));
@@ -3020,10 +3051,7 @@ bool Scene3DViewportWidget::draw_mesh_preview_if_available(const ScenePreviewWid
   }
 
   glPushMatrix();
-  apply_urdf_pose_gl(it.x, it.y, it.z, it.roll, it.pitch, it.yaw);
-  if (it.visual_origin_applied) {
-    apply_urdf_pose_gl(it.visual_origin_x, it.visual_origin_y, it.visual_origin_z, it.visual_origin_roll, it.visual_origin_pitch, it.visual_origin_yaw);
-  }
+  apply_authoritative_world_visual_transform_gl(it);
   apply_urdf_rpy_gl(it.mesh_r, it.mesh_p, it.mesh_y);
   if (preview_path && it.has_origin_offset) glTranslated(it.origin_offset_x, it.origin_offset_y, it.origin_offset_z);
   glScaled(it.mesh_scale_x, it.mesh_scale_y, it.mesh_scale_z);
@@ -3209,10 +3237,7 @@ void Scene3DViewportWidget::draw_realsense_d435_visual_surrogate(const ScenePrev
   // Preview-safe visual_surrogate for RealSense D435/D435i meshes whose DAE cannot be triangulated.
   // It uses the same pose, visual-origin, mesh RPY, mesh scale, and origin-offset placement path as real meshes.
   glPushMatrix();
-  apply_urdf_pose_gl(it.x, it.y, it.z, it.roll, it.pitch, it.yaw);
-  if (it.visual_origin_applied) {
-    apply_urdf_pose_gl(it.visual_origin_x, it.visual_origin_y, it.visual_origin_z, it.visual_origin_roll, it.visual_origin_pitch, it.visual_origin_yaw);
-  }
+  apply_authoritative_world_visual_transform_gl(it);
   apply_urdf_rpy_gl(it.mesh_r, it.mesh_p, it.mesh_y);
   if (it.has_origin_offset) glTranslated(it.origin_offset_x, it.origin_offset_y, it.origin_offset_z);
   glScaled(it.mesh_scale_x, it.mesh_scale_y, it.mesh_scale_z);
@@ -3655,11 +3680,7 @@ bool Scene3DViewportWidget::mesh_world_bounds_for_item(const ScenePreviewWidget:
   const MeshCacheEntry & cache = cache_it.value();
   if (!cache.loaded || !cache.valid || !cache.has_bounds) return false;
 
-  QMatrix4x4 transform;
-  apply_urdf_pose_matrix(transform, item.x, item.y, item.z, item.roll, item.pitch, item.yaw);
-  if (item.visual_origin_applied) {
-    apply_urdf_pose_matrix(transform, item.visual_origin_x, item.visual_origin_y, item.visual_origin_z, item.visual_origin_roll, item.visual_origin_pitch, item.visual_origin_yaw);
-  }
+  QMatrix4x4 transform = authoritative_world_visual_transform(item);
   apply_urdf_rpy_matrix(transform, item.mesh_r, item.mesh_p, item.mesh_y);
   if (item.has_origin_offset) transform.translate(item.origin_offset_x, item.origin_offset_y, item.origin_offset_z);
   transform.scale(item.mesh_scale_x, item.mesh_scale_y, item.mesh_scale_z);

--- a/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene3d_viewport_widget.h
@@ -118,6 +118,8 @@ public:
     int locked_generated_urdf_visual_count{ 0 };
     int transform_chain_applied_count{ 0 };
     int visual_origin_applied_count{ 0 };
+    int baked_world_visual_transform_count{ 0 };
+    int legacy_viewport_transform_count{ 0 };
     int overlay_count{ 0 };
     QString visual_quality_status{ QStringLiteral("UNAVAILABLE") };
     QStringList visual_quality_warnings;

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.cpp
@@ -694,6 +694,8 @@ ScenePreviewWidget::RenderDebugCounters ScenePreviewWidget::render_debug_counter
   out.locked_generated_urdf_visual_count = counters.locked_generated_urdf_visual_count;
   out.transform_chain_applied_count = counters.transform_chain_applied_count;
   out.visual_origin_applied_count = counters.visual_origin_applied_count;
+  out.baked_world_visual_transform_count = counters.baked_world_visual_transform_count;
+  out.legacy_viewport_transform_count = counters.legacy_viewport_transform_count;
   out.visual_quality_status = counters.visual_quality_status;
   out.visual_quality_warnings = counters.visual_quality_warnings;
   out.labels_drawn = counters.labels_drawn;

--- a/workcell_builder/workcell_builder/gui/scene_preview_widget.h
+++ b/workcell_builder/workcell_builder/gui/scene_preview_widget.h
@@ -75,6 +75,15 @@ public:
     double visual_origin_roll{ 0.0 }, visual_origin_pitch{ 0.0 }, visual_origin_yaw{ 0.0 };
     bool transform_chain_applied{ false };
     bool visual_origin_applied{ false };
+    bool has_baked_world_visual_transform{ false };
+    QString baked_world_visual_transform_source;
+    bool has_baked_world_visual_matrix{ false };
+    double baked_world_visual_matrix[16]{
+      1.0, 0.0, 0.0, 0.0,
+      0.0, 1.0, 0.0, 0.0,
+      0.0, 0.0, 1.0, 0.0,
+      0.0, 0.0, 0.0, 1.0
+    };
     bool robot_candidate{ false };
     QString robot_classification_source;
     QString robot_base_frame;
@@ -230,6 +239,8 @@ public:
     int locked_generated_urdf_visual_count{ 0 };
     int transform_chain_applied_count{ 0 };
     int visual_origin_applied_count{ 0 };
+    int baked_world_visual_transform_count{ 0 };
+    int legacy_viewport_transform_count{ 0 };
     QString visual_quality_status{ QStringLiteral("UNAVAILABLE") };
     QStringList visual_quality_warnings;
     int labels_drawn{ 0 };


### PR DESCRIPTION
### Motivation
- Generated URDF visual indices can contain authoritative world-space placement that must not be recomposed through the legacy pose->visual_origin transform chain, so Scene3D needs a single canonical world transform for baked visuals to avoid double transforms and mismatches.
- Add observability to measure how many visuals use baked transforms vs the legacy viewport composition so ingestion/loader diagnostics can surface indexing quality and migration progress.

### Description
- Added baked-transform state to `PreviewItem` in `workcell_builder/workcell_builder/gui/scene_preview_widget.h` (`has_baked_world_visual_transform`, `baked_world_visual_transform_source`, `has_baked_world_visual_matrix`, and `baked_world_visual_matrix[16]`).
- In `mainwindow.cpp` the visual index loader now reads `baked_world_visual_pose` and `baked_world_visual_matrix` from `generated/scene_visual_mesh_index.json` and marks items as baked (sets `has_baked_world_visual_transform`, clears `transform_chain_applied`/`visual_origin_applied`, and records a `baked_world_visual_transform_source`).
- Implemented an authoritative transform helper in `scene3d_viewport_widget.cpp` (`authoritative_world_visual_transform` and `apply_authoritative_world_visual_transform_gl`) and updated all generated-URDF rendering and bounds code paths to use that transform followed by mesh intrinsic correction, origin-offset and scale, instead of composing multiple transform chains.
- Kept the legacy composition path for non-baked items and added runtime diagnostics and logs: `baked_world_visual_transform_count` and `legacy_viewport_transform_count` were added to `RenderDebugCounters` (both viewport and preview layers) and are emitted in scene-load logs and diagnostics JSON.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch conflicts and it passed.
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` and it completed successfully (existing optional generated-file warnings remained); the scene validator reported OK for that scene.
- Attempted `colcon build --symlink-install --packages-select workcell_builder` but did not run because `/opt/ros/humble/setup.bash` is not present in this container, so a full ROS/Humble build was not executed.
- Performed static checks and updated logs/diagnostics and confirmed `render_debug_counters` and preview counters include the new baked/legacy transform counters (no runtime failures observed during static validation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33e0c821148331a09d1cef91fb64bf)