### PR TITLE
Fix workcell_builder compile after baked transform changes

### DIFF
--- a/workcell_builder/workcell_builder/gui/mainwindow.cpp
+++ b/workcell_builder/workcell_builder/gui/mainwindow.cpp
@@ -8362,6 +8362,8 @@ void MainWindow::populate_scene_hierarchy()
   int transform_chain_applied_count = 0;
   int visual_origin_applied_count = 0;
   int baked_world_visual_pose_count = 0;
+  int baked_world_visual_transform_count = 0;
+  int legacy_viewport_transform_count = 0;
   QString baked_world_visual_transform_source = QStringLiteral("urdf_fk_link_world_times_visual_origin");
   int missing_chain_warning_count = 0;
   {
@@ -8459,7 +8461,6 @@ void MainWindow::populate_scene_hierarchy()
           const YAML::Node world_pose = workcell_builder::yaml_map_key(v, "world_pose");
           const YAML::Node world_xyz = workcell_builder::yaml_map_key(world_pose, "xyz");
           const YAML::Node world_rpy = workcell_builder::yaml_map_key(world_pose, "rpy");
-          const YAML::Node baked_world_visual_pose = workcell_builder::yaml_map_key(v, "baked_world_visual_pose");
           const YAML::Node baked_world_visual_pose_xyz = workcell_builder::yaml_map_key(baked_world_visual_pose, "xyz");
           const YAML::Node baked_world_visual_pose_rpy = workcell_builder::yaml_map_key(baked_world_visual_pose, "rpy");
           const YAML::Node baked_world_visual_matrix = workcell_builder::yaml_map_key(v, "baked_world_visual_matrix");


### PR DESCRIPTION
Summary:
- Removed the duplicate `baked_world_visual_pose` declaration in `MainWindow::populate_scene_hierarchy()`.
- Added local diagnostics counters for baked visual transforms and legacy viewport transforms before they are incremented.
- Keeps the existing transform logic scoped to build recovery without a broader 3D refactor.

Validation:
- Attempted: `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select workcell_builder`
- Result: blocked in this container because `/opt/ros/humble/setup.bash` is not present.
- Static inspection confirmed only one `baked_world_visual_pose` declaration remains in the affected scope and both counters are declared before use.

Safety:
- No launch files, runtime services, controllers, hardware parameters, or real-robot execution paths were changed.
- Fake-hardware defaults and guarded real-hardware behavior are unaffected.

Risks / rollback:
- Compile validation still needs to be rerun in a ROS 2 Humble workspace.
- Rollback is safe by reverting commit `f100a9c` if needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33f5c859c88331ad4e7c0736dd12e7)