### PR TITLE
Validate UR5 rendered visual adjacency and tool attachment

### DIFF
--- a/scripts/validate_ur5_scene3d_transform_plausibility.py
+++ b/scripts/validate_ur5_scene3d_transform_plausibility.py
@@ -4,18 +4,18 @@
 This is an offline validator: it only reads scene_visual_mesh_index.json and does
 not require ROS, RViz, a GUI, screenshots, launch files, or EPD.
 """
+
 from __future__ import annotations
 
 import argparse
 import json
 import math
-import sys
 from pathlib import Path
 from typing import Any
 
 BASE_ALIASES = ("base_link_inertia", "base", "base_link")
 REQUIRED_CHAIN = (
-    "base",
+    "base_link",
     "shoulder_link",
     "upper_arm_link",
     "forearm_link",
@@ -24,7 +24,7 @@ REQUIRED_CHAIN = (
     "wrist_3_link",
 )
 LINK_ALIASES: dict[str, tuple[str, ...]] = {
-    "base": BASE_ALIASES,
+    "base_link": BASE_ALIASES,
     "shoulder_link": ("shoulder_link",),
     "upper_arm_link": ("upper_arm_link",),
     "forearm_link": ("forearm_link",),
@@ -38,8 +38,10 @@ LINK_ALIASES: dict[str, tuple[str, ...]] = {
 # without rejecting harmless mesh-origin differences.
 BASE_ORIGIN_MAX_M = 0.25
 ADJACENT_MAX_M = 0.70
+VISUAL_ADJACENT_MIN_M = 0.025
+TOOL_ATTACHMENT_MAX_M = 0.35
 ADJACENT_LIMITS_M: dict[tuple[str, str], float] = {
-    ("base", "shoulder_link"): 0.25,
+    ("base_link", "shoulder_link"): 0.25,
     ("shoulder_link", "upper_arm_link"): 0.35,
     ("upper_arm_link", "forearm_link"): 0.55,
     ("forearm_link", "wrist_1_link"): 0.55,
@@ -62,26 +64,37 @@ def _as_xyz(value: Any) -> list[float] | None:
     return xyz
 
 
-def _pose_xyz(record: dict[str, Any]) -> list[float] | None:
-    # Prefer the explicit link frame when present. Generated Scene3D visual
-    # poses may already include URDF visual_origin for rendering, while physical
-    # chain connectivity should be checked at the child-link frame.
-    for pose_key in ("link_world_pose", "world_pose"):
+def _pose_xyz_from_keys(
+    record: dict[str, Any],
+    pose_keys: tuple[str, ...],
+    scalar_keys: tuple[str, ...] = (),
+) -> list[float] | None:
+    for pose_key in pose_keys:
         pose = record.get(pose_key)
         if isinstance(pose, dict):
             xyz = _as_xyz(pose.get("xyz"))
             if xyz is not None:
                 return xyz
-    pose = record.get("pose")
-    if isinstance(pose, dict):
-        xyz = _as_xyz(pose.get("xyz"))
-        if xyz is not None:
-            return xyz
-    for key in ("xyz", "world_xyz", "translation"):
+    for key in scalar_keys:
         xyz = _as_xyz(record.get(key))
         if xyz is not None:
             return xyz
     return None
+
+
+def _link_frame_xyz(record: dict[str, Any]) -> list[float] | None:
+    return _pose_xyz_from_keys(
+        record, ("link_world_pose", "world_pose"), ("world_xyz", "xyz", "translation")
+    )
+
+
+def _visual_pose_xyz(record: dict[str, Any]) -> list[float] | None:
+    # Renderer adjacency must use the rendered visual center, not only the
+    # physical link frame.  baked_world_visual_pose is emitted by newer indexes;
+    # pose is the legacy rendered pose with visual_origin already applied.
+    return _pose_xyz_from_keys(
+        record, ("baked_world_visual_pose", "pose"), ("world_xyz", "xyz", "translation")
+    )
 
 
 def _diagnostic_records(data: dict[str, Any]) -> list[dict[str, Any]]:
@@ -107,7 +120,9 @@ def _record_link(record: dict[str, Any]) -> str:
     return ""
 
 
-def _locate_link_poses(data: dict[str, Any]) -> tuple[dict[str, list[float]], list[str]]:
+def _locate_link_poses(
+    data: dict[str, Any], *, visual: bool = False
+) -> tuple[dict[str, list[float]], list[str]]:
     records = _diagnostic_records(data)
     records.extend(x for x in data.get("visual_items", []) if isinstance(x, dict))
     poses: dict[str, list[float]] = {}
@@ -117,7 +132,7 @@ def _locate_link_poses(data: dict[str, Any]) -> tuple[dict[str, list[float]], li
             link = _record_link(record)
             if link not in aliases:
                 continue
-            xyz = _pose_xyz(record)
+            xyz = _visual_pose_xyz(record) if visual else _link_frame_xyz(record)
             if xyz is None:
                 # Preserve the missing/non-finite failure for this canonical link.
                 continue
@@ -137,24 +152,42 @@ def validate_index(index_path: Path) -> dict[str, Any]:
     try:
         data = json.loads(index_path.read_text(encoding="utf-8"))
     except Exception as exc:  # noqa: BLE001 - CLI should report parse/path failures clearly.
-        return {"ok": False, "index": str(index_path), "checks": [], "errors": [f"Failed to load JSON index: {exc}"]}
+        return {
+            "ok": False,
+            "index": str(index_path),
+            "checks": [],
+            "errors": [f"Failed to load JSON index: {exc}"],
+        }
 
-    poses, sources = _locate_link_poses(data if isinstance(data, dict) else {})
+    index_data = data if isinstance(data, dict) else {}
+    poses, sources = _locate_link_poses(index_data, visual=False)
+    visual_poses, visual_sources = _locate_link_poses(index_data, visual=True)
     for link in REQUIRED_CHAIN:
         ok = link in poses
         checks.append({"check": f"{link} pose present and finite", "ok": ok})
         if not ok:
             aliases = ", ".join(LINK_ALIASES[link])
-            errors.append(f"Missing finite UR5 link pose for {link} (accepted names: {aliases})")
+            errors.append(
+                f"Missing finite UR5 link pose for {link} (accepted names: {aliases})"
+            )
 
     distances: dict[str, float] = {}
-    if "base" in poses:
-        base_distance = _distance(poses["base"], [0.0, 0.0, 0.0])
+    if "base_link" in poses:
+        base_distance = _distance(poses["base_link"], [0.0, 0.0, 0.0])
         distances["base_to_origin"] = base_distance
         ok = base_distance <= BASE_ORIGIN_MAX_M
-        checks.append({"check": "base near world origin", "ok": ok, "distance_m": base_distance, "limit_m": BASE_ORIGIN_MAX_M})
+        checks.append(
+            {
+                "check": "base near world origin",
+                "ok": ok,
+                "distance_m": base_distance,
+                "limit_m": BASE_ORIGIN_MAX_M,
+            }
+        )
         if not ok:
-            errors.append(f"UR5 base is {base_distance:.3f} m from world origin; expected <= {BASE_ORIGIN_MAX_M:.3f} m")
+            errors.append(
+                f"UR5 base is {base_distance:.3f} m from world origin; expected <= {BASE_ORIGIN_MAX_M:.3f} m"
+            )
 
     adjacent_values: list[float] = []
     for parent, child in zip(REQUIRED_CHAIN, REQUIRED_CHAIN[1:]):
@@ -165,23 +198,150 @@ def validate_index(index_path: Path) -> dict[str, Any]:
         distances[f"{parent}_to_{child}"] = distance
         adjacent_values.append(distance)
         ok = distance <= limit
-        checks.append({"check": f"{child} attached near {parent}", "ok": ok, "distance_m": distance, "limit_m": limit})
+        checks.append(
+            {
+                "check": f"physical link frame {child} attached near {parent}",
+                "ok": ok,
+                "distance_m": distance,
+                "limit_m": limit,
+            }
+        )
         if not ok:
-            errors.append(f"UR5 adjacent link distance {parent}->{child} is {distance:.3f} m; expected <= {limit:.3f} m")
+            errors.append(
+                f"UR5 physical link-frame distance {parent}->{child} is {distance:.3f} m; expected <= {limit:.3f} m"
+            )
+
+    visual_distances: dict[str, float] = {}
+    for link in REQUIRED_CHAIN:
+        ok = link in visual_poses
+        checks.append(
+            {"check": f"{link} rendered visual pose present and finite", "ok": ok}
+        )
+        if not ok:
+            aliases = ", ".join(LINK_ALIASES[link])
+            errors.append(
+                f"Missing finite UR5 rendered visual pose for {link} (accepted names: {aliases})"
+            )
+
+    for parent, child in zip(REQUIRED_CHAIN, REQUIRED_CHAIN[1:]):
+        if parent not in visual_poses or child not in visual_poses:
+            continue
+        distance = _distance(visual_poses[parent], visual_poses[child])
+        limit = ADJACENT_LIMITS_M[(parent, child)]
+        key = f"visual_{parent}_to_{child}"
+        visual_distances[key] = distance
+        distances[key] = distance
+        max_ok = distance <= limit
+        min_ok = distance >= VISUAL_ADJACENT_MIN_M
+        checks.append(
+            {
+                "check": f"rendered visual {child} near {parent}",
+                "ok": max_ok,
+                "distance_m": distance,
+                "limit_m": limit,
+            }
+        )
+        checks.append(
+            {
+                "check": f"rendered visual {child} not collapsed onto {parent}",
+                "ok": min_ok,
+                "distance_m": distance,
+                "limit_m": VISUAL_ADJACENT_MIN_M,
+            }
+        )
+        if not max_ok:
+            errors.append(
+                f"UR5 rendered visual center distance {parent}->{child} is {distance:.3f} m; expected <= {limit:.3f} m"
+            )
+        if not min_ok:
+            errors.append(
+                f"UR5 rendered visual centers {parent}->{child} are collapsed at {distance:.3f} m; expected >= {VISUAL_ADJACENT_MIN_M:.3f} m"
+            )
+
+    tool_anchor = poses.get("tool0") or poses.get("wrist_3_link")
+    tool_records = [
+        record
+        for record in index_data.get("visual_items", [])
+        if isinstance(record, dict)
+        and any(
+            token
+            in " ".join(
+                str(record.get(k, "")).lower()
+                for k in (
+                    "link",
+                    "id",
+                    "source_path",
+                    "package_uri",
+                    "resolved_source_path",
+                )
+            )
+            for token in ("robotiq", "gripper", "tool")
+        )
+    ]
+    checks.append(
+        {
+            "check": "Robotiq/tool visuals present",
+            "ok": bool(tool_records),
+            "count": len(tool_records),
+        }
+    )
+    if not tool_records:
+        errors.append("Missing Robotiq/tool visuals near UR5 wrist/tool attachment")
+    if tool_anchor is not None and tool_records:
+        tool_distances = [
+            _distance(tool_anchor, xyz)
+            for record in tool_records
+            if (xyz := _visual_pose_xyz(record)) is not None
+        ]
+        if not tool_distances:
+            checks.append({"check": "Robotiq/tool visual poses finite", "ok": False})
+            errors.append(
+                "Robotiq/tool visuals were found but none had finite rendered visual poses"
+            )
+        else:
+            nearest = min(tool_distances)
+            farthest = max(tool_distances)
+            distances["nearest_tool_visual_to_wrist_3_link_or_tool0"] = nearest
+            distances["farthest_tool_visual_to_wrist_3_link_or_tool0"] = farthest
+            ok = farthest <= TOOL_ATTACHMENT_MAX_M
+            checks.append(
+                {
+                    "check": "Robotiq/tool visuals attached near wrist_3_link/tool0",
+                    "ok": ok,
+                    "nearest_distance_m": nearest,
+                    "farthest_distance_m": farthest,
+                    "limit_m": TOOL_ATTACHMENT_MAX_M,
+                }
+            )
+            if not ok:
+                errors.append(
+                    f"Robotiq/tool visual is {farthest:.3f} m from wrist_3_link/tool0; expected all <= {TOOL_ATTACHMENT_MAX_M:.3f} m"
+                )
 
     max_adjacent = max(adjacent_values) if adjacent_values else None
     if max_adjacent is not None:
         ok = max_adjacent <= ADJACENT_MAX_M
-        checks.append({"check": "maximum adjacent UR5 link distance reasonable", "ok": ok, "distance_m": max_adjacent, "limit_m": ADJACENT_MAX_M})
+        checks.append(
+            {
+                "check": "maximum adjacent UR5 link distance reasonable",
+                "ok": ok,
+                "distance_m": max_adjacent,
+                "limit_m": ADJACENT_MAX_M,
+            }
+        )
         if not ok:
-            errors.append(f"Maximum adjacent UR5 link distance is {max_adjacent:.3f} m; expected <= {ADJACENT_MAX_M:.3f} m")
+            errors.append(
+                f"Maximum adjacent UR5 link distance is {max_adjacent:.3f} m; expected <= {ADJACENT_MAX_M:.3f} m"
+            )
 
     return {
         "ok": not errors,
         "index": str(index_path),
         "required_chain": list(REQUIRED_CHAIN),
         "pose_sources": sources,
+        "visual_pose_sources": visual_sources,
         "poses": poses,
+        "visual_poses": visual_poses,
         "distances_m": distances,
         "checks": checks,
         "errors": errors,
@@ -190,8 +350,15 @@ def validate_index(index_path: Path) -> dict[str, Any]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--index", required=True, type=Path, help="Path to generated/scene_visual_mesh_index.json")
-    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON output")
+    parser.add_argument(
+        "--index",
+        required=True,
+        type=Path,
+        help="Path to generated/scene_visual_mesh_index.json",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Print machine-readable JSON output"
+    )
     args = parser.parse_args(argv)
 
     report = validate_index(args.index)

--- a/tests/test_ur5_scene3d_transform_plausibility.py
+++ b/tests/test_ur5_scene3d_transform_plausibility.py
@@ -11,18 +11,33 @@ from scripts.validate_ur5_scene3d_transform_plausibility import validate_index
 SCRIPT = Path("scripts/validate_ur5_scene3d_transform_plausibility.py")
 
 
-def _write_index(path: Path, poses: dict[str, list[float]]) -> Path:
-    path.write_text(
-        json.dumps(
-            {
-                "visual_items": [
-                    {"link": link, "pose": {"xyz": xyz, "rpy": [0.0, 0.0, 0.0]}}
-                    for link, xyz in poses.items()
-                ]
-            }
-        ),
-        encoding="utf-8",
+def _write_index(
+    path: Path,
+    poses: dict[str, list[float]],
+    *,
+    visual_poses: dict[str, list[float]] | None = None,
+) -> Path:
+    visual_poses = visual_poses or poses
+    visual_items = [
+        {
+            "link": link,
+            "link_world_pose": {"xyz": xyz, "rpy": [0.0, 0.0, 0.0]},
+            "pose": {"xyz": visual_poses.get(link, xyz), "rpy": [0.0, 0.0, 0.0]},
+        }
+        for link, xyz in poses.items()
+    ]
+    visual_items.append(
+        {
+            "link": "gripper_base_link",
+            "source_path": "package://robotiq_85_description/meshes/visual/robotiq_85_base_link.dae",
+            "link_world_pose": {"xyz": poses["wrist_3_link"], "rpy": [0.0, 0.0, 0.0]},
+            "pose": {
+                "xyz": visual_poses.get("wrist_3_link", poses["wrist_3_link"]),
+                "rpy": [0.0, 0.0, 0.0],
+            },
+        }
     )
+    path.write_text(json.dumps({"visual_items": visual_items}), encoding="utf-8")
     return path
 
 
@@ -65,7 +80,9 @@ def test_validator_cli_returns_zero_for_plausible_visual_items(tmp_path: Path) -
     assert not report["errors"]
 
 
-def test_validator_cli_returns_nonzero_for_implausible_adjacent_distance(tmp_path: Path) -> None:
+def test_validator_cli_returns_nonzero_for_implausible_adjacent_distance(
+    tmp_path: Path,
+) -> None:
     poses = _valid_ur5_poses()
     poses["forearm_link"] = [9.0, 0.0, 0.0]
     index = _write_index(tmp_path / "scene_visual_mesh_index.json", poses)
@@ -92,3 +109,41 @@ def test_validator_rejects_nan_or_infinite_required_link_pose(tmp_path: Path) ->
 
     assert report["ok"] is False
     assert any("wrist_3_link" in error for error in report["errors"])
+
+
+def test_validator_rejects_exploded_visuals_even_when_link_frames_are_plausible(
+    tmp_path: Path,
+) -> None:
+    poses = _valid_ur5_poses()
+    visual_poses = dict(poses)
+    visual_poses["forearm_link"] = [8.0, 0.0, 0.0]
+    index = _write_index(
+        tmp_path / "scene_visual_mesh_index.json", poses, visual_poses=visual_poses
+    )
+
+    report = validate_index(index)
+
+    assert report["ok"] is False
+    assert any(
+        "rendered visual center distance upper_arm_link->forearm_link" in error
+        for error in report["errors"]
+    )
+
+
+def test_validator_rejects_collapsed_visuals_even_when_link_frames_are_plausible(
+    tmp_path: Path,
+) -> None:
+    poses = _valid_ur5_poses()
+    visual_poses = dict(poses)
+    visual_poses["forearm_link"] = visual_poses["upper_arm_link"]
+    index = _write_index(
+        tmp_path / "scene_visual_mesh_index.json", poses, visual_poses=visual_poses
+    )
+
+    report = validate_index(index)
+
+    assert report["ok"] is False
+    assert any(
+        "rendered visual centers upper_arm_link->forearm_link are collapsed" in error
+        for error in report["errors"]
+    )


### PR DESCRIPTION
### Motivation
- Prevent cases where `link_world_pose` metadata appears plausible while rendered meshes are exploded or collapsed, causing visual disconnects to be missed by the validator. 
- Use representative UR5 link names for the required chain and add conservative checks for both physical link-frame adjacency and rendered visual adjacency. 
- Ensure Robotiq/tool attachments are present and plausibly near the wrist so tool-less or mis-attached visuals fail validation. 
- Make the validator reliably exit non-zero for exploded-screenshot failures even when `transform_chain_applied_count` and `missing_mesh` metrics look fine.

### Description
- Updated `REQUIRED_CHAIN` and `LINK_ALIASES` to use representative link names (`base_link` .. `wrist_3_link`) and adjusted adjacency limits via `ADJACENT_LIMITS_M`.
- Split pose extraction into link-frame (`link_world_pose`/`world_pose`) and rendered-visual (`baked_world_visual_pose` or legacy `pose`) APIs and extended `_locate_link_poses` to locate either kind.
- Added rendered-visual adjacency checks that enforce both a maximum adjacency (`ADJACENT_LIMITS_M`) and a minimum collapse threshold (`VISUAL_ADJACENT_MIN_M`) to detect exploded or collapsed visuals.
- Implemented Robotiq/tool visual detection that searches visual items for `robotiq`, `gripper`, or `tool` tokens and asserts tool visuals are near `wrist_3_link`/`tool0` within `TOOL_ATTACHMENT_MAX_M`.
- Augmented validator output with `visual_pose_sources`, `visual_poses`, and additional distance metrics; updated tests and test index writer to include `link_world_pose`/rendered `pose` and a gripper visual.
- Minor lint fix: removed an unused `sys` import and applied formatting.

### Testing
- Ran lint/format and fixes: `python3 -m ruff check --fix ...` and `python3 -m ruff format ...` and then `python3 -m ruff check ...`, all succeeded.
- Ran unit tests: `python3 -m pytest tests/test_ur5_scene3d_transform_plausibility.py -q` and all tests passed (`6 passed`).
- Ran the validator against the checked-in index: `python3 scripts/validate_ur5_scene3d_transform_plausibility.py --index scenes/ur5_2f_test/generated/scene_visual_mesh_index.json --json` and it produced a passing report for that scene (validator reported `ok: true`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33e0d12d988331a9b10f5a819da8cb)