### PR TITLE
Bake URDF visual transforms into generated mesh index and prefer baked pose in UI

### DIFF
--- a/scripts/extract_scene_urdf_visual_mesh_index.py
+++ b/scripts/extract_scene_urdf_visual_mesh_index.py
@@ -213,6 +213,40 @@ def xyz_rpy_from_tf(tf):
     else: roll=math.atan2(-tf[1][2],tf[1][1]); yaw=0.0
     return {"xyz":[x,y,z],"rpy":[roll,pitch,yaw]}
 
+def quaternion_from_tf(tf):
+    m00, m01, m02 = tf[0][0], tf[0][1], tf[0][2]
+    m10, m11, m12 = tf[1][0], tf[1][1], tf[1][2]
+    m20, m21, m22 = tf[2][0], tf[2][1], tf[2][2]
+    trace = m00 + m11 + m22
+    if trace > 0.0:
+        scale = math.sqrt(trace + 1.0) * 2.0
+        w = 0.25 * scale
+        x = (m21 - m12) / scale
+        y = (m02 - m20) / scale
+        z = (m10 - m01) / scale
+    elif m00 > m11 and m00 > m22:
+        scale = math.sqrt(1.0 + m00 - m11 - m22) * 2.0
+        w = (m21 - m12) / scale
+        x = 0.25 * scale
+        y = (m01 + m10) / scale
+        z = (m02 + m20) / scale
+    elif m11 > m22:
+        scale = math.sqrt(1.0 + m11 - m00 - m22) * 2.0
+        w = (m02 - m20) / scale
+        x = (m01 + m10) / scale
+        y = 0.25 * scale
+        z = (m12 + m21) / scale
+    else:
+        scale = math.sqrt(1.0 + m22 - m00 - m11) * 2.0
+        w = (m10 - m01) / scale
+        x = (m02 + m20) / scale
+        y = (m12 + m21) / scale
+        z = 0.25 * scale
+    norm = math.sqrt(x*x + y*y + z*z + w*w)
+    if norm > 1e-12:
+        x, y, z, w = x / norm, y / norm, z / norm, w / norm
+    return {"x": x, "y": y, "z": z, "w": w}
+
 
 
 def _repo_relative_path(path_value):
@@ -1142,11 +1176,14 @@ def extract_from_urdf(xml_text, package_map, include_diagnostics=False):
             if link_tf is None: link_tf=identity_tf()
             visual_tf=tf_from_xyz_rpy(vxyz, vrpy)
             link_world_pose=xyz_rpy_from_tf(link_tf)
-            expected_visual_pose=xyz_rpy_from_tf(matmul4(link_tf, visual_tf))
+            baked_world_visual_matrix=matmul4(link_tf, visual_tf)
+            baked_world_visual_pose=xyz_rpy_from_tf(baked_world_visual_matrix)
+            baked_world_visual_quaternion=quaternion_from_tf(baked_world_visual_matrix)
+            expected_visual_pose=baked_world_visual_pose
             # The generated pose is already the full visual world pose:
             # world/base -> joint origin -> joint axis rotation -> child link
             # -> visual origin. Scene3D must not apply visual_origin again.
-            pose=expected_visual_pose
+            pose=baked_world_visual_pose
             material_node=next((c for c in list(visual) if tag_name(c)=='material'),None)
             material={'name':'','color':None}
             if material_node is not None:
@@ -1161,7 +1198,7 @@ def extract_from_urdf(xml_text, package_map, include_diagnostics=False):
             joint_name=(joint_meta or {}).get('name','')
             joint_value=(joint_meta or {}).get('value',0.0)
             joint_axis=(joint_meta or {}).get('axis',[1.0,0.0,0.0])
-            common={'id':item_id,'link':lname,'visual':vname,'parent_link':root_link or '','joint_parent_link':(joint_meta or {}).get('parent',''),'pose':pose,'chain_pose':pose,'world_pose':link_pose,'link_world_pose':link_world_pose,'expected_visual_pose':expected_visual_pose,'visual_origin_applied_to_pose':True,'visual_origin':{'xyz':vxyz,'rpy':vrpy},'joint_name':joint_name,'joint_value':joint_value,'joint_axis':joint_axis,'material':material,'link_transform_status':link_status,'transform_status':link_status,'transform_chain':chain,'render_expected':True}
+            common={'id':item_id,'link':lname,'visual':vname,'parent_link':root_link or '','joint_parent_link':(joint_meta or {}).get('parent',''),'pose':pose,'chain_pose':pose,'world_pose':link_pose,'link_world_pose':link_world_pose,'expected_visual_pose':expected_visual_pose,'baked_world_visual_pose':baked_world_visual_pose,'baked_world_visual_matrix':baked_world_visual_matrix,'baked_world_visual_quaternion':baked_world_visual_quaternion,'baked_world_visual_transform_source':'urdf_fk_link_world_times_visual_origin','visual_origin_applied_to_pose':True,'visual_origin':{'xyz':vxyz,'rpy':vrpy},'joint_name':joint_name,'joint_value':joint_value,'joint_axis':joint_axis,'material':material,'link_transform_status':link_status,'transform_status':link_status,'transform_chain':chain,'render_expected':True}
             mesh=next((c for c in list(geom) if tag_name(c)=='mesh'),None)
             box=next((c for c in list(geom) if tag_name(c)=='box'),None)
             cyl=next((c for c in list(geom) if tag_name(c)=='cylinder'),None)

--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -8219,6 +8219,8 @@ void MainWindow::populate_scene_hierarchy()
   int stale_or_absolute_only_mesh_index_count = 0;
   int transform_chain_applied_count = 0;
   int visual_origin_applied_count = 0;
+  int baked_world_visual_pose_count = 0;
+  QString baked_world_visual_transform_source = QStringLiteral("urdf_fk_link_world_times_visual_origin");
   int missing_chain_warning_count = 0;
   {
     QStringList detected_asset_roots;
@@ -8301,8 +8303,17 @@ void MainWindow::populate_scene_hierarchy()
           else ++unknown_item_count;
           const bool render_expected = workcell_builder::yaml_map_key(v, "render_expected").as<bool>(false);
           const YAML::Node pose = workcell_builder::yaml_map_key(v, "pose");
-          const YAML::Node xyz = workcell_builder::yaml_map_key(pose, "xyz");
-          const YAML::Node rpy = workcell_builder::yaml_map_key(pose, "rpy");
+          const YAML::Node baked_world_visual_pose = workcell_builder::yaml_map_key(v, "baked_world_visual_pose");
+          const YAML::Node baked_xyz = workcell_builder::yaml_map_key(baked_world_visual_pose, "xyz");
+          const YAML::Node baked_rpy = workcell_builder::yaml_map_key(baked_world_visual_pose, "rpy");
+          const bool use_baked_world_visual_pose =
+            baked_xyz && baked_rpy && baked_xyz.IsSequence() && baked_rpy.IsSequence() &&
+            baked_xyz.size() >= 3 && baked_rpy.size() >= 3;
+          const YAML::Node xyz = use_baked_world_visual_pose ? baked_xyz : workcell_builder::yaml_map_key(pose, "xyz");
+          const YAML::Node rpy = use_baked_world_visual_pose ? baked_rpy : workcell_builder::yaml_map_key(pose, "rpy");
+          const QString transform_source = use_baked_world_visual_pose
+            ? QString::fromStdString(workcell_builder::yaml_map_value_or_empty(v, "baked_world_visual_transform_source")).trimmed()
+            : QStringLiteral("pose");
           const YAML::Node world_pose = workcell_builder::yaml_map_key(v, "world_pose");
           const YAML::Node world_xyz = workcell_builder::yaml_map_key(world_pose, "xyz");
           const YAML::Node world_rpy = workcell_builder::yaml_map_key(world_pose, "rpy");
@@ -8444,9 +8455,14 @@ void MainWindow::populate_scene_hierarchy()
           p.x = workcell_builder::yaml_seq_index(xyz,0).as<double>(0.0);
           p.y = workcell_builder::yaml_seq_index(xyz,1).as<double>(0.0);
           p.z = workcell_builder::yaml_seq_index(xyz,2).as<double>(0.0);
-          p.roll = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(rpy,0).as<double>(0.0), QStringLiteral("pose.rpy[0]"), &p.warnings);
-          p.pitch = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(rpy,1).as<double>(0.0), QStringLiteral("pose.rpy[1]"), &p.warnings);
-          p.yaw = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(rpy,2).as<double>(0.0), QStringLiteral("pose.rpy[2]"), &p.warnings);
+          const QString pose_field_name = use_baked_world_visual_pose ? QStringLiteral("baked_world_visual_pose") : QStringLiteral("pose");
+          p.roll = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(rpy,0).as<double>(0.0), QStringLiteral("%1.rpy[0]").arg(pose_field_name), &p.warnings);
+          p.pitch = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(rpy,1).as<double>(0.0), QStringLiteral("%1.rpy[1]").arg(pose_field_name), &p.warnings);
+          p.yaw = normalize_angle_radians_with_guard(workcell_builder::yaml_seq_index(rpy,2).as<double>(0.0), QStringLiteral("%1.rpy[2]").arg(pose_field_name), &p.warnings);
+          if (use_baked_world_visual_pose) {
+            ++baked_world_visual_pose_count;
+            if (!transform_source.isEmpty()) baked_world_visual_transform_source = transform_source;
+          }
           p.chain_pose_x = p.x; p.chain_pose_y = p.y; p.chain_pose_z = p.z;
           p.chain_pose_roll = p.roll; p.chain_pose_pitch = p.pitch; p.chain_pose_yaw = p.yaw;
           const bool transform_status_resolved =
@@ -8477,7 +8493,9 @@ void MainWindow::populate_scene_hierarchy()
           }
           p.robot_world_pose = robot_world_pose;
           const bool visual_origin_already_in_pose = workcell_builder::yaml_map_key(v, "visual_origin_applied_to_pose").as<bool>(false);
-          if (visual_origin_xyz && visual_origin_rpy &&
+          if (use_baked_world_visual_pose) {
+            p.visual_origin_applied = false;
+          } else if (visual_origin_xyz && visual_origin_rpy &&
               visual_origin_xyz.IsSequence() && visual_origin_rpy.IsSequence() &&
               visual_origin_xyz.size() >= 3 && visual_origin_rpy.size() >= 3 &&
               !visual_origin_already_in_pose) {
@@ -8680,9 +8698,15 @@ void MainWindow::populate_scene_hierarchy()
       append_studio_log(QString("Resolved source path diagnostics: stale_resolved_source_path=%1 package_uri_resolved_after_stale=%2")
         .arg(stale_resolved_source_path_count)
         .arg(package_uri_resolved_after_stale_resolved_source_path));
-      append_studio_log(QString("Transform diagnostics: transform_chain_applied_count=%1 visual_origin_applied_count=%2 robot_base_frame=%3 robot_world_pose=%4 missing_chain_warnings=%5")
+      if (baked_world_visual_pose_count > 0) {
+        append_studio_log(QString("Transform source: baked_world_visual_pose from generated/scene_visual_mesh_index.json (count=%1, source=%2)")
+          .arg(baked_world_visual_pose_count)
+          .arg(baked_world_visual_transform_source));
+      }
+      append_studio_log(QString("Transform diagnostics: transform_chain_applied_count=%1 visual_origin_applied_count=%2 baked_world_visual_pose_count=%3 robot_base_frame=%4 robot_world_pose=%5 missing_chain_warnings=%6")
         .arg(transform_chain_applied_count)
         .arg(visual_origin_applied_count)
+        .arg(baked_world_visual_pose_count)
         .arg(robot_base_frame)
         .arg(robot_world_pose)
         .arg(missing_chain_warning_count));


### PR DESCRIPTION
### Motivation
- Ensure generated URDF visual items carry authoritative world-space transforms computed by URDF forward-kinematics (`link_tf * visual_tf`) so the preview uses exact baked transforms instead of re-computing them in the viewport, preventing double-application of `visual_origin` and improving preview determinism.

### Description
- Added baked transform outputs in `scripts/extract_scene_urdf_visual_mesh_index.py`: `baked_world_visual_pose`, `baked_world_visual_matrix`, `baked_world_visual_quaternion`, and `baked_world_visual_transform_source`, computed from `matmul4(link_tf, visual_tf)`, and made `pose` mirror `baked_world_visual_pose` for compatibility; also added a `quaternion_from_tf` helper.
- Updated the Workcell Builder loader in `workcell_builder/workcell_builder/gui/mainwindow.cpp` to prefer `baked_world_visual_pose` over legacy `pose` when ingesting generated URDF visuals and to read the transform source string when present.
- Ensured viewport behavior does not reapply `visual_origin` when a baked world visual pose is used by setting `p.visual_origin_applied = false` whenever the baked pose is used, and added bookkeeping counters for baked-pose usage.
- Added a diagnostic log message reporting the transform source, for example: `Transform source: baked_world_visual_pose from generated/scene_visual_mesh_index.json (count=<n>, source=<token>)`, while retaining `pose`, `expected_visual_pose`, `world_pose`, and `link_world_pose` fields for backward compatibility.

### Testing
- Ran Python syntax check with `python3 -m py_compile scripts/extract_scene_urdf_visual_mesh_index.py`, which passed.
- Executed a focused extractor assertion via an inline Python run that parsed a minimal URDF and verified `pose == baked_world_visual_pose`, the baked matrix translation components, the quaternion, and the `baked_world_visual_transform_source`, which succeeded.
- Ran `python3 scripts/validate_builder_generated_scene.py scenes/ur5_2f_test --json` and `python3 scripts/extract_scene_urdf_visual_mesh_index.py --scene scenes/ur5_2f_test --no-write`, both of which completed successfully in this environment.
- Attempted to build the GUI package with `colcon build --symlink-install --packages-select workcell_builder` but the container lacked a ROS Humble install (`/opt/ros/humble/setup.bash`), so the full package build was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33e0aa32688331bf63dba9aaf74f37)